### PR TITLE
feat: implement Feishu adapter with WebSocket long connection

### DIFF
--- a/packages/server/drizzle/0003_feishu_adapter.sql
+++ b/packages/server/drizzle/0003_feishu_adapter.sql
@@ -1,0 +1,21 @@
+-- Webhook event deduplication table
+CREATE TABLE IF NOT EXISTS "processed_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "event_id" text NOT NULL,
+  "platform" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "uq_processed_event" UNIQUE("event_id","platform")
+);
+
+-- Performance indexes for adapter mapping lookups
+CREATE INDEX IF NOT EXISTS "idx_adapter_chat_mappings_lookup"
+  ON "adapter_chat_mappings" ("platform", "external_channel_id");
+
+CREATE INDEX IF NOT EXISTS "idx_adapter_agent_mappings_lookup"
+  ON "adapter_agent_mappings" ("platform", "external_user_id");
+
+CREATE INDEX IF NOT EXISTS "idx_adapter_message_refs_lookup"
+  ON "adapter_message_references" ("platform", "external_message_id");
+
+CREATE INDEX IF NOT EXISTS "idx_adapter_configs_active"
+  ON "adapter_configs" ("platform") WHERE "status" = 'active';

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774489200000,
       "tag": "0002_adapter_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1774531200000,
+      "tag": "0003_feishu_adapter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "@agent-hub/shared": "workspace:*",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "bcrypt": "^6.0.0",
     "drizzle-orm": "^0.44.0",
     "fastify": "^5.3.0",

--- a/packages/server/src/__tests__/adapter-mapping.test.ts
+++ b/packages/server/src/__tests__/adapter-mapping.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as mappingService from "../services/adapter-mapping.js";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Adapter mapping service", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  describe("event deduplication", () => {
+    it("claims an event the first time", async () => {
+      const app = await appPromise;
+      const claimed = await mappingService.claimEvent(app.db, "evt_unique_1", "feishu");
+      expect(claimed).toBe(true);
+    });
+
+    it("rejects a duplicate event", async () => {
+      const app = await appPromise;
+      await mappingService.claimEvent(app.db, "evt_dup_1", "feishu");
+      const duplicate = await mappingService.claimEvent(app.db, "evt_dup_1", "feishu");
+      expect(duplicate).toBe(false);
+    });
+
+    it("allows same event_id on different platforms", async () => {
+      const app = await appPromise;
+      const r1 = await mappingService.claimEvent(app.db, "evt_cross_1", "feishu");
+      const r2 = await mappingService.claimEvent(app.db, "evt_cross_1", "slack");
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+    });
+  });
+
+  describe("agent mapping", () => {
+    it("creates and finds agent mapping", async () => {
+      const app = await appPromise;
+      const { agent } = await createTestAgent(app, { id: "mapping-test-agent" });
+
+      await mappingService.createAgentMapping(app.db, {
+        platform: "feishu",
+        externalUserId: "ou_mapping_user_1",
+        agentId: agent.id,
+        boundVia: "manual",
+      });
+
+      const found = await mappingService.findAgentByExternalUser(app.db, "feishu", "ou_mapping_user_1");
+      expect(found).not.toBeNull();
+      expect(found?.agentId).toBe(agent.id);
+    });
+
+    it("returns null for unmapped user", async () => {
+      const app = await appPromise;
+      const found = await mappingService.findAgentByExternalUser(app.db, "feishu", "ou_nonexistent");
+      expect(found).toBeNull();
+    });
+
+    it("finds external user by agent", async () => {
+      const app = await appPromise;
+      const { agent } = await createTestAgent(app, { id: "reverse-mapping-agent" });
+
+      await mappingService.createAgentMapping(app.db, {
+        platform: "feishu",
+        externalUserId: "ou_reverse_1",
+        agentId: agent.id,
+      });
+
+      const found = await mappingService.findExternalUserByAgent(app.db, "feishu", agent.id);
+      expect(found).not.toBeNull();
+      expect(found?.externalUserId).toBe("ou_reverse_1");
+    });
+
+    it("handles duplicate mapping gracefully", async () => {
+      const app = await appPromise;
+      const { agent } = await createTestAgent(app, { id: "dup-mapping-agent" });
+
+      const r1 = await mappingService.createAgentMapping(app.db, {
+        platform: "feishu",
+        externalUserId: "ou_dup_user",
+        agentId: agent.id,
+      });
+      const r2 = await mappingService.createAgentMapping(app.db, {
+        platform: "feishu",
+        externalUserId: "ou_dup_user",
+        agentId: agent.id,
+      });
+      expect(r1.agentId).toBe(r2.agentId);
+    });
+  });
+
+  describe("chat mapping", () => {
+    it("creates chat for new external channel", async () => {
+      const app = await appPromise;
+      const { agent: adapter } = await createTestAgent(app, { id: "chat-map-adapter" });
+      const { agent: sender } = await createTestAgent(app, { id: "chat-map-sender" });
+
+      const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_new_channel_1",
+        chatType: "group",
+        adapterAgentId: adapter.id,
+        senderAgentId: sender.id,
+      });
+
+      expect(chatId).toBeTruthy();
+
+      // Second call should return same chatId
+      const chatId2 = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_new_channel_1",
+        chatType: "group",
+        adapterAgentId: adapter.id,
+        senderAgentId: sender.id,
+      });
+      expect(chatId2).toBe(chatId);
+    });
+
+    it("creates separate chats for different external channels", async () => {
+      const app = await appPromise;
+      const { agent: adapter } = await createTestAgent(app, { id: "multi-ch-adapter" });
+      const { agent: sender } = await createTestAgent(app, { id: "multi-ch-sender" });
+
+      const chatId1 = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_multi_1",
+        chatType: "group",
+        adapterAgentId: adapter.id,
+        senderAgentId: sender.id,
+      });
+
+      const chatId2 = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_multi_2",
+        chatType: "p2p",
+        adapterAgentId: adapter.id,
+        senderAgentId: sender.id,
+      });
+
+      expect(chatId1).not.toBe(chatId2);
+    });
+
+    it("finds external channel by chat", async () => {
+      const app = await appPromise;
+      const { agent: adapter } = await createTestAgent(app, { id: "reverse-ch-adapter" });
+      const { agent: sender } = await createTestAgent(app, { id: "reverse-ch-sender" });
+
+      const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_reverse_1",
+        chatType: "group",
+        adapterAgentId: adapter.id,
+        senderAgentId: sender.id,
+      });
+
+      const found = await mappingService.findExternalChannelByChat(app.db, "feishu", chatId);
+      expect(found).not.toBeNull();
+      expect(found?.externalChannelId).toBe("oc_reverse_1");
+    });
+  });
+
+  describe("message references", () => {
+    it("creates and finds message reference", async () => {
+      const app = await appPromise;
+      // First create a real message for FK constraint
+      const { agent } = await createTestAgent(app, { id: "msg-ref-agent" });
+      const { createChat } = await import("../services/chat.js");
+      const { sendMessage } = await import("../services/message.js");
+
+      const chat = await createChat(app.db, agent.id, {
+        type: "direct",
+        participantIds: [agent.id],
+      });
+      const msg = await sendMessage(app.db, chat.id, agent.id, {
+        format: "text",
+        content: "test message for ref",
+      });
+
+      await mappingService.createMessageReference(app.db, {
+        messageId: msg.id,
+        platform: "feishu",
+        externalMessageId: "om_ext_123",
+        externalChannelId: "oc_ext_456",
+      });
+
+      const byExternal = await mappingService.findMessageByExternalId(app.db, "feishu", "om_ext_123");
+      expect(byExternal?.messageId).toBe(msg.id);
+
+      const byInternal = await mappingService.findExternalMessageByInternalId(app.db, "feishu", msg.id);
+      expect(byInternal?.externalMessageId).toBe("om_ext_123");
+    });
+
+    it("returns null for unmapped messages", async () => {
+      const app = await appPromise;
+      const result = await mappingService.findMessageByExternalId(app.db, "feishu", "om_nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Feishu Adapter (WebSocket mode)", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  async function authedRequest(app: Awaited<ReturnType<typeof createTestApp>>) {
+    const admin = await createTestAdmin(app);
+    return (method: string, url: string, payload?: unknown) =>
+      app.inject({
+        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        url,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        ...(payload ? { payload } : {}),
+      });
+  }
+
+  it("creates adapter config with feishu credentials", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_ws_test", app_secret: "secret_123" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().platform).toBe("feishu");
+    expect(res.json().hasCredentials).toBe(true);
+  });
+
+  it("adapter manager reload picks up new config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    // Create a new adapter config
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_reload_test", app_secret: "secret_reload" },
+    });
+    expect(createRes.statusCode).toBe(201);
+
+    // adapterManager.reload() is called automatically after create
+    // We can't easily test WS connection without a real Feishu server,
+    // but we can verify the config was stored correctly
+    const listRes = await req("GET", "/api/v1/admin/adapters");
+    const adapters = listRes.json();
+    const found = adapters.find((a: { platform: string }) => a.platform === "feishu");
+    expect(found).toBeDefined();
+  });
+
+  it("adapter manager reloads on config update", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_update_reload", app_secret: "secret_u" },
+    });
+    const created = createRes.json();
+
+    const updateRes = await req("PATCH", `/api/v1/admin/adapters/${created.id}`, {
+      status: "inactive",
+    });
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.json().status).toBe("inactive");
+  });
+
+  it("adapter manager reloads on config delete", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_delete_reload", app_secret: "secret_d" },
+    });
+    const created = createRes.json();
+
+    const delRes = await req("DELETE", `/api/v1/admin/adapters/${created.id}`);
+    expect(delRes.statusCode).toBe(204);
+  });
+
+  it("no feishu webhook route exists (replaced by WebSocket)", async () => {
+    const app = await appPromise;
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/webhooks/feishu/cli_test",
+      payload: { test: true },
+    });
+    // Should be 404 since webhook route was removed
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/api/admin/adapters.ts
+++ b/packages/server/src/api/admin/adapters.ts
@@ -24,8 +24,8 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
   app.post("/", async (request, reply) => {
     const body = createAdapterConfigSchema.parse(request.body);
     const config = await adapterService.createAdapterConfig(app.db, body, app.config.adapterEncryptionKey);
-    // Hot-reload adapter manager to pick up new config
-    await app.adapterManager.reload();
+    // Fire-and-forget: reload must not block the API response or turn a DB success into 500
+    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after create"));
     return reply.status(201).send({
       ...config,
       createdAt: config.createdAt.toISOString(),
@@ -47,8 +47,7 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
     const body = updateAdapterConfigSchema.parse(request.body);
     const id = parseId(request.params.id);
     const config = await adapterService.updateAdapterConfig(app.db, id, body, app.config.adapterEncryptionKey);
-    // Hot-reload adapter manager to pick up updated config
-    await app.adapterManager.reload();
+    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after update"));
     return {
       ...config,
       createdAt: config.createdAt.toISOString(),
@@ -59,8 +58,7 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
   app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {
     const id = parseId(request.params.id);
     await adapterService.deleteAdapterConfig(app.db, id);
-    // Hot-reload adapter manager to remove deleted config
-    await app.adapterManager.reload();
+    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after delete"));
     return reply.status(204).send();
   });
 }

--- a/packages/server/src/api/admin/adapters.ts
+++ b/packages/server/src/api/admin/adapters.ts
@@ -24,6 +24,8 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
   app.post("/", async (request, reply) => {
     const body = createAdapterConfigSchema.parse(request.body);
     const config = await adapterService.createAdapterConfig(app.db, body, app.config.adapterEncryptionKey);
+    // Hot-reload adapter manager to pick up new config
+    await app.adapterManager.reload();
     return reply.status(201).send({
       ...config,
       createdAt: config.createdAt.toISOString(),
@@ -45,6 +47,8 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
     const body = updateAdapterConfigSchema.parse(request.body);
     const id = parseId(request.params.id);
     const config = await adapterService.updateAdapterConfig(app.db, id, body, app.config.adapterEncryptionKey);
+    // Hot-reload adapter manager to pick up updated config
+    await app.adapterManager.reload();
     return {
       ...config,
       createdAt: config.createdAt.toISOString(),
@@ -55,6 +59,8 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
   app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {
     const id = parseId(request.params.id);
     await adapterService.deleteAdapterConfig(app.db, id);
+    // Hot-reload adapter manager to remove deleted config
+    await app.adapterManager.reload();
     return reply.status(204).send();
   });
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -22,6 +22,7 @@ import { connectDatabase } from "./db/connection.js";
 import { AppError } from "./errors.js";
 import { adminAuthHook } from "./middleware/admin-auth.js";
 import { agentAuthHook } from "./middleware/agent-auth.js";
+import { type AdapterManager, createAdapterManager } from "./services/adapter-manager.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
 
@@ -31,6 +32,7 @@ import "./types.js";
 export type AppContext = {
   notifier: Notifier;
   backgroundTasks: BackgroundTasks;
+  adapterManager: AdapterManager;
 };
 
 export async function buildApp(config: Config) {
@@ -137,8 +139,12 @@ export async function buildApp(config: Config) {
     }
   }
 
+  // Adapter manager — decorated so admin routes can trigger reload
+  const adapterManager = createAdapterManager(db, config.adapterEncryptionKey, app.log);
+  app.decorate("adapterManager", adapterManager);
+
   // Background tasks
-  const backgroundTasks = createBackgroundTasks(app, config.instanceId);
+  const backgroundTasks = createBackgroundTasks(app, config.instanceId, adapterManager);
 
   // Start notifier and background tasks on server start
   app.addHook("onReady", async () => {
@@ -146,12 +152,15 @@ export async function buildApp(config: Config) {
     backgroundTasks.start();
     if (!config.adapterEncryptionKey) {
       app.log.warn("ADAPTER_ENCRYPTION_KEY is not set — adapter create/update will be unavailable");
+    } else {
+      await adapterManager.reload();
     }
   });
 
   // Cleanup on close
   app.addHook("onClose", async () => {
     backgroundTasks.stop();
+    adapterManager.shutdown();
     await notifier.stop();
     await listenClient.end();
   });

--- a/packages/server/src/db/schema/processed-events.ts
+++ b/packages/server/src/db/schema/processed-events.ts
@@ -1,0 +1,17 @@
+import { pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+
+/**
+ * Webhook event deduplication.
+ * Multiple bots in the same group chat receive the same event from Feishu,
+ * so we use INSERT ... ON CONFLICT DO NOTHING to ensure single processing.
+ */
+export const processedEvents = pgTable(
+  "processed_events",
+  {
+    id: serial("id").primaryKey(),
+    eventId: text("event_id").notNull(),
+    platform: text("platform").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [unique("uq_processed_event").on(table.eventId, table.platform)],
+);

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -42,6 +42,8 @@ const OUTBOUND_BATCH_SIZE = 10;
 
 type ManagedBot = {
   configId: number;
+  /** Track updatedAt to detect credential/setting changes on same config row. */
+  configUpdatedAt: string;
   appId: string;
   agentId: string | null;
   adapterAgentId: string;
@@ -83,7 +85,13 @@ export function createAdapterManager(
       // Skip bot messages (avoid echo)
       if (event.senderType === "bot") return;
 
-      await processInboundMessage(db, event, appId, log);
+      try {
+        await processInboundMessage(db, event, appId, log);
+      } catch (err) {
+        // Unclaim the event so it can be retried on next delivery
+        await mappingService.unclaimEvent(db, event.eventId, "feishu");
+        throw err;
+      }
     } catch (err) {
       log.error({ appId, err }, "Failed to handle inbound Feishu event");
     }
@@ -113,9 +121,10 @@ export function createAdapterManager(
         const appId = creds.app_id;
         seen.add(appId);
 
-        // Skip if already running with same config
+        // Skip if already running with same config version (detect credential changes)
+        const configVersion = config.updatedAt.toISOString();
         const existing = bots.get(appId);
-        if (existing && existing.configId === config.id) continue;
+        if (existing && existing.configId === config.id && existing.configUpdatedAt === configVersion) continue;
 
         // Stop old connection if config changed
         if (existing) {
@@ -154,6 +163,7 @@ export function createAdapterManager(
 
         bots.set(appId, {
           configId: config.id,
+          configUpdatedAt: configVersion,
           appId,
           agentId: config.agentId,
           adapterAgentId,

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -1,0 +1,475 @@
+import { Client, EventDispatcher, LoggerLevel, WSClient } from "@larksuiteoapi/node-sdk";
+import { eq, sql } from "drizzle-orm";
+import type { FastifyBaseLogger } from "fastify";
+import type { Database } from "../db/connection.js";
+import { adapterConfigs } from "../db/schema/adapter-configs.js";
+import { agents } from "../db/schema/agents.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
+import * as mappingService from "./adapter-mapping.js";
+import { createAgent } from "./agent.js";
+import { decryptCredentials } from "./crypto.js";
+import type { FeishuBotCredentials, InboundEvent } from "./feishu/types.js";
+import { sendMessage } from "./message.js";
+
+const FEISHU_ADAPTER_ID_PREFIX = "feishu-adapter";
+const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"];
+
+/**
+ * Temporarily clear proxy env vars while running a callback.
+ * The Lark SDK's internal HTTP client (axios) reads proxy env vars
+ * but does not respect NO_PROXY, causing connection failures behind proxies.
+ * Other code that needs the proxy is unaffected — vars are restored immediately.
+ */
+async function withoutProxy<T>(fn: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string> = {};
+  for (const key of PROXY_ENV_KEYS) {
+    const val = process.env[key];
+    if (val !== undefined) {
+      saved[key] = val;
+      delete process.env[key];
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, val] of Object.entries(saved)) {
+      process.env[key] = val;
+    }
+  }
+}
+const OUTBOUND_BATCH_SIZE = 10;
+
+type ManagedBot = {
+  configId: number;
+  appId: string;
+  agentId: string | null;
+  adapterAgentId: string;
+  client: InstanceType<typeof Client>;
+  wsClient: WSClient;
+};
+
+export type AdapterManager = {
+  /** Load active adapter configs and start/stop WS connections. */
+  reload(): Promise<void>;
+  /** Process pending outbound messages for all adapter agents. */
+  processOutbound(): Promise<{ sent: number; errors: number }>;
+  /** Stop all WS connections. */
+  shutdown(): void;
+};
+
+/**
+ * Manages Feishu adapter bot instances using the official Lark SDK.
+ * - Inbound: WSClient receives events via WebSocket (no public URL needed)
+ * - Outbound: SDK Client sends messages via Feishu API
+ */
+export function createAdapterManager(
+  db: Database,
+  encryptionKey: string | undefined,
+  log: FastifyBaseLogger,
+): AdapterManager {
+  const bots = new Map<string, ManagedBot>();
+
+  /** Handle an inbound message event from Feishu WebSocket. */
+  async function handleInboundEvent(appId: string, data: Record<string, unknown>): Promise<void> {
+    try {
+      const event = parseEventData(appId, data);
+      if (!event) return;
+
+      // Deduplicate
+      const isNew = await mappingService.claimEvent(db, event.eventId, "feishu");
+      if (!isNew) return;
+
+      // Skip bot messages (avoid echo)
+      if (event.senderType === "bot") return;
+
+      await processInboundMessage(db, event, appId, log);
+    } catch (err) {
+      log.error({ appId, err }, "Failed to handle inbound Feishu event");
+    }
+  }
+
+  return {
+    async reload() {
+      if (!encryptionKey) {
+        log.warn("ADAPTER_ENCRYPTION_KEY not set — adapter manager disabled");
+        return;
+      }
+
+      const configs = await db.select().from(adapterConfigs).where(eq(adapterConfigs.status, "active"));
+      const seen = new Set<string>();
+
+      for (const config of configs) {
+        if (config.platform !== "feishu" || !config.credentials) continue;
+
+        let creds: FeishuBotCredentials;
+        try {
+          creds = decryptCredentials(config.credentials as string, encryptionKey) as FeishuBotCredentials;
+        } catch (err) {
+          log.error({ configId: config.id, err }, "Failed to decrypt adapter credentials");
+          continue;
+        }
+
+        const appId = creds.app_id;
+        seen.add(appId);
+
+        // Skip if already running with same config
+        const existing = bots.get(appId);
+        if (existing && existing.configId === config.id) continue;
+
+        // Stop old connection if config changed
+        if (existing) {
+          existing.wsClient.close({ force: true });
+          log.info({ appId }, "Stopped old Feishu WS connection (config changed)");
+        }
+
+        // Ensure adapter system agent
+        const adapterAgentId = `${FEISHU_ADAPTER_ID_PREFIX}-${appId}`;
+        await ensureAdapterAgent(db, adapterAgentId, appId);
+
+        // bypass_proxy defaults to true (Lark SDK ignores NO_PROXY — known bug)
+        const bypassProxy = creds.bypass_proxy !== false;
+        const wrap = bypassProxy ? withoutProxy : <T>(fn: () => Promise<T>) => fn();
+
+        // Create SDK client for outbound API calls
+        const client = await wrap(() => Promise.resolve(new Client({ appId, appSecret: creds.app_secret })));
+
+        // Create WSClient for inbound events
+        const eventDispatcher = new EventDispatcher({}).register({
+          "im.message.receive_v1": async (data: Record<string, unknown>) => {
+            await handleInboundEvent(appId, data);
+          },
+        });
+
+        const wsClient = await wrap(async () => {
+          const ws = new WSClient({
+            appId,
+            appSecret: creds.app_secret,
+            loggerLevel: LoggerLevel.warn,
+            autoReconnect: true,
+          });
+          await ws.start({ eventDispatcher });
+          return ws;
+        });
+
+        bots.set(appId, {
+          configId: config.id,
+          appId,
+          agentId: config.agentId,
+          adapterAgentId,
+          client,
+          wsClient,
+        });
+
+        log.info({ appId, configId: config.id }, "Started Feishu adapter bot (WebSocket)");
+      }
+
+      // Stop bots that are no longer active
+      for (const [appId, bot] of bots) {
+        if (!seen.has(appId)) {
+          bot.wsClient.close({ force: true });
+          bots.delete(appId);
+          log.info({ appId }, "Stopped inactive Feishu adapter bot");
+        }
+      }
+    },
+
+    async processOutbound() {
+      let sent = 0;
+      let errors = 0;
+
+      for (const [, bot] of bots) {
+        try {
+          const result = await processAdapterOutbound(db, bot, log);
+          sent += result.sent;
+          errors += result.errors;
+        } catch (err) {
+          log.error({ appId: bot.appId, err }, "Adapter outbound processing error");
+          errors++;
+        }
+      }
+
+      return { sent, errors };
+    },
+
+    shutdown() {
+      for (const [appId, bot] of bots) {
+        bot.wsClient.close({ force: true });
+        log.info({ appId }, "Shut down Feishu WS connection");
+      }
+      bots.clear();
+    },
+  };
+}
+
+// ── Inbound helpers ─────────────────────────────────────────────────
+
+/** Parse SDK event data into our normalized InboundEvent. */
+function parseEventData(appId: string, data: Record<string, unknown>): InboundEvent | null {
+  // The SDK's EventDispatcher delivers the event.event payload directly
+  const sender = data.sender as { sender_id?: Record<string, string>; sender_type?: string } | undefined;
+  const message = data.message as Record<string, unknown> | undefined;
+
+  if (!sender?.sender_id?.open_id || !message) return null;
+
+  const eventId = (data.event_id as string) ?? `ws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  let parsedContent: unknown;
+  try {
+    parsedContent = JSON.parse((message.content as string) ?? "{}");
+  } catch {
+    parsedContent = { text: message.content };
+  }
+
+  const mentions = Array.isArray(message.mentions)
+    ? (message.mentions as Array<{ key: string; id: { open_id: string }; name: string }>).map((m) => ({
+        key: m.key,
+        openId: m.id.open_id,
+        name: m.name,
+      }))
+    : [];
+
+  return {
+    eventId,
+    platform: "feishu",
+    appId,
+    senderId: sender.sender_id.open_id,
+    senderType: sender.sender_type ?? "user",
+    externalChannelId: (message.chat_id as string) ?? "",
+    chatType: (message.chat_type as string) ?? "group",
+    messageId: (message.message_id as string) ?? "",
+    messageType: (message.message_type as string) ?? "text",
+    content: parsedContent,
+    threadId: (message.root_id as string) || null,
+    mentions,
+    timestamp: (message.create_time as string) ?? "",
+  };
+}
+
+async function processInboundMessage(
+  db: Database,
+  event: InboundEvent,
+  appId: string,
+  log: FastifyBaseLogger,
+): Promise<void> {
+  // 1. Resolve sender → internal agent
+  const agentMapping = await mappingService.findAgentByExternalUser(db, "feishu", event.senderId);
+
+  let senderAgentId: string;
+  if (agentMapping) {
+    senderAgentId = agentMapping.agentId;
+  } else {
+    // Auto-create agent for Feishu user
+    const autoAgentId = `feishu-user-${event.senderId}`;
+    const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, autoAgentId)).limit(1);
+
+    if (existing) {
+      senderAgentId = existing.id;
+    } else {
+      try {
+        const agent = await createAgent(db, {
+          id: autoAgentId,
+          type: "human",
+          displayName: `Feishu User ${event.senderId.slice(0, 8)}`,
+          metadata: { source: "feishu", externalUserId: event.senderId, autoCreated: true },
+        });
+        senderAgentId = agent.id;
+      } catch {
+        senderAgentId = autoAgentId;
+      }
+    }
+    await mappingService.createAgentMapping(db, {
+      platform: "feishu",
+      externalUserId: event.senderId,
+      agentId: senderAgentId,
+      boundVia: "auto",
+      metadata: { appId },
+    });
+  }
+
+  // 2. Ensure adapter system agent
+  const adapterAgentId = `${FEISHU_ADAPTER_ID_PREFIX}-${appId}`;
+  await ensureAdapterAgent(db, adapterAgentId, appId);
+
+  // 3. Resolve chat → internal chat (auto-create if needed)
+  const chatId = await mappingService.findOrCreateChatForChannel(db, {
+    platform: "feishu",
+    externalChannelId: event.externalChannelId,
+    threadId: event.threadId,
+    chatType: event.chatType,
+    adapterAgentId,
+    senderAgentId,
+  });
+
+  // 4. Send message into internal system
+  const content =
+    typeof event.content === "object" && event.content !== null && "text" in event.content
+      ? (event.content as { text: string }).text
+      : JSON.stringify(event.content);
+
+  const msg = await sendMessage(db, chatId, senderAgentId, {
+    format: event.messageType === "text" ? "text" : "card",
+    content: event.messageType === "text" ? content : event.content,
+    metadata: {
+      source: "feishu",
+      externalMessageId: event.messageId,
+      externalChannelId: event.externalChannelId,
+      messageType: event.messageType,
+    },
+  });
+
+  // 5. Store message reference
+  await mappingService.createMessageReference(db, {
+    messageId: msg.id,
+    platform: "feishu",
+    externalMessageId: event.messageId,
+    externalChannelId: event.externalChannelId,
+  });
+
+  log.info({ appId, chatId, messageId: msg.id }, "Processed inbound Feishu message");
+}
+
+// ── Outbound helpers ────────────────────────────────────────────────
+
+async function processAdapterOutbound(
+  db: Database,
+  bot: ManagedBot,
+  log: FastifyBaseLogger,
+): Promise<{ sent: number; errors: number }> {
+  let sent = 0;
+  let errorCount = 0;
+
+  const [adapterAgent] = await db
+    .select({ inboxId: agents.inboxId })
+    .from(agents)
+    .where(eq(agents.id, bot.adapterAgentId))
+    .limit(1);
+
+  if (!adapterAgent) return { sent: 0, errors: 0 };
+
+  const claimed = await db.execute<{
+    id: number;
+    inbox_id: string;
+    message_id: string;
+    chat_id: string | null;
+  }>(sql`
+    UPDATE inbox_entries
+    SET status = 'delivered', delivered_at = NOW()
+    WHERE id IN (
+      SELECT id FROM inbox_entries
+      WHERE inbox_id = ${adapterAgent.inboxId} AND status = 'pending'
+      ORDER BY created_at
+      LIMIT ${OUTBOUND_BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING id, inbox_id, message_id, chat_id
+  `);
+
+  for (const entry of claimed) {
+    try {
+      const [msg] = await db.select().from(messages).where(eq(messages.id, entry.message_id)).limit(1);
+
+      if (!msg) {
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
+      // Skip messages from adapter itself
+      if (msg.senderId === bot.adapterAgentId) {
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
+      // Skip inbound messages that originated from Feishu (avoid echo)
+      const meta = msg.metadata as Record<string, unknown> | null;
+      if (meta?.source === "feishu") {
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
+      const chatId = entry.chat_id ?? msg.chatId;
+      const channelMapping = await mappingService.findExternalChannelByChat(db, "feishu", chatId);
+      if (!channelMapping) {
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
+      // Format and send via official SDK
+      const { msgType, content } = formatForFeishu(msg.format, msg.content);
+
+      const result = await bot.client.im.v1.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: channelMapping.externalChannelId,
+          msg_type: msgType,
+          content,
+        },
+      });
+
+      // Store message reference
+      const externalMsgId = result?.data?.message_id;
+      if (externalMsgId) {
+        await mappingService.createMessageReference(db, {
+          messageId: msg.id,
+          platform: "feishu",
+          externalMessageId: externalMsgId,
+          externalChannelId: channelMapping.externalChannelId,
+        });
+      }
+
+      await ackEntry(db, entry.id);
+      sent++;
+    } catch (err) {
+      log.error({ entryId: entry.id, err }, "Failed to send outbound Feishu message");
+      errorCount++;
+    }
+  }
+
+  return { sent, errors: errorCount };
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+async function ensureAdapterAgent(db: Database, adapterAgentId: string, appId: string): Promise<void> {
+  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, adapterAgentId)).limit(1);
+  if (existing) return;
+
+  try {
+    await createAgent(db, {
+      id: adapterAgentId,
+      type: "autonomous_agent",
+      displayName: `Feishu Adapter (${appId})`,
+      metadata: { source: "feishu", managed: true, appId },
+    });
+  } catch {
+    // Concurrent creation — OK
+  }
+}
+
+async function ackEntry(db: Database, entryId: number): Promise<void> {
+  await db.update(inboxEntries).set({ status: "acked", ackedAt: new Date() }).where(eq(inboxEntries.id, entryId));
+}
+
+/** Convert internal message format to Feishu msg_type + content string. */
+function formatForFeishu(format: string, content: unknown): { msgType: string; content: string } {
+  if (format === "text") {
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    return { msgType: "text", content: JSON.stringify({ text }) };
+  }
+
+  if (format === "markdown") {
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    const card = {
+      config: { wide_screen_mode: true },
+      elements: [{ tag: "markdown", content: text }],
+    };
+    return { msgType: "interactive", content: JSON.stringify(card) };
+  }
+
+  if (format === "card" && typeof content === "object") {
+    return { msgType: "interactive", content: JSON.stringify(content) };
+  }
+
+  const text = typeof content === "string" ? content : JSON.stringify(content);
+  return { msgType: "text", content: JSON.stringify({ text }) };
+}

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { adapterAgentMappings } from "../db/schema/adapter-agent-mappings.js";
+import { adapterChatMappings } from "../db/schema/adapter-chat-mappings.js";
+import { adapterMessageReferences } from "../db/schema/adapter-message-references.js";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants, chats } from "../db/schema/chats.js";
+
+// ── Event deduplication ─────────────────────────────────────────────
+
+/**
+ * Attempt to claim an event for processing.
+ * Returns true if this is the first time the event is seen, false if duplicate.
+ */
+export async function claimEvent(db: Database, eventId: string, platform: string): Promise<boolean> {
+  const result = await db.execute<{ event_id: string }>(
+    sql`INSERT INTO processed_events (event_id, platform) VALUES (${eventId}, ${platform}) ON CONFLICT DO NOTHING RETURNING event_id`,
+  );
+  return result.length > 0;
+}
+
+// ── Agent mapping ───────────────────────────────────────────────────
+
+/** Look up the internal agent ID for an external user. */
+export async function findAgentByExternalUser(
+  db: Database,
+  platform: string,
+  externalUserId: string,
+): Promise<{ agentId: string; displayName: string | null } | null> {
+  const [row] = await db
+    .select({ agentId: adapterAgentMappings.agentId, displayName: adapterAgentMappings.displayName })
+    .from(adapterAgentMappings)
+    .where(and(eq(adapterAgentMappings.platform, platform), eq(adapterAgentMappings.externalUserId, externalUserId)))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Look up the external user ID for an internal agent. */
+export async function findExternalUserByAgent(
+  db: Database,
+  platform: string,
+  agentId: string,
+): Promise<{ externalUserId: string } | null> {
+  const [row] = await db
+    .select({ externalUserId: adapterAgentMappings.externalUserId })
+    .from(adapterAgentMappings)
+    .where(and(eq(adapterAgentMappings.platform, platform), eq(adapterAgentMappings.agentId, agentId)))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Create an agent mapping. */
+export async function createAgentMapping(
+  db: Database,
+  data: {
+    platform: string;
+    externalUserId: string;
+    agentId: string;
+    boundVia?: string;
+    displayName?: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<typeof adapterAgentMappings.$inferSelect> {
+  const [row] = await db
+    .insert(adapterAgentMappings)
+    .values({
+      platform: data.platform,
+      externalUserId: data.externalUserId,
+      agentId: data.agentId,
+      boundVia: data.boundVia ?? null,
+      displayName: data.displayName ?? null,
+      metadata: data.metadata ?? {},
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  // If conflict, fetch the existing row
+  if (!row) {
+    const [existing] = await db
+      .select()
+      .from(adapterAgentMappings)
+      .where(
+        and(
+          eq(adapterAgentMappings.platform, data.platform),
+          eq(adapterAgentMappings.externalUserId, data.externalUserId),
+        ),
+      )
+      .limit(1);
+    if (!existing) throw new Error("Unexpected: concurrent insert failed and row not found");
+    return existing;
+  }
+  return row;
+}
+
+// ── Chat mapping ────────────────────────────────────────────────────
+
+/** Look up the internal chat ID for an external channel. */
+export async function findChatByExternalChannel(
+  db: Database,
+  platform: string,
+  externalChannelId: string,
+  threadId?: string | null,
+): Promise<{ chatId: string } | null> {
+  const conditions = [
+    eq(adapterChatMappings.platform, platform),
+    eq(adapterChatMappings.externalChannelId, externalChannelId),
+  ];
+
+  // Match COALESCE(thread_id, '') semantics
+  if (threadId) {
+    conditions.push(eq(adapterChatMappings.threadId, threadId));
+  } else {
+    conditions.push(sql`${adapterChatMappings.threadId} IS NULL`);
+  }
+
+  const [row] = await db
+    .select({ chatId: adapterChatMappings.chatId })
+    .from(adapterChatMappings)
+    .where(and(...conditions))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Look up the external channel for an internal chat. */
+export async function findExternalChannelByChat(
+  db: Database,
+  platform: string,
+  chatId: string,
+): Promise<{ externalChannelId: string; threadId: string | null } | null> {
+  const [row] = await db
+    .select({
+      externalChannelId: adapterChatMappings.externalChannelId,
+      threadId: adapterChatMappings.threadId,
+    })
+    .from(adapterChatMappings)
+    .where(and(eq(adapterChatMappings.platform, platform), eq(adapterChatMappings.chatId, chatId)))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Find or create an internal Chat for an external channel.
+ * Also ensures the adapter agent is a participant.
+ */
+export async function findOrCreateChatForChannel(
+  db: Database,
+  data: {
+    platform: string;
+    externalChannelId: string;
+    threadId?: string | null;
+    chatType: string;
+    topic?: string;
+    adapterAgentId: string;
+    senderAgentId: string;
+  },
+): Promise<string> {
+  // Check existing mapping
+  const existing = await findChatByExternalChannel(db, data.platform, data.externalChannelId, data.threadId);
+  if (existing) {
+    // Ensure both adapter and sender are participants
+    await ensureParticipant(db, existing.chatId, data.adapterAgentId);
+    await ensureParticipant(db, existing.chatId, data.senderAgentId);
+    return existing.chatId;
+  }
+
+  // Create new chat + mapping in transaction
+  const chatId = randomUUID();
+  const internalType = data.chatType === "p2p" ? "direct" : "group";
+
+  return db.transaction(async (tx) => {
+    // Get adapter agent's org
+    const [adapterAgent] = await tx
+      .select({ organizationId: agents.organizationId })
+      .from(agents)
+      .where(eq(agents.id, data.adapterAgentId))
+      .limit(1);
+
+    const orgId = adapterAgent?.organizationId ?? "default";
+
+    await tx.insert(chats).values({
+      id: chatId,
+      organizationId: orgId,
+      type: internalType,
+      topic: data.topic ?? null,
+      lifecyclePolicy: "adapter_managed",
+      metadata: { source: "feishu", externalChannelId: data.externalChannelId },
+    });
+
+    // Add adapter and sender as participants
+    await tx.insert(chatParticipants).values([
+      { chatId, agentId: data.adapterAgentId, role: "member" },
+      { chatId, agentId: data.senderAgentId, role: "member" },
+    ]);
+
+    // Create mapping
+    await tx.insert(adapterChatMappings).values({
+      platform: data.platform,
+      externalChannelId: data.externalChannelId,
+      chatId,
+      threadId: data.threadId ?? null,
+      metadata: {},
+    });
+
+    return chatId;
+  });
+}
+
+/** Ensure an agent is a participant of a chat (no-op if already). */
+async function ensureParticipant(db: Database, chatId: string, agentId: string): Promise<void> {
+  const [exists] = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.agentId, agentId)))
+    .limit(1);
+
+  if (!exists) {
+    await db.insert(chatParticipants).values({ chatId, agentId, role: "member" }).onConflictDoNothing();
+  }
+}
+
+// ── Message references ──────────────────────────────────────────────
+
+/** Store a cross-reference between internal and external message. */
+export async function createMessageReference(
+  db: Database,
+  data: {
+    messageId: string;
+    platform: string;
+    externalMessageId: string;
+    externalChannelId: string;
+  },
+): Promise<void> {
+  await db
+    .insert(adapterMessageReferences)
+    .values({
+      messageId: data.messageId,
+      platform: data.platform,
+      externalMessageId: data.externalMessageId,
+      externalChannelId: data.externalChannelId,
+    })
+    .onConflictDoNothing();
+}
+
+/** Find internal message ID from external message reference. */
+export async function findMessageByExternalId(
+  db: Database,
+  platform: string,
+  externalMessageId: string,
+): Promise<{ messageId: string } | null> {
+  const [row] = await db
+    .select({ messageId: adapterMessageReferences.messageId })
+    .from(adapterMessageReferences)
+    .where(
+      and(
+        eq(adapterMessageReferences.platform, platform),
+        eq(adapterMessageReferences.externalMessageId, externalMessageId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/** Find external message ID from internal message reference. */
+export async function findExternalMessageByInternalId(
+  db: Database,
+  platform: string,
+  messageId: string,
+): Promise<{ externalMessageId: string; externalChannelId: string } | null> {
+  const [row] = await db
+    .select({
+      externalMessageId: adapterMessageReferences.externalMessageId,
+      externalChannelId: adapterMessageReferences.externalChannelId,
+    })
+    .from(adapterMessageReferences)
+    .where(and(eq(adapterMessageReferences.platform, platform), eq(adapterMessageReferences.messageId, messageId)))
+    .limit(1);
+  return row ?? null;
+}

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -20,6 +20,14 @@ export async function claimEvent(db: Database, eventId: string, platform: string
   return result.length > 0;
 }
 
+/**
+ * Remove a claimed event so it can be retried on next delivery.
+ * Called when processing fails after claimEvent() succeeded.
+ */
+export async function unclaimEvent(db: Database, eventId: string, platform: string): Promise<void> {
+  await db.execute(sql`DELETE FROM processed_events WHERE event_id = ${eventId} AND platform = ${platform}`);
+}
+
 // ── Agent mapping ───────────────────────────────────────────────────
 
 /** Look up the internal agent ID for an external user. */

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import type { AdapterManager } from "./adapter-manager.js";
 import * as inboxService from "./inbox.js";
 import * as presenceService from "./presence.js";
 import * as systemConfigService from "./system-config.js";
@@ -8,9 +9,14 @@ export type BackgroundTasks = {
   stop(): void;
 };
 
-export function createBackgroundTasks(app: FastifyInstance, instanceId: string): BackgroundTasks {
+export function createBackgroundTasks(
+  app: FastifyInstance,
+  instanceId: string,
+  adapterManager: AdapterManager,
+): BackgroundTasks {
   let inboxTimer: ReturnType<typeof setInterval> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let adapterOutboundTimer: ReturnType<typeof setInterval> | null = null;
 
   return {
     start() {
@@ -38,6 +44,15 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
         }
       }, 30_000);
 
+      // Adapter outbound processing — runs every 5 seconds
+      adapterOutboundTimer = setInterval(async () => {
+        try {
+          await adapterManager.processOutbound();
+        } catch (err) {
+          app.log.error(err, "Adapter outbound processing failed");
+        }
+      }, 5_000);
+
       // Initial heartbeat
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
         app.log.error(err, "Failed initial heartbeat");
@@ -52,6 +67,10 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
       if (heartbeatTimer) {
         clearInterval(heartbeatTimer);
         heartbeatTimer = null;
+      }
+      if (adapterOutboundTimer) {
+        clearInterval(adapterOutboundTimer);
+        adapterOutboundTimer = null;
       }
     },
   };

--- a/packages/server/src/services/feishu/types.ts
+++ b/packages/server/src/services/feishu/types.ts
@@ -1,0 +1,28 @@
+/** Feishu adapter types (used with @larksuiteoapi/node-sdk). */
+
+// ── Normalized inbound event ────────────────────────────────────────
+
+export type InboundEvent = {
+  eventId: string;
+  platform: "feishu";
+  appId: string;
+  senderId: string;
+  senderType: string;
+  externalChannelId: string;
+  chatType: string;
+  messageId: string;
+  messageType: string;
+  content: unknown;
+  threadId: string | null;
+  mentions: Array<{ key: string; openId: string; name: string }>;
+  timestamp: string;
+};
+
+// ── Bot credentials stored in adapter_configs ───────────────────────
+
+export type FeishuBotCredentials = {
+  app_id: string;
+  app_secret: string;
+  /** Skip HTTP proxy for SDK connections. Defaults to true (Lark SDK proxy bug workaround). */
+  bypass_proxy?: boolean;
+};

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,4 +1,5 @@
 import type { Database } from "./db/connection.js";
+import type { AdapterManager } from "./services/adapter-manager.js";
 
 export type AgentIdentity = {
   id: string;
@@ -16,6 +17,7 @@ declare module "fastify" {
   interface FastifyInstance {
     db: Database;
     config: import("./config.js").Config;
+    adapterManager: AdapterManager;
   }
   interface FastifyRequest {
     agent?: AgentIdentity;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@fastify/websocket':
         specifier: ^11.2.0
         version: 11.2.0
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -847,6 +850,9 @@ packages:
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
+  '@larksuiteoapi/node-sdk@1.59.0':
+    resolution: {integrity: sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==}
+
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
@@ -1615,12 +1621,18 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -1733,6 +1745,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
@@ -1768,6 +1788,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -1826,6 +1850,10 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1963,6 +1991,10 @@ packages:
       oxc-resolver:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
@@ -1989,8 +2021,24 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2072,9 +2120,22 @@ packages:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2084,6 +2145,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2092,6 +2156,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -2099,6 +2167,10 @@ packages:
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -2112,8 +2184,24 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -2258,6 +2346,15 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.identity@3.0.0:
+    resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.pickby@4.6.0:
+    resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -2284,6 +2381,18 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -2339,6 +2448,10 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -2418,8 +2531,15 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -2599,6 +2719,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3489,6 +3625,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@larksuiteoapi/node-sdk@1.59.0':
+    dependencies:
+      axios: 1.13.6
+      lodash.identity: 3.0.0
+      lodash.merge: 4.6.2
+      lodash.pickby: 4.6.0
+      protobufjs: 7.5.4
+      qs: 6.15.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@lukeed/ms@2.0.2': {}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -4137,12 +4287,22 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
 
   avvio@9.2.0:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
+
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   b4a@1.8.0: {}
 
@@ -4241,6 +4401,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001780: {}
 
   chai@5.3.3:
@@ -4276,6 +4446,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@13.1.0: {}
 
@@ -4323,6 +4497,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -4372,6 +4548,12 @@ snapshots:
 
   dts-resolver@2.1.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexify@4.1.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -4398,7 +4580,22 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -4558,23 +4755,53 @@ snapshots:
       fast-querystring: 1.1.2
       safe-regex2: 5.1.0
 
+  follow-redirects@1.15.11: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-port@7.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -4595,7 +4822,19 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hookable@5.5.3: {}
 
@@ -4706,6 +4945,12 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.identity@3.0.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.pickby@4.6.0: {}
+
   lodash@4.17.23: {}
 
   long@5.3.2: {}
@@ -4727,6 +4972,14 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime@3.0.0: {}
 
@@ -4762,6 +5015,8 @@ snapshots:
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -4855,10 +5110,16 @@ snapshots:
       '@types/node': 22.19.15
       long: 5.3.2
 
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@1.0.0: {}
 
@@ -5052,6 +5313,34 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- Use official Lark SDK (`@larksuiteoapi/node-sdk`) WebSocket long connection for inbound messages — no public URL needed
- Implement adapter-manager with WS lifecycle management, outbound delivery, and hot-reload on config changes
- Implement adapter-mapping service (chat/agent/message reference CRUD + event deduplication)
- Add processed_events table + performance indexes migration
- Outbound messages skip Feishu-originated echo, support text/markdown/card format conversion
- Per-adapter `bypass_proxy` option (defaults true, workaround for Lark SDK proxy bug)

## Test plan
- [x] 19 test files, 94 tests passing (`pnpm check && pnpm typecheck && pnpm test`)
- [x] Manual verification: send message in Feishu → server logs "Processed inbound Feishu message" → messages table populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)