### PR TITLE
chore: add npm publish workflow and bump to v0.2.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,59 @@
+name: npm Publish
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Check version early to avoid unnecessary install/build
+      - name: Check version
+        id: version
+        working-directory: packages/command
+        run: |
+          LOCAL=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view @unispark.ai/agent-hub version 2>/dev/null || echo "0.0.0")
+          if [[ "$LOCAL" != "$PUBLISHED" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $PUBLISHED -> $LOCAL"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($LOCAL), skipping publish"
+          fi
+
+      - if: steps.version.outputs.changed == 'true'
+        uses: pnpm/action-setup@v4
+
+      - if: steps.version.outputs.changed == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - if: steps.version.outputs.changed == 'true'
+        run: pnpm build
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        working-directory: packages/command
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unispark.ai/agent-hub",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Agent Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary
- Add `npm-publish.yml` GitHub Actions workflow that auto-publishes `@unispark.ai/agent-hub` to npm after CI passes on main
- Workflow uses `workflow_run` trigger (depends on CI success), checks version diff before building/publishing
- Bump package version from `0.1.0` to `0.2.0`

## Prerequisites
- Add `NPM_TOKEN` secret in repo Settings → Secrets → Actions

## Test plan
- [ ] Verify CI workflow passes on this PR
- [ ] After merge, confirm npm-publish workflow triggers and version check detects `0.2.0 != 0.1.0`
- [ ] Confirm package published at https://www.npmjs.com/package/@unispark.ai/agent-hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)