### PR TITLE
fix: externalize claude-agent-sdk to fix client session crash

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",
-    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts && node scripts/embed-assets.mjs",
+    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk && node scripts/embed-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
@@ -34,6 +34,7 @@
     "node": ">=22.16.0"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.84",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   packages/command:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.84
+        version: 0.2.84(zod@3.25.76)
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0


### PR DESCRIPTION
## Summary

- Mark `@anthropic-ai/claude-agent-sdk` as external in tsdown and add it as a runtime dependency
- Fixes client `Claude Code process exited with code 1` crash after global install
- Bump version to 0.3.2

## Root Cause

When tsdown bundles the SDK into `dist/core-*.mjs`, the SDK's `import.meta.url` resolves to the dist file instead of its own source. The SDK uses this to locate its bundled `cli.js` (the Claude Code CLI binary), resulting in a path like `dist/cli.js` which doesn't exist. The spawned `node dist/cli.js` process exits immediately with code 1, and all retry attempts fail.

## Fix

Externalize the SDK so it remains a proper `node_modules` dependency with its `cli.js` + `vendor/` assets intact at runtime. Two changes in `packages/command/package.json`:

1. `--external @anthropic-ai/claude-agent-sdk` in the tsdown build command
2. `@anthropic-ai/claude-agent-sdk` added to `dependencies`

## Test plan

- [ ] `pnpm build` succeeds, verify `dist/core-*.mjs` contains `import { query } from "@anthropic-ai/claude-agent-sdk"` (not bundled)
- [ ] `npm install -g .` from command package, verify `node_modules/@anthropic-ai/claude-agent-sdk/cli.js` exists
- [ ] `first-tree-hub client start` — session starts without exit code 1 crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)