### PR TITLE
refactor: adapter architecture — eliminate adapter agent, enforce age…

### DIFF
--- a/packages/server/drizzle/0004_adapter_refactor.sql
+++ b/packages/server/drizzle/0004_adapter_refactor.sql
@@ -1,0 +1,13 @@
+-- Adapter refactor: agentId required + unique constraint per design doc
+-- Clean up any rows with NULL agent_id before adding NOT NULL constraint
+DELETE FROM "adapter_configs" WHERE "agent_id" IS NULL;
+
+--> statement-breakpoint
+ALTER TABLE "adapter_configs" ALTER COLUMN "agent_id" SET NOT NULL;
+
+--> statement-breakpoint
+ALTER TABLE "adapter_configs" ADD CONSTRAINT "uq_adapter_configs_agent_platform" UNIQUE("agent_id", "platform");
+
+--> statement-breakpoint
+-- Drop messages.sender_id FK — agents may be soft-deleted while messages are preserved
+ALTER TABLE "messages" DROP CONSTRAINT IF EXISTS "messages_sender_id_agents_id_fk";

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774531200000,
       "tag": "0003_feishu_adapter",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1774972800000,
+      "tag": "0004_adapter_refactor",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/adapter-mapping.test.ts
+++ b/packages/server/src/__tests__/adapter-mapping.test.ts
@@ -88,14 +88,14 @@ describe("Adapter mapping service", () => {
   describe("chat mapping", () => {
     it("creates chat for new external channel", async () => {
       const app = await appPromise;
-      const { agent: adapter } = await createTestAgent(app, { id: "chat-map-adapter" });
+      const { agent: botAgent } = await createTestAgent(app, { id: "chat-map-bot-agent" });
       const { agent: sender } = await createTestAgent(app, { id: "chat-map-sender" });
 
       const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_new_channel_1",
         chatType: "group",
-        adapterAgentId: adapter.id,
+        botAgentId: botAgent.id,
         senderAgentId: sender.id,
       });
 
@@ -106,7 +106,7 @@ describe("Adapter mapping service", () => {
         platform: "feishu",
         externalChannelId: "oc_new_channel_1",
         chatType: "group",
-        adapterAgentId: adapter.id,
+        botAgentId: botAgent.id,
         senderAgentId: sender.id,
       });
       expect(chatId2).toBe(chatId);
@@ -114,14 +114,14 @@ describe("Adapter mapping service", () => {
 
     it("creates separate chats for different external channels", async () => {
       const app = await appPromise;
-      const { agent: adapter } = await createTestAgent(app, { id: "multi-ch-adapter" });
+      const { agent: botAgent } = await createTestAgent(app, { id: "multi-ch-bot-agent" });
       const { agent: sender } = await createTestAgent(app, { id: "multi-ch-sender" });
 
       const chatId1 = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_multi_1",
         chatType: "group",
-        adapterAgentId: adapter.id,
+        botAgentId: botAgent.id,
         senderAgentId: sender.id,
       });
 
@@ -129,7 +129,7 @@ describe("Adapter mapping service", () => {
         platform: "feishu",
         externalChannelId: "oc_multi_2",
         chatType: "p2p",
-        adapterAgentId: adapter.id,
+        botAgentId: botAgent.id,
         senderAgentId: sender.id,
       });
 
@@ -138,20 +138,35 @@ describe("Adapter mapping service", () => {
 
     it("finds external channel by chat", async () => {
       const app = await appPromise;
-      const { agent: adapter } = await createTestAgent(app, { id: "reverse-ch-adapter" });
+      const { agent: botAgent } = await createTestAgent(app, { id: "reverse-ch-bot-agent" });
       const { agent: sender } = await createTestAgent(app, { id: "reverse-ch-sender" });
 
       const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_reverse_1",
         chatType: "group",
-        adapterAgentId: adapter.id,
+        botAgentId: botAgent.id,
         senderAgentId: sender.id,
       });
 
       const found = await mappingService.findExternalChannelByChat(app.db, "feishu", chatId);
       expect(found).not.toBeNull();
       expect(found?.externalChannelId).toBe("oc_reverse_1");
+    });
+
+    it("handles same agent as both bot and sender (p2p self-chat)", async () => {
+      const app = await appPromise;
+      const { agent } = await createTestAgent(app, { id: "self-chat-agent" });
+
+      const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
+        platform: "feishu",
+        externalChannelId: "oc_self_chat",
+        chatType: "p2p",
+        botAgentId: agent.id,
+        senderAgentId: agent.id,
+      });
+
+      expect(chatId).toBeTruthy();
     });
   });
 

--- a/packages/server/src/__tests__/admin-adapters.test.ts
+++ b/packages/server/src/__tests__/admin-adapters.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { createTestAdmin, createTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, createTestApp } from "./helpers.js";
 
 describe("Admin Adapters API", () => {
   const appPromise = createTestApp();
@@ -16,17 +16,20 @@ describe("Admin Adapters API", () => {
       });
   }
 
-  it("creates and lists adapter configs", async () => {
+  it("creates and lists adapter configs (agentId required)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-create-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_test", app_secret: "secret" },
     });
     expect(createRes.statusCode).toBe(201);
     const config = createRes.json();
     expect(config.platform).toBe("feishu");
+    expect(config.agentId).toBe(agent.id);
     expect(config.hasCredentials).toBe(true);
     // Credentials must NOT be returned in the response
     expect(config.credentials).toBeUndefined();
@@ -41,9 +44,11 @@ describe("Admin Adapters API", () => {
   it("gets a single adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-get-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "slack",
+      agentId: agent.id,
       credentials: { bot_token: "xoxb-test" },
     });
     const created = createRes.json();
@@ -51,14 +56,17 @@ describe("Admin Adapters API", () => {
     const getRes = await req("GET", `/api/v1/admin/adapters/${created.id}`);
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().platform).toBe("slack");
+    expect(getRes.json().agentId).toBe(agent.id);
   });
 
   it("updates adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-upd-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_upd", app_secret: "secret" },
     });
     const created = createRes.json();
@@ -70,12 +78,34 @@ describe("Admin Adapters API", () => {
     expect(updateRes.json().status).toBe("inactive");
   });
 
-  it("deletes adapter config", async () => {
+  it("updates agentId to another valid agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent: agent1 } = await createTestAgent(app, { id: "adapter-switch-1" });
+    const { agent: agent2 } = await createTestAgent(app, { id: "adapter-switch-2" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent1.id,
+      credentials: { app_id: "cli_switch", app_secret: "secret" },
+    });
+    const created = createRes.json();
+
+    const updateRes = await req("PATCH", `/api/v1/admin/adapters/${created.id}`, {
+      agentId: agent2.id,
+    });
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.json().agentId).toBe(agent2.id);
+  });
+
+  it("deletes adapter config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-del-agent" });
+
+    const createRes = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_del", app_secret: "secret" },
     });
     const created = createRes.json();
@@ -107,6 +137,7 @@ describe("Admin Adapters API", () => {
 
     const res = await req("POST", "/api/v1/admin/adapters", {
       platform: "invalid_platform",
+      agentId: "some-agent",
       credentials: { key: "value" },
     });
     expect(res.statusCode).toBe(400);
@@ -118,6 +149,18 @@ describe("Admin Adapters API", () => {
 
     const res = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: "some-agent",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects missing agentId", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "x", app_secret: "y" },
     });
     expect(res.statusCode).toBe(400);
   });
@@ -125,9 +168,11 @@ describe("Admin Adapters API", () => {
   it("updates credentials (re-encrypts)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-reencrypt-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "old_id", app_secret: "old_secret" },
     });
     const created = createRes.json();
@@ -141,19 +186,6 @@ describe("Admin Adapters API", () => {
     expect(updateRes.json().credentials).toBeUndefined();
   });
 
-  it("defaults status to active when not provided", async () => {
-    const app = await appPromise;
-    const req = await authedRequest(app);
-
-    const res = await req("POST", "/api/v1/admin/adapters", {
-      platform: "slack",
-      credentials: { bot_token: "xoxb-default" },
-    });
-    expect(res.statusCode).toBe(201);
-    expect(res.json().status).toBe("active");
-    expect(res.json().agentId).toBeNull();
-  });
-
   it("rejects non-existent agentId", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
@@ -164,6 +196,19 @@ describe("Admin Adapters API", () => {
       credentials: { app_id: "x", app_secret: "y" },
     });
     expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects human agent for adapter config", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "human-adapter-reject", type: "human" });
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
+      credentials: { app_id: "cli_human", app_secret: "s" },
+    });
+    expect(res.statusCode).toBe(400);
   });
 
   it("rejects non-numeric adapter ID", async () => {
@@ -184,5 +229,46 @@ describe("Admin Adapters API", () => {
     const app = await appPromise;
     const res = await app.inject({ method: "GET", url: "/api/v1/admin/adapters" });
     expect(res.statusCode).toBe(401);
+  });
+
+  it("enforces unique agent+platform constraint", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-unique-agent" });
+
+    const res1 = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
+      credentials: { app_id: "cli_u1", app_secret: "s1" },
+    });
+    expect(res1.statusCode).toBe(201);
+
+    // Same agent + same platform should fail with 409
+    const res2 = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
+      credentials: { app_id: "cli_u2", app_secret: "s2" },
+    });
+    expect(res2.statusCode).toBe(409);
+  });
+
+  it("allows same agent on different platforms", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "adapter-cross-plat-agent" });
+
+    const res1 = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
+      credentials: { app_id: "cli_cross", app_secret: "s1" },
+    });
+    expect(res1.statusCode).toBe(201);
+
+    const res2 = await req("POST", "/api/v1/admin/adapters", {
+      platform: "slack",
+      agentId: agent.id,
+      credentials: { bot_token: "xoxb-cross" },
+    });
+    expect(res2.statusCode).toBe(201);
   });
 });

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { createTestAdmin, createTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, createTestApp } from "./helpers.js";
 
 describe("Admin DELETE Agent API", () => {
   const appPromise = createTestApp();
@@ -16,7 +16,7 @@ describe("Admin DELETE Agent API", () => {
       });
   }
 
-  it("deletes (suspends) an agent and revokes all tokens", async () => {
+  it("soft-deletes an agent and revokes all tokens", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
@@ -38,10 +38,15 @@ describe("Admin DELETE Agent API", () => {
     const delRes = await req("DELETE", "/api/v1/admin/agents/del-agent");
     expect(delRes.statusCode).toBe(204);
 
-    // Verify agent is suspended
+    // Deleted agent is no longer visible via GET
     const getRes = await req("GET", "/api/v1/admin/agents/del-agent");
-    expect(getRes.statusCode).toBe(200);
-    expect(getRes.json().status).toBe("suspended");
+    expect(getRes.statusCode).toBe(404);
+
+    // Deleted agent is not in list
+    const listRes = await req("GET", "/api/v1/admin/agents");
+    const agents = listRes.json().items;
+    const found = agents.find((a: { id: string }) => a.id === "del-agent");
+    expect(found).toBeUndefined();
 
     // Token should no longer work
     const meRes2 = await app.inject({
@@ -52,11 +57,80 @@ describe("Admin DELETE Agent API", () => {
     expect(meRes2.statusCode).toBe(401);
   });
 
+  it("can recreate a deleted agent with the same ID", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    // Create and delete
+    await req("POST", "/api/v1/admin/agents", {
+      id: "recreate-agent",
+      type: "autonomous_agent",
+      displayName: "Original",
+    });
+    const delRes = await req("DELETE", "/api/v1/admin/agents/recreate-agent");
+    expect(delRes.statusCode).toBe(204);
+
+    // Recreate with same ID but different data
+    const createRes = await req("POST", "/api/v1/admin/agents", {
+      id: "recreate-agent",
+      type: "personal_assistant",
+      displayName: "Recreated",
+    });
+    expect(createRes.statusCode).toBe(201);
+    expect(createRes.json().type).toBe("personal_assistant");
+    expect(createRes.json().displayName).toBe("Recreated");
+    expect(createRes.json().status).toBe("active");
+  });
+
+  it("cannot recreate an active agent", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    await req("POST", "/api/v1/admin/agents", { id: "active-agent", type: "autonomous_agent" });
+
+    const createRes = await req("POST", "/api/v1/admin/agents", { id: "active-agent", type: "human" });
+    expect(createRes.statusCode).toBe(409);
+  });
+
+  it("deletes agent's adapter bindings", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "del-adapter-agent" });
+
+    // Create an adapter config bound to this agent
+    await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      agentId: agent.id,
+      credentials: { app_id: "cli_del_test", app_secret: "secret" },
+    });
+
+    // Delete agent
+    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.id}`);
+    expect(delRes.statusCode).toBe(204);
+
+    // Adapter config should be cleaned up
+    const listRes = await req("GET", "/api/v1/admin/adapters");
+    const configs = listRes.json();
+    const found = configs.find((c: { agentId: string }) => c.agentId === agent.id);
+    expect(found).toBeUndefined();
+  });
+
   it("returns 404 for non-existent agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
     const res = await req("DELETE", "/api/v1/admin/agents/non-existent");
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 for already deleted agent", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    await req("POST", "/api/v1/admin/agents", { id: "double-del", type: "human" });
+    await req("DELETE", "/api/v1/admin/agents/double-del");
+
+    const res = await req("DELETE", "/api/v1/admin/agents/double-del");
     expect(res.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { createTestAdmin, createTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, createTestApp } from "./helpers.js";
 
 describe("Feishu Adapter (WebSocket mode)", () => {
   const appPromise = createTestApp();
@@ -16,26 +16,31 @@ describe("Feishu Adapter (WebSocket mode)", () => {
       });
   }
 
-  it("creates adapter config with feishu credentials", async () => {
+  it("creates adapter config with feishu credentials (agentId required)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "feishu-ws-agent" });
 
     const res = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_ws_test", app_secret: "secret_123" },
     });
     expect(res.statusCode).toBe(201);
     expect(res.json().platform).toBe("feishu");
+    expect(res.json().agentId).toBe(agent.id);
     expect(res.json().hasCredentials).toBe(true);
   });
 
   it("adapter manager reload picks up new config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "feishu-reload-agent" });
 
     // Create a new adapter config
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_reload_test", app_secret: "secret_reload" },
     });
     expect(createRes.statusCode).toBe(201);
@@ -52,9 +57,11 @@ describe("Feishu Adapter (WebSocket mode)", () => {
   it("adapter manager reloads on config update", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "feishu-upd-reload-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_update_reload", app_secret: "secret_u" },
     });
     const created = createRes.json();
@@ -69,9 +76,11 @@ describe("Feishu Adapter (WebSocket mode)", () => {
   it("adapter manager reloads on config delete", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
+    const { agent } = await createTestAgent(app, { id: "feishu-del-reload-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
+      agentId: agent.id,
       credentials: { app_id: "cli_delete_reload", app_secret: "secret_d" },
     });
     const created = createRes.json();
@@ -89,5 +98,16 @@ describe("Feishu Adapter (WebSocket mode)", () => {
     });
     // Should be 404 since webhook route was removed
     expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects adapter config without agentId", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    const res = await req("POST", "/api/v1/admin/adapters", {
+      platform: "feishu",
+      credentials: { app_id: "cli_no_agent", app_secret: "secret" },
+    });
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/packages/server/src/api/admin/overview.ts
+++ b/packages/server/src/api/admin/overview.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { agents } from "../../db/schema/agents.js";
 import { chats } from "../../db/schema/chats.js";
@@ -6,7 +6,10 @@ import * as presenceService from "../../services/presence.js";
 
 export async function adminOverviewRoutes(app: FastifyInstance): Promise<void> {
   app.get("/", async () => {
-    const [agentCount] = await app.db.select({ count: sql<number>`count(*)::int` }).from(agents);
+    const [agentCount] = await app.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agents)
+      .where(ne(agents.status, "deleted"));
 
     const [chatCount] = await app.db.select({ count: sql<number>`count(*)::int` }).from(chats);
 

--- a/packages/server/src/db/schema/adapter-configs.ts
+++ b/packages/server/src/db/schema/adapter-configs.ts
@@ -1,16 +1,22 @@
-import { jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { jsonb, pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 
 /** Bot credentials for external platform adapters. Credentials are encrypted at application layer (AES-256-GCM). */
-export const adapterConfigs = pgTable("adapter_configs", {
-  id: serial("id").primaryKey(),
-  /** "feishu" | "slack" */
-  platform: text("platform").notNull(),
-  agentId: text("agent_id").references(() => agents.id),
-  /** Encrypted JSONB — application-layer AES-256-GCM */
-  credentials: jsonb("credentials").$type<unknown>().notNull(),
-  /** "active" | "inactive" */
-  status: text("status").notNull().default("active"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+export const adapterConfigs = pgTable(
+  "adapter_configs",
+  {
+    id: serial("id").primaryKey(),
+    /** "feishu" | "slack" */
+    platform: text("platform").notNull(),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id),
+    /** Encrypted JSONB — application-layer AES-256-GCM */
+    credentials: jsonb("credentials").$type<unknown>().notNull(),
+    /** "active" | "inactive" */
+    status: text("status").notNull().default("active"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [unique("uq_adapter_configs_agent_platform").on(t.agentId, t.platform)],
+);

--- a/packages/server/src/db/schema/messages.ts
+++ b/packages/server/src/db/schema/messages.ts
@@ -1,5 +1,4 @@
 import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
-import { agents } from "./agents.js";
 import { chats } from "./chats.js";
 
 /** Messages. Immutable after creation. Each message belongs to exactly one Chat. */
@@ -10,9 +9,8 @@ export const messages = pgTable(
     chatId: text("chat_id")
       .notNull()
       .references(() => chats.id),
-    senderId: text("sender_id")
-      .notNull()
-      .references(() => agents.id),
+    /** No FK constraint — agents may be soft-deleted while messages are preserved. */
+    senderId: text("sender_id").notNull(),
     /** "text" | "markdown" | "card" | "reference" | "file" */
     format: text("format").notNull(),
     content: jsonb("content").$type<unknown>().notNull(),

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -3,16 +3,13 @@ import { eq, sql } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
 import type { Database } from "../db/connection.js";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
-import { agents } from "../db/schema/agents.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import * as mappingService from "./adapter-mapping.js";
-import { createAgent } from "./agent.js";
 import { decryptCredentials } from "./crypto.js";
 import type { FeishuBotCredentials, InboundEvent } from "./feishu/types.js";
 import { sendMessage } from "./message.js";
 
-const FEISHU_ADAPTER_ID_PREFIX = "feishu-adapter";
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"];
 
 /**
@@ -38,6 +35,7 @@ async function withoutProxy<T>(fn: () => Promise<T>): Promise<T> {
     }
   }
 }
+
 const OUTBOUND_BATCH_SIZE = 10;
 
 type ManagedBot = {
@@ -45,16 +43,23 @@ type ManagedBot = {
   /** Track updatedAt to detect credential/setting changes on same config row. */
   configUpdatedAt: string;
   appId: string;
-  agentId: string | null;
-  adapterAgentId: string;
+  /** The agent bound to this bot via adapter_configs.agentId (required). */
+  agentId: string;
+  /** Whether to clear proxy env vars for SDK API calls (Lark SDK ignores NO_PROXY). */
+  bypassProxy: boolean;
   client: InstanceType<typeof Client>;
   wsClient: WSClient;
 };
 
+/** Wrap an SDK API call with proxy bypass if needed. */
+function botApiCall<T>(bot: ManagedBot, fn: () => Promise<T>): Promise<T> {
+  return bot.bypassProxy ? withoutProxy(fn) : fn();
+}
+
 export type AdapterManager = {
   /** Load active adapter configs and start/stop WS connections. */
   reload(): Promise<void>;
-  /** Process pending outbound messages for all adapter agents. */
+  /** Process pending outbound messages for feishu-bound human agents. */
   processOutbound(): Promise<{ sent: number; errors: number }>;
   /** Stop all WS connections. */
   shutdown(): void;
@@ -64,6 +69,8 @@ export type AdapterManager = {
  * Manages Feishu adapter bot instances using the official Lark SDK.
  * - Inbound: WSClient receives events via WebSocket (no public URL needed)
  * - Outbound: SDK Client sends messages via Feishu API
+ *
+ * Adapter is a service, not an agent — no adapter agents are created.
  */
 export function createAdapterManager(
   db: Database,
@@ -71,6 +78,14 @@ export function createAdapterManager(
   log: FastifyBaseLogger,
 ): AdapterManager {
   const bots = new Map<string, ManagedBot>();
+
+  /** Find a managed bot by its bound agentId. */
+  function findBotByAgentId(agentId: string): ManagedBot | undefined {
+    for (const bot of bots.values()) {
+      if (bot.agentId === agentId) return bot;
+    }
+    return undefined;
+  }
 
   /** Handle an inbound message event from Feishu WebSocket. */
   async function handleInboundEvent(appId: string, data: Record<string, unknown>): Promise<void> {
@@ -85,8 +100,11 @@ export function createAdapterManager(
       // Skip bot messages (avoid echo)
       if (event.senderType === "bot") return;
 
+      const bot = bots.get(appId);
+      if (!bot) return;
+
       try {
-        await processInboundMessage(db, event, appId, log);
+        await processInboundMessage(db, event, bot, log);
       } catch (err) {
         // Unclaim the event so it can be retried on next delivery
         await mappingService.unclaimEvent(db, event.eventId, "feishu");
@@ -132,10 +150,6 @@ export function createAdapterManager(
           log.info({ appId }, "Stopped old Feishu WS connection (config changed)");
         }
 
-        // Ensure adapter system agent
-        const adapterAgentId = `${FEISHU_ADAPTER_ID_PREFIX}-${appId}`;
-        await ensureAdapterAgent(db, adapterAgentId, appId);
-
         // bypass_proxy defaults to true (Lark SDK ignores NO_PROXY — known bug)
         const bypassProxy = creds.bypass_proxy !== false;
         const wrap = bypassProxy ? withoutProxy : <T>(fn: () => Promise<T>) => fn();
@@ -166,12 +180,12 @@ export function createAdapterManager(
           configUpdatedAt: configVersion,
           appId,
           agentId: config.agentId,
-          adapterAgentId,
+          bypassProxy,
           client,
           wsClient,
         });
 
-        log.info({ appId, configId: config.id }, "Started Feishu adapter bot (WebSocket)");
+        log.info({ appId, configId: config.id, agentId: config.agentId }, "Started Feishu adapter bot (WebSocket)");
       }
 
       // Stop bots that are no longer active
@@ -185,21 +199,14 @@ export function createAdapterManager(
     },
 
     async processOutbound() {
-      let sent = 0;
-      let errors = 0;
+      if (bots.size === 0) return { sent: 0, errors: 0 };
 
-      for (const [, bot] of bots) {
-        try {
-          const result = await processAdapterOutbound(db, bot, log);
-          sent += result.sent;
-          errors += result.errors;
-        } catch (err) {
-          log.error({ appId: bot.appId, err }, "Adapter outbound processing error");
-          errors++;
-        }
+      try {
+        return await processFeishuOutbound(db, findBotByAgentId, log);
+      } catch (err) {
+        log.error({ err }, "Feishu outbound processing error");
+        return { sent: 0, errors: 1 };
       }
-
-      return { sent, errors };
     },
 
     shutdown() {
@@ -259,59 +266,32 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
 async function processInboundMessage(
   db: Database,
   event: InboundEvent,
-  appId: string,
+  bot: ManagedBot,
   log: FastifyBaseLogger,
 ): Promise<void> {
   // 1. Resolve sender → internal agent
   const agentMapping = await mappingService.findAgentByExternalUser(db, "feishu", event.senderId);
 
-  let senderAgentId: string;
-  if (agentMapping) {
-    senderAgentId = agentMapping.agentId;
-  } else {
-    // Auto-create agent for Feishu user
-    const autoAgentId = `feishu-user-${event.senderId}`;
-    const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, autoAgentId)).limit(1);
-
-    if (existing) {
-      senderAgentId = existing.id;
-    } else {
-      try {
-        const agent = await createAgent(db, {
-          id: autoAgentId,
-          type: "human",
-          displayName: `Feishu User ${event.senderId.slice(0, 8)}`,
-          metadata: { source: "feishu", externalUserId: event.senderId, autoCreated: true },
-        });
-        senderAgentId = agent.id;
-      } catch {
-        senderAgentId = autoAgentId;
-      }
-    }
-    await mappingService.createAgentMapping(db, {
-      platform: "feishu",
-      externalUserId: event.senderId,
-      agentId: senderAgentId,
-      boundVia: "auto",
-      metadata: { appId },
-    });
+  if (!agentMapping) {
+    // Unknown user — reply with binding prompt, do not create agent
+    await replyUnknownUser(bot, event, log);
+    return;
   }
 
-  // 2. Ensure adapter system agent
-  const adapterAgentId = `${FEISHU_ADAPTER_ID_PREFIX}-${appId}`;
-  await ensureAdapterAgent(db, adapterAgentId, appId);
+  const senderAgentId = agentMapping.agentId;
 
-  // 3. Resolve chat → internal chat (auto-create if needed)
+  // 2. Resolve chat → internal chat (auto-create if needed)
+  //    Use bot.agentId (from adapter_configs) as the chat participant, not an adapter agent
   const chatId = await mappingService.findOrCreateChatForChannel(db, {
     platform: "feishu",
     externalChannelId: event.externalChannelId,
     threadId: event.threadId,
     chatType: event.chatType,
-    adapterAgentId,
+    botAgentId: bot.agentId,
     senderAgentId,
   });
 
-  // 4. Send message into internal system
+  // 3. Send message into internal system
   const content =
     typeof event.content === "object" && event.content !== null && "text" in event.content
       ? (event.content as { text: string }).text
@@ -328,7 +308,7 @@ async function processInboundMessage(
     },
   });
 
-  // 5. Store message reference
+  // 4. Store message reference
   await mappingService.createMessageReference(db, {
     messageId: msg.id,
     platform: "feishu",
@@ -336,27 +316,49 @@ async function processInboundMessage(
     externalChannelId: event.externalChannelId,
   });
 
-  log.info({ appId, chatId, messageId: msg.id }, "Processed inbound Feishu message");
+  log.info({ appId: bot.appId, chatId, messageId: msg.id }, "Processed inbound Feishu message");
+}
+
+/** Reply to unknown (unbound) user with binding instructions. */
+async function replyUnknownUser(bot: ManagedBot, event: InboundEvent, log: FastifyBaseLogger): Promise<void> {
+  const text = [
+    "Your account is not linked to Agent Hub yet.",
+    "Please contact your admin to set up the binding.",
+    `Your user ID: ${event.senderId}`,
+  ].join("\n");
+
+  try {
+    await botApiCall(bot, () =>
+      bot.client.im.v1.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: event.externalChannelId,
+          msg_type: "text",
+          content: JSON.stringify({ text }),
+        },
+      }),
+    );
+  } catch (err) {
+    log.warn({ senderId: event.senderId, err }, "Failed to send unknown-user reply");
+  }
 }
 
 // ── Outbound helpers ────────────────────────────────────────────────
 
-async function processAdapterOutbound(
+/**
+ * Process outbound messages for all feishu-bound human agents.
+ * Consumes pending inbox entries for human agents that have feishu platform bindings,
+ * then sends via the message sender's bound bot.
+ */
+async function processFeishuOutbound(
   db: Database,
-  bot: ManagedBot,
+  findBotByAgentId: (agentId: string) => ManagedBot | undefined,
   log: FastifyBaseLogger,
 ): Promise<{ sent: number; errors: number }> {
   let sent = 0;
   let errorCount = 0;
 
-  const [adapterAgent] = await db
-    .select({ inboxId: agents.inboxId })
-    .from(agents)
-    .where(eq(agents.id, bot.adapterAgentId))
-    .limit(1);
-
-  if (!adapterAgent) return { sent: 0, errors: 0 };
-
+  // Claim pending inbox entries for feishu-bound human agents
   const claimed = await db.execute<{
     id: number;
     inbox_id: string;
@@ -366,26 +368,26 @@ async function processAdapterOutbound(
     UPDATE inbox_entries
     SET status = 'delivered', delivered_at = NOW()
     WHERE id IN (
-      SELECT id FROM inbox_entries
-      WHERE inbox_id = ${adapterAgent.inboxId} AND status = 'pending'
-      ORDER BY created_at
+      SELECT ie.id FROM inbox_entries ie
+      JOIN agents a ON ie.inbox_id = a.inbox_id
+      JOIN adapter_agent_mappings aam ON a.id = aam.agent_id
+      WHERE aam.platform = 'feishu' AND ie.status = 'pending'
+      ORDER BY ie.created_at
       LIMIT ${OUTBOUND_BATCH_SIZE}
       FOR UPDATE SKIP LOCKED
     )
     RETURNING id, inbox_id, message_id, chat_id
   `);
 
+  // Dedup: when a chat has multiple feishu-bound humans, the same message
+  // produces multiple inbox entries. We only send once per (message, channel).
+  const sentMessages = new Set<string>();
+
   for (const entry of claimed) {
     try {
       const [msg] = await db.select().from(messages).where(eq(messages.id, entry.message_id)).limit(1);
 
       if (!msg) {
-        await ackEntry(db, entry.id);
-        continue;
-      }
-
-      // Skip messages from adapter itself
-      if (msg.senderId === bot.adapterAgentId) {
         await ackEntry(db, entry.id);
         continue;
       }
@@ -404,17 +406,37 @@ async function processAdapterOutbound(
         continue;
       }
 
+      // Dedup: skip if this message was already sent to this channel
+      const dedupKey = `${msg.id}:${channelMapping.externalChannelId}`;
+      if (sentMessages.has(dedupKey)) {
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
+      // Find the sender's bot (the agent who sent the message must have a feishu bot binding)
+      const bot = findBotByAgentId(msg.senderId);
+      if (!bot) {
+        // Sender has no feishu bot — cannot deliver to external platform
+        log.warn({ messageId: msg.id, senderId: msg.senderId }, "Outbound skip: sender has no feishu bot binding");
+        await ackEntry(db, entry.id);
+        continue;
+      }
+
       // Format and send via official SDK
       const { msgType, content } = formatForFeishu(msg.format, msg.content);
 
-      const result = await bot.client.im.v1.message.create({
-        params: { receive_id_type: "chat_id" },
-        data: {
-          receive_id: channelMapping.externalChannelId,
-          msg_type: msgType,
-          content,
-        },
-      });
+      const result = await botApiCall(bot, () =>
+        bot.client.im.v1.message.create({
+          params: { receive_id_type: "chat_id" },
+          data: {
+            receive_id: channelMapping.externalChannelId,
+            msg_type: msgType,
+            content,
+          },
+        }),
+      );
+
+      sentMessages.add(dedupKey);
 
       // Store message reference
       const externalMsgId = result?.data?.message_id;
@@ -439,22 +461,6 @@ async function processAdapterOutbound(
 }
 
 // ── Shared helpers ──────────────────────────────────────────────────
-
-async function ensureAdapterAgent(db: Database, adapterAgentId: string, appId: string): Promise<void> {
-  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, adapterAgentId)).limit(1);
-  if (existing) return;
-
-  try {
-    await createAgent(db, {
-      id: adapterAgentId,
-      type: "autonomous_agent",
-      displayName: `Feishu Adapter (${appId})`,
-      metadata: { source: "feishu", managed: true, appId },
-    });
-  } catch {
-    // Concurrent creation — OK
-  }
-}
 
 async function ackEntry(db: Database, entryId: number): Promise<void> {
   await db.update(inboxEntries).set({ status: "acked", ackedAt: new Date() }).where(eq(inboxEntries.id, entryId));

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -149,7 +149,7 @@ export async function findExternalChannelByChat(
 
 /**
  * Find or create an internal Chat for an external channel.
- * Also ensures the adapter agent is a participant.
+ * Ensures the bot's bound agent and the sender are participants.
  */
 export async function findOrCreateChatForChannel(
   db: Database,
@@ -159,15 +159,16 @@ export async function findOrCreateChatForChannel(
     threadId?: string | null;
     chatType: string;
     topic?: string;
-    adapterAgentId: string;
+    /** The agent bound to the bot via adapter_configs.agentId */
+    botAgentId: string;
     senderAgentId: string;
   },
 ): Promise<string> {
   // Check existing mapping
   const existing = await findChatByExternalChannel(db, data.platform, data.externalChannelId, data.threadId);
   if (existing) {
-    // Ensure both adapter and sender are participants
-    await ensureParticipant(db, existing.chatId, data.adapterAgentId);
+    // Ensure both bot agent and sender are participants
+    await ensureParticipant(db, existing.chatId, data.botAgentId);
     await ensureParticipant(db, existing.chatId, data.senderAgentId);
     return existing.chatId;
   }
@@ -177,14 +178,14 @@ export async function findOrCreateChatForChannel(
   const internalType = data.chatType === "p2p" ? "direct" : "group";
 
   return db.transaction(async (tx) => {
-    // Get adapter agent's org
-    const [adapterAgent] = await tx
+    // Get bot agent's org
+    const [botAgent] = await tx
       .select({ organizationId: agents.organizationId })
       .from(agents)
-      .where(eq(agents.id, data.adapterAgentId))
+      .where(eq(agents.id, data.botAgentId))
       .limit(1);
 
-    const orgId = adapterAgent?.organizationId ?? "default";
+    const orgId = botAgent?.organizationId ?? "default";
 
     await tx.insert(chats).values({
       id: chatId,
@@ -192,14 +193,18 @@ export async function findOrCreateChatForChannel(
       type: internalType,
       topic: data.topic ?? null,
       lifecyclePolicy: "adapter_managed",
-      metadata: { source: "feishu", externalChannelId: data.externalChannelId },
+      metadata: { source: data.platform, externalChannelId: data.externalChannelId },
     });
 
-    // Add adapter and sender as participants
-    await tx.insert(chatParticipants).values([
-      { chatId, agentId: data.adapterAgentId, role: "member" },
-      { chatId, agentId: data.senderAgentId, role: "member" },
-    ]);
+    // Add bot agent and sender as participants
+    const participants =
+      data.botAgentId === data.senderAgentId
+        ? [{ chatId, agentId: data.botAgentId, role: "member" as const }]
+        : [
+            { chatId, agentId: data.botAgentId, role: "member" as const },
+            { chatId, agentId: data.senderAgentId, role: "member" as const },
+          ];
+    await tx.insert(chatParticipants).values(participants);
 
     // Create mapping
     await tx.insert(adapterChatMappings).values({

--- a/packages/server/src/services/adapter.ts
+++ b/packages/server/src/services/adapter.ts
@@ -79,8 +79,7 @@ export async function createAdapterConfig(db: Database, data: CreateAdapterConfi
   } catch (err) {
     // PostgreSQL unique_violation (23505) on (agent_id, platform)
     // Drizzle wraps the PG error; the code may be on the error itself or on a nested cause
-    const pgCode =
-      (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code ?? "";
+    const pgCode = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code ?? "";
     if (pgCode === "23505") {
       throw new ConflictError(`Agent "${data.agentId}" already has a ${data.platform} adapter config`);
     }

--- a/packages/server/src/services/adapter.ts
+++ b/packages/server/src/services/adapter.ts
@@ -1,9 +1,9 @@
 import type { CreateAdapterConfig, UpdateAdapterConfig } from "@agent-hub/shared";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agents } from "../db/schema/agents.js";
-import { AppError, NotFoundError } from "../errors.js";
+import { AppError, BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { encryptCredentials } from "./crypto.js";
 
 /** Server misconfiguration — not a client error. */
@@ -22,9 +22,16 @@ function requireEncryptionKey(key: string | undefined): string {
 }
 
 async function validateAgentId(db: Database, agentId: string): Promise<void> {
-  const [agent] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, agentId)).limit(1);
+  const [agent] = await db
+    .select({ id: agents.id, type: agents.type })
+    .from(agents)
+    .where(and(eq(agents.id, agentId), ne(agents.status, "deleted")))
+    .limit(1);
   if (!agent) {
     throw new NotFoundError(`Agent "${agentId}" not found`);
+  }
+  if (agent.type === "human") {
+    throw new BadRequestError("Adapter configs can only be bound to non-human agents");
   }
 }
 
@@ -53,21 +60,32 @@ export async function getAdapterConfig(db: Database, id: number) {
 
 export async function createAdapterConfig(db: Database, data: CreateAdapterConfig, encryptionKey: string | undefined) {
   const key = requireEncryptionKey(encryptionKey);
-  if (data.agentId) await validateAgentId(db, data.agentId);
+  await validateAgentId(db, data.agentId);
   const encrypted = encryptCredentials(data.credentials, key);
 
-  const [row] = await db
-    .insert(adapterConfigs)
-    .values({
-      platform: data.platform,
-      agentId: data.agentId ?? null,
-      credentials: encrypted,
-      status: data.status ?? "active",
-    })
-    .returning();
+  try {
+    const [row] = await db
+      .insert(adapterConfigs)
+      .values({
+        platform: data.platform,
+        agentId: data.agentId,
+        credentials: encrypted,
+        status: data.status ?? "active",
+      })
+      .returning();
 
-  if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
-  return toResponse(row);
+    if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
+    return toResponse(row);
+  } catch (err) {
+    // PostgreSQL unique_violation (23505) on (agent_id, platform)
+    // Drizzle wraps the PG error; the code may be on the error itself or on a nested cause
+    const pgCode =
+      (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code ?? "";
+    if (pgCode === "23505") {
+      throw new ConflictError(`Agent "${data.agentId}" already has a ${data.platform} adapter config`);
+    }
+    throw err;
+  }
 }
 
 export async function updateAdapterConfig(
@@ -79,8 +97,8 @@ export async function updateAdapterConfig(
   const setClause: Record<string, unknown> = { updatedAt: new Date() };
 
   if (data.agentId !== undefined) {
-    if (data.agentId) await validateAgentId(db, data.agentId);
-    setClause.agentId = data.agentId ?? null;
+    await validateAgentId(db, data.agentId);
+    setClause.agentId = data.agentId;
   }
   if (data.status !== undefined) setClause.status = data.status;
   if (data.credentials !== undefined) {

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@agent-hub/shared";
-import { and, desc, eq, isNull, lt } from "drizzle-orm";
+import { AGENT_STATUSES } from "@agent-hub/shared";
+import { and, desc, eq, isNull, lt, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { adapterAgentMappings } from "../db/schema/adapter-agent-mappings.js";
+import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
@@ -15,9 +18,31 @@ export async function createAgent(db: Database, data: CreateAgent) {
   const id = data.id ?? randomUUID();
   const inboxId = `inbox_${id}`;
 
-  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, id)).limit(1);
+  const [existing] = await db
+    .select({ id: agents.id, status: agents.status })
+    .from(agents)
+    .where(eq(agents.id, id))
+    .limit(1);
+
   if (existing) {
-    throw new ConflictError(`Agent "${id}" already exists`);
+    if (existing.status !== AGENT_STATUSES.DELETED) {
+      throw new ConflictError(`Agent "${id}" already exists`);
+    }
+    // Overwrite deleted agent — reuse the row
+    const [agent] = await db
+      .update(agents)
+      .set({
+        organizationId: data.organizationId ?? "default",
+        type: data.type,
+        displayName: data.displayName ?? null,
+        status: "active",
+        metadata: data.metadata ?? {},
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.id, id))
+      .returning();
+    if (!agent) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+    return agent;
   }
 
   const [agent] = await db
@@ -38,7 +63,11 @@ export async function createAgent(db: Database, data: CreateAgent) {
 }
 
 export async function getAgent(db: Database, id: string) {
-  const [agent] = await db.select().from(agents).where(eq(agents.id, id)).limit(1);
+  const [agent] = await db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.id, id), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .limit(1);
   if (!agent) {
     throw new NotFoundError(`Agent "${id}" not found`);
   }
@@ -46,7 +75,8 @@ export async function getAgent(db: Database, id: string) {
 }
 
 export async function listAgents(db: Database, limit: number, cursor?: string) {
-  const where = cursor ? lt(agents.createdAt, new Date(cursor)) : undefined;
+  const notDeleted = ne(agents.status, AGENT_STATUSES.DELETED);
+  const where = cursor ? and(notDeleted, lt(agents.createdAt, new Date(cursor))) : notDeleted;
 
   const rows = await db
     .select({
@@ -84,7 +114,7 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
       ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
       updatedAt: new Date(),
     })
-    .where(eq(agents.id, id))
+    .where(and(eq(agents.id, id), ne(agents.status, AGENT_STATUSES.DELETED)))
     .returning();
 
   if (!agent) {
@@ -103,8 +133,35 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
 }
 
 export async function deleteAgent(db: Database, id: string) {
-  // Delete = suspend + revoke all tokens (per design doc)
-  return updateAgent(db, id, { status: "suspended" });
+  // Verify agent exists and is not already deleted
+  const [existing] = await db
+    .select({ id: agents.id, status: agents.status })
+    .from(agents)
+    .where(eq(agents.id, id))
+    .limit(1);
+  if (!existing || existing.status === AGENT_STATUSES.DELETED) {
+    throw new NotFoundError(`Agent "${id}" not found`);
+  }
+
+  // 1. Set status to deleted
+  const [agent] = await db
+    .update(agents)
+    .set({ status: AGENT_STATUSES.DELETED, updatedAt: new Date() })
+    .where(eq(agents.id, id))
+    .returning();
+
+  // 2. Revoke all active tokens
+  await db
+    .update(agentTokens)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
+
+  // 3. Clean up adapter bindings (bot credentials + user mappings)
+  await db.delete(adapterConfigs).where(eq(adapterConfigs.agentId, id));
+  await db.delete(adapterAgentMappings).where(eq(adapterAgentMappings.agentId, id));
+
+  if (!agent) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+  return agent;
 }
 
 export async function createToken(db: Database, agentId: string, data: CreateAgentToken) {

--- a/packages/shared/src/schemas/adapter.ts
+++ b/packages/shared/src/schemas/adapter.ts
@@ -18,14 +18,14 @@ export type AdapterStatus = z.infer<typeof adapterStatusSchema>;
 
 export const createAdapterConfigSchema = z.object({
   platform: adapterPlatformSchema,
-  agentId: z.string().optional(),
+  agentId: z.string().min(1),
   credentials: z.record(z.unknown()),
   status: adapterStatusSchema.default("active"),
 });
 export type CreateAdapterConfig = z.infer<typeof createAdapterConfigSchema>;
 
 export const updateAdapterConfigSchema = z.object({
-  agentId: z.string().nullish(),
+  agentId: z.string().min(1).optional(),
   credentials: z.record(z.unknown()).optional(),
   status: adapterStatusSchema.optional(),
 });
@@ -35,7 +35,7 @@ export type UpdateAdapterConfig = z.infer<typeof updateAdapterConfigSchema>;
 export const adapterConfigSchema = z.object({
   id: z.number(),
   platform: z.string(),
-  agentId: z.string().nullable(),
+  agentId: z.string(),
   hasCredentials: z.boolean(),
   status: z.string(),
   createdAt: z.string(),

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -13,6 +13,7 @@ export type AgentType = z.infer<typeof agentTypeSchema>;
 export const AGENT_STATUSES = {
   ACTIVE: "active",
   SUSPENDED: "suspended",
+  DELETED: "deleted",
 } as const;
 
 export const agentStatusSchema = z.enum(["active", "suspended"]);

--- a/packages/web/src/pages/adapters.tsx
+++ b/packages/web/src/pages/adapters.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, useState } from "react";
 import { createAdapter, deleteAdapter, listAdapters, updateAdapter } from "../api/adapters.js";
+import { listAgents } from "../api/agents.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import {
@@ -23,11 +24,36 @@ const platformValues = Object.values(ADAPTER_PLATFORMS);
 type FormState = {
   platform: string;
   agentId: string;
-  credentials: string;
+  /** Raw JSON fallback for non-feishu platforms */
+  credentialsJson: string;
+  /** Feishu-specific fields */
+  feishuAppId: string;
+  feishuAppSecret: string;
   status: string;
 };
 
-const emptyForm: FormState = { platform: "feishu", agentId: "", credentials: "{}", status: "active" };
+const emptyForm: FormState = {
+  platform: "feishu",
+  agentId: "",
+  credentialsJson: "{}",
+  feishuAppId: "",
+  feishuAppSecret: "",
+  status: "active",
+};
+
+/** Build credentials object from form state. Returns null if empty (edit mode, keep existing). */
+function buildCredentials(form: FormState, isCreate: boolean): Record<string, unknown> | null {
+  if (form.platform === "feishu") {
+    if (!form.feishuAppId && !form.feishuAppSecret) {
+      return isCreate ? null : null; // empty = keep existing in edit mode
+    }
+    return { app_id: form.feishuAppId, app_secret: form.feishuAppSecret };
+  }
+  // Fallback: raw JSON for other platforms
+  const trimmed = form.credentialsJson.trim();
+  if (!trimmed) return null;
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
 
 export function AdaptersPage() {
   const queryClient = useQueryClient();
@@ -38,12 +64,18 @@ export function AdaptersPage() {
 
   const { data: adapters, isLoading, error } = useQuery({ queryKey: ["adapters"], queryFn: listAdapters });
 
+  const { data: agentsData } = useQuery({
+    queryKey: ["agents", "all"],
+    queryFn: () => listAgents({ limit: 100 }),
+  });
+
   const createMutation = useMutation({
     mutationFn: () => {
-      const creds = JSON.parse(form.credentials) as Record<string, unknown>;
+      const creds = buildCredentials(form, true);
+      if (!creds) throw new Error("Credentials are required");
       return createAdapter({
         platform: form.platform as "feishu" | "slack",
-        agentId: form.agentId || undefined,
+        agentId: form.agentId,
         credentials: creds,
         status: form.status as "active" | "inactive",
       });
@@ -57,11 +89,9 @@ export function AdaptersPage() {
   const updateMutation = useMutation({
     mutationFn: () => {
       const data: Record<string, unknown> = { status: form.status as "active" | "inactive" };
-      if (form.agentId !== undefined) data.agentId = form.agentId || null;
-      const credsTrimmed = form.credentials.trim();
-      if (credsTrimmed) {
-        data.credentials = JSON.parse(credsTrimmed) as Record<string, unknown>;
-      }
+      if (form.agentId) data.agentId = form.agentId;
+      const creds = buildCredentials(form, false);
+      if (creds) data.credentials = creds;
       if (!editingId) throw new Error("No adapter selected for editing");
       return updateAdapter(editingId, data);
     },
@@ -83,12 +113,14 @@ export function AdaptersPage() {
     setCredError("");
   }
 
-  function openEdit(adapter: { id: number; platform: string; agentId: string | null; status: string }) {
+  function openEdit(adapter: { id: number; platform: string; agentId: string; status: string }) {
     setEditingId(adapter.id);
     setForm({
       platform: adapter.platform,
-      agentId: adapter.agentId ?? "",
-      credentials: "",
+      agentId: adapter.agentId,
+      credentialsJson: "",
+      feishuAppId: "",
+      feishuAppSecret: "",
       status: adapter.status,
     });
     setDialogOpen(true);
@@ -96,23 +128,32 @@ export function AdaptersPage() {
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const credsTrimmed = form.credentials.trim();
-    // Empty credentials = "unchanged" in edit mode, required in create mode
-    if (!editingId && !credsTrimmed) {
-      setCredError("Credentials are required");
-      return;
-    }
-    if (credsTrimmed) {
-      try {
-        JSON.parse(credsTrimmed);
-        setCredError("");
-      } catch {
-        setCredError("Invalid JSON");
+    setCredError("");
+
+    if (!editingId && !form.agentId) return;
+
+    // Validate credentials
+    if (form.platform === "feishu") {
+      if (!editingId && (!form.feishuAppId || !form.feishuAppSecret)) {
+        setCredError("App ID and App Secret are required");
         return;
       }
     } else {
-      setCredError("");
+      const trimmed = form.credentialsJson.trim();
+      if (!editingId && !trimmed) {
+        setCredError("Credentials are required");
+        return;
+      }
+      if (trimmed) {
+        try {
+          JSON.parse(trimmed);
+        } catch {
+          setCredError("Invalid JSON");
+          return;
+        }
+      }
     }
+
     if (editingId) {
       updateMutation.mutate();
     } else {
@@ -128,6 +169,8 @@ export function AdaptersPage() {
 
   const mutationError = createMutation.error ?? updateMutation.error;
   const isPending = createMutation.isPending || updateMutation.isPending;
+  const availableAgents = agentsData?.items?.filter((a) => a.type !== "human") ?? [];
+  const isFeishu = form.platform === "feishu";
 
   return (
     <div>
@@ -162,28 +205,68 @@ export function AdaptersPage() {
                 </select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="adapter-agent">Agent ID (optional)</Label>
-                <Input
+                <Label htmlFor="adapter-agent">Agent</Label>
+                <select
                   id="adapter-agent"
                   value={form.agentId}
                   onChange={(e) => setForm({ ...form, agentId: e.target.value })}
-                  placeholder="Bound agent ID"
-                />
+                  required={!editingId}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+                >
+                  <option value="">Select an agent...</option>
+                  {availableAgents.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.displayName ? `${a.displayName} (${a.id})` : a.id}
+                    </option>
+                  ))}
+                </select>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="adapter-creds">
-                  Credentials (JSON){editingId ? " — leave empty to keep existing" : ""}
-                </Label>
-                <textarea
-                  id="adapter-creds"
-                  value={form.credentials}
-                  onChange={(e) => setForm({ ...form, credentials: e.target.value })}
-                  rows={4}
-                  className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  placeholder='{"app_id": "...", "app_secret": "..."}'
-                />
-                {credError && <p className="text-sm text-destructive">{credError}</p>}
-              </div>
+
+              {/* Platform-specific credential fields */}
+              {isFeishu ? (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="feishu-app-id">App ID{editingId ? " — leave empty to keep existing" : ""}</Label>
+                    <Input
+                      id="feishu-app-id"
+                      value={form.feishuAppId}
+                      onChange={(e) => setForm({ ...form, feishuAppId: e.target.value })}
+                      placeholder="cli_xxxxxxxx"
+                      className="font-mono"
+                      autoComplete="off"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="feishu-app-secret">
+                      App Secret{editingId ? " — leave empty to keep existing" : ""}
+                    </Label>
+                    <Input
+                      id="feishu-app-secret"
+                      type="password"
+                      autoComplete="new-password"
+                      value={form.feishuAppSecret}
+                      onChange={(e) => setForm({ ...form, feishuAppSecret: e.target.value })}
+                      placeholder="••••••••"
+                    />
+                  </div>
+                </>
+              ) : (
+                <div className="space-y-2">
+                  <Label htmlFor="adapter-creds">
+                    Credentials (JSON){editingId ? " — leave empty to keep existing" : ""}
+                  </Label>
+                  <textarea
+                    id="adapter-creds"
+                    value={form.credentialsJson}
+                    onChange={(e) => setForm({ ...form, credentialsJson: e.target.value })}
+                    rows={4}
+                    className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm font-mono transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    placeholder='{"bot_token": "xoxb-...", "signing_secret": "..."}'
+                  />
+                </div>
+              )}
+              {credError && <p className="text-sm text-destructive">{credError}</p>}
+
               <div className="space-y-2">
                 <Label htmlFor="adapter-status">Status</Label>
                 <select
@@ -247,7 +330,7 @@ export function AdaptersPage() {
                   <TableCell>
                     <Badge variant="secondary">{a.platform}</Badge>
                   </TableCell>
-                  <TableCell className="font-mono text-sm">{a.agentId ?? "—"}</TableCell>
+                  <TableCell className="font-mono text-sm">{a.agentId}</TableCell>
                   <TableCell>
                     <Badge variant={a.status === "active" ? "default" : "destructive"}>{a.status}</Badge>
                   </TableCell>


### PR DESCRIPTION
…nt identity model

Implements the new adapter design where adapter is a pure service, not an agent:

- Remove adapter agent auto-creation (ensureAdapterAgent deleted)
- Route inbound messages via adapter_configs.agentId (now required + UNIQUE per platform)
- Outbound consumes feishu-bound human agent inboxes instead of adapter agent inbox
- Dedup outbound by (message_id, channel) to prevent duplicate sends in multi-human chats
- Unknown feishu user: bot replies with binding prompt instead of auto-creating agent
- Wrap all Lark SDK API calls with proxy bypass (withoutProxy)

Agent lifecycle:
- Soft delete (status='deleted') with adapter binding cleanup
- Recreate same ID overwrites deleted agent; active/suspended still conflicts
- Deleted agents hidden from all API endpoints (list, get, overview count)
- Drop messages.sender_id FK constraint to allow agent deletion without losing history

Validation & error handling:
- adapter_configs.agentId required (schema + DB NOT NULL)
- UNIQUE(agent_id, platform) constraint; violation returns 409
- Server rejects human agent for adapter config (not just web filter)
- updateAgent rejects operations on deleted agents

Web:
- Agent dropdown replaces text input in adapter form
- Platform-specific credential fields (App ID + App Secret for Feishu)
- autoComplete attributes to prevent browser autofill