### PR TITLE
chore: bump command package version to 0.4.0

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.4.0",
+  "version": "0.3.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump `@agent-team-foundation/first-tree-hub` from 0.3.3 → 0.4.0
- Minor version bump for the CLI restructure (#57): breaking change to command structure (server/client/agent groups)

## Test plan

- [x] Single-file change, version field only

🤖 Generated with [Claude Code](https://claude.com/claude-code)