### PR TITLE
docs: add first-tree-hub-cli playbooks

### DIFF
--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -14,6 +14,7 @@ Keep the central mental model straight: First Tree Hub is the communication back
 
 1. Classify the task before acting.
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
+   - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -87,5 +88,6 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 ## References
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
+- `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -1,0 +1,245 @@
+# First Tree Hub Scenario Playbooks
+
+Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
+
+## 1. "Help me get First Tree Hub running locally"
+
+Use this when the user is setting up a local Hub for the first time.
+
+### Recommended flow
+
+1. Start with:
+
+```bash
+first-tree-hub server start
+```
+
+2. If the user wants a non-interactive setup, switch to:
+
+```bash
+first-tree-hub server start --no-interactive
+```
+
+and make sure the required environment variables or config already exist.
+
+3. If startup fails, move to:
+
+```bash
+first-tree-hub server doctor
+first-tree-hub status
+```
+
+### What to remember
+
+- `server start` is the happy-path bootstrap command.
+- It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
+- If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+
+## 2. "Connect my local agent machine to an existing Hub"
+
+Use this when the Hub server already exists and the user wants a local client runtime.
+
+### Recommended flow
+
+1. Ensure client config points at the server:
+
+```bash
+first-tree-hub config setup -c
+```
+
+or:
+
+```bash
+first-tree-hub config set -c server.url http://host:8000
+```
+
+2. Add the local agent config:
+
+```bash
+first-tree-hub agent add <name> --token <token>
+```
+
+3. Start the runtime:
+
+```bash
+first-tree-hub client start
+```
+
+4. If something looks wrong, inspect:
+
+```bash
+first-tree-hub client doctor
+first-tree-hub client status
+```
+
+### What to remember
+
+- `agent add` is local-only configuration.
+- `client start` runs all locally configured agents, not just one.
+
+## 3. "Onboard a new human member"
+
+Use this when the user wants to add a real person to the team through the supported identity flow.
+
+### Recommended flow
+
+1. Dry-run requirements first:
+
+```bash
+first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+3. After the PR is merged, continue:
+
+```bash
+first-tree-hub onboard --continue
+```
+
+4. Start the local runtime if this machine should run the assistant:
+
+```bash
+first-tree-hub client start
+```
+
+### What to remember
+
+- `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
+- For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
+
+## 4. "Onboard a standalone autonomous agent"
+
+Use this when the new member is a bot with no human owner.
+
+### Recommended flow
+
+1. Check:
+
+```bash
+first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+3. After merge:
+
+```bash
+first-tree-hub onboard --continue
+first-tree-hub client start
+```
+
+### What to remember
+
+- Do not use `--assistant` for `autonomous_agent`.
+- Feishu bot binding is optional here, unlike the human `/bind` flow.
+
+## 5. "Why can't the client connect?" or "Why does startup fail?"
+
+Use this for diagnosis before editing code.
+
+### Recommended flow
+
+1. Check top-level state:
+
+```bash
+first-tree-hub status
+```
+
+2. Run the relevant doctor:
+
+```bash
+first-tree-hub client doctor
+```
+
+or:
+
+```bash
+first-tree-hub server doctor
+```
+
+3. Inspect effective config:
+
+```bash
+first-tree-hub config list -c
+first-tree-hub config list -s
+```
+
+4. If the server should already be running, probe health directly:
+
+```bash
+first-tree-hub server status
+```
+
+### What to remember
+
+- Prefer diagnosis commands before changing YAML files by hand.
+- Server issues and client issues often look similar; make the user goal explicit before debugging.
+
+## 6. "Help me debug messaging between agents"
+
+Use this when the user wants to verify delivery, inspect chats, or send test messages manually.
+
+### Recommended flow
+
+1. Make sure agent debug auth is available:
+
+```bash
+export FIRST_TREE_HUB_TOKEN=...
+```
+
+2. Send a message:
+
+```bash
+first-tree-hub agent send <agentId> "hello"
+```
+
+or to an existing chat:
+
+```bash
+first-tree-hub agent send <chatId> "hello" --chat
+```
+
+3. Inspect chats and history:
+
+```bash
+first-tree-hub agent chats
+first-tree-hub agent history <chatId>
+```
+
+4. Fall back to low-level inbox polling if needed:
+
+```bash
+first-tree-hub agent pull
+```
+
+### What to remember
+
+- These commands are for debugging and operator visibility, not the normal runtime path.
+- If a user only wants to run their agents normally, `client start` is the main flow.
+
+## 7. "Change how the CLI behaves"
+
+Use this when the user wants a code change rather than an operational action.
+
+### Recommended flow
+
+1. Find the matching command handler in `packages/command/src/commands/`.
+2. Move behavior into `packages/command/src/core/` if the logic is reusable.
+3. Update the corresponding docs in `docs/cli-reference.md` or `docs/onboarding-guide.md`.
+4. Validate with the smallest relevant command/package test set.
+
+### What to remember
+
+- Command handlers should stay thin.
+- Config changes usually require updates in `packages/shared/src/config/`.
+- Onboarding changes often touch both `commands/onboard.ts` and `core/onboard.ts`.


### PR DESCRIPTION
## Summary
- add scenario-based playbooks that map natural-language requests to the right First Tree Hub CLI flows
- link the new playbook reference from `skills/first-tree-hub-cli/SKILL.md`

## Validation
- `uv run --with pyyaml python /Users/bingran_you/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/first-tree-hub-cli`