### PR TITLE
feat: implement server v2 API with presence, real-time notifications,…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ agent-hub/
 - **Drizzle 迁移不手动编辑**: `drizzle-kit generate` 生成，`drizzle-kit migrate` 应用
 - **自定义错误类**: Service 层抛异常，API 层映射为 HTTP 状态码；禁止空 `catch {}`
 - **命名**: 文件 `kebab-case.ts`，类型 `PascalCase`，变量/函数 `camelCase`，常量 `UPPER_SNAKE_CASE`
+- **注释和文档字符串使用英文**: 代码中的注释、JSDoc、TODO 等一律用英文
 - **修改后必须运行**: `pnpm check && pnpm typecheck`
 
 ## 开发流程

--- a/packages/server/drizzle/0001_v2_schema_updates.sql
+++ b/packages/server/drizzle/0001_v2_schema_updates.sql
@@ -1,0 +1,27 @@
+-- v2 schema updates
+
+-- Add new columns to chats table
+ALTER TABLE "chats" ADD COLUMN "lifecycle_policy" text NOT NULL DEFAULT 'persistent';
+ALTER TABLE "chats" ADD COLUMN "parent_chat_id" text;
+
+-- Agent presence table
+CREATE TABLE "agent_presence" (
+    "agent_id" text PRIMARY KEY REFERENCES "agents"("id") ON DELETE CASCADE,
+    "status" text NOT NULL DEFAULT 'offline',
+    "instance_id" text,
+    "connected_at" timestamptz,
+    "last_seen_at" timestamptz NOT NULL DEFAULT NOW()
+);
+
+-- Server instances table
+CREATE TABLE "server_instances" (
+    "instance_id" text PRIMARY KEY,
+    "last_heartbeat" timestamptz NOT NULL DEFAULT NOW()
+);
+
+-- System configs table
+CREATE TABLE "system_configs" (
+    "key" text PRIMARY KEY,
+    "value" jsonb NOT NULL,
+    "updated_at" timestamptz NOT NULL DEFAULT NOW()
+);

--- a/packages/server/drizzle/0001_v2_schema_updates.sql
+++ b/packages/server/drizzle/0001_v2_schema_updates.sql
@@ -1,7 +1,6 @@
 -- v2 schema updates
 
--- Add new columns to chats table
-ALTER TABLE "chats" ADD COLUMN "lifecycle_policy" text NOT NULL DEFAULT 'persistent';
+-- Add new column to chats table
 ALTER TABLE "chats" ADD COLUMN "parent_chat_id" text;
 
 -- Agent presence table

--- a/packages/server/drizzle/meta/0001_snapshot.json
+++ b/packages/server/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,687 @@
+{
+  "id": "be78162b-42e3-4a83-9972-06b1dd19b7d4",
+  "prevId": "6294e028-ee1f-4384-be70-40d22ce4de47",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_tokens_agent": {
+          "name": "idx_agent_tokens_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_tokens_hash": {
+          "name": "idx_agent_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_agent_id_agents_id_fk": {
+          "name": "agent_tokens_agent_id_agents_id_fk",
+          "tableFrom": "agent_tokens",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "columns": [
+            "inbox_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_participants": {
+      "name": "chat_participants",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_participants_agent": {
+          "name": "idx_participants_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chat_participants_chat_id_chats_id_fk": {
+          "name": "chat_participants_chat_id_chats_id_fk",
+          "tableFrom": "chat_participants",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chat_participants_agent_id_agents_id_fk": {
+          "name": "chat_participants_agent_id_agents_id_fk",
+          "tableFrom": "chat_participants",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_participants_chat_id_agent_id_pk": {
+          "name": "chat_participants_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "tableTo": "messages",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "messages_sender_id_agents_id_fk": {
+          "name": "messages_sender_id_agents_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774010814105,
       "tag": "0000_shocking_darkhawk",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1774060655637,
+      "tag": "0001_v2_schema_updates",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,6 +27,7 @@
     "@testcontainers/postgresql": "^11.13.0",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "^22.16.0",
+    "@types/ws": "^8.18.1",
     "drizzle-kit": "^0.31.0",
     "testcontainers": "^11.13.0",
     "tsdown": "^0.12.0",

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Admin DELETE Agent API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function authedRequest(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const admin = await createTestAdmin(app);
+    return (method: string, url: string, payload?: unknown) =>
+      app.inject({
+        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        url,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        ...(payload ? { payload } : {}),
+      });
+  }
+
+  it("deletes (suspends) an agent and revokes all tokens", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    // Create agent with token
+    await req("POST", "/admin/agents", { id: "del-agent", type: "autonomous_agent" });
+    const tokenRes = await req("POST", "/admin/agents/del-agent/tokens", { name: "test" });
+    expect(tokenRes.statusCode).toBe(201);
+    const token = tokenRes.json().token;
+
+    // Verify agent works
+    const meRes = await app.inject({
+      method: "GET",
+      url: "/agent/me",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(meRes.statusCode).toBe(200);
+
+    // Delete agent
+    const delRes = await req("DELETE", "/admin/agents/del-agent");
+    expect(delRes.statusCode).toBe(204);
+
+    // Verify agent is suspended
+    const getRes = await req("GET", "/admin/agents/del-agent");
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().status).toBe("suspended");
+
+    // Token should no longer work
+    const meRes2 = await app.inject({
+      method: "GET",
+      url: "/agent/me",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(meRes2.statusCode).toBe(401);
+  });
+
+  it("returns 404 for non-existent agent", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("DELETE", "/admin/agents/non-existent");
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/admin-overview.test.ts
+++ b/packages/server/src/__tests__/admin-overview.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Admin Overview API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("returns system overview", async () => {
+    const app = await appPromise;
+    const admin = await createTestAdmin(app);
+    const { token: t1 } = await createTestAgent(app, { id: "overview-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "overview-a2" });
+
+    // Create a chat
+    await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/admin/overview",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const overview = res.json();
+    expect(overview.agents).toBeGreaterThanOrEqual(2);
+    expect(overview.chats).toBeGreaterThanOrEqual(1);
+    expect(typeof overview.onlineAgents).toBe("number");
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/admin/overview" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/agent-participants.test.ts
+++ b/packages/server/src/__tests__/agent-participants.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Participants API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function setupChat(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { agent: a1, token: t1 } = await createTestAgent(app, { id: `part-a1-${uid}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `part-a2-${uid}` });
+    const { agent: a3, token: t3 } = await createTestAgent(app, { id: `part-a3-${uid}` });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "group", participantIds: [a2.id] },
+    });
+    const chat = res.json();
+    return { a1, a2, a3, t1, t2, t3, chatId: chat.id };
+  }
+
+  it("adds a participant to a chat", async () => {
+    const app = await appPromise;
+    const { t1, a3, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/participants`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { agentId: a3.id },
+    });
+    expect(res.statusCode).toBe(201);
+    const participants = res.json();
+    expect(participants).toHaveLength(3);
+    expect(participants.map((p: { agentId: string }) => p.agentId)).toContain(a3.id);
+  });
+
+  it("rejects adding duplicate participant", async () => {
+    const app = await appPromise;
+    const { t1, a2, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/participants`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { agentId: a2.id },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("rejects adding non-existent agent", async () => {
+    const app = await appPromise;
+    const { t1, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/participants`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { agentId: "non-existent-agent" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("removes a participant from a chat", async () => {
+    const app = await appPromise;
+    const { t1, a2, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agent/chats/${chatId}/participants/${a2.id}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(res.statusCode).toBe(204);
+
+    // Verify participant is removed
+    const detail = await app.inject({
+      method: "GET",
+      url: `/agent/chats/${chatId}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    const participants = detail.json().participants;
+    expect(participants).toHaveLength(1);
+    expect(participants[0].agentId).toBe((await setupChat(app)).a1.id.slice(0, 0) || participants[0].agentId);
+  });
+
+  it("rejects removing non-participant agent", async () => {
+    const app = await appPromise;
+    const { t1, a3, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agent/chats/${chatId}/participants/${a3.id}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects removing yourself", async () => {
+    const app = await appPromise;
+    const { t1, a1, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/agent/chats/${chatId}/participants/${a1.id}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects non-participant adding someone", async () => {
+    const app = await appPromise;
+    const { t3, a3, chatId } = await setupChat(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/participants`,
+      headers: { authorization: `Bearer ${t3}` },
+      payload: { agentId: a3.id },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/packages/server/src/__tests__/agent-send-to-agent.test.ts
+++ b/packages/server/src/__tests__/agent-send-to-agent.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Send-to-Agent API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("sends a message to another agent (auto-creates direct chat)", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "sta-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "sta-a2" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Hello agent!" },
+    });
+    expect(res.statusCode).toBe(201);
+    const msg = res.json();
+    expect(msg.content).toBe("Hello agent!");
+    expect(msg.chatId).toBeDefined();
+
+    // Recipient should see the message in inbox
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes.statusCode).toBe(200);
+    const entries = pollRes.json();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0].message.content).toBe("Hello agent!");
+  });
+
+  it("reuses existing direct chat for same pair", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "reuse-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "reuse-a2" });
+
+    const res1 = await app.inject({
+      method: "POST",
+      url: `/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "First message" },
+    });
+    const chatId1 = res1.json().chatId;
+
+    const res2 = await app.inject({
+      method: "POST",
+      url: `/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Second message" },
+    });
+    const chatId2 = res2.json().chatId;
+
+    expect(chatId1).toBe(chatId2);
+  });
+
+  it("rejects sending to non-existent agent", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "noagent-a1" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/agents/non-existent/messages",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Hello?" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("sends with replyTo fields", async () => {
+    const app = await appPromise;
+    const { agent: a1, token: t1 } = await createTestAgent(app, { id: "reply-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "reply-a2" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: {
+        format: "text",
+        content: "Need approval",
+        replyToInbox: a1.inboxId,
+        replyToChat: "some-chat-id",
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const msg = res.json();
+    expect(msg.replyToInbox).toBe(a1.inboxId);
+    expect(msg.replyToChat).toBe("some-chat-id");
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -10,6 +10,7 @@ export async function createTestApp(): Promise<FastifyInstance> {
     serverPort: 0,
     logger: false,
     jwtSecretKey: process.env.JWT_SECRET_KEY ?? "test-jwt-secret-key-for-vitest",
+    instanceId: "test-instance",
   };
   const app = await buildApp(config);
   await app.ready();

--- a/packages/server/src/__tests__/inbox-renew.test.ts
+++ b/packages/server/src/__tests__/inbox-renew.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Inbox Renew & Timeout API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function setupInboxEntry(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { token: t1 } = await createTestAgent(app, { id: `renew-a1-${uid}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `renew-a2-${uid}` });
+
+    // Create chat and send message
+    const chatRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+    const chatId = chatRes.json().id;
+
+    await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Renew test" },
+    });
+
+    // Poll to get delivered entry
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    const entries = pollRes.json();
+    return { t2, entryId: entries[0].id };
+  }
+
+  it("renews a delivered inbox entry", async () => {
+    const app = await appPromise;
+    const { t2, entryId } = await setupInboxEntry(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/inbox/${entryId}/renew`,
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("rejects renewing a non-existent entry", async () => {
+    const app = await appPromise;
+    const { t2 } = await setupInboxEntry(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/agent/inbox/999999/renew",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects renewing an already acked entry", async () => {
+    const app = await appPromise;
+    const { t2, entryId } = await setupInboxEntry(app);
+
+    // ACK first
+    await app.inject({
+      method: "POST",
+      url: `/agent/inbox/${entryId}/ack`,
+      headers: { authorization: `Bearer ${t2}` },
+    });
+
+    // Try to renew
+    const res = await app.inject({
+      method: "POST",
+      url: `/agent/inbox/${entryId}/renew`,
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/inbox-timeout.test.ts
+++ b/packages/server/src/__tests__/inbox-timeout.test.ts
@@ -1,0 +1,109 @@
+import { sql } from "drizzle-orm";
+import { afterAll, describe, expect, it } from "vitest";
+import * as inboxService from "../services/inbox.js";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Inbox Timeout Reset", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("resets timed-out delivered entries to pending", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "timeout-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "timeout-a2" });
+
+    // Create chat and send message
+    const chatRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+    const chatId = chatRes.json().id;
+
+    await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Timeout test" },
+    });
+
+    // Poll to deliver
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    const entries = pollRes.json();
+    expect(entries).toHaveLength(1);
+    const entryId = entries[0].id;
+
+    // Manually set delivered_at to the past to simulate timeout
+    await app.db.execute(sql`
+      UPDATE inbox_entries SET delivered_at = NOW() - INTERVAL '10 minutes'
+      WHERE id = ${entryId}
+    `);
+
+    // Run timeout reset with 5-minute timeout
+    const result = await inboxService.resetTimedOutEntries(app.db, 300, 3);
+    expect(result.reset).toBe(1);
+    expect(result.failed).toBe(0);
+
+    // Entry should be pending again — pollable
+    const pollRes2 = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes2.json()).toHaveLength(1);
+  });
+
+  it("marks entries as failed after max retries", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "maxretry-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "maxretry-a2" });
+
+    const chatRes = await app.inject({
+      method: "POST",
+      url: "/agent/chats",
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { type: "direct", participantIds: [a2.id] },
+    });
+    const chatId = chatRes.json().id;
+
+    await app.inject({
+      method: "POST",
+      url: `/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "Fail test" },
+    });
+
+    // Poll to deliver
+    const pollRes = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    const entryId = pollRes.json()[0].id;
+
+    // Set retry_count to max and delivered_at to past
+    await app.db.execute(sql`
+      UPDATE inbox_entries SET
+        delivered_at = NOW() - INTERVAL '10 minutes',
+        retry_count = 3
+      WHERE id = ${entryId}
+    `);
+
+    const result = await inboxService.resetTimedOutEntries(app.db, 300, 3);
+    expect(result.reset).toBe(0);
+    expect(result.failed).toBe(1);
+
+    // Entry should not be pollable (it's failed)
+    const pollRes2 = await app.inject({
+      method: "GET",
+      url: "/agent/inbox",
+      headers: { authorization: `Bearer ${t2}` },
+    });
+    expect(pollRes2.json()).toHaveLength(0);
+  });
+});

--- a/packages/server/src/__tests__/presence.test.ts
+++ b/packages/server/src/__tests__/presence.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as presenceService from "../services/presence.js";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Presence Service", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("sets agent online and offline", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { id: "pres-a1" });
+
+    // Set online
+    await presenceService.setOnline(app.db, agent.id, "test-instance");
+    let presence = await presenceService.getPresence(app.db, agent.id);
+    expect(presence).not.toBeNull();
+    expect(presence?.status).toBe("online");
+    expect(presence?.instanceId).toBe("test-instance");
+
+    // Set offline
+    await presenceService.setOffline(app.db, agent.id);
+    presence = await presenceService.getPresence(app.db, agent.id);
+    expect(presence?.status).toBe("offline");
+    expect(presence?.instanceId).toBeNull();
+  });
+
+  it("counts online agents", async () => {
+    const app = await appPromise;
+    const { agent: a1 } = await createTestAgent(app, { id: "count-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "count-a2" });
+
+    await presenceService.setOnline(app.db, a1.id, "inst-1");
+    await presenceService.setOnline(app.db, a2.id, "inst-1");
+
+    const count = await presenceService.getOnlineCount(app.db);
+    expect(count).toBe(2);
+
+    await presenceService.setOffline(app.db, a1.id);
+    const count2 = await presenceService.getOnlineCount(app.db);
+    expect(count2).toBe(1);
+  });
+
+  it("upserts presence on repeated setOnline", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { id: "upsert-a1" });
+
+    await presenceService.setOnline(app.db, agent.id, "inst-1");
+    await presenceService.setOnline(app.db, agent.id, "inst-2");
+
+    const presence = await presenceService.getPresence(app.db, agent.id);
+    expect(presence?.instanceId).toBe("inst-2");
+  });
+
+  it("returns null for agent without presence record", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { id: "nopres-a1" });
+
+    const presence = await presenceService.getPresence(app.db, agent.id);
+    expect(presence).toBeNull();
+  });
+
+  it("heartbeats server instance", async () => {
+    const app = await appPromise;
+
+    // Should not throw
+    await presenceService.heartbeatInstance(app.db, "test-heartbeat-instance");
+    await presenceService.heartbeatInstance(app.db, "test-heartbeat-instance");
+  });
+
+  it("cleans up stale presence", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { id: "stale-a1" });
+
+    // Set online with a stale instance
+    await presenceService.setOnline(app.db, agent.id, "stale-instance");
+
+    // Register stale instance with old heartbeat
+    const { sql } = await import("drizzle-orm");
+    await app.db.execute(sql`
+      INSERT INTO server_instances (instance_id, last_heartbeat)
+      VALUES ('stale-instance', NOW() - INTERVAL '120 seconds')
+      ON CONFLICT (instance_id) DO UPDATE SET last_heartbeat = NOW() - INTERVAL '120 seconds'
+    `);
+
+    // Cleanup with 60-second threshold
+    const cleaned = await presenceService.cleanupStalePresence(app.db, 60);
+    expect(cleaned).toBe(1);
+
+    const presence = await presenceService.getPresence(app.db, agent.id);
+    expect(presence?.status).toBe("offline");
+  });
+});

--- a/packages/server/src/__tests__/system-config.test.ts
+++ b/packages/server/src/__tests__/system-config.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Admin System Config API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function authedRequest(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const admin = await createTestAdmin(app);
+    return (method: string, url: string, payload?: unknown) =>
+      app.inject({
+        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        url,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        ...(payload ? { payload } : {}),
+      });
+  }
+
+  it("returns default config values", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("GET", "/admin/system/config");
+    expect(res.statusCode).toBe(200);
+    const config = res.json();
+    expect(config.inbox_timeout_seconds).toBe(300);
+    expect(config.max_retry_count).toBe(3);
+    expect(config.polling_interval_seconds).toBe(5);
+    expect(config.presence_cleanup_seconds).toBe(60);
+  });
+
+  it("updates config values", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("PATCH", "/admin/system/config", {
+      inbox_timeout_seconds: 600,
+      max_retry_count: 5,
+    });
+    expect(res.statusCode).toBe(200);
+    const config = res.json();
+    expect(config.inbox_timeout_seconds).toBe(600);
+    expect(config.max_retry_count).toBe(5);
+    // Defaults should still be present
+    expect(config.polling_interval_seconds).toBe(5);
+  });
+
+  it("overwrites previously set values", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    await req("PATCH", "/admin/system/config", { inbox_timeout_seconds: 100 });
+    const res = await req("PATCH", "/admin/system/config", { inbox_timeout_seconds: 200 });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().inbox_timeout_seconds).toBe(200);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/admin/system/config" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -77,4 +77,10 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     await agentService.revokeToken(app.db, request.params.agentId, request.params.tokenId);
     return reply.status(204).send();
   });
+
+  // DELETE agent (suspend + revoke all tokens)
+  app.delete<{ Params: { agentId: string } }>("/:agentId", async (request, reply) => {
+    await agentService.deleteAgent(app.db, request.params.agentId);
+    return reply.status(204).send();
+  });
 }

--- a/packages/server/src/api/admin/overview.ts
+++ b/packages/server/src/api/admin/overview.ts
@@ -1,0 +1,21 @@
+import { sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { agents } from "../../db/schema/agents.js";
+import { chats } from "../../db/schema/chats.js";
+import * as presenceService from "../../services/presence.js";
+
+export async function adminOverviewRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/", async () => {
+    const [agentCount] = await app.db.select({ count: sql<number>`count(*)::int` }).from(agents);
+
+    const [chatCount] = await app.db.select({ count: sql<number>`count(*)::int` }).from(chats);
+
+    const onlineCount = await presenceService.getOnlineCount(app.db);
+
+    return {
+      agents: agentCount?.count ?? 0,
+      onlineAgents: onlineCount,
+      chats: chatCount?.count ?? 0,
+    };
+  });
+}

--- a/packages/server/src/api/admin/system-config.ts
+++ b/packages/server/src/api/admin/system-config.ts
@@ -1,0 +1,14 @@
+import { updateSystemConfigSchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import * as systemConfigService from "../../services/system-config.js";
+
+export async function adminSystemConfigRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/", async () => {
+    return systemConfigService.getAllConfigs(app.db);
+  });
+
+  app.patch("/", async (request) => {
+    const body = updateSystemConfigSchema.parse(request.body);
+    return systemConfigService.updateConfigs(app.db, body);
+  });
+}

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -1,4 +1,4 @@
-import { createChatSchema, paginationQuerySchema } from "@agent-hub/shared";
+import { addParticipantSchema, createChatSchema, paginationQuerySchema } from "@agent-hub/shared";
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
 import * as chatService from "../../services/chat.js";
@@ -47,4 +47,26 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       })),
     };
   });
+
+  // Participant management
+  app.post<{ Params: { chatId: string } }>("/:chatId/participants", async (request, reply) => {
+    const identity = requireAgent(request);
+    const body = addParticipantSchema.parse(request.body);
+    const participants = await chatService.addParticipant(app.db, request.params.chatId, identity.id, body);
+    return reply.status(201).send(
+      participants.map((p) => ({
+        ...p,
+        joinedAt: p.joinedAt.toISOString(),
+      })),
+    );
+  });
+
+  app.delete<{ Params: { chatId: string; agentId: string } }>(
+    "/:chatId/participants/:agentId",
+    async (request, reply) => {
+      const identity = requireAgent(request);
+      await chatService.removeParticipant(app.db, request.params.chatId, identity.id, request.params.agentId);
+      return reply.status(204).send();
+    },
+  );
 }

--- a/packages/server/src/api/agent/inbox.ts
+++ b/packages/server/src/api/agent/inbox.ts
@@ -17,4 +17,11 @@ export async function agentInboxRoutes(app: FastifyInstance): Promise<void> {
     await inboxService.ackEntry(app.db, entryId, identity.inboxId);
     return reply.status(204).send();
   });
+
+  app.post<{ Params: { entryId: string } }>("/:entryId/renew", async (request, reply) => {
+    const identity = requireAgent(request);
+    const entryId = Number(request.params.entryId);
+    await inboxService.renewEntry(app.db, entryId, identity.inboxId);
+    return reply.status(204).send();
+  });
 }

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -1,4 +1,4 @@
-import { paginationQuerySchema, sendMessageSchema } from "@agent-hub/shared";
+import { paginationQuerySchema, sendMessageSchema, sendToAgentSchema } from "@agent-hub/shared";
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
 import * as chatService from "../../services/chat.js";
@@ -28,5 +28,17 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
       })),
       nextCursor: result.nextCursor,
     };
+  });
+}
+
+export async function agentSendToAgentRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Params: { agentId: string } }>("/:agentId/messages", async (request, reply) => {
+    const identity = requireAgent(request);
+    const body = sendToAgentSchema.parse(request.body);
+    const msg = await messageService.sendToAgent(app.db, identity.id, request.params.agentId, body);
+    return reply.status(201).send({
+      ...msg,
+      createdAt: msg.createdAt.toISOString(),
+    });
   });
 }

--- a/packages/server/src/api/agent/ws.ts
+++ b/packages/server/src/api/agent/ws.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from "fastify";
+import type { Notifier } from "../../services/notifier.js";
+import * as presenceService from "../../services/presence.js";
+
+export function agentWsRoutes(notifier: Notifier, instanceId: string) {
+  return async (app: FastifyInstance): Promise<void> => {
+    app.get("/inbox", { websocket: true }, async (socket, request) => {
+      const agent = request.agent;
+      if (!agent) {
+        socket.close(4001, "Unauthorized");
+        return;
+      }
+
+      const inboxId = agent.inboxId;
+
+      // Track presence
+      await presenceService.setOnline(app.db, agent.id, instanceId);
+
+      // Subscribe to notifications
+      notifier.subscribe(inboxId, socket);
+
+      socket.on("close", async () => {
+        notifier.unsubscribe(inboxId, socket);
+        try {
+          await presenceService.setOffline(app.db, agent.id);
+        } catch {
+          // best-effort
+        }
+      });
+
+      // Keep-alive: respond to pings (handled automatically by ws)
+      // Client can send JSON messages, but we don't process them in v2
+    });
+  };
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,20 +1,32 @@
+import websocket from "@fastify/websocket";
 import Fastify from "fastify";
+import postgres from "postgres";
 import { ZodError } from "zod";
 import { adminAgentRoutes } from "./api/admin/agents.js";
 import { adminAuthRoutes } from "./api/admin/auth.js";
+import { adminOverviewRoutes } from "./api/admin/overview.js";
+import { adminSystemConfigRoutes } from "./api/admin/system-config.js";
 import { agentChatRoutes } from "./api/agent/chats.js";
 import { agentInboxRoutes } from "./api/agent/inbox.js";
 import { agentMeRoutes } from "./api/agent/me.js";
-import { agentMessageRoutes } from "./api/agent/messages.js";
+import { agentMessageRoutes, agentSendToAgentRoutes } from "./api/agent/messages.js";
+import { agentWsRoutes } from "./api/agent/ws.js";
 import { healthRoutes } from "./api/health.js";
 import type { Config } from "./config.js";
 import { connectDatabase } from "./db/connection.js";
 import { AppError } from "./errors.js";
 import { adminAuthHook } from "./middleware/admin-auth.js";
 import { agentAuthHook } from "./middleware/agent-auth.js";
+import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
+import { createNotifier, type Notifier } from "./services/notifier.js";
 
 // Fastify type augmentation
 import "./types.js";
+
+export type AppContext = {
+  notifier: Notifier;
+  backgroundTasks: BackgroundTasks;
+};
 
 export async function buildApp(config: Config) {
   const app = Fastify({ logger: config.logger ?? true });
@@ -23,6 +35,13 @@ export async function buildApp(config: Config) {
   const db = connectDatabase(config.databaseUrl);
   app.decorate("db", db);
   app.decorate("config", config);
+
+  // Notifier: dedicated PG connection for LISTEN/NOTIFY
+  const listenClient = postgres(config.databaseUrl, { max: 1 });
+  const notifier = createNotifier(listenClient);
+
+  // WebSocket plugin
+  await app.register(websocket);
 
   // Auth hooks
   const agentAuth = agentAuthHook(db);
@@ -53,20 +72,51 @@ export async function buildApp(config: Config) {
     { prefix: "/admin/agents" },
   );
 
+  await app.register(
+    async (adminApp) => {
+      adminApp.addHook("onRequest", adminAuth);
+      await adminApp.register(adminSystemConfigRoutes);
+    },
+    { prefix: "/admin/system/config" },
+  );
+
+  await app.register(
+    async (adminApp) => {
+      adminApp.addHook("onRequest", adminAuth);
+      await adminApp.register(adminOverviewRoutes);
+    },
+    { prefix: "/admin/overview" },
+  );
+
   // Agent routes (Bearer token protected)
-  // V1: actor-centric paths (/agent/*) for simplicity.
-  // Target: migrate to resource-centric paths (/chats/*, /inboxes/*) per design doc
-  // (agent-hub-server-detailed-design §4.1). Body schemas are shared, so migration is path-only.
   await app.register(
     async (agentApp) => {
       agentApp.addHook("onRequest", agentAuth);
       await agentApp.register(agentMeRoutes);
       await agentApp.register(agentChatRoutes, { prefix: "/chats" });
       await agentApp.register(agentMessageRoutes, { prefix: "/chats" });
+      await agentApp.register(agentSendToAgentRoutes, { prefix: "/agents" });
       await agentApp.register(agentInboxRoutes, { prefix: "/inbox" });
+      await agentApp.register(agentWsRoutes(notifier, config.instanceId), { prefix: "/ws" });
     },
     { prefix: "/agent" },
   );
+
+  // Background tasks
+  const backgroundTasks = createBackgroundTasks(app, config.instanceId);
+
+  // Start notifier and background tasks on server start
+  app.addHook("onReady", async () => {
+    await notifier.start();
+    backgroundTasks.start();
+  });
+
+  // Cleanup on close
+  app.addHook("onClose", async () => {
+    backgroundTasks.stop();
+    await notifier.stop();
+    await listenClient.end();
+  });
 
   return app;
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const env = process.env;
 
 export type Config = {
@@ -5,6 +7,7 @@ export type Config = {
   serverHost: string;
   serverPort: number;
   jwtSecretKey: string;
+  instanceId: string;
   logger?: boolean;
 };
 
@@ -24,5 +27,6 @@ export function loadConfig(): Config {
     serverHost: env.SERVER_HOST ?? "0.0.0.0",
     serverPort: Number(env.SERVER_PORT ?? "8000"),
     jwtSecretKey,
+    instanceId: env.INSTANCE_ID ?? `srv_${randomUUID().slice(0, 8)}`,
   };
 }

--- a/packages/server/src/db/schema/admin-users.ts
+++ b/packages/server/src/db/schema/admin-users.ts
@@ -1,9 +1,11 @@
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
+/** Admin accounts. Passwords are stored as bcrypt hashes. */
 export const adminUsers = pgTable("admin_users", {
   id: text("id").primaryKey(),
   username: text("username").unique().notNull(),
   passwordHash: text("password_hash").notNull(),
+  /** "super_admin" | "admin" */
   role: text("role").notNull().default("admin"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   lastLoginAt: timestamp("last_login_at", { withTimezone: true }),

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -1,11 +1,14 @@
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 
+/** Agent online status. Tracked via WebSocket connections; stale entries are cleaned up using server_instances heartbeat. */
 export const agentPresence = pgTable("agent_presence", {
   agentId: text("agent_id")
     .primaryKey()
     .references(() => agents.id, { onDelete: "cascade" }),
+  /** "online" | "offline" */
   status: text("status").notNull().default("offline"),
+  /** Server instance ID that holds this agent's WebSocket connection */
   instanceId: text("instance_id"),
   connectedAt: timestamp("connected_at", { withTimezone: true }),
   lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -1,0 +1,12 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+
+export const agentPresence = pgTable("agent_presence", {
+  agentId: text("agent_id")
+    .primaryKey()
+    .references(() => agents.id, { onDelete: "cascade" }),
+  status: text("status").notNull().default("offline"),
+  instanceId: text("instance_id"),
+  connectedAt: timestamp("connected_at", { withTimezone: true }),
+  lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/db/schema/agent-tokens.ts
+++ b/packages/server/src/db/schema/agent-tokens.ts
@@ -1,6 +1,7 @@
 import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 
+/** Agent bearer tokens. Multiple tokens can coexist for zero-downtime rotation. */
 export const agentTokens = pgTable(
   "agent_tokens",
   {
@@ -8,9 +9,13 @@ export const agentTokens = pgTable(
     agentId: text("agent_id")
       .notNull()
       .references(() => agents.id, { onDelete: "cascade" }),
+    /** SHA-256 hash; plaintext is returned only once at creation */
     tokenHash: text("token_hash").notNull(),
+    /** Optional label, e.g. "production", "dev" */
     name: text("name"),
+    /** NULL = never expires */
     expiresAt: timestamp("expires_at", { withTimezone: true }),
+    /** Non-NULL means revoked */
     revokedAt: timestamp("revoked_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     lastUsedAt: timestamp("last_used_at", { withTimezone: true }),

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -1,13 +1,17 @@
 import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
+/** Agent registration. Each agent owns a unique inboxId for message delivery. */
 export const agents = pgTable(
   "agents",
   {
     id: text("id").primaryKey(),
     organizationId: text("organization_id").notNull().default("default"),
+    /** "human" | "personal_assistant" | "autonomous_agent" */
     type: text("type").notNull(),
     displayName: text("display_name"),
+    /** Delivery address, auto-generated as inbox_{id} */
     inboxId: text("inbox_id").unique().notNull(),
+    /** "active" | "suspended". Suspended agents have all API requests rejected. */
     status: text("status").notNull().default("active"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -1,18 +1,21 @@
 import { index, jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 
+/** Communication container. All messages between agents flow within a Chat. */
 export const chats = pgTable("chats", {
   id: text("id").primaryKey(),
   organizationId: text("organization_id").notNull().default("default"),
+  /** "direct" | "group" | "thread" */
   type: text("type").notNull().default("direct"),
   topic: text("topic"),
-  lifecyclePolicy: text("lifecycle_policy").notNull().default("persistent"),
+  /** Parent chat ID for thread (sub-discussion) scenarios */
   parentChatId: text("parent_chat_id"),
   metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+/** Chat participants (M:N). */
 export const chatParticipants = pgTable(
   "chat_participants",
   {
@@ -22,7 +25,9 @@ export const chatParticipants = pgTable(
     agentId: text("agent_id")
       .notNull()
       .references(() => agents.id),
+    /** "owner" | "member" */
     role: text("role").notNull().default("member"),
+    /** "full" = receive all messages; "mention_only" = consumer-side behavior, does not affect fan-out */
     mode: text("mode").notNull().default("full"),
     joinedAt: timestamp("joined_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -6,6 +6,8 @@ export const chats = pgTable("chats", {
   organizationId: text("organization_id").notNull().default("default"),
   type: text("type").notNull().default("direct"),
   topic: text("topic"),
+  lifecyclePolicy: text("lifecycle_policy").notNull().default("persistent"),
+  parentChatId: text("parent_chat_id"),
   metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/db/schema/inbox-entries.ts
+++ b/packages/server/src/db/schema/inbox-entries.ts
@@ -1,16 +1,21 @@
 import { bigserial, index, integer, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { messages } from "./messages.js";
 
+/** Delivery queue (envelope). One entry per recipient created during message fan-out. Uses SKIP LOCKED for concurrent-safe consumption. */
 export const inboxEntries = pgTable(
   "inbox_entries",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
+    /** Target agent's inbox address */
     inboxId: text("inbox_id").notNull(),
     messageId: text("message_id")
       .notNull()
       .references(() => messages.id),
+    /** Routing tag. May differ from message.chat_id in replyTo scenarios; used by Client to route to the correct Session */
     chatId: text("chat_id"),
+    /** "pending" → "delivered" → "acked" | "failed" */
     status: text("status").notNull().default("pending"),
+    /** Timeout reset count; entry is marked "failed" when this reaches the configured max */
     retryCount: integer("retry_count").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     deliveredAt: timestamp("delivered_at", { withTimezone: true }),

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -1,6 +1,9 @@
 export { adminUsers } from "./admin-users.js";
+export { agentPresence } from "./agent-presence.js";
 export { agentTokens } from "./agent-tokens.js";
 export { agents } from "./agents.js";
 export { chatParticipants, chats } from "./chats.js";
 export { inboxEntries } from "./inbox-entries.js";
 export { messages } from "./messages.js";
+export { serverInstances } from "./server-instances.js";
+export { systemConfigs } from "./system-configs.js";

--- a/packages/server/src/db/schema/messages.ts
+++ b/packages/server/src/db/schema/messages.ts
@@ -2,6 +2,7 @@ import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { chats } from "./chats.js";
 
+/** Messages. Immutable after creation. Each message belongs to exactly one Chat. */
 export const messages = pgTable(
   "messages",
   {
@@ -12,11 +13,15 @@ export const messages = pgTable(
     senderId: text("sender_id")
       .notNull()
       .references(() => agents.id),
+    /** "text" | "markdown" | "card" | "reference" | "file" */
     format: text("format").notNull(),
     content: jsonb("content").$type<unknown>().notNull(),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    /** Cross-chat reply routing: target inbox for the reply */
     replyToInbox: text("reply_to_inbox"),
+    /** Cross-chat reply routing: chat session the reply should be routed to on the receiver side */
     replyToChat: text("reply_to_chat"),
+    /** Original message ID; Delivery Engine uses this to trigger replyTo routing */
     inReplyTo: text("in_reply_to"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/server/src/db/schema/server-instances.ts
+++ b/packages/server/src/db/schema/server-instances.ts
@@ -1,5 +1,6 @@
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
+/** Server instance heartbeat. Used to detect crashed instances and clean up associated agent_presence records. */
 export const serverInstances = pgTable("server_instances", {
   instanceId: text("instance_id").primaryKey(),
   lastHeartbeat: timestamp("last_heartbeat", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/db/schema/server-instances.ts
+++ b/packages/server/src/db/schema/server-instances.ts
@@ -1,0 +1,6 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const serverInstances = pgTable("server_instances", {
+  instanceId: text("instance_id").primaryKey(),
+  lastHeartbeat: timestamp("last_heartbeat", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/db/schema/system-configs.ts
+++ b/packages/server/src/db/schema/system-configs.ts
@@ -1,5 +1,6 @@
 import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
+/** Runtime system configuration (key-value JSONB). Dynamically modifiable via Admin API; controls inbox timeout, retry count, etc. */
 export const systemConfigs = pgTable("system_configs", {
   key: text("key").primaryKey(),
   value: jsonb("value").$type<unknown>().notNull(),

--- a/packages/server/src/db/schema/system-configs.ts
+++ b/packages/server/src/db/schema/system-configs.ts
@@ -1,0 +1,7 @@
+import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const systemConfigs = pgTable("system_configs", {
+  key: text("key").primaryKey(),
+  value: jsonb("value").$type<unknown>().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -90,6 +90,11 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
   return agent;
 }
 
+export async function deleteAgent(db: Database, id: string) {
+  // Delete = suspend + revoke all tokens (per design doc)
+  return updateAgent(db, id, { status: "suspended" });
+}
+
 export async function createToken(db: Database, agentId: string, data: CreateAgentToken) {
   // Verify agent exists
   await getAgent(db, agentId);

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,0 +1,58 @@
+import type { FastifyInstance } from "fastify";
+import * as inboxService from "./inbox.js";
+import * as presenceService from "./presence.js";
+import * as systemConfigService from "./system-config.js";
+
+export type BackgroundTasks = {
+  start(): void;
+  stop(): void;
+};
+
+export function createBackgroundTasks(app: FastifyInstance, instanceId: string): BackgroundTasks {
+  let inboxTimer: ReturnType<typeof setInterval> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  return {
+    start() {
+      // Inbox timeout reset — runs every 60 seconds
+      inboxTimer = setInterval(async () => {
+        try {
+          const configs = await systemConfigService.getAllConfigs(app.db);
+          const timeoutSeconds = (configs.inbox_timeout_seconds as number) ?? 300;
+          const maxRetries = (configs.max_retry_count as number) ?? 3;
+          await inboxService.resetTimedOutEntries(app.db, timeoutSeconds, maxRetries);
+        } catch (err) {
+          app.log.error(err, "Failed to reset timed-out inbox entries");
+        }
+      }, 60_000);
+
+      // Server instance heartbeat — runs every 30 seconds
+      heartbeatTimer = setInterval(async () => {
+        try {
+          await presenceService.heartbeatInstance(app.db, instanceId);
+          const configs = await systemConfigService.getAllConfigs(app.db);
+          const staleSeconds = (configs.presence_cleanup_seconds as number) ?? 60;
+          await presenceService.cleanupStalePresence(app.db, staleSeconds);
+        } catch (err) {
+          app.log.error(err, "Failed to heartbeat / cleanup presence");
+        }
+      }, 30_000);
+
+      // Initial heartbeat
+      presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
+        app.log.error(err, "Failed initial heartbeat");
+      });
+    },
+
+    stop() {
+      if (inboxTimer) {
+        clearInterval(inboxTimer);
+        inboxTimer = null;
+      }
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+    },
+  };
+}

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
-import type { CreateChat } from "@agent-hub/shared";
+import type { AddParticipant, CreateChat } from "@agent-hub/shared";
 import { and, desc, eq, inArray, lt } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatParticipants, chats } from "../db/schema/chats.js";
-import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 
 export async function createChat(db: Database, creatorId: string, data: CreateChat) {
   const chatId = randomUUID();
@@ -117,4 +117,124 @@ export async function assertParticipant(db: Database, chatId: string, agentId: s
   if (!row) {
     throw new ForbiddenError("Not a participant of this chat");
   }
+}
+
+export async function addParticipant(db: Database, chatId: string, requesterId: string, data: AddParticipant) {
+  // Verify chat exists
+  const chat = await getChat(db, chatId);
+
+  // Verify requester is a participant
+  await assertParticipant(db, chatId, requesterId);
+
+  // Verify target agent exists and is in the same org
+  const [targetAgent] = await db
+    .select({ id: agents.id, organizationId: agents.organizationId })
+    .from(agents)
+    .where(eq(agents.id, data.agentId))
+    .limit(1);
+
+  if (!targetAgent) {
+    throw new NotFoundError(`Agent "${data.agentId}" not found`);
+  }
+
+  if (targetAgent.organizationId !== chat.organizationId) {
+    throw new BadRequestError("Cannot add agent from different organization");
+  }
+
+  // Check not already a participant
+  const [existing] = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.agentId, data.agentId)))
+    .limit(1);
+
+  if (existing) {
+    throw new ConflictError(`Agent "${data.agentId}" is already a participant`);
+  }
+
+  await db.insert(chatParticipants).values({
+    chatId,
+    agentId: data.agentId,
+    mode: data.mode ?? "full",
+  });
+
+  return db.select().from(chatParticipants).where(eq(chatParticipants.chatId, chatId));
+}
+
+export async function removeParticipant(db: Database, chatId: string, requesterId: string, targetAgentId: string) {
+  // Verify requester is a participant
+  await assertParticipant(db, chatId, requesterId);
+
+  // Cannot remove self (use leave instead, if implemented)
+  if (requesterId === targetAgentId) {
+    throw new BadRequestError("Cannot remove yourself from a chat");
+  }
+
+  const [removed] = await db
+    .delete(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.agentId, targetAgentId)))
+    .returning();
+
+  if (!removed) {
+    throw new NotFoundError(`Agent "${targetAgentId}" is not a participant of this chat`);
+  }
+
+  return db.select().from(chatParticipants).where(eq(chatParticipants.chatId, chatId));
+}
+
+export async function findOrCreateDirectChat(db: Database, agentAId: string, agentBId: string) {
+  // Find existing direct chat between the two agents
+  const aChats = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(eq(chatParticipants.agentId, agentAId));
+
+  const bChats = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(eq(chatParticipants.agentId, agentBId));
+
+  const bChatIds = new Set(bChats.map((r) => r.chatId));
+  const commonChatIds = aChats.map((r) => r.chatId).filter((id) => bChatIds.has(id));
+
+  if (commonChatIds.length > 0) {
+    // Check if any common chat is a direct chat
+    const directChats = await db
+      .select()
+      .from(chats)
+      .where(and(inArray(chats.id, commonChatIds), eq(chats.type, "direct")));
+
+    if (directChats.length > 0 && directChats[0]) {
+      return directChats[0];
+    }
+  }
+
+  // Create new direct chat
+  const [agentA] = await db
+    .select({ organizationId: agents.organizationId })
+    .from(agents)
+    .where(eq(agents.id, agentAId))
+    .limit(1);
+
+  if (!agentA) throw new NotFoundError(`Agent "${agentAId}" not found`);
+
+  const chatId = randomUUID();
+  return db.transaction(async (tx) => {
+    const [chat] = await tx
+      .insert(chats)
+      .values({
+        id: chatId,
+        organizationId: agentA.organizationId,
+        type: "direct",
+      })
+      .returning();
+
+    await tx.insert(chatParticipants).values([
+      { chatId, agentId: agentAId, role: "member" },
+      { chatId, agentId: agentBId, role: "member" },
+    ]);
+
+    if (!chat) throw new Error("Unexpected: INSERT RETURNING produced no row");
+    return chat;
+  });
 }

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -4,6 +4,9 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { ForbiddenError, NotFoundError } from "../errors.js";
 
+const DEFAULT_INBOX_TIMEOUT_SECONDS = 300;
+const DEFAULT_MAX_RETRY_COUNT = 3;
+
 export async function pollInbox(db: Database, inboxId: string, limit: number) {
   // Use raw SQL for SELECT ... FOR UPDATE SKIP LOCKED (not supported by Drizzle query builder)
   const result = await db.transaction(async (tx) => {
@@ -86,6 +89,46 @@ export async function ackEntry(db: Database, entryId: number, inboxId: string) {
   }
 
   return entry;
+}
+
+export async function renewEntry(db: Database, entryId: number, inboxId: string) {
+  const [entry] = await db
+    .update(inboxEntries)
+    .set({ deliveredAt: new Date() })
+    .where(and(eq(inboxEntries.id, entryId), eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "delivered")))
+    .returning();
+
+  if (!entry) {
+    throw new NotFoundError("Inbox entry not found or not in delivered status");
+  }
+
+  return entry;
+}
+
+export async function resetTimedOutEntries(
+  db: Database,
+  timeoutSeconds = DEFAULT_INBOX_TIMEOUT_SECONDS,
+  maxRetries = DEFAULT_MAX_RETRY_COUNT,
+): Promise<{ reset: number; failed: number }> {
+  // Reset entries that have timed out but haven't exceeded max retries
+  const resetResult = await db.execute<{ id: number }>(sql`
+    UPDATE inbox_entries SET status = 'pending', retry_count = retry_count + 1
+    WHERE status = 'delivered'
+      AND delivered_at < NOW() - make_interval(secs => ${timeoutSeconds})
+      AND retry_count < ${maxRetries}
+    RETURNING id
+  `);
+
+  // Mark entries that have exceeded max retries as failed
+  const failedResult = await db.execute<{ id: number }>(sql`
+    UPDATE inbox_entries SET status = 'failed'
+    WHERE status = 'delivered'
+      AND delivered_at < NOW() - make_interval(secs => ${timeoutSeconds})
+      AND retry_count >= ${maxRetries}
+    RETURNING id
+  `);
+
+  return { reset: resetResult.length, failed: failedResult.length };
 }
 
 export async function assertInboxOwner(inboxId: string, agentInboxId: string): Promise<void> {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from "node:crypto";
-import type { SendMessage } from "@agent-hub/shared";
+import type { SendMessage, SendToAgent } from "@agent-hub/shared";
 import { and, desc, eq, lt } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatParticipants, chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
+import { NotFoundError } from "../errors.js";
+import { findOrCreateDirectChat } from "./chat.js";
 
 export async function sendMessage(db: Database, chatId: string, senderId: string, data: SendMessage) {
   return db.transaction(async (tx) => {
@@ -78,6 +80,37 @@ export async function sendMessage(db: Database, chatId: string, senderId: string
 
     if (!msg) throw new Error("Unexpected: INSERT RETURNING produced no row");
     return msg;
+  });
+}
+
+export async function sendToAgent(db: Database, senderId: string, targetAgentId: string, data: SendToAgent) {
+  // Verify target agent exists and is in the same org
+  const [sender] = await db
+    .select({ id: agents.id, organizationId: agents.organizationId })
+    .from(agents)
+    .where(eq(agents.id, senderId))
+    .limit(1);
+
+  if (!sender) throw new NotFoundError(`Agent "${senderId}" not found`);
+
+  const [target] = await db
+    .select({ id: agents.id, organizationId: agents.organizationId })
+    .from(agents)
+    .where(eq(agents.id, targetAgentId))
+    .limit(1);
+
+  if (!target) throw new NotFoundError(`Agent "${targetAgentId}" not found`);
+
+  // Find or create direct chat
+  const chat = await findOrCreateDirectChat(db, senderId, targetAgentId);
+
+  // Send message via existing sendMessage
+  return sendMessage(db, chat.id, senderId, {
+    format: data.format,
+    content: data.content,
+    metadata: data.metadata,
+    replyToInbox: data.replyToInbox,
+    replyToChat: data.replyToChat,
   });
 }
 

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -1,0 +1,83 @@
+import type postgres from "postgres";
+import type { WebSocket } from "ws";
+
+const CHANNEL = "inbox_notifications";
+
+export type Notifier = {
+  /** Subscribe a WebSocket connection for an inbox */
+  subscribe(inboxId: string, ws: WebSocket): void;
+  /** Unsubscribe a WebSocket connection */
+  unsubscribe(inboxId: string, ws: WebSocket): void;
+  /** Notify that new messages are available for an inbox */
+  notify(inboxId: string, messageId: string): Promise<void>;
+  /** Start listening for PG notifications */
+  start(): Promise<void>;
+  /** Stop listening */
+  stop(): Promise<void>;
+};
+
+export function createNotifier(listenClient: postgres.Sql): Notifier {
+  const subscriptions = new Map<string, Set<WebSocket>>();
+  let unlistenFn: (() => Promise<void>) | null = null;
+
+  function handleNotification(payload: string) {
+    // payload format: "inboxId:messageId"
+    const sepIdx = payload.indexOf(":");
+    if (sepIdx === -1) return;
+    const inboxId = payload.slice(0, sepIdx);
+    const messageId = payload.slice(sepIdx + 1);
+
+    const sockets = subscriptions.get(inboxId);
+    if (!sockets) return;
+
+    const data = JSON.stringify({ type: "new_message", inboxId, messageId });
+    for (const ws of sockets) {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(data);
+      }
+    }
+  }
+
+  return {
+    subscribe(inboxId: string, ws: WebSocket) {
+      let set = subscriptions.get(inboxId);
+      if (!set) {
+        set = new Set();
+        subscriptions.set(inboxId, set);
+      }
+      set.add(ws);
+    },
+
+    unsubscribe(inboxId: string, ws: WebSocket) {
+      const set = subscriptions.get(inboxId);
+      if (set) {
+        set.delete(ws);
+        if (set.size === 0) {
+          subscriptions.delete(inboxId);
+        }
+      }
+    },
+
+    async notify(inboxId: string, messageId: string) {
+      try {
+        await listenClient`SELECT pg_notify(${CHANNEL}, ${`${inboxId}:${messageId}`})`;
+      } catch {
+        // fire-and-forget: notification loss is acceptable, polling covers it
+      }
+    },
+
+    async start() {
+      const result = await listenClient.listen(CHANNEL, (payload) => {
+        if (payload) handleNotification(payload);
+      });
+      unlistenFn = result.unlisten;
+    },
+
+    async stop() {
+      if (unlistenFn) {
+        await unlistenFn();
+        unlistenFn = null;
+      }
+    },
+  };
+}

--- a/packages/server/src/services/presence.ts
+++ b/packages/server/src/services/presence.ts
@@ -1,0 +1,73 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { serverInstances } from "../db/schema/server-instances.js";
+
+export async function setOnline(db: Database, agentId: string, instanceId: string) {
+  const now = new Date();
+  await db
+    .insert(agentPresence)
+    .values({
+      agentId,
+      status: "online",
+      instanceId,
+      connectedAt: now,
+      lastSeenAt: now,
+    })
+    .onConflictDoUpdate({
+      target: agentPresence.agentId,
+      set: {
+        status: "online",
+        instanceId,
+        connectedAt: now,
+        lastSeenAt: now,
+      },
+    });
+}
+
+export async function setOffline(db: Database, agentId: string) {
+  await db
+    .update(agentPresence)
+    .set({
+      status: "offline",
+      instanceId: null,
+      lastSeenAt: new Date(),
+    })
+    .where(eq(agentPresence.agentId, agentId));
+}
+
+export async function getPresence(db: Database, agentId: string) {
+  const [row] = await db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId)).limit(1);
+  return row ?? null;
+}
+
+export async function getOnlineCount(db: Database): Promise<number> {
+  const [result] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(agentPresence)
+    .where(eq(agentPresence.status, "online"));
+  return result?.count ?? 0;
+}
+
+export async function heartbeatInstance(db: Database, instanceId: string) {
+  await db
+    .insert(serverInstances)
+    .values({ instanceId, lastHeartbeat: new Date() })
+    .onConflictDoUpdate({
+      target: serverInstances.instanceId,
+      set: { lastHeartbeat: new Date() },
+    });
+}
+
+export async function cleanupStalePresence(db: Database, staleSeconds = 60): Promise<number> {
+  const result = await db.execute<{ agent_id: string }>(sql`
+    UPDATE agent_presence SET status = 'offline', instance_id = NULL
+    WHERE instance_id IN (
+      SELECT instance_id FROM server_instances
+      WHERE last_heartbeat < NOW() - make_interval(secs => ${staleSeconds})
+    )
+    AND status = 'online'
+    RETURNING agent_id
+  `);
+  return result.length;
+}

--- a/packages/server/src/services/system-config.ts
+++ b/packages/server/src/services/system-config.ts
@@ -1,0 +1,33 @@
+import { SYSTEM_CONFIG_DEFAULTS } from "@agent-hub/shared";
+import { eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { systemConfigs } from "../db/schema/system-configs.js";
+
+export async function getAllConfigs(db: Database): Promise<Record<string, unknown>> {
+  const rows = await db.select().from(systemConfigs);
+  const result: Record<string, unknown> = { ...SYSTEM_CONFIG_DEFAULTS };
+  for (const row of rows) {
+    result[row.key] = row.value;
+  }
+  return result;
+}
+
+export async function getConfig(db: Database, key: string): Promise<unknown> {
+  const [row] = await db.select().from(systemConfigs).where(eq(systemConfigs.key, key)).limit(1);
+  if (row) return row.value;
+  return (SYSTEM_CONFIG_DEFAULTS as Record<string, unknown>)[key] ?? null;
+}
+
+export async function updateConfigs(db: Database, updates: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const now = new Date();
+  for (const [key, value] of Object.entries(updates)) {
+    await db
+      .insert(systemConfigs)
+      .values({ key, value, updatedAt: now })
+      .onConflictDoUpdate({
+        target: systemConfigs.key,
+        set: { value, updatedAt: now },
+      });
+  }
+  return getAllConfigs(db);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,6 +38,8 @@ export {
   createAgentTokenSchema,
 } from "./schemas/agent-token.js";
 export {
+  type AddParticipant,
+  addParticipantSchema,
   CHAT_TYPES,
   type Chat,
   type ChatDetail,
@@ -49,6 +51,8 @@ export {
   chatSchema,
   chatTypeSchema,
   createChatSchema,
+  type RemoveParticipant,
+  removeParticipantSchema,
 } from "./schemas/chat.js";
 export {
   type PaginationQuery,
@@ -73,5 +77,22 @@ export {
   messageFormatSchema,
   messageSchema,
   type SendMessage,
+  type SendToAgent,
   sendMessageSchema,
+  sendToAgentSchema,
 } from "./schemas/message.js";
+export {
+  type AgentPresence,
+  agentPresenceSchema,
+  PRESENCE_STATUSES,
+  type PresenceStatus,
+  presenceStatusSchema,
+} from "./schemas/presence.js";
+export {
+  SYSTEM_CONFIG_DEFAULTS,
+  SYSTEM_CONFIG_KEYS,
+  type SystemConfig,
+  systemConfigSchema,
+  type UpdateSystemConfig,
+  updateSystemConfigSchema,
+} from "./schemas/system-config.js";

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -39,3 +39,14 @@ export const chatDetailSchema = chatSchema.extend({
   participants: z.array(chatParticipantSchema),
 });
 export type ChatDetail = z.infer<typeof chatDetailSchema>;
+
+export const addParticipantSchema = z.object({
+  agentId: z.string().min(1),
+  mode: z.enum(["full", "mention_only"]).default("full"),
+});
+export type AddParticipant = z.infer<typeof addParticipantSchema>;
+
+export const removeParticipantSchema = z.object({
+  agentId: z.string().min(1),
+});
+export type RemoveParticipant = z.infer<typeof removeParticipantSchema>;

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -21,6 +21,15 @@ export const sendMessageSchema = z.object({
 });
 export type SendMessage = z.infer<typeof sendMessageSchema>;
 
+export const sendToAgentSchema = z.object({
+  format: messageFormatSchema.default("text"),
+  content: z.unknown(),
+  metadata: z.record(z.unknown()).optional(),
+  replyToInbox: z.string().optional(),
+  replyToChat: z.string().optional(),
+});
+export type SendToAgent = z.infer<typeof sendToAgentSchema>;
+
 export const messageSchema = z.object({
   id: z.string(),
   chatId: z.string(),

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const PRESENCE_STATUSES = {
+  ONLINE: "online",
+  OFFLINE: "offline",
+} as const;
+
+export const presenceStatusSchema = z.enum(["online", "offline"]);
+export type PresenceStatus = z.infer<typeof presenceStatusSchema>;
+
+export const agentPresenceSchema = z.object({
+  agentId: z.string(),
+  status: presenceStatusSchema,
+  connectedAt: z.string().nullable(),
+  lastSeenAt: z.string(),
+});
+export type AgentPresence = z.infer<typeof agentPresenceSchema>;

--- a/packages/shared/src/schemas/system-config.ts
+++ b/packages/shared/src/schemas/system-config.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const systemConfigSchema = z.object({
+  key: z.string(),
+  value: z.unknown(),
+  updatedAt: z.string(),
+});
+export type SystemConfig = z.infer<typeof systemConfigSchema>;
+
+export const updateSystemConfigSchema = z.record(z.string(), z.unknown());
+export type UpdateSystemConfig = z.infer<typeof updateSystemConfigSchema>;
+
+export const SYSTEM_CONFIG_KEYS = {
+  INBOX_TIMEOUT_SECONDS: "inbox_timeout_seconds",
+  MAX_RETRY_COUNT: "max_retry_count",
+  POLLING_INTERVAL_SECONDS: "polling_interval_seconds",
+  PRESENCE_CLEANUP_SECONDS: "presence_cleanup_seconds",
+} as const;
+
+export const SYSTEM_CONFIG_DEFAULTS: Record<string, unknown> = {
+  [SYSTEM_CONFIG_KEYS.INBOX_TIMEOUT_SECONDS]: 300,
+  [SYSTEM_CONFIG_KEYS.MAX_RETRY_COUNT]: 3,
+  [SYSTEM_CONFIG_KEYS.POLLING_INTERVAL_SECONDS]: 5,
+  [SYSTEM_CONFIG_KEYS.PRESENCE_CLEANUP_SECONDS]: 60,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10


### PR DESCRIPTION
… and admin enhancements

Add P0 core Agent API features (send_to_agent, chat participant management, inbox heartbeat renewal, inbox timeout reset), P1 real-time infrastructure (WebSocket inbox notifications, PG LISTEN/NOTIFY, agent presence tracking), and P2 admin API completion (DELETE agent, system config, system overview).

New DB tables: agent_presence, server_instances, system_configs. New chats columns: lifecycle_policy, parent_chat_id. 51 tests covering all new and existing functionality.