### PR TITLE
chore: bump command package version to 0.4.0

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `@agent-team-foundation/first-tree-hub` version from 0.3.5 to 0.4.0

## Test plan
- [ ] Verify `packages/command/package.json` version is `0.4.0`
- [ ] Build passes: `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)