### PR TITLE
fix: strip parent Claude Code env vars from child process

### DIFF
--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -49,9 +49,27 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     };
   }
 
+  /**
+   * Build env for the child Claude Code process.
+   *
+   * When the client runtime runs inside a Claude Code session (nested env),
+   * process.env contains internal markers (CLAUDECODE, CLAUDE_CODE_ENTRYPOINT,
+   * CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, npm_lifecycle_script) that cause the
+   * child to enable Agent Teams infrastructure and use wrong init paths,
+   * resulting in ~90s cold start vs ~17s standalone. Strip these so the child
+   * starts clean; the SDK sets its own CLAUDE_CODE_ENTRYPOINT="sdk-ts".
+   */
   function buildEnv(sessionCtx: SessionContext): Record<string, string | undefined> {
+    const env: Record<string, string | undefined> = { ...process.env };
+
+    // Parent session markers — not needed by the child
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_ENTRYPOINT;
+    delete env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+    delete env.npm_lifecycle_script;
+
     return {
-      ...process.env,
+      ...env,
       FIRST_TREE_HUB_SERVER_URL: sessionCtx.sdk.serverUrl,
       FIRST_TREE_HUB_AGENT_TOKEN: sessionCtx.sdk.agentToken,
       FIRST_TREE_HUB_CHAT_ID: sessionCtx.chatId,


### PR DESCRIPTION
## Summary

- Strip inherited Claude Code env vars (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `npm_lifecycle_script`) from child process env in `buildEnv()`
- Prevents child from enabling Agent Teams infrastructure and using wrong init paths when client runtime runs inside a nested Claude Code session
- SDK sets its own `CLAUDE_CODE_ENTRYPOINT="sdk-ts"` automatically; these vars are not needed

## Root Cause

When the client runtime runs inside a Claude Code session, `process.env` contains parent session markers that leak into the child via `...process.env`. Key culprits:

| Variable | Impact |
|----------|--------|
| `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` | Child enables Agent Teams mode (35+ code paths in cli.js) |
| `CLAUDECODE=1` | Child detects nested environment, alters init behavior |
| `CLAUDE_CODE_ENTRYPOINT=cli` | Overrides SDK default `"sdk-ts"`, wrong init path |
| `npm_lifecycle_script` | npm internal, not needed by child |

## Verification

- Standalone isolation benchmark: `CLAUDECODE=1` adds +8.7s, `AGENT_TEAMS=1` adds +4.9s
- Full E2E test (server + WebSocket + session manager + Claude Code child): confirmed fix under nested env
- `pnpm check && pnpm typecheck` pass

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)