### PR TITLE
feat: add Agent Hub runtime context and message sender attribution

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -73,6 +73,10 @@ describe("bootstrapWorkspace", () => {
     const content = readFileSync(toolsPath, "utf-8");
     expect(content).toContain("FIRST_TREE_HUB_SERVER_URL");
     expect(content).toContain("FIRST_TREE_HUB_AGENT_TOKEN");
+    expect(content).toContain("How You Communicate");
+    expect(content).toContain("Agent Hub");
+    expect(content).toContain("[From: sender-id]");
+    expect(content).toContain("Use your judgment about when to respond");
   });
 
   it("copies self.md from context tree when available", () => {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -36,11 +36,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let ctx: SessionContext | null = null;
 
   function toSDKUserMessage(message: SessionMessage, sessionId: string): SDKUserMessage {
+    const rawContent = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+    const content = message.senderId ? `[From: ${message.senderId}]\n\n${rawContent}` : rawContent;
     return {
       type: "user",
       message: {
         role: "user",
-        content: typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+        content,
       },
       parent_tool_use_id: null,
       session_id: sessionId,

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -186,6 +186,20 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
 function generateToolsDoc(): string {
   return `# Agent Hub SDK
 
+## How You Communicate
+
+You are running inside **Agent Hub**, a messaging platform for agent teams.
+
+- Messages from other team members arrive as your prompt input
+- Each message includes a \`[From: sender-id]\` header so you know who sent it
+- To respond or send messages, use the API endpoints below (curl or any HTTP client)
+- **Use your judgment about when to respond.** Not every message requires a reply.
+  Your role and responsibilities (defined in your profile above) guide your behavior.
+  For example: a direct question — respond; a notification/FYI — maybe no reply needed;
+  a task request — do the work, then respond with results.
+- To communicate with other agents, use the "Send to another agent" endpoint
+- Your current chat ID is in \`$FIRST_TREE_HUB_CHAT_ID\`
+
 ## Environment Variables
 
 These are injected automatically when the agent process starts:


### PR DESCRIPTION
## Summary
- Add "How You Communicate" section to generated tools.md explaining the Agent Hub runtime model
- Add `[From: senderId]` prefix to messages passed to Claude Code so agents know who sent each message
- Agents use their role/responsibilities to judge when to respond (not every message needs a reply)

Unblocks dogfood: agents now have enough context to communicate through the SDK on their own judgment.

## Test plan
- [ ] `pnpm --filter @first-tree-hub/client test` passes (71 tests)
- [ ] Deploy, start client, click "Test Connection" on staging dashboard
- [ ] Agent responds via SDK within 30s
- [ ] Response reflects agent identity and organizational context

🤖 Generated with [Claude Code](https://claude.com/claude-code)