### PR TITLE
feat: deployment config — Docker, GitHub Actions, npm publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.turbo
+.git
+.env
+.envrc
+.venv
+.pytest_cache
+.ruff_cache
+*.tsbuildinfo
+coverage
+.DS_Store
+*.log
+.claude

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -49,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:24-alpine AS deps
+RUN apk add --no-cache python3 make g++
+RUN corepack enable
+WORKDIR /app
+
+# Copy package manifests for dependency layer caching
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/client/package.json packages/client/
+COPY packages/command/package.json packages/command/
+COPY packages/web/package.json packages/web/
+RUN pnpm install --frozen-lockfile
+
+# --- Build stage ---
+FROM deps AS build
+COPY . .
+RUN pnpm build
+
+# --- Production dependencies (no devDependencies, native modules pre-compiled) ---
+FROM deps AS prod-deps
+RUN pnpm install --frozen-lockfile --prod
+
+# --- Runtime ---
+FROM node:24-alpine
+WORKDIR /app
+
+# Production node_modules (includes compiled bcrypt, workspace links)
+COPY --from=prod-deps /app ./
+
+# Build artifacts
+COPY --from=build /app/packages/shared/dist packages/shared/dist/
+COPY --from=build /app/packages/server/dist packages/server/dist/
+COPY --from=build /app/packages/client/dist packages/client/dist/
+COPY --from=build /app/packages/command/dist packages/command/dist/
+
+# Runtime data: database migrations + web static files
+COPY --from=build /app/packages/server/drizzle packages/server/drizzle/
+COPY --from=build /app/packages/web/dist packages/web/dist/
+
+ENV NODE_ENV=production
+EXPOSE 8000
+
+CMD ["node", "packages/command/dist/cli/index.mjs", "server", "start", "--no-interactive"]

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,35 @@
+services:
+  server:
+    build: .
+    ports:
+      - "${AGENT_HUB_PORT:-8000}:8000"
+    environment:
+      AGENT_HUB_DATABASE_URL: postgresql://${POSTGRES_USER:-agenthub}:${POSTGRES_PASSWORD:-agenthub}@postgres:5432/${POSTGRES_DB:-agenthub}
+      AGENT_HUB_HOST: "0.0.0.0"
+      AGENT_HUB_PORT: "8000"
+      AGENT_HUB_JWT_SECRET: ${AGENT_HUB_JWT_SECRET}
+      AGENT_HUB_ENCRYPTION_KEY: ${AGENT_HUB_ENCRYPTION_KEY}
+      AGENT_HUB_CONTEXT_TREE_REPO: ${AGENT_HUB_CONTEXT_TREE_REPO}
+      AGENT_HUB_GITHUB_TOKEN: ${AGENT_HUB_GITHUB_TOKEN}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-agenthub}
+      POSTGRES_USER: ${POSTGRES_USER:-agenthub}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-agenthub}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agenthub}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts",
+    "build": "tsdown src/index.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -13,15 +13,14 @@
     "agent-hub": "./dist/cli/index.mjs"
   },
   "files": [
-    "dist",
-    "templates"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",
-    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts",
+    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts && node scripts/embed-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
@@ -35,16 +34,25 @@
     "node": ">=22.16.0"
   },
   "dependencies": {
-    "@agent-hub/client": "workspace:*",
-    "@agent-hub/server": "workspace:*",
-    "@agent-hub/shared": "workspace:*",
+    "@fastify/static": "^9.0.0",
+    "@fastify/websocket": "^11.2.0",
     "@inquirer/prompts": "^8.3.0",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "bcrypt": "^6.0.0",
     "commander": "^13.1.0",
     "drizzle-orm": "^0.44.0",
-    "postgres": "^3.4.0"
+    "fastify": "^5.3.0",
+    "gray-matter": "^4.0.3",
+    "jose": "^6.0.0",
+    "postgres": "^3.4.0",
+    "ws": "^8.20.0",
+    "yaml": "^2.8.3",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@agent-hub/client": "workspace:*",
+    "@agent-hub/server": "workspace:*",
+    "@agent-hub/shared": "workspace:*",
     "@agent-hub/web": "workspace:*",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "^22.16.0",

--- a/packages/command/scripts/embed-assets.mjs
+++ b/packages/command/scripts/embed-assets.mjs
@@ -1,0 +1,32 @@
+/**
+ * Post-build script: embed runtime assets into dist/ for npm publishing.
+ *
+ * - dist/drizzle/  ← packages/server/drizzle/ (SQL migrations + journal)
+ * - dist/web/      ← packages/web/dist/        (static frontend assets)
+ */
+
+import { cpSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const dist = resolve(root, "dist");
+
+// Embed database migrations
+const migrSrc = resolve(root, "..", "server", "drizzle");
+const migrDst = resolve(dist, "drizzle");
+if (existsSync(migrSrc)) {
+  cpSync(migrSrc, migrDst, { recursive: true });
+  console.log("  Embedded drizzle migrations → dist/drizzle/");
+} else {
+  console.warn("  ⚠ server/drizzle/ not found, skipping migrations embed");
+}
+
+// Embed web frontend
+const webSrc = resolve(root, "..", "web", "dist");
+const webDst = resolve(dist, "web");
+if (existsSync(webSrc)) {
+  cpSync(webSrc, webDst, { recursive: true });
+  console.log("  Embedded web dist → dist/web/");
+} else {
+  console.warn("  ⚠ web/dist/ not found, skipping web embed (build web first)");
+}

--- a/packages/command/src/server/migrate.ts
+++ b/packages/command/src/server/migrate.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -5,13 +6,26 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
 /**
+ * Resolve the drizzle migrations directory.
+ * 1. npm install: embedded at dist/drizzle/ (relative to the built CLI)
+ * 2. Monorepo dev: resolved from @agent-hub/server package
+ */
+function resolveMigrationsFolder(): string {
+  // npm publish: migrations are embedded next to the built CLI
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const embeddedPath = join(cliDir, "..", "drizzle");
+  if (existsSync(embeddedPath)) return embeddedPath;
+
+  // Monorepo dev: resolve from server package
+  const serverDir = dirname(fileURLToPath(import.meta.resolve("@agent-hub/server/package.json")));
+  return join(serverDir, "drizzle");
+}
+
+/**
  * Run Drizzle database migrations.
- * Migration files are located in the server package's drizzle/ directory.
  */
 export async function runMigrations(databaseUrl: string): Promise<number> {
-  // Resolve migration path relative to the server package
-  const serverDir = dirname(fileURLToPath(import.meta.resolve("@agent-hub/server/package.json")));
-  const migrationsFolder = join(serverDir, "drizzle");
+  const migrationsFolder = resolveMigrationsFolder();
 
   const client = postgres(databaseUrl, { max: 1 });
   const db = drizzle(client);

--- a/packages/command/src/server/startup.ts
+++ b/packages/command/src/server/startup.ts
@@ -138,9 +138,17 @@ export async function startServer(options: StartOptions): Promise<void> {
 }
 
 /**
- * Resolve web dist path — find and build @agent-hub/web if available.
+ * Resolve web dist path.
+ * 1. npm install: embedded at dist/web/ (relative to the built CLI)
+ * 2. Monorepo dev: resolved from @agent-hub/web package (builds if needed)
  */
 function resolveWebDist(): string | undefined {
+  // npm publish: web assets are embedded next to the built CLI
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const embeddedPath = join(cliDir, "..", "web");
+  if (existsSync(join(embeddedPath, "index.html"))) return embeddedPath;
+
+  // Monorepo dev: resolve from web package
   try {
     const webPkgUrl = import.meta.resolve("@agent-hub/web/package.json");
     const webDir = dirname(fileURLToPath(webPkgUrl));

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,13 +4,16 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/app.ts",
+    ".": {
+      "types": "./src/app.ts",
+      "import": "./dist/app.mjs"
+    },
     "./config": "./src/config.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "tsx watch --env-file=../../.env src/index.ts",
-    "build": "tsdown src/index.ts --format esm --dts",
+    "build": "tsdown src/index.ts src/app.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -30,6 +30,7 @@ import { agentAuthHook } from "./middleware/agent-auth.js";
 import { type AdapterManager, createAdapterManager } from "./services/adapter-manager.js";
 import { stopPeriodicSync } from "./services/agent-sync.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
+import { syncFromGitHub } from "./services/context-tree-graphql.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
 
 // Fastify type augmentation
@@ -212,7 +213,6 @@ export async function buildApp(config: Config) {
     // Context Tree sync via GitHub GraphQL
     const { repo: ctRepo, branch: ctBranch, syncInterval } = config.contextTree;
     const { token: ghToken } = config.github;
-    const { syncFromGitHub } = await import("./services/context-tree-graphql.js");
     try {
       const report = await syncFromGitHub(db, ctRepo, ctBranch, ghToken);
       app.log.info(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,18 +48,18 @@ importers:
 
   packages/command:
     dependencies:
-      '@agent-hub/client':
-        specifier: workspace:*
-        version: link:../client
-      '@agent-hub/server':
-        specifier: workspace:*
-        version: link:../server
-      '@agent-hub/shared':
-        specifier: workspace:*
-        version: link:../shared
+      '@fastify/static':
+        specifier: ^9.0.0
+        version: 9.0.0
+      '@fastify/websocket':
+        specifier: ^11.2.0
+        version: 11.2.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.59.0
+        version: 1.59.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -69,10 +69,37 @@ importers:
       drizzle-orm:
         specifier: ^0.44.0
         version: 0.44.7(postgres@3.4.8)
+      fastify:
+        specifier: ^5.3.0
+        version: 5.8.2
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      jose:
+        specifier: ^6.0.0
+        version: 6.2.2
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
     devDependencies:
+      '@agent-hub/client':
+        specifier: workspace:*
+        version: link:../client
+      '@agent-hub/server':
+        specifier: workspace:*
+        version: link:../server
+      '@agent-hub/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@agent-hub/web':
         specifier: workspace:*
         version: link:../web


### PR DESCRIPTION
## Summary

- **Docker deployment**: multi-stage Dockerfile, production docker-compose (server + PG), GitHub Actions auto-build to GHCR on `main` push and version tags
- **npm publish readiness**: workspace packages bundled into CLI, drizzle migrations + web assets embedded in `dist/`, all transitive runtime deps declared — `npm install -g @unispark.ai/agent-hub && agent-hub server start` ready
- **Build fixes**: server conditional exports for Node.js runtime, remove unused `--dts` from client/server, fix `INEFFECTIVE_DYNAMIC_IMPORT` warning

## Test plan

- [ ] `pnpm check && pnpm typecheck && pnpm build` passes with zero warnings
- [ ] `npm pack --dry-run` in command package shows correct file list (CLI + migrations + web assets, no workspace refs)
- [ ] `docker build .` succeeds locally
- [ ] `docker compose -f docker-compose.production.yml up` starts server + PG
- [ ] Verify `dist/cli/index.mjs` has no `@agent-hub/*` external imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)