### PR TITLE
feat: recursive Context Tree sync with tree_path support

### DIFF
--- a/packages/server/drizzle/0006_agent_tree_path.sql
+++ b/packages/server/drizzle/0006_agent_tree_path.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "tree_path" text;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774972900000,
       "tag": "0005_delegate_mention",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1775073600000,
+      "tag": "0006_agent_tree_path",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -11,6 +11,8 @@ export const agents = pgTable(
     displayName: text("display_name"),
     /** Agent ID to forward @mentions to (e.g. personal assistant) */
     delegateMention: text("delegate_mention"),
+    /** Materialized path within members/ tree, e.g. "engineering/agent-a" */
+    treePath: text("tree_path"),
     /** Delivery address, auto-generated as inbox_{id} */
     inboxId: text("inbox_id").unique().notNull(),
     /** "active" | "suspended". Suspended agents have all API requests rejected. */

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -85,6 +85,7 @@ export async function listAgents(db: Database, limit: number, cursor?: string) {
       type: agents.type,
       displayName: agents.displayName,
       delegateMention: agents.delegateMention,
+      treePath: agents.treePath,
       inboxId: agents.inboxId,
       status: agents.status,
       metadata: agents.metadata,

--- a/packages/server/src/services/context-tree-graphql.ts
+++ b/packages/server/src/services/context-tree-graphql.ts
@@ -101,7 +101,9 @@ async function fetchRecursiveTree(owner: string, name: string, treeSha: string, 
   const json = (await res.json()) as TreeResponse;
 
   if (json.truncated) {
-    console.warn("[context-tree-sync] Warning: tree response was truncated — very large members/ directory");
+    throw new Error(
+      "[context-tree-sync] GitHub REST tree API returned truncated response — members/ subtree is too large. Sync aborted to prevent incorrect agent suspension from partial data.",
+    );
   }
 
   return json.tree;

--- a/packages/server/src/services/context-tree-graphql.ts
+++ b/packages/server/src/services/context-tree-graphql.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 
 const GRAPHQL_URL = "https://api.github.com/graphql";
+const REST_API_URL = "https://api.github.com";
 
 /** Parse "owner/repo" or "https://github.com/owner/repo" into { owner, name }. */
 export function parseRepo(input: string): { owner: string; name: string } {
@@ -17,6 +18,7 @@ export function parseRepo(input: string): { owner: string; name: string } {
 
 type MemberEntry = {
   name: string;
+  treePath: string;
   nodeContent: string | null;
 };
 
@@ -30,33 +32,13 @@ export type ContextTreeSyncResult = {
   syncedAt: string;
 };
 
-/**
- * Fetch all members from a Context Tree repo via GitHub GraphQL API.
- * Single request regardless of member count.
- */
-async function fetchMembers(repo: string, branch: string, token: string): Promise<MemberEntry[]> {
-  const { owner, name } = parseRepo(repo);
-
-  if (!owner || !name) throw new Error(`Invalid repo format: "${repo}" — expected "owner/repo" or a GitHub URL`);
-
+/** Step 1: Get the tree OID of the members/ directory via GraphQL. */
+async function fetchMembersTreeOid(owner: string, name: string, branch: string, token: string): Promise<string | null> {
   const query = `
     query($owner: String!, $name: String!, $expr: String!) {
       repository(owner: $owner, name: $name) {
         object(expression: $expr) {
-          ... on Tree {
-            entries {
-              name
-              type
-              object {
-                ... on Tree {
-                  entries {
-                    name
-                    object { ... on Blob { text } }
-                  }
-                }
-              }
-            }
-          }
+          ... on Tree { oid }
         }
       }
     }
@@ -78,45 +60,194 @@ async function fetchMembers(repo: string, branch: string, token: string): Promis
     throw new Error(`GitHub API returned ${res.status}: ${await res.text()}`);
   }
 
-  type GraphQLResponse = {
-    data?: {
-      repository?: {
-        object?: {
-          entries?: Array<{
-            name: string;
-            type: string;
-            object?: {
-              entries?: Array<{
-                name: string;
-                object?: { text?: string };
-              }>;
-            };
-          }>;
-        };
-      };
-    };
+  type OidResponse = {
+    data?: { repository?: { object?: { oid?: string } } };
     errors?: Array<{ message: string }>;
   };
 
-  const json = (await res.json()) as GraphQLResponse;
-
+  const json = (await res.json()) as OidResponse;
   if (json.errors) {
     throw new Error(`GitHub GraphQL errors: ${json.errors.map((e) => e.message).join(", ")}`);
   }
 
-  const entries = json.data?.repository?.object?.entries ?? [];
-  const members: MemberEntry[] = [];
+  return json.data?.repository?.object?.oid ?? null;
+}
 
-  for (const entry of entries) {
-    if (entry.type !== "tree") continue;
-    const nodeFile = entry.object?.entries?.find((f) => f.name === "NODE.md");
-    members.push({
-      name: entry.name,
-      nodeContent: nodeFile?.object?.text ?? null,
-    });
+type TreeEntry = {
+  path: string;
+  type: string;
+  sha: string;
+};
+
+/** Step 2: Recursively list all entries under the members/ tree via REST API. */
+async function fetchRecursiveTree(owner: string, name: string, treeSha: string, token: string): Promise<TreeEntry[]> {
+  const url = `${REST_API_URL}/repos/${owner}/${name}/git/trees/${treeSha}?recursive=1`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub REST API returned ${res.status}: ${await res.text()}`);
   }
 
-  return members;
+  type TreeResponse = {
+    tree: Array<{ path: string; type: string; sha: string }>;
+    truncated: boolean;
+  };
+
+  const json = (await res.json()) as TreeResponse;
+
+  if (json.truncated) {
+    console.warn("[context-tree-sync] Warning: tree response was truncated — very large members/ directory");
+  }
+
+  return json.tree;
+}
+
+/**
+ * Step 3: Batch-fetch NODE.md content for all member directories via GraphQL aliases.
+ * Each alias fetches one NODE.md file by expression.
+ */
+async function batchFetchNodeMd(
+  owner: string,
+  name: string,
+  branch: string,
+  memberPaths: string[],
+  token: string,
+): Promise<Map<string, string>> {
+  if (memberPaths.length === 0) return new Map();
+
+  // Build aliased query: m0: object(expression: "main:members/alice/NODE.md") { ...on Blob { text } }
+  const aliases = memberPaths.map((p, i) => {
+    const expr = `${branch}:members/${p}/NODE.md`;
+    return `m${i}: object(expression: ${JSON.stringify(expr)}) { ... on Blob { text } }`;
+  });
+
+  const query = `
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        ${aliases.join("\n        ")}
+      }
+    }
+  `;
+
+  const res = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query,
+      variables: { owner, name },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub API returned ${res.status}: ${await res.text()}`);
+  }
+
+  type BatchResponse = {
+    data?: { repository?: Record<string, { text?: string } | null> };
+    errors?: Array<{ message: string }>;
+  };
+
+  const json = (await res.json()) as BatchResponse;
+  if (json.errors) {
+    throw new Error(`GitHub GraphQL errors: ${json.errors.map((e) => e.message).join(", ")}`);
+  }
+
+  const repo = json.data?.repository ?? {};
+  const result = new Map<string, string>();
+  for (let i = 0; i < memberPaths.length; i++) {
+    const blob = repo[`m${i}`];
+    const path = memberPaths[i];
+    if (blob?.text && path) {
+      result.set(path, blob.text);
+    }
+  }
+  return result;
+}
+
+/**
+ * Extract member directory paths from a recursive tree listing.
+ * A directory is a member if it contains a NODE.md blob.
+ */
+function extractMemberDirs(treeEntries: TreeEntry[]): string[] {
+  // Collect all NODE.md blob paths, then derive their parent directories
+  const nodeMdPaths = new Set<string>();
+  for (const entry of treeEntries) {
+    if (entry.type === "blob" && entry.path.endsWith("/NODE.md")) {
+      nodeMdPaths.add(entry.path);
+    }
+  }
+
+  const memberDirs: string[] = [];
+  for (const entry of treeEntries) {
+    if (entry.type !== "tree") continue;
+    // Check if this directory has a NODE.md
+    if (nodeMdPaths.has(`${entry.path}/NODE.md`)) {
+      memberDirs.push(entry.path);
+    }
+  }
+
+  return memberDirs.sort();
+}
+
+/**
+ * Fetch all members from a Context Tree repo via GitHub API.
+ * Uses 3 API calls:
+ *   1. GraphQL: get members/ tree OID
+ *   2. REST: recursive tree listing (scoped to members/ only)
+ *   3. GraphQL: batch-fetch all NODE.md contents via aliases
+ */
+async function fetchMembers(repo: string, branch: string, token: string): Promise<MemberEntry[]> {
+  const { owner, name } = parseRepo(repo);
+
+  if (!owner || !name) throw new Error(`Invalid repo format: "${repo}" — expected "owner/repo" or a GitHub URL`);
+
+  // Step 1: Get members/ tree OID
+  const treeOid = await fetchMembersTreeOid(owner, name, branch, token);
+  if (!treeOid) {
+    console.warn("[context-tree-sync] members/ directory not found in repo");
+    return [];
+  }
+
+  // Step 2: Recursive tree listing (only members/ subtree)
+  const treeEntries = await fetchRecursiveTree(owner, name, treeOid, token);
+
+  // Step 3: Identify member directories (those with NODE.md)
+  const memberDirs = extractMemberDirs(treeEntries);
+
+  if (memberDirs.length === 0) {
+    console.warn("[context-tree-sync] No member directories with NODE.md found");
+    return [];
+  }
+
+  // Defensive check: duplicate directory names
+  const nameMap = new Map<string, string>();
+  for (const dir of memberDirs) {
+    const dirName = dir.split("/").pop() ?? dir;
+    const existing = nameMap.get(dirName);
+    if (existing) {
+      throw new Error(
+        `[context-tree-sync] Duplicate member directory name '${dirName}' found at 'members/${existing}' and 'members/${dir}' — directory names must be unique across all levels under members/. Fix this in the Context Tree repo.`,
+      );
+    }
+    nameMap.set(dirName, dir);
+  }
+
+  // Step 4: Batch-fetch NODE.md contents
+  const nodeContents = await batchFetchNodeMd(owner, name, branch, memberDirs, token);
+
+  return memberDirs.map((dir) => ({
+    name: dir.split("/").pop() ?? dir,
+    treePath: dir,
+    nodeContent: nodeContents.get(dir) ?? null,
+  }));
 }
 
 /** Parse NODE.md frontmatter for agent metadata. */
@@ -187,14 +318,14 @@ export async function syncFromGitHub(
         : { type: "autonomous_agent", displayName: null, delegateMention: null };
 
       const existing = await db.execute(
-        sql`SELECT id, status, type, display_name, delegate_mention FROM agents WHERE id = ${member.name}`,
+        sql`SELECT id, status, type, display_name, delegate_mention, tree_path FROM agents WHERE id = ${member.name}`,
       );
 
       if (existing.length === 0) {
         // New agent — create
         await db.execute(sql`
-          INSERT INTO agents (id, type, display_name, delegate_mention, status, inbox_id)
-          VALUES (${member.name}, ${meta.type}, ${meta.displayName}, ${meta.delegateMention}, 'active', ${`inbox_${member.name}`})
+          INSERT INTO agents (id, type, display_name, delegate_mention, tree_path, status, inbox_id)
+          VALUES (${member.name}, ${meta.type}, ${meta.displayName}, ${meta.delegateMention}, ${member.treePath}, 'active', ${`inbox_${member.name}`})
         `);
         result.created++;
       } else {
@@ -204,23 +335,25 @@ export async function syncFromGitHub(
           type: string;
           display_name: string | null;
           delegate_mention: string | null;
+          tree_path: string | null;
         };
 
         if (agent.status === "suspended") {
           // Reactivate — member is back in tree
           await db.execute(sql`
-            UPDATE agents SET status = 'active', type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}
+            UPDATE agents SET status = 'active', type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}, tree_path = ${member.treePath}
             WHERE id = ${member.name}
           `);
           result.reactivated++;
         } else if (
           agent.type !== meta.type ||
           agent.display_name !== meta.displayName ||
-          agent.delegate_mention !== meta.delegateMention
+          agent.delegate_mention !== meta.delegateMention ||
+          agent.tree_path !== member.treePath
         ) {
           // Fields changed — update
           await db.execute(sql`
-            UPDATE agents SET type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}
+            UPDATE agents SET type = ${meta.type}, display_name = ${meta.displayName}, delegate_mention = ${meta.delegateMention}, tree_path = ${member.treePath}
             WHERE id = ${member.name}
           `);
           result.updated++;
@@ -229,7 +362,10 @@ export async function syncFromGitHub(
         }
       }
     } catch (err) {
-      console.error(`[context-tree-sync] Failed to sync member "${member.name}":`, err);
+      console.error(
+        `[context-tree-sync] Failed to sync member "${member.name}" (path: members/${member.treePath}):`,
+        err,
+      );
       result.errors++;
     }
   }

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -63,6 +63,7 @@ export const agentSchema = z.object({
   type: agentTypeSchema,
   displayName: z.string().nullable(),
   delegateMention: z.string().nullable(),
+  treePath: z.string().nullable(),
   inboxId: z.string(),
   status: z.string(),
   metadata: z.record(z.unknown()),


### PR DESCRIPTION
## Summary
- `fetchMembers()` rewritten from fixed 2-level GraphQL query to 3-step API approach:
  1. GraphQL: get `members/` tree OID
  2. REST: recursive tree listing (scoped to `members/` subtree only)
  3. GraphQL: batch-fetch all `NODE.md` contents via aliases
- Added `tree_path` column to `agents` table — materialized path within `members/` tree (e.g. `engineering/agent-a`)
- Defensive duplicate name detection during sync with detailed error messages
- Updated `listAgents()`, sync create/update/reactivate logic to read/write `tree_path`
- DB migration `0006_agent_tree_path`

## Context
Companion to agent-team-foundation/first-tree#12 (recursive member validation). Together they enable hierarchical agent structures under `members/` at any depth, with agent ID remaining the directory name and `tree_path` recording the full materialized path.

## Test plan
- [x] `pnpm check` (biome lint + format) passes
- [x] `pnpm typecheck` passes
- [x] All server tests pass
- [ ] Apply migration on dev DB and verify `tree_path` column exists
- [ ] Trigger manual sync and verify nested members are discovered with correct `tree_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)