### PR TITLE
docs: add agent onboarding guidance to hub skill

### DIFF
--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -16,6 +16,7 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
+   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -74,6 +75,34 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Clean stale chat workspaces: `first-tree-hub agent workspace clean`
 - Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
 
+### Run Onboarding From an Agent Prompt
+
+- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
+- If the environment does not already have the repo checked out or the CLI installed:
+  - Ensure `gh` is available and authenticated.
+  - Install the published package.
+    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
+    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
+  - Read the canonical onboarding guide with `gh` before acting, for example:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
+- Default operator flow:
+
+```bash
+first-tree-hub onboard --check ...
+first-tree-hub onboard --server <url> ...
+# wait for Context Tree PR merge
+first-tree-hub onboard --continue --server <url> ...
+first-tree-hub client start
+```
+
+- Prefer `onboard --check` before asking follow-up questions or creating the PR.
+- Do not manually create Context Tree member files, branches, commits, or PRs when `first-tree-hub onboard` can do it.
+
 ### Modify Code Safely
 
 - For new or changed CLI behavior, inspect:
@@ -101,5 +130,6 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
 - `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
+- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/skills/first-tree-hub-cli/references/onboarding-operator.md
+++ b/skills/first-tree-hub-cli/references/onboarding-operator.md
@@ -1,0 +1,137 @@
+# First Tree Hub Onboarding Operator Playbook
+
+Use this file when an external agent receives an onboarding task such as "install First Tree Hub CLI, read the onboarding guide with `gh`, and add a member."
+
+## Core Rule
+
+- Use `first-tree-hub onboard` for the workflow.
+- Do not manually edit the Context Tree, create git branches, or open PRs by hand unless the CLI flow is broken and the user explicitly wants a manual fallback.
+
+## When the Prompt Starts From Scratch
+
+If the task only gives you a package name, a docs URL, and a server URL, normalize it into this sequence:
+
+1. Confirm tooling:
+   - `gh` is installed and authenticated with write access to the Context Tree repository.
+   - Node is new enough to run the published CLI.
+2. Install the CLI:
+   - Preferred: `npm install -g @agent-team-foundation/first-tree-hub`
+   - If the caller installed locally with `npm i @agent-team-foundation/first-tree-hub`, use `npx first-tree-hub ...`
+3. Read the canonical guide with `gh`:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+4. Run readiness first:
+
+```bash
+first-tree-hub onboard --check --server <url> ...
+```
+
+5. Run Phase 1 to create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --server <url> ...
+```
+
+6. After the PR is merged, run Phase 2:
+
+```bash
+first-tree-hub onboard --continue --server <url> ...
+```
+
+7. Start the runtime when this machine should host the configured agent:
+
+```bash
+first-tree-hub client start
+```
+
+## Prompt Template Interpretation
+
+If the automation says something like:
+
+```text
+请先安装 npm i @agent-team-foundation/first-tree-hub
+然后使用 gh 命令阅读 docs/onboarding-guide.md，帮我添加成员。
+Server url 是 https://first-tree.staging.unispark.dev/
+```
+
+interpret it as:
+
+- Install or invoke the published CLI.
+- Fetch the guide with `gh` rather than relying on a browser-only read.
+- Use `https://first-tree.staging.unispark.dev/` as the Hub server URL in the onboarding commands.
+- Execute the supported `onboard` flow instead of hand-editing member files.
+
+## Minimal Inputs to Collect
+
+- Required:
+  - member type: `human`, `personal_assistant`, or `autonomous_agent`
+  - `id`
+  - `role`
+  - `domains`
+  - `server` URL when it is not already configured
+- Optional:
+  - `display-name`
+  - `assistant` only for `human`
+  - Feishu bot credentials only when a bot binding should be created
+
+Prefer `first-tree-hub onboard --check` to reveal missing fields instead of guessing.
+
+## Type-Specific Notes
+
+- `human`
+  - May include `--assistant <id>` to create a personal assistant.
+  - If Feishu bot binding is configured, remind the human to send `/bind <id>` afterwards.
+- `autonomous_agent`
+  - Do not use `--assistant`.
+  - Feishu bot binding is optional.
+- `personal_assistant`
+  - Usually created through the human flow rather than as a separate top-level request.
+
+## Example Commands
+
+### Human + assistant
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+### Autonomous agent
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```

--- a/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -116,25 +116,30 @@ Use this when the user wants to add a real person to the team through the suppor
 
 ### Recommended flow
 
-1. Dry-run requirements first:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Dry-run requirements first:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After the PR is merged, continue:
+4. After the PR is merged, continue:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 ```
 
-4. Start the local runtime if this machine should run the assistant:
+5. Start the local runtime if this machine should run the assistant:
 
 ```bash
 first-tree-hub client start
@@ -144,6 +149,7 @@ first-tree-hub client start
 
 - `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
 - For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
 
 ## 4. "Onboard a standalone autonomous agent"
@@ -152,28 +158,34 @@ Use this when the new member is a bot with no human owner.
 
 ### Recommended flow
 
-1. Check:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Check:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After merge:
+4. After merge:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 first-tree-hub client start
 ```
 
 ### What to remember
 
 - Do not use `--assistant` for `autonomous_agent`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - Feishu bot binding is optional here, unlike the human `/bind` flow.
 
 ## 5. "Why can't the client connect?" or "Why does startup fail?"


### PR DESCRIPTION
## Summary
- teach the first-tree-hub CLI skill how to execute onboarding from an external agent prompt
- add an onboarding operator playbook with install, gh-read, and server-url handling guidance
- thread automation-friendly onboarding examples through the scenario playbooks

## Validation
- git diff --check