### PR TITLE
feat: prepare @unispark.ai/agent-hub for public npm publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Agent Hub ≠ Context Tree
 
 **Server:** Fastify / Drizzle ORM / PostgreSQL / Zod / bcrypt / jose
 
-**Client:** fetch / ws / Zod
+**Client:** fetch / Commander.js
 
 **Shared:** Zod schemas + TypeScript 类型（三端共享）
 
@@ -67,7 +67,7 @@ agent-hub/
 ├── packages/
 │   ├── shared/                # @agent-hub/shared — 共享 Zod schema + 类型
 │   ├── server/                # @agent-hub/server — Fastify API 服务
-│   ├── client/                # @agent-hub/client — Agent Runtime
+│   ├── client/                # @unispark.ai/agent-hub — Agent Runtime
 │   └── web/                   # @agent-hub/web — React 管理后台
 ```
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@agent-hub/client",
+  "name": "@unispark.ai/agent-hub",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "description": "Agent Hub CLI and SDK — agent-facing client for Agent Hub server",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -12,20 +12,32 @@
   "bin": {
     "agent-hub": "./dist/cli/index.js"
   },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsdown src/index.ts src/cli/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agent-team-foundation/agent-hub.git",
+    "directory": "packages/client"
+  },
+  "engines": {
+    "node": ">=22.16.0"
+  },
   "dependencies": {
-    "@agent-hub/shared": "workspace:*",
-    "commander": "^13.1.0",
-    "ws": "^8.18.0",
-    "zod": "^3.25.0"
+    "commander": "^13.1.0"
   },
   "devDependencies": {
+    "@agent-hub/shared": "workspace:*",
     "@types/node": "^22.16.0",
-    "@types/ws": "^8.18.0",
     "tsdown": "^0.12.0",
     "vitest": "^3.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,25 +20,16 @@ importers:
 
   packages/client:
     dependencies:
-      '@agent-hub/shared':
-        specifier: workspace:*
-        version: link:../shared
       commander:
         specifier: ^13.1.0
         version: 13.1.0
-      ws:
-        specifier: ^8.18.0
-        version: 8.19.0
-      zod:
-        specifier: ^3.25.0
-        version: 3.25.76
     devDependencies:
+      '@agent-hub/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
-      '@types/ws':
-        specifier: ^8.18.0
-        version: 8.18.1
       tsdown:
         specifier: ^0.12.0
         version: 0.12.9(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Rename package from `@agent-hub/client` to `@unispark.ai/agent-hub` for public npm publishing
- Remove `private: true`, add `publishConfig`, `files`, `license`, `repository`, `engines`
- Move `@agent-hub/shared` to devDependencies (type-only import, already bundled by tsdown)
- Remove unused `ws`, `@types/ws`, `zod` from dependencies
- Update `AGENTS.md` references (package name and tech stack)

Published as `@unispark.ai/agent-hub@0.1.0`. Install via:
```bash
npm install -g @unispark.ai/agent-hub
```

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm publish --dry-run` shows correct package contents (9 files, 5.1 kB)
- [x] Successfully published to npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)