### PR TITLE
fix: add diagnostic logging for Claude Code process crashes

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@first-tree-hub/client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "First Tree Hub SDK — programmatic client for First Tree Hub server",

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -88,12 +88,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           sessionCtx.touch();
 
           if (message.type === "result") {
-            const result = message as { type: "result"; subtype: string; errors?: string[] };
+            const result = message as {
+              type: "result";
+              subtype: string;
+              errors?: string[];
+              duration_ms?: number;
+              total_cost_usd?: number;
+              num_turns?: number;
+              session_id?: string;
+            };
             if (result.subtype === "success") {
               retryCount = 0;
             } else {
               const errors = result.errors ? result.errors.join("; ") : result.subtype;
-              sessionCtx.log(`Query result error: ${errors}`);
+              sessionCtx.log(
+                `Query result error: ${errors} (subtype=${result.subtype}, turns=${result.num_turns ?? "?"}, duration=${result.duration_ms ?? "?"}ms)`,
+              );
             }
           }
         }
@@ -103,6 +113,16 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // Process crash, OOM, or unexpected termination
         const errMsg = err instanceof Error ? err.message : String(err);
         sessionCtx.log(`Query error: ${errMsg}`);
+
+        // Log additional diagnostic details when available
+        if (err instanceof Error) {
+          if (err.cause)
+            sessionCtx.log(`  cause: ${err.cause instanceof Error ? err.cause.message : String(err.cause)}`);
+          if ("exitCode" in err) sessionCtx.log(`  exitCode: ${(err as Record<string, unknown>).exitCode}`);
+          if ("stderr" in err) sessionCtx.log(`  stderr: ${(err as Record<string, unknown>).stderr}`);
+          if ("code" in err) sessionCtx.log(`  code: ${(err as Record<string, unknown>).code}`);
+          if (err.stack) sessionCtx.log(`  stack: ${err.stack.split("\n").slice(1, 4).join(" | ")}`);
+        }
 
         if (retryCount >= MAX_RETRIES || !claudeSessionId) {
           sessionCtx.log("Exhausted retries, session will be suspended");
@@ -127,6 +147,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       ctx = sessionCtx;
       claudeSessionId = randomUUID();
 
+      sessionCtx.log(
+        `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
+      );
       spawnQuery(claudeSessionId, sessionCtx);
       inputController?.push(toSDKUserMessage(message, claudeSessionId));
 
@@ -139,6 +162,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       claudeSessionId = sessionId;
       retryCount = 0;
 
+      sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
       spawnQuery(sessionId, sessionCtx, sessionId);
       inputController?.push(toSDKUserMessage(message, sessionId));
 


### PR DESCRIPTION
## Summary
- Add detailed error diagnostics (cause, exitCode, stderr, code, stack) when Claude Code subprocess crashes unexpectedly
- Enrich result error logs with subtype, num_turns, and duration_ms to distinguish "never started" from "crashed mid-run"
- Log cwd and permissionMode at session start/resume for environment verification

## Context
A colleague's agent kept failing with `Claude Code process exited with code 1` but the logs provided no actionable information to diagnose the root cause. These additional fields will surface the underlying issue on first occurrence.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm --filter @first-tree-hub/client test` passes (5/5)
- [ ] Deploy and reproduce the exit-code-1 scenario to verify new log fields appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)