### PR TITLE
fix: prevent super_admin deletion and restrict docker CI to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/packages/server/src/services/admin-user.ts
+++ b/packages/server/src/services/admin-user.ts
@@ -4,7 +4,7 @@ import bcrypt from "bcrypt";
 import { desc, eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { adminUsers } from "../db/schema/admin-users.js";
-import { ConflictError, NotFoundError } from "../errors.js";
+import { ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 
 const SALT_ROUNDS = 10;
 
@@ -71,6 +71,10 @@ export async function updateAdminUser(db: Database, id: string, data: UpdateAdmi
 }
 
 export async function deleteAdminUser(db: Database, id: string) {
-  const [row] = await db.delete(adminUsers).where(eq(adminUsers.id, id)).returning();
-  if (!row) throw new NotFoundError(`Admin user "${id}" not found`);
+  const [target] = await db.select().from(adminUsers).where(eq(adminUsers.id, id)).limit(1);
+  if (!target) throw new NotFoundError(`Admin user "${id}" not found`);
+  if (target.role === "super_admin") {
+    throw new ForbiddenError("Cannot delete a super_admin account");
+  }
+  await db.delete(adminUsers).where(eq(adminUsers.id, id));
 }

--- a/packages/web/src/pages/admin-users.tsx
+++ b/packages/web/src/pages/admin-users.tsx
@@ -229,15 +229,17 @@ export function AdminUsersPage() {
                       <Button variant="ghost" size="sm" onClick={() => openResetPassword(u.id)} title="Reset password">
                         Reset PW
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(u.id)}
-                        disabled={deleteMutation.isPending}
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      {u.role !== "super_admin" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDelete(u.id)}
+                          disabled={deleteMutation.isPending}
+                          title="Delete"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
                     </div>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary
- Forbid deleting `super_admin` accounts: service layer returns 403, web dashboard hides the delete button
- Remove `pull_request` trigger from `docker.yml` so docker build only runs on `main` branch pushes, version tags, and manual dispatch

## Test plan
- [ ] Attempt to delete a `super_admin` via API — expect 403
- [ ] Verify the delete button is hidden for `super_admin` users in the web dashboard
- [ ] Verify docker workflow no longer triggers on PR branches
- [ ] Verify docker workflow still triggers on push to `main` and `v*` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)