### PR TITLE
feat: add GitHub webhook adapter, client SDK, and CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ JWT_SECRET_KEY=
 # Adapter 凭证加密密钥 (生成方式: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
 ENCRYPTION_KEY=
 
+# GitHub Webhook (optional — if not set, signature verification is skipped)
+GITHUB_WEBHOOK_SECRET=
+
 # Docker Compose (可选, 覆盖 docker-compose.yml 默认值)
 # POSTGRES_DB=agenthub
 # POSTGRES_USER=agenthub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
+      - run: pnpm build
       - run: pnpm typecheck
 
   test:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,15 +9,19 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "agent-hub": "./dist/cli/index.js"
+  },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts",
+    "build": "tsdown src/index.ts src/cli/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",
-    "zod": "^3.25.0",
-    "ws": "^8.18.0"
+    "commander": "^13.1.0",
+    "ws": "^8.18.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.0",

--- a/packages/client/src/cli/index.ts
+++ b/packages/client/src/cli/index.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { AgentHubSDK, SdkError } from "../sdk.js";
+import { fail, success } from "./output.js";
+
+function resolveConfig(): { serverUrl: string; token: string } {
+  const token = process.env.AGENT_HUB_TOKEN;
+  if (!token) {
+    fail("MISSING_TOKEN", "AGENT_HUB_TOKEN environment variable is required.", 2);
+  }
+  const serverUrl = process.env.AGENT_HUB_SERVER ?? "http://localhost:8000";
+  return { serverUrl, token };
+}
+
+function createSdk(): AgentHubSDK {
+  const config = resolveConfig();
+  return new AgentHubSDK(config);
+}
+
+function handleError(error: unknown): never {
+  if (error instanceof SdkError) {
+    const exitCode = error.statusCode === 401 ? 3 : 1;
+    fail(`HTTP_${error.statusCode}`, error.message, exitCode);
+  }
+  if (error instanceof TypeError && "cause" in error) {
+    fail("CONNECTION_ERROR", `Cannot connect to server: ${error.message}`, 6);
+  }
+  const msg = error instanceof Error ? error.message : String(error);
+  fail("UNKNOWN_ERROR", msg, 1);
+}
+
+const program = new Command();
+
+program.name("agent-hub").description("Agent Hub CLI — agent-facing entry point").version("0.1.0");
+
+program
+  .command("register")
+  .description("Register this agent and return identity info")
+  .action(async () => {
+    try {
+      const sdk = createSdk();
+      const result = await sdk.register();
+      success(result);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program
+  .command("pull")
+  .description("Pull pending messages from inbox")
+  .option("-l, --limit <number>", "Maximum entries to return", "10")
+  .option("-a, --ack", "Automatically ACK entries after pulling")
+  .action(async (options: { limit: string; ack?: boolean }) => {
+    try {
+      const sdk = createSdk();
+      const limit = Number.parseInt(options.limit, 10);
+      if (Number.isNaN(limit) || limit < 1 || limit > 50) {
+        fail("INVALID_LIMIT", "Limit must be between 1 and 50.", 2);
+      }
+      const result = await sdk.pull(limit);
+
+      if (options.ack && result.entries.length > 0) {
+        await Promise.all(result.entries.map((entry) => sdk.ack(entry.id)));
+      }
+
+      success(result);
+    } catch (error) {
+      handleError(error);
+    }
+  });
+
+program.parse();

--- a/packages/client/src/cli/output.ts
+++ b/packages/client/src/cli/output.ts
@@ -1,0 +1,10 @@
+/** Write a success JSON envelope to stdout. */
+export function success(data: unknown): void {
+  process.stdout.write(`${JSON.stringify({ ok: true, data })}\n`);
+}
+
+/** Write an error JSON envelope to stderr and exit with the given code. */
+export function fail(code: string, message: string, exitCode = 1): never {
+  process.stderr.write(`${JSON.stringify({ ok: false, error: { code, message } })}\n`);
+  process.exit(exitCode);
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,1 +1,2 @@
-// @agent-hub/client
+export type { PullResult, RegisterResult, SdkConfig } from "./sdk.js";
+export { AgentHubSDK, SdkError } from "./sdk.js";

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -14,7 +14,6 @@ export type RegisterResult = {
 
 export type PullResult = {
   entries: InboxEntryWithMessage[];
-  remaining: number;
 };
 
 export class AgentHubSDK {
@@ -29,7 +28,7 @@ export class AgentHubSDK {
 
   /** Validate token, return agent identity. */
   async register(): Promise<RegisterResult> {
-    const agent = await this.request<Agent>("/agent/me");
+    const agent = await this.requestJson<Agent>("/agent/me");
     return {
       agentId: agent.id,
       inboxId: agent.inboxId,
@@ -40,24 +39,36 @@ export class AgentHubSDK {
 
   /** Fetch pending inbox entries. */
   async pull(limit = 10): Promise<PullResult> {
-    const entries = await this.request<InboxEntryWithMessage[]>(`/agent/inbox?limit=${limit}`);
-    return {
-      entries,
-      remaining: 0, // Server doesn't return remaining count yet
-    };
+    const entries = await this.requestJson<InboxEntryWithMessage[]>(`/agent/inbox?limit=${limit}`);
+    return { entries };
   }
 
   /** Acknowledge an inbox entry. */
   async ack(entryId: number): Promise<void> {
-    await this.request(`/agent/inbox/${entryId}/ack`, { method: "POST" });
+    await this.requestVoid(`/agent/inbox/${entryId}/ack`, { method: "POST" });
   }
 
   /** Renew lease on an inbox entry. */
   async renew(entryId: number): Promise<void> {
-    await this.request(`/agent/inbox/${entryId}/renew`, { method: "POST" });
+    await this.requestVoid(`/agent/inbox/${entryId}/renew`, { method: "POST" });
   }
 
-  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+  private async requestVoid(path: string, init?: RequestInit): Promise<void> {
+    const response = await this.doFetch(path, init);
+    if (!response.ok) {
+      throw await this.toSdkError(response);
+    }
+  }
+
+  private async requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.doFetch(path, init);
+    if (!response.ok) {
+      throw await this.toSdkError(response);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async doFetch(path: string, init?: RequestInit): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.token}`,
@@ -66,26 +77,19 @@ export class AgentHubSDK {
     if (init?.body) {
       headers["Content-Type"] = "application/json";
     }
-    const response = await fetch(url, { ...init, headers });
+    return fetch(url, { ...init, headers });
+  }
 
-    if (!response.ok) {
-      const body = await response.text();
-      let message: string;
-      try {
-        const json = JSON.parse(body) as { error?: string };
-        message = json.error ?? body;
-      } catch {
-        message = body;
-      }
-      throw new SdkError(response.status, message);
+  private async toSdkError(response: Response): Promise<SdkError> {
+    const body = await response.text();
+    let message: string;
+    try {
+      const json = JSON.parse(body) as { error?: string };
+      message = json.error ?? body;
+    } catch {
+      message = body;
     }
-
-    // 204 No Content
-    if (response.status === 204) {
-      return undefined as T;
-    }
-
-    return (await response.json()) as T;
+    return new SdkError(response.status, message);
   }
 }
 

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -1,0 +1,100 @@
+import type { Agent, InboxEntryWithMessage } from "@agent-hub/shared";
+
+export type SdkConfig = {
+  serverUrl: string;
+  token: string;
+};
+
+export type RegisterResult = {
+  agentId: string;
+  inboxId: string;
+  status: string;
+  displayName: string | null;
+};
+
+export type PullResult = {
+  entries: InboxEntryWithMessage[];
+  remaining: number;
+};
+
+export class AgentHubSDK {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(config: SdkConfig) {
+    // Strip trailing slash
+    this.baseUrl = config.serverUrl.replace(/\/+$/, "");
+    this.token = config.token;
+  }
+
+  /** Validate token, return agent identity. */
+  async register(): Promise<RegisterResult> {
+    const agent = await this.request<Agent>("/agent/me");
+    return {
+      agentId: agent.id,
+      inboxId: agent.inboxId,
+      status: agent.status,
+      displayName: agent.displayName,
+    };
+  }
+
+  /** Fetch pending inbox entries. */
+  async pull(limit = 10): Promise<PullResult> {
+    const entries = await this.request<InboxEntryWithMessage[]>(`/agent/inbox?limit=${limit}`);
+    return {
+      entries,
+      remaining: 0, // Server doesn't return remaining count yet
+    };
+  }
+
+  /** Acknowledge an inbox entry. */
+  async ack(entryId: number): Promise<void> {
+    await this.request(`/agent/inbox/${entryId}/ack`, { method: "POST" });
+  }
+
+  /** Renew lease on an inbox entry. */
+  async renew(entryId: number): Promise<void> {
+    await this.request(`/agent/inbox/${entryId}/renew`, { method: "POST" });
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+    };
+    // Only set Content-Type for requests with a body — Fastify rejects empty JSON bodies
+    if (init?.body) {
+      headers["Content-Type"] = "application/json";
+    }
+    const response = await fetch(url, { ...init, headers });
+
+    if (!response.ok) {
+      const body = await response.text();
+      let message: string;
+      try {
+        const json = JSON.parse(body) as { error?: string };
+        message = json.error ?? body;
+      } catch {
+        message = body;
+      }
+      throw new SdkError(response.status, message);
+    }
+
+    // 204 No Content
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+export class SdkError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SdkError";
+  }
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "references": [{ "path": "../shared" }]
+  "include": ["src"]
 }

--- a/packages/server/src/__tests__/e2e-github-to-cli.test.ts
+++ b/packages/server/src/__tests__/e2e-github-to-cli.test.ts
@@ -1,7 +1,9 @@
 import { createHmac } from "node:crypto";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { buildApp } from "../app.js";
+import { agents } from "../db/schema/agents.js";
+import { createAgent, createToken } from "../services/agent.js";
 
 /**
  * E2E: GitHub webhook → Server routes message → Agent pulls via SDK-equivalent fetch calls.
@@ -46,7 +48,6 @@ function sdkAck(baseUrl: string, token: string, entryId: number) {
 
 // Helper: create agent + token directly via admin-like DB operations
 async function createTestAgent(app: Awaited<ReturnType<typeof buildApp>>, opts: { id: string; displayName?: string }) {
-  const { createAgent, createToken } = await import("../services/agent.js");
   const agent = await createAgent(app.db, {
     id: opts.id,
     type: "autonomous_agent",
@@ -92,8 +93,6 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       displayName: "Issue Handler",
     });
 
-    const { agents } = await import("../db/schema/agents.js");
-    const { eq } = await import("drizzle-orm");
     await app.db
       .update(agents)
       .set({ metadata: { github: { repos: ["acme/my-repo"] } } })
@@ -234,7 +233,11 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
   });
 
   it("issue_comment event", async () => {
-    const { token } = await createTestAgent(app, { id: "comment-handler" });
+    const { agent, token } = await createTestAgent(app, { id: "comment-handler" });
+    await app.db
+      .update(agents)
+      .set({ metadata: { github: { repos: ["acme/repo"] } } })
+      .where(eq(agents.id, agent.id));
 
     const res = await fetch(`${address}/webhooks/github`, {
       method: "POST",

--- a/packages/server/src/__tests__/e2e-github-to-cli.test.ts
+++ b/packages/server/src/__tests__/e2e-github-to-cli.test.ts
@@ -1,0 +1,274 @@
+import { createHmac } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../app.js";
+
+/**
+ * E2E: GitHub webhook → Server routes message → Agent pulls via SDK-equivalent fetch calls.
+ *
+ * This test uses the local docker-compose PG (DATABASE_URL env) instead of testcontainers,
+ * to avoid Docker registry connectivity issues.
+ */
+
+const DATABASE_URL = process.env.DATABASE_URL ?? "postgresql://agenthub:agenthub@localhost:5432/agenthub";
+
+// SDK-equivalent helpers (same HTTP calls the CLI makes)
+async function sdkRequest<T>(baseUrl: string, token: string, path: string, init?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    ...Object.fromEntries(Object.entries(init?.headers ?? {})),
+  };
+  // Only set Content-Type for requests that have a body
+  if (init?.body) {
+    headers["Content-Type"] = "application/json";
+  }
+  const res = await fetch(`${baseUrl}${path}`, { ...init, headers });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function sdkRegister(baseUrl: string, token: string) {
+  return sdkRequest<{ id: string; inboxId: string; status: string }>(baseUrl, token, "/agent/me");
+}
+
+function sdkPull(baseUrl: string, token: string, limit = 10) {
+  return sdkRequest<Array<{ id: number; message: Record<string, unknown> }>>(
+    baseUrl,
+    token,
+    `/agent/inbox?limit=${limit}`,
+  );
+}
+
+function sdkAck(baseUrl: string, token: string, entryId: number) {
+  return sdkRequest<void>(baseUrl, token, `/agent/inbox/${entryId}/ack`, { method: "POST" });
+}
+
+// Helper: create agent + token directly via admin-like DB operations
+async function createTestAgent(app: Awaited<ReturnType<typeof buildApp>>, opts: { id: string; displayName?: string }) {
+  const { createAgent, createToken } = await import("../services/agent.js");
+  const agent = await createAgent(app.db, {
+    id: opts.id,
+    type: "autonomous_agent",
+    displayName: opts.displayName ?? "Test Agent",
+  });
+  const tokenResult = await createToken(app.db, agent.id, { name: "test" });
+  return { agent, token: tokenResult.token };
+}
+
+describe("E2E: GitHub issue → Server → CLI pull", () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+  let address: string;
+
+  beforeAll(async () => {
+    app = await buildApp({
+      databaseUrl: DATABASE_URL,
+      serverHost: "127.0.0.1",
+      serverPort: 0,
+      logger: false,
+      jwtSecretKey: "test-jwt-secret-key-for-e2e",
+      instanceId: "e2e-test",
+    });
+    await app.ready();
+    address = await app.listen({ port: 0, host: "127.0.0.1" });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  afterEach(async () => {
+    await app.db.execute(sql`
+      TRUNCATE TABLE inbox_entries, messages, chat_participants, chats,
+        agent_tokens, agent_presence, agents, admin_users, system_configs,
+        server_instances CASCADE
+    `);
+  });
+
+  it("full flow: webhook → inbox → pull → ack", async () => {
+    // 1. Create target agent with github.repos metadata
+    const { agent, token } = await createTestAgent(app, {
+      id: "issue-handler",
+      displayName: "Issue Handler",
+    });
+
+    const { agents } = await import("../db/schema/agents.js");
+    const { eq } = await import("drizzle-orm");
+    await app.db
+      .update(agents)
+      .set({ metadata: { github: { repos: ["acme/my-repo"] } } })
+      .where(eq(agents.id, agent.id));
+
+    // 2. Send GitHub issue webhook
+    const webhookRes = await fetch(`${address}/webhooks/github`, {
+      method: "POST",
+      headers: { "x-github-event": "issues", "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "opened",
+        issue: {
+          number: 42,
+          title: "Login page broken on mobile",
+          body: "Steps to reproduce:\n1. Open on iPhone\n2. Blank page",
+          html_url: "https://github.com/acme/my-repo/issues/42",
+          labels: [{ name: "bug" }, { name: "priority:high" }],
+          state: "open",
+        },
+        repository: { full_name: "acme/my-repo" },
+        sender: { login: "alice" },
+      }),
+    });
+
+    expect(webhookRes.status).toBe(200);
+    const webhookBody = (await webhookRes.json()) as Record<string, unknown>;
+    expect(webhookBody.ok).toBe(true);
+    expect(webhookBody.routed).toBe(true);
+
+    // 3. Register — verify agent identity
+    const identity = await sdkRegister(address, token);
+    expect(identity.id).toBe("issue-handler");
+    expect(identity.inboxId).toBe("inbox_issue-handler");
+
+    // 4. Pull — should have the GitHub issue message
+    const entries = await sdkPull(address, token, 10);
+    expect(entries.length).toBe(1);
+
+    const entry = entries[0];
+    if (!entry) throw new Error("Expected entry");
+
+    expect(entry.message.format).toBe("card");
+    expect(entry.message.senderId).toBe("github-adapter");
+
+    const content = entry.message.content as Record<string, unknown>;
+    expect(content.type).toBe("github_issue");
+    expect(content.action).toBe("opened");
+
+    const issue = content.issue as Record<string, unknown>;
+    expect(issue.number).toBe(42);
+    expect(issue.title).toBe("Login page broken on mobile");
+    expect(issue.url).toBe("https://github.com/acme/my-repo/issues/42");
+    expect(issue.labels).toEqual(["bug", "priority:high"]);
+    expect(content.repository).toBe("acme/my-repo");
+    expect(content.sender).toBe("alice");
+
+    const metadata = entry.message.metadata as Record<string, unknown>;
+    expect(metadata.source).toBe("github");
+    expect(metadata.event).toBe("issues");
+
+    // 5. ACK
+    await sdkAck(address, token, entry.id);
+
+    // 6. Pull again — empty
+    const entries2 = await sdkPull(address, token, 10);
+    expect(entries2.length).toBe(0);
+  });
+
+  it("webhook signature verification", async () => {
+    // Create app with webhook secret
+    const secret = "test-secret-123";
+    const app2 = await buildApp({
+      databaseUrl: DATABASE_URL,
+      serverHost: "127.0.0.1",
+      serverPort: 0,
+      logger: false,
+      jwtSecretKey: "test-jwt-secret-key-for-e2e-sig",
+      instanceId: "e2e-test-sig",
+      githubWebhookSecret: secret,
+    });
+    await app2.ready();
+    const addr2 = await app2.listen({ port: 0, host: "127.0.0.1" });
+
+    try {
+      const payload = JSON.stringify({
+        action: "opened",
+        issue: { number: 1, title: "Test", body: null, html_url: "", labels: [], state: "open" },
+        repository: { full_name: "acme/test" },
+        sender: { login: "bob" },
+      });
+
+      // No signature → 401
+      const noSig = await fetch(`${addr2}/webhooks/github`, {
+        method: "POST",
+        headers: { "x-github-event": "issues", "content-type": "application/json" },
+        body: payload,
+      });
+      expect(noSig.status).toBe(401);
+
+      // Wrong signature → 401
+      const wrongSig = await fetch(`${addr2}/webhooks/github`, {
+        method: "POST",
+        headers: {
+          "x-github-event": "issues",
+          "content-type": "application/json",
+          "x-hub-signature-256": "sha256=wrong",
+        },
+        body: payload,
+      });
+      expect(wrongSig.status).toBe(401);
+
+      // Correct signature → 200
+      const sig = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
+      const ok = await fetch(`${addr2}/webhooks/github`, {
+        method: "POST",
+        headers: {
+          "x-github-event": "issues",
+          "content-type": "application/json",
+          "x-hub-signature-256": sig,
+        },
+        body: payload,
+      });
+      expect(ok.status).toBe(200);
+    } finally {
+      await app2.close();
+    }
+  });
+
+  it("ping event", async () => {
+    const res = await fetch(`${address}/webhooks/github`, {
+      method: "POST",
+      headers: { "x-github-event": "ping", "content-type": "application/json" },
+      body: JSON.stringify({ zen: "Anything added dilutes everything else." }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.event).toBe("ping");
+  });
+
+  it("issue_comment event", async () => {
+    const { token } = await createTestAgent(app, { id: "comment-handler" });
+
+    const res = await fetch(`${address}/webhooks/github`, {
+      method: "POST",
+      headers: { "x-github-event": "issue_comment", "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "created",
+        issue: {
+          number: 7,
+          title: "Feature request",
+          body: "Add dark mode",
+          html_url: "https://github.com/acme/repo/issues/7",
+          labels: [{ name: "enhancement" }],
+          state: "open",
+        },
+        comment: {
+          body: "I'd love this feature too! +1",
+          html_url: "https://github.com/acme/repo/issues/7#issuecomment-123",
+          user: { login: "charlie" },
+        },
+        repository: { full_name: "acme/repo" },
+        sender: { login: "charlie" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).routed).toBe(true);
+
+    // Pull
+    const entries = await sdkPull(address, token, 10);
+    expect(entries.length).toBe(1);
+
+    const content = entries[0]?.message.content as Record<string, unknown>;
+    expect(content.type).toBe("github_issue_comment");
+    const comment = content.comment as Record<string, unknown>;
+    expect(comment.body).toBe("I'd love this feature too! +1");
+    expect(comment.author).toBe("charlie");
+  });
+});

--- a/packages/server/src/__tests__/global-setup.ts
+++ b/packages/server/src/__tests__/global-setup.ts
@@ -3,7 +3,7 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql";
 let container: Awaited<ReturnType<PostgreSqlContainer["start"]>>;
 
 export async function setup() {
-  container = await new PostgreSqlContainer("postgres:16-alpine").start();
+  container = await new PostgreSqlContainer("postgres:17").start();
 
   const url = container.getConnectionUri();
   process.env.DATABASE_URL = url;

--- a/packages/server/src/__tests__/global-setup.ts
+++ b/packages/server/src/__tests__/global-setup.ts
@@ -3,7 +3,7 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql";
 let container: Awaited<ReturnType<PostgreSqlContainer["start"]>>;
 
 export async function setup() {
-  container = await new PostgreSqlContainer("postgres:17").start();
+  container = await new PostgreSqlContainer("postgres:16-alpine").start();
 
   const url = container.getConnectionUri();
   process.env.DATABASE_URL = url;

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -1,0 +1,322 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance, FastifyReply } from "fastify";
+import type { Database } from "../../db/connection.js";
+import { agents } from "../../db/schema/agents.js";
+import { BadRequestError, UnauthorizedError } from "../../errors.js";
+import { createAgent } from "../../services/agent.js";
+import { sendToAgent } from "../../services/message.js";
+
+// ── GitHub payload types ────────────────────────────────────────────
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  labels: Array<{ name: string }>;
+  state: string;
+};
+
+type GitHubComment = {
+  body: string;
+  html_url: string;
+  user: { login: string };
+};
+
+type GitHubRepository = {
+  full_name: string;
+};
+
+type GitHubSender = {
+  login: string;
+};
+
+type GitHubIssuesPayload = {
+  action: string;
+  issue: GitHubIssue;
+  repository: GitHubRepository;
+  sender: GitHubSender;
+};
+
+type GitHubIssueCommentPayload = {
+  action: string;
+  issue: GitHubIssue;
+  comment: GitHubComment;
+  repository: GitHubRepository;
+  sender: GitHubSender;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const GITHUB_ADAPTER_ID = "github-adapter";
+
+function verifySignature(secret: string, rawBody: Buffer, signatureHeader: string): void {
+  const expected = `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+  const expectedBuf = Buffer.from(expected, "utf8");
+  const receivedBuf = Buffer.from(signatureHeader, "utf8");
+
+  if (expectedBuf.length !== receivedBuf.length || !timingSafeEqual(expectedBuf, receivedBuf)) {
+    throw new UnauthorizedError("Invalid webhook signature");
+  }
+}
+
+async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
+  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, GITHUB_ADAPTER_ID)).limit(1);
+
+  if (existing) {
+    return existing.id;
+  }
+
+  const agent = await createAgent(db, {
+    id: GITHUB_ADAPTER_ID,
+    type: "autonomous_agent",
+    displayName: "GitHub Adapter",
+    metadata: { source: "github", managed: true },
+  });
+
+  return agent.id;
+}
+
+async function findTargetAgent(db: Database, repoFullName: string): Promise<string | null> {
+  // First: look for an agent whose metadata has github.repos containing the repo full_name
+  const allAgents = await db
+    .select({ id: agents.id, metadata: agents.metadata, type: agents.type })
+    .from(agents)
+    .where(eq(agents.status, "active"));
+
+  for (const agent of allAgents) {
+    if (agent.id === GITHUB_ADAPTER_ID) continue;
+    const meta = agent.metadata;
+    if (meta && typeof meta === "object" && "github" in meta) {
+      const github = meta.github;
+      if (isRecord(github) && "repos" in github) {
+        const repos = github.repos;
+        if (Array.isArray(repos) && repos.includes(repoFullName)) {
+          return agent.id;
+        }
+      }
+    }
+  }
+
+  // Fallback: any autonomous_agent that is not the github-adapter
+  for (const agent of allAgents) {
+    if (agent.id === GITHUB_ADAPTER_ID) continue;
+    if (agent.type === "autonomous_agent") {
+      return agent.id;
+    }
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseIssuesPayload(body: unknown): GitHubIssuesPayload {
+  if (!isRecord(body)) throw new BadRequestError("Invalid payload: expected object");
+  if (typeof body.action !== "string") throw new BadRequestError("Invalid payload: missing action");
+  if (!isRecord(body.issue)) throw new BadRequestError("Invalid payload: missing issue");
+  if (!isRecord(body.repository)) throw new BadRequestError("Invalid payload: missing repository");
+  if (!isRecord(body.sender)) throw new BadRequestError("Invalid payload: missing sender");
+
+  const issue = body.issue;
+  const labels = Array.isArray(issue.labels)
+    ? issue.labels.filter((l): l is { name: string } => isRecord(l) && typeof l.name === "string")
+    : [];
+
+  return {
+    action: body.action,
+    issue: {
+      number: typeof issue.number === "number" ? issue.number : 0,
+      title: typeof issue.title === "string" ? issue.title : "",
+      body: typeof issue.body === "string" ? issue.body : null,
+      html_url: typeof issue.html_url === "string" ? issue.html_url : "",
+      labels,
+      state: typeof issue.state === "string" ? issue.state : "open",
+    },
+    repository: {
+      full_name: typeof body.repository.full_name === "string" ? body.repository.full_name : "",
+    },
+    sender: {
+      login: typeof body.sender.login === "string" ? body.sender.login : "",
+    },
+  };
+}
+
+function parseIssueCommentPayload(body: unknown): GitHubIssueCommentPayload {
+  const base = parseIssuesPayload(body);
+  const record = body as Record<string, unknown>; // validated by parseIssuesPayload
+  if (!isRecord(record.comment)) throw new BadRequestError("Invalid payload: missing comment");
+
+  const comment = record.comment;
+  const commentUser = isRecord(comment.user) ? comment.user : { login: "" };
+
+  return {
+    ...base,
+    comment: {
+      body: typeof comment.body === "string" ? comment.body : "",
+      html_url: typeof comment.html_url === "string" ? comment.html_url : "",
+      user: {
+        login: typeof commentUser.login === "string" ? commentUser.login : "",
+      },
+    },
+  };
+}
+
+// ── Route ───────────────────────────────────────────────────────────
+
+export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
+  // Register a custom content type parser to capture the raw body for signature verification
+  app.addContentTypeParser("application/json", { parseAs: "buffer" }, (_request, body, done) => {
+    done(null, body);
+  });
+
+  app.post("/github", async (request, reply) => {
+    const rawBody = request.body;
+    if (!Buffer.isBuffer(rawBody)) {
+      throw new BadRequestError("Expected raw body buffer");
+    }
+
+    // Verify signature if secret is configured
+    const secret = app.config.githubWebhookSecret;
+    if (secret) {
+      const signatureHeader = request.headers["x-hub-signature-256"];
+      if (typeof signatureHeader !== "string") {
+        throw new UnauthorizedError("Missing x-hub-signature-256 header");
+      }
+      verifySignature(secret, rawBody, signatureHeader);
+    }
+
+    // Parse JSON from raw body
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody.toString("utf8"));
+    } catch {
+      throw new BadRequestError("Invalid JSON payload");
+    }
+
+    const eventType = request.headers["x-github-event"];
+    if (typeof eventType !== "string") {
+      throw new BadRequestError("Missing x-github-event header");
+    }
+
+    // Handle ping event (GitHub sends this when webhook is first configured)
+    if (eventType === "ping") {
+      return reply.status(200).send({ ok: true, event: "ping" });
+    }
+
+    if (eventType === "issues") {
+      return handleIssuesEvent(app, payload, reply);
+    }
+
+    if (eventType === "issue_comment") {
+      return handleIssueCommentEvent(app, payload, reply);
+    }
+
+    // Unhandled event type — acknowledge but do nothing
+    return reply.status(200).send({ ok: true, event: eventType, handled: false });
+  });
+}
+
+async function handleIssuesEvent(app: FastifyInstance, payload: unknown, reply: FastifyReply): Promise<unknown> {
+  const data = parseIssuesPayload(payload);
+
+  // Only handle specific actions
+  const handledActions = ["opened", "edited", "labeled"];
+  if (!handledActions.includes(data.action)) {
+    return reply.status(200).send({ ok: true, event: "issues", action: data.action, handled: false });
+  }
+
+  const [senderId, targetAgentId] = await Promise.all([
+    ensureGitHubAdapterAgent(app.db),
+    findTargetAgent(app.db, data.repository.full_name),
+  ]);
+
+  if (!targetAgentId) {
+    app.log.warn(`No target agent found for GitHub issue event on ${data.repository.full_name}`);
+    return reply.status(200).send({ ok: true, event: "issues", action: data.action, routed: false });
+  }
+
+  const content = {
+    type: "github_issue",
+    action: data.action,
+    issue: {
+      number: data.issue.number,
+      title: data.issue.title,
+      body: data.issue.body,
+      url: data.issue.html_url,
+      labels: data.issue.labels.map((l) => l.name),
+      state: data.issue.state,
+    },
+    repository: data.repository.full_name,
+    sender: data.sender.login,
+  };
+
+  const metadata = {
+    source: "github",
+    event: "issues",
+    action: data.action,
+  };
+
+  await sendToAgent(app.db, senderId, targetAgentId, {
+    format: "card",
+    content,
+    metadata,
+  });
+
+  return reply.status(200).send({ ok: true, event: "issues", action: data.action, routed: true });
+}
+
+async function handleIssueCommentEvent(app: FastifyInstance, payload: unknown, reply: FastifyReply): Promise<unknown> {
+  const data = parseIssueCommentPayload(payload);
+
+  // Only handle "created" action
+  if (data.action !== "created") {
+    return reply.status(200).send({ ok: true, event: "issue_comment", action: data.action, handled: false });
+  }
+
+  const [senderId, targetAgentId] = await Promise.all([
+    ensureGitHubAdapterAgent(app.db),
+    findTargetAgent(app.db, data.repository.full_name),
+  ]);
+
+  if (!targetAgentId) {
+    app.log.warn(`No target agent found for GitHub issue_comment event on ${data.repository.full_name}`);
+    return reply.status(200).send({ ok: true, event: "issue_comment", action: data.action, routed: false });
+  }
+
+  const content = {
+    type: "github_issue_comment",
+    action: data.action,
+    issue: {
+      number: data.issue.number,
+      title: data.issue.title,
+      url: data.issue.html_url,
+      labels: data.issue.labels.map((l) => l.name),
+      state: data.issue.state,
+    },
+    comment: {
+      body: data.comment.body,
+      url: data.comment.html_url,
+      author: data.comment.user.login,
+    },
+    repository: data.repository.full_name,
+    sender: data.sender.login,
+  };
+
+  const metadata = {
+    source: "github",
+    event: "issue_comment",
+    action: data.action,
+  };
+
+  await sendToAgent(app.db, senderId, targetAgentId, {
+    format: "card",
+    content,
+    metadata,
+  });
+
+  return reply.status(200).send({ ok: true, event: "issue_comment", action: data.action, routed: true });
+}

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply } from "fastify";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
-import { BadRequestError, UnauthorizedError } from "../../errors.js";
+import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
 import { createAgent } from "../../services/agent.js";
 import { sendToAgent } from "../../services/message.js";
 
@@ -68,14 +68,26 @@ async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
     return existing.id;
   }
 
-  const agent = await createAgent(db, {
-    id: GITHUB_ADAPTER_ID,
-    type: "autonomous_agent",
-    displayName: "GitHub Adapter",
-    metadata: { source: "github", managed: true },
-  });
-
-  return agent.id;
+  try {
+    const agent = await createAgent(db, {
+      id: GITHUB_ADAPTER_ID,
+      type: "autonomous_agent",
+      displayName: "GitHub Adapter",
+      metadata: { source: "github", managed: true },
+    });
+    return agent.id;
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      // Another concurrent request created it first
+      const [created] = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(eq(agents.id, GITHUB_ADAPTER_ID))
+        .limit(1);
+      if (created) return created.id;
+    }
+    throw err;
+  }
 }
 
 async function findTargetAgent(db: Database, repoFullName: string): Promise<string | null> {
@@ -96,14 +108,6 @@ async function findTargetAgent(db: Database, repoFullName: string): Promise<stri
           return agent.id;
         }
       }
-    }
-  }
-
-  // Fallback: any autonomous_agent that is not the github-adapter
-  for (const agent of allAgents) {
-    if (agent.id === GITHUB_ADAPTER_ID) continue;
-    if (agent.type === "autonomous_agent") {
-      return agent.id;
     }
   }
 
@@ -147,10 +151,10 @@ function parseIssuesPayload(body: unknown): GitHubIssuesPayload {
 
 function parseIssueCommentPayload(body: unknown): GitHubIssueCommentPayload {
   const base = parseIssuesPayload(body);
-  const record = body as Record<string, unknown>; // validated by parseIssuesPayload
-  if (!isRecord(record.comment)) throw new BadRequestError("Invalid payload: missing comment");
+  if (!isRecord(body)) throw new BadRequestError("Invalid payload: expected object");
+  if (!isRecord(body.comment)) throw new BadRequestError("Invalid payload: missing comment");
 
-  const comment = record.comment;
+  const comment = body.comment;
   const commentUser = isRecord(comment.user) ? comment.user : { login: "" };
 
   return {
@@ -168,10 +172,16 @@ function parseIssueCommentPayload(body: unknown): GitHubIssueCommentPayload {
 // ── Route ───────────────────────────────────────────────────────────
 
 export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
-  // Register a custom content type parser to capture the raw body for signature verification
+  // Scoped to this plugin only (/webhooks). If other webhook adapters (Slack, Feishu)
+  // are added under the same prefix, they should be registered as separate sub-plugins
+  // to avoid inheriting this raw-buffer parser.
   app.addContentTypeParser("application/json", { parseAs: "buffer" }, (_request, body, done) => {
     done(null, body);
   });
+
+  if (!app.config.githubWebhookSecret) {
+    app.log.warn("GITHUB_WEBHOOK_SECRET is not set — webhook signature verification is disabled");
+  }
 
   app.post("/github", async (request, reply) => {
     const rawBody = request.body;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -12,6 +12,7 @@ import { agentMeRoutes } from "./api/agent/me.js";
 import { agentMessageRoutes, agentSendToAgentRoutes } from "./api/agent/messages.js";
 import { agentWsRoutes } from "./api/agent/ws.js";
 import { healthRoutes } from "./api/health.js";
+import { githubWebhookRoutes } from "./api/webhooks/github.js";
 import type { Config } from "./config.js";
 import { connectDatabase } from "./db/connection.js";
 import { AppError } from "./errors.js";
@@ -61,6 +62,7 @@ export async function buildApp(config: Config) {
 
   // Public routes
   await app.register(healthRoutes);
+  await app.register(githubWebhookRoutes, { prefix: "/webhooks" });
   await app.register(adminAuthRoutes, { prefix: "/admin/auth" });
 
   // Admin routes (JWT protected)

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -9,6 +9,7 @@ export type Config = {
   jwtSecretKey: string;
   instanceId: string;
   logger?: boolean;
+  githubWebhookSecret?: string;
 };
 
 export function loadConfig(): Config {
@@ -28,5 +29,6 @@ export function loadConfig(): Config {
     serverPort: Number(env.SERVER_PORT ?? "8000"),
     jwtSecretKey,
     instanceId: env.INSTANCE_ID ?? `srv_${randomUUID().slice(0, 8)}`,
+    githubWebhookSecret: env.GITHUB_WEBHOOK_SECRET || undefined,
   };
 }

--- a/packages/server/vitest.e2e.config.ts
+++ b/packages/server/vitest.e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+/** E2E tests — uses local docker-compose PG, no testcontainers. */
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/e2e-*.test.ts"],
+    fileParallelism: false,
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@agent-hub/shared':
         specifier: workspace:*
         version: link:../shared
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -1399,6 +1402,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -3411,6 +3418,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@13.1.0: {}
 
   compress-commons@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- **GitHub Webhook Adapter** (`POST /webhooks/github`): handles `issues`, `issue_comment`, `ping` events with optional HMAC-SHA256 signature verification. Auto-creates `github-adapter` agent and routes messages by agent `metadata.github.repos`.
- **Client SDK** (`AgentHubSDK`): stateless HTTP client with `register()`, `pull()`, `ack()`, `renew()` methods and structured `SdkError`.
- **CLI** (`agent-hub`): two commands — `register` (validate token) and `pull [--ack]` (fetch + optional auto-ACK). JSON-only output, auth via env vars.
- **E2E Tests**: 4 test cases covering full flow, signature verification, ping, and issue_comment events.

## Verified

Tested the full real-world flow locally:

```
GitHub Issue #6 created → webhook POST to local server (via ngrok)
  → Server routes to issue-bot agent inbox
  → agent-hub pull → receives github_issue card
  → agent-hub pull --ack → ACK and consume
```

Both `issues` and `issue_comment` events verified end-to-end with real GitHub webhooks.

## Test plan

- [x] E2E tests pass (`vitest --config vitest.e2e.config.ts`)
- [x] Typecheck clean (`tsc --noEmit` for server and client)
- [x] Lint/format clean (`biome check`)
- [x] Real GitHub webhook delivery verified via ngrok tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)