### PR TITLE
feat: improve autonomous_agent onboard and use Feishu union_id

### DIFF
--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -72,7 +72,59 @@ After onboarding, the human user binds their own Feishu account by sending this 
 /bind alice
 ```
 
-## Onboard a Standalone Agent
+## Onboard a Standalone Agent (autonomous_agent)
+
+An `autonomous_agent` operates independently — it has no human owner and no personal assistant.
+Use this type for bots that perform a specific function (code review, monitoring, etc.).
+
+### Differences from Human Onboarding
+
+| | Human | Autonomous Agent |
+|---|---|---|
+| `--assistant` | Optional (creates a personal_assistant) | Not applicable |
+| `github` field in NODE.md | Auto-filled from `gh` user | Not set |
+| `delegate_mention` | Points to assistant | Not set |
+| Feishu bot binding | Not applicable (human binds as user) | Optional |
+| NODE.md template | About + Current Focus | About + Capabilities + Current Focus |
+
+### Phase 1: Create PR
+
+```bash
+first-tree-hub onboard \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review" \
+  --server http://localhost:8000
+```
+
+The command creates a NODE.md with a `## Capabilities` section, validates, and opens a PR.
+
+### Phase 2: After PR Merge
+
+```bash
+first-tree-hub onboard --continue
+```
+
+Expected output:
+
+```
+✅ Onboard complete!
+
+  Agent:     code-reviewer
+  Token:     ~/.first-tree-hub/config/agents/code-reviewer/agent.yaml
+
+  Start the agent:
+    first-tree-hub client start
+```
+
+### Phase 3: Start the Agent
+
+```bash
+first-tree-hub client start
+```
+
+### With Feishu Bot
 
 ```bash
 first-tree-hub onboard \
@@ -83,10 +135,9 @@ first-tree-hub onboard \
   --server http://localhost:8000
 
 # After PR merge
-first-tree-hub onboard --continue
-
-# Start the agent
-first-tree-hub client start
+first-tree-hub onboard --continue \
+  --feishu-bot-app-id cli_abcdef \
+  --feishu-bot-app-secret "$FEISHU_APP_SECRET"
 ```
 
 ## The `--check` Flag
@@ -115,6 +166,14 @@ When required parameters are missing, the same checklist is shown as an error.
 | `FEISHU_APP_ID` | Feishu bot App ID (alternative to `--feishu-bot-app-id`) |
 | `FEISHU_APP_SECRET` | Feishu bot App Secret (alternative to `--feishu-bot-app-secret`) |
 
+## Choosing the Right Type
+
+| Type | When to Use |
+|------|-------------|
+| `human` | A real person joining the team. Can optionally have a `personal_assistant`. |
+| `personal_assistant` | A bot that acts on behalf of a specific human (created via `--assistant` on a human onboard). |
+| `autonomous_agent` | A standalone bot that operates independently — code reviewers, monitors, pipeline agents, etc. |
+
 ## For AI Agents
 
 ### Rules
@@ -122,26 +181,46 @@ When required parameters are missing, the same checklist is shown as an error.
 - **Use `onboard` command for everything** — do not manually clone repos, create files, or run git commands.
 - **Use `--check` to discover what's needed** — don't guess required fields.
 - **Ask the user using AskUser-type tools** — prefer interactive question tools (with predefined options) over plain text output when asking the user for choices. Ask choices before details (type, assistant, feishu), then gather remaining info.
-- **Ask about optional items too** — the user should be asked about assistant and Feishu bot, not just required fields.
+- **Ask about optional items too** — but only ask about options that apply to the chosen type (e.g., don't ask about `--assistant` for `autonomous_agent`).
 - **`--id` defaults to GitHub username** — suggest it as default but let the user choose a different ID.
 - **`--owner` and repo are auto-handled** — do not ask the user for these.
+
+### Type-Specific Parameters
+
+| Parameter | human | personal_assistant | autonomous_agent |
+|-----------|-------|--------------------|------------------|
+| `--assistant` | ✅ optional | ❌ not applicable | ❌ not applicable |
+| `--feishu-bot-app-id` | ❌ not applicable | ✅ optional | ✅ optional |
+| `--feishu-bot-app-secret` | ❌ not applicable | ✅ optional | ✅ optional |
+| `--delegate-mention` | auto (from `--assistant`) | ❌ not applicable | ❌ not applicable |
+| Feishu `/bind` hint (Phase 2) | ✅ show to user | ❌ skip | ❌ skip |
+
+Do **not** ask the user about parameters marked ❌ for their chosen type.
 
 ### Command Flow
 
 ```bash
-# 1. Check readiness (repeat with more params until all ✅)
+# 1. Ask user for --type first (determines which optional params to ask)
+
+# 2. Check readiness (repeat with more params until all ✅)
 first-tree-hub onboard --check [params...]
 
-# 2. Execute Phase 1 (creates PR)
+# 3. Execute Phase 1 (creates PR)
 first-tree-hub onboard [params...]
 
-# 3. User reviews and merges PR
+# 4. User reviews and merges PR
 
-# 4. Execute Phase 2 (sync + token + bindings + client config)
+# 5. Execute Phase 2 (sync + token + bindings + client config)
+#    human:            first-tree-hub onboard --continue [--feishu-bot-app-id ... --feishu-bot-app-secret ...]
+#    autonomous_agent: first-tree-hub onboard --continue [--feishu-bot-app-id ... --feishu-bot-app-secret ...]
+#    personal_assistant (standalone): first-tree-hub onboard --continue
 first-tree-hub onboard --continue
 
-# 5. Start the agent
+# 6. Start the agent
 first-tree-hub client start
 
-# 6. If human + feishu: tell user to send "/bind <id>" to bot in Feishu
+# 7. Post-onboard hints (type-specific):
+#    human + feishu bot: tell user to send "/bind <id>" to bot in Feishu
+#    autonomous_agent:   no additional steps
+#    personal_assistant: no additional steps
 ```

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -162,6 +162,7 @@ When required parameters are missing, the same checklist is shown as an error.
 
 | Variable | Purpose |
 |----------|---------|
+| `FIRST_TREE_HUB_HOME` | Override config/data home directory (default: `~/.first-tree-hub`) |
 | `FIRST_TREE_HUB_SERVER` | Hub server URL (alternative to `--server`) |
 | `FEISHU_APP_ID` | Feishu bot App ID (alternative to `--feishu-bot-app-id`) |
 | `FEISHU_APP_SECRET` | Feishu bot App Secret (alternative to `--feishu-bot-app-secret`) |

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -6,6 +6,7 @@ import {
   agentConfigSchema,
   DEFAULT_CONFIG_DIR,
   DEFAULT_DATA_DIR,
+  DEFAULT_HOME_DIR,
   loadAgents,
   setConfigValue,
 } from "@first-tree-hub/shared/config";
@@ -217,7 +218,7 @@ export function registerAgentCommands(program: Command): void {
         const result = await bootstrapToken(serverUrl, agentId, { saveTo: options.saveTo });
 
         if (options.saveTo === "agent") {
-          process.stderr.write(`Token saved to ~/.first-tree-hub/config/agents/${agentId}/agent.yaml\n`);
+          process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${agentId}/agent.yaml\n`);
         } else {
           process.stderr.write(`Token saved to ${options.saveTo}\n`);
         }

--- a/packages/command/src/commands/onboard.ts
+++ b/packages/command/src/commands/onboard.ts
@@ -81,9 +81,9 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
     }
   }
 
-  // Feishu bot binding is relevant for non-human agents
-  if (!args.feishuBotAppId && args.type !== "human") {
-    const wantFeishu = await confirm({ message: "Bind Feishu bot for this agent?", default: false });
+  // Feishu bot binding is relevant for non-human agents, or human with assistant (bot binds to assistant)
+  if (!args.feishuBotAppId && (args.type !== "human" || args.assistant)) {
+    const wantFeishu = await confirm({ message: "Bind Feishu bot?", default: false });
     if (wantFeishu) {
       args.feishuBotAppId = await input({ message: "Feishu App ID:" });
       args.feishuBotAppSecret = await input({ message: "Feishu App Secret:" });

--- a/packages/command/src/commands/onboard.ts
+++ b/packages/command/src/commands/onboard.ts
@@ -59,7 +59,8 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
     }
   }
 
-  if (!args.assistant) {
+  // Only human agents can have a personal assistant
+  if (!args.assistant && args.type === "human") {
     const wantAssistant = await confirm({ message: "Create a personal assistant?", default: false });
     if (wantAssistant) {
       args.assistant = await input({
@@ -80,8 +81,9 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
     }
   }
 
-  if (!args.feishuBotAppId) {
-    const wantFeishu = await confirm({ message: "Bind Feishu bot?", default: false });
+  // Feishu bot binding is relevant for non-human agents
+  if (!args.feishuBotAppId && args.type !== "human") {
+    const wantFeishu = await confirm({ message: "Bind Feishu bot for this agent?", default: false });
     if (wantFeishu) {
       args.feishuBotAppId = await input({ message: "Feishu App ID:" });
       args.feishuBotAppSecret = await input({ message: "Feishu App Secret:" });

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -165,8 +165,8 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
     );
   }
 
-  // Feishu bot binding is only applicable for non-human agents
-  if (args.type !== "human") {
+  // Feishu bot binding: applicable for non-human agents, or human with assistant (bot binds to assistant)
+  if (args.type !== "human" || args.assistant) {
     items.push(
       args.feishuBotAppId
         ? { key: "feishu_bot", label: "feishu-bot-app-id", status: "ok", value: args.feishuBotAppId }
@@ -174,7 +174,7 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
             key: "feishu_bot",
             label: "feishu-bot-app-id",
             status: "missing_optional",
-            hint: "Feishu bot App ID for this agent",
+            hint: "Feishu bot App ID",
           },
     );
   }

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -1,8 +1,7 @@
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_CONFIG_DIR, setConfigValue } from "@first-tree-hub/shared/config";
+import { DEFAULT_CONFIG_DIR, DEFAULT_HOME_DIR, setConfigValue } from "@first-tree-hub/shared/config";
 import { bootstrapToken, checkBootstrapStatus, getGitHubUsername, resolveServerUrl } from "./bootstrap.js";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -32,12 +31,11 @@ type CheckItem = {
   hint?: string;
 };
 
-export const STATE_FILE = join(homedir(), ".first-tree-hub", ".onboard-state.json");
+export const STATE_FILE = join(DEFAULT_HOME_DIR, ".onboard-state.json");
 
 /** Save current onboard args to state file for resume. */
 export function saveOnboardState(args: Record<string, unknown>): void {
-  const dir = join(homedir(), ".first-tree-hub");
-  mkdirSync(dir, { recursive: true });
+  mkdirSync(DEFAULT_HOME_DIR, { recursive: true });
   writeFileSync(STATE_FILE, JSON.stringify({ args }, null, 2));
 }
 
@@ -96,7 +94,7 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
     });
   }
 
-  // Context Tree repo (auto-managed at ~/.first-tree-hub/context-tree/)
+  // Context Tree repo (auto-managed at $FIRST_TREE_HUB_HOME/context-tree/)
   const repoPath = await resolveContextTreeRepo(args.server);
   if (repoPath) {
     items.push({ key: "repo", label: "Context Tree repo", status: "ok", value: repoPath });
@@ -153,23 +151,33 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
         },
   );
 
-  items.push(
-    args.assistant
-      ? { key: "assistant", label: "assistant", status: "ok", value: args.assistant }
-      : { key: "assistant", label: "assistant", status: "missing_optional", hint: "Also create a personal_assistant" },
-  );
+  // Assistant is only applicable for human agents
+  if (args.type === "human") {
+    items.push(
+      args.assistant
+        ? { key: "assistant", label: "assistant", status: "ok", value: args.assistant }
+        : {
+            key: "assistant",
+            label: "assistant",
+            status: "missing_optional",
+            hint: "Also create a personal_assistant",
+          },
+    );
+  }
 
-  // Feishu (optional)
-  items.push(
-    args.feishuBotAppId
-      ? { key: "feishu_bot", label: "feishu-bot-app-id", status: "ok", value: args.feishuBotAppId }
-      : {
-          key: "feishu_bot",
-          label: "feishu-bot-app-id",
-          status: "missing_optional",
-          hint: "Feishu bot App ID for assistant",
-        },
-  );
+  // Feishu bot binding is only applicable for non-human agents
+  if (args.type !== "human") {
+    items.push(
+      args.feishuBotAppId
+        ? { key: "feishu_bot", label: "feishu-bot-app-id", status: "ok", value: args.feishuBotAppId }
+        : {
+            key: "feishu_bot",
+            label: "feishu-bot-app-id",
+            status: "missing_optional",
+            hint: "Feishu bot App ID for this agent",
+          },
+    );
+  }
 
   // Check conflicts — distinguish between committed (real conflict) and uncommitted (resume)
   if (args.id && repoPath) {
@@ -231,6 +239,11 @@ export async function onboardCreate(args: OnboardArgs): Promise<{ prUrl: string 
   const repoPath = await resolveContextTreeRepo(args.server);
   if (!repoPath)
     throw new Error("Context Tree repo not available. Ensure --server is configured and the server is running.");
+
+  // Autonomous agents and personal assistants cannot have a personal assistant
+  if (args.assistant && args.type !== "human") {
+    throw new Error(`--assistant is only valid for human agents, not ${args.type}`);
+  }
 
   const ghUsername = getGitHubUsername();
 
@@ -370,7 +383,7 @@ export async function onboardCreate(args: OnboardArgs): Promise<{ prUrl: string 
 
   // Save state for --continue
   const state = { args, branch, prUrl: prOutput };
-  mkdirSync(join(homedir(), ".first-tree-hub"), { recursive: true });
+  mkdirSync(DEFAULT_HOME_DIR, { recursive: true });
   writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
 
   return { prUrl: prOutput };
@@ -393,6 +406,8 @@ export async function onboardContinue(args: OnboardArgs): Promise<void> {
 
   const mergedArgs = { ...state?.args, ...stripUndefined(args) };
   const serverUrl = resolveServerUrl(mergedArgs.server).replace(/\/+$/, "");
+  // For human+assistant, bootstrap the assistant (it's the one that runs as a client).
+  // For autonomous_agent or standalone personal_assistant, bootstrap the agent itself.
   const agentToBootstrap = mergedArgs.assistant ?? mergedArgs.id;
 
   if (!agentToBootstrap)
@@ -438,7 +453,7 @@ export async function onboardContinue(args: OnboardArgs): Promise<void> {
     }
     throw err;
   }
-  process.stderr.write(`Token saved to ~/.first-tree-hub/agents/${agentToBootstrap}/agent.yaml\n`);
+  process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${agentToBootstrap}/agent.yaml\n`);
 
   // 3. Bind Feishu bot (if requested)
   if (mergedArgs.feishuBotAppId && mergedArgs.feishuBotAppSecret) {
@@ -457,12 +472,14 @@ export async function onboardContinue(args: OnboardArgs): Promise<void> {
   }
 
   // Summary
+  const typeLabel =
+    mergedArgs.type === "human" ? "Human" : mergedArgs.type === "autonomous_agent" ? "Agent" : "Assistant";
   process.stderr.write("\n✅ Onboard complete!\n\n");
-  process.stderr.write(`  Human:     ${mergedArgs.id}\n`);
+  process.stderr.write(`  ${typeLabel}:${" ".repeat(Math.max(1, 10 - typeLabel.length))}${mergedArgs.id}\n`);
   if (mergedArgs.assistant) {
     process.stderr.write(`  Assistant: ${mergedArgs.assistant}\n`);
   }
-  process.stderr.write(`  Token:     ~/.first-tree-hub/config/agents/${agentToBootstrap}/agent.yaml\n`);
+  process.stderr.write(`  Token:     ${DEFAULT_HOME_DIR}/config/agents/${agentToBootstrap}/agent.yaml\n`);
   if (mergedArgs.feishuBotAppId) {
     process.stderr.write(`  Feishu:    bot bound (${mergedArgs.feishuBotAppId})\n`);
   }
@@ -509,7 +526,23 @@ function createMemberNodeMd(
 
   const domainsList = data.domains.map((d) => `  - "${d}"`).join("\n");
   const githubLine = data.github ? `\ngithub: ${data.github}` : "";
-  const delegateLine = data.delegateMention ? `\ndelegate_mention: ${data.delegateMention}` : "";
+  // delegate_mention is only meaningful for human agents (points to their PA)
+  const delegateLine =
+    data.delegateMention && data.type === "human" ? `\ndelegate_mention: ${data.delegateMention}` : "";
+
+  // Type-specific body sections
+  const bodySections =
+    data.type === "autonomous_agent"
+      ? `## About
+
+## Capabilities
+
+## Current Focus
+`
+      : `## About
+
+## Current Focus
+`;
 
   const content = `---
 title: "${data.displayName}"
@@ -522,10 +555,7 @@ ${domainsList}${githubLine}${delegateLine}
 
 # ${data.displayName}
 
-## About
-
-## Current Focus
-`;
+${bodySections}`;
 
   writeFileSync(join(memberDir, "NODE.md"), content);
 }
@@ -539,10 +569,10 @@ function isTrackedByGit(repoPath: string, filePath: string): boolean {
   }
 }
 
-const CONTEXT_TREE_DIR = join(homedir(), ".first-tree-hub", "context-tree");
+const CONTEXT_TREE_DIR = join(DEFAULT_HOME_DIR, "context-tree");
 
 /**
- * Resolve Context Tree to a **local path** at ~/.first-tree-hub/context-tree/.
+ * Resolve Context Tree to a **local path** at $FIRST_TREE_HUB_HOME/context-tree/.
  *
  * Repo URL is obtained from the Hub server. The local clone is always
  * managed in the standard location — no custom paths allowed.
@@ -599,7 +629,7 @@ async function resolveContextTreeRepo(serverUrl?: string): Promise<string | null
     }
 
     // Different repo or broken — delete and re-clone
-    const safePrefix = join(homedir(), ".first-tree-hub");
+    const safePrefix = DEFAULT_HOME_DIR;
     if (!CONTEXT_TREE_DIR.startsWith(safePrefix) || CONTEXT_TREE_DIR === safePrefix) {
       throw new Error(`Refusing to delete unsafe path: ${CONTEXT_TREE_DIR}`);
     }
@@ -609,7 +639,7 @@ async function resolveContextTreeRepo(serverUrl?: string): Promise<string | null
   // Fresh clone
   try {
     process.stderr.write(`Cloning Context Tree to ${CONTEXT_TREE_DIR}...\n`);
-    mkdirSync(join(homedir(), ".first-tree-hub"), { recursive: true });
+    mkdirSync(DEFAULT_HOME_DIR, { recursive: true });
     execSync(`git ${gitConfigArgs} clone ${repoUrl} ${CONTEXT_TREE_DIR}`, { stdio: "pipe", env: gitEnv });
     return CONTEXT_TREE_DIR;
   } catch {

--- a/packages/command/src/core/prompt.ts
+++ b/packages/command/src/core/prompt.ts
@@ -1,6 +1,11 @@
 import { join } from "node:path";
 import type { PromptDef } from "@first-tree-hub/shared/config";
-import { collectMissingPrompts, DEFAULT_CONFIG_DIR, setConfigValue } from "@first-tree-hub/shared/config";
+import {
+  collectMissingPrompts,
+  DEFAULT_CONFIG_DIR,
+  DEFAULT_HOME_DIR,
+  setConfigValue,
+} from "@first-tree-hub/shared/config";
 import { input, password, select } from "@inquirer/prompts";
 
 /**
@@ -44,7 +49,7 @@ export async function promptMissingFields(options: {
     });
     throw new Error(
       `Missing required configuration:\n${lines.join("\n")}\n\n` +
-        "Provide values via environment variables, config file (~/.first-tree-hub/server.yaml),\n" +
+        `Provide values via environment variables, config file (${DEFAULT_HOME_DIR}/server.yaml),\n` +
         "or run without --no-interactive to use the interactive setup wizard.",
     );
   }

--- a/packages/server/src/__tests__/kael-runtime.test.ts
+++ b/packages/server/src/__tests__/kael-runtime.test.ts
@@ -310,7 +310,7 @@ describe("KaelRuntime", () => {
       const [updated] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(updated).status).toBe("acked");
 
       vi.unstubAllGlobals();
@@ -398,7 +398,7 @@ describe("KaelRuntime", () => {
       const [updated] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(updated).status).toBe("acked");
       expect(defined(updated).ackedAt).not.toBeNull();
 
@@ -440,7 +440,7 @@ describe("KaelRuntime", () => {
       const [updated] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       // NACKed back to pending with retry_count incremented
       expect(defined(updated).status).toBe("pending");
       expect(defined(updated).retryCount).toBe(1);
@@ -476,7 +476,7 @@ describe("KaelRuntime", () => {
       const [updated] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(updated).status).toBe("pending");
       expect(defined(updated).retryCount).toBe(1);
 
@@ -523,7 +523,7 @@ describe("KaelRuntime", () => {
       const [updated] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(updated).status).toBe("failed");
 
       vi.unstubAllGlobals();
@@ -564,7 +564,7 @@ describe("KaelRuntime", () => {
       const [unchanged] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(unchanged).status).toBe("pending");
 
       vi.unstubAllGlobals();
@@ -667,7 +667,7 @@ describe("KaelRuntime", () => {
       const [unchanged] = await app.db
         .select()
         .from(inboxEntries)
-        .where(eq(inboxEntries.id, defined(entry).id)); // biome-ignore lint/style/noNonNullAssertion: test assertion - entry always exists;
+        .where(eq(inboxEntries.id, defined(entry).id));
       expect(defined(unchanged).status).toBe("pending");
 
       vi.unstubAllGlobals();

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -296,7 +296,15 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
   const sender = data.sender as { sender_id?: Record<string, string>; sender_type?: string } | undefined;
   const message = data.message as Record<string, unknown> | undefined;
 
-  if (!sender?.sender_id?.open_id || !sender.sender_id.union_id || !message) return null;
+  if (!sender?.sender_id?.open_id || !message) return null;
+
+  // Prefer union_id (stable across apps), fallback to open_id (per-app)
+  if (!sender.sender_id.union_id) {
+    process.stderr.write(
+      `[warn] Feishu event missing union_id for sender ${sender.sender_id.open_id}, falling back to open_id\n`,
+    );
+  }
+  const resolvedSenderId = sender.sender_id.union_id ?? sender.sender_id.open_id;
 
   const eventId = (data.event_id as string) ?? `ws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
@@ -319,7 +327,7 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
     eventId,
     platform: "feishu",
     appId,
-    senderId: sender.sender_id.union_id,
+    senderId: resolvedSenderId,
     senderOpenId: sender.sender_id.open_id,
     senderType: sender.sender_type ?? "user",
     externalChannelId: (message.chat_id as string) ?? "",

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -296,7 +296,7 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
   const sender = data.sender as { sender_id?: Record<string, string>; sender_type?: string } | undefined;
   const message = data.message as Record<string, unknown> | undefined;
 
-  if (!sender?.sender_id?.open_id || !message) return null;
+  if (!sender?.sender_id?.open_id || !sender.sender_id.union_id || !message) return null;
 
   const eventId = (data.event_id as string) ?? `ws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
@@ -319,7 +319,8 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
     eventId,
     platform: "feishu",
     appId,
-    senderId: sender.sender_id.open_id,
+    senderId: sender.sender_id.union_id,
+    senderOpenId: sender.sender_id.open_id,
     senderType: sender.sender_type ?? "user",
     externalChannelId: (message.chat_id as string) ?? "",
     chatType: (message.chat_type as string) ?? "group",

--- a/packages/server/src/services/feishu/types.ts
+++ b/packages/server/src/services/feishu/types.ts
@@ -6,7 +6,10 @@ export type InboundEvent = {
   eventId: string;
   platform: "feishu";
   appId: string;
+  /** Feishu union_id — stable across all apps within the same enterprise. */
   senderId: string;
+  /** Feishu open_id — per-app, used for API calls that require it. */
+  senderOpenId: string;
   senderType: string;
   externalChannelId: string;
   chatType: string;

--- a/packages/shared/src/config/resolver.ts
+++ b/packages/shared/src/config/resolver.ts
@@ -14,7 +14,7 @@ import type {
   ResolvedFieldInfo,
 } from "./types.js";
 
-export const DEFAULT_HOME_DIR = join(homedir(), ".first-tree-hub");
+export const DEFAULT_HOME_DIR = process.env.FIRST_TREE_HUB_HOME ?? join(homedir(), ".first-tree-hub");
 export const DEFAULT_CONFIG_DIR = join(DEFAULT_HOME_DIR, "config");
 export const DEFAULT_DATA_DIR = join(DEFAULT_HOME_DIR, "data");
 


### PR DESCRIPTION
## Summary

- **Type-aware onboarding**: interactive prompts, `--check` output, NODE.md template, and Phase 2 summary now differentiate between human / personal_assistant / autonomous_agent
- **`FIRST_TREE_HUB_HOME` env var**: allows multiple isolated environments (test vs production) on the same machine
- **Feishu union_id**: switch user mapping from per-app `open_id` to cross-app `union_id`, so one `/bind` works across all bots in the same enterprise. Falls back to `open_id` with warning when `union_id` is unavailable
- **Docs**: expanded onboarding guide with type comparison table, type-specific parameter matrix, AI agent instructions, and `FIRST_TREE_HUB_HOME` env var
- **Cleanup**: remove 7 stale biome-ignore comments in kael-runtime tests

## Breaking changes

- **Feishu user bindings**: existing `/bind` mappings use `open_id` (`ou_` prefix) and will no longer match after this change (new mappings use `union_id` / `on_` prefix). Users need to re-run `/bind <agent-id>` once. No migration script needed — just rebind.

## Test plan

- [ ] `pnpm check` passes (0 errors, 0 warnings)
- [ ] `pnpm typecheck` passes
- [ ] `first-tree-hub onboard --type autonomous_agent` skips assistant prompt, shows Feishu bot prompt
- [ ] `first-tree-hub onboard --type human --assistant foo` shows both assistant and Feishu bot prompts
- [ ] `first-tree-hub onboard --type human` (no assistant) skips Feishu bot prompt
- [ ] `first-tree-hub onboard --check --type autonomous_agent` hides assistant item, shows feishu-bot item
- [ ] `FIRST_TREE_HUB_HOME=/tmp/test-hub first-tree-hub onboard --check` uses custom home dir
- [ ] Feishu `/bind` with new bot uses `union_id` (verify in DB: `on_` prefix instead of `ou_`)
- [ ] Feishu message from sender without `union_id` falls back to `open_id` with stderr warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)