### PR TITLE
feat: add adapter foundation — DB tables, admin API, encryption, and …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ SERVER_PORT=8000
 JWT_SECRET_KEY=
 
 # Adapter 凭证加密密钥 (生成方式: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
-ENCRYPTION_KEY=
+ADAPTER_ENCRYPTION_KEY=
 
 # GitHub Webhook (optional — if not set, signature verification is skipped)
 GITHUB_WEBHOOK_SECRET=

--- a/packages/server/drizzle/0002_adapter_tables.sql
+++ b/packages/server/drizzle/0002_adapter_tables.sql
@@ -1,0 +1,64 @@
+-- Add lifecycle_policy column to chats
+ALTER TABLE "chats" ADD COLUMN "lifecycle_policy" text DEFAULT 'persistent';
+
+--> statement-breakpoint
+-- Adapter configs: Bot credentials for external platform adapters
+CREATE TABLE "adapter_configs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"platform" text NOT NULL,
+	"agent_id" text,
+	"credentials" jsonb NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+-- Adapter chat mappings: internal Chat <-> external IM channel
+CREATE TABLE "adapter_chat_mappings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"platform" text NOT NULL,
+	"external_channel_id" text NOT NULL,
+	"chat_id" text NOT NULL,
+	"thread_id" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_adapter_chat_mapping" ON "adapter_chat_mappings" ("platform", "external_channel_id", COALESCE("thread_id", ''));
+
+--> statement-breakpoint
+-- Adapter agent mappings: external user identity <-> internal Agent
+CREATE TABLE "adapter_agent_mappings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"platform" text NOT NULL,
+	"external_user_id" text NOT NULL,
+	"agent_id" text NOT NULL,
+	"bound_via" text,
+	"display_name" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_adapter_agent_mapping" UNIQUE("platform","external_user_id")
+);
+
+--> statement-breakpoint
+-- Adapter message references: internal Message <-> external message ID
+CREATE TABLE "adapter_message_references" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"message_id" text NOT NULL,
+	"platform" text NOT NULL,
+	"external_message_id" text NOT NULL,
+	"external_channel_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_adapter_message_ref" UNIQUE("message_id","platform")
+);
+
+--> statement-breakpoint
+-- Foreign keys for adapter tables
+ALTER TABLE "adapter_configs" ADD CONSTRAINT "adapter_configs_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "adapter_chat_mappings" ADD CONSTRAINT "adapter_chat_mappings_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "adapter_agent_mappings" ADD CONSTRAINT "adapter_agent_mappings_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "adapter_message_references" ADD CONSTRAINT "adapter_message_references_message_id_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."messages"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774060655637,
       "tag": "0001_v2_schema_updates",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1774489200000,
+      "tag": "0002_adapter_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/admin-adapters.test.ts
+++ b/packages/server/src/__tests__/admin-adapters.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Admin Adapters API", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function authedRequest(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const admin = await createTestAdmin(app);
+    return (method: string, url: string, payload?: unknown) =>
+      app.inject({
+        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        url,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        ...(payload ? { payload } : {}),
+      });
+  }
+
+  it("creates and lists adapter configs", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_test", app_secret: "secret" },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const config = createRes.json();
+    expect(config.platform).toBe("feishu");
+    expect(config.hasCredentials).toBe(true);
+    // Credentials must NOT be returned in the response
+    expect(config.credentials).toBeUndefined();
+
+    const listRes = await req("GET", "/api/v1/admin/adapters");
+    expect(listRes.statusCode).toBe(200);
+    const list = listRes.json();
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    expect(list[0].hasCredentials).toBe(true);
+  });
+
+  it("gets a single adapter config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "slack",
+      credentials: { bot_token: "xoxb-test" },
+    });
+    const created = createRes.json();
+
+    const getRes = await req("GET", `/api/v1/admin/adapters/${created.id}`);
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().platform).toBe("slack");
+  });
+
+  it("updates adapter config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_upd", app_secret: "secret" },
+    });
+    const created = createRes.json();
+
+    const updateRes = await req("PATCH", `/api/v1/admin/adapters/${created.id}`, {
+      status: "inactive",
+    });
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.json().status).toBe("inactive");
+  });
+
+  it("deletes adapter config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_del", app_secret: "secret" },
+    });
+    const created = createRes.json();
+
+    const delRes = await req("DELETE", `/api/v1/admin/adapters/${created.id}`);
+    expect(delRes.statusCode).toBe(204);
+
+    const getRes = await req("GET", `/api/v1/admin/adapters/${created.id}`);
+    expect(getRes.statusCode).toBe(404);
+  });
+
+  it("returns 404 for non-existent adapter", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const getRes = await req("GET", "/api/v1/admin/adapters/99999");
+    expect(getRes.statusCode).toBe(404);
+
+    const patchRes = await req("PATCH", "/api/v1/admin/adapters/99999", { status: "inactive" });
+    expect(patchRes.statusCode).toBe(404);
+
+    const delRes = await req("DELETE", "/api/v1/admin/adapters/99999");
+    expect(delRes.statusCode).toBe(404);
+  });
+
+  it("rejects invalid platform", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "invalid_platform",
+      credentials: { key: "value" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects missing credentials", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("updates credentials (re-encrypts)", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "old_id", app_secret: "old_secret" },
+    });
+    const created = createRes.json();
+
+    const updateRes = await req("PATCH", `/api/v1/admin/adapters/${created.id}`, {
+      credentials: { app_id: "new_id", app_secret: "new_secret" },
+    });
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.json().hasCredentials).toBe(true);
+    // Credentials still not exposed
+    expect(updateRes.json().credentials).toBeUndefined();
+  });
+
+  it("defaults status to active when not provided", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "slack",
+      credentials: { bot_token: "xoxb-default" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().status).toBe("active");
+    expect(res.json().agentId).toBeNull();
+  });
+
+  it("rejects non-existent agentId", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: "does-not-exist",
+      credentials: { app_id: "x", app_secret: "y" },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects non-numeric adapter ID", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const getRes = await req("GET", "/api/v1/admin/adapters/abc");
+    expect(getRes.statusCode).toBe(400);
+
+    const patchRes = await req("PATCH", "/api/v1/admin/adapters/abc", { status: "inactive" });
+    expect(patchRes.statusCode).toBe(400);
+
+    const delRes = await req("DELETE", "/api/v1/admin/adapters/abc");
+    expect(delRes.statusCode).toBe(400);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const app = await appPromise;
+    const res = await app.inject({ method: "GET", url: "/api/v1/admin/adapters" });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -48,6 +48,20 @@ describe("Admin Agents API", () => {
     expect(body.nextCursor).toBeDefined();
   });
 
+  it("lists agents with presenceStatus field", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    await req("POST", "/api/v1/admin/agents", { id: "presence-test", type: "autonomous_agent" });
+
+    const res = await req("GET", "/api/v1/admin/agents?limit=50");
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const agent = body.items.find((a: { id: string }) => a.id === "presence-test");
+    expect(agent).toBeDefined();
+    // No presence record → defaults to "offline"
+    expect(agent.presenceStatus).toBe("offline");
+  });
+
   it("updates an agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);

--- a/packages/server/src/__tests__/crypto.test.ts
+++ b/packages/server/src/__tests__/crypto.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { decryptCredentials, encryptCredentials } from "../services/crypto.js";
+
+const TEST_KEY_HEX = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+// Same 32 bytes encoded as base64url
+const TEST_KEY_B64 = Buffer.from(TEST_KEY_HEX, "hex").toString("base64url");
+
+describe("Credential encryption", () => {
+  it("encrypts and decrypts round-trip with hex key", () => {
+    const data = { app_id: "cli_xxx", app_secret: "secret123" };
+    const encrypted = encryptCredentials(data, TEST_KEY_HEX);
+    expect(typeof encrypted).toBe("string");
+    const decrypted = decryptCredentials(encrypted, TEST_KEY_HEX);
+    expect(decrypted).toEqual(data);
+  });
+
+  it("encrypts and decrypts round-trip with base64url key", () => {
+    const data = { app_id: "cli_xxx", app_secret: "secret123" };
+    const encrypted = encryptCredentials(data, TEST_KEY_B64);
+    const decrypted = decryptCredentials(encrypted, TEST_KEY_B64);
+    expect(decrypted).toEqual(data);
+  });
+
+  it("hex and base64url keys are interchangeable (same 32 bytes)", () => {
+    const data = { cross: "format" };
+    const encrypted = encryptCredentials(data, TEST_KEY_HEX);
+    const decrypted = decryptCredentials(encrypted, TEST_KEY_B64);
+    expect(decrypted).toEqual(data);
+  });
+
+  it("produces different ciphertext for same plaintext (random IV)", () => {
+    const data = { key: "value" };
+    const a = encryptCredentials(data, TEST_KEY_HEX);
+    const b = encryptCredentials(data, TEST_KEY_HEX);
+    expect(a).not.toBe(b);
+  });
+
+  it("throws on wrong key", () => {
+    const data = { key: "value" };
+    const encrypted = encryptCredentials(data, TEST_KEY_HEX);
+    const wrongKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    expect(() => decryptCredentials(encrypted, wrongKey)).toThrow();
+  });
+
+  it("throws on invalid key length", () => {
+    expect(() => encryptCredentials({}, "short")).toThrow();
+  });
+
+  it("handles complex nested JSON", () => {
+    const data = {
+      nested: { deep: { value: [1, 2, 3] } },
+      unicode: "你好世界",
+      special: "key=val&foo=bar",
+    };
+    const encrypted = encryptCredentials(data, TEST_KEY_HEX);
+    expect(decryptCredentials(encrypted, TEST_KEY_HEX)).toEqual(data);
+  });
+
+  it("throws on corrupted ciphertext", () => {
+    const encrypted = encryptCredentials({ key: "value" }, TEST_KEY_HEX);
+    const corrupted = `${encrypted.slice(0, -4)}XXXX`;
+    expect(() => decryptCredentials(corrupted, TEST_KEY_HEX)).toThrow();
+  });
+
+  it("rejects hex string with wrong length (not 64 chars)", () => {
+    // 32 hex chars = only 16 bytes, not 32
+    expect(() => encryptCredentials({}, "0123456789abcdef0123456789abcdef")).toThrow();
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -11,6 +11,7 @@ export async function createTestApp(): Promise<FastifyInstance> {
     logger: false,
     jwtSecretKey: process.env.JWT_SECRET_KEY ?? "test-jwt-secret-key-for-vitest",
     instanceId: "test-instance",
+    adapterEncryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   };
   const app = await buildApp(config);
   await app.ready();

--- a/packages/server/src/api/admin/adapters.ts
+++ b/packages/server/src/api/admin/adapters.ts
@@ -1,0 +1,60 @@
+import { createAdapterConfigSchema, updateAdapterConfigSchema } from "@agent-hub/shared";
+import type { FastifyInstance } from "fastify";
+import { BadRequestError } from "../../errors.js";
+import * as adapterService from "../../services/adapter.js";
+
+function parseId(raw: string): number {
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new BadRequestError(`Invalid adapter ID: "${raw}"`);
+  }
+  return id;
+}
+
+export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/", async () => {
+    const configs = await adapterService.listAdapterConfigs(app.db);
+    return configs.map((c) => ({
+      ...c,
+      createdAt: c.createdAt.toISOString(),
+      updatedAt: c.updatedAt.toISOString(),
+    }));
+  });
+
+  app.post("/", async (request, reply) => {
+    const body = createAdapterConfigSchema.parse(request.body);
+    const config = await adapterService.createAdapterConfig(app.db, body, app.config.adapterEncryptionKey);
+    return reply.status(201).send({
+      ...config,
+      createdAt: config.createdAt.toISOString(),
+      updatedAt: config.updatedAt.toISOString(),
+    });
+  });
+
+  app.get<{ Params: { id: string } }>("/:id", async (request) => {
+    const id = parseId(request.params.id);
+    const config = await adapterService.getAdapterConfig(app.db, id);
+    return {
+      ...config,
+      createdAt: config.createdAt.toISOString(),
+      updatedAt: config.updatedAt.toISOString(),
+    };
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id", async (request) => {
+    const body = updateAdapterConfigSchema.parse(request.body);
+    const id = parseId(request.params.id);
+    const config = await adapterService.updateAdapterConfig(app.db, id, body, app.config.adapterEncryptionKey);
+    return {
+      ...config,
+      createdAt: config.createdAt.toISOString(),
+      updatedAt: config.updatedAt.toISOString(),
+    };
+  });
+
+  app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {
+    const id = parseId(request.params.id);
+    await adapterService.deleteAdapterConfig(app.db, id);
+    return reply.status(204).send();
+  });
+}

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -13,6 +13,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     return {
       items: result.items.map((a) => ({
         ...a,
+        presenceStatus: a.presenceStatus ?? "offline",
         createdAt: a.createdAt.toISOString(),
         updatedAt: a.updatedAt.toISOString(),
       })),

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -5,6 +5,7 @@ import websocket from "@fastify/websocket";
 import Fastify from "fastify";
 import postgres from "postgres";
 import { ZodError } from "zod";
+import { adminAdapterRoutes } from "./api/admin/adapters.js";
 import { adminAgentRoutes } from "./api/admin/agents.js";
 import { adminAuthRoutes } from "./api/admin/auth.js";
 import { adminOverviewRoutes } from "./api/admin/overview.js";
@@ -96,6 +97,14 @@ export async function buildApp(config: Config) {
         { prefix: "/admin/overview" },
       );
 
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminAdapterRoutes);
+        },
+        { prefix: "/admin/adapters" },
+      );
+
       // Agent routes (Bearer token protected)
       await api.register(
         async (agentApp) => {
@@ -135,6 +144,9 @@ export async function buildApp(config: Config) {
   app.addHook("onReady", async () => {
     await notifier.start();
     backgroundTasks.start();
+    if (!config.adapterEncryptionKey) {
+      app.log.warn("ADAPTER_ENCRYPTION_KEY is not set — adapter create/update will be unavailable");
+    }
   });
 
   // Cleanup on close

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -11,6 +11,7 @@ export type Config = {
   logger?: boolean;
   githubWebhookSecret?: string;
   webDistPath?: string;
+  adapterEncryptionKey?: string;
 };
 
 export function loadConfig(): Config {
@@ -32,5 +33,6 @@ export function loadConfig(): Config {
     instanceId: env.INSTANCE_ID ?? `srv_${randomUUID().slice(0, 8)}`,
     githubWebhookSecret: env.GITHUB_WEBHOOK_SECRET || undefined,
     webDistPath: env.WEB_DIST_PATH,
+    adapterEncryptionKey: env.ADAPTER_ENCRYPTION_KEY || undefined,
   };
 }

--- a/packages/server/src/db/schema/adapter-agent-mappings.ts
+++ b/packages/server/src/db/schema/adapter-agent-mappings.ts
@@ -1,0 +1,21 @@
+import { jsonb, pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+
+/** Maps external user identities to internal Agents. */
+export const adapterAgentMappings = pgTable(
+  "adapter_agent_mappings",
+  {
+    id: serial("id").primaryKey(),
+    platform: text("platform").notNull(),
+    externalUserId: text("external_user_id").notNull(),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id),
+    /** "code" | "reverse_token" | "oauth" | "manual" */
+    boundVia: text("bound_via"),
+    displayName: text("display_name"),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [unique("uq_adapter_agent_mapping").on(table.platform, table.externalUserId)],
+);

--- a/packages/server/src/db/schema/adapter-chat-mappings.ts
+++ b/packages/server/src/db/schema/adapter-chat-mappings.ts
@@ -1,0 +1,21 @@
+import { jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { chats } from "./chats.js";
+
+/**
+ * Maps internal Chats to external IM platform channels.
+ * NOTE: The unique constraint uses COALESCE(thread_id, '') which cannot be
+ * expressed in Drizzle ORM. It is defined in the migration SQL directly as:
+ *   CREATE UNIQUE INDEX uq_adapter_chat_mapping ON adapter_chat_mappings
+ *     (platform, external_channel_id, COALESCE(thread_id, ''));
+ */
+export const adapterChatMappings = pgTable("adapter_chat_mappings", {
+  id: serial("id").primaryKey(),
+  platform: text("platform").notNull(),
+  externalChannelId: text("external_channel_id").notNull(),
+  chatId: text("chat_id")
+    .notNull()
+    .references(() => chats.id),
+  threadId: text("thread_id"),
+  metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/db/schema/adapter-configs.ts
+++ b/packages/server/src/db/schema/adapter-configs.ts
@@ -1,0 +1,16 @@
+import { jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+
+/** Bot credentials for external platform adapters. Credentials are encrypted at application layer (AES-256-GCM). */
+export const adapterConfigs = pgTable("adapter_configs", {
+  id: serial("id").primaryKey(),
+  /** "feishu" | "slack" */
+  platform: text("platform").notNull(),
+  agentId: text("agent_id").references(() => agents.id),
+  /** Encrypted JSONB — application-layer AES-256-GCM */
+  credentials: jsonb("credentials").$type<unknown>().notNull(),
+  /** "active" | "inactive" */
+  status: text("status").notNull().default("active"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/server/src/db/schema/adapter-message-references.ts
+++ b/packages/server/src/db/schema/adapter-message-references.ts
@@ -1,0 +1,18 @@
+import { pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { messages } from "./messages.js";
+
+/** Cross-reference between internal messages and external platform message IDs. */
+export const adapterMessageReferences = pgTable(
+  "adapter_message_references",
+  {
+    id: serial("id").primaryKey(),
+    messageId: text("message_id")
+      .notNull()
+      .references(() => messages.id),
+    platform: text("platform").notNull(),
+    externalMessageId: text("external_message_id").notNull(),
+    externalChannelId: text("external_channel_id").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [unique("uq_adapter_message_ref").on(table.messageId, table.platform)],
+);

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -8,6 +8,7 @@ export const chats = pgTable("chats", {
   /** "direct" | "group" | "thread" */
   type: text("type").notNull().default("direct"),
   topic: text("topic"),
+  lifecyclePolicy: text("lifecycle_policy").default("persistent"),
   /** Parent chat ID for thread (sub-discussion) scenarios */
   parentChatId: text("parent_chat_id"),
   metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -1,3 +1,7 @@
+export { adapterAgentMappings } from "./adapter-agent-mappings.js";
+export { adapterChatMappings } from "./adapter-chat-mappings.js";
+export { adapterConfigs } from "./adapter-configs.js";
+export { adapterMessageReferences } from "./adapter-message-references.js";
 export { adminUsers } from "./admin-users.js";
 export { agentPresence } from "./agent-presence.js";
 export { agentTokens } from "./agent-tokens.js";

--- a/packages/server/src/services/adapter.ts
+++ b/packages/server/src/services/adapter.ts
@@ -1,0 +1,100 @@
+import type { CreateAdapterConfig, UpdateAdapterConfig } from "@agent-hub/shared";
+import { desc, eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { adapterConfigs } from "../db/schema/adapter-configs.js";
+import { agents } from "../db/schema/agents.js";
+import { AppError, NotFoundError } from "../errors.js";
+import { encryptCredentials } from "./crypto.js";
+
+/** Server misconfiguration — not a client error. */
+class ConfigurationError extends AppError {
+  constructor(message: string) {
+    super(503, message);
+    this.name = "ConfigurationError";
+  }
+}
+
+function requireEncryptionKey(key: string | undefined): string {
+  if (!key) {
+    throw new ConfigurationError("ADAPTER_ENCRYPTION_KEY is not configured on the server");
+  }
+  return key;
+}
+
+async function validateAgentId(db: Database, agentId: string): Promise<void> {
+  const [agent] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, agentId)).limit(1);
+  if (!agent) {
+    throw new NotFoundError(`Agent "${agentId}" not found`);
+  }
+}
+
+function toResponse(row: typeof adapterConfigs.$inferSelect) {
+  return {
+    id: row.id,
+    platform: row.platform,
+    agentId: row.agentId,
+    hasCredentials: row.credentials !== null,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function listAdapterConfigs(db: Database) {
+  const rows = await db.select().from(adapterConfigs).orderBy(desc(adapterConfigs.createdAt));
+  return rows.map(toResponse);
+}
+
+export async function getAdapterConfig(db: Database, id: number) {
+  const [row] = await db.select().from(adapterConfigs).where(eq(adapterConfigs.id, id)).limit(1);
+  if (!row) throw new NotFoundError(`Adapter config "${id}" not found`);
+  return toResponse(row);
+}
+
+export async function createAdapterConfig(db: Database, data: CreateAdapterConfig, encryptionKey: string | undefined) {
+  const key = requireEncryptionKey(encryptionKey);
+  if (data.agentId) await validateAgentId(db, data.agentId);
+  const encrypted = encryptCredentials(data.credentials, key);
+
+  const [row] = await db
+    .insert(adapterConfigs)
+    .values({
+      platform: data.platform,
+      agentId: data.agentId ?? null,
+      credentials: encrypted,
+      status: data.status ?? "active",
+    })
+    .returning();
+
+  if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
+  return toResponse(row);
+}
+
+export async function updateAdapterConfig(
+  db: Database,
+  id: number,
+  data: UpdateAdapterConfig,
+  encryptionKey: string | undefined,
+) {
+  const setClause: Record<string, unknown> = { updatedAt: new Date() };
+
+  if (data.agentId !== undefined) {
+    if (data.agentId) await validateAgentId(db, data.agentId);
+    setClause.agentId = data.agentId ?? null;
+  }
+  if (data.status !== undefined) setClause.status = data.status;
+  if (data.credentials !== undefined) {
+    const key = requireEncryptionKey(encryptionKey);
+    setClause.credentials = encryptCredentials(data.credentials, key);
+  }
+
+  const [row] = await db.update(adapterConfigs).set(setClause).where(eq(adapterConfigs.id, id)).returning();
+
+  if (!row) throw new NotFoundError(`Adapter config "${id}" not found`);
+  return toResponse(row);
+}
+
+export async function deleteAdapterConfig(db: Database, id: number) {
+  const [row] = await db.delete(adapterConfigs).where(eq(adapterConfigs.id, id)).returning();
+  if (!row) throw new NotFoundError(`Adapter config "${id}" not found`);
+}

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@agent-hub/shared";
 import { and, desc, eq, isNull, lt } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
 import { ConflictError, NotFoundError } from "../errors.js";
@@ -47,14 +48,25 @@ export async function getAgent(db: Database, id: string) {
 export async function listAgents(db: Database, limit: number, cursor?: string) {
   const where = cursor ? lt(agents.createdAt, new Date(cursor)) : undefined;
 
-  const query = db
-    .select()
+  const rows = await db
+    .select({
+      id: agents.id,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      displayName: agents.displayName,
+      inboxId: agents.inboxId,
+      status: agents.status,
+      metadata: agents.metadata,
+      createdAt: agents.createdAt,
+      updatedAt: agents.updatedAt,
+      presenceStatus: agentPresence.status,
+    })
     .from(agents)
+    .leftJoin(agentPresence, eq(agents.id, agentPresence.agentId))
     .where(where)
     .orderBy(desc(agents.createdAt))
     .limit(limit + 1);
 
-  const rows = await query;
   const hasMore = rows.length > limit;
   const items = hasMore ? rows.slice(0, limit) : rows;
   const last = items[items.length - 1];

--- a/packages/server/src/services/crypto.ts
+++ b/packages/server/src/services/crypto.ts
@@ -1,0 +1,51 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+/**
+ * Parse a 32-byte key from either hex (64 chars) or base64url (43 chars) encoding.
+ */
+function parseKey(encoded: string): Buffer {
+  // Try hex first (64 hex chars = 32 bytes)
+  if (/^[0-9a-f]{64}$/i.test(encoded)) {
+    return Buffer.from(encoded, "hex");
+  }
+  // Try base64url (43 chars + optional padding = 32 bytes)
+  const buf = Buffer.from(encoded, "base64url");
+  if (buf.length === 32) {
+    return buf;
+  }
+  throw new Error("ADAPTER_ENCRYPTION_KEY must be 32 bytes, encoded as hex (64 chars) or base64url (43 chars)");
+}
+
+/**
+ * Encrypt a JSON-serializable value using AES-256-GCM.
+ * Returns a base64 string containing: IV (12 bytes) + auth tag (16 bytes) + ciphertext.
+ */
+export function encryptCredentials(data: unknown, keyEncoded: string): string {
+  const key = parseKey(keyEncoded);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const plaintext = JSON.stringify(data);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  const combined = Buffer.concat([iv, authTag, encrypted]);
+  return combined.toString("base64");
+}
+
+/**
+ * Decrypt a base64-encoded AES-256-GCM ciphertext back to the original value.
+ */
+export function decryptCredentials(encryptedBase64: string, keyEncoded: string): unknown {
+  const key = parseKey(keyEncoded);
+  const combined = Buffer.from(encryptedBase64, "base64");
+  const iv = combined.subarray(0, IV_LENGTH);
+  const authTag = combined.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = combined.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return JSON.parse(decrypted.toString("utf8")) as unknown;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,23 @@
 // Schemas
 
 export {
+  ADAPTER_BIND_METHODS,
+  ADAPTER_PLATFORMS,
+  ADAPTER_STATUSES,
+  type AdapterBindMethod,
+  type AdapterConfig,
+  type AdapterPlatform,
+  type AdapterStatus,
+  adapterBindMethodSchema,
+  adapterConfigSchema,
+  adapterPlatformSchema,
+  adapterStatusSchema,
+  type CreateAdapterConfig,
+  createAdapterConfigSchema,
+  type UpdateAdapterConfig,
+  updateAdapterConfigSchema,
+} from "./schemas/adapter.js";
+export {
   ADMIN_ROLES,
   type AdminRole,
   type AdminUser,
@@ -13,7 +30,6 @@ export {
   type RefreshToken,
   refreshTokenSchema,
 } from "./schemas/admin-auth.js";
-
 export {
   AGENT_STATUSES,
   AGENT_TYPES,
@@ -28,7 +44,6 @@ export {
   type UpdateAgent,
   updateAgentSchema,
 } from "./schemas/agent.js";
-
 export {
   type AgentToken,
   type AgentTokenCreated,

--- a/packages/shared/src/schemas/adapter.ts
+++ b/packages/shared/src/schemas/adapter.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export const ADAPTER_PLATFORMS = {
+  FEISHU: "feishu",
+  SLACK: "slack",
+} as const;
+
+export const adapterPlatformSchema = z.enum(["feishu", "slack"]);
+export type AdapterPlatform = z.infer<typeof adapterPlatformSchema>;
+
+export const ADAPTER_STATUSES = {
+  ACTIVE: "active",
+  INACTIVE: "inactive",
+} as const;
+
+export const adapterStatusSchema = z.enum(["active", "inactive"]);
+export type AdapterStatus = z.infer<typeof adapterStatusSchema>;
+
+export const createAdapterConfigSchema = z.object({
+  platform: adapterPlatformSchema,
+  agentId: z.string().optional(),
+  credentials: z.record(z.unknown()),
+  status: adapterStatusSchema.default("active"),
+});
+export type CreateAdapterConfig = z.infer<typeof createAdapterConfigSchema>;
+
+export const updateAdapterConfigSchema = z.object({
+  agentId: z.string().nullish(),
+  credentials: z.record(z.unknown()).optional(),
+  status: adapterStatusSchema.optional(),
+});
+export type UpdateAdapterConfig = z.infer<typeof updateAdapterConfigSchema>;
+
+/** Response schema — credentials are never returned, only a boolean flag. */
+export const adapterConfigSchema = z.object({
+  id: z.number(),
+  platform: z.string(),
+  agentId: z.string().nullable(),
+  hasCredentials: z.boolean(),
+  status: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type AdapterConfig = z.infer<typeof adapterConfigSchema>;
+
+export const ADAPTER_BIND_METHODS = {
+  CODE: "code",
+  REVERSE_TOKEN: "reverse_token",
+  OAUTH: "oauth",
+  MANUAL: "manual",
+} as const;
+
+export const adapterBindMethodSchema = z.enum(["code", "reverse_token", "oauth", "manual"]);
+export type AdapterBindMethod = z.infer<typeof adapterBindMethodSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { presenceStatusSchema } from "./presence.js";
 
 export const AGENT_TYPES = {
   HUMAN: "human",
@@ -46,6 +47,7 @@ export const agentSchema = z.object({
   inboxId: z.string(),
   status: z.string(),
   metadata: z.record(z.unknown()),
+  presenceStatus: presenceStatusSchema.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -3,9 +3,10 @@ import { z } from "zod";
 export const CHAT_TYPES = {
   DIRECT: "direct",
   GROUP: "group",
+  THREAD: "thread",
 } as const;
 
-export const chatTypeSchema = z.enum(["direct", "group"]);
+export const chatTypeSchema = z.enum(["direct", "group", "thread"]);
 export type ChatType = z.infer<typeof chatTypeSchema>;
 
 export const createChatSchema = z.object({
@@ -29,6 +30,7 @@ export const chatSchema = z.object({
   organizationId: z.string(),
   type: z.string(),
   topic: z.string().nullable(),
+  lifecyclePolicy: z.string().nullable().optional(),
   metadata: z.record(z.unknown()),
   createdAt: z.string(),
   updatedAt: z.string(),

--- a/packages/web/src/api/adapters.ts
+++ b/packages/web/src/api/adapters.ts
@@ -1,0 +1,22 @@
+import type { AdapterConfig, CreateAdapterConfig, UpdateAdapterConfig } from "@agent-hub/shared";
+import { api } from "./client.js";
+
+export function listAdapters(): Promise<AdapterConfig[]> {
+  return api.get<AdapterConfig[]>("/admin/adapters");
+}
+
+export function getAdapter(id: number): Promise<AdapterConfig> {
+  return api.get<AdapterConfig>(`/admin/adapters/${id}`);
+}
+
+export function createAdapter(data: CreateAdapterConfig): Promise<AdapterConfig> {
+  return api.post<AdapterConfig>("/admin/adapters", data);
+}
+
+export function updateAdapter(id: number, data: UpdateAdapterConfig): Promise<AdapterConfig> {
+  return api.patch<AdapterConfig>(`/admin/adapters/${id}`, data);
+}
+
+export function deleteAdapter(id: number): Promise<void> {
+  return api.delete<void>(`/admin/adapters/${id}`);
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
 import { Layout } from "./components/layout.js";
+import { AdaptersPage } from "./pages/adapters.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { AgentsPage } from "./pages/agents.js";
 import { LoginPage } from "./pages/login.js";
@@ -30,6 +31,7 @@ export function App() {
                 <Route index element={<OverviewPage />} />
                 <Route path="agents" element={<AgentsPage />} />
                 <Route path="agents/:agentId" element={<AgentDetailPage />} />
+                <Route path="adapters" element={<AdaptersPage />} />
                 <Route path="settings" element={<SettingsPage />} />
               </Route>
             </Route>

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,4 +1,4 @@
-import { Bot, LayoutDashboard, LogOut, Settings } from "lucide-react";
+import { Bot, Cable, LayoutDashboard, LogOut, Settings } from "lucide-react";
 import { NavLink, Outlet } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
@@ -6,6 +6,7 @@ import { cn } from "../lib/utils.js";
 const navItems = [
   { to: "/", icon: LayoutDashboard, label: "Overview" },
   { to: "/agents", icon: Bot, label: "Agents" },
+  { to: "/adapters", icon: Cable, label: "Adapters" },
   { to: "/settings", icon: Settings, label: "Settings" },
 ];
 

--- a/packages/web/src/pages/adapters.tsx
+++ b/packages/web/src/pages/adapters.tsx
@@ -1,0 +1,279 @@
+import { ADAPTER_PLATFORMS } from "@agent-hub/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { createAdapter, deleteAdapter, listAdapters, updateAdapter } from "../api/adapters.js";
+import { Badge } from "../components/ui/badge.js";
+import { Button } from "../components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../components/ui/dialog.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { formatDate } from "../lib/utils.js";
+
+const platformValues = Object.values(ADAPTER_PLATFORMS);
+
+type FormState = {
+  platform: string;
+  agentId: string;
+  credentials: string;
+  status: string;
+};
+
+const emptyForm: FormState = { platform: "feishu", agentId: "", credentials: "{}", status: "active" };
+
+export function AdaptersPage() {
+  const queryClient = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [credError, setCredError] = useState("");
+
+  const { data: adapters, isLoading, error } = useQuery({ queryKey: ["adapters"], queryFn: listAdapters });
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      const creds = JSON.parse(form.credentials) as Record<string, unknown>;
+      return createAdapter({
+        platform: form.platform as "feishu" | "slack",
+        agentId: form.agentId || undefined,
+        credentials: creds,
+        status: form.status as "active" | "inactive",
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adapters"] });
+      closeDialog();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: () => {
+      const data: Record<string, unknown> = { status: form.status as "active" | "inactive" };
+      if (form.agentId !== undefined) data.agentId = form.agentId || null;
+      const credsTrimmed = form.credentials.trim();
+      if (credsTrimmed) {
+        data.credentials = JSON.parse(credsTrimmed) as Record<string, unknown>;
+      }
+      if (!editingId) throw new Error("No adapter selected for editing");
+      return updateAdapter(editingId, data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adapters"] });
+      closeDialog();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteAdapter,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["adapters"] }),
+  });
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setEditingId(null);
+    setForm(emptyForm);
+    setCredError("");
+  }
+
+  function openEdit(adapter: { id: number; platform: string; agentId: string | null; status: string }) {
+    setEditingId(adapter.id);
+    setForm({
+      platform: adapter.platform,
+      agentId: adapter.agentId ?? "",
+      credentials: "",
+      status: adapter.status,
+    });
+    setDialogOpen(true);
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const credsTrimmed = form.credentials.trim();
+    // Empty credentials = "unchanged" in edit mode, required in create mode
+    if (!editingId && !credsTrimmed) {
+      setCredError("Credentials are required");
+      return;
+    }
+    if (credsTrimmed) {
+      try {
+        JSON.parse(credsTrimmed);
+        setCredError("");
+      } catch {
+        setCredError("Invalid JSON");
+        return;
+      }
+    } else {
+      setCredError("");
+    }
+    if (editingId) {
+      updateMutation.mutate();
+    } else {
+      createMutation.mutate();
+    }
+  }
+
+  function handleDelete(id: number) {
+    if (window.confirm("Delete this adapter config?")) {
+      deleteMutation.mutate(id);
+    }
+  }
+
+  const mutationError = createMutation.error ?? updateMutation.error;
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Adapters</h1>
+        <Dialog open={dialogOpen} onOpenChange={(open) => (open ? setDialogOpen(true) : closeDialog())}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Adapter
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{editingId ? "Edit Adapter" : "Add Adapter"}</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="adapter-platform">Platform</Label>
+                <select
+                  id="adapter-platform"
+                  value={form.platform}
+                  onChange={(e) => setForm({ ...form, platform: e.target.value })}
+                  disabled={!!editingId}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+                >
+                  {platformValues.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="adapter-agent">Agent ID (optional)</Label>
+                <Input
+                  id="adapter-agent"
+                  value={form.agentId}
+                  onChange={(e) => setForm({ ...form, agentId: e.target.value })}
+                  placeholder="Bound agent ID"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="adapter-creds">
+                  Credentials (JSON){editingId ? " — leave empty to keep existing" : ""}
+                </Label>
+                <textarea
+                  id="adapter-creds"
+                  value={form.credentials}
+                  onChange={(e) => setForm({ ...form, credentials: e.target.value })}
+                  rows={4}
+                  className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  placeholder='{"app_id": "...", "app_secret": "..."}'
+                />
+                {credError && <p className="text-sm text-destructive">{credError}</p>}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="adapter-status">Status</Label>
+                <select
+                  id="adapter-status"
+                  value={form.status}
+                  onChange={(e) => setForm({ ...form, status: e.target.value })}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <option value="active">active</option>
+                  <option value="inactive">inactive</option>
+                </select>
+              </div>
+              {mutationError instanceof Error && (
+                <div className="text-sm text-destructive">{mutationError.message}</div>
+              )}
+              <DialogFooter>
+                <Button type="submit" disabled={isPending}>
+                  {isPending ? "Saving..." : editingId ? "Update" : "Create"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="border rounded-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Platform</TableHead>
+              <TableHead>Agent ID</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                  Loading...
+                </TableCell>
+              </TableRow>
+            ) : error ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-8 text-destructive">
+                  Failed to load adapters: {error instanceof Error ? error.message : "Unknown error"}
+                </TableCell>
+              </TableRow>
+            ) : adapters?.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                  No adapters configured
+                </TableCell>
+              </TableRow>
+            ) : (
+              adapters?.map((a) => (
+                <TableRow key={a.id}>
+                  <TableCell className="font-mono text-sm">{a.id}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{a.platform}</Badge>
+                  </TableCell>
+                  <TableCell className="font-mono text-sm">{a.agentId ?? "—"}</TableCell>
+                  <TableCell>
+                    <Badge variant={a.status === "active" ? "default" : "destructive"}>{a.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{formatDate(a.createdAt)}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-1">
+                      <Button variant="ghost" size="icon" onClick={() => openEdit(a)} title="Edit">
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(a.id)}
+                        disabled={deleteMutation.isPending}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -17,7 +17,7 @@ import {
 import { Input } from "../components/ui/input.js";
 import { Label } from "../components/ui/label.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
-import { formatDate } from "../lib/utils.js";
+import { cn, formatDate } from "../lib/utils.js";
 
 const agentTypeValues = Object.values(AGENT_TYPES);
 
@@ -120,6 +120,7 @@ export function AgentsPage() {
               <TableHead>ID</TableHead>
               <TableHead>Display Name</TableHead>
               <TableHead>Type</TableHead>
+              <TableHead>Online</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Created</TableHead>
             </TableRow>
@@ -127,19 +128,19 @@ export function AgentsPage() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
                   Loading...
                 </TableCell>
               </TableRow>
             ) : error ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-destructive">
+                <TableCell colSpan={6} className="text-center py-8 text-destructive">
                   Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
                 </TableCell>
               </TableRow>
             ) : data?.items.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
                   No agents yet
                 </TableCell>
               </TableRow>
@@ -150,6 +151,15 @@ export function AgentsPage() {
                   <TableCell>{agent.displayName ?? "—"}</TableCell>
                   <TableCell>
                     <Badge variant="secondary">{agent.type}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      className={cn(
+                        "inline-block h-2 w-2 rounded-full",
+                        agent.presenceStatus === "online" ? "bg-green-500" : "bg-gray-300",
+                      )}
+                      title={agent.presenceStatus ?? "offline"}
+                    />
                   </TableCell>
                   <TableCell>
                     <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>


### PR DESCRIPTION
…web management

Batch 1: Schema alignment & presence
- Add "thread" to chat type enum, add lifecyclePolicy field to chats
- Agent list API now returns presenceStatus via LEFT JOIN agent_presence
- Web agents page shows online/offline indicator dot

Batch 2: Adapter data infrastructure
- 4 new DB tables: adapter_configs, adapter_chat_mappings, adapter_agent_mappings, adapter_message_references
- AES-256-GCM credential encryption (supports hex and base64url keys)
- Adapter Admin API: 5 endpoints (list, get, create, update, delete) with agentId validation, ID param parsing, and proper error codes
- Web adapters page with create/edit dialog and JSON credential input
- Shared Zod schemas for adapter types
- 77 tests passing (13 new: adapter CRUD, crypto, presence, validation)