### PR TITLE
docs: add first-tree-hub-cli skill

### DIFF
--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: first-tree-hub-cli
+description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+---
+
+# First Tree Hub CLI
+
+## Overview
+
+Use this skill to map user intent onto the correct First Tree Hub command or code path without re-discovering the whole monorepo each time.
+Keep the central mental model straight: First Tree Hub is the communication backbone for agent teams. It is not the agent framework, not the orchestration engine, and not the Context Tree itself.
+
+## Start Here
+
+1. Classify the task before acting.
+   - Operate or diagnose a Hub deployment: read `references/command-surface.md`
+   - Explain product or architecture concepts: read `references/core-concepts.md`
+   - Modify CLI or related behavior in code: read `references/developer-map.md`
+2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
+   - Use `onboard` for member onboarding
+   - Use `config` for config inspection and updates
+   - Use `server start` or `client start` instead of stitching together ad hoc boot flows
+3. Read the canonical repo docs directly when the task becomes specialized.
+   - `docs/cli-reference.md` for exact flags and environment variables
+   - `docs/onboarding-guide.md` for the full onboarding flow
+   - `docs/claim-agent-guide.md` when claim or binding flows matter
+   - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
+
+## Operating Rules
+
+- Keep subsystem boundaries clear.
+  - `server` manages Hub server lifecycle, database setup, migrations, and admin users.
+  - `client` runs configured agents and hydrates their local workspaces and context.
+  - `agent` manages local agent configs, tokens, bindings, workspace cleanup, and debug messaging.
+  - `config` edits YAML-backed config by scope.
+  - `status` is read-only overview.
+  - `onboard` is the high-level member onboarding flow.
+- Remember the identity model.
+  - Agent identities come from the Context Tree repo and sync into Hub.
+  - Hub does not author identities directly; it reads them and turns them into runtime infrastructure.
+- Respect auth isolation.
+  - Admin JWT and agent Bearer token are separate paths.
+  - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
+- Respect config layering.
+  - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
+- Distinguish config scopes and paths.
+  - Server: `~/.first-tree-hub/config/server.yaml`
+  - Client: `~/.first-tree-hub/config/client.yaml`
+  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+- Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
+
+## Common Workflows
+
+### Choose a Command
+
+- First local boot or quick demo: `first-tree-hub server start`
+- Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
+- Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
+- Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
+- Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
+- Clean stale chat workspaces: `first-tree-hub agent workspace clean`
+- Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
+
+### Modify Code Safely
+
+- For new or changed CLI behavior, inspect:
+  - `packages/command/src/commands/*.ts` for command registration and args
+  - `packages/command/src/core/*.ts` for reusable logic
+  - `packages/shared/src/config/*` if flags, env vars, or config schema change
+  - `docs/cli-reference.md` and `docs/onboarding-guide.md` if user-facing behavior changes
+- Keep command modules thin. Reusable business logic belongs in `packages/command/src/core/`.
+- Re-export new reusable core functions from `packages/command/src/core/index.ts` and `packages/command/src/index.ts` when external callers should be able to import them.
+
+## Validation
+
+- For skill-only documentation work, run the skill validator and inspect `agents/openai.yaml`.
+- For CLI or behavior changes, prefer:
+
+```bash
+pnpm check
+pnpm typecheck
+pnpm --filter @agent-team-foundation/first-tree-hub test
+```
+
+- Add more targeted package tests when you change runtime behavior.
+
+## References
+
+- `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
+- `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
+- `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "First Tree Hub CLI"
+  short_description: "Understand and operate First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."

--- a/skills/first-tree-hub-cli/references/command-surface.md
+++ b/skills/first-tree-hub-cli/references/command-surface.md
@@ -1,0 +1,156 @@
+# First Tree Hub Command Surface
+
+## Quick Decision Guide
+
+| User intent | Preferred entry point | Non-obvious note |
+| --- | --- | --- |
+| Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
+| Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
+| See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
+| Start all configured agents | `first-tree-hub client start` | Loads every agent config under `~/.first-tree-hub/config/agents/` |
+| Manage local config files | `first-tree-hub config ...` | Scope defaults to server unless `-c` or `-a <name>` is passed |
+| Add or remove a local agent config | `first-tree-hub agent add/remove/list` | This is local configuration, not Context Tree identity management |
+| Bootstrap an agent token from GitHub identity | `first-tree-hub agent token bootstrap <agentId>` | Requires `gh` auth and a Hub server that already knows the agent |
+| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_TOKEN`; these are low-level debugging utilities |
+| Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Removes stale workspaces only when there is no active non-evicted session |
+| Onboard a new human or autonomous agent | `first-tree-hub onboard` | Creates a PR in the Context Tree repo, not in `first-tree-hub` itself |
+
+## Command Families
+
+### `server`
+
+- `server start`
+  - Best default for first-run local usage.
+  - Prompts for missing required server config unless `--no-interactive` is used.
+  - If no database URL is provided, it can auto-start a managed PostgreSQL container via Docker.
+  - Runs migrations automatically.
+  - Creates the default `admin` user if the database has none.
+  - Resolves or builds the web dist so the server can host the admin UI.
+- `server stop`
+  - Only stops the managed PostgreSQL container used by the CLI workflow.
+  - It does not stop an already-running standalone Fastify process.
+- `server doctor`
+  - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
+- `server status`
+  - Performs a health request against `/api/v1/health`.
+- `server db:migrate`
+  - Uses the configured database and applies migrations.
+- `server admin:create`
+  - Creates an admin user directly against the configured database.
+
+### `client`
+
+- `client start`
+  - Initializes client config, loads all configured agents, creates a `ClientRuntime`, and keeps it alive until interrupted.
+  - Fails if there are no configured agents.
+- `client doctor`
+  - Checks Node version, client config, server reachability, agent configs, token validity, and WebSocket reachability.
+- `client status`
+  - Lists configured local agents and masked tokens.
+- `client stop`
+  - Currently informational only; there is no daemon manager yet.
+
+### `agent`
+
+- `agent add [name]`
+  - Writes `~/.first-tree-hub/config/agents/<name>/agent.yaml`.
+  - Prompts interactively if name or token is missing.
+- `agent remove <name>`
+  - Deletes the agent config and also removes runtime workspaces and the saved session registry for that agent.
+- `agent list`
+  - Reads local configured agents and masks tokens in output.
+- `agent workspace clean [agent-name] [--ttl <days>]`
+  - Cleans stale workspace directories under `~/.first-tree-hub/data/workspaces/`.
+  - Skips chat workspaces that still have an active session in the session registry.
+- `agent token bootstrap <agentId>`
+  - Uses GitHub identity and the server's bootstrap endpoint to create or retrieve an agent token.
+  - `--save-to agent` stores the token in the local agent config by default.
+- `agent bind ...`
+  - Used for Feishu bindings. Read `docs/claim-agent-guide.md` when claim/bind flows matter.
+- `agent send/chats/history/register/pull`
+  - These are SDK-style debugging commands.
+  - They require `FIRST_TREE_HUB_TOKEN`.
+  - `send` supports direct target vs `--chat`, stdin piping, and reply metadata.
+  - `pull` is the low-level inbox polling path.
+
+### `config`
+
+- `config setup`
+  - Runs schema-driven interactive prompts for server or client config.
+- `config set/get/list`
+  - Supports `-s/--server`, `-c/--client`, and `-a <name>/--agent <name>`.
+  - Defaults to server scope if no scope flag is provided.
+  - `list` and `get` hide secret fields unless `--show-secrets` is passed.
+
+### Top-Level `status`
+
+- Summarizes:
+  - Current server health
+  - Database config presence
+  - Number of local configured agents
+  - Whether client config exists and what server URL it points to
+- Use this when the user asks for a compact overall state, not a deep readiness diagnosis.
+
+### `onboard`
+
+- `onboard --check`
+  - Shows readiness and missing inputs without making changes.
+- `onboard`
+  - Phase 1 workflow.
+  - Resolves or clones the Context Tree repo using server configuration.
+  - Creates or updates member `NODE.md` entries in the Context Tree.
+  - Verifies the tree with `first-tree verify`.
+  - Creates a branch, commit, push, and PR in the Context Tree repo.
+- `onboard --continue`
+  - Phase 2 workflow after the Context Tree PR is merged.
+  - Waits for the server to sync the new agent.
+  - Bootstraps the token.
+  - Optionally binds a Feishu bot.
+  - Writes `client.yaml` so `client start` works without extra setup.
+
+## Config and Environment Model
+
+### Config priority
+
+1. CLI args
+2. Environment variables
+3. YAML config files
+4. Auto-generated values
+5. Built-in defaults
+
+### Default config paths
+
+- `~/.first-tree-hub/config/server.yaml`
+- `~/.first-tree-hub/config/client.yaml`
+- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+
+### Default runtime paths
+
+- `~/.first-tree-hub/data/sessions/`
+- `~/.first-tree-hub/data/workspaces/`
+- `~/.first-tree-hub/data/postgres/`
+
+### Important environment variables
+
+- Server:
+  - `FIRST_TREE_HUB_DATABASE_URL`
+  - `FIRST_TREE_HUB_PORT`
+  - `FIRST_TREE_HUB_HOST`
+  - `FIRST_TREE_HUB_JWT_SECRET`
+  - `FIRST_TREE_HUB_ENCRYPTION_KEY`
+  - `FIRST_TREE_HUB_CONTEXT_TREE_REPO`
+  - `FIRST_TREE_HUB_GITHUB_TOKEN`
+  - `FIRST_TREE_HUB_WEB_DIST_PATH`
+- Client:
+  - `FIRST_TREE_HUB_SERVER_URL`
+  - `FIRST_TREE_HUB_LOG_LEVEL`
+- Agent debugging:
+  - `FIRST_TREE_HUB_TOKEN`
+  - `FIRST_TREE_HUB_SERVER`
+
+## When to Read Other Docs
+
+- Read `docs/cli-reference.md` for the full public command reference.
+- Read `docs/onboarding-guide.md` for onboarding examples and type-specific behavior.
+- Read `docs/claim-agent-guide.md` for claim-agent and Feishu user binding flows.
+- Read `docs/deployment-guide.md` when the request is about Docker, Railway, Render, Supabase, HTTPS, or multi-machine deployment.

--- a/skills/first-tree-hub-cli/references/core-concepts.md
+++ b/skills/first-tree-hub-cli/references/core-concepts.md
@@ -1,0 +1,117 @@
+# First Tree Hub Core Concepts
+
+## Product Boundary
+
+First Tree Hub is shared infrastructure for agent teams.
+
+- It provides identity sync, authentication, messaging, adapter bridges, and the admin dashboard.
+- It is not the LLM agent runtime itself.
+- It is not the orchestration framework.
+- It is not the Context Tree.
+
+Use this distinction consistently when explaining the system or choosing where a change belongs.
+
+## Package Roles
+
+- `packages/server`
+  - Fastify API server, admin APIs, agent APIs, database access, sync jobs, adapters, notifications
+- `packages/client`
+  - Agent SDK, runtime, WebSocket connection management, workspace/session handling
+- `packages/command`
+  - Unified CLI entry point plus reusable core orchestration helpers
+- `packages/shared`
+  - Zod schemas, TypeScript types, and schema-driven config system shared across packages
+- `packages/web`
+  - React admin dashboard served by the server
+
+The command package depends on server and client packages, but it is still an entry layer. Keep business logic in reusable core modules instead of duplicating it in Commander handlers.
+
+## Architecture Invariants
+
+### PostgreSQL is the single persistent system
+
+- Persistent business state lives in PostgreSQL.
+- The server is otherwise stateless.
+- There is no Redis or separate message queue in the intended design.
+
+### Context Tree is the source of identity truth
+
+- Agent identities come from a Context Tree GitHub repo.
+- The server syncs those identities on startup, periodically, and via manual trigger paths.
+- Hub reads the tree and turns it into runtime identity records.
+- Removed members are suspended rather than silently forgotten.
+
+### Inbox is the server-client boundary
+
+- The server writes messages to inbox rows.
+- Delivery is fan-out on write and at-least-once.
+- Clients receive WebSocket notifications and can also pull.
+- The client side is responsible for deduplication and session/workspace management.
+
+### Auth paths are isolated
+
+- Agent API uses agent Bearer tokens.
+- Admin API uses admin JWT.
+- These are separate security domains even on localhost.
+
+### Messages are immutable and time-ordered
+
+- Message IDs use UUID v7.
+- Messages are treated as immutable after creation.
+
+## Runtime Mental Model
+
+### Server startup
+
+`server start` is more than "run Fastify".
+
+It can:
+
+- collect missing config interactively
+- provision PostgreSQL if the user did not provide one
+- run migrations
+- create the first admin account
+- discover or build the web dist
+- start the server with a generated instance ID
+
+### Client startup
+
+`client start` runs all locally configured agents against one Hub server.
+
+The client runtime:
+
+- reads `client.yaml`
+- reads all configured agent YAML files
+- establishes WebSocket and HTTP communication
+- manages session state and isolated chat workspaces
+- syncs a shared Context Tree clone for local context hydration
+
+### Workspace bootstrap
+
+When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files.
+
+If the Context Tree clone is available, it copies:
+
+- `self.md` from the agent's `members/.../NODE.md`
+- `agent-instructions.md` from the root `AGENT.md`
+- `domain-map.md` from the root `NODE.md`
+
+If the Context Tree is unavailable, it writes degraded-mode context so the runtime can continue without organizational metadata.
+
+## Onboarding Mental Model
+
+`onboard` is intentionally higher-level than the rest of the CLI.
+
+- Phase 1 works in the Context Tree repo, not the Hub repo.
+- Phase 2 waits for the server to sync the newly merged identity, then bootstraps runtime access.
+- This is the supported path for creating new members because identity lives outside Hub itself.
+
+Do not replace this with ad hoc file creation or manual local git operations unless the user explicitly wants to bypass the normal flow for development or debugging.
+
+## Common Misunderstandings to Avoid
+
+- Do not say that `agent add` creates an identity in Hub. It only creates local client config.
+- Do not say that `client start` starts the server. It only runs configured agent clients.
+- Do not say that Hub owns organizational truth. The Context Tree does.
+- Do not frame the inbox as exactly-once delivery. The contract is at-least-once with client-side deduplication.
+- Do not mix up admin and agent credentials.

--- a/skills/first-tree-hub-cli/references/developer-map.md
+++ b/skills/first-tree-hub-cli/references/developer-map.md
@@ -1,0 +1,139 @@
+# First Tree Hub Developer Map
+
+## Repo Entry Points
+
+- `AGENTS.md`
+  - Architecture rules, conventions, package map, and development workflow
+- `README.md`
+  - Product framing, quick start, and top-level documentation links
+- `docs/cli-reference.md`
+  - Public command and environment variable reference
+- `docs/onboarding-guide.md`
+  - End-to-end onboarding flow
+- `docs/claim-agent-guide.md`
+  - Claim and Feishu binding details
+
+## CLI Source Map
+
+- `packages/command/src/cli/index.ts`
+  - Top-level Commander program and command registration
+- `packages/command/src/commands/server.ts`
+  - `server` subcommands
+- `packages/command/src/commands/client.ts`
+  - `client` subcommands
+- `packages/command/src/commands/agent.ts`
+  - local agent management, bindings, workspace cleanup, messaging utilities
+- `packages/command/src/commands/config.ts`
+  - scope-aware config set/get/list/setup flows
+- `packages/command/src/commands/status.ts`
+  - top-level overview command
+- `packages/command/src/commands/onboard.ts`
+  - high-level interactive entry for onboarding
+
+## Reusable Core Logic
+
+- `packages/command/src/core/server.ts`
+  - orchestration for `server start`, including config prompts, Docker PostgreSQL, migrations, admin creation, and web dist resolution
+- `packages/command/src/core/onboard.ts`
+  - Context Tree checkout, member file generation, verification, PR creation, and post-merge continuation flow
+- `packages/command/src/core/bootstrap.ts`
+  - token bootstrap helpers and server URL resolution
+- `packages/command/src/core/doctor.ts`
+  - readiness checks used by `server doctor` and `client doctor`
+- `packages/command/src/core/feishu.ts`
+  - Feishu binding helpers
+- `packages/command/src/core/prompt.ts`
+  - schema-driven prompting behavior
+
+If you change command behavior, there is a good chance the real logic belongs in one of these core modules rather than in the command handler itself.
+
+## Shared Config and Schema Files
+
+- `packages/shared/src/config/server-config.ts`
+  - server config schema, defaults, prompts, env names
+- `packages/shared/src/config/client-config.ts`
+  - client config schema
+- `packages/shared/src/config/agent-config.ts`
+  - agent config schema
+- `packages/shared/src/config/resolver.ts`
+  - config priority resolution, YAML reading/writing, auto-generation
+
+If a flag, env var, or config key changes, inspect these files and update docs accordingly.
+
+## Client and Server Runtime Files
+
+- `packages/client/src/sdk.ts`
+  - agent SDK surface used by debugging flows and runtime internals
+- `packages/client/src/runtime/runtime.ts`
+  - runtime orchestration for configured agents
+- `packages/client/src/runtime/bootstrap.ts`
+  - Context Tree clone sync and `.agent/` workspace bootstrap
+- `packages/client/src/runtime/session-manager.ts`
+  - session lifecycle and dedup-sensitive message dispatch
+- `packages/server/src/app.ts`
+  - server wiring, route registration, background jobs, Context Tree sync start
+- `packages/server/src/services/inbox.ts`
+  - inbox poll/ack/renew behavior
+- `packages/server/src/services/context-tree-graphql.ts`
+  - Context Tree member fetch and sync behavior
+
+## Change Patterns
+
+### Add or change a CLI command
+
+1. Update or add the command handler in `packages/command/src/commands/`.
+2. Move reusable logic into `packages/command/src/core/`.
+3. Register the command from `packages/command/src/cli/index.ts` if it is new.
+4. Update barrel exports if the functionality should be imported by external consumers.
+5. Update `docs/cli-reference.md`.
+
+### Change onboarding behavior
+
+1. Update `packages/command/src/commands/onboard.ts` only for argument shape or interaction flow.
+2. Put the real behavior in `packages/command/src/core/onboard.ts`.
+3. Update `docs/onboarding-guide.md`.
+4. Update `docs/claim-agent-guide.md` too if claim or binding behavior changes.
+
+### Change config behavior
+
+1. Update the relevant schema under `packages/shared/src/config/`.
+2. Check whether prompt text, defaults, env names, or secret masking rules also need changes.
+3. Update `docs/cli-reference.md`.
+4. Re-test the matching `config`, `server`, or `client` flows.
+
+### Change messaging or agent runtime behavior
+
+1. Start with `packages/command/src/commands/agent.ts` if the CLI surface changes.
+2. Inspect `packages/client/src/sdk.ts` and `packages/client/src/runtime/` if client runtime semantics change.
+3. Inspect `packages/server/src/api/agent/` and `packages/server/src/services/` if server contracts change.
+4. Update shared schemas in `packages/shared/src/schemas/` when payload shapes change.
+
+## Validation Commands
+
+Run the smallest relevant set first, then expand if the change touches cross-package behavior.
+
+```bash
+pnpm check
+pnpm typecheck
+pnpm --filter @agent-team-foundation/first-tree-hub test
+pnpm --filter @first-tree-hub/client test
+pnpm --filter @first-tree-hub/server test
+```
+
+Use the package-specific commands when only one area changed, but keep in mind that the command package depends on shared behavior in `client`, `server`, and `shared`.
+
+## External Consumption
+
+The published CLI package is `@agent-team-foundation/first-tree-hub`.
+
+Its public CLI binary is:
+
+```bash
+first-tree-hub
+```
+
+Its reusable code surface is also intended to be importable by other tools. When you add reusable CLI-adjacent behavior, preserve that separation:
+
+- thin command handler for argument parsing
+- reusable `core/*` function for behavior
+- re-export through `packages/command/src/index.ts` when appropriate


### PR DESCRIPTION
## Summary
- add a new `skills/first-tree-hub-cli/` skill at the repo root
- document the First Tree Hub CLI command surface, operating rules, and architecture concepts for agent use
- add a developer map that points agents to the right command, core, shared-config, and runtime files

## Validation
- `uv run --with pyyaml python /Users/bingran_you/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/first-tree-hub-cli`