### PR TITLE
feat: delegate_mention — forward @mentions to personal assistants

### DIFF
--- a/packages/server/drizzle/0005_delegate_mention.sql
+++ b/packages/server/drizzle/0005_delegate_mention.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "delegate_mention" text;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774972800000,
       "tag": "0004_adapter_refactor",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1774972900000,
+      "tag": "0005_delegate_mention",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/context-tree-graphql.test.ts
+++ b/packages/server/src/__tests__/context-tree-graphql.test.ts
@@ -99,4 +99,35 @@ display_name: 'My Agent'
     expect(meta.type).toBe("autonomous_agent");
     expect(meta.displayName).toBe("My Agent");
   });
+
+  it("parses delegate_mention field", () => {
+    const content = `---
+title: "baixiaohang"
+type: human
+delegate_mention: kael-agent
+---`;
+
+    const meta = parseNodeMetadata(content);
+    expect(meta.delegateMention).toBe("kael-agent");
+  });
+
+  it("returns null delegateMention when not specified", () => {
+    const content = `---
+title: "bestony"
+type: human
+---`;
+
+    const meta = parseNodeMetadata(content);
+    expect(meta.delegateMention).toBeNull();
+  });
+
+  it("parses delegate_mention with quotes", () => {
+    const content = `---
+type: human
+delegate_mention: "my-assistant"
+---`;
+
+    const meta = parseNodeMetadata(content);
+    expect(meta.delegateMention).toBe("my-assistant");
+  });
 });

--- a/packages/server/src/__tests__/extract-mentions.test.ts
+++ b/packages/server/src/__tests__/extract-mentions.test.ts
@@ -38,11 +38,16 @@ describe("extractMentions", () => {
     expect(extractMentions("just some text")).toEqual([]);
   });
 
-  it("ignores email-like patterns", () => {
-    // @mention must not be preceded by a word character
+  it("ignores email addresses", () => {
     const result = extractMentions("email user@example.com but @real mention");
-    expect(result).toContain("real");
-    // email pattern has @ preceded by word char, may or may not match depending on regex
+    expect(result).toEqual(["real"]);
+    expect(result).not.toContain("example");
+  });
+
+  it("ignores team mentions (@org/team)", () => {
+    const result = extractMentions("cc @org/team-name and @baixiaohang");
+    expect(result).toEqual(["baixiaohang"]);
+    expect(result).not.toContain("org");
   });
 
   it("handles mention at start of text", () => {

--- a/packages/server/src/__tests__/extract-mentions.test.ts
+++ b/packages/server/src/__tests__/extract-mentions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { extractMentions } from "../api/webhooks/github.js";
+
+describe("extractMentions", () => {
+  it("extracts single mention", () => {
+    expect(extractMentions("Hey @baixiaohang please review")).toEqual(["baixiaohang"]);
+  });
+
+  it("extracts multiple mentions", () => {
+    const result = extractMentions("cc @baixiaohang @bestony for visibility");
+    expect(result).toContain("baixiaohang");
+    expect(result).toContain("bestony");
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates mentions", () => {
+    expect(extractMentions("@alice @alice @alice")).toEqual(["alice"]);
+  });
+
+  it("lowercases mentions", () => {
+    expect(extractMentions("@BaiXiaoHang")).toEqual(["baixiaohang"]);
+  });
+
+  it("handles hyphens in usernames", () => {
+    expect(extractMentions("@kael-agent")).toEqual(["kael-agent"]);
+  });
+
+  it("handles underscores in usernames", () => {
+    expect(extractMentions("@my_agent")).toEqual(["my_agent"]);
+  });
+
+  it("returns empty array for null/undefined", () => {
+    expect(extractMentions(null)).toEqual([]);
+    expect(extractMentions(undefined)).toEqual([]);
+  });
+
+  it("returns empty array when no mentions", () => {
+    expect(extractMentions("just some text")).toEqual([]);
+  });
+
+  it("ignores email-like patterns", () => {
+    // @mention must not be preceded by a word character
+    const result = extractMentions("email user@example.com but @real mention");
+    expect(result).toContain("real");
+    // email pattern has @ preceded by word char, may or may not match depending on regex
+  });
+
+  it("handles mention at start of text", () => {
+    expect(extractMentions("@admin check this")).toEqual(["admin"]);
+  });
+
+  it("handles mention at end of text", () => {
+    expect(extractMentions("check this @admin")).toEqual(["admin"]);
+  });
+});

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -119,13 +119,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Extract unique @mentions from text. Returns lowercase usernames. */
+/** Extract unique @mentions from text. Returns lowercase usernames.
+ * Excludes email patterns (user@example.com) and team mentions (@org/team). */
 export function extractMentions(text: string | null | undefined): string[] {
   if (!text) return [];
-  const matches = text.match(/@([a-zA-Z0-9][\w-]*)/g);
-  if (!matches) return [];
-  const unique = new Set(matches.map((m) => m.slice(1).toLowerCase()));
-  return [...unique];
+  // Negative lookbehind: @ must not be preceded by a word char (excludes emails)
+  // Capture optional trailing / to detect team mentions (@org/team) and skip them
+  const re = /(?<!\w)@([a-zA-Z0-9][\w-]*)(\/)?/g;
+  const names = new Set<string>();
+  for (const m of text.matchAll(re)) {
+    if (m[2]) continue; // Skip team mentions like @org/team
+    names.add((m[1] as string).toLowerCase());
+  }
+  return [...names];
 }
 
 type MentionContext = {
@@ -303,25 +309,23 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(200).send({ ok: true, event: "ping" });
     }
 
-    // --- @mention delegation (all event types) ---
-    const mentionText = extractEventText(eventType, payload);
-    const mentions = extractMentions(mentionText);
-    const mentionCtx = extractEventContext(eventType, payload);
-    let mentionsRouted = 0;
-    if (mentions.length > 0 && mentionCtx) {
-      mentionsRouted = await routeMentionDelegations(app, mentions, mentionCtx);
-    }
-
-    // --- Existing event-specific handlers ---
+    // --- Event-specific handlers (mention delegation runs inside, after action gating) ---
     if (eventType === "issues") {
-      return handleIssuesEvent(app, payload, reply);
+      return handleIssuesEvent(app, eventType, payload, reply);
     }
 
     if (eventType === "issue_comment") {
-      return handleIssueCommentEvent(app, payload, reply);
+      return handleIssueCommentEvent(app, eventType, payload, reply);
     }
 
-    // Other event types — mention delegation may have been routed above
+    // Other event types with @mention support (PRs, discussions, reviews, etc.)
+    // Only run delegation if the action represents new/changed content
+    let mentionsRouted = 0;
+    const allowedActions = MENTION_ACTIONS[eventType];
+    const action = isRecord(payload) && typeof payload.action === "string" ? payload.action : undefined;
+    if (allowedActions && action && allowedActions.includes(action)) {
+      mentionsRouted = await handleMentionDelegation(app, eventType, payload);
+    }
     return reply.status(200).send({ ok: true, event: eventType, handled: mentionsRouted > 0, mentionsRouted });
   });
 }
@@ -474,10 +478,46 @@ function extractEventContext(eventType: string, payload: unknown): MentionContex
   }
 }
 
-async function handleIssuesEvent(app: FastifyInstance, payload: unknown, reply: FastifyReply): Promise<unknown> {
+/**
+ * Run mention delegation for a given event type and payload.
+ * Only called after action gating confirms this is a "new content" event.
+ */
+async function handleMentionDelegation(app: FastifyInstance, eventType: string, payload: unknown): Promise<number> {
+  const mentionText = extractEventText(eventType, payload);
+  const mentions = extractMentions(mentionText);
+  const mentionCtx = extractEventContext(eventType, payload);
+  if (mentions.length > 0 && mentionCtx) {
+    return routeMentionDelegations(app, mentions, mentionCtx);
+  }
+  return 0;
+}
+
+/** Actions that represent new/changed content (worth scanning for @mentions). */
+const MENTION_ACTIONS: Record<string, string[]> = {
+  issues: ["opened", "edited"],
+  issue_comment: ["created"],
+  pull_request: ["opened", "edited"],
+  pull_request_review: ["submitted"],
+  pull_request_review_comment: ["created"],
+  discussion: ["created", "edited"],
+  discussion_comment: ["created"],
+  commit_comment: ["created"],
+};
+
+async function handleIssuesEvent(
+  app: FastifyInstance,
+  eventType: string,
+  payload: unknown,
+  reply: FastifyReply,
+): Promise<unknown> {
   const data = parseIssuesPayload(payload);
 
-  // Only handle specific actions
+  // Mention delegation — only on new/changed content
+  if (MENTION_ACTIONS.issues?.includes(data.action)) {
+    await handleMentionDelegation(app, eventType, payload);
+  }
+
+  // Only handle specific actions for repo-targeted routing
   const handledActions = ["opened", "edited", "labeled"];
   if (!handledActions.includes(data.action)) {
     return reply.status(200).send({ ok: true, event: "issues", action: data.action, handled: false });
@@ -525,10 +565,20 @@ async function handleIssuesEvent(app: FastifyInstance, payload: unknown, reply: 
   return reply.status(200).send({ ok: true, event: "issues", action: data.action, routed: true });
 }
 
-async function handleIssueCommentEvent(app: FastifyInstance, payload: unknown, reply: FastifyReply): Promise<unknown> {
+async function handleIssueCommentEvent(
+  app: FastifyInstance,
+  eventType: string,
+  payload: unknown,
+  reply: FastifyReply,
+): Promise<unknown> {
   const data = parseIssueCommentPayload(payload);
 
-  // Only handle "created" action
+  // Mention delegation — only on new comments
+  if (MENTION_ACTIONS.issue_comment?.includes(data.action)) {
+    await handleMentionDelegation(app, eventType, payload);
+  }
+
+  // Only handle "created" action for repo-targeted routing
   if (data.action !== "created") {
     return reply.status(200).send({ ok: true, event: "issue_comment", action: data.action, handled: false });
   }

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -120,7 +120,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /** Extract unique @mentions from text. Returns lowercase usernames. */
-function extractMentions(text: string | null | undefined): string[] {
+export function extractMentions(text: string | null | undefined): string[] {
   if (!text) return [];
   const matches = text.match(/@([a-zA-Z0-9][\w-]*)/g);
   if (!matches) return [];

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply } from "fastify";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
@@ -119,6 +119,91 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Extract unique @mentions from text. Returns lowercase usernames. */
+function extractMentions(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const matches = text.match(/@([a-zA-Z0-9][\w-]*)/g);
+  if (!matches) return [];
+  const unique = new Set(matches.map((m) => m.slice(1).toLowerCase()));
+  return [...unique];
+}
+
+type MentionContext = {
+  event: string;
+  repository: string;
+  sender: string;
+  title: string;
+  body: string;
+  url: string;
+};
+
+/**
+ * Route @mentions to delegate agents.
+ * For each mentioned user who has delegate_mention configured,
+ * send a card message from the mentioned user to their delegate.
+ */
+async function routeMentionDelegations(
+  app: FastifyInstance,
+  mentionedNames: string[],
+  ctx: MentionContext,
+): Promise<number> {
+  if (mentionedNames.length === 0) return 0;
+
+  // Batch lookup: find agents with delegate_mention set
+  const delegates = await app.db
+    .select({
+      id: agents.id,
+      delegateMention: agents.delegateMention,
+      status: agents.status,
+    })
+    .from(agents)
+    .where(and(inArray(agents.id, mentionedNames), isNotNull(agents.delegateMention)));
+
+  let routed = 0;
+  for (const agent of delegates) {
+    if (agent.status !== "active" || !agent.delegateMention) continue;
+
+    // Verify delegate target exists and is active
+    const [target] = await app.db
+      .select({ id: agents.id, status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agent.delegateMention))
+      .limit(1);
+
+    if (!target || target.status !== "active") {
+      app.log.warn(`delegate_mention target "${agent.delegateMention}" for "${agent.id}" is not active, skipping`);
+      continue;
+    }
+
+    try {
+      const { message: msg, recipients } = await sendToAgent(app.db, agent.id, agent.delegateMention, {
+        format: "card",
+        content: {
+          type: "github_mention",
+          mentionedUser: agent.id,
+          event: ctx.event,
+          repository: ctx.repository,
+          sender: ctx.sender,
+          title: ctx.title,
+          body: ctx.body,
+          url: ctx.url,
+        },
+        metadata: {
+          source: "github",
+          event: "mention_delegation",
+          mentionedUser: agent.id,
+        },
+      });
+      notifyRecipients(app.notifier, recipients, msg.id);
+      routed++;
+    } catch (err) {
+      app.log.error(err, `Failed to route mention delegation from "${agent.id}" to "${agent.delegateMention}"`);
+    }
+  }
+
+  return routed;
+}
+
 function parseIssuesPayload(body: unknown): GitHubIssuesPayload {
   if (!isRecord(body)) throw new BadRequestError("Invalid payload: expected object");
   if (typeof body.action !== "string") throw new BadRequestError("Invalid payload: missing action");
@@ -218,6 +303,16 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(200).send({ ok: true, event: "ping" });
     }
 
+    // --- @mention delegation (all event types) ---
+    const mentionText = extractEventText(eventType, payload);
+    const mentions = extractMentions(mentionText);
+    const mentionCtx = extractEventContext(eventType, payload);
+    let mentionsRouted = 0;
+    if (mentions.length > 0 && mentionCtx) {
+      mentionsRouted = await routeMentionDelegations(app, mentions, mentionCtx);
+    }
+
+    // --- Existing event-specific handlers ---
     if (eventType === "issues") {
       return handleIssuesEvent(app, payload, reply);
     }
@@ -226,9 +321,157 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
       return handleIssueCommentEvent(app, payload, reply);
     }
 
-    // Unhandled event type — acknowledge but do nothing
-    return reply.status(200).send({ ok: true, event: eventType, handled: false });
+    // Other event types — mention delegation may have been routed above
+    return reply.status(200).send({ ok: true, event: eventType, handled: mentionsRouted > 0, mentionsRouted });
   });
+}
+
+/** Extract text body from any GitHub webhook event for @mention scanning. */
+function extractEventText(eventType: string, payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+
+  switch (eventType) {
+    case "issues": {
+      const issue = isRecord(payload.issue) ? payload.issue : null;
+      return typeof issue?.body === "string" ? issue.body : null;
+    }
+    case "issue_comment":
+    case "pull_request_review_comment":
+    case "commit_comment":
+    case "discussion_comment": {
+      const comment = isRecord(payload.comment) ? payload.comment : null;
+      return typeof comment?.body === "string" ? comment.body : null;
+    }
+    case "pull_request": {
+      const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+      return typeof pr?.body === "string" ? pr.body : null;
+    }
+    case "pull_request_review": {
+      const review = isRecord(payload.review) ? payload.review : null;
+      return typeof review?.body === "string" ? review.body : null;
+    }
+    case "discussion": {
+      const disc = isRecord(payload.discussion) ? payload.discussion : null;
+      return typeof disc?.body === "string" ? disc.body : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** Extract context info from any GitHub webhook event for delegation messages. */
+function extractEventContext(eventType: string, payload: unknown): MentionContext | null {
+  if (!isRecord(payload)) return null;
+
+  const repo = isRecord(payload.repository) ? payload.repository : null;
+  const sender = isRecord(payload.sender) ? payload.sender : null;
+  const repository = typeof repo?.full_name === "string" ? repo.full_name : "";
+  const senderLogin = typeof sender?.login === "string" ? sender.login : "";
+
+  switch (eventType) {
+    case "issues": {
+      const issue = isRecord(payload.issue) ? payload.issue : null;
+      if (!issue) return null;
+      return {
+        event: "issues",
+        repository,
+        sender: senderLogin,
+        title: `Issue #${issue.number}: ${issue.title}`,
+        body: typeof issue.body === "string" ? issue.body : "",
+        url: typeof issue.html_url === "string" ? issue.html_url : "",
+      };
+    }
+    case "issue_comment": {
+      const issue = isRecord(payload.issue) ? payload.issue : null;
+      const comment = isRecord(payload.comment) ? payload.comment : null;
+      if (!issue || !comment) return null;
+      return {
+        event: "issue_comment",
+        repository,
+        sender: senderLogin,
+        title: `Issue #${issue.number}: ${issue.title}`,
+        body: typeof comment.body === "string" ? comment.body : "",
+        url: typeof comment.html_url === "string" ? comment.html_url : "",
+      };
+    }
+    case "pull_request": {
+      const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+      if (!pr) return null;
+      return {
+        event: "pull_request",
+        repository,
+        sender: senderLogin,
+        title: `PR #${pr.number}: ${pr.title}`,
+        body: typeof pr.body === "string" ? pr.body : "",
+        url: typeof pr.html_url === "string" ? pr.html_url : "",
+      };
+    }
+    case "pull_request_review": {
+      const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+      const review = isRecord(payload.review) ? payload.review : null;
+      if (!pr || !review) return null;
+      return {
+        event: "pull_request_review",
+        repository,
+        sender: senderLogin,
+        title: `PR #${pr.number}: ${pr.title}`,
+        body: typeof review.body === "string" ? review.body : "",
+        url: typeof review.html_url === "string" ? review.html_url : "",
+      };
+    }
+    case "pull_request_review_comment": {
+      const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+      const comment = isRecord(payload.comment) ? payload.comment : null;
+      if (!pr || !comment) return null;
+      return {
+        event: "pull_request_review_comment",
+        repository,
+        sender: senderLogin,
+        title: `PR #${pr.number}: ${pr.title}`,
+        body: typeof comment.body === "string" ? comment.body : "",
+        url: typeof comment.html_url === "string" ? comment.html_url : "",
+      };
+    }
+    case "discussion": {
+      const disc = isRecord(payload.discussion) ? payload.discussion : null;
+      if (!disc) return null;
+      return {
+        event: "discussion",
+        repository,
+        sender: senderLogin,
+        title: typeof disc.title === "string" ? disc.title : "",
+        body: typeof disc.body === "string" ? disc.body : "",
+        url: typeof disc.html_url === "string" ? disc.html_url : "",
+      };
+    }
+    case "discussion_comment": {
+      const disc = isRecord(payload.discussion) ? payload.discussion : null;
+      const comment = isRecord(payload.comment) ? payload.comment : null;
+      if (!disc || !comment) return null;
+      return {
+        event: "discussion_comment",
+        repository,
+        sender: senderLogin,
+        title: typeof disc.title === "string" ? disc.title : "",
+        body: typeof comment.body === "string" ? comment.body : "",
+        url: typeof comment.html_url === "string" ? comment.html_url : "",
+      };
+    }
+    case "commit_comment": {
+      const comment = isRecord(payload.comment) ? payload.comment : null;
+      if (!comment) return null;
+      return {
+        event: "commit_comment",
+        repository,
+        sender: senderLogin,
+        title: "Commit comment",
+        body: typeof comment.body === "string" ? comment.body : "",
+        url: typeof comment.html_url === "string" ? comment.html_url : "",
+      };
+    }
+    default:
+      return null;
+  }
 }
 
 async function handleIssuesEvent(app: FastifyInstance, payload: unknown, reply: FastifyReply): Promise<unknown> {

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -9,6 +9,8 @@ export const agents = pgTable(
     /** "human" | "personal_assistant" | "autonomous_agent" */
     type: text("type").notNull(),
     displayName: text("display_name"),
+    /** Agent ID to forward @mentions to (e.g. personal assistant) */
+    delegateMention: text("delegate_mention"),
     /** Delivery address, auto-generated as inbox_{id} */
     inboxId: text("inbox_id").unique().notNull(),
     /** "active" | "suspended". Suspended agents have all API requests rejected. */

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -84,6 +84,7 @@ export async function listAgents(db: Database, limit: number, cursor?: string) {
       organizationId: agents.organizationId,
       type: agents.type,
       displayName: agents.displayName,
+      delegateMention: agents.delegateMention,
       inboxId: agents.inboxId,
       status: agents.status,
       metadata: agents.metadata,

--- a/packages/server/src/services/context-tree-graphql.ts
+++ b/packages/server/src/services/context-tree-graphql.ts
@@ -123,10 +123,11 @@ async function fetchMembers(repo: string, branch: string, token: string): Promis
 export function parseNodeMetadata(content: string): {
   type: string;
   displayName: string | null;
+  delegateMention: string | null;
 } {
   const match = /^---\n([\s\S]*?)\n---/.exec(content);
   if (!match) {
-    return { type: "autonomous_agent", displayName: null };
+    return { type: "autonomous_agent", displayName: null, delegateMention: null };
   }
 
   const frontmatter = match[1] ?? "";
@@ -138,6 +139,7 @@ export function parseNodeMetadata(content: string): {
   return {
     type: getValue("type") ?? "autonomous_agent",
     displayName: getValue("display_name") ?? getValue("title") ?? getValue("name"),
+    delegateMention: getValue("delegate_mention"),
   };
 }
 
@@ -182,33 +184,43 @@ export async function syncFromGitHub(
     try {
       const meta = member.nodeContent
         ? parseNodeMetadata(member.nodeContent)
-        : { type: "autonomous_agent", displayName: null };
+        : { type: "autonomous_agent", displayName: null, delegateMention: null };
 
       const existing = await db.execute(
-        sql`SELECT id, status, type, display_name FROM agents WHERE id = ${member.name}`,
+        sql`SELECT id, status, type, display_name, delegate_mention FROM agents WHERE id = ${member.name}`,
       );
 
       if (existing.length === 0) {
         // New agent — create
         await db.execute(sql`
-          INSERT INTO agents (id, type, display_name, status, inbox_id)
-          VALUES (${member.name}, ${meta.type}, ${meta.displayName}, 'active', ${`inbox_${member.name}`})
+          INSERT INTO agents (id, type, display_name, delegate_mention, status, inbox_id)
+          VALUES (${member.name}, ${meta.type}, ${meta.displayName}, ${meta.delegateMention}, 'active', ${`inbox_${member.name}`})
         `);
         result.created++;
       } else {
-        const agent = existing[0] as { id: string; status: string; type: string; display_name: string | null };
+        const agent = existing[0] as {
+          id: string;
+          status: string;
+          type: string;
+          display_name: string | null;
+          delegate_mention: string | null;
+        };
 
         if (agent.status === "suspended") {
           // Reactivate — member is back in tree
           await db.execute(sql`
-            UPDATE agents SET status = 'active', type = ${meta.type}, display_name = ${meta.displayName}
+            UPDATE agents SET status = 'active', type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}
             WHERE id = ${member.name}
           `);
           result.reactivated++;
-        } else if (agent.type !== meta.type || agent.display_name !== meta.displayName) {
+        } else if (
+          agent.type !== meta.type ||
+          agent.display_name !== meta.displayName ||
+          agent.delegate_mention !== meta.delegateMention
+        ) {
           // Fields changed — update
           await db.execute(sql`
-            UPDATE agents SET type = ${meta.type}, display_name = ${meta.displayName}
+            UPDATE agents SET type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}
             WHERE id = ${member.name}
           `);
           result.updated++;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -71,6 +71,7 @@ export const agentSchema = z.object({
   organizationId: z.string(),
   type: agentTypeSchema,
   displayName: z.string().nullable(),
+  delegateMention: z.string().nullable(),
   inboxId: z.string(),
   status: z.string(),
   metadata: z.record(z.unknown()),

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -306,6 +306,12 @@ export function AgentDetailPage() {
               <dt className="text-muted-foreground mb-1">Inbox ID</dt>
               <dd className="font-mono">{agent.inboxId}</dd>
             </div>
+            {agent.delegateMention && (
+              <div>
+                <dt className="text-muted-foreground mb-1">Delegate Mention</dt>
+                <dd className="font-mono">{agent.delegateMention}</dd>
+              </div>
+            )}
             {role && (
               <div>
                 <dt className="text-muted-foreground mb-1">Role</dt>

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -106,6 +106,7 @@ export function AgentsPage() {
               <TableHead>ID</TableHead>
               <TableHead>Display Name</TableHead>
               <TableHead>Type</TableHead>
+              <TableHead>Delegate</TableHead>
               <TableHead>Online</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Created</TableHead>
@@ -114,13 +115,13 @@ export function AgentsPage() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
                   Loading...
                 </TableCell>
               </TableRow>
             ) : error ? (
               <TableRow>
-                <TableCell colSpan={6} className="text-center py-8 text-destructive">
+                <TableCell colSpan={7} className="text-center py-8 text-destructive">
                   Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
                 </TableCell>
               </TableRow>
@@ -130,7 +131,7 @@ export function AgentsPage() {
                 if (!filtered || filtered.length === 0) {
                   return (
                     <TableRow>
-                      <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
+                      <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
                         {typeFilter
                           ? `No ${typeFilter} agents`
                           : "No agents yet — click Sync Now to import from Context Tree"}
@@ -144,6 +145,9 @@ export function AgentsPage() {
                     <TableCell>{agent.displayName ?? "—"}</TableCell>
                     <TableCell>
                       <Badge variant="secondary">{agent.type}</Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-sm text-muted-foreground">
+                      {agent.delegateMention ?? "—"}
                     </TableCell>
                     <TableCell>
                       <span


### PR DESCRIPTION
## Summary

- When a Context Tree member has `delegate_mention: agent-id` in NODE.md, GitHub @mentions are automatically forwarded to the specified agent's inbox
- Sender = the mentioned member → creates a natural owner ↔ assistant conversation
- Supports all GitHub event types: issues, PRs, discussions, reviews, comments

## Changes

- **Database**: new `delegate_mention` column on agents table (migration 0005)
- **Sync**: parse `delegate_mention` from NODE.md frontmatter, sync to DB
- **Webhook**: extract @mentions from event body, batch-lookup delegates, route via `sendToAgent()`
- **Web UI**: show Delegate column in agents list, show field in agent detail
- **Shared schema**: add `delegateMention` to Agent type

## Test plan

- [ ] Add `delegate_mention: kael-agent` to a member's NODE.md, sync, verify DB
- [ ] Create a GitHub issue @mentioning that member, verify message appears in delegate's inbox
- [ ] Verify Web UI shows delegate relationship on agents list and detail pages
- [ ] Verify unmentioned agents or agents without delegate are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)