### PR TITLE
feat: auto-bridge Claude Code result to chat

### DIFF
--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -104,6 +104,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             const result = message as {
               type: "result";
               subtype: string;
+              result?: string;
               errors?: string[];
               duration_ms?: number;
               total_cost_usd?: number;
@@ -112,6 +113,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             };
             if (result.subtype === "success") {
               retryCount = 0;
+              // Auto-bridge: forward result text back to the chat
+              if (result.result && sessionCtx.chatId) {
+                sessionCtx.sdk
+                  .sendMessage(sessionCtx.chatId, { format: "text", content: result.result })
+                  .then(() => sessionCtx.log("Result forwarded to chat"))
+                  .catch((err) =>
+                    sessionCtx.log(`Failed to forward result: ${err instanceof Error ? err.message : String(err)}`),
+                  );
+              }
             } else {
               const errors = result.errors ? result.errors.join("; ") : result.subtype;
               sessionCtx.log(
@@ -182,7 +192,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
       );
       spawnQuery(claudeSessionId, sessionCtx);
-      inputController?.push(toSDKUserMessage(message, claudeSessionId));
+      const sdkMsg = toSDKUserMessage(message, claudeSessionId);
+      inputController?.push(sdkMsg);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
       return claudeSessionId;

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -192,13 +192,11 @@ You are running inside **Agent Hub**, a messaging platform for agent teams.
 
 - Messages from other team members arrive as your prompt input
 - Each message includes a \`[From: sender-id]\` header so you know who sent it
-- To respond or send messages, use the API endpoints below (curl or any HTTP client)
+- **Your final text response is automatically delivered** to the chat — just respond normally
+- For **proactive communication** (sending to other agents, other chats, or structured data),
+  use the curl API endpoints below
 - **Use your judgment about when to respond.** Not every message requires a reply.
-  Your role and responsibilities (defined in your profile above) guide your behavior.
-  For example: a direct question — respond; a notification/FYI — maybe no reply needed;
-  a task request — do the work, then respond with results.
-- To communicate with other agents, use the "Send to another agent" endpoint
-- Your current chat ID is in \`$FIRST_TREE_HUB_CHAT_ID\`
+  Your role and responsibilities (defined in your profile above) guide your behavior
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- Handler auto-forwards successful Claude Code result text back to the chat via SDK
- Updated CLAUDE.md "How You Communicate": agent responds normally, reply is auto-delivered
- Agents can still use curl for proactive communication (other agents, other chats)

Tested: agent receives message → Claude Code processes → result forwarded to chat ✓

## Known issue
Nested Claude Code environment (~90s cold start vs ~17s standalone). Root cause TBD.

## Test plan
- [ ] Start client in standalone terminal, click Test Connection → response appears in chat
- [ ] `pnpm --filter @first-tree-hub/client test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)