### PR TITLE
feat: add send, chats, history CLI commands for agent messaging

### DIFF
--- a/packages/client/src/__tests__/sdk-messaging.test.ts
+++ b/packages/client/src/__tests__/sdk-messaging.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentHubSDK, SdkError } from "../sdk.js";
+
+describe("AgentHubSDK messaging methods", () => {
+  let sdk: AgentHubSDK;
+  const mockFetch = vi.fn<typeof globalThis.fetch>();
+
+  beforeEach(() => {
+    sdk = new AgentHubSDK({ serverUrl: "http://localhost:8000", token: "aghub_test" });
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockJsonResponse(data: unknown, status = 200) {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(data), { status }));
+  }
+
+  function mockErrorResponse(error: string, status: number) {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error }), { status }));
+  }
+
+  describe("listChats", () => {
+    it("fetches chats with default params", async () => {
+      const payload = { items: [{ id: "chat-1", type: "direct" }], nextCursor: null };
+      mockJsonResponse(payload);
+
+      const result = await sdk.listChats();
+      expect(result).toEqual(payload);
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("http://localhost:8000/api/v1/agent/chats");
+    });
+
+    it("passes limit and cursor as query params", async () => {
+      mockJsonResponse({ items: [], nextCursor: null });
+
+      await sdk.listChats({ limit: 5, cursor: "2026-01-01T00:00:00Z" });
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("limit=5");
+      expect(url).toContain("cursor=2026-01-01T00%3A00%3A00Z");
+    });
+
+    it("throws SdkError on auth failure", async () => {
+      mockErrorResponse("Unauthorized", 401);
+
+      try {
+        await sdk.listChats();
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(SdkError);
+        expect((err as SdkError).statusCode).toBe(401);
+      }
+    });
+  });
+
+  describe("listMessages", () => {
+    it("fetches messages for a chat", async () => {
+      const payload = {
+        items: [{ id: "msg-1", senderId: "a1", format: "text", content: "hello" }],
+        nextCursor: null,
+      };
+      mockJsonResponse(payload);
+
+      const result = await sdk.listMessages("chat-abc");
+      expect(result).toEqual(payload);
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("http://localhost:8000/api/v1/agent/chats/chat-abc/messages");
+    });
+
+    it("passes limit and cursor as query params", async () => {
+      mockJsonResponse({ items: [], nextCursor: null });
+
+      await sdk.listMessages("chat-abc", { limit: 10, cursor: "2026-03-25T00:00:00Z" });
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("chat-abc/messages?");
+      expect(url).toContain("limit=10");
+      expect(url).toContain("cursor=");
+    });
+
+    it("throws SdkError on 403 (not participant)", async () => {
+      mockErrorResponse("Not a participant of this chat", 403);
+
+      try {
+        await sdk.listMessages("chat-private");
+        expect.fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(SdkError);
+        expect((err as SdkError).statusCode).toBe(403);
+      }
+    });
+  });
+
+  describe("sendToAgent", () => {
+    it("sends a direct message to another agent", async () => {
+      const msg = { id: "msg-1", chatId: "chat-1", senderId: "sender", format: "text", content: "hi" };
+      mockJsonResponse(msg, 201);
+
+      const result = await sdk.sendToAgent("target-agent", { format: "text", content: "hi" });
+      expect(result).toEqual(msg);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("http://localhost:8000/api/v1/agent/agents/target-agent/messages");
+      expect(init.method).toBe("POST");
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("sends a message to a chat", async () => {
+      const msg = { id: "msg-1", chatId: "chat-1", senderId: "sender", format: "markdown", content: "# Hi" };
+      mockJsonResponse(msg, 201);
+
+      const result = await sdk.sendMessage("chat-1", { format: "markdown", content: "# Hi" });
+      expect(result).toEqual(msg);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("http://localhost:8000/api/v1/agent/chats/chat-1/messages");
+      expect(init.method).toBe("POST");
+    });
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -13,5 +13,5 @@ export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 export { Semaphore } from "./runtime/semaphore.js";
 export { SessionManager } from "./runtime/session-manager.js";
-export type { PullResult, RegisterResult, SdkConfig } from "./sdk.js";
+export type { PaginatedResult, PullResult, RegisterResult, SdkConfig } from "./sdk.js";
 export { AgentHubSDK, SdkError } from "./sdk.js";

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -1,4 +1,4 @@
-import type { Agent, InboxEntryWithMessage, Message, SendMessage, SendToAgent } from "@agent-hub/shared";
+import type { Agent, Chat, InboxEntryWithMessage, Message, SendMessage, SendToAgent } from "@agent-hub/shared";
 
 export type SdkConfig = {
   serverUrl: string;
@@ -14,6 +14,11 @@ export type RegisterResult = {
 
 export type PullResult = {
   entries: InboxEntryWithMessage[];
+};
+
+export type PaginatedResult<T> = {
+  items: T[];
+  nextCursor: string | null;
 };
 
 export class AgentHubSDK {
@@ -67,6 +72,24 @@ export class AgentHubSDK {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  /** List chats the current agent participates in. */
+  async listChats(options?: { limit?: number; cursor?: string }): Promise<PaginatedResult<Chat>> {
+    return this.requestJson(`/api/v1/agent/chats${this.queryString(options)}`);
+  }
+
+  /** List messages in a chat. Requires caller to be a participant. */
+  async listMessages(chatId: string, options?: { limit?: number; cursor?: string }): Promise<PaginatedResult<Message>> {
+    return this.requestJson(`/api/v1/agent/chats/${chatId}/messages${this.queryString(options)}`);
+  }
+
+  private queryString(options?: { limit?: number; cursor?: string }): string {
+    const params = new URLSearchParams();
+    if (options?.limit !== undefined) params.set("limit", String(options.limit));
+    if (options?.cursor) params.set("cursor", options.cursor);
+    const qs = params.toString();
+    return qs ? `?${qs}` : "";
   }
 
   private async requestVoid(path: string, init?: RequestInit): Promise<void> {

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -3,9 +3,12 @@
 import { Command } from "commander";
 import { registerAdminCommands } from "../commands/admin.js";
 import { registerAgentCommands } from "../commands/agent.js";
+import { registerChatsCommand } from "../commands/chats.js";
 import { registerClientCommands } from "../commands/client.js";
 import { registerConfigCommands } from "../commands/config.js";
 import { registerDbCommands } from "../commands/db.js";
+import { registerHistoryCommand } from "../commands/history.js";
+import { registerSendCommand } from "../commands/send.js";
 import { registerServerCommands } from "../commands/server.js";
 import { registerStatusCommand } from "../commands/status.js";
 import { registerConnectCommand } from "./connect.js";
@@ -32,5 +35,10 @@ registerStartCommand(program);
 
 // Legacy agent commands (register, pull) — at top level
 registerAgentCommands(program);
+
+// Messaging commands (send, chats, history) — at top level
+registerSendCommand(program);
+registerChatsCommand(program);
+registerHistoryCommand(program);
 
 program.parse();

--- a/packages/command/src/cli/util.ts
+++ b/packages/command/src/cli/util.ts
@@ -27,6 +27,15 @@ export function handleError(error: unknown): never {
   fail("UNKNOWN_ERROR", msg, 1);
 }
 
+/** Parse and validate a numeric limit option from Commander string. */
+export function parseLimit(value: string, max: number): number {
+  const limit = Number.parseInt(value, 10);
+  if (Number.isNaN(limit) || limit < 1 || limit > max) {
+    fail("INVALID_LIMIT", `Limit must be between 1 and ${max}.`, 2);
+  }
+  return limit;
+}
+
 /** Write a log line to stderr. */
 export function log(tag: string, message: string): void {
   process.stderr.write(`[${tag}] ${message}\n`);

--- a/packages/command/src/commands/chats.ts
+++ b/packages/command/src/commands/chats.ts
@@ -1,0 +1,21 @@
+import type { Command } from "commander";
+import { success } from "../cli/output.js";
+import { createSdk, handleError, parseLimit } from "../cli/util.js";
+
+export function registerChatsCommand(program: Command): void {
+  program
+    .command("chats")
+    .description("List chats this agent participates in")
+    .option("-l, --limit <number>", "Maximum chats to return (1-100)", "20")
+    .option("--cursor <cursor>", "Pagination cursor from previous response")
+    .action(async (options: { limit: string; cursor?: string }) => {
+      try {
+        const limit = parseLimit(options.limit, 100);
+        const sdk = createSdk();
+        const result = await sdk.listChats({ limit, cursor: options.cursor });
+        success(result);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/command/src/commands/history.ts
+++ b/packages/command/src/commands/history.ts
@@ -1,0 +1,21 @@
+import type { Command } from "commander";
+import { success } from "../cli/output.js";
+import { createSdk, handleError, parseLimit } from "../cli/util.js";
+
+export function registerHistoryCommand(program: Command): void {
+  program
+    .command("history <chatId>")
+    .description("View message history in a chat")
+    .option("-l, --limit <number>", "Maximum messages to return (1-100)", "20")
+    .option("--cursor <cursor>", "Pagination cursor from previous response")
+    .action(async (chatId: string, options: { limit: string; cursor?: string }) => {
+      try {
+        const limit = parseLimit(options.limit, 100);
+        const sdk = createSdk();
+        const result = await sdk.listMessages(chatId, { limit, cursor: options.cursor });
+        success(result);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/command/src/commands/send.ts
+++ b/packages/command/src/commands/send.ts
@@ -1,0 +1,93 @@
+import type { Command } from "commander";
+import { fail, success } from "../cli/output.js";
+import { createSdk, handleError } from "../cli/util.js";
+
+const MAX_STDIN_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/** Read all of stdin as a string. Returns null if stdin is a TTY. */
+function readStdin(): Promise<string | null> {
+  if (process.stdin.isTTY) return Promise.resolve(null);
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalSize = 0;
+    process.stdin.on("data", (chunk: Buffer) => {
+      totalSize += chunk.length;
+      if (totalSize > MAX_STDIN_BYTES) {
+        process.stdin.destroy();
+        reject(new Error(`stdin exceeds ${MAX_STDIN_BYTES} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface SendOptions {
+  format: string;
+  chat?: boolean;
+  metadata?: string;
+  replyTo?: string;
+  replyToInbox?: string;
+  replyToChat?: string;
+}
+
+export function registerSendCommand(program: Command): void {
+  program
+    .command("send <target> [message]")
+    .description("Send a message to an agent or chat")
+    .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
+    .option("--chat", "Treat target as chat ID instead of agent ID")
+    .option("-m, --metadata <json>", "JSON metadata to attach")
+    .option("--reply-to <messageId>", "Message ID to reply to")
+    .option("--reply-to-inbox <inboxId>", "Cross-chat reply target inbox")
+    .option("--reply-to-chat <chatId>", "Cross-chat reply target chat")
+    .action(async (target: string, message: string | undefined, options: SendOptions) => {
+      try {
+        // Resolve message content: argument > stdin > error
+        const content = message ?? (await readStdin());
+        if (!content) {
+          fail("NO_MESSAGE", "No message provided. Pass as argument or pipe via stdin.", 2);
+        }
+
+        // Parse metadata if provided
+        let metadata: Record<string, unknown> | undefined;
+        if (options.metadata) {
+          try {
+            metadata = JSON.parse(options.metadata) as Record<string, unknown>;
+          } catch {
+            fail("INVALID_METADATA", "Metadata must be valid JSON.", 2);
+          }
+        }
+
+        const sdk = createSdk();
+
+        if (options.chat) {
+          // Send to existing chat
+          const result = await sdk.sendMessage(target, {
+            format: options.format,
+            content,
+            metadata,
+            inReplyTo: options.replyTo,
+            replyToInbox: options.replyToInbox,
+            replyToChat: options.replyToChat,
+          });
+          success(result);
+        } else {
+          // Send direct message to agent
+          const result = await sdk.sendToAgent(target, {
+            format: options.format,
+            content,
+            metadata,
+            replyToInbox: options.replyToInbox,
+            replyToChat: options.replyToChat,
+          });
+          success(result);
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/command/src/commands/send.ts
+++ b/packages/command/src/commands/send.ts
@@ -1,3 +1,4 @@
+import type { MessageFormat } from "@agent-hub/shared";
 import type { Command } from "commander";
 import { fail, success } from "../cli/output.js";
 import { createSdk, handleError } from "../cli/util.js";
@@ -26,7 +27,7 @@ function readStdin(): Promise<string | null> {
 }
 
 interface SendOptions {
-  format: string;
+  format: MessageFormat;
   chat?: boolean;
   metadata?: string;
   replyTo?: string;

--- a/packages/server/src/__tests__/agent-messaging-flow.test.ts
+++ b/packages/server/src/__tests__/agent-messaging-flow.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+describe("Agent Messaging Flow (send → chats → history)", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("full flow: send to agent, list chats, view history", async () => {
+    const app = await appPromise;
+    const { agent: sender, token: senderToken } = await createTestAgent(app, { id: "flow-sender" });
+    const { agent: receiver, token: receiverToken } = await createTestAgent(app, { id: "flow-receiver" });
+
+    // 1. Send a direct message to another agent
+    const sendRes = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/agents/${receiver.id}/messages`,
+      headers: { authorization: `Bearer ${senderToken}` },
+      payload: { format: "text", content: "Hello from sender" },
+    });
+    expect(sendRes.statusCode).toBe(201);
+    const sentMessage = sendRes.json();
+    expect(sentMessage.senderId).toBe(sender.id);
+    expect(sentMessage.content).toBe("Hello from sender");
+    expect(sentMessage.chatId).toBeDefined();
+
+    const chatId = sentMessage.chatId as string;
+
+    // 2. Sender lists their chats — should include the new direct chat
+    const senderChatsRes = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/chats",
+      headers: { authorization: `Bearer ${senderToken}` },
+    });
+    expect(senderChatsRes.statusCode).toBe(200);
+    const senderChats = senderChatsRes.json();
+    expect(senderChats.items.some((c: { id: string }) => c.id === chatId)).toBe(true);
+
+    // 3. Receiver lists their chats — should also include it
+    const receiverChatsRes = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/chats",
+      headers: { authorization: `Bearer ${receiverToken}` },
+    });
+    expect(receiverChatsRes.statusCode).toBe(200);
+    const receiverChats = receiverChatsRes.json();
+    expect(receiverChats.items.some((c: { id: string }) => c.id === chatId)).toBe(true);
+
+    // 4. View message history in the chat
+    const historyRes = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${senderToken}` },
+    });
+    expect(historyRes.statusCode).toBe(200);
+    const history = historyRes.json();
+    expect(history.items).toHaveLength(1);
+    expect(history.items[0].content).toBe("Hello from sender");
+    expect(history.items[0].senderId).toBe(sender.id);
+
+    // 5. Receiver replies in the same chat
+    const replyRes = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${receiverToken}` },
+      payload: { format: "text", content: "Hello back!" },
+    });
+    expect(replyRes.statusCode).toBe(201);
+    expect(replyRes.json().senderId).toBe(receiver.id);
+
+    // 6. History now has 2 messages
+    const historyRes2 = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${senderToken}` },
+    });
+    expect(historyRes2.statusCode).toBe(200);
+    expect(historyRes2.json().items).toHaveLength(2);
+  });
+
+  it("chats list respects pagination", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "page-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "page-a2" });
+    const { agent: a3 } = await createTestAgent(app, { id: "page-a3" });
+    const { agent: a4 } = await createTestAgent(app, { id: "page-a4" });
+
+    // Create 3 chats
+    for (const target of [a2, a3, a4]) {
+      await app.inject({
+        method: "POST",
+        url: `/api/v1/agent/agents/${target.id}/messages`,
+        headers: { authorization: `Bearer ${t1}` },
+        payload: { format: "text", content: `hi ${target.id}` },
+      });
+    }
+
+    // Page 1: limit=2
+    const page1 = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/chats?limit=2",
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(page1.statusCode).toBe(200);
+    const p1 = page1.json();
+    expect(p1.items).toHaveLength(2);
+    expect(p1.nextCursor).toBeTruthy();
+
+    // Page 2: use cursor
+    const page2 = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats?limit=2&cursor=${p1.nextCursor}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(page2.statusCode).toBe(200);
+    const p2 = page2.json();
+    expect(p2.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("message history respects pagination", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "msghist-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "msghist-a2" });
+
+    // Send first message to create chat
+    const firstMsg = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "msg-1" },
+    });
+    const chatId = firstMsg.json().chatId as string;
+
+    // Send 2 more messages
+    for (const text of ["msg-2", "msg-3"]) {
+      await app.inject({
+        method: "POST",
+        url: `/api/v1/agent/chats/${chatId}/messages`,
+        headers: { authorization: `Bearer ${t1}` },
+        payload: { format: "text", content: text },
+      });
+    }
+
+    // Page 1: limit=2
+    const page1 = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages?limit=2`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(page1.statusCode).toBe(200);
+    const p1 = page1.json();
+    expect(p1.items).toHaveLength(2);
+    expect(p1.nextCursor).toBeTruthy();
+
+    // Page 2
+    const page2 = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages?limit=2&cursor=${p1.nextCursor}`,
+      headers: { authorization: `Bearer ${t1}` },
+    });
+    expect(page2.statusCode).toBe(200);
+    expect(page2.json().items).toHaveLength(1);
+  });
+
+  it("non-participant cannot view history", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "noaccess-a1" });
+    const { agent: a2 } = await createTestAgent(app, { id: "noaccess-a2" });
+    const { token: t3 } = await createTestAgent(app, { id: "noaccess-a3" });
+
+    // a1 sends to a2 → creates direct chat
+    const sendRes = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "text", content: "private" },
+    });
+    const chatId = sendRes.json().chatId as string;
+
+    // a3 tries to read history → 403
+    const historyRes = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: { authorization: `Bearer ${t3}` },
+    });
+    expect(historyRes.statusCode).toBe(403);
+  });
+
+  it("send with markdown format", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "md-sender" });
+    const { agent: a2 } = await createTestAgent(app, { id: "md-receiver" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: { format: "markdown", content: "## Hello\n\nThis is **bold**" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().format).toBe("markdown");
+    expect(res.json().content).toBe("## Hello\n\nThis is **bold**");
+  });
+
+  it("send with metadata", async () => {
+    const app = await appPromise;
+    const { token: t1 } = await createTestAgent(app, { id: "meta-sender" });
+    const { agent: a2 } = await createTestAgent(app, { id: "meta-receiver" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      headers: { authorization: `Bearer ${t1}` },
+      payload: {
+        format: "text",
+        content: "approval needed",
+        metadata: { intent: "approval", urgency: "high" },
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const msg = res.json();
+    expect(msg.metadata.intent).toBe("approval");
+    expect(msg.metadata.urgency).toBe("high");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `agent-hub send <target> [message]` — send messages to agents (by first-tree member name) or existing chats, with format/metadata/stdin-pipe/cross-chat-reply support
- Add `agent-hub chats` — list chats the current agent participates in, with cursor pagination
- Add `agent-hub history <chatId>` — view message history in a chat, with cursor pagination and participant access control
- Add `listChats()` / `listMessages()` SDK methods with `PaginatedResult<T>` type
- Add `parseLimit()` shared CLI utility for consistent limit option validation
- Add unit tests (8 SDK tests) and integration tests (6 server flow tests)

No server changes needed — all three commands use existing API endpoints.

## Test plan

- [x] `pnpm check` — Biome lint + format clean
- [x] `pnpm --filter @agent-hub/client typecheck` — passes
- [x] `pnpm --filter @agent-hub/client test` — 30/30 tests pass
- [x] Manual verification against local server:
  - `register` returns correct identity for both agents
  - `send baixiaohang "..."` creates direct chat and delivers message
  - `send -f markdown -m '{"intent":"review"}' baixiaohang "..."` — format + metadata preserved
  - `echo "..." | send baixiaohang` — stdin pipe works
  - `send --chat <chatId> "..."` — reply in existing chat works
  - `chats` — both participants see the shared chat
  - `history <chatId>` — full conversation in time order, all fields present
  - `history --limit 2` + `--cursor` — pagination works correctly
  - Non-participant gets `403 Not a participant of this chat`
  - `pull --ack` — receiver gets all sent messages in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)