### PR TITLE
refactor: add /api/v1 prefix and web static file hosting

### DIFF
--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -28,7 +28,7 @@ export class AgentHubSDK {
 
   /** Validate token, return agent identity. */
   async register(): Promise<RegisterResult> {
-    const agent = await this.requestJson<Agent>("/agent/me");
+    const agent = await this.requestJson<Agent>("/api/v1/agent/me");
     return {
       agentId: agent.id,
       inboxId: agent.inboxId,
@@ -39,18 +39,18 @@ export class AgentHubSDK {
 
   /** Fetch pending inbox entries. */
   async pull(limit = 10): Promise<PullResult> {
-    const entries = await this.requestJson<InboxEntryWithMessage[]>(`/agent/inbox?limit=${limit}`);
+    const entries = await this.requestJson<InboxEntryWithMessage[]>(`/api/v1/agent/inbox?limit=${limit}`);
     return { entries };
   }
 
   /** Acknowledge an inbox entry. */
   async ack(entryId: number): Promise<void> {
-    await this.requestVoid(`/agent/inbox/${entryId}/ack`, { method: "POST" });
+    await this.requestVoid(`/api/v1/agent/inbox/${entryId}/ack`, { method: "POST" });
   }
 
   /** Renew lease on an inbox entry. */
   async renew(entryId: number): Promise<void> {
-    await this.requestVoid(`/agent/inbox/${entryId}/renew`, { method: "POST" });
+    await this.requestVoid(`/api/v1/agent/inbox/${entryId}/renew`, { method: "POST" });
   }
 
   private async requestVoid(path: string, init?: RequestInit): Promise<void> {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@agent-hub/shared": "workspace:*",
+    "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
     "bcrypt": "^6.0.0",
     "drizzle-orm": "^0.44.0",

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -20,7 +20,7 @@ describe("Admin Agents API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    const createRes = await req("POST", "/admin/agents", {
+    const createRes = await req("POST", "/api/v1/admin/agents", {
       id: "agent-1",
       type: "autonomous_agent",
       displayName: "Bot One",
@@ -30,7 +30,7 @@ describe("Admin Agents API", () => {
     expect(agent.id).toBe("agent-1");
     expect(agent.inboxId).toBe("inbox_agent-1");
 
-    const getRes = await req("GET", "/admin/agents/agent-1");
+    const getRes = await req("GET", "/api/v1/admin/agents/agent-1");
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().id).toBe("agent-1");
   });
@@ -38,10 +38,10 @@ describe("Admin Agents API", () => {
   it("lists agents with pagination", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await req("POST", "/admin/agents", { id: "a1", type: "human" });
-    await req("POST", "/admin/agents", { id: "a2", type: "human" });
+    await req("POST", "/api/v1/admin/agents", { id: "a1", type: "human" });
+    await req("POST", "/api/v1/admin/agents", { id: "a2", type: "human" });
 
-    const res = await req("GET", "/admin/agents?limit=1");
+    const res = await req("GET", "/api/v1/admin/agents?limit=1");
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.items).toHaveLength(1);
@@ -51,9 +51,9 @@ describe("Admin Agents API", () => {
   it("updates an agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await req("POST", "/admin/agents", { id: "upd-1", type: "human" });
+    await req("POST", "/api/v1/admin/agents", { id: "upd-1", type: "human" });
 
-    const res = await req("PATCH", "/admin/agents/upd-1", {
+    const res = await req("PATCH", "/api/v1/admin/agents/upd-1", {
       displayName: "Updated",
       status: "suspended",
     });
@@ -64,7 +64,7 @@ describe("Admin Agents API", () => {
 
   it("rejects unauthenticated requests", async () => {
     const app = await appPromise;
-    const res = await app.inject({ method: "GET", url: "/admin/agents" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/admin/agents" });
     expect(res.statusCode).toBe(401);
   });
 
@@ -72,22 +72,22 @@ describe("Admin Agents API", () => {
     it("creates, lists, and revokes tokens", async () => {
       const app = await appPromise;
       const req = await authedRequest(app);
-      await req("POST", "/admin/agents", { id: "tok-agent", type: "autonomous_agent" });
+      await req("POST", "/api/v1/admin/agents", { id: "tok-agent", type: "autonomous_agent" });
 
       // Create token
-      const createRes = await req("POST", "/admin/agents/tok-agent/tokens", { name: "dev" });
+      const createRes = await req("POST", "/api/v1/admin/agents/tok-agent/tokens", { name: "dev" });
       expect(createRes.statusCode).toBe(201);
       const tokenBody = createRes.json();
       expect(tokenBody.token).toMatch(/^aghub_/);
       expect(tokenBody.name).toBe("dev");
 
       // List tokens
-      const listRes = await req("GET", "/admin/agents/tok-agent/tokens");
+      const listRes = await req("GET", "/api/v1/admin/agents/tok-agent/tokens");
       expect(listRes.statusCode).toBe(200);
       expect(listRes.json()).toHaveLength(1);
 
       // Revoke token
-      const revokeRes = await req("DELETE", `/admin/agents/tok-agent/tokens/${tokenBody.id}`);
+      const revokeRes = await req("DELETE", `/api/v1/admin/agents/tok-agent/tokens/${tokenBody.id}`);
       expect(revokeRes.statusCode).toBe(204);
     });
   });

--- a/packages/server/src/__tests__/admin-auth.test.ts
+++ b/packages/server/src/__tests__/admin-auth.test.ts
@@ -5,7 +5,7 @@ describe("Admin Auth", () => {
   const appPromise = createTestApp();
   afterAll(async () => (await appPromise).close());
 
-  describe("POST /admin/auth/login", () => {
+  describe("POST /api/v1/admin/auth/login", () => {
     it("returns tokens on valid credentials", async () => {
       const app = await appPromise;
       const admin = await createTestAdmin(app);
@@ -18,7 +18,7 @@ describe("Admin Auth", () => {
       await createTestAdmin(app);
       const res = await app.inject({
         method: "POST",
-        url: "/admin/auth/login",
+        url: "/api/v1/admin/auth/login",
         payload: { username: "admin", password: "wrong" },
       });
       expect(res.statusCode).toBe(401);
@@ -28,20 +28,20 @@ describe("Admin Auth", () => {
       const app = await appPromise;
       const res = await app.inject({
         method: "POST",
-        url: "/admin/auth/login",
+        url: "/api/v1/admin/auth/login",
         payload: { username: "nobody", password: "whatever" },
       });
       expect(res.statusCode).toBe(401);
     });
   });
 
-  describe("POST /admin/auth/refresh", () => {
+  describe("POST /api/v1/admin/auth/refresh", () => {
     it("returns new access token", async () => {
       const app = await appPromise;
       const admin = await createTestAdmin(app);
       const res = await app.inject({
         method: "POST",
-        url: "/admin/auth/refresh",
+        url: "/api/v1/admin/auth/refresh",
         payload: { refreshToken: admin.refreshToken },
       });
       expect(res.statusCode).toBe(200);
@@ -52,7 +52,7 @@ describe("Admin Auth", () => {
       const app = await appPromise;
       const res = await app.inject({
         method: "POST",
-        url: "/admin/auth/refresh",
+        url: "/api/v1/admin/auth/refresh",
         payload: { refreshToken: "invalid" },
       });
       expect(res.statusCode).toBe(401);

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -21,32 +21,32 @@ describe("Admin DELETE Agent API", () => {
     const req = await authedRequest(app);
 
     // Create agent with token
-    await req("POST", "/admin/agents", { id: "del-agent", type: "autonomous_agent" });
-    const tokenRes = await req("POST", "/admin/agents/del-agent/tokens", { name: "test" });
+    await req("POST", "/api/v1/admin/agents", { id: "del-agent", type: "autonomous_agent" });
+    const tokenRes = await req("POST", "/api/v1/admin/agents/del-agent/tokens", { name: "test" });
     expect(tokenRes.statusCode).toBe(201);
     const token = tokenRes.json().token;
 
     // Verify agent works
     const meRes = await app.inject({
       method: "GET",
-      url: "/agent/me",
+      url: "/api/v1/agent/me",
       headers: { authorization: `Bearer ${token}` },
     });
     expect(meRes.statusCode).toBe(200);
 
     // Delete agent
-    const delRes = await req("DELETE", "/admin/agents/del-agent");
+    const delRes = await req("DELETE", "/api/v1/admin/agents/del-agent");
     expect(delRes.statusCode).toBe(204);
 
     // Verify agent is suspended
-    const getRes = await req("GET", "/admin/agents/del-agent");
+    const getRes = await req("GET", "/api/v1/admin/agents/del-agent");
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().status).toBe("suspended");
 
     // Token should no longer work
     const meRes2 = await app.inject({
       method: "GET",
-      url: "/agent/me",
+      url: "/api/v1/agent/me",
       headers: { authorization: `Bearer ${token}` },
     });
     expect(meRes2.statusCode).toBe(401);
@@ -56,7 +56,7 @@ describe("Admin DELETE Agent API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    const res = await req("DELETE", "/admin/agents/non-existent");
+    const res = await req("DELETE", "/api/v1/admin/agents/non-existent");
     expect(res.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/__tests__/admin-overview.test.ts
+++ b/packages/server/src/__tests__/admin-overview.test.ts
@@ -14,14 +14,14 @@ describe("Admin Overview API", () => {
     // Create a chat
     await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
 
     const res = await app.inject({
       method: "GET",
-      url: "/admin/overview",
+      url: "/api/v1/admin/overview",
       headers: { authorization: `Bearer ${admin.accessToken}` },
     });
     expect(res.statusCode).toBe(200);
@@ -33,7 +33,7 @@ describe("Admin Overview API", () => {
 
   it("rejects unauthenticated requests", async () => {
     const app = await appPromise;
-    const res = await app.inject({ method: "GET", url: "/admin/overview" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/admin/overview" });
     expect(res.statusCode).toBe(401);
   });
 });

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -12,7 +12,7 @@ describe("Agent Chats API", () => {
 
     const createRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         type: "direct",
@@ -28,7 +28,7 @@ describe("Agent Chats API", () => {
 
     const getRes = await app.inject({
       method: "GET",
-      url: `/agent/chats/${chat.id}`,
+      url: `/api/v1/agent/chats/${chat.id}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(getRes.statusCode).toBe(200);
@@ -42,14 +42,14 @@ describe("Agent Chats API", () => {
 
     await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
 
     const res = await app.inject({
       method: "GET",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(200);
@@ -62,7 +62,7 @@ describe("Agent Chats API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: ["non-existent"] },
     });
@@ -77,7 +77,7 @@ describe("Agent Chats API", () => {
 
     const createRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t2}` },
       payload: { type: "direct", participantIds: [a3.id] },
     });
@@ -85,7 +85,7 @@ describe("Agent Chats API", () => {
 
     const res = await app.inject({
       method: "GET",
-      url: `/agent/chats/${chatId}`,
+      url: `/api/v1/agent/chats/${chatId}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(403);

--- a/packages/server/src/__tests__/agent-inbox.test.ts
+++ b/packages/server/src/__tests__/agent-inbox.test.ts
@@ -13,7 +13,7 @@ describe("Agent Inbox API", () => {
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
@@ -21,7 +21,7 @@ describe("Agent Inbox API", () => {
 
     await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Inbox test" },
     });
@@ -29,7 +29,7 @@ describe("Agent Inbox API", () => {
     // Poll inbox as recipient
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes.statusCode).toBe(200);
@@ -40,7 +40,7 @@ describe("Agent Inbox API", () => {
     // ACK the entry
     const ackRes = await app.inject({
       method: "POST",
-      url: `/agent/inbox/${entryId}/ack`,
+      url: `/api/v1/agent/inbox/${entryId}/ack`,
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(ackRes.statusCode).toBe(204);
@@ -48,7 +48,7 @@ describe("Agent Inbox API", () => {
     // Poll again — should be empty
     const pollRes2 = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes2.json()).toHaveLength(0);
@@ -56,7 +56,7 @@ describe("Agent Inbox API", () => {
 
   it("rejects unauthenticated inbox access", async () => {
     const app = await appPromise;
-    const res = await app.inject({ method: "GET", url: "/agent/inbox" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/agent/inbox" });
     expect(res.statusCode).toBe(401);
   });
 });

--- a/packages/server/src/__tests__/agent-messages.test.ts
+++ b/packages/server/src/__tests__/agent-messages.test.ts
@@ -11,7 +11,7 @@ describe("Agent Messages API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
@@ -25,7 +25,7 @@ describe("Agent Messages API", () => {
 
     const sendRes = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Hello!" },
     });
@@ -34,7 +34,7 @@ describe("Agent Messages API", () => {
 
     const listRes = await app.inject({
       method: "GET",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(listRes.statusCode).toBe(200);
@@ -47,7 +47,7 @@ describe("Agent Messages API", () => {
 
     const sendRes = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         format: "text",
@@ -68,7 +68,7 @@ describe("Agent Messages API", () => {
 
     await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Fan-out test" },
     });
@@ -76,7 +76,7 @@ describe("Agent Messages API", () => {
     // Recipient should have inbox entries
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes.statusCode).toBe(200);
@@ -92,7 +92,7 @@ describe("Agent Messages API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${outsider}` },
       payload: { format: "text", content: "Intruder!" },
     });

--- a/packages/server/src/__tests__/agent-participants.test.ts
+++ b/packages/server/src/__tests__/agent-participants.test.ts
@@ -13,7 +13,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "group", participantIds: [a2.id] },
     });
@@ -27,7 +27,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/participants`,
+      url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { agentId: a3.id },
     });
@@ -43,7 +43,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/participants`,
+      url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { agentId: a2.id },
     });
@@ -56,7 +56,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/participants`,
+      url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { agentId: "non-existent-agent" },
     });
@@ -69,7 +69,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/agent/chats/${chatId}/participants/${a2.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a2.id}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(204);
@@ -77,7 +77,7 @@ describe("Agent Participants API", () => {
     // Verify participant is removed
     const detail = await app.inject({
       method: "GET",
-      url: `/agent/chats/${chatId}`,
+      url: `/api/v1/agent/chats/${chatId}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     const participants = detail.json().participants;
@@ -91,7 +91,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/agent/chats/${chatId}/participants/${a3.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a3.id}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(404);
@@ -103,7 +103,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/agent/chats/${chatId}/participants/${a1.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a1.id}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(400);
@@ -115,7 +115,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/participants`,
+      url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t3}` },
       payload: { agentId: a3.id },
     });

--- a/packages/server/src/__tests__/agent-send-to-agent.test.ts
+++ b/packages/server/src/__tests__/agent-send-to-agent.test.ts
@@ -12,7 +12,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Hello agent!" },
     });
@@ -24,7 +24,7 @@ describe("Agent Send-to-Agent API", () => {
     // Recipient should see the message in inbox
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes.statusCode).toBe(200);
@@ -40,7 +40,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res1 = await app.inject({
       method: "POST",
-      url: `/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "First message" },
     });
@@ -48,7 +48,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res2 = await app.inject({
       method: "POST",
-      url: `/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Second message" },
     });
@@ -63,7 +63,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: "/agent/agents/non-existent/messages",
+      url: "/api/v1/agent/agents/non-existent/messages",
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Hello?" },
     });
@@ -77,7 +77,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         format: "text",

--- a/packages/server/src/__tests__/e2e-github-to-cli.test.ts
+++ b/packages/server/src/__tests__/e2e-github-to-cli.test.ts
@@ -31,19 +31,19 @@ async function sdkRequest<T>(baseUrl: string, token: string, path: string, init?
 }
 
 function sdkRegister(baseUrl: string, token: string) {
-  return sdkRequest<{ id: string; inboxId: string; status: string }>(baseUrl, token, "/agent/me");
+  return sdkRequest<{ id: string; inboxId: string; status: string }>(baseUrl, token, "/api/v1/agent/me");
 }
 
 function sdkPull(baseUrl: string, token: string, limit = 10) {
   return sdkRequest<Array<{ id: number; message: Record<string, unknown> }>>(
     baseUrl,
     token,
-    `/agent/inbox?limit=${limit}`,
+    `/api/v1/agent/inbox?limit=${limit}`,
   );
 }
 
 function sdkAck(baseUrl: string, token: string, entryId: number) {
-  return sdkRequest<void>(baseUrl, token, `/agent/inbox/${entryId}/ack`, { method: "POST" });
+  return sdkRequest<void>(baseUrl, token, `/api/v1/agent/inbox/${entryId}/ack`, { method: "POST" });
 }
 
 // Helper: create agent + token directly via admin-like DB operations
@@ -99,7 +99,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       .where(eq(agents.id, agent.id));
 
     // 2. Send GitHub issue webhook
-    const webhookRes = await fetch(`${address}/webhooks/github`, {
+    const webhookRes = await fetch(`${address}/api/v1/webhooks/github`, {
       method: "POST",
       headers: { "x-github-event": "issues", "content-type": "application/json" },
       body: JSON.stringify({
@@ -185,7 +185,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       });
 
       // No signature → 401
-      const noSig = await fetch(`${addr2}/webhooks/github`, {
+      const noSig = await fetch(`${addr2}/api/v1/webhooks/github`, {
         method: "POST",
         headers: { "x-github-event": "issues", "content-type": "application/json" },
         body: payload,
@@ -193,7 +193,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       expect(noSig.status).toBe(401);
 
       // Wrong signature → 401
-      const wrongSig = await fetch(`${addr2}/webhooks/github`, {
+      const wrongSig = await fetch(`${addr2}/api/v1/webhooks/github`, {
         method: "POST",
         headers: {
           "x-github-event": "issues",
@@ -206,7 +206,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
 
       // Correct signature → 200
       const sig = `sha256=${createHmac("sha256", secret).update(payload).digest("hex")}`;
-      const ok = await fetch(`${addr2}/webhooks/github`, {
+      const ok = await fetch(`${addr2}/api/v1/webhooks/github`, {
         method: "POST",
         headers: {
           "x-github-event": "issues",
@@ -222,7 +222,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
   });
 
   it("ping event", async () => {
-    const res = await fetch(`${address}/webhooks/github`, {
+    const res = await fetch(`${address}/api/v1/webhooks/github`, {
       method: "POST",
       headers: { "x-github-event": "ping", "content-type": "application/json" },
       body: JSON.stringify({ zen: "Anything added dilutes everything else." }),
@@ -239,7 +239,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       .set({ metadata: { github: { repos: ["acme/repo"] } } })
       .where(eq(agents.id, agent.id));
 
-    const res = await fetch(`${address}/webhooks/github`, {
+    const res = await fetch(`${address}/api/v1/webhooks/github`, {
       method: "POST",
       headers: { "x-github-event": "issue_comment", "content-type": "application/json" },
       body: JSON.stringify({

--- a/packages/server/src/__tests__/health.test.ts
+++ b/packages/server/src/__tests__/health.test.ts
@@ -1,13 +1,13 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { createTestApp } from "./helpers.js";
 
-describe("GET /health", () => {
+describe("GET /api/v1/health", () => {
   const appPromise = createTestApp();
   afterAll(async () => (await appPromise).close());
 
   it("returns ok with db connected", async () => {
     const app = await appPromise;
-    const res = await app.inject({ method: "GET", url: "/health" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/health" });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ status: "ok", db: "connected" });
   });

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -51,7 +51,7 @@ export async function createTestAdmin(app: FastifyInstance, opts: { username?: s
 
   const loginRes = await app.inject({
     method: "POST",
-    url: "/admin/auth/login",
+    url: "/api/v1/admin/auth/login",
     payload: { username, password },
   });
   const body = loginRes.json<{ accessToken: string; refreshToken: string }>();

--- a/packages/server/src/__tests__/inbox-renew.test.ts
+++ b/packages/server/src/__tests__/inbox-renew.test.ts
@@ -13,7 +13,7 @@ describe("Inbox Renew & Timeout API", () => {
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
@@ -21,7 +21,7 @@ describe("Inbox Renew & Timeout API", () => {
 
     await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Renew test" },
     });
@@ -29,7 +29,7 @@ describe("Inbox Renew & Timeout API", () => {
     // Poll to get delivered entry
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     const entries = pollRes.json();
@@ -42,7 +42,7 @@ describe("Inbox Renew & Timeout API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: `/agent/inbox/${entryId}/renew`,
+      url: `/api/v1/agent/inbox/${entryId}/renew`,
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(res.statusCode).toBe(204);
@@ -54,7 +54,7 @@ describe("Inbox Renew & Timeout API", () => {
 
     const res = await app.inject({
       method: "POST",
-      url: "/agent/inbox/999999/renew",
+      url: "/api/v1/agent/inbox/999999/renew",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(res.statusCode).toBe(404);
@@ -67,14 +67,14 @@ describe("Inbox Renew & Timeout API", () => {
     // ACK first
     await app.inject({
       method: "POST",
-      url: `/agent/inbox/${entryId}/ack`,
+      url: `/api/v1/agent/inbox/${entryId}/ack`,
       headers: { authorization: `Bearer ${t2}` },
     });
 
     // Try to renew
     const res = await app.inject({
       method: "POST",
-      url: `/agent/inbox/${entryId}/renew`,
+      url: `/api/v1/agent/inbox/${entryId}/renew`,
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(res.statusCode).toBe(404);

--- a/packages/server/src/__tests__/inbox-timeout.test.ts
+++ b/packages/server/src/__tests__/inbox-timeout.test.ts
@@ -15,7 +15,7 @@ describe("Inbox Timeout Reset", () => {
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
@@ -23,7 +23,7 @@ describe("Inbox Timeout Reset", () => {
 
     await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Timeout test" },
     });
@@ -31,7 +31,7 @@ describe("Inbox Timeout Reset", () => {
     // Poll to deliver
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     const entries = pollRes.json();
@@ -52,7 +52,7 @@ describe("Inbox Timeout Reset", () => {
     // Entry should be pending again — pollable
     const pollRes2 = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes2.json()).toHaveLength(1);
@@ -65,7 +65,7 @@ describe("Inbox Timeout Reset", () => {
 
     const chatRes = await app.inject({
       method: "POST",
-      url: "/agent/chats",
+      url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
       payload: { type: "direct", participantIds: [a2.id] },
     });
@@ -73,7 +73,7 @@ describe("Inbox Timeout Reset", () => {
 
     await app.inject({
       method: "POST",
-      url: `/agent/chats/${chatId}/messages`,
+      url: `/api/v1/agent/chats/${chatId}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Fail test" },
     });
@@ -81,7 +81,7 @@ describe("Inbox Timeout Reset", () => {
     // Poll to deliver
     const pollRes = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     const entryId = pollRes.json()[0].id;
@@ -101,7 +101,7 @@ describe("Inbox Timeout Reset", () => {
     // Entry should not be pollable (it's failed)
     const pollRes2 = await app.inject({
       method: "GET",
-      url: "/agent/inbox",
+      url: "/api/v1/agent/inbox",
       headers: { authorization: `Bearer ${t2}` },
     });
     expect(pollRes2.json()).toHaveLength(0);

--- a/packages/server/src/__tests__/system-config.test.ts
+++ b/packages/server/src/__tests__/system-config.test.ts
@@ -20,7 +20,7 @@ describe("Admin System Config API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    const res = await req("GET", "/admin/system/config");
+    const res = await req("GET", "/api/v1/admin/system/config");
     expect(res.statusCode).toBe(200);
     const config = res.json();
     expect(config.inbox_timeout_seconds).toBe(300);
@@ -33,7 +33,7 @@ describe("Admin System Config API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    const res = await req("PATCH", "/admin/system/config", {
+    const res = await req("PATCH", "/api/v1/admin/system/config", {
       inbox_timeout_seconds: 600,
       max_retry_count: 5,
     });
@@ -49,15 +49,15 @@ describe("Admin System Config API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    await req("PATCH", "/admin/system/config", { inbox_timeout_seconds: 100 });
-    const res = await req("PATCH", "/admin/system/config", { inbox_timeout_seconds: 200 });
+    await req("PATCH", "/api/v1/admin/system/config", { inbox_timeout_seconds: 100 });
+    const res = await req("PATCH", "/api/v1/admin/system/config", { inbox_timeout_seconds: 200 });
     expect(res.statusCode).toBe(200);
     expect(res.json().inbox_timeout_seconds).toBe(200);
   });
 
   it("rejects unauthenticated requests", async () => {
     const app = await appPromise;
-    const res = await app.inject({ method: "GET", url: "/admin/system/config" });
+    const res = await app.inject({ method: "GET", url: "/api/v1/admin/system/config" });
     expect(res.statusCode).toBe(401);
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
 import Fastify from "fastify";
 import postgres from "postgres";
@@ -60,49 +63,70 @@ export async function buildApp(config: Config) {
     return reply.status(500).send({ error: "Internal server error" });
   });
 
-  // Public routes
-  await app.register(healthRoutes);
-  await app.register(githubWebhookRoutes, { prefix: "/webhooks" });
-  await app.register(adminAuthRoutes, { prefix: "/admin/auth" });
-
-  // Admin routes (JWT protected)
+  // All API routes under /api/v1 prefix
   await app.register(
-    async (adminApp) => {
-      adminApp.addHook("onRequest", adminAuth);
-      await adminApp.register(adminAgentRoutes);
+    async (api) => {
+      // Public routes
+      await api.register(healthRoutes);
+      await api.register(githubWebhookRoutes, { prefix: "/webhooks" });
+      await api.register(adminAuthRoutes, { prefix: "/admin/auth" });
+
+      // Admin routes (JWT protected)
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminAgentRoutes);
+        },
+        { prefix: "/admin/agents" },
+      );
+
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminSystemConfigRoutes);
+        },
+        { prefix: "/admin/system/config" },
+      );
+
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminOverviewRoutes);
+        },
+        { prefix: "/admin/overview" },
+      );
+
+      // Agent routes (Bearer token protected)
+      await api.register(
+        async (agentApp) => {
+          agentApp.addHook("onRequest", agentAuth);
+          await agentApp.register(agentMeRoutes);
+          await agentApp.register(agentChatRoutes, { prefix: "/chats" });
+          await agentApp.register(agentMessageRoutes, { prefix: "/chats" });
+          await agentApp.register(agentSendToAgentRoutes, { prefix: "/agents" });
+          await agentApp.register(agentInboxRoutes, { prefix: "/inbox" });
+          await agentApp.register(agentWsRoutes(notifier, config.instanceId), { prefix: "/ws" });
+        },
+        { prefix: "/agent" },
+      );
     },
-    { prefix: "/admin/agents" },
+    { prefix: "/api/v1" },
   );
 
-  await app.register(
-    async (adminApp) => {
-      adminApp.addHook("onRequest", adminAuth);
-      await adminApp.register(adminSystemConfigRoutes);
-    },
-    { prefix: "/admin/system/config" },
-  );
-
-  await app.register(
-    async (adminApp) => {
-      adminApp.addHook("onRequest", adminAuth);
-      await adminApp.register(adminOverviewRoutes);
-    },
-    { prefix: "/admin/overview" },
-  );
-
-  // Agent routes (Bearer token protected)
-  await app.register(
-    async (agentApp) => {
-      agentApp.addHook("onRequest", agentAuth);
-      await agentApp.register(agentMeRoutes);
-      await agentApp.register(agentChatRoutes, { prefix: "/chats" });
-      await agentApp.register(agentMessageRoutes, { prefix: "/chats" });
-      await agentApp.register(agentSendToAgentRoutes, { prefix: "/agents" });
-      await agentApp.register(agentInboxRoutes, { prefix: "/inbox" });
-      await agentApp.register(agentWsRoutes(notifier, config.instanceId), { prefix: "/ws" });
-    },
-    { prefix: "/agent" },
-  );
+  // Serve Web static files when WEB_DIST_PATH is configured
+  if (config.webDistPath) {
+    const webRoot = resolve(config.webDistPath);
+    if (existsSync(webRoot)) {
+      await app.register(fastifyStatic, { root: webRoot, wildcard: false });
+      app.setNotFoundHandler((request, reply) => {
+        if (request.url.startsWith("/api/")) {
+          return reply.status(404).send({ error: "Not found" });
+        }
+        // SPA fallback: serve index.html for non-API routes
+        return reply.sendFile("index.html");
+      });
+    }
+  }
 
   // Background tasks
   const backgroundTasks = createBackgroundTasks(app, config.instanceId);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -10,6 +10,7 @@ export type Config = {
   instanceId: string;
   logger?: boolean;
   githubWebhookSecret?: string;
+  webDistPath?: string;
 };
 
 export function loadConfig(): Config {
@@ -30,5 +31,6 @@ export function loadConfig(): Config {
     jwtSecretKey,
     instanceId: env.INSTANCE_ID ?? `srv_${randomUUID().slice(0, 8)}`,
     githubWebhookSecret: env.GITHUB_WEBHOOK_SECRET || undefined,
+    webDistPath: env.WEB_DIST_PATH,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@agent-hub/shared':
         specifier: workspace:*
         version: link:../shared
+      '@fastify/static':
+        specifier: ^9.0.0
+        version: 9.0.0
       '@fastify/websocket':
         specifier: ^11.2.0
         version: 11.2.0
@@ -747,6 +750,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -764,6 +770,12 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
 
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
@@ -807,6 +819,10 @@ packages:
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -1282,6 +1298,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -1343,6 +1363,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1411,6 +1435,10 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -1456,6 +1484,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1626,6 +1658,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1716,11 +1751,19 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1800,11 +1843,24 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -1869,6 +1925,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2057,6 +2117,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2105,6 +2168,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2199,6 +2266,10 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   tsdown@0.12.9:
     resolution: {integrity: sha512-MfrXm9PIlT3saovtWKf/gCJJ/NQCdE0SiREkdNC+9Qy6UHhdeDPxnkFaBD7xttVUmgp0yUHtGirpoLB+OVLuLA==}
@@ -2805,6 +2876,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -2827,6 +2900,23 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
 
   '@fastify/websocket@11.2.0':
     dependencies:
@@ -2891,6 +2981,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  '@lukeed/ms@2.0.2': {}
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -3302,6 +3394,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.6:
@@ -3359,6 +3453,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.1:
     dependencies:
@@ -3429,6 +3527,8 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  content-disposition@1.0.1: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
@@ -3463,6 +3563,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   defu@6.1.4: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -3614,6 +3716,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -3714,9 +3818,23 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   graceful-fs@4.2.11: {}
 
   hookable@5.5.3: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   ieee754@1.2.1: {}
 
@@ -3776,6 +3894,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3783,6 +3903,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mime@3.0.0: {}
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
 
   minimatch@5.1.9:
     dependencies:
@@ -3826,6 +3952,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.7
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -4055,6 +4186,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -4098,6 +4231,8 @@ snapshots:
       nan: 2.26.2
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -4242,6 +4377,8 @@ snapshots:
   tmp@0.2.5: {}
 
   toad-cache@3.7.0: {}
+
+  toidentifier@1.0.1: {}
 
   tsdown@0.12.9(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- All server routes now live under `/api/v1` prefix (e.g., `/api/v1/admin/agents`, `/api/v1/agent/inbox`)
- Added `@fastify/static` to serve web admin console's built assets with SPA fallback
- Added optional `WEB_DIST_PATH` env var for configuring static file directory
- Updated all 14 test files (86 URL references) to match new prefix

## Why

1. **API versioning**: Design doc states "面向开源，接口不轻易 break" — adding `/api/v1` from day one is far cheaper than retrofitting later
2. **Web integration**: Server can now host the web admin console's static files, enabling single-port single-domain deployment
3. **Clean separation**: `/api/v1/*` → API routes, `/*` → SPA (when `WEB_DIST_PATH` is set)

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 51/51 tests pass across 14 test files


🤖 Generated with [Claude Code](https://claude.com/claude-code)