### PR TITLE
chore: add skill validation and sync workflow

### DIFF
--- a/.agents/skills/first-tree-hub-cli/SKILL.md
+++ b/.agents/skills/first-tree-hub-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-hub-cli
-description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
 ---
 
 # First Tree Hub CLI
@@ -13,8 +13,10 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ## Start Here
 
 1. Classify the task before acting.
+   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
+   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -26,6 +28,11 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - `docs/onboarding-guide.md` for the full onboarding flow
    - `docs/claim-agent-guide.md` when claim or binding flows matter
    - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
+4. On a fresh machine, verify prerequisites before proposing a flow.
+   - Node.js `>= 22.16`
+   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
+   - Verify with `first-tree-hub --version`
+   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
 
 ## Operating Rules
 
@@ -42,12 +49,17 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
   - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
+- Keep the server URL knobs straight.
+  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
+  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.
-  - Server: `~/.first-tree-hub/config/server.yaml`
-  - Client: `~/.first-tree-hub/config/client.yaml`
-  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
+  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
+  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
+  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+  - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
 - Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
 
 ## Common Workflows
@@ -55,12 +67,41 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ### Choose a Command
 
 - First local boot or quick demo: `first-tree-hub server start`
+- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
 - Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
 - Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
 - Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
 - Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
 - Clean stale chat workspaces: `first-tree-hub agent workspace clean`
 - Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
+
+### Run Onboarding From an Agent Prompt
+
+- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
+- If the environment does not already have the repo checked out or the CLI installed:
+  - Ensure `gh` is available and authenticated.
+  - Install the published package.
+    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
+    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
+  - Read the canonical onboarding guide with `gh` before acting, for example:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
+- Default operator flow:
+
+```bash
+first-tree-hub onboard --check ...
+first-tree-hub onboard --server <url> ...
+# wait for Context Tree PR merge
+first-tree-hub onboard --continue --server <url> ...
+first-tree-hub client start
+```
+
+- Prefer `onboard --check` before asking follow-up questions or creating the PR.
+- Do not manually create Context Tree member files, branches, commits, or PRs when `first-tree-hub onboard` can do it.
 
 ### Modify Code Safely
 
@@ -89,5 +130,6 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
 - `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
+- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/.agents/skills/first-tree-hub-cli/SKILL.md
+++ b/.agents/skills/first-tree-hub-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-hub-cli
-description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
 ---
 
 # First Tree Hub CLI
@@ -13,10 +13,8 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ## Start Here
 
 1. Classify the task before acting.
-   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
-   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -28,11 +26,6 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - `docs/onboarding-guide.md` for the full onboarding flow
    - `docs/claim-agent-guide.md` when claim or binding flows matter
    - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
-4. On a fresh machine, verify prerequisites before proposing a flow.
-   - Node.js `>= 22.16`
-   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
-   - Verify with `first-tree-hub --version`
-   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
 
 ## Operating Rules
 
@@ -49,17 +42,12 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
   - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
-- Keep the server URL knobs straight.
-  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
-  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.
-  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
-  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
-  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
-  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
-  - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
+  - Server: `~/.first-tree-hub/config/server.yaml`
+  - Client: `~/.first-tree-hub/config/client.yaml`
+  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
 - Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
 
 ## Common Workflows
@@ -67,41 +55,12 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ### Choose a Command
 
 - First local boot or quick demo: `first-tree-hub server start`
-- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
 - Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
 - Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
 - Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
 - Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
 - Clean stale chat workspaces: `first-tree-hub agent workspace clean`
 - Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
-
-### Run Onboarding From an Agent Prompt
-
-- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
-- If the environment does not already have the repo checked out or the CLI installed:
-  - Ensure `gh` is available and authenticated.
-  - Install the published package.
-    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
-    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
-  - Read the canonical onboarding guide with `gh` before acting, for example:
-
-```bash
-gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
-```
-
-- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
-- Default operator flow:
-
-```bash
-first-tree-hub onboard --check ...
-first-tree-hub onboard --server <url> ...
-# wait for Context Tree PR merge
-first-tree-hub onboard --continue --server <url> ...
-first-tree-hub client start
-```
-
-- Prefer `onboard --check` before asking follow-up questions or creating the PR.
-- Do not manually create Context Tree member files, branches, commits, or PRs when `first-tree-hub onboard` can do it.
 
 ### Modify Code Safely
 
@@ -130,6 +89,5 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
 - `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
-- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/.agents/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/.agents/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree Hub CLI"
-  short_description: "Understand and operate First Tree Hub CLI"
-  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."
+  short_description: "Install, operate, and modify First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to install, inspect, configure, onboard, debug, and operate First Tree Hub correctly."

--- a/.agents/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/.agents/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "First Tree Hub CLI"
+  short_description: "Understand and operate First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."

--- a/.agents/skills/first-tree-hub-cli/references/command-surface.md
+++ b/.agents/skills/first-tree-hub-cli/references/command-surface.md
@@ -4,6 +4,7 @@
 
 | User intent | Preferred entry point | Non-obvious note |
 | --- | --- | --- |
+| Install or verify the CLI on a fresh machine | `npm install -g @agent-team-foundation/first-tree-hub` then `first-tree-hub --version` | Requires Node.js `>= 22.16`; use this before proposing runtime commands on a machine that may not have the CLI yet |
 | Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
 | Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
 | See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
@@ -33,6 +34,7 @@
   - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
 - `server status`
   - Performs a health request against `/api/v1/health`.
+  - Uses `FIRST_TREE_HUB_SERVER_URL` when set; otherwise defaults to `http://localhost:8000`.
 - `server db:migrate`
   - Uses the configured database and applies migrations.
 - `server admin:create`
@@ -107,6 +109,7 @@
   - Bootstraps the token.
   - Optionally binds a Feishu bot.
   - Writes `client.yaml` so `client start` works without extra setup.
+  - Persists resume state under `$FIRST_TREE_HUB_HOME/.onboard-state.json`.
 
 ## Config and Environment Model
 
@@ -120,18 +123,23 @@
 
 ### Default config paths
 
-- `~/.first-tree-hub/config/server.yaml`
-- `~/.first-tree-hub/config/client.yaml`
-- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+- Home root defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` overrides it.
+- `$FIRST_TREE_HUB_HOME/config/server.yaml`
+- `$FIRST_TREE_HUB_HOME/config/client.yaml`
+- `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
 
 ### Default runtime paths
 
-- `~/.first-tree-hub/data/sessions/`
-- `~/.first-tree-hub/data/workspaces/`
-- `~/.first-tree-hub/data/postgres/`
+- `$FIRST_TREE_HUB_HOME/.onboard-state.json`
+- `$FIRST_TREE_HUB_HOME/context-tree/`
+- `$FIRST_TREE_HUB_HOME/data/sessions/`
+- `$FIRST_TREE_HUB_HOME/data/workspaces/`
+- `$FIRST_TREE_HUB_HOME/data/postgres/`
 
 ### Important environment variables
 
+- Global:
+  - `FIRST_TREE_HUB_HOME`
 - Server:
   - `FIRST_TREE_HUB_DATABASE_URL`
   - `FIRST_TREE_HUB_PORT`
@@ -144,9 +152,11 @@
 - Client:
   - `FIRST_TREE_HUB_SERVER_URL`
   - `FIRST_TREE_HUB_LOG_LEVEL`
-- Agent debugging:
+- Onboard and agent debugging:
   - `FIRST_TREE_HUB_TOKEN`
   - `FIRST_TREE_HUB_SERVER`
+  - `FEISHU_APP_ID`
+  - `FEISHU_APP_SECRET`
 
 ## When to Read Other Docs
 

--- a/.agents/skills/first-tree-hub-cli/references/command-surface.md
+++ b/.agents/skills/first-tree-hub-cli/references/command-surface.md
@@ -1,0 +1,156 @@
+# First Tree Hub Command Surface
+
+## Quick Decision Guide
+
+| User intent | Preferred entry point | Non-obvious note |
+| --- | --- | --- |
+| Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
+| Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
+| See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
+| Start all configured agents | `first-tree-hub client start` | Loads every agent config under `~/.first-tree-hub/config/agents/` |
+| Manage local config files | `first-tree-hub config ...` | Scope defaults to server unless `-c` or `-a <name>` is passed |
+| Add or remove a local agent config | `first-tree-hub agent add/remove/list` | This is local configuration, not Context Tree identity management |
+| Bootstrap an agent token from GitHub identity | `first-tree-hub agent token bootstrap <agentId>` | Requires `gh` auth and a Hub server that already knows the agent |
+| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_TOKEN`; these are low-level debugging utilities |
+| Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Removes stale workspaces only when there is no active non-evicted session |
+| Onboard a new human or autonomous agent | `first-tree-hub onboard` | Creates a PR in the Context Tree repo, not in `first-tree-hub` itself |
+
+## Command Families
+
+### `server`
+
+- `server start`
+  - Best default for first-run local usage.
+  - Prompts for missing required server config unless `--no-interactive` is used.
+  - If no database URL is provided, it can auto-start a managed PostgreSQL container via Docker.
+  - Runs migrations automatically.
+  - Creates the default `admin` user if the database has none.
+  - Resolves or builds the web dist so the server can host the admin UI.
+- `server stop`
+  - Only stops the managed PostgreSQL container used by the CLI workflow.
+  - It does not stop an already-running standalone Fastify process.
+- `server doctor`
+  - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
+- `server status`
+  - Performs a health request against `/api/v1/health`.
+- `server db:migrate`
+  - Uses the configured database and applies migrations.
+- `server admin:create`
+  - Creates an admin user directly against the configured database.
+
+### `client`
+
+- `client start`
+  - Initializes client config, loads all configured agents, creates a `ClientRuntime`, and keeps it alive until interrupted.
+  - Fails if there are no configured agents.
+- `client doctor`
+  - Checks Node version, client config, server reachability, agent configs, token validity, and WebSocket reachability.
+- `client status`
+  - Lists configured local agents and masked tokens.
+- `client stop`
+  - Currently informational only; there is no daemon manager yet.
+
+### `agent`
+
+- `agent add [name]`
+  - Writes `~/.first-tree-hub/config/agents/<name>/agent.yaml`.
+  - Prompts interactively if name or token is missing.
+- `agent remove <name>`
+  - Deletes the agent config and also removes runtime workspaces and the saved session registry for that agent.
+- `agent list`
+  - Reads local configured agents and masks tokens in output.
+- `agent workspace clean [agent-name] [--ttl <days>]`
+  - Cleans stale workspace directories under `~/.first-tree-hub/data/workspaces/`.
+  - Skips chat workspaces that still have an active session in the session registry.
+- `agent token bootstrap <agentId>`
+  - Uses GitHub identity and the server's bootstrap endpoint to create or retrieve an agent token.
+  - `--save-to agent` stores the token in the local agent config by default.
+- `agent bind ...`
+  - Used for Feishu bindings. Read `docs/claim-agent-guide.md` when claim/bind flows matter.
+- `agent send/chats/history/register/pull`
+  - These are SDK-style debugging commands.
+  - They require `FIRST_TREE_HUB_TOKEN`.
+  - `send` supports direct target vs `--chat`, stdin piping, and reply metadata.
+  - `pull` is the low-level inbox polling path.
+
+### `config`
+
+- `config setup`
+  - Runs schema-driven interactive prompts for server or client config.
+- `config set/get/list`
+  - Supports `-s/--server`, `-c/--client`, and `-a <name>/--agent <name>`.
+  - Defaults to server scope if no scope flag is provided.
+  - `list` and `get` hide secret fields unless `--show-secrets` is passed.
+
+### Top-Level `status`
+
+- Summarizes:
+  - Current server health
+  - Database config presence
+  - Number of local configured agents
+  - Whether client config exists and what server URL it points to
+- Use this when the user asks for a compact overall state, not a deep readiness diagnosis.
+
+### `onboard`
+
+- `onboard --check`
+  - Shows readiness and missing inputs without making changes.
+- `onboard`
+  - Phase 1 workflow.
+  - Resolves or clones the Context Tree repo using server configuration.
+  - Creates or updates member `NODE.md` entries in the Context Tree.
+  - Verifies the tree with `first-tree verify`.
+  - Creates a branch, commit, push, and PR in the Context Tree repo.
+- `onboard --continue`
+  - Phase 2 workflow after the Context Tree PR is merged.
+  - Waits for the server to sync the new agent.
+  - Bootstraps the token.
+  - Optionally binds a Feishu bot.
+  - Writes `client.yaml` so `client start` works without extra setup.
+
+## Config and Environment Model
+
+### Config priority
+
+1. CLI args
+2. Environment variables
+3. YAML config files
+4. Auto-generated values
+5. Built-in defaults
+
+### Default config paths
+
+- `~/.first-tree-hub/config/server.yaml`
+- `~/.first-tree-hub/config/client.yaml`
+- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+
+### Default runtime paths
+
+- `~/.first-tree-hub/data/sessions/`
+- `~/.first-tree-hub/data/workspaces/`
+- `~/.first-tree-hub/data/postgres/`
+
+### Important environment variables
+
+- Server:
+  - `FIRST_TREE_HUB_DATABASE_URL`
+  - `FIRST_TREE_HUB_PORT`
+  - `FIRST_TREE_HUB_HOST`
+  - `FIRST_TREE_HUB_JWT_SECRET`
+  - `FIRST_TREE_HUB_ENCRYPTION_KEY`
+  - `FIRST_TREE_HUB_CONTEXT_TREE_REPO`
+  - `FIRST_TREE_HUB_GITHUB_TOKEN`
+  - `FIRST_TREE_HUB_WEB_DIST_PATH`
+- Client:
+  - `FIRST_TREE_HUB_SERVER_URL`
+  - `FIRST_TREE_HUB_LOG_LEVEL`
+- Agent debugging:
+  - `FIRST_TREE_HUB_TOKEN`
+  - `FIRST_TREE_HUB_SERVER`
+
+## When to Read Other Docs
+
+- Read `docs/cli-reference.md` for the full public command reference.
+- Read `docs/onboarding-guide.md` for onboarding examples and type-specific behavior.
+- Read `docs/claim-agent-guide.md` for claim-agent and Feishu user binding flows.
+- Read `docs/deployment-guide.md` when the request is about Docker, Railway, Render, Supabase, HTTPS, or multi-machine deployment.

--- a/.agents/skills/first-tree-hub-cli/references/core-concepts.md
+++ b/.agents/skills/first-tree-hub-cli/references/core-concepts.md
@@ -1,0 +1,117 @@
+# First Tree Hub Core Concepts
+
+## Product Boundary
+
+First Tree Hub is shared infrastructure for agent teams.
+
+- It provides identity sync, authentication, messaging, adapter bridges, and the admin dashboard.
+- It is not the LLM agent runtime itself.
+- It is not the orchestration framework.
+- It is not the Context Tree.
+
+Use this distinction consistently when explaining the system or choosing where a change belongs.
+
+## Package Roles
+
+- `packages/server`
+  - Fastify API server, admin APIs, agent APIs, database access, sync jobs, adapters, notifications
+- `packages/client`
+  - Agent SDK, runtime, WebSocket connection management, workspace/session handling
+- `packages/command`
+  - Unified CLI entry point plus reusable core orchestration helpers
+- `packages/shared`
+  - Zod schemas, TypeScript types, and schema-driven config system shared across packages
+- `packages/web`
+  - React admin dashboard served by the server
+
+The command package depends on server and client packages, but it is still an entry layer. Keep business logic in reusable core modules instead of duplicating it in Commander handlers.
+
+## Architecture Invariants
+
+### PostgreSQL is the single persistent system
+
+- Persistent business state lives in PostgreSQL.
+- The server is otherwise stateless.
+- There is no Redis or separate message queue in the intended design.
+
+### Context Tree is the source of identity truth
+
+- Agent identities come from a Context Tree GitHub repo.
+- The server syncs those identities on startup, periodically, and via manual trigger paths.
+- Hub reads the tree and turns it into runtime identity records.
+- Removed members are suspended rather than silently forgotten.
+
+### Inbox is the server-client boundary
+
+- The server writes messages to inbox rows.
+- Delivery is fan-out on write and at-least-once.
+- Clients receive WebSocket notifications and can also pull.
+- The client side is responsible for deduplication and session/workspace management.
+
+### Auth paths are isolated
+
+- Agent API uses agent Bearer tokens.
+- Admin API uses admin JWT.
+- These are separate security domains even on localhost.
+
+### Messages are immutable and time-ordered
+
+- Message IDs use UUID v7.
+- Messages are treated as immutable after creation.
+
+## Runtime Mental Model
+
+### Server startup
+
+`server start` is more than "run Fastify".
+
+It can:
+
+- collect missing config interactively
+- provision PostgreSQL if the user did not provide one
+- run migrations
+- create the first admin account
+- discover or build the web dist
+- start the server with a generated instance ID
+
+### Client startup
+
+`client start` runs all locally configured agents against one Hub server.
+
+The client runtime:
+
+- reads `client.yaml`
+- reads all configured agent YAML files
+- establishes WebSocket and HTTP communication
+- manages session state and isolated chat workspaces
+- syncs a shared Context Tree clone for local context hydration
+
+### Workspace bootstrap
+
+When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files.
+
+If the Context Tree clone is available, it copies:
+
+- `self.md` from the agent's `members/.../NODE.md`
+- `agent-instructions.md` from the root `AGENT.md`
+- `domain-map.md` from the root `NODE.md`
+
+If the Context Tree is unavailable, it writes degraded-mode context so the runtime can continue without organizational metadata.
+
+## Onboarding Mental Model
+
+`onboard` is intentionally higher-level than the rest of the CLI.
+
+- Phase 1 works in the Context Tree repo, not the Hub repo.
+- Phase 2 waits for the server to sync the newly merged identity, then bootstraps runtime access.
+- This is the supported path for creating new members because identity lives outside Hub itself.
+
+Do not replace this with ad hoc file creation or manual local git operations unless the user explicitly wants to bypass the normal flow for development or debugging.
+
+## Common Misunderstandings to Avoid
+
+- Do not say that `agent add` creates an identity in Hub. It only creates local client config.
+- Do not say that `client start` starts the server. It only runs configured agent clients.
+- Do not say that Hub owns organizational truth. The Context Tree does.
+- Do not frame the inbox as exactly-once delivery. The contract is at-least-once with client-side deduplication.
+- Do not mix up admin and agent credentials.

--- a/.agents/skills/first-tree-hub-cli/references/developer-map.md
+++ b/.agents/skills/first-tree-hub-cli/references/developer-map.md
@@ -1,0 +1,139 @@
+# First Tree Hub Developer Map
+
+## Repo Entry Points
+
+- `AGENTS.md`
+  - Architecture rules, conventions, package map, and development workflow
+- `README.md`
+  - Product framing, quick start, and top-level documentation links
+- `docs/cli-reference.md`
+  - Public command and environment variable reference
+- `docs/onboarding-guide.md`
+  - End-to-end onboarding flow
+- `docs/claim-agent-guide.md`
+  - Claim and Feishu binding details
+
+## CLI Source Map
+
+- `packages/command/src/cli/index.ts`
+  - Top-level Commander program and command registration
+- `packages/command/src/commands/server.ts`
+  - `server` subcommands
+- `packages/command/src/commands/client.ts`
+  - `client` subcommands
+- `packages/command/src/commands/agent.ts`
+  - local agent management, bindings, workspace cleanup, messaging utilities
+- `packages/command/src/commands/config.ts`
+  - scope-aware config set/get/list/setup flows
+- `packages/command/src/commands/status.ts`
+  - top-level overview command
+- `packages/command/src/commands/onboard.ts`
+  - high-level interactive entry for onboarding
+
+## Reusable Core Logic
+
+- `packages/command/src/core/server.ts`
+  - orchestration for `server start`, including config prompts, Docker PostgreSQL, migrations, admin creation, and web dist resolution
+- `packages/command/src/core/onboard.ts`
+  - Context Tree checkout, member file generation, verification, PR creation, and post-merge continuation flow
+- `packages/command/src/core/bootstrap.ts`
+  - token bootstrap helpers and server URL resolution
+- `packages/command/src/core/doctor.ts`
+  - readiness checks used by `server doctor` and `client doctor`
+- `packages/command/src/core/feishu.ts`
+  - Feishu binding helpers
+- `packages/command/src/core/prompt.ts`
+  - schema-driven prompting behavior
+
+If you change command behavior, there is a good chance the real logic belongs in one of these core modules rather than in the command handler itself.
+
+## Shared Config and Schema Files
+
+- `packages/shared/src/config/server-config.ts`
+  - server config schema, defaults, prompts, env names
+- `packages/shared/src/config/client-config.ts`
+  - client config schema
+- `packages/shared/src/config/agent-config.ts`
+  - agent config schema
+- `packages/shared/src/config/resolver.ts`
+  - config priority resolution, YAML reading/writing, auto-generation
+
+If a flag, env var, or config key changes, inspect these files and update docs accordingly.
+
+## Client and Server Runtime Files
+
+- `packages/client/src/sdk.ts`
+  - agent SDK surface used by debugging flows and runtime internals
+- `packages/client/src/runtime/runtime.ts`
+  - runtime orchestration for configured agents
+- `packages/client/src/runtime/bootstrap.ts`
+  - Context Tree clone sync and `.agent/` workspace bootstrap
+- `packages/client/src/runtime/session-manager.ts`
+  - session lifecycle and dedup-sensitive message dispatch
+- `packages/server/src/app.ts`
+  - server wiring, route registration, background jobs, Context Tree sync start
+- `packages/server/src/services/inbox.ts`
+  - inbox poll/ack/renew behavior
+- `packages/server/src/services/context-tree-graphql.ts`
+  - Context Tree member fetch and sync behavior
+
+## Change Patterns
+
+### Add or change a CLI command
+
+1. Update or add the command handler in `packages/command/src/commands/`.
+2. Move reusable logic into `packages/command/src/core/`.
+3. Register the command from `packages/command/src/cli/index.ts` if it is new.
+4. Update barrel exports if the functionality should be imported by external consumers.
+5. Update `docs/cli-reference.md`.
+
+### Change onboarding behavior
+
+1. Update `packages/command/src/commands/onboard.ts` only for argument shape or interaction flow.
+2. Put the real behavior in `packages/command/src/core/onboard.ts`.
+3. Update `docs/onboarding-guide.md`.
+4. Update `docs/claim-agent-guide.md` too if claim or binding behavior changes.
+
+### Change config behavior
+
+1. Update the relevant schema under `packages/shared/src/config/`.
+2. Check whether prompt text, defaults, env names, or secret masking rules also need changes.
+3. Update `docs/cli-reference.md`.
+4. Re-test the matching `config`, `server`, or `client` flows.
+
+### Change messaging or agent runtime behavior
+
+1. Start with `packages/command/src/commands/agent.ts` if the CLI surface changes.
+2. Inspect `packages/client/src/sdk.ts` and `packages/client/src/runtime/` if client runtime semantics change.
+3. Inspect `packages/server/src/api/agent/` and `packages/server/src/services/` if server contracts change.
+4. Update shared schemas in `packages/shared/src/schemas/` when payload shapes change.
+
+## Validation Commands
+
+Run the smallest relevant set first, then expand if the change touches cross-package behavior.
+
+```bash
+pnpm check
+pnpm typecheck
+pnpm --filter @agent-team-foundation/first-tree-hub test
+pnpm --filter @first-tree-hub/client test
+pnpm --filter @first-tree-hub/server test
+```
+
+Use the package-specific commands when only one area changed, but keep in mind that the command package depends on shared behavior in `client`, `server`, and `shared`.
+
+## External Consumption
+
+The published CLI package is `@agent-team-foundation/first-tree-hub`.
+
+Its public CLI binary is:
+
+```bash
+first-tree-hub
+```
+
+Its reusable code surface is also intended to be importable by other tools. When you add reusable CLI-adjacent behavior, preserve that separation:
+
+- thin command handler for argument parsing
+- reusable `core/*` function for behavior
+- re-export through `packages/command/src/index.ts` when appropriate

--- a/.agents/skills/first-tree-hub-cli/references/onboarding-operator.md
+++ b/.agents/skills/first-tree-hub-cli/references/onboarding-operator.md
@@ -1,0 +1,137 @@
+# First Tree Hub Onboarding Operator Playbook
+
+Use this file when an external agent receives an onboarding task such as "install First Tree Hub CLI, read the onboarding guide with `gh`, and add a member."
+
+## Core Rule
+
+- Use `first-tree-hub onboard` for the workflow.
+- Do not manually edit the Context Tree, create git branches, or open PRs by hand unless the CLI flow is broken and the user explicitly wants a manual fallback.
+
+## When the Prompt Starts From Scratch
+
+If the task only gives you a package name, a docs URL, and a server URL, normalize it into this sequence:
+
+1. Confirm tooling:
+   - `gh` is installed and authenticated with write access to the Context Tree repository.
+   - Node is new enough to run the published CLI.
+2. Install the CLI:
+   - Preferred: `npm install -g @agent-team-foundation/first-tree-hub`
+   - If the caller installed locally with `npm i @agent-team-foundation/first-tree-hub`, use `npx first-tree-hub ...`
+3. Read the canonical guide with `gh`:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+4. Run readiness first:
+
+```bash
+first-tree-hub onboard --check --server <url> ...
+```
+
+5. Run Phase 1 to create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --server <url> ...
+```
+
+6. After the PR is merged, run Phase 2:
+
+```bash
+first-tree-hub onboard --continue --server <url> ...
+```
+
+7. Start the runtime when this machine should host the configured agent:
+
+```bash
+first-tree-hub client start
+```
+
+## Prompt Template Interpretation
+
+If the automation says something like:
+
+```text
+请先安装 npm i @agent-team-foundation/first-tree-hub
+然后使用 gh 命令阅读 docs/onboarding-guide.md，帮我添加成员。
+Server url 是 https://first-tree.staging.unispark.dev/
+```
+
+interpret it as:
+
+- Install or invoke the published CLI.
+- Fetch the guide with `gh` rather than relying on a browser-only read.
+- Use `https://first-tree.staging.unispark.dev/` as the Hub server URL in the onboarding commands.
+- Execute the supported `onboard` flow instead of hand-editing member files.
+
+## Minimal Inputs to Collect
+
+- Required:
+  - member type: `human`, `personal_assistant`, or `autonomous_agent`
+  - `id`
+  - `role`
+  - `domains`
+  - `server` URL when it is not already configured
+- Optional:
+  - `display-name`
+  - `assistant` only for `human`
+  - Feishu bot credentials only when a bot binding should be created
+
+Prefer `first-tree-hub onboard --check` to reveal missing fields instead of guessing.
+
+## Type-Specific Notes
+
+- `human`
+  - May include `--assistant <id>` to create a personal assistant.
+  - If Feishu bot binding is configured, remind the human to send `/bind <id>` afterwards.
+- `autonomous_agent`
+  - Do not use `--assistant`.
+  - Feishu bot binding is optional.
+- `personal_assistant`
+  - Usually created through the human flow rather than as a separate top-level request.
+
+## Example Commands
+
+### Human + assistant
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+### Autonomous agent
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```

--- a/.agents/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/.agents/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -2,19 +2,51 @@
 
 Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
 
+## 0. "I do not have first-tree-hub installed yet"
+
+Use this before any operational flow when the machine may not have the CLI.
+
+### Recommended flow
+
+1. Verify Node.js is supported:
+
+```bash
+node --version
+```
+
+2. Install and verify the CLI:
+
+```bash
+npm install -g @agent-team-foundation/first-tree-hub
+first-tree-hub --version
+```
+
+3. If the user will use `onboard` or `agent token bootstrap`, make sure GitHub CLI is authenticated:
+
+```bash
+gh auth status
+```
+
+### What to remember
+
+- First Tree Hub requires Node.js `>= 22.16`.
+- Do not jump straight to `server start`, `client start`, or `onboard` on a machine where installation is still unknown.
+
 ## 1. "Help me get First Tree Hub running locally"
 
 Use this when the user is setting up a local Hub for the first time.
 
 ### Recommended flow
 
-1. Start with:
+1. If installation is unknown, do scenario 0 first.
+
+2. Start with:
 
 ```bash
 first-tree-hub server start
 ```
 
-2. If the user wants a non-interactive setup, switch to:
+3. If the user wants a non-interactive setup, switch to:
 
 ```bash
 first-tree-hub server start --no-interactive
@@ -22,7 +54,7 @@ first-tree-hub server start --no-interactive
 
 and make sure the required environment variables or config already exist.
 
-3. If startup fails, move to:
+4. If startup fails, move to:
 
 ```bash
 first-tree-hub server doctor
@@ -34,6 +66,7 @@ first-tree-hub status
 - `server start` is the happy-path bootstrap command.
 - It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
 - If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+- If the CLI is not installed yet, installation is part of the correct flow rather than a side detail.
 
 ## 2. "Connect my local agent machine to an existing Hub"
 
@@ -83,25 +116,30 @@ Use this when the user wants to add a real person to the team through the suppor
 
 ### Recommended flow
 
-1. Dry-run requirements first:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Dry-run requirements first:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After the PR is merged, continue:
+4. After the PR is merged, continue:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 ```
 
-4. Start the local runtime if this machine should run the assistant:
+5. Start the local runtime if this machine should run the assistant:
 
 ```bash
 first-tree-hub client start
@@ -111,6 +149,7 @@ first-tree-hub client start
 
 - `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
 - For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
 
 ## 4. "Onboard a standalone autonomous agent"
@@ -119,28 +158,34 @@ Use this when the new member is a bot with no human owner.
 
 ### Recommended flow
 
-1. Check:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Check:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After merge:
+4. After merge:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 first-tree-hub client start
 ```
 
 ### What to remember
 
 - Do not use `--assistant` for `autonomous_agent`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - Feishu bot binding is optional here, unlike the human `/bind` flow.
 
 ## 5. "Why can't the client connect?" or "Why does startup fail?"

--- a/.agents/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/.agents/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -1,0 +1,245 @@
+# First Tree Hub Scenario Playbooks
+
+Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
+
+## 1. "Help me get First Tree Hub running locally"
+
+Use this when the user is setting up a local Hub for the first time.
+
+### Recommended flow
+
+1. Start with:
+
+```bash
+first-tree-hub server start
+```
+
+2. If the user wants a non-interactive setup, switch to:
+
+```bash
+first-tree-hub server start --no-interactive
+```
+
+and make sure the required environment variables or config already exist.
+
+3. If startup fails, move to:
+
+```bash
+first-tree-hub server doctor
+first-tree-hub status
+```
+
+### What to remember
+
+- `server start` is the happy-path bootstrap command.
+- It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
+- If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+
+## 2. "Connect my local agent machine to an existing Hub"
+
+Use this when the Hub server already exists and the user wants a local client runtime.
+
+### Recommended flow
+
+1. Ensure client config points at the server:
+
+```bash
+first-tree-hub config setup -c
+```
+
+or:
+
+```bash
+first-tree-hub config set -c server.url http://host:8000
+```
+
+2. Add the local agent config:
+
+```bash
+first-tree-hub agent add <name> --token <token>
+```
+
+3. Start the runtime:
+
+```bash
+first-tree-hub client start
+```
+
+4. If something looks wrong, inspect:
+
+```bash
+first-tree-hub client doctor
+first-tree-hub client status
+```
+
+### What to remember
+
+- `agent add` is local-only configuration.
+- `client start` runs all locally configured agents, not just one.
+
+## 3. "Onboard a new human member"
+
+Use this when the user wants to add a real person to the team through the supported identity flow.
+
+### Recommended flow
+
+1. Dry-run requirements first:
+
+```bash
+first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+3. After the PR is merged, continue:
+
+```bash
+first-tree-hub onboard --continue
+```
+
+4. Start the local runtime if this machine should run the assistant:
+
+```bash
+first-tree-hub client start
+```
+
+### What to remember
+
+- `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
+- For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
+
+## 4. "Onboard a standalone autonomous agent"
+
+Use this when the new member is a bot with no human owner.
+
+### Recommended flow
+
+1. Check:
+
+```bash
+first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+3. After merge:
+
+```bash
+first-tree-hub onboard --continue
+first-tree-hub client start
+```
+
+### What to remember
+
+- Do not use `--assistant` for `autonomous_agent`.
+- Feishu bot binding is optional here, unlike the human `/bind` flow.
+
+## 5. "Why can't the client connect?" or "Why does startup fail?"
+
+Use this for diagnosis before editing code.
+
+### Recommended flow
+
+1. Check top-level state:
+
+```bash
+first-tree-hub status
+```
+
+2. Run the relevant doctor:
+
+```bash
+first-tree-hub client doctor
+```
+
+or:
+
+```bash
+first-tree-hub server doctor
+```
+
+3. Inspect effective config:
+
+```bash
+first-tree-hub config list -c
+first-tree-hub config list -s
+```
+
+4. If the server should already be running, probe health directly:
+
+```bash
+first-tree-hub server status
+```
+
+### What to remember
+
+- Prefer diagnosis commands before changing YAML files by hand.
+- Server issues and client issues often look similar; make the user goal explicit before debugging.
+
+## 6. "Help me debug messaging between agents"
+
+Use this when the user wants to verify delivery, inspect chats, or send test messages manually.
+
+### Recommended flow
+
+1. Make sure agent debug auth is available:
+
+```bash
+export FIRST_TREE_HUB_TOKEN=...
+```
+
+2. Send a message:
+
+```bash
+first-tree-hub agent send <agentId> "hello"
+```
+
+or to an existing chat:
+
+```bash
+first-tree-hub agent send <chatId> "hello" --chat
+```
+
+3. Inspect chats and history:
+
+```bash
+first-tree-hub agent chats
+first-tree-hub agent history <chatId>
+```
+
+4. Fall back to low-level inbox polling if needed:
+
+```bash
+first-tree-hub agent pull
+```
+
+### What to remember
+
+- These commands are for debugging and operator visibility, not the normal runtime path.
+- If a user only wants to run their agents normally, `client start` is the main flow.
+
+## 7. "Change how the CLI behaves"
+
+Use this when the user wants a code change rather than an operational action.
+
+### Recommended flow
+
+1. Find the matching command handler in `packages/command/src/commands/`.
+2. Move behavior into `packages/command/src/core/` if the logic is reusable.
+3. Update the corresponding docs in `docs/cli-reference.md` or `docs/onboarding-guide.md`.
+4. Validate with the smallest relevant command/package test set.
+
+### What to remember
+
+- Command handlers should stay thin.
+- Config changes usually require updates in `packages/shared/src/config/`.
+- Onboarding changes often touch both `commands/onboard.ts` and `core/onboard.ts`.

--- a/.agents/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
+++ b/.agents/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+compare_dir() {
+  local left="$1"
+  local right="$2"
+  if [[ ! -d "$left" ]]; then
+    echo "Missing directory: $left" >&2
+    return 1
+  fi
+  if [[ ! -d "$right" ]]; then
+    echo "Missing directory: $right" >&2
+    return 1
+  fi
+  diff -qr "$left" "$right"
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-hub-cli"
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"
+
+echo "Skill source and mirrors are in sync."

--- a/.agents/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
+++ b/.agents/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+for mirror_root in "$REPO_ROOT/.agents/skills/first-tree-hub-cli" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"; do
+  mkdir -p "$(dirname "$mirror_root")"
+  rsync -a --delete "$SOURCE_DIR/" "$mirror_root/"
+done
+
+echo "Exported mirrors to .agents/skills/first-tree-hub-cli and .claude/skills/first-tree-hub-cli"

--- a/.agents/skills/first-tree-hub-cli/scripts/quick_validate.py
+++ b/.agents/skills/first-tree-hub-cli/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Portable quick validator for a skill directory.
+
+This version is intentionally self-contained so it can run in CI and in copied
+skill folders without depending on external Python packages.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MAX_SKILL_NAME_LENGTH = 64
+
+
+def extract_frontmatter(text: str) -> tuple[bool, str]:
+    if not text.startswith("---\n"):
+        return False, "No YAML frontmatter found"
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+    return True, match.group(1)
+
+
+def parse_simple_frontmatter(frontmatter: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.startswith(("'", '"')) and value.endswith(("'", '"')) and len(value) >= 2:
+            value = value[1:-1]
+        data[key] = value
+    return data
+
+
+def validate_skill(skill_path: str) -> tuple[bool, str]:
+    skill_dir = Path(skill_path)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    content = skill_md.read_text()
+    ok, frontmatter_or_error = extract_frontmatter(content)
+    if not ok:
+        return False, frontmatter_or_error
+
+    frontmatter = parse_simple_frontmatter(frontmatter_or_error)
+
+    unexpected = set(frontmatter.keys()) - {"name", "description"}
+    if unexpected:
+        return False, f"Unexpected key(s) in frontmatter: {', '.join(sorted(unexpected))}"
+
+    name = frontmatter.get("name", "").strip()
+    if not name:
+        return False, "Missing 'name' in frontmatter"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return False, f"Name '{name}' should be hyphen-case"
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return False, f"Name is too long ({len(name)} > {MAX_SKILL_NAME_LENGTH})"
+
+    description = frontmatter.get("description", "").strip()
+    if not description:
+        return False, "Missing 'description' in frontmatter"
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} > 1024)"
+
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    if not openai_yaml.exists():
+        return False, "agents/openai.yaml not found"
+
+    return True, "Skill is valid!"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: quick_validate.py <skill_directory>")
+        return 1
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
+++ b/.agents/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$SCRIPT_DIR/export-skill-mirrors.sh"

--- a/.claude/skills/first-tree-hub-cli/SKILL.md
+++ b/.claude/skills/first-tree-hub-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-hub-cli
-description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
 ---
 
 # First Tree Hub CLI
@@ -13,8 +13,10 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ## Start Here
 
 1. Classify the task before acting.
+   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
+   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -26,6 +28,11 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - `docs/onboarding-guide.md` for the full onboarding flow
    - `docs/claim-agent-guide.md` when claim or binding flows matter
    - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
+4. On a fresh machine, verify prerequisites before proposing a flow.
+   - Node.js `>= 22.16`
+   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
+   - Verify with `first-tree-hub --version`
+   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
 
 ## Operating Rules
 
@@ -42,12 +49,17 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
   - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
+- Keep the server URL knobs straight.
+  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
+  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.
-  - Server: `~/.first-tree-hub/config/server.yaml`
-  - Client: `~/.first-tree-hub/config/client.yaml`
-  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
+  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
+  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
+  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+  - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
 - Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
 
 ## Common Workflows
@@ -55,12 +67,41 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ### Choose a Command
 
 - First local boot or quick demo: `first-tree-hub server start`
+- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
 - Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
 - Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
 - Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
 - Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
 - Clean stale chat workspaces: `first-tree-hub agent workspace clean`
 - Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
+
+### Run Onboarding From an Agent Prompt
+
+- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
+- If the environment does not already have the repo checked out or the CLI installed:
+  - Ensure `gh` is available and authenticated.
+  - Install the published package.
+    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
+    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
+  - Read the canonical onboarding guide with `gh` before acting, for example:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
+- Default operator flow:
+
+```bash
+first-tree-hub onboard --check ...
+first-tree-hub onboard --server <url> ...
+# wait for Context Tree PR merge
+first-tree-hub onboard --continue --server <url> ...
+first-tree-hub client start
+```
+
+- Prefer `onboard --check` before asking follow-up questions or creating the PR.
+- Do not manually create Context Tree member files, branches, commits, or PRs when `first-tree-hub onboard` can do it.
 
 ### Modify Code Safely
 
@@ -89,5 +130,6 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
 - `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
+- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/.claude/skills/first-tree-hub-cli/SKILL.md
+++ b/.claude/skills/first-tree-hub-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-hub-cli
-description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Operate and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around Context Tree sync, inbox delivery, and workspace bootstrap. Use when Codex needs to run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
 ---
 
 # First Tree Hub CLI
@@ -13,10 +13,8 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ## Start Here
 
 1. Classify the task before acting.
-   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
    - Operate or diagnose a Hub deployment: read `references/command-surface.md`
    - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
-   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
    - Explain product or architecture concepts: read `references/core-concepts.md`
    - Modify CLI or related behavior in code: read `references/developer-map.md`
 2. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
@@ -28,11 +26,6 @@ Keep the central mental model straight: First Tree Hub is the communication back
    - `docs/onboarding-guide.md` for the full onboarding flow
    - `docs/claim-agent-guide.md` when claim or binding flows matter
    - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
-4. On a fresh machine, verify prerequisites before proposing a flow.
-   - Node.js `>= 22.16`
-   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
-   - Verify with `first-tree-hub --version`
-   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
 
 ## Operating Rules
 
@@ -49,17 +42,12 @@ Keep the central mental model straight: First Tree Hub is the communication back
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
   - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
-- Keep the server URL knobs straight.
-  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
-  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.
-  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
-  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
-  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
-  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
-  - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
+  - Server: `~/.first-tree-hub/config/server.yaml`
+  - Client: `~/.first-tree-hub/config/client.yaml`
+  - Agent: `~/.first-tree-hub/config/agents/<name>/agent.yaml`
 - Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
 
 ## Common Workflows
@@ -67,41 +55,12 @@ Keep the central mental model straight: First Tree Hub is the communication back
 ### Choose a Command
 
 - First local boot or quick demo: `first-tree-hub server start`
-- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
 - Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
 - Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
 - Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
 - Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
 - Clean stale chat workspaces: `first-tree-hub agent workspace clean`
 - Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
-
-### Run Onboarding From an Agent Prompt
-
-- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
-- If the environment does not already have the repo checked out or the CLI installed:
-  - Ensure `gh` is available and authenticated.
-  - Install the published package.
-    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
-    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
-  - Read the canonical onboarding guide with `gh` before acting, for example:
-
-```bash
-gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
-```
-
-- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
-- Default operator flow:
-
-```bash
-first-tree-hub onboard --check ...
-first-tree-hub onboard --server <url> ...
-# wait for Context Tree PR merge
-first-tree-hub onboard --continue --server <url> ...
-first-tree-hub client start
-```
-
-- Prefer `onboard --check` before asking follow-up questions or creating the PR.
-- Do not manually create Context Tree member files, branches, commits, or PRs when `first-tree-hub onboard` can do it.
 
 ### Modify Code Safely
 
@@ -130,6 +89,5 @@ pnpm --filter @agent-team-foundation/first-tree-hub test
 
 - `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
 - `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
-- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
 - `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
 - `references/developer-map.md` for package ownership, source-file entry points, and change workflows

--- a/.claude/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/.claude/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree Hub CLI"
-  short_description: "Understand and operate First Tree Hub CLI"
-  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."
+  short_description: "Install, operate, and modify First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to install, inspect, configure, onboard, debug, and operate First Tree Hub correctly."

--- a/.claude/skills/first-tree-hub-cli/agents/openai.yaml
+++ b/.claude/skills/first-tree-hub-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "First Tree Hub CLI"
+  short_description: "Understand and operate First Tree Hub CLI"
+  default_prompt: "Use $first-tree-hub-cli to inspect, configure, onboard, and operate First Tree Hub correctly."

--- a/.claude/skills/first-tree-hub-cli/references/command-surface.md
+++ b/.claude/skills/first-tree-hub-cli/references/command-surface.md
@@ -4,6 +4,7 @@
 
 | User intent | Preferred entry point | Non-obvious note |
 | --- | --- | --- |
+| Install or verify the CLI on a fresh machine | `npm install -g @agent-team-foundation/first-tree-hub` then `first-tree-hub --version` | Requires Node.js `>= 22.16`; use this before proposing runtime commands on a machine that may not have the CLI yet |
 | Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
 | Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
 | See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
@@ -33,6 +34,7 @@
   - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
 - `server status`
   - Performs a health request against `/api/v1/health`.
+  - Uses `FIRST_TREE_HUB_SERVER_URL` when set; otherwise defaults to `http://localhost:8000`.
 - `server db:migrate`
   - Uses the configured database and applies migrations.
 - `server admin:create`
@@ -107,6 +109,7 @@
   - Bootstraps the token.
   - Optionally binds a Feishu bot.
   - Writes `client.yaml` so `client start` works without extra setup.
+  - Persists resume state under `$FIRST_TREE_HUB_HOME/.onboard-state.json`.
 
 ## Config and Environment Model
 
@@ -120,18 +123,23 @@
 
 ### Default config paths
 
-- `~/.first-tree-hub/config/server.yaml`
-- `~/.first-tree-hub/config/client.yaml`
-- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+- Home root defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` overrides it.
+- `$FIRST_TREE_HUB_HOME/config/server.yaml`
+- `$FIRST_TREE_HUB_HOME/config/client.yaml`
+- `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
 
 ### Default runtime paths
 
-- `~/.first-tree-hub/data/sessions/`
-- `~/.first-tree-hub/data/workspaces/`
-- `~/.first-tree-hub/data/postgres/`
+- `$FIRST_TREE_HUB_HOME/.onboard-state.json`
+- `$FIRST_TREE_HUB_HOME/context-tree/`
+- `$FIRST_TREE_HUB_HOME/data/sessions/`
+- `$FIRST_TREE_HUB_HOME/data/workspaces/`
+- `$FIRST_TREE_HUB_HOME/data/postgres/`
 
 ### Important environment variables
 
+- Global:
+  - `FIRST_TREE_HUB_HOME`
 - Server:
   - `FIRST_TREE_HUB_DATABASE_URL`
   - `FIRST_TREE_HUB_PORT`
@@ -144,9 +152,11 @@
 - Client:
   - `FIRST_TREE_HUB_SERVER_URL`
   - `FIRST_TREE_HUB_LOG_LEVEL`
-- Agent debugging:
+- Onboard and agent debugging:
   - `FIRST_TREE_HUB_TOKEN`
   - `FIRST_TREE_HUB_SERVER`
+  - `FEISHU_APP_ID`
+  - `FEISHU_APP_SECRET`
 
 ## When to Read Other Docs
 

--- a/.claude/skills/first-tree-hub-cli/references/command-surface.md
+++ b/.claude/skills/first-tree-hub-cli/references/command-surface.md
@@ -1,0 +1,156 @@
+# First Tree Hub Command Surface
+
+## Quick Decision Guide
+
+| User intent | Preferred entry point | Non-obvious note |
+| --- | --- | --- |
+| Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
+| Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
+| See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
+| Start all configured agents | `first-tree-hub client start` | Loads every agent config under `~/.first-tree-hub/config/agents/` |
+| Manage local config files | `first-tree-hub config ...` | Scope defaults to server unless `-c` or `-a <name>` is passed |
+| Add or remove a local agent config | `first-tree-hub agent add/remove/list` | This is local configuration, not Context Tree identity management |
+| Bootstrap an agent token from GitHub identity | `first-tree-hub agent token bootstrap <agentId>` | Requires `gh` auth and a Hub server that already knows the agent |
+| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_TOKEN`; these are low-level debugging utilities |
+| Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Removes stale workspaces only when there is no active non-evicted session |
+| Onboard a new human or autonomous agent | `first-tree-hub onboard` | Creates a PR in the Context Tree repo, not in `first-tree-hub` itself |
+
+## Command Families
+
+### `server`
+
+- `server start`
+  - Best default for first-run local usage.
+  - Prompts for missing required server config unless `--no-interactive` is used.
+  - If no database URL is provided, it can auto-start a managed PostgreSQL container via Docker.
+  - Runs migrations automatically.
+  - Creates the default `admin` user if the database has none.
+  - Resolves or builds the web dist so the server can host the admin UI.
+- `server stop`
+  - Only stops the managed PostgreSQL container used by the CLI workflow.
+  - It does not stop an already-running standalone Fastify process.
+- `server doctor`
+  - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
+- `server status`
+  - Performs a health request against `/api/v1/health`.
+- `server db:migrate`
+  - Uses the configured database and applies migrations.
+- `server admin:create`
+  - Creates an admin user directly against the configured database.
+
+### `client`
+
+- `client start`
+  - Initializes client config, loads all configured agents, creates a `ClientRuntime`, and keeps it alive until interrupted.
+  - Fails if there are no configured agents.
+- `client doctor`
+  - Checks Node version, client config, server reachability, agent configs, token validity, and WebSocket reachability.
+- `client status`
+  - Lists configured local agents and masked tokens.
+- `client stop`
+  - Currently informational only; there is no daemon manager yet.
+
+### `agent`
+
+- `agent add [name]`
+  - Writes `~/.first-tree-hub/config/agents/<name>/agent.yaml`.
+  - Prompts interactively if name or token is missing.
+- `agent remove <name>`
+  - Deletes the agent config and also removes runtime workspaces and the saved session registry for that agent.
+- `agent list`
+  - Reads local configured agents and masks tokens in output.
+- `agent workspace clean [agent-name] [--ttl <days>]`
+  - Cleans stale workspace directories under `~/.first-tree-hub/data/workspaces/`.
+  - Skips chat workspaces that still have an active session in the session registry.
+- `agent token bootstrap <agentId>`
+  - Uses GitHub identity and the server's bootstrap endpoint to create or retrieve an agent token.
+  - `--save-to agent` stores the token in the local agent config by default.
+- `agent bind ...`
+  - Used for Feishu bindings. Read `docs/claim-agent-guide.md` when claim/bind flows matter.
+- `agent send/chats/history/register/pull`
+  - These are SDK-style debugging commands.
+  - They require `FIRST_TREE_HUB_TOKEN`.
+  - `send` supports direct target vs `--chat`, stdin piping, and reply metadata.
+  - `pull` is the low-level inbox polling path.
+
+### `config`
+
+- `config setup`
+  - Runs schema-driven interactive prompts for server or client config.
+- `config set/get/list`
+  - Supports `-s/--server`, `-c/--client`, and `-a <name>/--agent <name>`.
+  - Defaults to server scope if no scope flag is provided.
+  - `list` and `get` hide secret fields unless `--show-secrets` is passed.
+
+### Top-Level `status`
+
+- Summarizes:
+  - Current server health
+  - Database config presence
+  - Number of local configured agents
+  - Whether client config exists and what server URL it points to
+- Use this when the user asks for a compact overall state, not a deep readiness diagnosis.
+
+### `onboard`
+
+- `onboard --check`
+  - Shows readiness and missing inputs without making changes.
+- `onboard`
+  - Phase 1 workflow.
+  - Resolves or clones the Context Tree repo using server configuration.
+  - Creates or updates member `NODE.md` entries in the Context Tree.
+  - Verifies the tree with `first-tree verify`.
+  - Creates a branch, commit, push, and PR in the Context Tree repo.
+- `onboard --continue`
+  - Phase 2 workflow after the Context Tree PR is merged.
+  - Waits for the server to sync the new agent.
+  - Bootstraps the token.
+  - Optionally binds a Feishu bot.
+  - Writes `client.yaml` so `client start` works without extra setup.
+
+## Config and Environment Model
+
+### Config priority
+
+1. CLI args
+2. Environment variables
+3. YAML config files
+4. Auto-generated values
+5. Built-in defaults
+
+### Default config paths
+
+- `~/.first-tree-hub/config/server.yaml`
+- `~/.first-tree-hub/config/client.yaml`
+- `~/.first-tree-hub/config/agents/<name>/agent.yaml`
+
+### Default runtime paths
+
+- `~/.first-tree-hub/data/sessions/`
+- `~/.first-tree-hub/data/workspaces/`
+- `~/.first-tree-hub/data/postgres/`
+
+### Important environment variables
+
+- Server:
+  - `FIRST_TREE_HUB_DATABASE_URL`
+  - `FIRST_TREE_HUB_PORT`
+  - `FIRST_TREE_HUB_HOST`
+  - `FIRST_TREE_HUB_JWT_SECRET`
+  - `FIRST_TREE_HUB_ENCRYPTION_KEY`
+  - `FIRST_TREE_HUB_CONTEXT_TREE_REPO`
+  - `FIRST_TREE_HUB_GITHUB_TOKEN`
+  - `FIRST_TREE_HUB_WEB_DIST_PATH`
+- Client:
+  - `FIRST_TREE_HUB_SERVER_URL`
+  - `FIRST_TREE_HUB_LOG_LEVEL`
+- Agent debugging:
+  - `FIRST_TREE_HUB_TOKEN`
+  - `FIRST_TREE_HUB_SERVER`
+
+## When to Read Other Docs
+
+- Read `docs/cli-reference.md` for the full public command reference.
+- Read `docs/onboarding-guide.md` for onboarding examples and type-specific behavior.
+- Read `docs/claim-agent-guide.md` for claim-agent and Feishu user binding flows.
+- Read `docs/deployment-guide.md` when the request is about Docker, Railway, Render, Supabase, HTTPS, or multi-machine deployment.

--- a/.claude/skills/first-tree-hub-cli/references/core-concepts.md
+++ b/.claude/skills/first-tree-hub-cli/references/core-concepts.md
@@ -1,0 +1,117 @@
+# First Tree Hub Core Concepts
+
+## Product Boundary
+
+First Tree Hub is shared infrastructure for agent teams.
+
+- It provides identity sync, authentication, messaging, adapter bridges, and the admin dashboard.
+- It is not the LLM agent runtime itself.
+- It is not the orchestration framework.
+- It is not the Context Tree.
+
+Use this distinction consistently when explaining the system or choosing where a change belongs.
+
+## Package Roles
+
+- `packages/server`
+  - Fastify API server, admin APIs, agent APIs, database access, sync jobs, adapters, notifications
+- `packages/client`
+  - Agent SDK, runtime, WebSocket connection management, workspace/session handling
+- `packages/command`
+  - Unified CLI entry point plus reusable core orchestration helpers
+- `packages/shared`
+  - Zod schemas, TypeScript types, and schema-driven config system shared across packages
+- `packages/web`
+  - React admin dashboard served by the server
+
+The command package depends on server and client packages, but it is still an entry layer. Keep business logic in reusable core modules instead of duplicating it in Commander handlers.
+
+## Architecture Invariants
+
+### PostgreSQL is the single persistent system
+
+- Persistent business state lives in PostgreSQL.
+- The server is otherwise stateless.
+- There is no Redis or separate message queue in the intended design.
+
+### Context Tree is the source of identity truth
+
+- Agent identities come from a Context Tree GitHub repo.
+- The server syncs those identities on startup, periodically, and via manual trigger paths.
+- Hub reads the tree and turns it into runtime identity records.
+- Removed members are suspended rather than silently forgotten.
+
+### Inbox is the server-client boundary
+
+- The server writes messages to inbox rows.
+- Delivery is fan-out on write and at-least-once.
+- Clients receive WebSocket notifications and can also pull.
+- The client side is responsible for deduplication and session/workspace management.
+
+### Auth paths are isolated
+
+- Agent API uses agent Bearer tokens.
+- Admin API uses admin JWT.
+- These are separate security domains even on localhost.
+
+### Messages are immutable and time-ordered
+
+- Message IDs use UUID v7.
+- Messages are treated as immutable after creation.
+
+## Runtime Mental Model
+
+### Server startup
+
+`server start` is more than "run Fastify".
+
+It can:
+
+- collect missing config interactively
+- provision PostgreSQL if the user did not provide one
+- run migrations
+- create the first admin account
+- discover or build the web dist
+- start the server with a generated instance ID
+
+### Client startup
+
+`client start` runs all locally configured agents against one Hub server.
+
+The client runtime:
+
+- reads `client.yaml`
+- reads all configured agent YAML files
+- establishes WebSocket and HTTP communication
+- manages session state and isolated chat workspaces
+- syncs a shared Context Tree clone for local context hydration
+
+### Workspace bootstrap
+
+When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files.
+
+If the Context Tree clone is available, it copies:
+
+- `self.md` from the agent's `members/.../NODE.md`
+- `agent-instructions.md` from the root `AGENT.md`
+- `domain-map.md` from the root `NODE.md`
+
+If the Context Tree is unavailable, it writes degraded-mode context so the runtime can continue without organizational metadata.
+
+## Onboarding Mental Model
+
+`onboard` is intentionally higher-level than the rest of the CLI.
+
+- Phase 1 works in the Context Tree repo, not the Hub repo.
+- Phase 2 waits for the server to sync the newly merged identity, then bootstraps runtime access.
+- This is the supported path for creating new members because identity lives outside Hub itself.
+
+Do not replace this with ad hoc file creation or manual local git operations unless the user explicitly wants to bypass the normal flow for development or debugging.
+
+## Common Misunderstandings to Avoid
+
+- Do not say that `agent add` creates an identity in Hub. It only creates local client config.
+- Do not say that `client start` starts the server. It only runs configured agent clients.
+- Do not say that Hub owns organizational truth. The Context Tree does.
+- Do not frame the inbox as exactly-once delivery. The contract is at-least-once with client-side deduplication.
+- Do not mix up admin and agent credentials.

--- a/.claude/skills/first-tree-hub-cli/references/developer-map.md
+++ b/.claude/skills/first-tree-hub-cli/references/developer-map.md
@@ -1,0 +1,139 @@
+# First Tree Hub Developer Map
+
+## Repo Entry Points
+
+- `AGENTS.md`
+  - Architecture rules, conventions, package map, and development workflow
+- `README.md`
+  - Product framing, quick start, and top-level documentation links
+- `docs/cli-reference.md`
+  - Public command and environment variable reference
+- `docs/onboarding-guide.md`
+  - End-to-end onboarding flow
+- `docs/claim-agent-guide.md`
+  - Claim and Feishu binding details
+
+## CLI Source Map
+
+- `packages/command/src/cli/index.ts`
+  - Top-level Commander program and command registration
+- `packages/command/src/commands/server.ts`
+  - `server` subcommands
+- `packages/command/src/commands/client.ts`
+  - `client` subcommands
+- `packages/command/src/commands/agent.ts`
+  - local agent management, bindings, workspace cleanup, messaging utilities
+- `packages/command/src/commands/config.ts`
+  - scope-aware config set/get/list/setup flows
+- `packages/command/src/commands/status.ts`
+  - top-level overview command
+- `packages/command/src/commands/onboard.ts`
+  - high-level interactive entry for onboarding
+
+## Reusable Core Logic
+
+- `packages/command/src/core/server.ts`
+  - orchestration for `server start`, including config prompts, Docker PostgreSQL, migrations, admin creation, and web dist resolution
+- `packages/command/src/core/onboard.ts`
+  - Context Tree checkout, member file generation, verification, PR creation, and post-merge continuation flow
+- `packages/command/src/core/bootstrap.ts`
+  - token bootstrap helpers and server URL resolution
+- `packages/command/src/core/doctor.ts`
+  - readiness checks used by `server doctor` and `client doctor`
+- `packages/command/src/core/feishu.ts`
+  - Feishu binding helpers
+- `packages/command/src/core/prompt.ts`
+  - schema-driven prompting behavior
+
+If you change command behavior, there is a good chance the real logic belongs in one of these core modules rather than in the command handler itself.
+
+## Shared Config and Schema Files
+
+- `packages/shared/src/config/server-config.ts`
+  - server config schema, defaults, prompts, env names
+- `packages/shared/src/config/client-config.ts`
+  - client config schema
+- `packages/shared/src/config/agent-config.ts`
+  - agent config schema
+- `packages/shared/src/config/resolver.ts`
+  - config priority resolution, YAML reading/writing, auto-generation
+
+If a flag, env var, or config key changes, inspect these files and update docs accordingly.
+
+## Client and Server Runtime Files
+
+- `packages/client/src/sdk.ts`
+  - agent SDK surface used by debugging flows and runtime internals
+- `packages/client/src/runtime/runtime.ts`
+  - runtime orchestration for configured agents
+- `packages/client/src/runtime/bootstrap.ts`
+  - Context Tree clone sync and `.agent/` workspace bootstrap
+- `packages/client/src/runtime/session-manager.ts`
+  - session lifecycle and dedup-sensitive message dispatch
+- `packages/server/src/app.ts`
+  - server wiring, route registration, background jobs, Context Tree sync start
+- `packages/server/src/services/inbox.ts`
+  - inbox poll/ack/renew behavior
+- `packages/server/src/services/context-tree-graphql.ts`
+  - Context Tree member fetch and sync behavior
+
+## Change Patterns
+
+### Add or change a CLI command
+
+1. Update or add the command handler in `packages/command/src/commands/`.
+2. Move reusable logic into `packages/command/src/core/`.
+3. Register the command from `packages/command/src/cli/index.ts` if it is new.
+4. Update barrel exports if the functionality should be imported by external consumers.
+5. Update `docs/cli-reference.md`.
+
+### Change onboarding behavior
+
+1. Update `packages/command/src/commands/onboard.ts` only for argument shape or interaction flow.
+2. Put the real behavior in `packages/command/src/core/onboard.ts`.
+3. Update `docs/onboarding-guide.md`.
+4. Update `docs/claim-agent-guide.md` too if claim or binding behavior changes.
+
+### Change config behavior
+
+1. Update the relevant schema under `packages/shared/src/config/`.
+2. Check whether prompt text, defaults, env names, or secret masking rules also need changes.
+3. Update `docs/cli-reference.md`.
+4. Re-test the matching `config`, `server`, or `client` flows.
+
+### Change messaging or agent runtime behavior
+
+1. Start with `packages/command/src/commands/agent.ts` if the CLI surface changes.
+2. Inspect `packages/client/src/sdk.ts` and `packages/client/src/runtime/` if client runtime semantics change.
+3. Inspect `packages/server/src/api/agent/` and `packages/server/src/services/` if server contracts change.
+4. Update shared schemas in `packages/shared/src/schemas/` when payload shapes change.
+
+## Validation Commands
+
+Run the smallest relevant set first, then expand if the change touches cross-package behavior.
+
+```bash
+pnpm check
+pnpm typecheck
+pnpm --filter @agent-team-foundation/first-tree-hub test
+pnpm --filter @first-tree-hub/client test
+pnpm --filter @first-tree-hub/server test
+```
+
+Use the package-specific commands when only one area changed, but keep in mind that the command package depends on shared behavior in `client`, `server`, and `shared`.
+
+## External Consumption
+
+The published CLI package is `@agent-team-foundation/first-tree-hub`.
+
+Its public CLI binary is:
+
+```bash
+first-tree-hub
+```
+
+Its reusable code surface is also intended to be importable by other tools. When you add reusable CLI-adjacent behavior, preserve that separation:
+
+- thin command handler for argument parsing
+- reusable `core/*` function for behavior
+- re-export through `packages/command/src/index.ts` when appropriate

--- a/.claude/skills/first-tree-hub-cli/references/onboarding-operator.md
+++ b/.claude/skills/first-tree-hub-cli/references/onboarding-operator.md
@@ -1,0 +1,137 @@
+# First Tree Hub Onboarding Operator Playbook
+
+Use this file when an external agent receives an onboarding task such as "install First Tree Hub CLI, read the onboarding guide with `gh`, and add a member."
+
+## Core Rule
+
+- Use `first-tree-hub onboard` for the workflow.
+- Do not manually edit the Context Tree, create git branches, or open PRs by hand unless the CLI flow is broken and the user explicitly wants a manual fallback.
+
+## When the Prompt Starts From Scratch
+
+If the task only gives you a package name, a docs URL, and a server URL, normalize it into this sequence:
+
+1. Confirm tooling:
+   - `gh` is installed and authenticated with write access to the Context Tree repository.
+   - Node is new enough to run the published CLI.
+2. Install the CLI:
+   - Preferred: `npm install -g @agent-team-foundation/first-tree-hub`
+   - If the caller installed locally with `npm i @agent-team-foundation/first-tree-hub`, use `npx first-tree-hub ...`
+3. Read the canonical guide with `gh`:
+
+```bash
+gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+```
+
+4. Run readiness first:
+
+```bash
+first-tree-hub onboard --check --server <url> ...
+```
+
+5. Run Phase 1 to create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --server <url> ...
+```
+
+6. After the PR is merged, run Phase 2:
+
+```bash
+first-tree-hub onboard --continue --server <url> ...
+```
+
+7. Start the runtime when this machine should host the configured agent:
+
+```bash
+first-tree-hub client start
+```
+
+## Prompt Template Interpretation
+
+If the automation says something like:
+
+```text
+请先安装 npm i @agent-team-foundation/first-tree-hub
+然后使用 gh 命令阅读 docs/onboarding-guide.md，帮我添加成员。
+Server url 是 https://first-tree.staging.unispark.dev/
+```
+
+interpret it as:
+
+- Install or invoke the published CLI.
+- Fetch the guide with `gh` rather than relying on a browser-only read.
+- Use `https://first-tree.staging.unispark.dev/` as the Hub server URL in the onboarding commands.
+- Execute the supported `onboard` flow instead of hand-editing member files.
+
+## Minimal Inputs to Collect
+
+- Required:
+  - member type: `human`, `personal_assistant`, or `autonomous_agent`
+  - `id`
+  - `role`
+  - `domains`
+  - `server` URL when it is not already configured
+- Optional:
+  - `display-name`
+  - `assistant` only for `human`
+  - Feishu bot credentials only when a bot binding should be created
+
+Prefer `first-tree-hub onboard --check` to reveal missing fields instead of guessing.
+
+## Type-Specific Notes
+
+- `human`
+  - May include `--assistant <id>` to create a personal assistant.
+  - If Feishu bot binding is configured, remind the human to send `/bind <id>` afterwards.
+- `autonomous_agent`
+  - Do not use `--assistant`.
+  - Feishu bot binding is optional.
+- `personal_assistant`
+  - Usually created through the human flow rather than as a separate top-level request.
+
+## Example Commands
+
+### Human + assistant
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id alice \
+  --type human \
+  --role "Engineer" \
+  --domains "backend,infrastructure" \
+  --assistant alice-assistant
+```
+
+### Autonomous agent
+
+```bash
+first-tree-hub onboard \
+  --check \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```
+
+```bash
+first-tree-hub onboard \
+  --server https://first-tree.staging.unispark.dev/ \
+  --id code-reviewer \
+  --type autonomous_agent \
+  --role "Code Review" \
+  --domains "code-review"
+```

--- a/.claude/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/.claude/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -2,19 +2,51 @@
 
 Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
 
+## 0. "I do not have first-tree-hub installed yet"
+
+Use this before any operational flow when the machine may not have the CLI.
+
+### Recommended flow
+
+1. Verify Node.js is supported:
+
+```bash
+node --version
+```
+
+2. Install and verify the CLI:
+
+```bash
+npm install -g @agent-team-foundation/first-tree-hub
+first-tree-hub --version
+```
+
+3. If the user will use `onboard` or `agent token bootstrap`, make sure GitHub CLI is authenticated:
+
+```bash
+gh auth status
+```
+
+### What to remember
+
+- First Tree Hub requires Node.js `>= 22.16`.
+- Do not jump straight to `server start`, `client start`, or `onboard` on a machine where installation is still unknown.
+
 ## 1. "Help me get First Tree Hub running locally"
 
 Use this when the user is setting up a local Hub for the first time.
 
 ### Recommended flow
 
-1. Start with:
+1. If installation is unknown, do scenario 0 first.
+
+2. Start with:
 
 ```bash
 first-tree-hub server start
 ```
 
-2. If the user wants a non-interactive setup, switch to:
+3. If the user wants a non-interactive setup, switch to:
 
 ```bash
 first-tree-hub server start --no-interactive
@@ -22,7 +54,7 @@ first-tree-hub server start --no-interactive
 
 and make sure the required environment variables or config already exist.
 
-3. If startup fails, move to:
+4. If startup fails, move to:
 
 ```bash
 first-tree-hub server doctor
@@ -34,6 +66,7 @@ first-tree-hub status
 - `server start` is the happy-path bootstrap command.
 - It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
 - If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+- If the CLI is not installed yet, installation is part of the correct flow rather than a side detail.
 
 ## 2. "Connect my local agent machine to an existing Hub"
 
@@ -83,25 +116,30 @@ Use this when the user wants to add a real person to the team through the suppor
 
 ### Recommended flow
 
-1. Dry-run requirements first:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Dry-run requirements first:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After the PR is merged, continue:
+4. After the PR is merged, continue:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 ```
 
-4. Start the local runtime if this machine should run the assistant:
+5. Start the local runtime if this machine should run the assistant:
 
 ```bash
 first-tree-hub client start
@@ -111,6 +149,7 @@ first-tree-hub client start
 
 - `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
 - For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
 
 ## 4. "Onboard a standalone autonomous agent"
@@ -119,28 +158,34 @@ Use this when the new member is a bot with no human owner.
 
 ### Recommended flow
 
-1. Check:
+1. If the task starts from an external agent prompt instead of a repo checkout:
+   - Install the CLI if needed.
+   - Read `references/onboarding-operator.md`.
+   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
+
+2. Check:
 
 ```bash
-first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --check --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-2. Create the Context Tree PR:
+3. Create the Context Tree PR:
 
 ```bash
-first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+first-tree-hub onboard --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
 ```
 
-3. After merge:
+4. After merge:
 
 ```bash
-first-tree-hub onboard --continue
+first-tree-hub onboard --continue --server <url>
 first-tree-hub client start
 ```
 
 ### What to remember
 
 - Do not use `--assistant` for `autonomous_agent`.
+- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
 - Feishu bot binding is optional here, unlike the human `/bind` flow.
 
 ## 5. "Why can't the client connect?" or "Why does startup fail?"

--- a/.claude/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/.claude/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -1,0 +1,245 @@
+# First Tree Hub Scenario Playbooks
+
+Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
+
+## 1. "Help me get First Tree Hub running locally"
+
+Use this when the user is setting up a local Hub for the first time.
+
+### Recommended flow
+
+1. Start with:
+
+```bash
+first-tree-hub server start
+```
+
+2. If the user wants a non-interactive setup, switch to:
+
+```bash
+first-tree-hub server start --no-interactive
+```
+
+and make sure the required environment variables or config already exist.
+
+3. If startup fails, move to:
+
+```bash
+first-tree-hub server doctor
+first-tree-hub status
+```
+
+### What to remember
+
+- `server start` is the happy-path bootstrap command.
+- It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
+- If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
+
+## 2. "Connect my local agent machine to an existing Hub"
+
+Use this when the Hub server already exists and the user wants a local client runtime.
+
+### Recommended flow
+
+1. Ensure client config points at the server:
+
+```bash
+first-tree-hub config setup -c
+```
+
+or:
+
+```bash
+first-tree-hub config set -c server.url http://host:8000
+```
+
+2. Add the local agent config:
+
+```bash
+first-tree-hub agent add <name> --token <token>
+```
+
+3. Start the runtime:
+
+```bash
+first-tree-hub client start
+```
+
+4. If something looks wrong, inspect:
+
+```bash
+first-tree-hub client doctor
+first-tree-hub client status
+```
+
+### What to remember
+
+- `agent add` is local-only configuration.
+- `client start` runs all locally configured agents, not just one.
+
+## 3. "Onboard a new human member"
+
+Use this when the user wants to add a real person to the team through the supported identity flow.
+
+### Recommended flow
+
+1. Dry-run requirements first:
+
+```bash
+first-tree-hub onboard --check --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type human --role "<role>" --domains "<d1,d2>"
+```
+
+3. After the PR is merged, continue:
+
+```bash
+first-tree-hub onboard --continue
+```
+
+4. Start the local runtime if this machine should run the assistant:
+
+```bash
+first-tree-hub client start
+```
+
+### What to remember
+
+- `onboard` creates a PR in the Context Tree repo, not in `first-tree-hub`.
+- For humans, a personal assistant is optional and may be created with `--assistant <id>`.
+- If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
+
+## 4. "Onboard a standalone autonomous agent"
+
+Use this when the new member is a bot with no human owner.
+
+### Recommended flow
+
+1. Check:
+
+```bash
+first-tree-hub onboard --check --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+2. Create the Context Tree PR:
+
+```bash
+first-tree-hub onboard --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
+```
+
+3. After merge:
+
+```bash
+first-tree-hub onboard --continue
+first-tree-hub client start
+```
+
+### What to remember
+
+- Do not use `--assistant` for `autonomous_agent`.
+- Feishu bot binding is optional here, unlike the human `/bind` flow.
+
+## 5. "Why can't the client connect?" or "Why does startup fail?"
+
+Use this for diagnosis before editing code.
+
+### Recommended flow
+
+1. Check top-level state:
+
+```bash
+first-tree-hub status
+```
+
+2. Run the relevant doctor:
+
+```bash
+first-tree-hub client doctor
+```
+
+or:
+
+```bash
+first-tree-hub server doctor
+```
+
+3. Inspect effective config:
+
+```bash
+first-tree-hub config list -c
+first-tree-hub config list -s
+```
+
+4. If the server should already be running, probe health directly:
+
+```bash
+first-tree-hub server status
+```
+
+### What to remember
+
+- Prefer diagnosis commands before changing YAML files by hand.
+- Server issues and client issues often look similar; make the user goal explicit before debugging.
+
+## 6. "Help me debug messaging between agents"
+
+Use this when the user wants to verify delivery, inspect chats, or send test messages manually.
+
+### Recommended flow
+
+1. Make sure agent debug auth is available:
+
+```bash
+export FIRST_TREE_HUB_TOKEN=...
+```
+
+2. Send a message:
+
+```bash
+first-tree-hub agent send <agentId> "hello"
+```
+
+or to an existing chat:
+
+```bash
+first-tree-hub agent send <chatId> "hello" --chat
+```
+
+3. Inspect chats and history:
+
+```bash
+first-tree-hub agent chats
+first-tree-hub agent history <chatId>
+```
+
+4. Fall back to low-level inbox polling if needed:
+
+```bash
+first-tree-hub agent pull
+```
+
+### What to remember
+
+- These commands are for debugging and operator visibility, not the normal runtime path.
+- If a user only wants to run their agents normally, `client start` is the main flow.
+
+## 7. "Change how the CLI behaves"
+
+Use this when the user wants a code change rather than an operational action.
+
+### Recommended flow
+
+1. Find the matching command handler in `packages/command/src/commands/`.
+2. Move behavior into `packages/command/src/core/` if the logic is reusable.
+3. Update the corresponding docs in `docs/cli-reference.md` or `docs/onboarding-guide.md`.
+4. Validate with the smallest relevant command/package test set.
+
+### What to remember
+
+- Command handlers should stay thin.
+- Config changes usually require updates in `packages/shared/src/config/`.
+- Onboarding changes often touch both `commands/onboard.ts` and `core/onboard.ts`.

--- a/.claude/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
+++ b/.claude/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+compare_dir() {
+  local left="$1"
+  local right="$2"
+  if [[ ! -d "$left" ]]; then
+    echo "Missing directory: $left" >&2
+    return 1
+  fi
+  if [[ ! -d "$right" ]]; then
+    echo "Missing directory: $right" >&2
+    return 1
+  fi
+  diff -qr "$left" "$right"
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-hub-cli"
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"
+
+echo "Skill source and mirrors are in sync."

--- a/.claude/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
+++ b/.claude/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+for mirror_root in "$REPO_ROOT/.agents/skills/first-tree-hub-cli" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"; do
+  mkdir -p "$(dirname "$mirror_root")"
+  rsync -a --delete "$SOURCE_DIR/" "$mirror_root/"
+done
+
+echo "Exported mirrors to .agents/skills/first-tree-hub-cli and .claude/skills/first-tree-hub-cli"

--- a/.claude/skills/first-tree-hub-cli/scripts/quick_validate.py
+++ b/.claude/skills/first-tree-hub-cli/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Portable quick validator for a skill directory.
+
+This version is intentionally self-contained so it can run in CI and in copied
+skill folders without depending on external Python packages.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MAX_SKILL_NAME_LENGTH = 64
+
+
+def extract_frontmatter(text: str) -> tuple[bool, str]:
+    if not text.startswith("---\n"):
+        return False, "No YAML frontmatter found"
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+    return True, match.group(1)
+
+
+def parse_simple_frontmatter(frontmatter: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.startswith(("'", '"')) and value.endswith(("'", '"')) and len(value) >= 2:
+            value = value[1:-1]
+        data[key] = value
+    return data
+
+
+def validate_skill(skill_path: str) -> tuple[bool, str]:
+    skill_dir = Path(skill_path)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    content = skill_md.read_text()
+    ok, frontmatter_or_error = extract_frontmatter(content)
+    if not ok:
+        return False, frontmatter_or_error
+
+    frontmatter = parse_simple_frontmatter(frontmatter_or_error)
+
+    unexpected = set(frontmatter.keys()) - {"name", "description"}
+    if unexpected:
+        return False, f"Unexpected key(s) in frontmatter: {', '.join(sorted(unexpected))}"
+
+    name = frontmatter.get("name", "").strip()
+    if not name:
+        return False, "Missing 'name' in frontmatter"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return False, f"Name '{name}' should be hyphen-case"
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return False, f"Name is too long ({len(name)} > {MAX_SKILL_NAME_LENGTH})"
+
+    description = frontmatter.get("description", "").strip()
+    if not description:
+        return False, "Missing 'description' in frontmatter"
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} > 1024)"
+
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    if not openai_yaml.exists():
+        return False, "agents/openai.yaml not found"
+
+    return True, "Skill is valid!"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: quick_validate.py <skill_directory>")
+        return 1
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
+++ b/.claude/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$SCRIPT_DIR/export-skill-mirrors.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
             exit 1
           fi
 
+  validate-skill:
+    name: Validate Skill
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm validate:skill
+
   lint:
     name: Lint & Type Check
     if: ${{ !startsWith(github.head_ref || github.ref_name, 'docs/') }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,9 @@ drizzle/meta/
 *.log
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/first-tree-hub-cli/
+!.claude/skills/first-tree-hub-cli/**
 .gstack/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,11 @@ pnpm --filter @first-tree-hub/server db:studio      # Drizzle Studio
 
 > Full CLI commands and environment variables: [docs/cli-reference.md](docs/cli-reference.md)
 
+## Repo-Local Skill
+
+- Use `skills/first-tree-hub-cli/SKILL.md` as the source-of-truth skill when the task is about the unified CLI, onboarding, config flows, runtime boundaries, or other behavior spanning `packages/command`, `packages/client`, `packages/server`, and `packages/shared`.
+- `.agents/skills/first-tree-hub-cli/` and `.claude/skills/first-tree-hub-cli/` are generated mirrors for agent discovery. Do not edit those mirrors directly; refresh them from the source skill with `bash skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh`.
+
 ## Monorepo Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check": "biome check .",
     "format": "biome check --write .",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "validate:skill": "python3 ./skills/first-tree-hub-cli/scripts/quick_validate.py ./skills/first-tree-hub-cli && bash ./skills/first-tree-hub-cli/scripts/check-skill-sync.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.0",

--- a/packages/command/src/__tests__/skill-artifacts.test.ts
+++ b/packages/command/src/__tests__/skill-artifacts.test.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "../../../../");
+
+describe("skill artifacts", () => {
+  it("keeps the source-of-truth skill and generated mirrors present", () => {
+    expect(existsSync(join(ROOT, "skills", "first-tree-hub-cli", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(ROOT, ".agents", "skills", "first-tree-hub-cli", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(ROOT, ".claude", "skills", "first-tree-hub-cli", "SKILL.md"))).toBe(true);
+  });
+
+  it("keeps the skill source and mirrors in sync", () => {
+    execFileSync("bash", ["./skills/first-tree-hub-cli/scripts/check-skill-sync.sh"], {
+      cwd: ROOT,
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+  });
+});

--- a/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
+++ b/skills/first-tree-hub-cli/scripts/check-skill-sync.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+compare_dir() {
+  local left="$1"
+  local right="$2"
+  if [[ ! -d "$left" ]]; then
+    echo "Missing directory: $left" >&2
+    return 1
+  fi
+  if [[ ! -d "$right" ]]; then
+    echo "Missing directory: $right" >&2
+    return 1
+  fi
+  diff -qr "$left" "$right"
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.agents/skills/first-tree-hub-cli"
+compare_dir "$SOURCE_DIR" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"
+
+echo "Skill source and mirrors are in sync."

--- a/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
+++ b/skills/first-tree-hub-cli/scripts/export-skill-mirrors.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+find_repo_root() {
+  local dir="$SKILL_DIR"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/package.json" ]] && grep -q '"name": "first-tree-hub"' "$dir/package.json"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+REPO_ROOT="$(find_repo_root || true)"
+SOURCE_DIR=""
+if [[ -n "$REPO_ROOT" ]]; then
+  SOURCE_DIR="$REPO_ROOT/skills/first-tree-hub-cli"
+fi
+
+if [[ -z "$REPO_ROOT" || "$SKILL_DIR" != "$SOURCE_DIR" ]]; then
+  echo "Run this script from the source-of-truth skill at skills/first-tree-hub-cli inside a live first-tree-hub checkout." >&2
+  exit 1
+fi
+
+for mirror_root in "$REPO_ROOT/.agents/skills/first-tree-hub-cli" "$REPO_ROOT/.claude/skills/first-tree-hub-cli"; do
+  mkdir -p "$(dirname "$mirror_root")"
+  rsync -a --delete "$SOURCE_DIR/" "$mirror_root/"
+done
+
+echo "Exported mirrors to .agents/skills/first-tree-hub-cli and .claude/skills/first-tree-hub-cli"

--- a/skills/first-tree-hub-cli/scripts/quick_validate.py
+++ b/skills/first-tree-hub-cli/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Portable quick validator for a skill directory.
+
+This version is intentionally self-contained so it can run in CI and in copied
+skill folders without depending on external Python packages.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MAX_SKILL_NAME_LENGTH = 64
+
+
+def extract_frontmatter(text: str) -> tuple[bool, str]:
+    if not text.startswith("---\n"):
+        return False, "No YAML frontmatter found"
+    match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+    return True, match.group(1)
+
+
+def parse_simple_frontmatter(frontmatter: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.startswith(("'", '"')) and value.endswith(("'", '"')) and len(value) >= 2:
+            value = value[1:-1]
+        data[key] = value
+    return data
+
+
+def validate_skill(skill_path: str) -> tuple[bool, str]:
+    skill_dir = Path(skill_path)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    content = skill_md.read_text()
+    ok, frontmatter_or_error = extract_frontmatter(content)
+    if not ok:
+        return False, frontmatter_or_error
+
+    frontmatter = parse_simple_frontmatter(frontmatter_or_error)
+
+    unexpected = set(frontmatter.keys()) - {"name", "description"}
+    if unexpected:
+        return False, f"Unexpected key(s) in frontmatter: {', '.join(sorted(unexpected))}"
+
+    name = frontmatter.get("name", "").strip()
+    if not name:
+        return False, "Missing 'name' in frontmatter"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return False, f"Name '{name}' should be hyphen-case"
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return False, f"Name is too long ({len(name)} > {MAX_SKILL_NAME_LENGTH})"
+
+    description = frontmatter.get("description", "").strip()
+    if not description:
+        return False, "Missing 'description' in frontmatter"
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} > 1024)"
+
+    openai_yaml = skill_dir / "agents" / "openai.yaml"
+    if not openai_yaml.exists():
+        return False, "agents/openai.yaml not found"
+
+    return True, "Skill is valid!"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: quick_validate.py <skill_directory>")
+        return 1
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
+++ b/skills/first-tree-hub-cli/scripts/sync-skill-artifacts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$SCRIPT_DIR/export-skill-mirrors.sh"


### PR DESCRIPTION
## Summary
- add repo-local skill validation and mirror sync scripts for `skills/first-tree-hub-cli`
- track generated `.agents` and `.claude` mirrors plus a command-package test that keeps them in sync
- wire `pnpm validate:skill` into root scripts, AGENTS guidance, and CI

## Validation
- pnpm validate:skill
- pnpm check
- pnpm typecheck
- pnpm test