### PR TITLE
feat: read title from NODE.md as agent display name

### DIFF
--- a/packages/server/src/services/context-tree-graphql.ts
+++ b/packages/server/src/services/context-tree-graphql.ts
@@ -137,7 +137,7 @@ export function parseNodeMetadata(content: string): {
 
   return {
     type: getValue("type") ?? "autonomous_agent",
-    displayName: getValue("display_name") ?? getValue("name"),
+    displayName: getValue("display_name") ?? getValue("title") ?? getValue("name"),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `title` to the NODE.md frontmatter field priority chain for agent display name
- Priority: `display_name` → `title` → `name`
- Context Tree NODE.md files use `title` in frontmatter, which was previously ignored

## Test plan

- [ ] Sync agents from Context Tree, verify display_name is populated from NODE.md title field

🤖 Generated with [Claude Code](https://claude.com/claude-code)