### PR TITLE
docs: fix hub cli skill and stale command docs

### DIFF
--- a/docs/claim-agent-guide.md
+++ b/docs/claim-agent-guide.md
@@ -7,6 +7,7 @@ This guide walks through claiming an agent identity from First Tree Hub so it ca
 - Node.js >= 22.16
 - A First Tree Hub server running and accessible (e.g., `http://localhost:8000`)
 - Your agent registered in First Tree Hub (auto-synced from Context Tree `members/` directory)
+- `gh` authenticated if you want to use self-service token bootstrap
 
 ## Step 1 — Install the CLI
 
@@ -17,16 +18,30 @@ first-tree-hub --version
 
 ## Step 2 — Get Your Agent Token
 
-An admin creates a token for your agent through the First Tree Hub Admin UI or API.
+Choose one of these paths:
 
-**Option A: Admin UI**
+**Option A: Self-service bootstrap (preferred when your agent identity is already synced and you have `gh` access)**
+
+```bash
+first-tree-hub agent token bootstrap <your-agent-id>
+```
+
+This uses your current GitHub identity to request a token from the Hub bootstrap endpoint. By default it saves the token to:
+
+```text
+~/.first-tree-hub/config/agents/<your-agent-id>/agent.yaml
+```
+
+Use `--server <url>` if the Hub URL is not already configured, or `--save-to <path>` if you want the raw token written somewhere else.
+
+**Option B: Admin UI**
 
 1. Open the First Tree Hub web console
 2. Navigate to your agent's detail page
 3. Click "Create Token"
 4. Copy the token — it is shown only once
 
-**Option B: Admin API**
+**Option C: Admin API**
 
 ```bash
 curl -X POST http://localhost:8000/api/v1/admin/agents/<your-agent-id>/tokens \
@@ -37,7 +52,7 @@ curl -X POST http://localhost:8000/api/v1/admin/agents/<your-agent-id>/tokens \
 
 The response contains a `token` field (format: `aghub_...`). Save it immediately.
 
-## Step 3 — Set Environment Variables
+## Step 3 — Set Environment Variables for Debugging / SDK Use
 
 ```bash
 export FIRST_TREE_HUB_TOKEN=aghub_your_token_here
@@ -66,7 +81,7 @@ Expected output:
 ## Step 5 — Add Agent and Start Client
 
 ```bash
-# Add agent to client config (if not already added via onboard)
+# Add agent to client config only if bootstrap or onboard has not already done it
 first-tree-hub agent add my-agent --token $FIRST_TREE_HUB_TOKEN
 
 # Configure server URL
@@ -74,6 +89,12 @@ first-tree-hub config set -c server.url http://localhost:8000
 
 # Start client — connects all configured agents
 first-tree-hub client start
+```
+
+If you used `first-tree-hub agent token bootstrap <your-agent-id>` with the default `--save-to agent`, the local agent config is already written for you. In that case you can skip `agent add` and just confirm it exists with:
+
+```bash
+first-tree-hub agent list
 ```
 
 The `client start` command starts a persistent process that connects all configured agents to the server, polls inboxes, and dispatches messages to handlers.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,15 @@
 # First Tree Hub CLI Reference
 
+## Prerequisites
+
+```bash
+npm install -g @agent-team-foundation/first-tree-hub
+first-tree-hub --version
+```
+
+- Node.js `>= 22.16`
+- `gh` authenticated when using `onboard` or `agent token bootstrap`
+
 ## Commands
 
 ```
@@ -24,7 +34,8 @@ first-tree-hub
 │   ├── token bootstrap <agentId> [--save-to] [--server]
 │   ├── bind bot --platform feishu --app-id <id> --app-secret <s>
 │   ├── bind user <humanAgentId> --platform feishu --feishu-id <id>
-│   ├── send <target> [message] [-f format] [--chat]
+│   ├── send <target> [message] [-f format] [--chat] [--metadata]
+│   │   [--reply-to] [--reply-to-inbox] [--reply-to-chat]
 │   ├── chats [-l <limit>] [--cursor]
 │   ├── history <chatId> [-l <limit>] [--cursor]
 │   ├── register
@@ -36,6 +47,7 @@ first-tree-hub
 │   └── list [-s|-c|-a <name>] [--show-secrets]
 ├── onboard [--check] [--continue]
 │   [--id] [--type] [--display-name] [--role] [--domains]
+│   [--delegate-mention]
 │   [--assistant] [--server] [--feishu-bot-app-id] [--feishu-bot-app-secret]
 └── status
 ```
@@ -132,6 +144,11 @@ first-tree-hub agent send <agentId> "hello"
 first-tree-hub agent send <chatId> "hello" --chat
 echo "piped message" | first-tree-hub agent send <agentId>
 
+# Attach metadata or reply routing
+first-tree-hub agent send <agentId> "hello" --metadata '{"priority":"high"}'
+first-tree-hub agent send <chatId> "follow-up" --chat --reply-to <messageId>
+first-tree-hub agent send <agentId> "continue there" --reply-to-inbox <inboxId> --reply-to-chat <chatId>
+
 # List chats / view history
 first-tree-hub agent chats
 first-tree-hub agent history <chatId>
@@ -142,7 +159,7 @@ first-tree-hub agent pull
 first-tree-hub agent pull --ack
 ```
 
-Messaging commands require `FIRST_TREE_HUB_TOKEN` environment variable.
+Messaging commands require `FIRST_TREE_HUB_TOKEN`. Use `FIRST_TREE_HUB_SERVER` to override the server URL for these low-level agent commands.
 
 ## config
 
@@ -173,6 +190,7 @@ first-tree-hub onboard --check --id alice --type human --role Engineer
 
 # Phase 1: Create Context Tree PR
 first-tree-hub onboard --id alice --type human --role Engineer --domains backend,infra
+first-tree-hub onboard --id alice --type human --role Engineer --domains backend,infra --delegate-mention alice-assistant
 
 # Phase 2: After PR merge — sync + token + bindings + client config
 first-tree-hub onboard --continue
@@ -185,7 +203,13 @@ See [onboarding-guide.md](onboarding-guide.md) for the full walkthrough.
 
 ## Environment Variables
 
-All environment variables use the `FIRST_TREE_HUB_` prefix. When set, interactive prompts automatically skip the corresponding field.
+Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also accepts `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. When set, interactive prompts automatically skip the corresponding field.
+
+### Global
+
+| Variable | Purpose | Default |
+|---------|------|--------|
+| `FIRST_TREE_HUB_HOME` | Override the CLI home directory for config, data, cloned Context Tree, and onboard resume state | `~/.first-tree-hub` |
 
 ### Server
 
@@ -214,10 +238,20 @@ All environment variables use the `FIRST_TREE_HUB_` prefix. When set, interactiv
 | `FIRST_TREE_HUB_TOKEN` | Agent token (required for `agent send/chats/history/register/pull`) |
 | `FIRST_TREE_HUB_SERVER` | Server URL override for messaging commands |
 
+### Onboard
+
+| Variable | Purpose |
+|---------|------|
+| `FIRST_TREE_HUB_SERVER` | Hub server URL alternative to `--server` |
+| `FEISHU_APP_ID` | Feishu bot App ID alternative to `--feishu-bot-app-id` |
+| `FEISHU_APP_SECRET` | Feishu bot App Secret alternative to `--feishu-bot-app-secret` |
+
 ## Directory Structure
 
 ```
 ~/.first-tree-hub/
+├── .onboard-state.json           # Saved args for `onboard --continue`
+├── context-tree/                 # Auto-managed clone used by onboarding
 ├── config/                      # Configuration (human-edited)
 │   ├── server.yaml
 │   ├── client.yaml
@@ -231,6 +265,8 @@ All environment variables use the `FIRST_TREE_HUB_` prefix. When set, interactiv
     │       └── <chatId>/
     └── postgres/                # Docker PG data
 ```
+
+If `FIRST_TREE_HUB_HOME` is set, replace `~/.first-tree-hub/` with that location.
 
 ## Config Resolution Order
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -117,7 +117,7 @@ npm install -g @agent-team-foundation/first-tree-hub
 first-tree-hub config set -c server.url https://hub.example.com
 
 # Add agents
-first-tree-hub client add my-agent --token aht_xxxxxxxxxxxx
+first-tree-hub agent add my-agent --token aghub_xxxxxxxxxxxx
 
 # Start
 first-tree-hub client start
@@ -128,7 +128,7 @@ first-tree-hub client start
 ```bash
 docker build -f Dockerfile.client -t first-tree-hub-client .
 docker run -e FIRST_TREE_HUB_SERVER_URL=https://hub.example.com \
-           -v ~/.first-tree-hub/agents:/root/.first-tree-hub/agents \
+           -v ~/.first-tree-hub/config/agents:/root/.first-tree-hub/config/agents \
            first-tree-hub-client
 ```
 
@@ -145,7 +145,7 @@ jobs:
       - run: npm install -g @agent-team-foundation/first-tree-hub
       - run: |
           first-tree-hub config set -c server.url ${{ secrets.HUB_URL }}
-          first-tree-hub client add ci-agent --token ${{ secrets.AGENT_TOKEN }}
+          first-tree-hub agent add ci-agent --token ${{ secrets.AGENT_TOKEN }}
           first-tree-hub client start
 ```
 

--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-hub-cli
-description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
 ---
 
 # First Tree Hub CLI
@@ -13,6 +13,7 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ## Start Here
 
 1. Classify the task before acting.
+   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
@@ -26,6 +27,11 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - `docs/onboarding-guide.md` for the full onboarding flow
    - `docs/claim-agent-guide.md` when claim or binding flows matter
    - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
+4. On a fresh machine, verify prerequisites before proposing a flow.
+   - Node.js `>= 22.16`
+   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
+   - Verify with `first-tree-hub --version`
+   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
 
 ## Operating Rules
 
@@ -42,12 +48,17 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
   - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
+- Keep the server URL knobs straight.
+  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
+  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.
-  - Server: `~/.first-tree-hub/config/server.yaml`
-  - Client: `~/.first-tree-hub/config/client.yaml`
-  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
+  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
+  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
+  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+  - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
 - Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
 
 ## Common Workflows
@@ -55,6 +66,7 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ### Choose a Command
 
 - First local boot or quick demo: `first-tree-hub server start`
+- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
 - Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
 - Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
 - Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`

--- a/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree Hub CLI"
-  short_description: "Understand and operate First Tree Hub CLI"
-  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."
+  short_description: "Install, operate, and modify First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to install, inspect, configure, onboard, debug, and operate First Tree Hub correctly."

--- a/skills/first-tree-hub-cli/references/command-surface.md
+++ b/skills/first-tree-hub-cli/references/command-surface.md
@@ -4,6 +4,7 @@
 
 | User intent | Preferred entry point | Non-obvious note |
 | --- | --- | --- |
+| Install or verify the CLI on a fresh machine | `npm install -g @agent-team-foundation/first-tree-hub` then `first-tree-hub --version` | Requires Node.js `>= 22.16`; use this before proposing runtime commands on a machine that may not have the CLI yet |
 | Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
 | Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
 | See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
@@ -33,6 +34,7 @@
   - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
 - `server status`
   - Performs a health request against `/api/v1/health`.
+  - Uses `FIRST_TREE_HUB_SERVER_URL` when set; otherwise defaults to `http://localhost:8000`.
 - `server db:migrate`
   - Uses the configured database and applies migrations.
 - `server admin:create`
@@ -107,6 +109,7 @@
   - Bootstraps the token.
   - Optionally binds a Feishu bot.
   - Writes `client.yaml` so `client start` works without extra setup.
+  - Persists resume state under `$FIRST_TREE_HUB_HOME/.onboard-state.json`.
 
 ## Config and Environment Model
 
@@ -120,18 +123,23 @@
 
 ### Default config paths
 
-- `~/.first-tree-hub/config/server.yaml`
-- `~/.first-tree-hub/config/client.yaml`
-- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+- Home root defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` overrides it.
+- `$FIRST_TREE_HUB_HOME/config/server.yaml`
+- `$FIRST_TREE_HUB_HOME/config/client.yaml`
+- `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
 
 ### Default runtime paths
 
-- `~/.first-tree-hub/data/sessions/`
-- `~/.first-tree-hub/data/workspaces/`
-- `~/.first-tree-hub/data/postgres/`
+- `$FIRST_TREE_HUB_HOME/.onboard-state.json`
+- `$FIRST_TREE_HUB_HOME/context-tree/`
+- `$FIRST_TREE_HUB_HOME/data/sessions/`
+- `$FIRST_TREE_HUB_HOME/data/workspaces/`
+- `$FIRST_TREE_HUB_HOME/data/postgres/`
 
 ### Important environment variables
 
+- Global:
+  - `FIRST_TREE_HUB_HOME`
 - Server:
   - `FIRST_TREE_HUB_DATABASE_URL`
   - `FIRST_TREE_HUB_PORT`
@@ -144,9 +152,11 @@
 - Client:
   - `FIRST_TREE_HUB_SERVER_URL`
   - `FIRST_TREE_HUB_LOG_LEVEL`
-- Agent debugging:
+- Onboard and agent debugging:
   - `FIRST_TREE_HUB_TOKEN`
   - `FIRST_TREE_HUB_SERVER`
+  - `FEISHU_APP_ID`
+  - `FEISHU_APP_SECRET`
 
 ## When to Read Other Docs
 

--- a/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -2,19 +2,51 @@
 
 Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
 
+## 0. "I do not have first-tree-hub installed yet"
+
+Use this before any operational flow when the machine may not have the CLI.
+
+### Recommended flow
+
+1. Verify Node.js is supported:
+
+```bash
+node --version
+```
+
+2. Install and verify the CLI:
+
+```bash
+npm install -g @agent-team-foundation/first-tree-hub
+first-tree-hub --version
+```
+
+3. If the user will use `onboard` or `agent token bootstrap`, make sure GitHub CLI is authenticated:
+
+```bash
+gh auth status
+```
+
+### What to remember
+
+- First Tree Hub requires Node.js `>= 22.16`.
+- Do not jump straight to `server start`, `client start`, or `onboard` on a machine where installation is still unknown.
+
 ## 1. "Help me get First Tree Hub running locally"
 
 Use this when the user is setting up a local Hub for the first time.
 
 ### Recommended flow
 
-1. Start with:
+1. If installation is unknown, do scenario 0 first.
+
+2. Start with:
 
 ```bash
 first-tree-hub server start
 ```
 
-2. If the user wants a non-interactive setup, switch to:
+3. If the user wants a non-interactive setup, switch to:
 
 ```bash
 first-tree-hub server start --no-interactive
@@ -22,7 +54,7 @@ first-tree-hub server start --no-interactive
 
 and make sure the required environment variables or config already exist.
 
-3. If startup fails, move to:
+4. If startup fails, move to:
 
 ```bash
 first-tree-hub server doctor
@@ -34,6 +66,7 @@ first-tree-hub status
 - `server start` is the happy-path bootstrap command.
 - It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
 - If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+- If the CLI is not installed yet, installation is part of the correct flow rather than a side detail.
 
 ## 2. "Connect my local agent machine to an existing Hub"
 


### PR DESCRIPTION
## Summary\n- make the first-tree-hub CLI skill cover fresh-machine install, env var semantics, and relocated state paths\n- fix stale CLI/deployment docs so they match the current command surface\n- update the claim guide to include self-service token bootstrap\n\n## Validation\n- python3 /Users/bingran_you/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/bingran_you/.codex/worktrees/5207/first-tree-all/first-tree-hub/skills/first-tree-hub-cli\n- git diff --check