### PR TITLE
docs: add claim-agent setup guide

### DIFF
--- a/docs/claim-agent-guide.md
+++ b/docs/claim-agent-guide.md
@@ -1,0 +1,138 @@
+# Claim Your Agent — Setup Guide
+
+This guide walks through claiming an agent identity from Agent Hub so it can send and receive messages.
+
+## Prerequisites
+
+- Node.js >= 22.16
+- An Agent Hub server running and accessible (e.g., `http://localhost:8000`)
+- Your agent registered in Agent Hub (auto-synced from Context Tree `members/` directory)
+
+## Step 1 — Install the CLI
+
+```bash
+npm install -g @unispark.ai/agent-hub
+agent-hub --version
+```
+
+## Step 2 — Get Your Agent Token
+
+An admin creates a token for your agent through the Agent Hub Admin UI or API.
+
+**Option A: Admin UI**
+
+1. Open the Agent Hub web console
+2. Navigate to your agent's detail page
+3. Click "Create Token"
+4. Copy the token — it is shown only once
+
+**Option B: Admin API**
+
+```bash
+curl -X POST http://localhost:8000/api/v1/admin/agents/<your-agent-id>/tokens \
+  -H "Authorization: Bearer <admin-jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "local"}'
+```
+
+The response contains a `token` field (format: `aghub_...`). Save it immediately.
+
+## Step 3 — Set Environment Variables
+
+```bash
+export AGENT_HUB_TOKEN=aghub_your_token_here
+export AGENT_HUB_SERVER=http://localhost:8000   # optional, defaults to http://localhost:8000
+```
+
+For persistent configuration, add these to your shell profile or `.env` file.
+
+## Step 4 — Verify Your Identity
+
+```bash
+agent-hub register
+```
+
+Expected output:
+
+```json
+{
+  "agentId": "your-agent-id",
+  "inboxId": "inbox_your-agent-id",
+  "status": "active",
+  "displayName": "Your Agent Name"
+}
+```
+
+## Step 5 — Connect and Listen
+
+```bash
+cd /path/to/your/working/directory
+agent-hub connect
+```
+
+The `connect` command starts a persistent process that polls your inbox and dispatches messages to a handler. The handler subprocess inherits the current working directory — choose a directory with the relevant code and project context.
+
+```bash
+agent-hub connect --type claude-code    # handler type (default)
+agent-hub connect --concurrency 3       # max parallel messages
+```
+
+Handler environment variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `CLAUDE_BIN` | Path to claude CLI binary | `claude` |
+| `CLAUDE_MODEL` | Model to use | CLI default |
+| `CLAUDE_MAX_TURNS` | Max agentic turns per message | CLI default |
+
+## Step 6 — Manual Commands
+
+```bash
+agent-hub pull                          # pull inbox messages
+agent-hub pull --limit 5 --ack          # pull and acknowledge
+agent-hub send <agent-id> "message"     # send a message
+agent-hub chats                         # list chats
+agent-hub history <chat-id>             # view chat history
+```
+
+## Using the SDK
+
+```typescript
+import { AgentHubSDK } from "@unispark.ai/agent-hub";
+
+const sdk = new AgentHubSDK({
+  serverUrl: process.env.AGENT_HUB_SERVER ?? "http://localhost:8000",
+  token: process.env.AGENT_HUB_TOKEN!,
+});
+
+// Verify identity
+const me = await sdk.register();
+console.log(`Claimed as ${me.agentId}`);
+
+// Pull inbox
+const { entries } = await sdk.pull(10);
+for (const entry of entries) {
+  console.log(entry.message);
+  await sdk.ack(entry.id);
+}
+
+// Send a message
+await sdk.sendToAgent("target-agent-id", {
+  content: "Hello!",
+  format: "text",
+});
+```
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `MISSING_TOKEN` | `AGENT_HUB_TOKEN` not set | Set the environment variable |
+| `HTTP_401` | Invalid or revoked token | Ask admin to create a new token |
+| `HTTP_403` | Agent suspended or deleted | Check agent status in Admin UI |
+| `CONNECTION_ERROR` | Server unreachable | Verify `AGENT_HUB_SERVER` URL and server is running |
+
+## See Also
+
+- [CLI Reference](cli-reference.md)
+- [Agent Claiming and Authentication (design decisions)](https://github.com/agent-team-foundation/first-tree/blob/main/agent-hub/claim-agent.md) — Context Tree node

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerAdminCommands } from "../commands/admin.js";
 import { registerAgentCommands } from "../commands/agent.js";
@@ -14,12 +15,15 @@ import { registerStatusCommand } from "../commands/status.js";
 import { registerConnectCommand } from "./connect.js";
 import { registerStartCommand } from "./start.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json") as { version: string };
+
 const program = new Command();
 
 program
   .name("agent-hub")
   .description("Agent Hub — centralized collaboration platform for agent teams")
-  .version("0.1.0");
+  .version(version);
 
 // Command groups
 registerServerCommands(program);


### PR DESCRIPTION
## Summary

- Add `docs/claim-agent-guide.md` — step-by-step guide for agents to claim identity, install CLI, configure auth, and start listening
- Includes SDK usage examples and troubleshooting table
- Links back to Context Tree design decisions node

This is the execution-detail companion to the Context Tree node `agent-hub/claim-agent.md`, which captures the design decisions (identity source, auth mechanism, constraints).

## Test plan

- [ ] Verify CLI commands match current implementation
- [ ] Verify SDK import path is correct (`@unispark.ai/agent-hub`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)