### PR TITLE
feat: implement server v1 API with full agent/chat/messaging system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,4 @@ jobs:
           node-version: "22"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - name: Run tests
-        run: |
-          rc=0; pnpm test || rc=$?
-          if [ $rc -eq 1 ]; then echo "No tests found, skipping"; exit 0; fi
-          exit $rc
+      - run: pnpm test

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsdown src/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",

--- a/packages/server/drizzle.config.ts
+++ b/packages/server/drizzle.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema/index.ts",
+  out: "./drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    // eslint-disable-next-line -- drizzle-kit requires this at config level
+    url: process.env.DATABASE_URL ?? "",
+  },
+});

--- a/packages/server/drizzle/0000_shocking_darkhawk.sql
+++ b/packages/server/drizzle/0000_shocking_darkhawk.sql
@@ -1,0 +1,92 @@
+CREATE TABLE "admin_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"username" text NOT NULL,
+	"password_hash" text NOT NULL,
+	"role" text DEFAULT 'admin' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_login_at" timestamp with time zone,
+	CONSTRAINT "admin_users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+CREATE TABLE "agent_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"agent_id" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"name" text,
+	"expires_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "agents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text DEFAULT 'default' NOT NULL,
+	"type" text NOT NULL,
+	"display_name" text,
+	"inbox_id" text NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agents_inbox_id_unique" UNIQUE("inbox_id")
+);
+--> statement-breakpoint
+CREATE TABLE "chat_participants" (
+	"chat_id" text NOT NULL,
+	"agent_id" text NOT NULL,
+	"role" text DEFAULT 'member' NOT NULL,
+	"mode" text DEFAULT 'full' NOT NULL,
+	"joined_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "chat_participants_chat_id_agent_id_pk" PRIMARY KEY("chat_id","agent_id")
+);
+--> statement-breakpoint
+CREATE TABLE "chats" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text DEFAULT 'default' NOT NULL,
+	"type" text DEFAULT 'direct' NOT NULL,
+	"topic" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "inbox_entries" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"inbox_id" text NOT NULL,
+	"message_id" text NOT NULL,
+	"chat_id" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"retry_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"delivered_at" timestamp with time zone,
+	"acked_at" timestamp with time zone,
+	CONSTRAINT "uq_inbox_delivery" UNIQUE("inbox_id","message_id","chat_id")
+);
+--> statement-breakpoint
+CREATE TABLE "messages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"chat_id" text NOT NULL,
+	"sender_id" text NOT NULL,
+	"format" text NOT NULL,
+	"content" jsonb NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"reply_to_inbox" text,
+	"reply_to_chat" text,
+	"in_reply_to" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_tokens" ADD CONSTRAINT "agent_tokens_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chat_participants" ADD CONSTRAINT "chat_participants_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "chat_participants" ADD CONSTRAINT "chat_participants_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "inbox_entries" ADD CONSTRAINT "inbox_entries_message_id_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."messages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_sender_id_agents_id_fk" FOREIGN KEY ("sender_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_agent_tokens_agent" ON "agent_tokens" USING btree ("agent_id");--> statement-breakpoint
+CREATE INDEX "idx_agent_tokens_hash" ON "agent_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "idx_agents_org" ON "agents" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_participants_agent" ON "chat_participants" USING btree ("agent_id");--> statement-breakpoint
+CREATE INDEX "idx_inbox_pending" ON "inbox_entries" USING btree ("inbox_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_messages_chat_time" ON "messages" USING btree ("chat_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_messages_in_reply_to" ON "messages" USING btree ("in_reply_to");

--- a/packages/server/drizzle/meta/0000_snapshot.json
+++ b/packages/server/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,687 @@
+{
+  "id": "6294e028-ee1f-4384-be70-40d22ce4de47",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_tokens_agent": {
+          "name": "idx_agent_tokens_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_tokens_hash": {
+          "name": "idx_agent_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_agent_id_agents_id_fk": {
+          "name": "agent_tokens_agent_id_agents_id_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_participants": {
+      "name": "chat_participants",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_participants_agent": {
+          "name": "idx_participants_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_participants_chat_id_chats_id_fk": {
+          "name": "chat_participants_chat_id_chats_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_participants_agent_id_agents_id_fk": {
+          "name": "chat_participants_agent_id_agents_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_participants_chat_id_agent_id_pk": {
+          "name": "chat_participants_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_agents_id_fk": {
+          "name": "messages_sender_id_agents_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1774010814105,
+      "tag": "0000_shocking_darkhawk",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,18 +15,20 @@
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",
-    "fastify": "^5.3.0",
     "@fastify/websocket": "^11.2.0",
-    "drizzle-orm": "^0.44.0",
-    "postgres": "^3.4.0",
-    "zod": "^3.25.0",
     "bcrypt": "^6.0.0",
-    "jose": "^6.0.0"
+    "drizzle-orm": "^0.44.0",
+    "fastify": "^5.3.0",
+    "jose": "^6.0.0",
+    "postgres": "^3.4.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@testcontainers/postgresql": "^11.13.0",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "^22.16.0",
     "drizzle-kit": "^0.31.0",
+    "testcontainers": "^11.13.0",
     "tsdown": "^0.12.0",
     "tsx": "^4.19.0",
     "vitest": "^3.2.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "admin:create": "tsx src/scripts/create-admin.ts"
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Admin Agents API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function authedRequest(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const admin = await createTestAdmin(app);
+    return (method: string, url: string, payload?: unknown) =>
+      app.inject({
+        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        url,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        ...(payload ? { payload } : {}),
+      });
+  }
+
+  it("creates and retrieves an agent", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/admin/agents", {
+      id: "agent-1",
+      type: "autonomous_agent",
+      displayName: "Bot One",
+    });
+    expect(createRes.statusCode).toBe(201);
+    const agent = createRes.json();
+    expect(agent.id).toBe("agent-1");
+    expect(agent.inboxId).toBe("inbox_agent-1");
+
+    const getRes = await req("GET", "/admin/agents/agent-1");
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().id).toBe("agent-1");
+  });
+
+  it("lists agents with pagination", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    await req("POST", "/admin/agents", { id: "a1", type: "human" });
+    await req("POST", "/admin/agents", { id: "a2", type: "human" });
+
+    const res = await req("GET", "/admin/agents?limit=1");
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.items).toHaveLength(1);
+    expect(body.nextCursor).toBeDefined();
+  });
+
+  it("updates an agent", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    await req("POST", "/admin/agents", { id: "upd-1", type: "human" });
+
+    const res = await req("PATCH", "/admin/agents/upd-1", {
+      displayName: "Updated",
+      status: "suspended",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().displayName).toBe("Updated");
+    expect(res.json().status).toBe("suspended");
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/admin/agents" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  describe("Token management", () => {
+    it("creates, lists, and revokes tokens", async () => {
+      const app = await appPromise;
+      const req = await authedRequest(app);
+      await req("POST", "/admin/agents", { id: "tok-agent", type: "autonomous_agent" });
+
+      // Create token
+      const createRes = await req("POST", "/admin/agents/tok-agent/tokens", { name: "dev" });
+      expect(createRes.statusCode).toBe(201);
+      const tokenBody = createRes.json();
+      expect(tokenBody.token).toMatch(/^aghub_/);
+      expect(tokenBody.name).toBe("dev");
+
+      // List tokens
+      const listRes = await req("GET", "/admin/agents/tok-agent/tokens");
+      expect(listRes.statusCode).toBe(200);
+      expect(listRes.json()).toHaveLength(1);
+
+      // Revoke token
+      const revokeRes = await req("DELETE", `/admin/agents/tok-agent/tokens/${tokenBody.id}`);
+      expect(revokeRes.statusCode).toBe(204);
+    });
+  });
+});

--- a/packages/server/src/__tests__/admin-auth.test.ts
+++ b/packages/server/src/__tests__/admin-auth.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Admin Auth", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  describe("POST /admin/auth/login", () => {
+    it("returns tokens on valid credentials", async () => {
+      const app = await appPromise;
+      const admin = await createTestAdmin(app);
+      expect(admin.accessToken).toBeDefined();
+      expect(admin.refreshToken).toBeDefined();
+    });
+
+    it("rejects invalid password", async () => {
+      const app = await appPromise;
+      await createTestAdmin(app);
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/auth/login",
+        payload: { username: "admin", password: "wrong" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects non-existent user", async () => {
+      const app = await appPromise;
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/auth/login",
+        payload: { username: "nobody", password: "whatever" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe("POST /admin/auth/refresh", () => {
+    it("returns new access token", async () => {
+      const app = await appPromise;
+      const admin = await createTestAdmin(app);
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/auth/refresh",
+        payload: { refreshToken: admin.refreshToken },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toHaveProperty("accessToken");
+    });
+
+    it("rejects invalid refresh token", async () => {
+      const app = await appPromise;
+      const res = await app.inject({
+        method: "POST",
+        url: "/admin/auth/refresh",
+        payload: { refreshToken: "invalid" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+});

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Chats API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("creates a chat and retrieves it", async () => {
+    const app = await appPromise;
+    const { agent: a1, token: t1 } = await createTestAgent(app, { id: "chat-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "chat-a2" });
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: {
+        type: "direct",
+        participantIds: [a2.id],
+        topic: "Test chat",
+      },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const chat = createRes.json();
+    expect(chat.type).toBe("direct");
+    expect(chat.participants).toHaveLength(2);
+    expect(chat.participants.map((p: { agentId: string }) => p.agentId).sort()).toEqual([a1.id, a2.id].sort());
+
+    const getRes = await app.inject({
+      method: "GET",
+      url: `/agent/chats/${chat.id}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().id).toBe(chat.id);
+  });
+
+  it("lists chats for an agent", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "list-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "list-a2" });
+
+    await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects chat creation with non-existent participant", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "bad-a1" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: ["non-existent"] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects access to non-participant chat", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "deny-a1" });
+    const { token: t2 } = await createTestAgent(app, { id: "deny-a2" });
+    const { agent: a3 } = await createTestAgent(app, { id: "deny-a3" });
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t2}` },
+      payload: { type: "direct", participantIds: [a3.id] },
+    });
+    const chatId = createRes.json().id;
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/agent/chats/${chatId}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/packages/server/src/__tests__/agent-inbox.test.ts
+++ b/packages/server/src/__tests__/agent-inbox.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Inbox API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("polls inbox and acks entry", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "inbox-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "inbox-a2" });
+
+    // Create chat and send message
+    const chatRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+    const chatId = chatRes.json().id;
+
+    await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Inbox test" },
+    });
+
+    // Poll inbox as recipient
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes.statusCode).toBe(200);
+    const entries = pollRes.json();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    const entryId = entries[0].id;
+
+    // ACK the entry
+    const ackRes = await app.inject({
+      method: "POST",
+      url: `/agent/inbox/${entryId}/ack`,
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(ackRes.statusCode).toBe(204);
+
+    // Poll again — should be empty
+    const pollRes2 = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes2.json()).toHaveLength(0);
+  });
+
+  it("rejects unauthenticated inbox access", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/agent/inbox" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/agent-messages.test.ts
+++ b/packages/server/src/__tests__/agent-messages.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Messages API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function setupChat(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const { agent: a1, token: t1 } = await createTestAgent(app, { id: `msg-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `msg-a2-${crypto.randomUUID().slice(0, 6)}` });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+    const chat = res.json();
+    return { a1, a2, t1, t2, chatId: chat.id };
+  }
+
+  it("sends and retrieves messages", async () => {
+    const app = await appPromise;
+    const { t1, chatId } = await setupChat(app);
+
+    const sendRes = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Hello!" },
+    });
+    expect(sendRes.statusCode).toBe(201);
+    expect(sendRes.json().content).toBe("Hello!");
+
+    const listRes = await app.inject({
+      method: "GET",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(listRes.statusCode).toBe(200);
+    expect(listRes.json().items).toHaveLength(1);
+  });
+
+  it("sends message with replyTo fields", async () => {
+    const app = await appPromise;
+    const { t1, a1, chatId } = await setupChat(app);
+
+    const sendRes = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: {
+        format: "text",
+        content: "Need approval",
+        replyToInbox: a1.inboxId,
+        replyToChat: chatId,
+      },
+    });
+    expect(sendRes.statusCode).toBe(201);
+    const msg = sendRes.json();
+    expect(msg.replyToInbox).toBe(a1.inboxId);
+    expect(msg.replyToChat).toBe(chatId);
+  });
+
+  it("creates inbox entries for recipient (fan-out)", async () => {
+    const app = await appPromise;
+    const { t1, t2, chatId } = await setupChat(app);
+
+    await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Fan-out test" },
+    });
+
+    // Recipient should have inbox entries
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes.statusCode).toBe(200);
+    const entries = pollRes.json();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0].message.content).toBe("Fan-out test");
+  });
+
+  it("rejects message from non-participant", async () => {
+    const app = await appPromise;
+    const { chatId } = await setupChat(app);
+    const { token: outsider } = await createTestAgent(app, { id: "outsider" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${outsider}` },
+      payload: { format: "text", content: "Intruder!" },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/packages/server/src/__tests__/global-setup.ts
+++ b/packages/server/src/__tests__/global-setup.ts
@@ -1,0 +1,23 @@
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+
+let container: Awaited<ReturnType<PostgreSqlContainer["start"]>>;
+
+export async function setup() {
+  container = await new PostgreSqlContainer("postgres:17").start();
+
+  const url = container.getConnectionUri();
+  process.env.DATABASE_URL = url;
+  process.env.JWT_SECRET_KEY = "test-jwt-secret-key-for-vitest";
+
+  // Run migrations via drizzle-kit
+  const { execSync } = await import("node:child_process");
+  execSync("pnpm db:migrate", {
+    cwd: `${import.meta.dirname}/../..`,
+    env: { ...process.env, DATABASE_URL: url },
+    stdio: "pipe",
+  });
+}
+
+export async function teardown() {
+  await container?.stop();
+}

--- a/packages/server/src/__tests__/health.test.ts
+++ b/packages/server/src/__tests__/health.test.ts
@@ -1,0 +1,14 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestApp } from "./helpers.js";
+
+describe("GET /health", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("returns ok with db connected", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok", db: "connected" });
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -1,0 +1,58 @@
+import type { AgentType } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../app.js";
+import type { Config } from "../config.js";
+
+export async function createTestApp(): Promise<FastifyInstance> {
+  const config: Config = {
+    databaseUrl: process.env.DATABASE_URL ?? "",
+    serverHost: "127.0.0.1",
+    serverPort: 0,
+    logger: false,
+    jwtSecretKey: process.env.JWT_SECRET_KEY ?? "test-jwt-secret-key-for-vitest",
+  };
+  const app = await buildApp(config);
+  await app.ready();
+  return app;
+}
+
+/** Create an agent via direct DB insert and return its bearer token. */
+export async function createTestAgent(
+  app: FastifyInstance,
+  opts: { id?: string; type?: AgentType; displayName?: string } = {},
+) {
+  const { createAgent, createToken } = await import("../services/agent.js");
+  const agent = await createAgent(app.db, {
+    id: opts.id ?? `test-agent-${crypto.randomUUID().slice(0, 8)}`,
+    type: opts.type ?? "autonomous_agent",
+    displayName: opts.displayName ?? "Test Agent",
+  });
+  const token = await createToken(app.db, agent.id, { name: "test" });
+  return { agent, token: token.token };
+}
+
+/** Create an admin user and return JWT tokens. */
+export async function createTestAdmin(app: FastifyInstance, opts: { username?: string; password?: string } = {}) {
+  const bcrypt = await import("bcrypt");
+  const { randomUUID } = await import("node:crypto");
+  const { adminUsers } = await import("../db/schema/admin-users.js");
+
+  const username = opts.username ?? "admin";
+  const password = opts.password ?? "testpassword123";
+  const passwordHash = await bcrypt.hash(password, 10);
+
+  await app.db.insert(adminUsers).values({
+    id: randomUUID(),
+    username,
+    passwordHash,
+    role: "super_admin",
+  });
+
+  const loginRes = await app.inject({
+    method: "POST",
+    url: "/admin/auth/login",
+    payload: { username, password },
+  });
+  const body = loginRes.json<{ accessToken: string; refreshToken: string }>();
+  return { username, password, ...body };
+}

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -1,0 +1,18 @@
+import { sql } from "drizzle-orm";
+import { beforeEach } from "vitest";
+import { connectDatabase } from "../db/connection.js";
+
+beforeEach(async () => {
+  const db = connectDatabase(process.env.DATABASE_URL ?? "");
+  await db.execute(sql`
+    SET client_min_messages TO WARNING;
+    DO $$ DECLARE t text;
+    BEGIN
+      FOR t IN
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+      LOOP
+        EXECUTE 'TRUNCATE TABLE public.' || quote_ident(t) || ' CASCADE';
+      END LOOP;
+    END $$
+  `);
+});

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -1,0 +1,80 @@
+import { createAgentSchema, createAgentTokenSchema, paginationQuerySchema, updateAgentSchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import * as agentService from "../../services/agent.js";
+
+function serializeDate(d: Date | null): string | null {
+  return d ? d.toISOString() : null;
+}
+
+export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/", async (request) => {
+    const query = paginationQuerySchema.parse(request.query);
+    const result = await agentService.listAgents(app.db, query.limit, query.cursor);
+    return {
+      items: result.items.map((a) => ({
+        ...a,
+        createdAt: a.createdAt.toISOString(),
+        updatedAt: a.updatedAt.toISOString(),
+      })),
+      nextCursor: result.nextCursor,
+    };
+  });
+
+  app.post("/", async (request, reply) => {
+    const body = createAgentSchema.parse(request.body);
+    const agent = await agentService.createAgent(app.db, body);
+    return reply.status(201).send({
+      ...agent,
+      createdAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
+    });
+  });
+
+  app.get<{ Params: { agentId: string } }>("/:agentId", async (request) => {
+    const agent = await agentService.getAgent(app.db, request.params.agentId);
+    return {
+      ...agent,
+      createdAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
+    };
+  });
+
+  app.patch<{ Params: { agentId: string } }>("/:agentId", async (request) => {
+    const body = updateAgentSchema.parse(request.body);
+    const agent = await agentService.updateAgent(app.db, request.params.agentId, body);
+    return {
+      ...agent,
+      createdAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
+    };
+  });
+
+  // Token management
+  app.post<{ Params: { agentId: string } }>("/:agentId/tokens", async (request, reply) => {
+    const body = createAgentTokenSchema.parse(request.body);
+    const result = await agentService.createToken(app.db, request.params.agentId, body);
+    return reply.status(201).send({
+      ...result,
+      expiresAt: serializeDate(result.expiresAt),
+      revokedAt: serializeDate(result.revokedAt),
+      createdAt: result.createdAt.toISOString(),
+      lastUsedAt: serializeDate(result.lastUsedAt),
+    });
+  });
+
+  app.get<{ Params: { agentId: string } }>("/:agentId/tokens", async (request) => {
+    const tokens = await agentService.listTokens(app.db, request.params.agentId);
+    return tokens.map((t) => ({
+      ...t,
+      expiresAt: serializeDate(t.expiresAt),
+      revokedAt: serializeDate(t.revokedAt),
+      createdAt: t.createdAt.toISOString(),
+      lastUsedAt: serializeDate(t.lastUsedAt),
+    }));
+  });
+
+  app.delete<{ Params: { agentId: string; tokenId: string } }>("/:agentId/tokens/:tokenId", async (request, reply) => {
+    await agentService.revokeToken(app.db, request.params.agentId, request.params.tokenId);
+    return reply.status(204).send();
+  });
+}

--- a/packages/server/src/api/admin/auth.ts
+++ b/packages/server/src/api/admin/auth.ts
@@ -1,0 +1,17 @@
+import { loginSchema, refreshTokenSchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import * as adminAuthService from "../../services/admin-auth.js";
+
+export async function adminAuthRoutes(app: FastifyInstance): Promise<void> {
+  app.post("/login", async (request, reply) => {
+    const body = loginSchema.parse(request.body);
+    const result = await adminAuthService.login(app.db, body.username, body.password, app.config.jwtSecretKey);
+    return reply.send(result);
+  });
+
+  app.post("/refresh", async (request, reply) => {
+    const body = refreshTokenSchema.parse(request.body);
+    const result = await adminAuthService.refreshAccessToken(app.db, body.refreshToken, app.config.jwtSecretKey);
+    return reply.send(result);
+  });
+}

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -1,0 +1,50 @@
+import { createChatSchema, paginationQuerySchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import { requireAgent } from "../../middleware/require-identity.js";
+import * as chatService from "../../services/chat.js";
+
+function serializeChat(chat: { createdAt: Date; updatedAt: Date; [key: string]: unknown }) {
+  return {
+    ...chat,
+    createdAt: chat.createdAt.toISOString(),
+    updatedAt: chat.updatedAt.toISOString(),
+  };
+}
+
+export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
+  app.post("/", async (request, reply) => {
+    const identity = requireAgent(request);
+    const body = createChatSchema.parse(request.body);
+    const result = await chatService.createChat(app.db, identity.id, body);
+    return reply.status(201).send({
+      ...serializeChat(result),
+      participants: result.participants.map((p) => ({
+        ...p,
+        joinedAt: p.joinedAt.toISOString(),
+      })),
+    });
+  });
+
+  app.get("/", async (request) => {
+    const identity = requireAgent(request);
+    const query = paginationQuerySchema.parse(request.query);
+    const result = await chatService.listChats(app.db, identity.id, query.limit, query.cursor);
+    return {
+      items: result.items.map(serializeChat),
+      nextCursor: result.nextCursor,
+    };
+  });
+
+  app.get<{ Params: { chatId: string } }>("/:chatId", async (request) => {
+    const identity = requireAgent(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    const detail = await chatService.getChatDetail(app.db, request.params.chatId);
+    return {
+      ...serializeChat(detail),
+      participants: detail.participants.map((p) => ({
+        ...p,
+        joinedAt: p.joinedAt.toISOString(),
+      })),
+    };
+  });
+}

--- a/packages/server/src/api/agent/inbox.ts
+++ b/packages/server/src/api/agent/inbox.ts
@@ -8,7 +8,7 @@ export async function agentInboxRoutes(app: FastifyInstance): Promise<void> {
     const identity = requireAgent(request);
     const query = inboxPollQuerySchema.parse(request.query);
     const entries = await inboxService.pollInbox(app.db, identity.inboxId, query.limit);
-    return { items: entries };
+    return entries;
   });
 
   app.post<{ Params: { entryId: string } }>("/:entryId/ack", async (request, reply) => {

--- a/packages/server/src/api/agent/inbox.ts
+++ b/packages/server/src/api/agent/inbox.ts
@@ -1,0 +1,20 @@
+import { inboxPollQuerySchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import { requireAgent } from "../../middleware/require-identity.js";
+import * as inboxService from "../../services/inbox.js";
+
+export async function agentInboxRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/", async (request) => {
+    const identity = requireAgent(request);
+    const query = inboxPollQuerySchema.parse(request.query);
+    const entries = await inboxService.pollInbox(app.db, identity.inboxId, query.limit);
+    return { items: entries };
+  });
+
+  app.post<{ Params: { entryId: string } }>("/:entryId/ack", async (request, reply) => {
+    const identity = requireAgent(request);
+    const entryId = Number(request.params.entryId);
+    await inboxService.ackEntry(app.db, entryId, identity.inboxId);
+    return reply.status(204).send();
+  });
+}

--- a/packages/server/src/api/agent/me.ts
+++ b/packages/server/src/api/agent/me.ts
@@ -1,0 +1,15 @@
+import type { FastifyInstance } from "fastify";
+import { requireAgent } from "../../middleware/require-identity.js";
+import * as agentService from "../../services/agent.js";
+
+export async function agentMeRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/me", async (request) => {
+    const identity = requireAgent(request);
+    const agent = await agentService.getAgent(app.db, identity.id);
+    return {
+      ...agent,
+      createdAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
+    };
+  });
+}

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -1,0 +1,32 @@
+import { paginationQuerySchema, sendMessageSchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import { requireAgent } from "../../middleware/require-identity.js";
+import * as chatService from "../../services/chat.js";
+import * as messageService from "../../services/message.js";
+
+export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Params: { chatId: string } }>("/:chatId/messages", async (request, reply) => {
+    const identity = requireAgent(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    const body = sendMessageSchema.parse(request.body);
+    const msg = await messageService.sendMessage(app.db, request.params.chatId, identity.id, body);
+    return reply.status(201).send({
+      ...msg,
+      createdAt: msg.createdAt.toISOString(),
+    });
+  });
+
+  app.get<{ Params: { chatId: string } }>("/:chatId/messages", async (request) => {
+    const identity = requireAgent(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    const query = paginationQuerySchema.parse(request.query);
+    const result = await messageService.listMessages(app.db, request.params.chatId, query.limit, query.cursor);
+    return {
+      items: result.items.map((m) => ({
+        ...m,
+        createdAt: m.createdAt.toISOString(),
+      })),
+      nextCursor: result.nextCursor,
+    };
+  });
+}

--- a/packages/server/src/api/health.ts
+++ b/packages/server/src/api/health.ts
@@ -1,0 +1,13 @@
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+
+export async function healthRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/health", async () => {
+    try {
+      await app.db.execute(sql`SELECT 1`);
+      return { status: "ok", db: "connected" };
+    } catch {
+      return { status: "degraded", db: "disconnected" };
+    }
+  });
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,0 +1,72 @@
+import Fastify from "fastify";
+import { ZodError } from "zod";
+import { adminAgentRoutes } from "./api/admin/agents.js";
+import { adminAuthRoutes } from "./api/admin/auth.js";
+import { agentChatRoutes } from "./api/agent/chats.js";
+import { agentInboxRoutes } from "./api/agent/inbox.js";
+import { agentMeRoutes } from "./api/agent/me.js";
+import { agentMessageRoutes } from "./api/agent/messages.js";
+import { healthRoutes } from "./api/health.js";
+import type { Config } from "./config.js";
+import { connectDatabase } from "./db/connection.js";
+import { AppError } from "./errors.js";
+import { adminAuthHook } from "./middleware/admin-auth.js";
+import { agentAuthHook } from "./middleware/agent-auth.js";
+
+// Fastify type augmentation
+import "./types.js";
+
+export async function buildApp(config: Config) {
+  const app = Fastify({ logger: true });
+
+  // Decorate with config and db
+  const db = connectDatabase(config.databaseUrl);
+  app.decorate("db", db);
+  app.decorate("config", config);
+
+  // Auth hooks
+  const agentAuth = agentAuthHook(db);
+  const adminAuth = adminAuthHook(db, config.jwtSecretKey);
+
+  // Error handler
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof AppError) {
+      return reply.status(error.statusCode).send({ error: error.message });
+    }
+    if (error instanceof ZodError) {
+      return reply.status(400).send({ error: "Validation error", details: error.issues });
+    }
+    app.log.error(error);
+    return reply.status(500).send({ error: "Internal server error" });
+  });
+
+  // Public routes
+  await app.register(healthRoutes);
+  await app.register(adminAuthRoutes, { prefix: "/admin/auth" });
+
+  // Admin routes (JWT protected)
+  await app.register(
+    async (adminApp) => {
+      adminApp.addHook("onRequest", adminAuth);
+      await adminApp.register(adminAgentRoutes);
+    },
+    { prefix: "/admin/agents" },
+  );
+
+  // Agent routes (Bearer token protected)
+  // V1: actor-centric paths (/agent/*) for simplicity.
+  // Target: migrate to resource-centric paths (/chats/*, /inboxes/*) per design doc
+  // (agent-hub-server-detailed-design §4.1). Body schemas are shared, so migration is path-only.
+  await app.register(
+    async (agentApp) => {
+      agentApp.addHook("onRequest", agentAuth);
+      await agentApp.register(agentMeRoutes);
+      await agentApp.register(agentChatRoutes, { prefix: "/chats" });
+      await agentApp.register(agentMessageRoutes, { prefix: "/chats" });
+      await agentApp.register(agentInboxRoutes, { prefix: "/inbox" });
+    },
+    { prefix: "/agent" },
+  );
+
+  return app;
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -17,7 +17,7 @@ import { agentAuthHook } from "./middleware/agent-auth.js";
 import "./types.js";
 
 export async function buildApp(config: Config) {
-  const app = Fastify({ logger: true });
+  const app = Fastify({ logger: config.logger ?? true });
 
   // Decorate with config and db
   const db = connectDatabase(config.databaseUrl);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,0 +1,27 @@
+const env = process.env;
+
+export type Config = {
+  databaseUrl: string;
+  serverHost: string;
+  serverPort: number;
+  jwtSecretKey: string;
+};
+
+export function loadConfig(): Config {
+  const databaseUrl = env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const jwtSecretKey = env.JWT_SECRET_KEY;
+  if (!jwtSecretKey) {
+    throw new Error("JWT_SECRET_KEY is required");
+  }
+
+  return {
+    databaseUrl,
+    serverHost: env.SERVER_HOST ?? "0.0.0.0",
+    serverPort: Number(env.SERVER_PORT ?? "8000"),
+    jwtSecretKey,
+  };
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,6 +5,7 @@ export type Config = {
   serverHost: string;
   serverPort: number;
   jwtSecretKey: string;
+  logger?: boolean;
 };
 
 export function loadConfig(): Config {

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -1,0 +1,10 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema/index.js";
+
+export function connectDatabase(url: string) {
+  const client = postgres(url);
+  return drizzle(client, { schema });
+}
+
+export type Database = ReturnType<typeof connectDatabase>;

--- a/packages/server/src/db/schema/admin-users.ts
+++ b/packages/server/src/db/schema/admin-users.ts
@@ -1,0 +1,10 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const adminUsers = pgTable("admin_users", {
+  id: text("id").primaryKey(),
+  username: text("username").unique().notNull(),
+  passwordHash: text("password_hash").notNull(),
+  role: text("role").notNull().default("admin"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  lastLoginAt: timestamp("last_login_at", { withTimezone: true }),
+});

--- a/packages/server/src/db/schema/agent-tokens.ts
+++ b/packages/server/src/db/schema/agent-tokens.ts
@@ -1,0 +1,19 @@
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+
+export const agentTokens = pgTable(
+  "agent_tokens",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    name: text("name"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  },
+  (table) => [index("idx_agent_tokens_agent").on(table.agentId), index("idx_agent_tokens_hash").on(table.tokenHash)],
+);

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -1,0 +1,17 @@
+import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const agents = pgTable(
+  "agents",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id").notNull().default("default"),
+    type: text("type").notNull(),
+    displayName: text("display_name"),
+    inboxId: text("inbox_id").unique().notNull(),
+    status: text("status").notNull().default("active"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("idx_agents_org").on(table.organizationId)],
+);

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -1,0 +1,31 @@
+import { index, jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+
+export const chats = pgTable("chats", {
+  id: text("id").primaryKey(),
+  organizationId: text("organization_id").notNull().default("default"),
+  type: text("type").notNull().default("direct"),
+  topic: text("topic"),
+  metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const chatParticipants = pgTable(
+  "chat_participants",
+  {
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id),
+    role: text("role").notNull().default("member"),
+    mode: text("mode").notNull().default("full"),
+    joinedAt: timestamp("joined_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.chatId, table.agentId] }),
+    index("idx_participants_agent").on(table.agentId),
+  ],
+);

--- a/packages/server/src/db/schema/inbox-entries.ts
+++ b/packages/server/src/db/schema/inbox-entries.ts
@@ -1,0 +1,23 @@
+import { bigserial, index, integer, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { messages } from "./messages.js";
+
+export const inboxEntries = pgTable(
+  "inbox_entries",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    inboxId: text("inbox_id").notNull(),
+    messageId: text("message_id")
+      .notNull()
+      .references(() => messages.id),
+    chatId: text("chat_id"),
+    status: text("status").notNull().default("pending"),
+    retryCount: integer("retry_count").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    deliveredAt: timestamp("delivered_at", { withTimezone: true }),
+    ackedAt: timestamp("acked_at", { withTimezone: true }),
+  },
+  (table) => [
+    unique("uq_inbox_delivery").on(table.inboxId, table.messageId, table.chatId),
+    index("idx_inbox_pending").on(table.inboxId, table.createdAt),
+  ],
+);

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -1,0 +1,6 @@
+export { adminUsers } from "./admin-users.js";
+export { agentTokens } from "./agent-tokens.js";
+export { agents } from "./agents.js";
+export { chatParticipants, chats } from "./chats.js";
+export { inboxEntries } from "./inbox-entries.js";
+export { messages } from "./messages.js";

--- a/packages/server/src/db/schema/messages.ts
+++ b/packages/server/src/db/schema/messages.ts
@@ -1,0 +1,27 @@
+import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+import { chats } from "./chats.js";
+
+export const messages = pgTable(
+  "messages",
+  {
+    id: text("id").primaryKey(),
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id),
+    senderId: text("sender_id")
+      .notNull()
+      .references(() => agents.id),
+    format: text("format").notNull(),
+    content: jsonb("content").$type<unknown>().notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    replyToInbox: text("reply_to_inbox"),
+    replyToChat: text("reply_to_chat"),
+    inReplyTo: text("in_reply_to"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_messages_chat_time").on(table.chatId, table.createdAt),
+    index("idx_messages_in_reply_to").on(table.inReplyTo),
+  ],
+);

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,0 +1,44 @@
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Not found") {
+    super(404, message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Unauthorized") {
+    super(401, message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Forbidden") {
+    super(403, message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = "Conflict") {
+    super(409, message);
+    this.name = "ConflictError";
+  }
+}
+
+export class BadRequestError extends AppError {
+  constructor(message = "Bad request") {
+    super(400, message);
+    this.name = "BadRequestError";
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,14 @@
-// @agent-hub/server
+import { buildApp } from "./app.js";
+import { loadConfig } from "./config.js";
+
+async function main() {
+  const config = loadConfig();
+  const app = await buildApp(config);
+
+  await app.listen({ host: config.serverHost, port: config.serverPort });
+}
+
+main().catch((err) => {
+  console.error("Failed to start server:", err);
+  process.exit(1);
+});

--- a/packages/server/src/middleware/admin-auth.ts
+++ b/packages/server/src/middleware/admin-auth.ts
@@ -1,0 +1,47 @@
+import { eq } from "drizzle-orm";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { jwtVerify } from "jose";
+import type { Database } from "../db/connection.js";
+import { adminUsers } from "../db/schema/admin-users.js";
+import { UnauthorizedError } from "../errors.js";
+
+export function adminAuthHook(db: Database, jwtSecret: string) {
+  const secret = new TextEncoder().encode(jwtSecret);
+
+  return async (request: FastifyRequest, _reply: FastifyReply): Promise<void> => {
+    const header = request.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      throw new UnauthorizedError("Missing or invalid Authorization header");
+    }
+
+    const token = header.slice(7);
+
+    let payload: { sub?: string; type?: string };
+    try {
+      const { payload: p } = await jwtVerify(token, secret);
+      payload = p as { sub?: string; type?: string };
+    } catch {
+      throw new UnauthorizedError("Invalid or expired token");
+    }
+
+    if (payload.type !== "access" || !payload.sub) {
+      throw new UnauthorizedError("Invalid token type");
+    }
+
+    const [admin] = await db
+      .select({
+        id: adminUsers.id,
+        username: adminUsers.username,
+        role: adminUsers.role,
+      })
+      .from(adminUsers)
+      .where(eq(adminUsers.id, payload.sub))
+      .limit(1);
+
+    if (!admin) {
+      throw new UnauthorizedError("Admin user not found");
+    }
+
+    request.admin = admin;
+  };
+}

--- a/packages/server/src/middleware/agent-auth.ts
+++ b/packages/server/src/middleware/agent-auth.ts
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { Database } from "../db/connection.js";
+import { agentTokens } from "../db/schema/agent-tokens.js";
+import { agents } from "../db/schema/agents.js";
+import { UnauthorizedError } from "../errors.js";
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export function agentAuthHook(db: Database) {
+  return async (request: FastifyRequest, _reply: FastifyReply): Promise<void> => {
+    const header = request.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      throw new UnauthorizedError("Missing or invalid Authorization header");
+    }
+
+    const raw = header.slice(7);
+    if (!raw.startsWith("aghub_")) {
+      throw new UnauthorizedError("Invalid token format");
+    }
+
+    const hash = hashToken(raw);
+    const now = new Date();
+
+    const [tokenRow] = await db
+      .select({ agentId: agentTokens.agentId, tokenId: agentTokens.id })
+      .from(agentTokens)
+      .where(and(eq(agentTokens.tokenHash, hash), isNull(agentTokens.revokedAt)))
+      .limit(1);
+
+    if (!tokenRow) {
+      throw new UnauthorizedError("Invalid or revoked token");
+    }
+
+    // Check expiration in application layer (nullable expiresAt = no expiration)
+    const [tokenDetail] = await db
+      .select({ expiresAt: agentTokens.expiresAt })
+      .from(agentTokens)
+      .where(eq(agentTokens.id, tokenRow.tokenId))
+      .limit(1);
+
+    if (tokenDetail?.expiresAt && tokenDetail.expiresAt < now) {
+      throw new UnauthorizedError("Token has expired");
+    }
+
+    const [agent] = await db
+      .select({
+        id: agents.id,
+        organizationId: agents.organizationId,
+        inboxId: agents.inboxId,
+      })
+      .from(agents)
+      .where(and(eq(agents.id, tokenRow.agentId), eq(agents.status, "active")))
+      .limit(1);
+
+    if (!agent) {
+      throw new UnauthorizedError("Agent is suspended or not found");
+    }
+
+    // Update last_used_at (fire-and-forget)
+    db.update(agentTokens)
+      .set({ lastUsedAt: now })
+      .where(eq(agentTokens.id, tokenRow.tokenId))
+      .then(
+        () => {},
+        () => {},
+      );
+
+    request.agent = agent;
+  };
+}

--- a/packages/server/src/middleware/require-identity.ts
+++ b/packages/server/src/middleware/require-identity.ts
@@ -1,0 +1,19 @@
+import type { FastifyRequest } from "fastify";
+import { UnauthorizedError } from "../errors.js";
+import type { AdminIdentity, AgentIdentity } from "../types.js";
+
+export function requireAgent(request: FastifyRequest): AgentIdentity {
+  const agent = request.agent;
+  if (!agent) {
+    throw new UnauthorizedError("Agent authentication required");
+  }
+  return agent;
+}
+
+export function requireAdmin(request: FastifyRequest): AdminIdentity {
+  const admin = request.admin;
+  if (!admin) {
+    throw new UnauthorizedError("Admin authentication required");
+  }
+  return admin;
+}

--- a/packages/server/src/scripts/create-admin.ts
+++ b/packages/server/src/scripts/create-admin.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+import bcrypt from "bcrypt";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { adminUsers } from "../db/schema/admin-users.js";
+
+async function main() {
+  const [username, password] = process.argv.slice(2);
+
+  if (!username || !password) {
+    console.error("Usage: tsx src/scripts/create-admin.ts <username> <password>");
+    process.exit(1);
+  }
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL environment variable is required");
+    process.exit(1);
+  }
+
+  const client = postgres(url);
+  const db = drizzle(client);
+
+  const hash = await bcrypt.hash(password, 12);
+
+  await db.insert(adminUsers).values({
+    id: randomUUID(),
+    username,
+    passwordHash: hash,
+    role: "super_admin",
+  });
+
+  console.log(`Admin user "${username}" created successfully.`);
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error("Failed to create admin:", err);
+  process.exit(1);
+});

--- a/packages/server/src/services/admin-auth.ts
+++ b/packages/server/src/services/admin-auth.ts
@@ -1,0 +1,69 @@
+import bcrypt from "bcrypt";
+import { eq } from "drizzle-orm";
+import { jwtVerify, SignJWT } from "jose";
+import type { Database } from "../db/connection.js";
+import { adminUsers } from "../db/schema/admin-users.js";
+import { UnauthorizedError } from "../errors.js";
+
+const ACCESS_TOKEN_EXPIRY = "30m";
+const REFRESH_TOKEN_EXPIRY = "7d";
+
+async function signToken(secret: Uint8Array, sub: string, type: "access" | "refresh", expiry: string): Promise<string> {
+  return new SignJWT({ sub, type })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(expiry)
+    .sign(secret);
+}
+
+export async function login(db: Database, username: string, password: string, jwtSecretKey: string) {
+  const [user] = await db.select().from(adminUsers).where(eq(adminUsers.username, username)).limit(1);
+
+  if (!user) {
+    throw new UnauthorizedError("Invalid username or password");
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    throw new UnauthorizedError("Invalid username or password");
+  }
+
+  const secret = new TextEncoder().encode(jwtSecretKey);
+  const accessToken = await signToken(secret, user.id, "access", ACCESS_TOKEN_EXPIRY);
+  const refreshToken = await signToken(secret, user.id, "refresh", REFRESH_TOKEN_EXPIRY);
+
+  // Update last_login_at
+  await db.update(adminUsers).set({ lastLoginAt: new Date() }).where(eq(adminUsers.id, user.id));
+
+  return { accessToken, refreshToken };
+}
+
+export async function refreshAccessToken(db: Database, refreshToken: string, jwtSecretKey: string) {
+  const secret = new TextEncoder().encode(jwtSecretKey);
+
+  let payload: { sub?: string; type?: string };
+  try {
+    const { payload: p } = await jwtVerify(refreshToken, secret);
+    payload = p as { sub?: string; type?: string };
+  } catch {
+    throw new UnauthorizedError("Invalid or expired refresh token");
+  }
+
+  if (payload.type !== "refresh" || !payload.sub) {
+    throw new UnauthorizedError("Invalid token type");
+  }
+
+  // Verify admin still exists
+  const [admin] = await db
+    .select({ id: adminUsers.id })
+    .from(adminUsers)
+    .where(eq(adminUsers.id, payload.sub))
+    .limit(1);
+
+  if (!admin) {
+    throw new UnauthorizedError("Admin user not found");
+  }
+
+  const accessToken = await signToken(secret, admin.id, "access", ACCESS_TOKEN_EXPIRY);
+  return { accessToken };
+}

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,0 +1,152 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@agent-hub/shared";
+import { and, desc, eq, isNull, lt } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentTokens } from "../db/schema/agent-tokens.js";
+import { agents } from "../db/schema/agents.js";
+import { ConflictError, NotFoundError } from "../errors.js";
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export async function createAgent(db: Database, data: CreateAgent) {
+  const id = data.id ?? randomUUID();
+  const inboxId = `inbox_${id}`;
+
+  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, id)).limit(1);
+  if (existing) {
+    throw new ConflictError(`Agent "${id}" already exists`);
+  }
+
+  const [agent] = await db
+    .insert(agents)
+    .values({
+      id,
+      organizationId: data.organizationId ?? "default",
+      type: data.type,
+      displayName: data.displayName ?? null,
+      inboxId,
+      metadata: data.metadata ?? {},
+    })
+    .returning();
+
+  // INSERT ... RETURNING always returns a row
+  if (!agent) throw new Error("Unexpected: INSERT RETURNING produced no row");
+  return agent;
+}
+
+export async function getAgent(db: Database, id: string) {
+  const [agent] = await db.select().from(agents).where(eq(agents.id, id)).limit(1);
+  if (!agent) {
+    throw new NotFoundError(`Agent "${id}" not found`);
+  }
+  return agent;
+}
+
+export async function listAgents(db: Database, limit: number, cursor?: string) {
+  const where = cursor ? lt(agents.createdAt, new Date(cursor)) : undefined;
+
+  const query = db
+    .select()
+    .from(agents)
+    .where(where)
+    .orderBy(desc(agents.createdAt))
+    .limit(limit + 1);
+
+  const rows = await query;
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items[items.length - 1];
+  const nextCursor = hasMore && last ? last.createdAt.toISOString() : null;
+
+  return { items, nextCursor };
+}
+
+export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
+  const [agent] = await db
+    .update(agents)
+    .set({
+      ...(data.displayName !== undefined ? { displayName: data.displayName ?? null } : {}),
+      ...(data.status !== undefined ? { status: data.status } : {}),
+      ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(agents.id, id))
+    .returning();
+
+  if (!agent) {
+    throw new NotFoundError(`Agent "${id}" not found`);
+  }
+
+  // Suspend = revoke all active tokens (design: "停用 = suspended + 吊销所有 Token")
+  if (data.status === "suspended") {
+    await db
+      .update(agentTokens)
+      .set({ revokedAt: new Date() })
+      .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
+  }
+
+  return agent;
+}
+
+export async function createToken(db: Database, agentId: string, data: CreateAgentToken) {
+  // Verify agent exists
+  await getAgent(db, agentId);
+
+  const raw = `aghub_${randomBytes(32).toString("hex")}`;
+  const tokenHash = hashToken(raw);
+  const tokenId = randomUUID();
+
+  const [token] = await db
+    .insert(agentTokens)
+    .values({
+      id: tokenId,
+      agentId,
+      tokenHash,
+      name: data.name ?? null,
+      expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
+    })
+    .returning();
+
+  if (!token) throw new Error("Unexpected: INSERT RETURNING produced no row");
+  return {
+    id: token.id,
+    agentId: token.agentId,
+    name: token.name,
+    expiresAt: token.expiresAt,
+    revokedAt: token.revokedAt,
+    createdAt: token.createdAt,
+    lastUsedAt: token.lastUsedAt,
+    token: raw,
+  };
+}
+
+export async function listTokens(db: Database, agentId: string) {
+  return db
+    .select({
+      id: agentTokens.id,
+      agentId: agentTokens.agentId,
+      name: agentTokens.name,
+      expiresAt: agentTokens.expiresAt,
+      revokedAt: agentTokens.revokedAt,
+      createdAt: agentTokens.createdAt,
+      lastUsedAt: agentTokens.lastUsedAt,
+    })
+    .from(agentTokens)
+    .where(eq(agentTokens.agentId, agentId))
+    .orderBy(desc(agentTokens.createdAt));
+}
+
+export async function revokeToken(db: Database, agentId: string, tokenId: string) {
+  const [token] = await db
+    .update(agentTokens)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(agentTokens.id, tokenId), eq(agentTokens.agentId, agentId), isNull(agentTokens.revokedAt)))
+    .returning();
+
+  if (!token) {
+    throw new NotFoundError("Token not found or already revoked");
+  }
+  return token;
+}

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+import type { CreateChat } from "@agent-hub/shared";
+import { and, desc, eq, inArray, lt } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants, chats } from "../db/schema/chats.js";
+import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
+
+export async function createChat(db: Database, creatorId: string, data: CreateChat) {
+  const chatId = randomUUID();
+
+  // Ensure creator is included in participants
+  const allParticipantIds = new Set([creatorId, ...data.participantIds]);
+
+  // Verify all participants exist and belong to the same organization
+  const existingAgents = await db
+    .select({ id: agents.id, organizationId: agents.organizationId })
+    .from(agents)
+    .where(inArray(agents.id, [...allParticipantIds]));
+
+  if (existingAgents.length !== allParticipantIds.size) {
+    const found = new Set(existingAgents.map((a) => a.id));
+    const missing = [...allParticipantIds].filter((id) => !found.has(id));
+    throw new BadRequestError(`Agents not found: ${missing.join(", ")}`);
+  }
+
+  const creator = existingAgents.find((a) => a.id === creatorId);
+  if (!creator) throw new Error("Unexpected: creator not in existingAgents");
+  const orgId = creator.organizationId;
+
+  const crossOrg = existingAgents.filter((a) => a.organizationId !== orgId);
+  if (crossOrg.length > 0) {
+    throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
+  }
+
+  return db.transaction(async (tx) => {
+    const [chat] = await tx
+      .insert(chats)
+      .values({
+        id: chatId,
+        organizationId: orgId,
+        type: data.type,
+        topic: data.topic ?? null,
+        metadata: data.metadata ?? {},
+      })
+      .returning();
+
+    const participantRows = [...allParticipantIds].map((agentId) => ({
+      chatId,
+      agentId,
+      role: agentId === creatorId ? "owner" : "member",
+    }));
+
+    await tx.insert(chatParticipants).values(participantRows);
+
+    const participants = await tx.select().from(chatParticipants).where(eq(chatParticipants.chatId, chatId));
+
+    if (!chat) throw new Error("Unexpected: INSERT RETURNING produced no row");
+    return { ...chat, participants };
+  });
+}
+
+export async function getChat(db: Database, chatId: string) {
+  const [chat] = await db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
+  if (!chat) {
+    throw new NotFoundError(`Chat "${chatId}" not found`);
+  }
+  return chat;
+}
+
+export async function getChatDetail(db: Database, chatId: string) {
+  const chat = await getChat(db, chatId);
+  const participants = await db.select().from(chatParticipants).where(eq(chatParticipants.chatId, chatId));
+
+  return { ...chat, participants };
+}
+
+export async function listChats(db: Database, agentId: string, limit: number, cursor?: string) {
+  // Find all chat IDs where agent is a participant
+  const participantRows = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(eq(chatParticipants.agentId, agentId));
+
+  const chatIds = participantRows.map((r) => r.chatId);
+  if (chatIds.length === 0) {
+    return { items: [], nextCursor: null };
+  }
+
+  const where = cursor
+    ? and(inArray(chats.id, chatIds), lt(chats.updatedAt, new Date(cursor)))
+    : inArray(chats.id, chatIds);
+
+  const query = db
+    .select()
+    .from(chats)
+    .where(where)
+    .orderBy(desc(chats.updatedAt))
+    .limit(limit + 1);
+
+  const rows = await query;
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items[items.length - 1];
+  const nextCursor = hasMore && last ? last.updatedAt.toISOString() : null;
+
+  return { items, nextCursor };
+}
+
+export async function assertParticipant(db: Database, chatId: string, agentId: string): Promise<void> {
+  const [row] = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.agentId, agentId)))
+    .limit(1);
+
+  if (!row) {
+    throw new ForbiddenError("Not a participant of this chat");
+  }
+}

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,0 +1,105 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { ForbiddenError, NotFoundError } from "../errors.js";
+
+export async function pollInbox(db: Database, inboxId: string, limit: number) {
+  // Use raw SQL for SELECT ... FOR UPDATE SKIP LOCKED (not supported by Drizzle query builder)
+  const result = await db.transaction(async (tx) => {
+    // 1. Claim pending entries with SKIP LOCKED
+    const claimed = await tx.execute<{
+      id: number;
+      inbox_id: string;
+      message_id: string;
+      chat_id: string | null;
+      status: string;
+      retry_count: number;
+      created_at: Date;
+      delivered_at: Date | null;
+      acked_at: Date | null;
+    }>(sql`
+      UPDATE inbox_entries
+      SET status = 'delivered', delivered_at = NOW()
+      WHERE id IN (
+        SELECT id FROM inbox_entries
+        WHERE inbox_id = ${inboxId} AND status = 'pending'
+        ORDER BY created_at
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *
+    `);
+
+    if (claimed.length === 0) {
+      return [];
+    }
+
+    // 2. Fetch associated messages
+    const messageIds = claimed.map((e) => e.message_id);
+    const msgs = await tx.execute<{
+      id: string;
+      chat_id: string;
+      sender_id: string;
+      format: string;
+      content: unknown;
+      metadata: Record<string, unknown>;
+      reply_to: { inbox: string; chat: string } | null;
+      in_reply_to: string | null;
+      created_at: Date;
+    }>(sql`
+      SELECT * FROM messages WHERE id = ANY(${messageIds})
+    `);
+
+    const msgMap = new Map(msgs.map((m) => [m.id, m]));
+
+    // 3. Compose response
+    return claimed.map((entry) => {
+      const msg = msgMap.get(entry.message_id);
+      if (!msg) throw new Error(`Unexpected: message ${entry.message_id} not found`);
+      return {
+        id: entry.id,
+        inboxId: entry.inbox_id,
+        messageId: entry.message_id,
+        chatId: entry.chat_id,
+        status: entry.status,
+        retryCount: entry.retry_count,
+        createdAt: entry.created_at.toISOString(),
+        deliveredAt: entry.delivered_at?.toISOString() ?? null,
+        ackedAt: entry.acked_at?.toISOString() ?? null,
+        message: {
+          id: msg.id,
+          chatId: msg.chat_id,
+          senderId: msg.sender_id,
+          format: msg.format,
+          content: msg.content,
+          metadata: msg.metadata,
+          replyTo: msg.reply_to,
+          inReplyTo: msg.in_reply_to,
+          createdAt: msg.created_at.toISOString(),
+        },
+      };
+    });
+  });
+
+  return result;
+}
+
+export async function ackEntry(db: Database, entryId: number, inboxId: string) {
+  const [entry] = await db
+    .update(inboxEntries)
+    .set({ status: "acked", ackedAt: new Date() })
+    .where(and(eq(inboxEntries.id, entryId), eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "delivered")))
+    .returning();
+
+  if (!entry) {
+    throw new NotFoundError("Inbox entry not found or not in delivered status");
+  }
+
+  return entry;
+}
+
+export async function assertInboxOwner(inboxId: string, agentInboxId: string): Promise<void> {
+  if (inboxId !== agentInboxId) {
+    throw new ForbiddenError("Cannot access another agent's inbox");
+  }
+}

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,6 +1,7 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
 import { ForbiddenError, NotFoundError } from "../errors.js";
 
 export async function pollInbox(db: Database, inboxId: string, limit: number) {
@@ -14,9 +15,9 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
       chat_id: string | null;
       status: string;
       retry_count: number;
-      created_at: Date;
-      delivered_at: Date | null;
-      acked_at: Date | null;
+      created_at: string;
+      delivered_at: string | null;
+      acked_at: string | null;
     }>(sql`
       UPDATE inbox_entries
       SET status = 'delivered', delivered_at = NOW()
@@ -34,21 +35,9 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
       return [];
     }
 
-    // 2. Fetch associated messages
+    // 2. Fetch associated messages via Drizzle query builder
     const messageIds = claimed.map((e) => e.message_id);
-    const msgs = await tx.execute<{
-      id: string;
-      chat_id: string;
-      sender_id: string;
-      format: string;
-      content: unknown;
-      metadata: Record<string, unknown>;
-      reply_to: { inbox: string; chat: string } | null;
-      in_reply_to: string | null;
-      created_at: Date;
-    }>(sql`
-      SELECT * FROM messages WHERE id = ANY(${messageIds})
-    `);
+    const msgs = await tx.select().from(messages).where(inArray(messages.id, messageIds));
 
     const msgMap = new Map(msgs.map((m) => [m.id, m]));
 
@@ -63,19 +52,20 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
         chatId: entry.chat_id,
         status: entry.status,
         retryCount: entry.retry_count,
-        createdAt: entry.created_at.toISOString(),
-        deliveredAt: entry.delivered_at?.toISOString() ?? null,
-        ackedAt: entry.acked_at?.toISOString() ?? null,
+        createdAt: entry.created_at,
+        deliveredAt: entry.delivered_at ?? null,
+        ackedAt: entry.acked_at ?? null,
         message: {
           id: msg.id,
-          chatId: msg.chat_id,
-          senderId: msg.sender_id,
+          chatId: msg.chatId,
+          senderId: msg.senderId,
           format: msg.format,
           content: msg.content,
           metadata: msg.metadata,
-          replyTo: msg.reply_to,
-          inReplyTo: msg.in_reply_to,
-          createdAt: msg.created_at.toISOString(),
+          replyToInbox: msg.replyToInbox,
+          replyToChat: msg.replyToChat,
+          inReplyTo: msg.inReplyTo,
+          createdAt: msg.createdAt.toISOString(),
         },
       };
     });

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from "node:crypto";
+import type { SendMessage } from "@agent-hub/shared";
+import { and, desc, eq, lt } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants, chats } from "../db/schema/chats.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
+
+export async function sendMessage(db: Database, chatId: string, senderId: string, data: SendMessage) {
+  return db.transaction(async (tx) => {
+    // 1. Store message
+    const messageId = randomUUID();
+    const [msg] = await tx
+      .insert(messages)
+      .values({
+        id: messageId,
+        chatId,
+        senderId,
+        format: data.format,
+        content: data.content,
+        metadata: data.metadata ?? {},
+        replyToInbox: data.replyToInbox ?? null,
+        replyToChat: data.replyToChat ?? null,
+        inReplyTo: data.inReplyTo ?? null,
+      })
+      .returning();
+
+    // 2. Get all participants' inbox IDs
+    const participants = await tx
+      .select({
+        agentId: chatParticipants.agentId,
+        inboxId: agents.inboxId,
+      })
+      .from(chatParticipants)
+      .innerJoin(agents, eq(chatParticipants.agentId, agents.id))
+      .where(eq(chatParticipants.chatId, chatId));
+
+    // 3. Fan-out: create inbox entries for all participants (except sender)
+    const entries = participants
+      .filter((p) => p.agentId !== senderId)
+      .map((p) => ({
+        inboxId: p.inboxId,
+        messageId,
+        chatId,
+      }));
+
+    if (entries.length > 0) {
+      await tx.insert(inboxEntries).values(entries);
+    }
+
+    // 4. replyTo routing: if this message replies to another message that has a replyTo,
+    //    create an additional inbox entry for the original requester
+    if (data.inReplyTo) {
+      const [original] = await tx
+        .select({
+          replyToInbox: messages.replyToInbox,
+          replyToChat: messages.replyToChat,
+        })
+        .from(messages)
+        .where(eq(messages.id, data.inReplyTo))
+        .limit(1);
+
+      if (original?.replyToInbox && original?.replyToChat) {
+        await tx
+          .insert(inboxEntries)
+          .values({
+            inboxId: original.replyToInbox,
+            messageId,
+            chatId: original.replyToChat,
+          })
+          .onConflictDoNothing();
+      }
+    }
+
+    // 5. Update chat.updatedAt so chat list sorting reflects latest activity
+    await tx.update(chats).set({ updatedAt: new Date() }).where(eq(chats.id, chatId));
+
+    if (!msg) throw new Error("Unexpected: INSERT RETURNING produced no row");
+    return msg;
+  });
+}
+
+export async function listMessages(db: Database, chatId: string, limit: number, cursor?: string) {
+  const where = cursor
+    ? and(eq(messages.chatId, chatId), lt(messages.createdAt, new Date(cursor)))
+    : eq(messages.chatId, chatId);
+
+  const query = db
+    .select()
+    .from(messages)
+    .where(where)
+    .orderBy(desc(messages.createdAt))
+    .limit(limit + 1);
+
+  const rows = await query;
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items[items.length - 1];
+  const nextCursor = hasMore && last ? last.createdAt.toISOString() : null;
+
+  return { items, nextCursor };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,0 +1,24 @@
+import type { Database } from "./db/connection.js";
+
+export type AgentIdentity = {
+  id: string;
+  organizationId: string;
+  inboxId: string;
+};
+
+export type AdminIdentity = {
+  id: string;
+  username: string;
+  role: string;
+};
+
+declare module "fastify" {
+  interface FastifyInstance {
+    db: Database;
+    config: import("./config.js").Config;
+  }
+  interface FastifyRequest {
+    agent?: AgentIdentity;
+    admin?: AdminIdentity;
+  }
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "references": [{ "path": "../shared" }]
+  "include": ["src"]
 }

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globalSetup: "./src/__tests__/global-setup.ts",
+    setupFiles: ["./src/__tests__/setup.ts"],
+    fileParallelism: false,
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsdown src/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "devDependencies": {
     "tsdown": "^0.12.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts",
+      "import": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,77 @@
-// @agent-hub/shared
+// Schemas
+
+export {
+  ADMIN_ROLES,
+  type AdminRole,
+  type AdminUser,
+  adminRoleSchema,
+  adminUserSchema,
+  type Login,
+  type LoginResponse,
+  loginResponseSchema,
+  loginSchema,
+  type RefreshToken,
+  refreshTokenSchema,
+} from "./schemas/admin-auth.js";
+
+export {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  type Agent,
+  type AgentStatus,
+  type AgentType,
+  agentSchema,
+  agentStatusSchema,
+  agentTypeSchema,
+  type CreateAgent,
+  createAgentSchema,
+  type UpdateAgent,
+  updateAgentSchema,
+} from "./schemas/agent.js";
+
+export {
+  type AgentToken,
+  type AgentTokenCreated,
+  agentTokenCreatedSchema,
+  agentTokenSchema,
+  type CreateAgentToken,
+  createAgentTokenSchema,
+} from "./schemas/agent-token.js";
+export {
+  CHAT_TYPES,
+  type Chat,
+  type ChatDetail,
+  type ChatParticipant,
+  type ChatType,
+  type CreateChat,
+  chatDetailSchema,
+  chatParticipantSchema,
+  chatSchema,
+  chatTypeSchema,
+  createChatSchema,
+} from "./schemas/chat.js";
+export {
+  type PaginationQuery,
+  paginatedResponse,
+  paginationQuerySchema,
+} from "./schemas/common.js";
+export {
+  INBOX_ENTRY_STATUSES,
+  type InboxEntry,
+  type InboxEntryStatus,
+  type InboxEntryWithMessage,
+  type InboxPollQuery,
+  inboxEntrySchema,
+  inboxEntryStatusSchema,
+  inboxEntryWithMessageSchema,
+  inboxPollQuerySchema,
+} from "./schemas/inbox.js";
+export {
+  MESSAGE_FORMATS,
+  type Message,
+  type MessageFormat,
+  messageFormatSchema,
+  messageSchema,
+  type SendMessage,
+  sendMessageSchema,
+} from "./schemas/message.js";

--- a/packages/shared/src/schemas/admin-auth.ts
+++ b/packages/shared/src/schemas/admin-auth.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+export type Login = z.infer<typeof loginSchema>;
+
+export const loginResponseSchema = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string(),
+});
+export type LoginResponse = z.infer<typeof loginResponseSchema>;
+
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1),
+});
+export type RefreshToken = z.infer<typeof refreshTokenSchema>;
+
+export const ADMIN_ROLES = {
+  SUPER_ADMIN: "super_admin",
+  ADMIN: "admin",
+} as const;
+
+export const adminRoleSchema = z.enum(["super_admin", "admin"]);
+export type AdminRole = z.infer<typeof adminRoleSchema>;
+
+export const adminUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  role: adminRoleSchema,
+  createdAt: z.string(),
+  lastLoginAt: z.string().nullable(),
+});
+export type AdminUser = z.infer<typeof adminUserSchema>;

--- a/packages/shared/src/schemas/agent-token.ts
+++ b/packages/shared/src/schemas/agent-token.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const createAgentTokenSchema = z.object({
+  name: z.string().max(100).optional(),
+  expiresAt: z.string().datetime().optional(),
+});
+export type CreateAgentToken = z.infer<typeof createAgentTokenSchema>;
+
+export const agentTokenSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  name: z.string().nullable(),
+  expiresAt: z.string().nullable(),
+  revokedAt: z.string().nullable(),
+  createdAt: z.string(),
+  lastUsedAt: z.string().nullable(),
+});
+export type AgentToken = z.infer<typeof agentTokenSchema>;
+
+export const agentTokenCreatedSchema = agentTokenSchema.extend({
+  token: z.string(),
+});
+export type AgentTokenCreated = z.infer<typeof agentTokenCreatedSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const AGENT_TYPES = {
+  HUMAN: "human",
+  PERSONAL_ASSISTANT: "personal_assistant",
+  AUTONOMOUS_AGENT: "autonomous_agent",
+} as const;
+
+export const agentTypeSchema = z.enum(["human", "personal_assistant", "autonomous_agent"]);
+export type AgentType = z.infer<typeof agentTypeSchema>;
+
+export const AGENT_STATUSES = {
+  ACTIVE: "active",
+  SUSPENDED: "suspended",
+} as const;
+
+export const agentStatusSchema = z.enum(["active", "suspended"]);
+export type AgentStatus = z.infer<typeof agentStatusSchema>;
+
+export const createAgentSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9_-]+$/, "Only lowercase alphanumeric, hyphens, and underscores")
+    .optional(),
+  type: agentTypeSchema,
+  displayName: z.string().max(200).optional(),
+  organizationId: z.string().max(100).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type CreateAgent = z.infer<typeof createAgentSchema>;
+
+export const updateAgentSchema = z.object({
+  displayName: z.string().max(200).nullish(),
+  status: agentStatusSchema.optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type UpdateAgent = z.infer<typeof updateAgentSchema>;
+
+export const agentSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  type: agentTypeSchema,
+  displayName: z.string().nullable(),
+  inboxId: z.string(),
+  status: z.string(),
+  metadata: z.record(z.unknown()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Agent = z.infer<typeof agentSchema>;

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const CHAT_TYPES = {
+  DIRECT: "direct",
+  GROUP: "group",
+} as const;
+
+export const chatTypeSchema = z.enum(["direct", "group"]);
+export type ChatType = z.infer<typeof chatTypeSchema>;
+
+export const createChatSchema = z.object({
+  type: chatTypeSchema,
+  topic: z.string().max(500).optional(),
+  participantIds: z.array(z.string()).min(1),
+  metadata: z.record(z.unknown()).optional(),
+});
+export type CreateChat = z.infer<typeof createChatSchema>;
+
+export const chatParticipantSchema = z.object({
+  agentId: z.string(),
+  role: z.string(),
+  mode: z.string(),
+  joinedAt: z.string(),
+});
+export type ChatParticipant = z.infer<typeof chatParticipantSchema>;
+
+export const chatSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  type: z.string(),
+  topic: z.string().nullable(),
+  metadata: z.record(z.unknown()),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Chat = z.infer<typeof chatSchema>;
+
+export const chatDetailSchema = chatSchema.extend({
+  participants: z.array(chatParticipantSchema),
+});
+export type ChatDetail = z.infer<typeof chatDetailSchema>;

--- a/packages/shared/src/schemas/common.ts
+++ b/packages/shared/src/schemas/common.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const paginationQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+});
+
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;
+
+export function paginatedResponse<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z.object({
+    items: z.array(itemSchema),
+    nextCursor: z.string().nullable(),
+  });
+}

--- a/packages/shared/src/schemas/inbox.ts
+++ b/packages/shared/src/schemas/inbox.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { messageSchema } from "./message.js";
+
+export const INBOX_ENTRY_STATUSES = {
+  PENDING: "pending",
+  DELIVERED: "delivered",
+  ACKED: "acked",
+  FAILED: "failed",
+} as const;
+
+export const inboxEntryStatusSchema = z.enum(["pending", "delivered", "acked", "failed"]);
+export type InboxEntryStatus = z.infer<typeof inboxEntryStatusSchema>;
+
+export const inboxEntrySchema = z.object({
+  id: z.number(),
+  inboxId: z.string(),
+  messageId: z.string(),
+  chatId: z.string().nullable(),
+  status: z.string(),
+  retryCount: z.number(),
+  createdAt: z.string(),
+  deliveredAt: z.string().nullable(),
+  ackedAt: z.string().nullable(),
+});
+export type InboxEntry = z.infer<typeof inboxEntrySchema>;
+
+export const inboxEntryWithMessageSchema = inboxEntrySchema.extend({
+  message: messageSchema,
+});
+export type InboxEntryWithMessage = z.infer<typeof inboxEntryWithMessageSchema>;
+
+export const inboxPollQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+export type InboxPollQuery = z.infer<typeof inboxPollQuerySchema>;

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const MESSAGE_FORMATS = {
+  TEXT: "text",
+  MARKDOWN: "markdown",
+  CARD: "card",
+  REFERENCE: "reference",
+  FILE: "file",
+} as const;
+
+export const messageFormatSchema = z.enum(["text", "markdown", "card", "reference", "file"]);
+export type MessageFormat = z.infer<typeof messageFormatSchema>;
+
+export const sendMessageSchema = z.object({
+  format: messageFormatSchema.default("text"),
+  content: z.unknown(),
+  metadata: z.record(z.unknown()).optional(),
+  inReplyTo: z.string().optional(),
+  replyToInbox: z.string().optional(),
+  replyToChat: z.string().optional(),
+});
+export type SendMessage = z.infer<typeof sendMessageSchema>;
+
+export const messageSchema = z.object({
+  id: z.string(),
+  chatId: z.string(),
+  senderId: z.string(),
+  format: z.string(),
+  content: z.unknown(),
+  metadata: z.record(z.unknown()),
+  replyToInbox: z.string().nullable(),
+  replyToChat: z.string().nullable(),
+  inReplyTo: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type Message = z.infer<typeof messageSchema>;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-createRoot(document.getElementById("root")!).render(
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+createRoot(root).render(
   <StrictMode>
     <div>Agent Hub</div>
   </StrictMode>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 0.12.9(typescript@5.9.3)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/server:
     dependencies:
@@ -70,6 +70,9 @@ importers:
         specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
+      '@testcontainers/postgresql':
+        specifier: ^11.13.0
+        version: 11.13.0
       '@types/bcrypt':
         specifier: ^5.0.0
         version: 5.0.2
@@ -79,6 +82,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10
+      testcontainers:
+        specifier: ^11.13.0
+        version: 11.13.0
       tsdown:
         specifier: ^0.12.0
         version: 0.12.9(typescript@5.9.3)
@@ -87,7 +93,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/shared:
     dependencies:
@@ -100,7 +106,7 @@ importers:
         version: 0.12.9(typescript@5.9.3)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/web:
     dependencies:
@@ -122,13 +128,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.5.0
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       vite:
         specifier: ^6.3.0
-        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -214,6 +220,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@biomejs/biome@2.4.8':
     resolution: {integrity: sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==}
@@ -753,6 +762,24 @@ packages:
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -769,6 +796,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -777,6 +810,40 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1001,6 +1068,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@testcontainers/postgresql@11.13.0':
+    resolution: {integrity: sha512-Y+HLf+IEu9+h3MgxRhnFunw9ldk3jxN2PO6zyejN5AiDd1aSeBQ7hfpc/4MlMm65St2DdLGf39oE/vdW1+hc/Q==}
+
   '@turbo/darwin-64@2.8.20':
     resolution: {integrity: sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ==}
     cpu: [x64]
@@ -1055,8 +1125,17 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -1068,6 +1147,15 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1107,6 +1195,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1121,9 +1213,36 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1133,6 +1252,12 @@ packages:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
 
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -1140,10 +1265,65 @@ packages:
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.5.6:
+    resolution: {integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.0:
+    resolution: {integrity: sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.10.0:
+    resolution: {integrity: sha512-DOPZF/DDcDruKDA43cOw6e9Quq5daua7ygcAwJE/pKJsRWhgSSemi7qVNGE5kyDIxIeN1533G/zfbvWX7Wcb9w==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.0:
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.9:
     resolution: {integrity: sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bcrypt@6.0.0:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
@@ -1152,13 +1332,37 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1179,12 +1383,50 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1212,6 +1454,18 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  docker-compose@1.3.2:
+    resolution: {integrity: sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.10:
+    resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
+    engines: {node: '>= 8.0'}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -1321,8 +1575,17 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1356,6 +1619,17 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1365,6 +1639,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stringify@6.3.0:
     resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
@@ -1397,6 +1674,13 @@ packages:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1406,11 +1690,30 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-port@7.1.0:
+    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+    engines: {node: '>=16'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1418,6 +1721,23 @@ packages:
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1448,11 +1768,27 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1460,8 +1796,31 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1479,12 +1838,27 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1518,11 +1892,32 @@ packages:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
     engines: {node: '>=12'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -1543,9 +1938,19 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1554,6 +1959,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1565,6 +1974,10 @@ packages:
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1599,6 +2012,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1609,6 +2025,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1628,8 +2047,23 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -1645,9 +2079,19 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1658,11 +2102,55 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  testcontainers@11.13.0:
+    resolution: {integrity: sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -1693,6 +2181,10 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
@@ -1732,6 +2224,9 @@ packages:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1743,8 +2238,15 @@ packages:
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1754,6 +2256,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1828,10 +2334,23 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1848,8 +2367,29 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1967,6 +2507,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@biomejs/biome@2.4.8':
     optionalDependencies:
@@ -2285,6 +2827,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2304,6 +2874,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.9.1
@@ -2314,6 +2892,32 @@ snapshots:
   '@oxc-project/types@0.120.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2445,6 +3049,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@testcontainers/postgresql@11.13.0':
+    dependencies:
+      testcontainers: 11.13.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@turbo/darwin-64@2.8.20':
     optional: true
 
@@ -2500,7 +3113,22 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 22.19.15
+      '@types/ssh2': 1.15.5
+
   '@types/estree@1.0.8': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@22.19.15':
     dependencies:
@@ -2514,11 +3142,24 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.15
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2526,7 +3167,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2538,13 +3179,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2572,6 +3213,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   abstract-logging@2.0.1: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -2585,7 +3230,45 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   ansis@4.2.0: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.23
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.8
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -2594,6 +3277,10 @@ snapshots:
       '@babel/parser': 7.29.2
       pathe: 2.0.3
 
+  async-lock@1.4.1: {}
+
+  async@3.2.6: {}
+
   atomic-sleep@1.0.0: {}
 
   avvio@9.2.0:
@@ -2601,7 +3288,50 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  b4a@1.8.0: {}
+
+  balanced-match@1.0.2: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.5.6:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.10.0(bare-events@2.8.2)
+      bare-url: 2.4.0
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.0: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.0
+
+  bare-stream@2.10.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-url@2.4.0:
+    dependencies:
+      bare-path: 3.0.0
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.9: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   bcrypt@6.0.0:
     dependencies:
@@ -2609,6 +3339,16 @@ snapshots:
       node-gyp-build: 4.8.4
 
   birpc@2.9.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   browserslist@4.28.1:
     dependencies:
@@ -2618,7 +3358,24 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-crc32@1.0.0: {}
+
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
+
+  byline@5.0.0: {}
 
   cac@6.7.14: {}
 
@@ -2638,9 +3395,52 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.3: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.26.2
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.2.3: {}
 
@@ -2655,6 +3455,31 @@ snapshots:
   dequal@2.0.3: {}
 
   diff@8.0.3: {}
+
+  docker-compose@1.3.2:
+    dependencies:
+      yaml: 2.8.2
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.10:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.5.4
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -2676,7 +3501,13 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.321: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -2775,11 +3606,23 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-json-stringify@6.3.0:
     dependencies:
@@ -2830,20 +3673,58 @@ snapshots:
       fast-querystring: 1.1.2
       safe-regex2: 5.1.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
+  get-port@7.1.0: {}
+
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  graceful-fs@4.2.11: {}
+
   hookable@5.5.3: {}
+
+  ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
 
   ipaddr.js@2.3.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-stream@2.0.1: {}
+
+  isarray@1.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
 
@@ -2863,13 +3744,25 @@ snapshots:
 
   json5@2.2.3: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   light-my-request@6.6.0:
     dependencies:
       cookie: 1.1.1
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash@4.17.23: {}
+
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -2879,7 +3772,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@3.0.1: {}
+
   ms@2.1.3: {}
+
+  nan@2.26.2:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -2889,11 +3799,22 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  normalize-path@3.0.0: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2931,9 +3852,46 @@ snapshots:
 
   postgres@3.4.8: {}
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   quansync@1.0.0: {}
 
@@ -2948,21 +3906,47 @@ snapshots:
 
   react@19.2.4: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
+
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
   ret@0.5.0: {}
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 
@@ -3037,6 +4021,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
@@ -3044,6 +4030,8 @@ snapshots:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -3055,7 +4043,17 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
 
   sonic-boom@4.2.1:
     dependencies:
@@ -3070,7 +4068,22 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.26.2
 
   stackback@0.0.2: {}
 
@@ -3078,13 +4091,120 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.5.6
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.5.6
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  testcontainers@11.13.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.3.2
+      dockerode: 4.0.10
+      get-port: 7.1.0
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.2
+      tmp: 0.2.5
+      undici: 7.24.5
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thread-stream@4.0.0:
     dependencies:
@@ -3106,6 +4226,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  tmp@0.2.5: {}
 
   toad-cache@3.7.0: {}
 
@@ -3151,6 +4273,8 @@ snapshots:
       '@turbo/windows-64': 2.8.20
       '@turbo/windows-arm64': 2.8.20
 
+  tweetnacl@0.14.5: {}
+
   typescript@5.9.3: {}
 
   unconfig-core@7.5.0:
@@ -3166,7 +4290,11 @@ snapshots:
       quansync: 1.0.0
       unconfig-core: 7.5.0
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
+
+  undici@7.24.5: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -3176,13 +4304,15 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0):
+  uuid@10.0.0: {}
+
+  vite-node@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3197,7 +4327,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0):
+  vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3210,12 +4340,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.2
 
-  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3233,8 +4364,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -3252,15 +4383,53 @@ snapshots:
       - tsx
       - yaml
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.76: {}


### PR DESCRIPTION
Server V1 delivers the core API surface for Agent Hub:
- Dual-track auth: Agent Token (SHA-256) + Admin JWT (HS256), fully isolated
- Agent CRUD, token lifecycle (create/rotate/revoke), suspend with bulk revoke
- Chat system with org boundary enforcement and participant management
- Message delivery with fan-out on write and replyTo cross-chat routing
- Inbox polling with PostgreSQL SKIP LOCKED for concurrent-safe consumption
- Shared Zod schemas for all DTOs (agent, chat, message, inbox, admin-auth)
- Drizzle ORM schema (7 tables) with migration
- Health check with DB connectivity probe