### PR TITLE
chore: release v0.3.0

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `@agent-team-foundation/first-tree-hub` version from 0.2.0 → 0.3.0
- Includes all changes since last release: #48 ~ #53

## Changes since v0.2.0
- feat: recursive Context Tree sync with tree_path support (#52)
- feat: auto-bridge Claude Code result to chat and update runtime context (#49)
- fix: strip parent Claude Code env vars from child process (#53)
- fix: WebSocket stability — ping keepalive and rate limit backoff (#48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)