### PR TITLE
feat: auto-sync agents from Context Tree members directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ SERVER_PORT=8000
 # Admin JWT (生成方式: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
 JWT_SECRET_KEY=
 
+# Context Tree 根目录路径 (必填, Agent 身份从 members/ 目录自动同步)
+CONTEXT_TREE_PATH=
+
 # Adapter 凭证加密密钥 (生成方式: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
 ADAPTER_ENCRYPTION_KEY=
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,7 @@
     "bcrypt": "^6.0.0",
     "drizzle-orm": "^0.44.0",
     "fastify": "^5.3.0",
+    "gray-matter": "^4.0.3",
     "jose": "^6.0.0",
     "postgres": "^3.4.0",
     "zod": "^3.25.0"

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
+import { createAgent } from "../services/agent.js";
 import { createTestAdmin, createTestApp } from "./helpers.js";
 
 describe("Admin Agents API", () => {
@@ -16,30 +17,23 @@ describe("Admin Agents API", () => {
       });
   }
 
-  it("creates and retrieves an agent", async () => {
+  it("retrieves an agent created via service", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    const createRes = await req("POST", "/api/v1/admin/agents", {
-      id: "agent-1",
-      type: "autonomous_agent",
-      displayName: "Bot One",
-    });
-    expect(createRes.statusCode).toBe(201);
-    const agent = createRes.json();
-    expect(agent.id).toBe("agent-1");
-    expect(agent.inboxId).toBe("inbox_agent-1");
+    await createAgent(app.db, { id: "agent-1", type: "autonomous_agent", displayName: "Bot One" });
 
     const getRes = await req("GET", "/api/v1/admin/agents/agent-1");
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().id).toBe("agent-1");
+    expect(getRes.json().inboxId).toBe("inbox_agent-1");
   });
 
   it("lists agents with pagination", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await req("POST", "/api/v1/admin/agents", { id: "a1", type: "human" });
-    await req("POST", "/api/v1/admin/agents", { id: "a2", type: "human" });
+    await createAgent(app.db, { id: "a1", type: "human" });
+    await createAgent(app.db, { id: "a2", type: "human" });
 
     const res = await req("GET", "/api/v1/admin/agents?limit=1");
     expect(res.statusCode).toBe(200);
@@ -51,7 +45,7 @@ describe("Admin Agents API", () => {
   it("lists agents with presenceStatus field", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await req("POST", "/api/v1/admin/agents", { id: "presence-test", type: "autonomous_agent" });
+    await createAgent(app.db, { id: "presence-test", type: "autonomous_agent" });
 
     const res = await req("GET", "/api/v1/admin/agents?limit=50");
     expect(res.statusCode).toBe(200);
@@ -60,20 +54,6 @@ describe("Admin Agents API", () => {
     expect(agent).toBeDefined();
     // No presence record → defaults to "offline"
     expect(agent.presenceStatus).toBe("offline");
-  });
-
-  it("updates an agent", async () => {
-    const app = await appPromise;
-    const req = await authedRequest(app);
-    await req("POST", "/api/v1/admin/agents", { id: "upd-1", type: "human" });
-
-    const res = await req("PATCH", "/api/v1/admin/agents/upd-1", {
-      displayName: "Updated",
-      status: "suspended",
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json().displayName).toBe("Updated");
-    expect(res.json().status).toBe("suspended");
   });
 
   it("rejects unauthenticated requests", async () => {
@@ -86,7 +66,7 @@ describe("Admin Agents API", () => {
     it("creates, lists, and revokes tokens", async () => {
       const app = await appPromise;
       const req = await authedRequest(app);
-      await req("POST", "/api/v1/admin/agents", { id: "tok-agent", type: "autonomous_agent" });
+      await createAgent(app.db, { id: "tok-agent", type: "autonomous_agent" });
 
       // Create token
       const createRes = await req("POST", "/api/v1/admin/agents/tok-agent/tokens", { name: "dev" });

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
+import { createAgent, suspendAgent } from "../services/agent.js";
 import { createTestAdmin, createTestAgent, createTestApp } from "./helpers.js";
 
 describe("Admin DELETE Agent API", () => {
@@ -16,80 +17,60 @@ describe("Admin DELETE Agent API", () => {
       });
   }
 
-  it("soft-deletes an agent and revokes all tokens", async () => {
+  it("deletes a suspended agent and revokes all tokens", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    // Create agent with token
-    await req("POST", "/api/v1/admin/agents", { id: "del-agent", type: "autonomous_agent" });
-    const tokenRes = await req("POST", "/api/v1/admin/agents/del-agent/tokens", { name: "test" });
-    expect(tokenRes.statusCode).toBe(201);
-    const token = tokenRes.json().token;
+    // Create agent with token, then suspend (simulating sync removing it from tree)
+    const { agent, token } = await createTestAgent(app, { id: "del-agent" });
+    await suspendAgent(app.db, agent.id);
 
-    // Verify agent works
+    // Verify token no longer works (revoked by suspend)
     const meRes = await app.inject({
       method: "GET",
       url: "/api/v1/agent/me",
       headers: { authorization: `Bearer ${token}` },
     });
-    expect(meRes.statusCode).toBe(200);
+    expect(meRes.statusCode).toBe(401);
 
-    // Delete agent
-    const delRes = await req("DELETE", "/api/v1/admin/agents/del-agent");
+    // Delete suspended agent
+    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.id}`);
     expect(delRes.statusCode).toBe(204);
 
-    // Deleted agent is no longer visible via GET
-    const getRes = await req("GET", "/api/v1/admin/agents/del-agent");
+    // Deleted agent is no longer visible
+    const getRes = await req("GET", `/api/v1/admin/agents/${agent.id}`);
     expect(getRes.statusCode).toBe(404);
-
-    // Deleted agent is not in list
-    const listRes = await req("GET", "/api/v1/admin/agents");
-    const agents = listRes.json().items;
-    const found = agents.find((a: { id: string }) => a.id === "del-agent");
-    expect(found).toBeUndefined();
-
-    // Token should no longer work
-    const meRes2 = await app.inject({
-      method: "GET",
-      url: "/api/v1/agent/me",
-      headers: { authorization: `Bearer ${token}` },
-    });
-    expect(meRes2.statusCode).toBe(401);
   });
 
-  it("can recreate a deleted agent with the same ID", async () => {
+  it("rejects deleting an active agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    // Create and delete
-    await req("POST", "/api/v1/admin/agents", {
-      id: "recreate-agent",
-      type: "autonomous_agent",
-      displayName: "Original",
-    });
+    await createAgent(app.db, { id: "active-no-del", type: "autonomous_agent" });
+
+    const res = await req("DELETE", "/api/v1/admin/agents/active-no-del");
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("can recreate a deleted agent via service", async () => {
+    const app = await appPromise;
+    const req = await authedRequest(app);
+
+    // Create, suspend, then delete
+    await createAgent(app.db, { id: "recreate-agent", type: "autonomous_agent", displayName: "Original" });
+    await suspendAgent(app.db, "recreate-agent");
     const delRes = await req("DELETE", "/api/v1/admin/agents/recreate-agent");
     expect(delRes.statusCode).toBe(204);
 
-    // Recreate with same ID but different data
-    const createRes = await req("POST", "/api/v1/admin/agents", {
+    // Recreate with same ID (as sync would do)
+    const recreated = await createAgent(app.db, {
       id: "recreate-agent",
       type: "personal_assistant",
       displayName: "Recreated",
     });
-    expect(createRes.statusCode).toBe(201);
-    expect(createRes.json().type).toBe("personal_assistant");
-    expect(createRes.json().displayName).toBe("Recreated");
-    expect(createRes.json().status).toBe("active");
-  });
-
-  it("cannot recreate an active agent", async () => {
-    const app = await appPromise;
-    const req = await authedRequest(app);
-
-    await req("POST", "/api/v1/admin/agents", { id: "active-agent", type: "autonomous_agent" });
-
-    const createRes = await req("POST", "/api/v1/admin/agents", { id: "active-agent", type: "human" });
-    expect(createRes.statusCode).toBe(409);
+    expect(recreated.type).toBe("personal_assistant");
+    expect(recreated.displayName).toBe("Recreated");
+    expect(recreated.status).toBe("active");
   });
 
   it("deletes agent's adapter bindings", async () => {
@@ -104,7 +85,8 @@ describe("Admin DELETE Agent API", () => {
       credentials: { app_id: "cli_del_test", app_secret: "secret" },
     });
 
-    // Delete agent
+    // Suspend then delete
+    await suspendAgent(app.db, agent.id);
     const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.id}`);
     expect(delRes.statusCode).toBe(204);
 
@@ -127,7 +109,8 @@ describe("Admin DELETE Agent API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    await req("POST", "/api/v1/admin/agents", { id: "double-del", type: "human" });
+    await createAgent(app.db, { id: "double-del", type: "human" });
+    await suspendAgent(app.db, "double-del");
     await req("DELETE", "/api/v1/admin/agents/double-del");
 
     const res = await req("DELETE", "/api/v1/admin/agents/double-del");

--- a/packages/server/src/__tests__/e2e-github-to-cli.test.ts
+++ b/packages/server/src/__tests__/e2e-github-to-cli.test.ts
@@ -69,6 +69,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       logger: false,
       jwtSecretKey: "test-jwt-secret-key-for-e2e",
       instanceId: "e2e-test",
+      contextTreePath: "/tmp/agent-hub-test-tree",
     });
     await app.ready();
     address = await app.listen({ port: 0, host: "127.0.0.1" });
@@ -171,6 +172,7 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
       logger: false,
       jwtSecretKey: "test-jwt-secret-key-for-e2e-sig",
       instanceId: "e2e-test-sig",
+      contextTreePath: "/tmp/agent-hub-test-tree",
       githubWebhookSecret: secret,
     });
     await app2.ready();

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -11,6 +11,7 @@ export async function createTestApp(): Promise<FastifyInstance> {
     logger: false,
     jwtSecretKey: process.env.JWT_SECRET_KEY ?? "test-jwt-secret-key-for-vitest",
     instanceId: "test-instance",
+    contextTreePath: process.env.CONTEXT_TREE_PATH ?? "/tmp/agent-hub-test-tree",
     adapterEncryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   };
   const app = await buildApp(config);

--- a/packages/server/src/api/admin/agent-sync.ts
+++ b/packages/server/src/api/admin/agent-sync.ts
@@ -1,0 +1,16 @@
+import type { FastifyInstance } from "fastify";
+import { getLastSyncReport, syncAgents } from "../../services/agent-sync.js";
+
+export async function adminAgentSyncRoutes(app: FastifyInstance): Promise<void> {
+  // Trigger manual sync
+  app.post("/", async (_request, reply) => {
+    const report = await syncAgents(app.db, app.config.contextTreePath);
+    return reply.send(report);
+  });
+
+  // Get most recent sync status
+  app.get("/status", async (_request, reply) => {
+    const lastSync = getLastSyncReport();
+    return reply.send({ lastSync });
+  });
+}

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -1,4 +1,4 @@
-import { createAgentSchema, createAgentTokenSchema, paginationQuerySchema, updateAgentSchema } from "@agent-hub/shared";
+import { createAgentTokenSchema, paginationQuerySchema } from "@agent-hub/shared";
 import type { FastifyInstance } from "fastify";
 import * as agentService from "../../services/agent.js";
 
@@ -21,28 +21,11 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  app.post("/", async (request, reply) => {
-    const body = createAgentSchema.parse(request.body);
-    const agent = await agentService.createAgent(app.db, body);
-    return reply.status(201).send({
-      ...agent,
-      createdAt: agent.createdAt.toISOString(),
-      updatedAt: agent.updatedAt.toISOString(),
-    });
-  });
+  // POST / (create) removed — agents are created by Context Tree sync
+  // PATCH /:agentId (update) removed — status is managed by sync, admin controls via token revocation
 
   app.get<{ Params: { agentId: string } }>("/:agentId", async (request) => {
     const agent = await agentService.getAgent(app.db, request.params.agentId);
-    return {
-      ...agent,
-      createdAt: agent.createdAt.toISOString(),
-      updatedAt: agent.updatedAt.toISOString(),
-    };
-  });
-
-  app.patch<{ Params: { agentId: string } }>("/:agentId", async (request) => {
-    const body = updateAgentSchema.parse(request.body);
-    const agent = await agentService.updateAgent(app.db, request.params.agentId, body);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
@@ -79,7 +62,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     return reply.status(204).send();
   });
 
-  // DELETE agent (suspend + revoke all tokens)
+  // DELETE agent — only allowed for suspended agents (removed from tree)
   app.delete<{ Params: { agentId: string } }>("/:agentId", async (request, reply) => {
     await agentService.deleteAgent(app.db, request.params.agentId);
     return reply.status(204).send();

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -8,6 +8,7 @@ import { ZodError } from "zod";
 import { adminAdapterMappingRoutes } from "./api/admin/adapter-mappings.js";
 import { adminAdapterStatusRoutes } from "./api/admin/adapter-status.js";
 import { adminAdapterRoutes } from "./api/admin/adapters.js";
+import { adminAgentSyncRoutes } from "./api/admin/agent-sync.js";
 import { adminAgentRoutes } from "./api/admin/agents.js";
 import { adminAuthRoutes } from "./api/admin/auth.js";
 import { adminChatRoutes } from "./api/admin/chats.js";
@@ -27,8 +28,10 @@ import { AppError } from "./errors.js";
 import { adminAuthHook } from "./middleware/admin-auth.js";
 import { agentAuthHook } from "./middleware/agent-auth.js";
 import { type AdapterManager, createAdapterManager } from "./services/adapter-manager.js";
+import { startPeriodicSync, stopPeriodicSync, syncAgents } from "./services/agent-sync.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
+import * as systemConfigService from "./services/system-config.js";
 
 // Fastify type augmentation
 import "./types.js";
@@ -85,6 +88,14 @@ export async function buildApp(config: Config) {
           await adminApp.register(adminAgentRoutes);
         },
         { prefix: "/admin/agents" },
+      );
+
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminAgentSyncRoutes);
+        },
+        { prefix: "/admin/agents/sync" },
       );
 
       await api.register(
@@ -202,10 +213,27 @@ export async function buildApp(config: Config) {
     } else {
       await adapterManager.reload();
     }
+
+    // Initial agent sync from Context Tree
+    try {
+      const report = await syncAgents(db, config.contextTreePath);
+      const s = report.summary;
+      app.log.info(
+        `Initial agent sync: created=${s.created} updated=${s.updated} suspended=${s.suspended} unchanged=${s.unchanged} errors=${s.errors}`,
+      );
+    } catch (err) {
+      app.log.error(err, "Initial agent sync failed");
+    }
+
+    // Start periodic sync
+    const configs = await systemConfigService.getAllConfigs(db);
+    const intervalSeconds = (configs.agent_sync_interval_seconds as number) ?? 60;
+    startPeriodicSync(db, config.contextTreePath, intervalSeconds, app.log);
   });
 
   // Cleanup on close
   app.addHook("onClose", async () => {
+    stopPeriodicSync();
     backgroundTasks.stop();
     adapterManager.shutdown();
     await notifier.stop();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -8,6 +8,7 @@ export type Config = {
   serverPort: number;
   jwtSecretKey: string;
   instanceId: string;
+  contextTreePath: string;
   logger?: boolean;
   githubWebhookSecret?: string;
   webDistPath?: string;
@@ -25,12 +26,18 @@ export function loadConfig(): Config {
     throw new Error("JWT_SECRET_KEY is required");
   }
 
+  const contextTreePath = env.CONTEXT_TREE_PATH;
+  if (!contextTreePath) {
+    throw new Error("CONTEXT_TREE_PATH is required");
+  }
+
   return {
     databaseUrl,
     serverHost: env.SERVER_HOST ?? "0.0.0.0",
     serverPort: Number(env.SERVER_PORT ?? "8000"),
     jwtSecretKey,
     instanceId: env.INSTANCE_ID ?? `srv_${randomUUID().slice(0, 8)}`,
+    contextTreePath,
     githubWebhookSecret: env.GITHUB_WEBHOOK_SECRET || undefined,
     webDistPath: env.WEB_DIST_PATH,
     adapterEncryptionKey: env.ADAPTER_ENCRYPTION_KEY || undefined,

--- a/packages/server/src/services/agent-sync.ts
+++ b/packages/server/src/services/agent-sync.ts
@@ -1,0 +1,184 @@
+import { AGENT_STATUSES, type SyncReport } from "@agent-hub/shared";
+import { eq, ne } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import * as agentService from "./agent.js";
+import { type MemberEntry, readMembers } from "./tree-reader.js";
+
+// In-memory store for most recent sync result
+let lastSyncReport: SyncReport | null = null;
+let syncTimer: ReturnType<typeof setInterval> | null = null;
+
+export function getLastSyncReport(): SyncReport | null {
+  return lastSyncReport;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function buildTreeMeta(member: MemberEntry): Record<string, unknown> {
+  const tree: Record<string, unknown> = {};
+  if (member.role) tree.role = member.role;
+  if (member.domains) tree.domains = member.domains;
+  if (member.owners) tree.owners = member.owners;
+  return tree;
+}
+
+/**
+ * Merge tree-managed fields into existing metadata without overwriting
+ * other namespaces (e.g. metadata.github).
+ */
+function mergeMetadata(existing: Record<string, unknown>, treeMeta: Record<string, unknown>): Record<string, unknown> {
+  return { ...existing, tree: treeMeta };
+}
+
+function needsUpdate(
+  agent: { type: string; displayName: string | null; metadata: Record<string, unknown> },
+  member: MemberEntry,
+): boolean {
+  if (agent.type !== member.type) return true;
+  if (agent.displayName !== member.title) return true;
+  const existingTree = (agent.metadata?.tree ?? {}) as Record<string, unknown>;
+  if (!deepEqual(existingTree, buildTreeMeta(member))) return true;
+  return false;
+}
+
+/**
+ * Core sync: read context tree members, compare with DB, create/update/suspend.
+ */
+export async function syncAgents(db: Database, treePath: string): Promise<SyncReport> {
+  const report: SyncReport = {
+    syncedAt: new Date().toISOString(),
+    treePath,
+    summary: { created: 0, updated: 0, suspended: 0, unchanged: 0, errors: 0 },
+    created: [],
+    updated: [],
+    suspended: [],
+    errors: [],
+  };
+
+  // 1. Read tree
+  const { members, errors: readErrors } = await readMembers(treePath);
+  for (const err of readErrors) {
+    report.errors.push(err);
+  }
+
+  // 2. Read DB — all non-deleted agents
+  const dbAgents = await db.select().from(agents).where(ne(agents.status, AGENT_STATUSES.DELETED));
+
+  // 3. Build lookup maps
+  const treeMap = new Map(members.map((m) => [m.id, m]));
+  const dbMap = new Map(dbAgents.map((a) => [a.id, a]));
+
+  // 4a. Create or update from tree
+  for (const member of members) {
+    const existing = dbMap.get(member.id);
+    const treeMeta = buildTreeMeta(member);
+
+    if (!existing) {
+      try {
+        await agentService.createAgent(db, {
+          id: member.id,
+          type: member.type,
+          displayName: member.title,
+          metadata: { tree: treeMeta },
+        });
+        report.created.push(member.id);
+        report.summary.created++;
+      } catch (err) {
+        report.errors.push({ memberId: member.id, error: `Failed to create: ${String(err)}` });
+      }
+      continue;
+    }
+
+    // Existing agent — check if needs update or reactivation
+    let updated = false;
+    const merged = mergeMetadata(existing.metadata, treeMeta);
+
+    if (existing.status === AGENT_STATUSES.SUSPENDED) {
+      // Reactivate — member reappeared in tree
+      await db
+        .update(agents)
+        .set({
+          status: AGENT_STATUSES.ACTIVE,
+          type: member.type,
+          displayName: member.title,
+          metadata: merged,
+          updatedAt: new Date(),
+        })
+        .where(eq(agents.id, member.id));
+      updated = true;
+    } else if (needsUpdate(existing, member)) {
+      await db
+        .update(agents)
+        .set({
+          type: member.type,
+          displayName: member.title,
+          metadata: merged,
+          updatedAt: new Date(),
+        })
+        .where(eq(agents.id, member.id));
+      updated = true;
+    }
+
+    if (updated) {
+      report.updated.push(member.id);
+      report.summary.updated++;
+    } else {
+      report.summary.unchanged++;
+    }
+  }
+
+  // 4b. Suspend orphans — agents in DB but not in tree
+  for (const agent of dbAgents) {
+    if (!treeMap.has(agent.id) && agent.status === AGENT_STATUSES.ACTIVE) {
+      try {
+        await agentService.suspendAgent(db, agent.id);
+        report.suspended.push(agent.id);
+        report.summary.suspended++;
+      } catch (err) {
+        report.errors.push({ memberId: agent.id, error: `Failed to suspend: ${String(err)}` });
+      }
+    }
+  }
+
+  report.summary.errors = report.errors.length;
+
+  lastSyncReport = report;
+  return report;
+}
+
+/**
+ * Start periodic sync.
+ */
+export function startPeriodicSync(
+  db: Database,
+  treePath: string,
+  intervalSeconds: number,
+  log: { info: (msg: string) => void; error: (err: unknown, msg: string) => void },
+): void {
+  if (syncTimer) {
+    clearInterval(syncTimer);
+  }
+  if (intervalSeconds <= 0) return;
+
+  syncTimer = setInterval(async () => {
+    try {
+      const report = await syncAgents(db, treePath);
+      const s = report.summary;
+      if (s.created > 0 || s.updated > 0 || s.suspended > 0 || s.errors > 0) {
+        log.info(`Agent sync: created=${s.created} updated=${s.updated} suspended=${s.suspended} errors=${s.errors}`);
+      }
+    } catch (err) {
+      log.error(err, "Periodic agent sync failed");
+    }
+  }, intervalSeconds * 1000);
+}
+
+export function stopPeriodicSync(): void {
+  if (syncTimer) {
+    clearInterval(syncTimer);
+    syncTimer = null;
+  }
+}

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@agent-hub/shared";
+import type { CreateAgent, CreateAgentToken } from "@agent-hub/shared";
 import { AGENT_STATUSES } from "@agent-hub/shared";
 import { and, desc, eq, isNull, lt, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
@@ -8,7 +8,7 @@ import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
-import { ConflictError, NotFoundError } from "../errors.js";
+import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 
 function hashToken(raw: string): string {
   return createHash("sha256").update(raw).digest("hex");
@@ -105,15 +105,14 @@ export async function listAgents(db: Database, limit: number, cursor?: string) {
   return { items, nextCursor };
 }
 
-export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
+/**
+ * Suspend an agent (called by sync when member is removed from tree).
+ * Revokes all active tokens so the agent can no longer authenticate.
+ */
+export async function suspendAgent(db: Database, id: string) {
   const [agent] = await db
     .update(agents)
-    .set({
-      ...(data.displayName !== undefined ? { displayName: data.displayName ?? null } : {}),
-      ...(data.status !== undefined ? { status: data.status } : {}),
-      ...(data.metadata !== undefined ? { metadata: data.metadata } : {}),
-      updatedAt: new Date(),
-    })
+    .set({ status: AGENT_STATUSES.SUSPENDED, updatedAt: new Date() })
     .where(and(eq(agents.id, id), ne(agents.status, AGENT_STATUSES.DELETED)))
     .returning();
 
@@ -121,19 +120,19 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
     throw new NotFoundError(`Agent "${id}" not found`);
   }
 
-  // Suspend = revoke all active tokens (design: "停用 = suspended + 吊销所有 Token")
-  if (data.status === "suspended") {
-    await db
-      .update(agentTokens)
-      .set({ revokedAt: new Date() })
-      .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
-  }
+  // Revoke all active tokens
+  await db
+    .update(agentTokens)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
 
   return agent;
 }
 
+/**
+ * Delete an agent. Only allowed when status is "suspended" (removed from tree).
+ */
 export async function deleteAgent(db: Database, id: string) {
-  // Verify agent exists and is not already deleted
   const [existing] = await db
     .select({ id: agents.id, status: agents.status })
     .from(agents)
@@ -141,6 +140,9 @@ export async function deleteAgent(db: Database, id: string) {
     .limit(1);
   if (!existing || existing.status === AGENT_STATUSES.DELETED) {
     throw new NotFoundError(`Agent "${id}" not found`);
+  }
+  if (existing.status !== AGENT_STATUSES.SUSPENDED) {
+    throw new BadRequestError("Only suspended agents can be deleted. Active agents are managed by Context Tree.");
   }
 
   // 1. Set status to deleted
@@ -150,7 +152,7 @@ export async function deleteAgent(db: Database, id: string) {
     .where(eq(agents.id, id))
     .returning();
 
-  // 2. Revoke all active tokens
+  // 2. Revoke all active tokens (may already be revoked by suspend, but be safe)
   await db
     .update(agentTokens)
     .set({ revokedAt: new Date() })

--- a/packages/server/src/services/tree-reader.ts
+++ b/packages/server/src/services/tree-reader.ts
@@ -1,0 +1,72 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { type MemberNode, memberNodeSchema } from "@agent-hub/shared";
+import matter from "gray-matter";
+
+const AGENT_ID_REGEX = /^[a-z0-9_-]+$/;
+
+export type MemberEntry = MemberNode & { id: string };
+
+export type ReadMembersResult = {
+  members: MemberEntry[];
+  errors: Array<{ memberId: string; error: string }>;
+};
+
+/**
+ * Scan the context tree members/ directory and parse each member's NODE.md frontmatter.
+ * Skips the top-level members/NODE.md index file.
+ */
+export async function readMembers(treePath: string): Promise<ReadMembersResult> {
+  const membersDir = join(treePath, "members");
+
+  // Verify members/ directory exists
+  const dirStat = await stat(membersDir).catch(() => null);
+  if (!dirStat?.isDirectory()) {
+    throw new Error(`members/ directory not found at ${membersDir}`);
+  }
+
+  const entries = await readdir(membersDir, { withFileTypes: true });
+  const members: MemberEntry[] = [];
+  const errors: ReadMembersResult["errors"] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const memberId = entry.name;
+
+    // Validate directory name as agent ID
+    if (!AGENT_ID_REGEX.test(memberId)) {
+      errors.push({ memberId, error: `Invalid agent ID format: "${memberId}"` });
+      continue;
+    }
+
+    const nodePath = join(membersDir, memberId, "NODE.md");
+    let content: string;
+    try {
+      content = await readFile(nodePath, "utf-8");
+    } catch {
+      errors.push({ memberId, error: "NODE.md not found" });
+      continue;
+    }
+
+    let frontmatter: Record<string, unknown>;
+    try {
+      const parsed = matter(content);
+      frontmatter = parsed.data as Record<string, unknown>;
+    } catch (err) {
+      errors.push({ memberId, error: `Failed to parse NODE.md frontmatter: ${String(err)}` });
+      continue;
+    }
+
+    const result = memberNodeSchema.safeParse(frontmatter);
+    if (!result.success) {
+      const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
+      errors.push({ memberId, error: `Invalid frontmatter: ${issues}` });
+      continue;
+    }
+
+    members.push({ id: memberId, ...result.data });
+  }
+
+  return { members, errors };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,8 +57,10 @@ export {
   agentTypeSchema,
   type CreateAgent,
   createAgentSchema,
-  type UpdateAgent,
-  updateAgentSchema,
+  type MemberNode,
+  memberNodeSchema,
+  type SyncReport,
+  syncReportSchema,
 } from "./schemas/agent.js";
 export {
   type AgentToken,

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -33,12 +33,38 @@ export const createAgentSchema = z.object({
 });
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 
-export const updateAgentSchema = z.object({
-  displayName: z.string().max(200).nullish(),
-  status: agentStatusSchema.optional(),
-  metadata: z.record(z.unknown()).optional(),
+// -- Context Tree sync schemas --
+
+export const memberNodeSchema = z.object({
+  title: z.string().min(1),
+  type: agentTypeSchema,
+  owners: z.array(z.string()).min(1),
+  role: z.string().optional(),
+  domains: z.array(z.string()).optional(),
 });
-export type UpdateAgent = z.infer<typeof updateAgentSchema>;
+export type MemberNode = z.infer<typeof memberNodeSchema>;
+
+export const syncReportSchema = z.object({
+  syncedAt: z.string(),
+  treePath: z.string(),
+  summary: z.object({
+    created: z.number(),
+    updated: z.number(),
+    suspended: z.number(),
+    unchanged: z.number(),
+    errors: z.number(),
+  }),
+  created: z.array(z.string()),
+  updated: z.array(z.string()),
+  suspended: z.array(z.string()),
+  errors: z.array(
+    z.object({
+      memberId: z.string(),
+      error: z.string(),
+    }),
+  ),
+});
+export type SyncReport = z.infer<typeof syncReportSchema>;
 
 export const agentSchema = z.object({
   id: z.string(),

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -1,4 +1,4 @@
-import type { Agent, CreateAgent, UpdateAgent } from "@agent-hub/shared";
+import type { Agent, SyncReport } from "@agent-hub/shared";
 import { api } from "./client.js";
 
 type PaginatedAgents = {
@@ -18,14 +18,20 @@ export function getAgent(agentId: string): Promise<Agent> {
   return api.get<Agent>(`/admin/agents/${encodeURIComponent(agentId)}`);
 }
 
-export function createAgent(data: CreateAgent): Promise<Agent> {
-  return api.post<Agent>("/admin/agents", data);
-}
-
-export function updateAgent(agentId: string, data: UpdateAgent): Promise<Agent> {
-  return api.patch<Agent>(`/admin/agents/${encodeURIComponent(agentId)}`, data);
-}
-
 export function deleteAgent(agentId: string): Promise<void> {
   return api.delete<void>(`/admin/agents/${encodeURIComponent(agentId)}`);
+}
+
+// -- Sync API --
+
+export function triggerSync(): Promise<SyncReport> {
+  return api.post<SyncReport>("/admin/agents/sync", {});
+}
+
+type SyncStatus = {
+  lastSync: SyncReport | null;
+};
+
+export function getSyncStatus(): Promise<SyncStatus> {
+  return api.get<SyncStatus>("/admin/agents/sync/status");
 }

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -6,7 +6,7 @@ import { useNavigate, useParams } from "react-router";
 import { createAdapterMapping, deleteAdapterMapping, listAdapterMappings } from "../api/adapter-mappings.js";
 import { getAdapterStatuses } from "../api/adapter-status.js";
 import { createAdapter, deleteAdapter, listAdapters, updateAdapter } from "../api/adapters.js";
-import { deleteAgent, getAgent, updateAgent } from "../api/agents.js";
+import { deleteAgent, getAgent } from "../api/agents.js";
 import { createToken, listTokens, revokeToken } from "../api/tokens.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
@@ -51,11 +51,6 @@ export function AgentDetailPage() {
   const agentAdapters = adaptersQuery.data?.filter((a) => a.agentId === agentId) ?? [];
   const agentMappings = mappingsQuery.data?.filter((m) => m.agentId === agentId) ?? [];
 
-  // Edit state
-  const [editing, setEditing] = useState(false);
-  const [editName, setEditName] = useState("");
-  const [editStatus, setEditStatus] = useState("");
-
   // Token dialog
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
   const [tokenName, setTokenName] = useState("");
@@ -76,14 +71,6 @@ export function AgentDetailPage() {
   const [bindingCredError, setBindingCredError] = useState("");
 
   // Mutations — agent
-  const updateMutation = useMutation({
-    mutationFn: (data: { displayName?: string | null; status?: "active" | "suspended" }) => updateAgent(agentId, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["agent", agentId] });
-      setEditing(false);
-    },
-  });
-
   const deleteMutation = useMutation({
     mutationFn: () => deleteAgent(agentId),
     onSuccess: () => navigate("/agents"),
@@ -251,22 +238,8 @@ export function AgentDetailPage() {
     return <div className="text-muted-foreground">Agent not found</div>;
   }
 
-  const startEdit = () => {
-    setEditName(agent.displayName ?? "");
-    setEditStatus(agent.status);
-    setEditing(true);
-  };
-
-  const handleUpdate = (e: FormEvent) => {
-    e.preventDefault();
-    updateMutation.mutate({
-      displayName: editName || null,
-      status: editStatus as "active" | "suspended",
-    });
-  };
-
   const handleDelete = () => {
-    if (window.confirm("Are you sure you want to delete this agent?")) {
+    if (window.confirm("Are you sure you want to delete this agent? This cannot be undone.")) {
       deleteMutation.mutate();
     }
   };
@@ -281,6 +254,11 @@ export function AgentDetailPage() {
   const bindingIsPending =
     createAdapterMutation.isPending || updateAdapterMutation.isPending || createMappingMutation.isPending;
 
+  const metadata = agent.metadata as Record<string, unknown> | undefined;
+  const treeMeta = metadata?.tree as Record<string, unknown> | undefined;
+  const role = treeMeta?.role as string | undefined;
+  const domains = treeMeta?.domains as string[] | undefined;
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -292,84 +270,69 @@ export function AgentDetailPage() {
           <h1 className="text-2xl font-semibold">{agent.displayName ?? agent.id}</h1>
           <p className="text-sm text-muted-foreground font-mono">{agent.id}</p>
         </div>
-        <Button variant="destructive" size="sm" onClick={handleDelete}>
-          <Trash2 className="h-4 w-4 mr-2" />
-          Delete
-        </Button>
+        {agent.status === "suspended" && (
+          <Button variant="destructive" size="sm" onClick={handleDelete}>
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </Button>
+        )}
       </div>
 
-      {/* Agent Info */}
+      {/* Agent Info — read-only, managed by Context Tree */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Agent Info</CardTitle>
-          {!editing && (
-            <Button variant="outline" size="sm" onClick={startEdit}>
-              Edit
-            </Button>
-          )}
+          <span className="text-xs text-muted-foreground">Managed by Context Tree</span>
         </CardHeader>
         <CardContent>
-          {editing ? (
-            <form onSubmit={handleUpdate} className="space-y-4">
-              <div className="space-y-2">
-                <Label>Display Name</Label>
-                <Input value={editName} onChange={(e) => setEditName(e.target.value)} />
-              </div>
-              <div className="space-y-2">
-                <Label>Status</Label>
-                <select
-                  value={editStatus}
-                  onChange={(e) => setEditStatus(e.target.value)}
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  <option value="active">active</option>
-                  <option value="suspended">suspended</option>
-                </select>
-              </div>
-              {updateMutation.error instanceof Error && (
-                <div className="text-sm text-destructive">{updateMutation.error.message}</div>
-              )}
-              <div className="flex gap-2">
-                <Button type="submit" size="sm" disabled={updateMutation.isPending}>
-                  Save
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={() => setEditing(false)}>
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          ) : (
-            <dl className="grid grid-cols-2 gap-4 text-sm">
+          <dl className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <dt className="text-muted-foreground mb-1">Display Name</dt>
+              <dd>{agent.displayName ?? "—"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground mb-1">Type</dt>
+              <dd>
+                <Badge variant="secondary">{agent.type}</Badge>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground mb-1">Status</dt>
+              <dd>
+                <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground mb-1">Inbox ID</dt>
+              <dd className="font-mono">{agent.inboxId}</dd>
+            </div>
+            {role && (
               <div>
-                <dt className="text-muted-foreground mb-1">Type</dt>
-                <dd>
-                  <Badge variant="secondary">{agent.type}</Badge>
+                <dt className="text-muted-foreground mb-1">Role</dt>
+                <dd>{role}</dd>
+              </div>
+            )}
+            {domains && domains.length > 0 && (
+              <div>
+                <dt className="text-muted-foreground mb-1">Domains</dt>
+                <dd className="flex flex-wrap gap-1">
+                  {domains.map((d) => (
+                    <Badge key={d} variant="outline">
+                      {d}
+                    </Badge>
+                  ))}
                 </dd>
               </div>
-              <div>
-                <dt className="text-muted-foreground mb-1">Status</dt>
-                <dd>
-                  <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>
-                </dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground mb-1">Inbox ID</dt>
-                <dd className="font-mono">{agent.inboxId}</dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground mb-1">Organization</dt>
-                <dd className="font-mono">{agent.organizationId}</dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground mb-1">Created</dt>
-                <dd>{formatDate(agent.createdAt)}</dd>
-              </div>
-              <div>
-                <dt className="text-muted-foreground mb-1">Updated</dt>
-                <dd>{formatDate(agent.updatedAt)}</dd>
-              </div>
-            </dl>
-          )}
+            )}
+            <div>
+              <dt className="text-muted-foreground mb-1">Organization</dt>
+              <dd className="font-mono">{agent.organizationId}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground mb-1">Created</dt>
+              <dd>{formatDate(agent.createdAt)}</dd>
+            </div>
+          </dl>
         </CardContent>
       </Card>
 

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -1,21 +1,11 @@
 import { AGENT_TYPES } from "@agent-hub/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { useNavigate } from "react-router";
-import { createAgent, listAgents } from "../api/agents.js";
+import { getSyncStatus, listAgents, triggerSync } from "../api/agents.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../components/ui/dialog.js";
-import { Input } from "../components/ui/input.js";
-import { Label } from "../components/ui/label.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
 import { cn, formatDate } from "../lib/utils.js";
 
@@ -26,32 +16,25 @@ export function AgentsPage() {
   const queryClient = useQueryClient();
   const [cursor, setCursor] = useState<string | undefined>();
   const [typeFilter, setTypeFilter] = useState<string>("");
-  const [createOpen, setCreateOpen] = useState(false);
-  const [form, setForm] = useState({ id: "", type: "autonomous_agent", displayName: "" });
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["agents", cursor],
     queryFn: () => listAgents({ limit: 20, cursor }),
   });
 
-  const createMutation = useMutation({
-    mutationFn: () =>
-      createAgent({
-        id: form.id || undefined,
-        type: form.type as "human" | "personal_assistant" | "autonomous_agent",
-        displayName: form.displayName || undefined,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["agents"] });
-      setCreateOpen(false);
-      setForm({ id: "", type: "autonomous_agent", displayName: "" });
-    },
+  const { data: syncStatus } = useQuery({
+    queryKey: ["sync-status"],
+    queryFn: getSyncStatus,
+    refetchInterval: 30_000,
   });
 
-  const handleCreate = (e: FormEvent) => {
-    e.preventDefault();
-    createMutation.mutate();
-  };
+  const syncMutation = useMutation({
+    mutationFn: triggerSync,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      queryClient.invalidateQueries({ queryKey: ["sync-status"] });
+    },
+  });
 
   return (
     <div>
@@ -74,62 +57,47 @@ export function AgentsPage() {
             ))}
           </select>
         </div>
-        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Create Agent
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Create Agent</DialogTitle>
-            </DialogHeader>
-            <form onSubmit={handleCreate} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="agent-id">ID (optional)</Label>
-                <Input
-                  id="agent-id"
-                  value={form.id}
-                  onChange={(e) => setForm({ ...form, id: e.target.value })}
-                  placeholder="auto-generated if empty"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="agent-type">Type</Label>
-                <select
-                  id="agent-type"
-                  value={form.type}
-                  onChange={(e) => setForm({ ...form, type: e.target.value })}
-                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                >
-                  {agentTypeValues.map((t) => (
-                    <option key={t} value={t}>
-                      {t}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="agent-name">Display Name</Label>
-                <Input
-                  id="agent-name"
-                  value={form.displayName}
-                  onChange={(e) => setForm({ ...form, displayName: e.target.value })}
-                />
-              </div>
-              {createMutation.error instanceof Error && (
-                <div className="text-sm text-destructive">{createMutation.error.message}</div>
-              )}
-              <DialogFooter>
-                <Button type="submit" disabled={createMutation.isPending}>
-                  {createMutation.isPending ? "Creating..." : "Create"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+        <div className="flex items-center gap-3">
+          {syncStatus?.lastSync && (
+            <span className="text-xs text-muted-foreground">Last sync: {formatDate(syncStatus.lastSync.syncedAt)}</span>
+          )}
+          <Button variant="outline" size="sm" onClick={() => syncMutation.mutate()} disabled={syncMutation.isPending}>
+            <RefreshCw className={cn("h-4 w-4 mr-2", syncMutation.isPending && "animate-spin")} />
+            {syncMutation.isPending ? "Syncing..." : "Sync Now"}
+          </Button>
+        </div>
       </div>
+
+      {/* Sync result banner */}
+      {syncMutation.data && (
+        <div className="mb-4 rounded-md border bg-muted/50 p-3 text-sm">
+          <span className="font-medium">Sync complete: </span>
+          {syncMutation.data.summary.created > 0 && (
+            <Badge variant="default" className="mr-1">
+              +{syncMutation.data.summary.created} created
+            </Badge>
+          )}
+          {syncMutation.data.summary.updated > 0 && (
+            <Badge variant="secondary" className="mr-1">
+              {syncMutation.data.summary.updated} updated
+            </Badge>
+          )}
+          {syncMutation.data.summary.suspended > 0 && (
+            <Badge variant="destructive" className="mr-1">
+              {syncMutation.data.summary.suspended} suspended
+            </Badge>
+          )}
+          {syncMutation.data.summary.unchanged > 0 && (
+            <span className="text-muted-foreground mr-1">{syncMutation.data.summary.unchanged} unchanged</span>
+          )}
+          {syncMutation.data.summary.errors > 0 && (
+            <Badge variant="destructive">{syncMutation.data.summary.errors} errors</Badge>
+          )}
+        </div>
+      )}
+      {syncMutation.error instanceof Error && (
+        <div className="mb-4 text-sm text-destructive">{syncMutation.error.message}</div>
+      )}
 
       <div className="border rounded-lg">
         <Table>
@@ -163,7 +131,9 @@ export function AgentsPage() {
                   return (
                     <TableRow>
                       <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                        {typeFilter ? `No ${typeFilter} agents` : "No agents yet"}
+                        {typeFilter
+                          ? `No ${typeFilter} agents`
+                          : "No agents yet — click Sync Now to import from Context Tree"}
                       </TableCell>
                     </TableRow>
                   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       fastify:
         specifier: ^5.3.0
         version: 5.8.2
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       jose:
         specifier: ^6.0.0
         version: 6.2.2
@@ -1624,6 +1627,9 @@ packages:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -2082,6 +2088,11 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2099,6 +2110,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -2211,6 +2226,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2244,6 +2263,10 @@ packages:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2274,6 +2297,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2289,6 +2316,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -2720,6 +2751,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -2793,6 +2828,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   ssh-remote-port-forward@1.0.4:
     resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
 
@@ -2837,6 +2875,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -4335,6 +4377,10 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -4748,6 +4794,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  esprima@4.0.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4763,6 +4811,10 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.3.0: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -4890,6 +4942,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -4918,6 +4977,8 @@ snapshots:
 
   ipaddr.js@2.3.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-stream@2.0.1: {}
@@ -4940,6 +5001,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   jsesc@3.1.0: {}
 
   json-schema-ref-resolver@3.0.0:
@@ -4949,6 +5015,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
+
+  kind-of@6.0.3: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -5364,6 +5432,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -5431,6 +5504,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   ssh-remote-port-forward@1.0.4:
     dependencies:
       '@types/ssh2': 0.5.52
@@ -5488,6 +5563,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-literal@3.1.0:
     dependencies:


### PR DESCRIPTION
Replace manual agent creation with automatic sync from Context Tree's members/ directory. Server reads NODE.md frontmatter on startup and periodically to create/update/suspend agents.

Key changes:
- Add tree-reader service to scan members/ and parse NODE.md (gray-matter)
- Add agent-sync service with create/update/suspend logic
- Add POST /admin/agents/sync and GET /admin/agents/sync/status endpoints
- Remove POST /admin/agents (create) and PATCH /admin/agents/:id (update)
- Restrict DELETE to suspended agents only (removed from tree)
- Use metadata.tree namespace to avoid overwriting other metadata (e.g. github)
- Remove manual suspend — status fully managed by sync, admin controls via token revocation
- Add CONTEXT_TREE_PATH as required env var
- Update web: replace Create Agent with Sync Now, make agent info read-only, show Delete only for suspended agents