### PR TITLE
feat: add admin test connection endpoint for agents

### DIFF
--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -1,9 +1,12 @@
 import { createAgentTokenSchema, paginationQuerySchema } from "@first-tree-hub/shared";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import { agents } from "../../db/schema/agents.js";
+import { messages } from "../../db/schema/messages.js";
 import * as agentService from "../../services/agent.js";
 import { findOrCreateDirectChat } from "../../services/chat.js";
 import { forceDisconnect } from "../../services/connection-manager.js";
-import { listMessages, sendMessage } from "../../services/message.js";
+import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
 
@@ -84,13 +87,14 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     return reply.status(204).send();
   });
 
-  // Test connection — send a test message and wait for a response
   app.post<{ Params: { agentId: string } }>("/:agentId/test", async (request, reply) => {
     const { agentId } = request.params;
-    const agent = await agentService.getAgent(app.db, agentId);
 
-    // Check presence first
-    const presence = await presenceService.getPresence(app.db, agentId);
+    const [, presence] = await Promise.all([
+      agentService.getAgent(app.db, agentId),
+      presenceService.getPresence(app.db, agentId),
+    ]);
+
     if (!presence || presence.status !== "online") {
       return reply.status(200).send({
         status: "offline",
@@ -98,57 +102,66 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    // Find a sender: use delegateMention owner for personal_assistant, otherwise pick any other agent
-    let senderId: string | null = agent.delegateMention;
+    // Find sender: look for human owner (whose delegateMention points to this agent), then fall back to any other active agent
+    const [owner] = await app.db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.delegateMention, agentId), eq(agents.status, "active")))
+      .limit(1);
+
+    let senderId = owner?.id ?? null;
     if (!senderId) {
-      // Find any other active agent to act as sender
-      const allAgents = await agentService.listAgents(app.db, 10);
-      const other = allAgents.items.find((a) => a.id !== agentId && a.status === "active");
+      const [other] = await app.db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(ne(agents.id, agentId), eq(agents.status, "active")))
+        .limit(1);
       senderId = other?.id ?? null;
     }
 
     if (!senderId) {
-      return reply.status(400).send({
+      return reply.status(200).send({
         status: "error",
         message: "No suitable sender found. Need at least one other active agent.",
       });
     }
 
-    // Create or find a direct chat
     const chat = await findOrCreateDirectChat(app.db, senderId, agentId);
 
-    // Send test message
-    const testContent = `[System Test] This is an automated test message to verify your connection. Please respond with a brief confirmation that includes your identity and role. Time: ${new Date().toISOString()}`;
+    const testContent = `[System Test] Verify your connection. Respond with your identity and role. Time: ${new Date().toISOString()}`;
     const result = await sendMessage(app.db, chat.id, senderId, {
       format: "text",
       content: testContent,
     });
-
-    // Notify via WebSocket
     notifyRecipients(app.notifier, result.recipients, result.message.id);
 
-    // Poll for response (up to 30 seconds)
-    const pollStart = Date.now();
+    // Poll for response (admin diagnostic, acceptable to hold connection)
     const POLL_TIMEOUT = 30_000;
     const POLL_INTERVAL = 1_000;
+    const threshold = result.message.createdAt;
+    const pollStart = Date.now();
 
     while (Date.now() - pollStart < POLL_TIMEOUT) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL));
 
-      const recent = await listMessages(app.db, chat.id, 5);
-      const response = recent.items.find((m) => m.senderId === agentId && m.createdAt > result.message.createdAt);
+      const [response] = await app.db
+        .select()
+        .from(messages)
+        .where(
+          and(eq(messages.chatId, chat.id), eq(messages.senderId, agentId), sql`${messages.createdAt} > ${threshold}`),
+        )
+        .limit(1);
 
       if (response) {
+        const content =
+          typeof response.content === "string"
+            ? response.content.slice(0, 500)
+            : JSON.stringify(response.content).slice(0, 500);
         return reply.status(200).send({
           status: "success",
           chatId: chat.id,
-          testMessageId: result.message.id,
-          responseMessageId: response.id,
-          responseContent:
-            typeof response.content === "string"
-              ? response.content.slice(0, 500)
-              : JSON.stringify(response.content).slice(0, 500),
-          responseTime: response.createdAt.getTime() - result.message.createdAt.getTime(),
+          responseContent: content,
+          responseTime: response.createdAt.getTime() - threshold.getTime(),
         });
       }
     }
@@ -156,8 +169,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     return reply.status(200).send({
       status: "timeout",
       chatId: chat.id,
-      testMessageId: result.message.id,
-      message: "Agent is connected but did not respond within 30 seconds. The agent may still be processing.",
+      message: "Agent is connected but did not respond within 30 seconds.",
     });
   });
 }

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -1,7 +1,10 @@
 import { createAgentTokenSchema, paginationQuerySchema } from "@first-tree-hub/shared";
 import type { FastifyInstance } from "fastify";
 import * as agentService from "../../services/agent.js";
+import { findOrCreateDirectChat } from "../../services/chat.js";
 import { forceDisconnect } from "../../services/connection-manager.js";
+import { listMessages, sendMessage } from "../../services/message.js";
+import { notifyRecipients } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
 
 function serializeDate(d: Date | null): string | null {
@@ -79,5 +82,82 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   app.delete<{ Params: { agentId: string } }>("/:agentId", async (request, reply) => {
     await agentService.deleteAgent(app.db, request.params.agentId);
     return reply.status(204).send();
+  });
+
+  // Test connection — send a test message and wait for a response
+  app.post<{ Params: { agentId: string } }>("/:agentId/test", async (request, reply) => {
+    const { agentId } = request.params;
+    const agent = await agentService.getAgent(app.db, agentId);
+
+    // Check presence first
+    const presence = await presenceService.getPresence(app.db, agentId);
+    if (!presence || presence.status !== "online") {
+      return reply.status(200).send({
+        status: "offline",
+        message: "Agent is not connected. Start the client first.",
+      });
+    }
+
+    // Find a sender: use delegateMention owner for personal_assistant, otherwise pick any other agent
+    let senderId: string | null = agent.delegateMention;
+    if (!senderId) {
+      // Find any other active agent to act as sender
+      const allAgents = await agentService.listAgents(app.db, 10);
+      const other = allAgents.items.find((a) => a.id !== agentId && a.status === "active");
+      senderId = other?.id ?? null;
+    }
+
+    if (!senderId) {
+      return reply.status(400).send({
+        status: "error",
+        message: "No suitable sender found. Need at least one other active agent.",
+      });
+    }
+
+    // Create or find a direct chat
+    const chat = await findOrCreateDirectChat(app.db, senderId, agentId);
+
+    // Send test message
+    const testContent = `[System Test] This is an automated test message to verify your connection. Please respond with a brief confirmation that includes your identity and role. Time: ${new Date().toISOString()}`;
+    const result = await sendMessage(app.db, chat.id, senderId, {
+      format: "text",
+      content: testContent,
+    });
+
+    // Notify via WebSocket
+    notifyRecipients(app.notifier, result.recipients, result.message.id);
+
+    // Poll for response (up to 30 seconds)
+    const pollStart = Date.now();
+    const POLL_TIMEOUT = 30_000;
+    const POLL_INTERVAL = 1_000;
+
+    while (Date.now() - pollStart < POLL_TIMEOUT) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+
+      const recent = await listMessages(app.db, chat.id, 5);
+      const response = recent.items.find((m) => m.senderId === agentId && m.createdAt > result.message.createdAt);
+
+      if (response) {
+        return reply.status(200).send({
+          status: "success",
+          chatId: chat.id,
+          testMessageId: result.message.id,
+          responseMessageId: response.id,
+          responseContent:
+            typeof response.content === "string"
+              ? response.content.slice(0, 500)
+              : JSON.stringify(response.content).slice(0, 500),
+          responseTime: response.createdAt.getTime() - result.message.createdAt.getTime(),
+        });
+      }
+    }
+
+    return reply.status(200).send({
+      status: "timeout",
+      chatId: chat.id,
+      testMessageId: result.message.id,
+      message: "Agent is connected but did not respond within 30 seconds. The agent may still be processing.",
+    });
   });
 }

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -22,6 +22,20 @@ export function deleteAgent(agentId: string): Promise<void> {
   return api.delete<void>(`/admin/agents/${encodeURIComponent(agentId)}`);
 }
 
+// -- Test Connection --
+
+export type TestResult = {
+  status: "success" | "timeout" | "offline" | "error";
+  message?: string;
+  chatId?: string;
+  responseContent?: string;
+  responseTime?: number;
+};
+
+export function testAgentConnection(agentId: string): Promise<TestResult> {
+  return api.post<TestResult>(`/admin/agents/${encodeURIComponent(agentId)}/test`, {});
+}
+
 // -- Sync API --
 
 export function triggerSync(): Promise<SyncReport> {

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1,12 +1,12 @@
 import { ADAPTER_PLATFORMS } from "@first-tree-hub/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Cable, Copy, Key, Link2, Pencil, Plus, Trash2 } from "lucide-react";
+import { ArrowLeft, Cable, Copy, Key, Link2, Pencil, Play, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { createAdapterMapping, deleteAdapterMapping, listAdapterMappings } from "../api/adapter-mappings.js";
 import { getAdapterStatuses } from "../api/adapter-status.js";
 import { createAdapter, deleteAdapter, listAdapters, updateAdapter } from "../api/adapters.js";
-import { deleteAgent, getAgent } from "../api/agents.js";
+import { deleteAgent, getAgent, type TestResult, testAgentConnection } from "../api/agents.js";
 import { createToken, listTokens, revokeToken } from "../api/tokens.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
@@ -149,6 +149,14 @@ export function AgentDetailPage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["adapter-mappings"] }),
   });
 
+  // Test connection
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const testMutation = useMutation({
+    mutationFn: () => testAgentConnection(agentId),
+    onSuccess: (data) => setTestResult(data),
+    onError: () => setTestResult({ status: "error", message: "Failed to reach server" }),
+  });
+
   const agent = agentQuery.data;
   const isHuman = agent?.type === "human";
 
@@ -270,6 +278,20 @@ export function AgentDetailPage() {
           <h1 className="text-2xl font-semibold">{agent.displayName ?? agent.id}</h1>
           <p className="text-sm text-muted-foreground font-mono">{agent.id}</p>
         </div>
+        {!isHuman && agent.status === "active" && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setTestResult(null);
+              testMutation.mutate();
+            }}
+            disabled={testMutation.isPending}
+          >
+            <Play className="h-4 w-4 mr-2" />
+            {testMutation.isPending ? "Testing..." : "Test Connection"}
+          </Button>
+        )}
         {agent.status === "suspended" && (
           <Button variant="destructive" size="sm" onClick={handleDelete}>
             <Trash2 className="h-4 w-4 mr-2" />
@@ -277,6 +299,53 @@ export function AgentDetailPage() {
           </Button>
         )}
       </div>
+
+      {/* Test Connection Result */}
+      {testResult && (
+        <Card
+          className={cn(
+            "border-l-4",
+            testResult.status === "success" && "border-l-green-500",
+            testResult.status === "timeout" && "border-l-yellow-500",
+            testResult.status === "offline" && "border-l-gray-400",
+            testResult.status === "error" && "border-l-red-500",
+          )}
+        >
+          <CardContent className="pt-4">
+            <div className="flex items-start justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant={
+                      testResult.status === "success"
+                        ? "default"
+                        : testResult.status === "error" || testResult.status === "offline"
+                          ? "destructive"
+                          : "secondary"
+                    }
+                  >
+                    {testResult.status}
+                  </Badge>
+                  {testResult.responseTime != null && (
+                    <span className="text-xs text-muted-foreground">
+                      {(testResult.responseTime / 1000).toFixed(1)}s
+                    </span>
+                  )}
+                </div>
+                {testResult.message && <p className="text-sm text-muted-foreground">{testResult.message}</p>}
+                {testResult.responseContent && (
+                  <p className="text-sm mt-2 whitespace-pre-wrap bg-muted rounded p-2 max-h-40 overflow-auto">
+                    {testResult.responseContent}
+                  </p>
+                )}
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => setTestResult(null)}>
+                Dismiss
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Agent Info — read-only, managed by Context Tree */}
       <Card>

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -150,11 +150,8 @@ export function AgentDetailPage() {
   });
 
   // Test connection
-  const [testResult, setTestResult] = useState<TestResult | null>(null);
   const testMutation = useMutation({
     mutationFn: () => testAgentConnection(agentId),
-    onSuccess: (data) => setTestResult(data),
-    onError: () => setTestResult({ status: "error", message: "Failed to reach server" }),
   });
 
   const agent = agentQuery.data;
@@ -283,7 +280,7 @@ export function AgentDetailPage() {
             variant="outline"
             size="sm"
             onClick={() => {
-              setTestResult(null);
+              testMutation.reset();
               testMutation.mutate();
             }}
             disabled={testMutation.isPending}
@@ -301,50 +298,11 @@ export function AgentDetailPage() {
       </div>
 
       {/* Test Connection Result */}
-      {testResult && (
-        <Card
-          className={cn(
-            "border-l-4",
-            testResult.status === "success" && "border-l-green-500",
-            testResult.status === "timeout" && "border-l-yellow-500",
-            testResult.status === "offline" && "border-l-gray-400",
-            testResult.status === "error" && "border-l-red-500",
-          )}
-        >
-          <CardContent className="pt-4">
-            <div className="flex items-start justify-between">
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <Badge
-                    variant={
-                      testResult.status === "success"
-                        ? "default"
-                        : testResult.status === "error" || testResult.status === "offline"
-                          ? "destructive"
-                          : "secondary"
-                    }
-                  >
-                    {testResult.status}
-                  </Badge>
-                  {testResult.responseTime != null && (
-                    <span className="text-xs text-muted-foreground">
-                      {(testResult.responseTime / 1000).toFixed(1)}s
-                    </span>
-                  )}
-                </div>
-                {testResult.message && <p className="text-sm text-muted-foreground">{testResult.message}</p>}
-                {testResult.responseContent && (
-                  <p className="text-sm mt-2 whitespace-pre-wrap bg-muted rounded p-2 max-h-40 overflow-auto">
-                    {testResult.responseContent}
-                  </p>
-                )}
-              </div>
-              <Button variant="ghost" size="sm" onClick={() => setTestResult(null)}>
-                Dismiss
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+      {(testMutation.data || testMutation.error) && (
+        <TestResultCard
+          result={testMutation.data ?? { status: "error", message: "Failed to reach server" }}
+          onDismiss={() => testMutation.reset()}
+        />
       )}
 
       {/* Agent Info — read-only, managed by Context Tree */}
@@ -796,6 +754,53 @@ export function AgentDetailPage() {
         </Dialog>
       )}
     </div>
+  );
+}
+
+// ── Components ──────────────────────────────────────────────────────
+
+const STATUS_LABELS: Record<TestResult["status"], string> = {
+  success: "Connected",
+  timeout: "Timed out",
+  offline: "Offline",
+  error: "Error",
+};
+
+function TestResultCard({ result, onDismiss }: { result: TestResult; onDismiss: () => void }) {
+  const borderColor = {
+    success: "border-l-green-500",
+    timeout: "border-l-yellow-500",
+    offline: "border-l-gray-400",
+    error: "border-l-red-500",
+  }[result.status];
+
+  const badgeVariant =
+    result.status === "success" ? "default" : result.status === "timeout" ? "secondary" : "destructive";
+
+  return (
+    <Card className={cn("border-l-4", borderColor)}>
+      <CardContent className="pt-4">
+        <div className="flex items-start justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant={badgeVariant}>{STATUS_LABELS[result.status]}</Badge>
+              {result.responseTime != null && (
+                <span className="text-xs text-muted-foreground">{(result.responseTime / 1000).toFixed(1)}s</span>
+              )}
+            </div>
+            {result.message && <p className="text-sm text-muted-foreground">{result.message}</p>}
+            {result.responseContent && (
+              <p className="text-sm mt-2 whitespace-pre-wrap bg-muted rounded p-2 max-h-40 overflow-auto">
+                {result.responseContent}
+              </p>
+            )}
+          </div>
+          <Button variant="ghost" size="sm" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/admin/agents/:agentId/test` endpoint that sends a test message to an agent and waits up to 30s for a response
- Add "Test Connection" button on the web dashboard agent detail page
- Returns status: `success` (with response content + time), `timeout`, `offline`, or `error`

This unblocks dogfood by letting admins verify the full agent pipeline without needing a human agent token.

## Test plan
- [ ] Click "Test Connection" on an online agent — expect success with response preview
- [ ] Click "Test Connection" on an offline agent — expect "offline" status
- [ ] Verify response time is displayed correctly
- [ ] Verify long responses are truncated to 500 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)