### PR TITLE
refactor: agent identity UUID + name dual-ID system

### DIFF
--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -56,7 +56,7 @@ export class FirstTreeHubSDK {
   async register(): Promise<RegisterResult> {
     const agent = await this.requestJson<Agent>("/api/v1/agent/me");
     return {
-      agentId: agent.id,
+      agentId: agent.uuid,
       inboxId: agent.inboxId,
       status: agent.status,
       displayName: agent.displayName,
@@ -97,8 +97,8 @@ export class FirstTreeHubSDK {
   }
 
   /** Send a direct message to another agent. */
-  async sendToAgent(agentId: string, data: SendToAgent): Promise<Message> {
-    return this.requestJson<Message>(`/api/v1/agent/agents/${agentId}/messages`, {
+  async sendToAgent(agentName: string, data: SendToAgent): Promise<Message> {
+    return this.requestJson<Message>(`/api/v1/agent/agents/${agentName}/messages`, {
       method: "POST",
       body: JSON.stringify(data),
     });

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -208,17 +208,17 @@ export function registerAgentCommands(program: Command): void {
   const token = agent.command("token").description("Agent token management");
 
   token
-    .command("bootstrap <agentId>")
+    .command("bootstrap <agentName>")
     .description("Bootstrap a token using GitHub identity (requires gh CLI)")
     .option("--save-to <target>", 'Save token to: "agent" (default) or a file path', "agent")
     .option("--server <url>", "Hub server URL")
-    .action(async (agentId: string, options: { saveTo: string; server?: string }) => {
+    .action(async (agentName: string, options: { saveTo: string; server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);
-        const result = await bootstrapToken(serverUrl, agentId, { saveTo: options.saveTo });
+        const result = await bootstrapToken(serverUrl, agentName, { saveTo: options.saveTo });
 
         if (options.saveTo === "agent") {
-          process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${agentId}/agent.yaml\n`);
+          process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${agentName}/agent.yaml\n`);
         } else {
           process.stderr.write(`Token saved to ${options.saveTo}\n`);
         }

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -59,7 +59,7 @@ export function resolveServerUrl(flagValue?: string): string {
  */
 export async function bootstrapToken(
   serverUrl: string,
-  agentId: string,
+  agentName: string,
   options: {
     saveTo?: string;
     type?: string;
@@ -78,7 +78,7 @@ export async function bootstrapToken(
   if (options.profile) body.profile = options.profile;
   if (options.metadata) body.metadata = options.metadata;
 
-  const res = await fetch(`${serverUrl}/api/v1/bootstrap/${encodeURIComponent(agentId)}/token`, {
+  const res = await fetch(`${serverUrl}/api/v1/bootstrap/${encodeURIComponent(agentName)}/token`, {
     method: "POST",
     headers: {
       "X-GitHub-Token": githubToken,
@@ -90,14 +90,14 @@ export async function bootstrapToken(
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };
     const msg = body.error ?? `HTTP ${res.status}`;
-    throw new Error(`Bootstrap failed for "${agentId}": ${msg}`);
+    throw new Error(`Bootstrap failed for "${agentName}": ${msg}`);
   }
 
   const data = (await res.json()) as { token: string; agentId: string };
 
   // Save token to agent config if requested
   if (options.saveTo === "agent" || !options.saveTo) {
-    const configDir = join(DEFAULT_CONFIG_DIR, "agents", agentId);
+    const configDir = join(DEFAULT_CONFIG_DIR, "agents", agentName);
     const configPath = `${configDir}/agent.yaml`;
     mkdirSync(configDir, { recursive: true, mode: 0o700 });
     writeFileSync(configPath, `token: "${data.token}"\ntype: claude-code\n`, { mode: 0o600 });
@@ -127,11 +127,11 @@ export function resolveAgentToken(): string {
  */
 export async function checkBootstrapStatus(
   serverUrl: string,
-  agentId: string,
+  agentName: string,
 ): Promise<{ exists: boolean; status: string | null }> {
   const githubToken = getGitHubToken();
 
-  const res = await fetch(`${serverUrl}/api/v1/bootstrap/${encodeURIComponent(agentId)}/status`, {
+  const res = await fetch(`${serverUrl}/api/v1/bootstrap/${encodeURIComponent(agentName)}/status`, {
     headers: { "X-GitHub-Token": githubToken },
   });
 

--- a/packages/server/drizzle/0008_uuid_identity.sql
+++ b/packages/server/drizzle/0008_uuid_identity.sql
@@ -1,0 +1,12 @@
+-- Agent identity refactoring: id → uuid (PK) + name (human-readable, per-org unique)
+-- Run BEFORE the data migration script (scripts/migrate-uuid.ts).
+
+-- 1. Add name column
+ALTER TABLE "agents" ADD COLUMN "name" text;
+
+-- 2. Rename id → uuid (PG auto-updates FK constraints referencing this column)
+ALTER TABLE "agents" RENAME COLUMN "id" TO "uuid";
+
+-- 3. Add composite unique constraint (org + name)
+-- NULLs are distinct in PG unique constraints, so deleted agents (name=NULL) don't conflict
+ALTER TABLE "agents" ADD CONSTRAINT "uq_agents_org_name" UNIQUE("organization_id", "name");

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775692800000,
       "tag": "0007_decouple_context_tree",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1775952000000,
+      "tag": "0008_uuid_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/adapter-mapping.test.ts
+++ b/packages/server/src/__tests__/adapter-mapping.test.ts
@@ -32,18 +32,18 @@ describe("Adapter mapping service", () => {
   describe("agent mapping", () => {
     it("creates and finds agent mapping", async () => {
       const app = await appPromise;
-      const { agent } = await createTestAgent(app, { id: "mapping-test-agent" });
+      const { agent } = await createTestAgent(app, { name: "mapping-test-agent" });
 
       await mappingService.createAgentMapping(app.db, {
         platform: "feishu",
         externalUserId: "ou_mapping_user_1",
-        agentId: agent.id,
+        agentId: agent.uuid,
         boundVia: "manual",
       });
 
       const found = await mappingService.findAgentByExternalUser(app.db, "feishu", "ou_mapping_user_1");
       expect(found).not.toBeNull();
-      expect(found?.agentId).toBe(agent.id);
+      expect(found?.agentId).toBe(agent.uuid);
     });
 
     it("returns null for unmapped user", async () => {
@@ -54,32 +54,32 @@ describe("Adapter mapping service", () => {
 
     it("finds external user by agent", async () => {
       const app = await appPromise;
-      const { agent } = await createTestAgent(app, { id: "reverse-mapping-agent" });
+      const { agent } = await createTestAgent(app, { name: "reverse-mapping-agent" });
 
       await mappingService.createAgentMapping(app.db, {
         platform: "feishu",
         externalUserId: "ou_reverse_1",
-        agentId: agent.id,
+        agentId: agent.uuid,
       });
 
-      const found = await mappingService.findExternalUserByAgent(app.db, "feishu", agent.id);
+      const found = await mappingService.findExternalUserByAgent(app.db, "feishu", agent.uuid);
       expect(found).not.toBeNull();
       expect(found?.externalUserId).toBe("ou_reverse_1");
     });
 
     it("handles duplicate mapping gracefully", async () => {
       const app = await appPromise;
-      const { agent } = await createTestAgent(app, { id: "dup-mapping-agent" });
+      const { agent } = await createTestAgent(app, { name: "dup-mapping-agent" });
 
       const r1 = await mappingService.createAgentMapping(app.db, {
         platform: "feishu",
         externalUserId: "ou_dup_user",
-        agentId: agent.id,
+        agentId: agent.uuid,
       });
       const r2 = await mappingService.createAgentMapping(app.db, {
         platform: "feishu",
         externalUserId: "ou_dup_user",
-        agentId: agent.id,
+        agentId: agent.uuid,
       });
       expect(r1.agentId).toBe(r2.agentId);
     });
@@ -88,15 +88,15 @@ describe("Adapter mapping service", () => {
   describe("chat mapping", () => {
     it("creates chat for new external channel", async () => {
       const app = await appPromise;
-      const { agent: botAgent } = await createTestAgent(app, { id: "chat-map-bot-agent" });
-      const { agent: sender } = await createTestAgent(app, { id: "chat-map-sender" });
+      const { agent: botAgent } = await createTestAgent(app, { name: "chat-map-bot-agent" });
+      const { agent: sender } = await createTestAgent(app, { name: "chat-map-sender" });
 
       const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_new_channel_1",
         chatType: "group",
-        botAgentId: botAgent.id,
-        senderAgentId: sender.id,
+        botAgentId: botAgent.uuid,
+        senderAgentId: sender.uuid,
       });
 
       expect(chatId).toBeTruthy();
@@ -106,31 +106,31 @@ describe("Adapter mapping service", () => {
         platform: "feishu",
         externalChannelId: "oc_new_channel_1",
         chatType: "group",
-        botAgentId: botAgent.id,
-        senderAgentId: sender.id,
+        botAgentId: botAgent.uuid,
+        senderAgentId: sender.uuid,
       });
       expect(chatId2).toBe(chatId);
     });
 
     it("creates separate chats for different external channels", async () => {
       const app = await appPromise;
-      const { agent: botAgent } = await createTestAgent(app, { id: "multi-ch-bot-agent" });
-      const { agent: sender } = await createTestAgent(app, { id: "multi-ch-sender" });
+      const { agent: botAgent } = await createTestAgent(app, { name: "multi-ch-bot-agent" });
+      const { agent: sender } = await createTestAgent(app, { name: "multi-ch-sender" });
 
       const chatId1 = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_multi_1",
         chatType: "group",
-        botAgentId: botAgent.id,
-        senderAgentId: sender.id,
+        botAgentId: botAgent.uuid,
+        senderAgentId: sender.uuid,
       });
 
       const chatId2 = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_multi_2",
         chatType: "p2p",
-        botAgentId: botAgent.id,
-        senderAgentId: sender.id,
+        botAgentId: botAgent.uuid,
+        senderAgentId: sender.uuid,
       });
 
       expect(chatId1).not.toBe(chatId2);
@@ -138,15 +138,15 @@ describe("Adapter mapping service", () => {
 
     it("finds external channel by chat", async () => {
       const app = await appPromise;
-      const { agent: botAgent } = await createTestAgent(app, { id: "reverse-ch-bot-agent" });
-      const { agent: sender } = await createTestAgent(app, { id: "reverse-ch-sender" });
+      const { agent: botAgent } = await createTestAgent(app, { name: "reverse-ch-bot-agent" });
+      const { agent: sender } = await createTestAgent(app, { name: "reverse-ch-sender" });
 
       const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_reverse_1",
         chatType: "group",
-        botAgentId: botAgent.id,
-        senderAgentId: sender.id,
+        botAgentId: botAgent.uuid,
+        senderAgentId: sender.uuid,
       });
 
       const found = await mappingService.findExternalChannelByChat(app.db, "feishu", chatId);
@@ -156,14 +156,14 @@ describe("Adapter mapping service", () => {
 
     it("handles same agent as both bot and sender (p2p self-chat)", async () => {
       const app = await appPromise;
-      const { agent } = await createTestAgent(app, { id: "self-chat-agent" });
+      const { agent } = await createTestAgent(app, { name: "self-chat-agent" });
 
       const chatId = await mappingService.findOrCreateChatForChannel(app.db, {
         platform: "feishu",
         externalChannelId: "oc_self_chat",
         chatType: "p2p",
-        botAgentId: agent.id,
-        senderAgentId: agent.id,
+        botAgentId: agent.uuid,
+        senderAgentId: agent.uuid,
       });
 
       expect(chatId).toBeTruthy();
@@ -174,15 +174,15 @@ describe("Adapter mapping service", () => {
     it("creates and finds message reference", async () => {
       const app = await appPromise;
       // First create a real message for FK constraint
-      const { agent } = await createTestAgent(app, { id: "msg-ref-agent" });
+      const { agent } = await createTestAgent(app, { name: "msg-ref-agent" });
       const { createChat } = await import("../services/chat.js");
       const { sendMessage } = await import("../services/message.js");
 
-      const chat = await createChat(app.db, agent.id, {
+      const chat = await createChat(app.db, agent.uuid, {
         type: "direct",
-        participantIds: [agent.id],
+        participantIds: [agent.uuid],
       });
-      const { message: msg } = await sendMessage(app.db, chat.id, agent.id, {
+      const { message: msg } = await sendMessage(app.db, chat.id, agent.uuid, {
         format: "text",
         content: "test message for ref",
       });

--- a/packages/server/src/__tests__/admin-adapters.test.ts
+++ b/packages/server/src/__tests__/admin-adapters.test.ts
@@ -19,17 +19,17 @@ describe("Admin Adapters API", () => {
   it("creates and lists adapter configs (agentId required)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-create-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-create-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_test", app_secret: "secret" },
     });
     expect(createRes.statusCode).toBe(201);
     const config = createRes.json();
     expect(config.platform).toBe("feishu");
-    expect(config.agentId).toBe(agent.id);
+    expect(config.agentId).toBe(agent.uuid);
     expect(config.hasCredentials).toBe(true);
     // Credentials must NOT be returned in the response
     expect(config.credentials).toBeUndefined();
@@ -44,11 +44,11 @@ describe("Admin Adapters API", () => {
   it("gets a single adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-get-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-get-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "slack",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { bot_token: "xoxb-test" },
     });
     const created = createRes.json();
@@ -56,17 +56,17 @@ describe("Admin Adapters API", () => {
     const getRes = await req("GET", `/api/v1/admin/adapters/${created.id}`);
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().platform).toBe("slack");
-    expect(getRes.json().agentId).toBe(agent.id);
+    expect(getRes.json().agentId).toBe(agent.uuid);
   });
 
   it("updates adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-upd-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-upd-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_upd", app_secret: "secret" },
     });
     const created = createRes.json();
@@ -81,31 +81,31 @@ describe("Admin Adapters API", () => {
   it("updates agentId to another valid agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent: agent1 } = await createTestAgent(app, { id: "adapter-switch-1" });
-    const { agent: agent2 } = await createTestAgent(app, { id: "adapter-switch-2" });
+    const { agent: agent1 } = await createTestAgent(app, { name: "adapter-switch-1" });
+    const { agent: agent2 } = await createTestAgent(app, { name: "adapter-switch-2" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent1.id,
+      agentId: agent1.uuid,
       credentials: { app_id: "cli_switch", app_secret: "secret" },
     });
     const created = createRes.json();
 
     const updateRes = await req("PATCH", `/api/v1/admin/adapters/${created.id}`, {
-      agentId: agent2.id,
+      agentId: agent2.uuid,
     });
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.json().agentId).toBe(agent2.id);
+    expect(updateRes.json().agentId).toBe(agent2.uuid);
   });
 
   it("deletes adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-del-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-del-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_del", app_secret: "secret" },
     });
     const created = createRes.json();
@@ -168,11 +168,11 @@ describe("Admin Adapters API", () => {
   it("updates credentials (re-encrypts)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-reencrypt-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-reencrypt-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "old_id", app_secret: "old_secret" },
     });
     const created = createRes.json();
@@ -201,11 +201,11 @@ describe("Admin Adapters API", () => {
   it("rejects human agent for adapter config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "human-adapter-reject", type: "human" });
+    const { agent } = await createTestAgent(app, { name: "human-adapter-reject", type: "human" });
 
     const res = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_human", app_secret: "s" },
     });
     expect(res.statusCode).toBe(400);
@@ -234,11 +234,11 @@ describe("Admin Adapters API", () => {
   it("enforces unique agent+platform constraint", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-unique-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-unique-agent" });
 
     const res1 = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_u1", app_secret: "s1" },
     });
     expect(res1.statusCode).toBe(201);
@@ -246,7 +246,7 @@ describe("Admin Adapters API", () => {
     // Same agent + same platform should fail with 409
     const res2 = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_u2", app_secret: "s2" },
     });
     expect(res2.statusCode).toBe(409);
@@ -255,18 +255,18 @@ describe("Admin Adapters API", () => {
   it("allows same agent on different platforms", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "adapter-cross-plat-agent" });
+    const { agent } = await createTestAgent(app, { name: "adapter-cross-plat-agent" });
 
     const res1 = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_cross", app_secret: "s1" },
     });
     expect(res1.statusCode).toBe(201);
 
     const res2 = await req("POST", "/api/v1/admin/adapters", {
       platform: "slack",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { bot_token: "xoxb-cross" },
     });
     expect(res2.statusCode).toBe(201);

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -21,19 +21,19 @@ describe("Admin Agents API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    await createAgent(app.db, { id: "agent-1", type: "autonomous_agent", displayName: "Bot One" });
+    const agent = await createAgent(app.db, { name: "agent-1", type: "autonomous_agent", displayName: "Bot One" });
 
-    const getRes = await req("GET", "/api/v1/admin/agents/agent-1");
+    const getRes = await req("GET", `/api/v1/admin/agents/${agent.uuid}`);
     expect(getRes.statusCode).toBe(200);
-    expect(getRes.json().id).toBe("agent-1");
-    expect(getRes.json().inboxId).toBe("inbox_agent-1");
+    expect(getRes.json().uuid).toBe(agent.uuid);
+    expect(getRes.json().inboxId).toBe(`inbox_${agent.uuid}`);
   });
 
   it("lists agents with pagination", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await createAgent(app.db, { id: "a1", type: "human" });
-    await createAgent(app.db, { id: "a2", type: "human" });
+    await createAgent(app.db, { name: "a1", type: "human" });
+    await createAgent(app.db, { name: "a2", type: "human" });
 
     const res = await req("GET", "/api/v1/admin/agents?limit=1");
     expect(res.statusCode).toBe(200);
@@ -45,12 +45,12 @@ describe("Admin Agents API", () => {
   it("lists agents with presenceStatus field", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await createAgent(app.db, { id: "presence-test", type: "autonomous_agent" });
+    const created = await createAgent(app.db, { name: "presence-test", type: "autonomous_agent" });
 
     const res = await req("GET", "/api/v1/admin/agents?limit=50");
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    const agent = body.items.find((a: { id: string }) => a.id === "presence-test");
+    const agent = body.items.find((a: { uuid: string }) => a.uuid === created.uuid);
     expect(agent).toBeDefined();
     // No presence record → defaults to "offline"
     expect(agent.presenceStatus).toBe("offline");
@@ -61,7 +61,7 @@ describe("Admin Agents API", () => {
     const req = await authedRequest(app);
 
     const res = await req("POST", "/api/v1/admin/agents", {
-      id: "api-created",
+      name: "api-created",
       type: "autonomous_agent",
       displayName: "API Bot",
       profile: "I am a test bot.",
@@ -69,7 +69,7 @@ describe("Admin Agents API", () => {
     });
     expect(res.statusCode).toBe(201);
     const body = res.json();
-    expect(body.id).toBe("api-created");
+    expect(body.name).toBe("api-created");
     expect(body.displayName).toBe("API Bot");
     expect(body.profile).toBe("I am a test bot.");
     expect(body.metadata.role).toBe("testing");
@@ -78,9 +78,9 @@ describe("Admin Agents API", () => {
   it("updates an agent via PATCH", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await createAgent(app.db, { id: "patch-target", type: "human", displayName: "Old Name" });
+    const agent = await createAgent(app.db, { name: "patch-target", type: "human", displayName: "Old Name" });
 
-    const res = await req("PATCH", "/api/v1/admin/agents/patch-target", {
+    const res = await req("PATCH", `/api/v1/admin/agents/${agent.uuid}`, {
       displayName: "New Name",
       profile: "Updated profile.",
     });
@@ -92,15 +92,15 @@ describe("Admin Agents API", () => {
   it("suspends and reactivates an agent", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await createAgent(app.db, { id: "lifecycle-agent", type: "autonomous_agent" });
+    const agent = await createAgent(app.db, { name: "lifecycle-agent", type: "autonomous_agent" });
 
     // Suspend
-    const suspendRes = await req("POST", "/api/v1/admin/agents/lifecycle-agent/suspend");
+    const suspendRes = await req("POST", `/api/v1/admin/agents/${agent.uuid}/suspend`);
     expect(suspendRes.statusCode).toBe(200);
     expect(suspendRes.json().status).toBe("suspended");
 
     // Reactivate
-    const reactivateRes = await req("POST", "/api/v1/admin/agents/lifecycle-agent/reactivate");
+    const reactivateRes = await req("POST", `/api/v1/admin/agents/${agent.uuid}/reactivate`);
     expect(reactivateRes.statusCode).toBe(200);
     expect(reactivateRes.json().status).toBe("active");
   });
@@ -108,15 +108,15 @@ describe("Admin Agents API", () => {
   it("deletes only suspended agents", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    await createAgent(app.db, { id: "delete-test", type: "autonomous_agent" });
+    const agent = await createAgent(app.db, { name: "delete-test", type: "autonomous_agent" });
 
     // Cannot delete active agent
-    const failRes = await req("DELETE", "/api/v1/admin/agents/delete-test");
+    const failRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(failRes.statusCode).toBe(400);
 
     // Suspend first, then delete
-    await req("POST", "/api/v1/admin/agents/delete-test/suspend");
-    const okRes = await req("DELETE", "/api/v1/admin/agents/delete-test");
+    await req("POST", `/api/v1/admin/agents/${agent.uuid}/suspend`);
+    const okRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(okRes.statusCode).toBe(204);
   });
 
@@ -130,22 +130,22 @@ describe("Admin Agents API", () => {
     it("creates, lists, and revokes tokens", async () => {
       const app = await appPromise;
       const req = await authedRequest(app);
-      await createAgent(app.db, { id: "tok-agent", type: "autonomous_agent" });
+      const agent = await createAgent(app.db, { name: "tok-agent", type: "autonomous_agent" });
 
       // Create token
-      const createRes = await req("POST", "/api/v1/admin/agents/tok-agent/tokens", { name: "dev" });
+      const createRes = await req("POST", `/api/v1/admin/agents/${agent.uuid}/tokens`, { name: "dev" });
       expect(createRes.statusCode).toBe(201);
       const tokenBody = createRes.json();
       expect(tokenBody.token).toMatch(/^aghub_/);
       expect(tokenBody.name).toBe("dev");
 
       // List tokens
-      const listRes = await req("GET", "/api/v1/admin/agents/tok-agent/tokens");
+      const listRes = await req("GET", `/api/v1/admin/agents/${agent.uuid}/tokens`);
       expect(listRes.statusCode).toBe(200);
       expect(listRes.json()).toHaveLength(1);
 
       // Revoke token
-      const revokeRes = await req("DELETE", `/api/v1/admin/agents/tok-agent/tokens/${tokenBody.id}`);
+      const revokeRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}/tokens/${tokenBody.id}`);
       expect(revokeRes.statusCode).toBe(204);
     });
   });

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -22,8 +22,8 @@ describe("Admin DELETE Agent API", () => {
     const req = await authedRequest(app);
 
     // Create agent with token, then suspend (simulating sync removing it from tree)
-    const { agent, token } = await createTestAgent(app, { id: "del-agent" });
-    await suspendAgent(app.db, agent.id);
+    const { agent, token } = await createTestAgent(app, { name: "del-agent" });
+    await suspendAgent(app.db, agent.uuid);
 
     // Verify token no longer works (revoked by suspend)
     const meRes = await app.inject({
@@ -34,11 +34,11 @@ describe("Admin DELETE Agent API", () => {
     expect(meRes.statusCode).toBe(401);
 
     // Delete suspended agent
-    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.id}`);
+    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(delRes.statusCode).toBe(204);
 
     // Deleted agent is no longer visible
-    const getRes = await req("GET", `/api/v1/admin/agents/${agent.id}`);
+    const getRes = await req("GET", `/api/v1/admin/agents/${agent.uuid}`);
     expect(getRes.statusCode).toBe(404);
   });
 
@@ -46,9 +46,9 @@ describe("Admin DELETE Agent API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    await createAgent(app.db, { id: "active-no-del", type: "autonomous_agent" });
+    const agent = await createAgent(app.db, { name: "active-no-del", type: "autonomous_agent" });
 
-    const res = await req("DELETE", "/api/v1/admin/agents/active-no-del");
+    const res = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(res.statusCode).toBe(400);
   });
 
@@ -57,14 +57,18 @@ describe("Admin DELETE Agent API", () => {
     const req = await authedRequest(app);
 
     // Create, suspend, then delete
-    await createAgent(app.db, { id: "recreate-agent", type: "autonomous_agent", displayName: "Original" });
-    await suspendAgent(app.db, "recreate-agent");
-    const delRes = await req("DELETE", "/api/v1/admin/agents/recreate-agent");
+    const agent = await createAgent(app.db, {
+      name: "recreate-agent",
+      type: "autonomous_agent",
+      displayName: "Original",
+    });
+    await suspendAgent(app.db, agent.uuid);
+    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(delRes.statusCode).toBe(204);
 
-    // Recreate with same ID (as sync would do)
+    // Recreate with same name (as sync would do)
     const recreated = await createAgent(app.db, {
-      id: "recreate-agent",
+      name: "recreate-agent",
       type: "personal_assistant",
       displayName: "Recreated",
     });
@@ -76,24 +80,24 @@ describe("Admin DELETE Agent API", () => {
   it("deletes agent's adapter bindings", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "del-adapter-agent" });
+    const { agent } = await createTestAgent(app, { name: "del-adapter-agent" });
 
     // Create an adapter config bound to this agent
     await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_del_test", app_secret: "secret" },
     });
 
     // Suspend then delete
-    await suspendAgent(app.db, agent.id);
-    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.id}`);
+    await suspendAgent(app.db, agent.uuid);
+    const delRes = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(delRes.statusCode).toBe(204);
 
     // Adapter config should be cleaned up
     const listRes = await req("GET", "/api/v1/admin/adapters");
     const configs = listRes.json();
-    const found = configs.find((c: { agentId: string }) => c.agentId === agent.id);
+    const found = configs.find((c: { agentId: string }) => c.agentId === agent.uuid);
     expect(found).toBeUndefined();
   });
 
@@ -109,11 +113,11 @@ describe("Admin DELETE Agent API", () => {
     const app = await appPromise;
     const req = await authedRequest(app);
 
-    await createAgent(app.db, { id: "double-del", type: "human" });
-    await suspendAgent(app.db, "double-del");
-    await req("DELETE", "/api/v1/admin/agents/double-del");
+    const agent = await createAgent(app.db, { name: "double-del", type: "human" });
+    await suspendAgent(app.db, agent.uuid);
+    await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
 
-    const res = await req("DELETE", "/api/v1/admin/agents/double-del");
+    const res = await req("DELETE", `/api/v1/admin/agents/${agent.uuid}`);
     expect(res.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/__tests__/admin-disconnect.test.ts
+++ b/packages/server/src/__tests__/admin-disconnect.test.ts
@@ -23,25 +23,25 @@ describe("Admin Agent Disconnect API", () => {
     const req = await authedRequest(app);
 
     const agent = await createAgent(app.db, {
-      id: `disc-a1-${crypto.randomUUID().slice(0, 6)}`,
+      name: `disc-a1-${crypto.randomUUID().slice(0, 6)}`,
       type: "autonomous_agent",
       displayName: "Disc Agent",
     });
 
     // Simulate agent being online
-    await presenceService.setOnline(app.db, agent.id, "test-instance");
-    let presence = await presenceService.getPresence(app.db, agent.id);
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    let presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence?.status).toBe("online");
 
     // Call disconnect endpoint
-    const res = await req("POST", `/api/v1/admin/agents/${agent.id}/disconnect`);
+    const res = await req("POST", `/api/v1/admin/agents/${agent.uuid}/disconnect`);
     expect(res.statusCode).toBe(200);
     const body = res.json();
     // No actual WS connection in test, so wasConnected is false (forceDisconnect returns false)
     expect(body).toHaveProperty("disconnected");
 
     // Presence should now be offline
-    presence = await presenceService.getPresence(app.db, agent.id);
+    presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence?.status).toBe("offline");
   });
 
@@ -50,11 +50,11 @@ describe("Admin Agent Disconnect API", () => {
     const req = await authedRequest(app);
 
     const agent = await createAgent(app.db, {
-      id: `disc-a2-${crypto.randomUUID().slice(0, 6)}`,
+      name: `disc-a2-${crypto.randomUUID().slice(0, 6)}`,
       type: "autonomous_agent",
     });
 
-    const res = await req("POST", `/api/v1/admin/agents/${agent.id}/disconnect`);
+    const res = await req("POST", `/api/v1/admin/agents/${agent.uuid}/disconnect`);
     expect(res.statusCode).toBe(200);
     expect(res.json().disconnected).toBe(false);
   });

--- a/packages/server/src/__tests__/admin-overview.test.ts
+++ b/packages/server/src/__tests__/admin-overview.test.ts
@@ -8,15 +8,15 @@ describe("Admin Overview API", () => {
   it("returns system overview", async () => {
     const app = await appPromise;
     const admin = await createTestAdmin(app);
-    const { token: t1 } = await createTestAgent(app, { id: "overview-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "overview-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "overview-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "overview-a2" });
 
     // Create a chat
     await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
 
     const res = await app.inject({

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -7,8 +7,8 @@ describe("Agent Chats API", () => {
 
   it("creates a chat and retrieves it", async () => {
     const app = await appPromise;
-    const { agent: a1, token: t1 } = await createTestAgent(app, { id: "chat-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "chat-a2" });
+    const { agent: a1, token: t1 } = await createTestAgent(app, { name: "chat-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "chat-a2" });
 
     const createRes = await app.inject({
       method: "POST",
@@ -16,7 +16,7 @@ describe("Agent Chats API", () => {
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         type: "direct",
-        participantIds: [a2.id],
+        participantIds: [a2.uuid],
         topic: "Test chat",
       },
     });
@@ -24,7 +24,7 @@ describe("Agent Chats API", () => {
     const chat = createRes.json();
     expect(chat.type).toBe("direct");
     expect(chat.participants).toHaveLength(2);
-    expect(chat.participants.map((p: { agentId: string }) => p.agentId).sort()).toEqual([a1.id, a2.id].sort());
+    expect(chat.participants.map((p: { agentId: string }) => p.agentId).sort()).toEqual([a1.uuid, a2.uuid].sort());
 
     const getRes = await app.inject({
       method: "GET",
@@ -37,14 +37,14 @@ describe("Agent Chats API", () => {
 
   it("lists chats for an agent", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "list-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "list-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "list-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "list-a2" });
 
     await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
 
     const res = await app.inject({
@@ -58,7 +58,7 @@ describe("Agent Chats API", () => {
 
   it("rejects chat creation with non-existent participant", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "bad-a1" });
+    const { token: t1 } = await createTestAgent(app, { name: "bad-a1" });
 
     const res = await app.inject({
       method: "POST",
@@ -71,15 +71,15 @@ describe("Agent Chats API", () => {
 
   it("rejects access to non-participant chat", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "deny-a1" });
-    const { token: t2 } = await createTestAgent(app, { id: "deny-a2" });
-    const { agent: a3 } = await createTestAgent(app, { id: "deny-a3" });
+    const { token: t1 } = await createTestAgent(app, { name: "deny-a1" });
+    const { token: t2 } = await createTestAgent(app, { name: "deny-a2" });
+    const { agent: a3 } = await createTestAgent(app, { name: "deny-a3" });
 
     const createRes = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t2}` },
-      payload: { type: "direct", participantIds: [a3.id] },
+      payload: { type: "direct", participantIds: [a3.uuid] },
     });
     const chatId = createRes.json().id;
 

--- a/packages/server/src/__tests__/agent-identity.test.ts
+++ b/packages/server/src/__tests__/agent-identity.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createAgent, deleteAgent, getAgent, getAgentByName, listAgents, suspendAgent } from "../services/agent.js";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("Agent Identity (UUID + Name)", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  // ── Name recycling ──────────────────────────────────────────────
+
+  describe("name recycling", () => {
+    it("reusing a deleted name creates a new agent with a different uuid", async () => {
+      const app = await appPromise;
+
+      // Create → suspend → delete
+      const original = await createAgent(app.db, { name: "recycle-me", type: "human" });
+      await suspendAgent(app.db, original.uuid);
+      await deleteAgent(app.db, original.uuid);
+
+      // Recreate with same name
+      const recycled = await createAgent(app.db, { name: "recycle-me", type: "autonomous_agent" });
+
+      expect(recycled.uuid).not.toBe(original.uuid);
+      expect(recycled.name).toBe("recycle-me");
+      expect(recycled.type).toBe("autonomous_agent");
+      expect(recycled.status).toBe("active");
+    });
+
+    it("deleted agent retains uuid but loses name", async () => {
+      const app = await appPromise;
+
+      const agent = await createAgent(app.db, { name: "will-delete", type: "human" });
+      const savedUuid = agent.uuid;
+
+      await suspendAgent(app.db, agent.uuid);
+      await deleteAgent(app.db, agent.uuid);
+
+      // uuid still exists in DB (for historical message attribution)
+      // but getAgent (which excludes deleted) returns 404
+      await expect(getAgent(app.db, savedUuid)).rejects.toThrow(/not found/i);
+    });
+
+    it("multiple deleted agents can have name=NULL in the same org", async () => {
+      const app = await appPromise;
+
+      const a1 = await createAgent(app.db, { name: "multi-del-1", type: "human" });
+      const a2 = await createAgent(app.db, { name: "multi-del-2", type: "human" });
+
+      await suspendAgent(app.db, a1.uuid);
+      await deleteAgent(app.db, a1.uuid);
+      await suspendAgent(app.db, a2.uuid);
+      await deleteAgent(app.db, a2.uuid);
+
+      // Both deleted — no unique constraint violation (NULL != NULL in PG)
+      // Verify by creating new agents with those names
+      const r1 = await createAgent(app.db, { name: "multi-del-1", type: "autonomous_agent" });
+      const r2 = await createAgent(app.db, { name: "multi-del-2", type: "autonomous_agent" });
+      expect(r1.uuid).not.toBe(a1.uuid);
+      expect(r2.uuid).not.toBe(a2.uuid);
+    });
+  });
+
+  // ── getAgentByName ──────────────────────────────────────────────
+
+  describe("getAgentByName", () => {
+    it("resolves an active agent by org + name", async () => {
+      const app = await appPromise;
+
+      const created = await createAgent(app.db, { name: "find-by-name", type: "autonomous_agent" });
+      const found = await getAgentByName(app.db, "default", "find-by-name");
+
+      expect(found.uuid).toBe(created.uuid);
+      expect(found.name).toBe("find-by-name");
+    });
+
+    it("returns 404 for non-existent name", async () => {
+      const app = await appPromise;
+
+      await expect(getAgentByName(app.db, "default", "no-such-agent")).rejects.toThrow(/not found/i);
+    });
+
+    it("returns 404 for deleted agent name", async () => {
+      const app = await appPromise;
+
+      const agent = await createAgent(app.db, { name: "deleted-lookup", type: "human" });
+      await suspendAgent(app.db, agent.uuid);
+      await deleteAgent(app.db, agent.uuid);
+
+      await expect(getAgentByName(app.db, "default", "deleted-lookup")).rejects.toThrow(/not found/i);
+    });
+
+    it("returns 404 when name exists in a different org", async () => {
+      const app = await appPromise;
+
+      await createAgent(app.db, {
+        name: "org-scoped",
+        type: "autonomous_agent",
+        organizationId: "org-alpha",
+      });
+
+      // Same name, different org → not found
+      await expect(getAgentByName(app.db, "org-beta", "org-scoped")).rejects.toThrow(/not found/i);
+
+      // Correct org → found
+      const found = await getAgentByName(app.db, "org-alpha", "org-scoped");
+      expect(found.name).toBe("org-scoped");
+    });
+  });
+
+  // ── listAgents org filtering ────────────────────────────────────
+
+  describe("listAgents org filtering", () => {
+    it("only returns agents in the requested org", async () => {
+      const app = await appPromise;
+
+      const a1 = await createAgent(app.db, {
+        name: "list-org-a",
+        type: "human",
+        organizationId: "org-list-test",
+      });
+      await createAgent(app.db, {
+        name: "list-org-b",
+        type: "human",
+        organizationId: "org-other",
+      });
+
+      const result = await listAgents(app.db, "org-list-test", 50);
+      const uuids = result.items.map((a) => a.uuid);
+
+      expect(uuids).toContain(a1.uuid);
+      // Should not contain agents from "org-other" or "default"
+      for (const item of result.items) {
+        expect(item.organizationId).toBe("org-list-test");
+      }
+    });
+  });
+
+  // ── UUID generation ─────────────────────────────────────────────
+
+  describe("uuid generation", () => {
+    it("auto-generates uuid when creating an agent", async () => {
+      const app = await appPromise;
+
+      const agent = await createAgent(app.db, { name: "auto-uuid", type: "autonomous_agent" });
+
+      // UUID v7 format: 8-4-4-4-12 hex chars, version nibble = 7
+      expect(agent.uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it("generates inbox_id from uuid", async () => {
+      const app = await appPromise;
+
+      const agent = await createAgent(app.db, { name: "inbox-uuid", type: "autonomous_agent" });
+
+      expect(agent.inboxId).toBe(`inbox_${agent.uuid}`);
+    });
+  });
+
+  // ── Name uniqueness ─────────────────────────────────────────────
+
+  describe("name uniqueness", () => {
+    it("rejects duplicate name within the same org", async () => {
+      const app = await appPromise;
+
+      await createAgent(app.db, { name: "unique-name", type: "human" });
+
+      await expect(createAgent(app.db, { name: "unique-name", type: "autonomous_agent" })).rejects.toThrow(
+        /already exists/i,
+      );
+    });
+
+    it("allows same name in different orgs", async () => {
+      const app = await appPromise;
+
+      const a1 = await createAgent(app.db, {
+        name: "cross-org-name",
+        type: "human",
+        organizationId: "org-x",
+      });
+      const a2 = await createAgent(app.db, {
+        name: "cross-org-name",
+        type: "human",
+        organizationId: "org-y",
+      });
+
+      expect(a1.uuid).not.toBe(a2.uuid);
+      expect(a1.name).toBe(a2.name);
+      expect(a1.organizationId).toBe("org-x");
+      expect(a2.organizationId).toBe("org-y");
+    });
+
+    it("allows creating an agent without a name", async () => {
+      const app = await appPromise;
+
+      const agent = await createAgent(app.db, { type: "autonomous_agent" });
+
+      expect(agent.uuid).toBeDefined();
+      expect(agent.name).toBeNull();
+    });
+  });
+
+  // ── Admin API integration ───────────────────────────────────────
+
+  describe("admin API uuid routing", () => {
+    it("GET /admin/agents returns uuid + name fields", async () => {
+      const app = await appPromise;
+      const admin = await createTestAdmin(app, { username: `id-admin-${Date.now()}` });
+
+      await createAgent(app.db, { name: "api-check", type: "human" });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/admin/agents",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ items: Array<{ uuid: string; name: string | null }> }>();
+      const found = body.items.find((a) => a.name === "api-check");
+      expect(found).toBeDefined();
+      expect(found?.uuid).toMatch(/^[0-9a-f]{8}-/);
+    });
+
+    it("GET /admin/agents/:uuid fetches by uuid", async () => {
+      const app = await appPromise;
+      const admin = await createTestAdmin(app, { username: `id-admin2-${Date.now()}` });
+
+      const agent = await createAgent(app.db, { name: "get-by-uuid", type: "autonomous_agent" });
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/admin/agents/${agent.uuid}`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ uuid: string; name: string }>();
+      expect(body.uuid).toBe(agent.uuid);
+      expect(body.name).toBe("get-by-uuid");
+    });
+  });
+});

--- a/packages/server/src/__tests__/agent-inbox.test.ts
+++ b/packages/server/src/__tests__/agent-inbox.test.ts
@@ -7,15 +7,15 @@ describe("Agent Inbox API", () => {
 
   it("polls inbox and acks entry", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "inbox-a1" });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "inbox-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "inbox-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: "inbox-a2" });
 
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chatId = chatRes.json().id;
 

--- a/packages/server/src/__tests__/agent-messages.test.ts
+++ b/packages/server/src/__tests__/agent-messages.test.ts
@@ -6,14 +6,14 @@ describe("Agent Messages API", () => {
   afterAll(async () => (await appPromise).close());
 
   async function setupChat(app: Awaited<ReturnType<typeof createTestApp>>) {
-    const { agent: a1, token: t1 } = await createTestAgent(app, { id: `msg-a1-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `msg-a2-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1, token: t1 } = await createTestAgent(app, { name: `msg-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: `msg-a2-${crypto.randomUUID().slice(0, 6)}` });
 
     const res = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chat = res.json();
     return { a1, a2, t1, t2, chatId: chat.id };
@@ -88,7 +88,7 @@ describe("Agent Messages API", () => {
   it("rejects message from non-participant", async () => {
     const app = await appPromise;
     const { chatId } = await setupChat(app);
-    const { token: outsider } = await createTestAgent(app, { id: "outsider" });
+    const { token: outsider } = await createTestAgent(app, { name: "outsider" });
 
     const res = await app.inject({
       method: "POST",

--- a/packages/server/src/__tests__/agent-messaging-flow.test.ts
+++ b/packages/server/src/__tests__/agent-messaging-flow.test.ts
@@ -7,19 +7,19 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("full flow: send to agent, list chats, view history", async () => {
     const app = await appPromise;
-    const { agent: sender, token: senderToken } = await createTestAgent(app, { id: "flow-sender" });
-    const { agent: receiver, token: receiverToken } = await createTestAgent(app, { id: "flow-receiver" });
+    const { agent: sender, token: senderToken } = await createTestAgent(app, { name: "flow-sender" });
+    const { agent: receiver, token: receiverToken } = await createTestAgent(app, { name: "flow-receiver" });
 
     // 1. Send a direct message to another agent
     const sendRes = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${receiver.id}/messages`,
+      url: `/api/v1/agent/agents/${receiver.name}/messages`,
       headers: { authorization: `Bearer ${senderToken}` },
       payload: { format: "text", content: "Hello from sender" },
     });
     expect(sendRes.statusCode).toBe(201);
     const sentMessage = sendRes.json();
-    expect(sentMessage.senderId).toBe(sender.id);
+    expect(sentMessage.senderId).toBe(sender.uuid);
     expect(sentMessage.content).toBe("Hello from sender");
     expect(sentMessage.chatId).toBeDefined();
 
@@ -55,7 +55,7 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
     const history = historyRes.json();
     expect(history.items).toHaveLength(1);
     expect(history.items[0].content).toBe("Hello from sender");
-    expect(history.items[0].senderId).toBe(sender.id);
+    expect(history.items[0].senderId).toBe(sender.uuid);
 
     // 5. Receiver replies in the same chat
     const replyRes = await app.inject({
@@ -65,7 +65,7 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
       payload: { format: "text", content: "Hello back!" },
     });
     expect(replyRes.statusCode).toBe(201);
-    expect(replyRes.json().senderId).toBe(receiver.id);
+    expect(replyRes.json().senderId).toBe(receiver.uuid);
 
     // 6. History now has 2 messages
     const historyRes2 = await app.inject({
@@ -79,18 +79,18 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("chats list respects pagination", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "page-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "page-a2" });
-    const { agent: a3 } = await createTestAgent(app, { id: "page-a3" });
-    const { agent: a4 } = await createTestAgent(app, { id: "page-a4" });
+    const { token: t1 } = await createTestAgent(app, { name: "page-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "page-a2" });
+    const { agent: a3 } = await createTestAgent(app, { name: "page-a3" });
+    const { agent: a4 } = await createTestAgent(app, { name: "page-a4" });
 
     // Create 3 chats
     for (const target of [a2, a3, a4]) {
       await app.inject({
         method: "POST",
-        url: `/api/v1/agent/agents/${target.id}/messages`,
+        url: `/api/v1/agent/agents/${target.name}/messages`,
         headers: { authorization: `Bearer ${t1}` },
-        payload: { format: "text", content: `hi ${target.id}` },
+        payload: { format: "text", content: `hi ${target.name}` },
       });
     }
 
@@ -118,13 +118,13 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("message history respects pagination", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "msghist-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "msghist-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "msghist-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "msghist-a2" });
 
     // Send first message to create chat
     const firstMsg = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "msg-1" },
     });
@@ -163,14 +163,14 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("non-participant cannot view history", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "noaccess-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "noaccess-a2" });
-    const { token: t3 } = await createTestAgent(app, { id: "noaccess-a3" });
+    const { token: t1 } = await createTestAgent(app, { name: "noaccess-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "noaccess-a2" });
+    const { token: t3 } = await createTestAgent(app, { name: "noaccess-a3" });
 
     // a1 sends to a2 → creates direct chat
     const sendRes = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "private" },
     });
@@ -187,12 +187,12 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("send with markdown format", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "md-sender" });
-    const { agent: a2 } = await createTestAgent(app, { id: "md-receiver" });
+    const { token: t1 } = await createTestAgent(app, { name: "md-sender" });
+    const { agent: a2 } = await createTestAgent(app, { name: "md-receiver" });
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "markdown", content: "## Hello\n\nThis is **bold**" },
     });
@@ -203,12 +203,12 @@ describe("Agent Messaging Flow (send → chats → history)", () => {
 
   it("send with metadata", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "meta-sender" });
-    const { agent: a2 } = await createTestAgent(app, { id: "meta-receiver" });
+    const { token: t1 } = await createTestAgent(app, { name: "meta-sender" });
+    const { agent: a2 } = await createTestAgent(app, { name: "meta-receiver" });
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         format: "text",

--- a/packages/server/src/__tests__/agent-participants.test.ts
+++ b/packages/server/src/__tests__/agent-participants.test.ts
@@ -7,15 +7,15 @@ describe("Agent Participants API", () => {
 
   async function setupChat(app: Awaited<ReturnType<typeof createTestApp>>) {
     const uid = crypto.randomUUID().slice(0, 6);
-    const { agent: a1, token: t1 } = await createTestAgent(app, { id: `part-a1-${uid}` });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `part-a2-${uid}` });
-    const { agent: a3, token: t3 } = await createTestAgent(app, { id: `part-a3-${uid}` });
+    const { agent: a1, token: t1 } = await createTestAgent(app, { name: `part-a1-${uid}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: `part-a2-${uid}` });
+    const { agent: a3, token: t3 } = await createTestAgent(app, { name: `part-a3-${uid}` });
 
     const res = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "group", participantIds: [a2.id] },
+      payload: { type: "group", participantIds: [a2.uuid] },
     });
     const chat = res.json();
     return { a1, a2, a3, t1, t2, t3, chatId: chat.id };
@@ -29,12 +29,12 @@ describe("Agent Participants API", () => {
       method: "POST",
       url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t1}` },
-      payload: { agentId: a3.id },
+      payload: { agentId: a3.uuid },
     });
     expect(res.statusCode).toBe(201);
     const participants = res.json();
     expect(participants).toHaveLength(3);
-    expect(participants.map((p: { agentId: string }) => p.agentId)).toContain(a3.id);
+    expect(participants.map((p: { agentId: string }) => p.agentId)).toContain(a3.uuid);
   });
 
   it("rejects adding duplicate participant", async () => {
@@ -45,7 +45,7 @@ describe("Agent Participants API", () => {
       method: "POST",
       url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t1}` },
-      payload: { agentId: a2.id },
+      payload: { agentId: a2.uuid },
     });
     expect(res.statusCode).toBe(409);
   });
@@ -69,7 +69,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/api/v1/agent/chats/${chatId}/participants/${a2.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a2.uuid}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(204);
@@ -82,7 +82,7 @@ describe("Agent Participants API", () => {
     });
     const participants = detail.json().participants;
     expect(participants).toHaveLength(1);
-    expect(participants[0].agentId).toBe((await setupChat(app)).a1.id.slice(0, 0) || participants[0].agentId);
+    expect(participants[0].agentId).toBe((await setupChat(app)).a1.uuid.slice(0, 0) || participants[0].agentId);
   });
 
   it("rejects removing non-participant agent", async () => {
@@ -91,7 +91,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/api/v1/agent/chats/${chatId}/participants/${a3.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a3.uuid}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(404);
@@ -103,7 +103,7 @@ describe("Agent Participants API", () => {
 
     const res = await app.inject({
       method: "DELETE",
-      url: `/api/v1/agent/chats/${chatId}/participants/${a1.id}`,
+      url: `/api/v1/agent/chats/${chatId}/participants/${a1.uuid}`,
       headers: { authorization: `Bearer ${t1}` },
     });
     expect(res.statusCode).toBe(400);
@@ -117,7 +117,7 @@ describe("Agent Participants API", () => {
       method: "POST",
       url: `/api/v1/agent/chats/${chatId}/participants`,
       headers: { authorization: `Bearer ${t3}` },
-      payload: { agentId: a3.id },
+      payload: { agentId: a3.uuid },
     });
     expect(res.statusCode).toBe(403);
   });

--- a/packages/server/src/__tests__/agent-send-to-agent.test.ts
+++ b/packages/server/src/__tests__/agent-send-to-agent.test.ts
@@ -7,12 +7,12 @@ describe("Agent Send-to-Agent API", () => {
 
   it("sends a message to another agent (auto-creates direct chat)", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "sta-a1" });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "sta-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "sta-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: "sta-a2" });
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Hello agent!" },
     });
@@ -35,12 +35,12 @@ describe("Agent Send-to-Agent API", () => {
 
   it("reuses existing direct chat for same pair", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "reuse-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "reuse-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "reuse-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "reuse-a2" });
 
     const res1 = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "First message" },
     });
@@ -48,7 +48,7 @@ describe("Agent Send-to-Agent API", () => {
 
     const res2 = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "Second message" },
     });
@@ -59,7 +59,7 @@ describe("Agent Send-to-Agent API", () => {
 
   it("rejects sending to non-existent agent", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "noagent-a1" });
+    const { token: t1 } = await createTestAgent(app, { name: "noagent-a1" });
 
     const res = await app.inject({
       method: "POST",
@@ -72,12 +72,12 @@ describe("Agent Send-to-Agent API", () => {
 
   it("sends with replyTo fields", async () => {
     const app = await appPromise;
-    const { agent: a1, token: t1 } = await createTestAgent(app, { id: "reply-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "reply-a2" });
+    const { agent: a1, token: t1 } = await createTestAgent(app, { name: "reply-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "reply-a2" });
 
     const res = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: {
         format: "text",

--- a/packages/server/src/__tests__/e2e-github-to-cli.test.ts
+++ b/packages/server/src/__tests__/e2e-github-to-cli.test.ts
@@ -31,7 +31,7 @@ async function sdkRequest<T>(baseUrl: string, token: string, path: string, init?
 }
 
 function sdkRegister(baseUrl: string, token: string) {
-  return sdkRequest<{ id: string; inboxId: string; status: string }>(baseUrl, token, "/api/v1/agent/me");
+  return sdkRequest<{ uuid: string; inboxId: string; status: string }>(baseUrl, token, "/api/v1/agent/me");
 }
 
 function sdkPull(baseUrl: string, token: string, limit = 10) {
@@ -47,13 +47,16 @@ function sdkAck(baseUrl: string, token: string, entryId: number) {
 }
 
 // Helper: create agent + token directly via admin-like DB operations
-async function createTestAgent(app: Awaited<ReturnType<typeof buildApp>>, opts: { id: string; displayName?: string }) {
+async function createTestAgent(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  opts: { name: string; displayName?: string },
+) {
   const agent = await createAgent(app.db, {
-    id: opts.id,
+    name: opts.name,
     type: "autonomous_agent",
     displayName: opts.displayName ?? "Test Agent",
   });
-  const tokenResult = await createToken(app.db, agent.id, { name: "test" });
+  const tokenResult = await createToken(app.db, agent.uuid, { name: "test" });
   return { agent, token: tokenResult.token };
 }
 
@@ -97,14 +100,14 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
   it("full flow: webhook → inbox → pull → ack", async () => {
     // 1. Create target agent with github.repos metadata
     const { agent, token } = await createTestAgent(app, {
-      id: "issue-handler",
+      name: "issue-handler",
       displayName: "Issue Handler",
     });
 
     await app.db
       .update(agents)
       .set({ metadata: { github: { repos: ["acme/my-repo"] } } })
-      .where(eq(agents.id, agent.id));
+      .where(eq(agents.uuid, agent.uuid));
 
     // 2. Send GitHub issue webhook
     const issuePayload = JSON.stringify({
@@ -137,8 +140,8 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
 
     // 3. Register — verify agent identity
     const identity = await sdkRegister(address, token);
-    expect(identity.id).toBe("issue-handler");
-    expect(identity.inboxId).toBe("inbox_issue-handler");
+    expect(identity.uuid).toBe(agent.uuid);
+    expect(identity.inboxId).toBe(agent.inboxId);
 
     // 4. Pull — should have the GitHub issue message
     const entries = await sdkPull(address, token, 10);
@@ -148,7 +151,8 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
     if (!entry) throw new Error("Expected entry");
 
     expect(entry.message.format).toBe("card");
-    expect(entry.message.senderId).toBe("github-adapter");
+    // senderId is the github-adapter agent's UUID (auto-generated)
+    expect(entry.message.senderId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-/);
 
     const content = entry.message.content as Record<string, unknown>;
     expect(content.type).toBe("github_issue");
@@ -233,11 +237,11 @@ describe("E2E: GitHub issue → Server → CLI pull", () => {
   });
 
   it("issue_comment event", async () => {
-    const { agent, token } = await createTestAgent(app, { id: "comment-handler" });
+    const { agent, token } = await createTestAgent(app, { name: "comment-handler" });
     await app.db
       .update(agents)
       .set({ metadata: { github: { repos: ["acme/repo"] } } })
-      .where(eq(agents.id, agent.id));
+      .where(eq(agents.uuid, agent.uuid));
 
     const commentPayload = JSON.stringify({
       action: "created",

--- a/packages/server/src/__tests__/e2e-session-runtime.test.ts
+++ b/packages/server/src/__tests__/e2e-session-runtime.test.ts
@@ -60,13 +60,16 @@ function createTestHandler(events: LifecycleEvent[]): AgentHandler {
 
 // -- Helpers -----------------------------------------------------------------
 
-async function createTestAgent(app: Awaited<ReturnType<typeof buildApp>>, opts: { id: string; displayName?: string }) {
+async function createTestAgent(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  opts: { name: string; displayName?: string },
+) {
   const agent = await createAgent(app.db, {
-    id: opts.id,
+    name: opts.name,
     type: "autonomous_agent",
     displayName: opts.displayName ?? "Test Agent",
   });
-  const tokenResult = await createToken(app.db, agent.id, { name: "test" });
+  const tokenResult = await createToken(app.db, agent.uuid, { name: "test" });
   return { agent, token: tokenResult.token };
 }
 
@@ -104,8 +107,8 @@ describe("E2E: Session-oriented Runtime", () => {
 
   it("full session lifecycle: start → inject → shutdown", async () => {
     // 1. Create sender and receiver agents
-    const sender = await createTestAgent(app, { id: "sender-agent", displayName: "Sender" });
-    const receiver = await createTestAgent(app, { id: "receiver-agent", displayName: "Receiver" });
+    const sender = await createTestAgent(app, { name: "sender-agent", displayName: "Sender" });
+    const receiver = await createTestAgent(app, { name: "receiver-agent", displayName: "Receiver" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const receiverSdk = new FirstTreeHubSDK({ serverUrl: address, token: receiver.token });
@@ -113,8 +116,8 @@ describe("E2E: Session-oriented Runtime", () => {
     // Verify both agents are registered
     const senderIdentity = await senderSdk.register();
     const receiverIdentity = await receiverSdk.register();
-    expect(senderIdentity.agentId).toBe("sender-agent");
-    expect(receiverIdentity.agentId).toBe("receiver-agent");
+    expect(senderIdentity.agentId).toBe(sender.agent.uuid);
+    expect(receiverIdentity.agentId).toBe(receiver.agent.uuid);
 
     // 2. Send first message from sender → receiver (creates chat via sendToAgent)
     const msg1 = await senderSdk.sendToAgent("receiver-agent", {
@@ -204,9 +207,9 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("separate sessions for different chats", async () => {
-    const sender = await createTestAgent(app, { id: "sender-2", displayName: "Sender" });
-    const receiver = await createTestAgent(app, { id: "receiver-2", displayName: "Receiver" });
-    const otherAgent = await createTestAgent(app, { id: "other-agent", displayName: "Other" });
+    const sender = await createTestAgent(app, { name: "sender-2", displayName: "Sender" });
+    const receiver = await createTestAgent(app, { name: "receiver-2", displayName: "Receiver" });
+    const otherAgent = await createTestAgent(app, { name: "other-agent", displayName: "Other" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const otherSdk = new FirstTreeHubSDK({ serverUrl: address, token: otherAgent.token });
@@ -254,7 +257,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-2",
+        agentId: receiver.agent.uuid,
         displayName: "Receiver",
         type: "autonomous_agent",
         delegateMention: null,
@@ -289,8 +292,8 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("deduplicates redelivered messages", async () => {
-    const sender = await createTestAgent(app, { id: "sender-3" });
-    const receiver = await createTestAgent(app, { id: "receiver-3" });
+    const sender = await createTestAgent(app, { name: "sender-3" });
+    const receiver = await createTestAgent(app, { name: "receiver-3" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const receiverSdk = new FirstTreeHubSDK({ serverUrl: address, token: receiver.token });
@@ -304,7 +307,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-3",
+        agentId: receiver.agent.uuid,
         displayName: null,
         type: "autonomous_agent",
         delegateMention: null,
@@ -332,8 +335,8 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("immediate ACK ensures message is consumed from inbox", async () => {
-    const sender = await createTestAgent(app, { id: "sender-4" });
-    const receiver = await createTestAgent(app, { id: "receiver-4" });
+    const sender = await createTestAgent(app, { name: "sender-4" });
+    const receiver = await createTestAgent(app, { name: "receiver-4" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const receiverSdk = new FirstTreeHubSDK({ serverUrl: address, token: receiver.token });
@@ -347,7 +350,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-4",
+        agentId: receiver.agent.uuid,
         displayName: null,
         type: "autonomous_agent",
         delegateMention: null,
@@ -383,8 +386,8 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("idle suspend → resume preserves session identity", async () => {
-    const sender = await createTestAgent(app, { id: "sender-6" });
-    const receiver = await createTestAgent(app, { id: "receiver-6" });
+    const sender = await createTestAgent(app, { name: "sender-6" });
+    const receiver = await createTestAgent(app, { name: "receiver-6" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const receiverSdk = new FirstTreeHubSDK({ serverUrl: address, token: receiver.token });
@@ -400,7 +403,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-6",
+        agentId: receiver.agent.uuid,
         displayName: null,
         type: "autonomous_agent",
         delegateMention: null,
@@ -450,10 +453,10 @@ describe("E2E: Session-oriented Runtime", () => {
   }, 20_000);
 
   it("concurrency limit suspends oldest idle and drains pending queue", async () => {
-    const sender = await createTestAgent(app, { id: "sender-7" });
-    const receiver = await createTestAgent(app, { id: "receiver-7" });
-    const other1 = await createTestAgent(app, { id: "other-7a" });
-    const other2 = await createTestAgent(app, { id: "other-7b" });
+    const sender = await createTestAgent(app, { name: "sender-7" });
+    const receiver = await createTestAgent(app, { name: "receiver-7" });
+    const other1 = await createTestAgent(app, { name: "other-7a" });
+    const other2 = await createTestAgent(app, { name: "other-7b" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const other1Sdk = new FirstTreeHubSDK({ serverUrl: address, token: other1.token });
@@ -500,7 +503,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-7",
+        agentId: receiver.agent.uuid,
         displayName: null,
         type: "autonomous_agent",
         delegateMention: null,
@@ -539,10 +542,10 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("evicted session resumes (not starts) when new message arrives", async () => {
-    const sender = await createTestAgent(app, { id: "sender-8" });
-    const receiver = await createTestAgent(app, { id: "receiver-8" });
-    const other1 = await createTestAgent(app, { id: "other-8a" });
-    const other2 = await createTestAgent(app, { id: "other-8b" });
+    const sender = await createTestAgent(app, { name: "sender-8" });
+    const receiver = await createTestAgent(app, { name: "receiver-8" });
+    const other1 = await createTestAgent(app, { name: "other-8a" });
+    const other2 = await createTestAgent(app, { name: "other-8b" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const other1Sdk = new FirstTreeHubSDK({ serverUrl: address, token: other1.token });
@@ -579,7 +582,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-8",
+        agentId: receiver.agent.uuid,
         displayName: null,
         type: "autonomous_agent",
         delegateMention: null,
@@ -632,8 +635,8 @@ describe("E2E: Session-oriented Runtime", () => {
   });
 
   it("handler receives SessionContext with correct fields", async () => {
-    const sender = await createTestAgent(app, { id: "sender-5" });
-    const receiver = await createTestAgent(app, { id: "receiver-5" });
+    const sender = await createTestAgent(app, { name: "sender-5" });
+    const receiver = await createTestAgent(app, { name: "receiver-5" });
 
     const senderSdk = new FirstTreeHubSDK({ serverUrl: address, token: sender.token });
     const receiverSdk = new FirstTreeHubSDK({ serverUrl: address, token: receiver.token });
@@ -663,7 +666,7 @@ describe("E2E: Session-oriented Runtime", () => {
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/e2e-test" },
       agentIdentity: {
-        agentId: "receiver-5",
+        agentId: receiver.agent.uuid,
         displayName: "Receiver Five",
         type: "autonomous_agent",
         delegateMention: null,
@@ -682,7 +685,7 @@ describe("E2E: Session-oriented Runtime", () => {
     // Verify SessionContext
     const ctx = captured.ctx;
     expect(ctx).not.toBeNull();
-    expect(ctx?.agent.agentId).toBe("receiver-5");
+    expect(ctx?.agent.agentId).toBe(receiver.agent.uuid);
     expect(ctx?.agent.displayName).toBe("Receiver Five");
     expect(ctx?.chatId).toBeDefined();
     expect(typeof ctx?.touch).toBe("function");
@@ -694,7 +697,7 @@ describe("E2E: Session-oriented Runtime", () => {
     expect(msg).not.toBeNull();
     expect(msg?.content).toBe("context test");
     expect(msg?.format).toBe("text");
-    expect(msg?.senderId).toBe("sender-5");
+    expect(msg?.senderId).toBe(sender.agent.uuid);
     expect(msg?.chatId).toBeDefined();
     expect(msg?.id).toBeDefined();
 

--- a/packages/server/src/__tests__/feishu-adapter.test.ts
+++ b/packages/server/src/__tests__/feishu-adapter.test.ts
@@ -19,28 +19,28 @@ describe("Feishu Adapter (WebSocket mode)", () => {
   it("creates adapter config with feishu credentials (agentId required)", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "feishu-ws-agent" });
+    const { agent } = await createTestAgent(app, { name: "feishu-ws-agent" });
 
     const res = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_ws_test", app_secret: "secret_123" },
     });
     expect(res.statusCode).toBe(201);
     expect(res.json().platform).toBe("feishu");
-    expect(res.json().agentId).toBe(agent.id);
+    expect(res.json().agentId).toBe(agent.uuid);
     expect(res.json().hasCredentials).toBe(true);
   });
 
   it("adapter manager reload picks up new config", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "feishu-reload-agent" });
+    const { agent } = await createTestAgent(app, { name: "feishu-reload-agent" });
 
     // Create a new adapter config
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_reload_test", app_secret: "secret_reload" },
     });
     expect(createRes.statusCode).toBe(201);
@@ -57,11 +57,11 @@ describe("Feishu Adapter (WebSocket mode)", () => {
   it("adapter manager reloads on config update", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "feishu-upd-reload-agent" });
+    const { agent } = await createTestAgent(app, { name: "feishu-upd-reload-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_update_reload", app_secret: "secret_u" },
     });
     const created = createRes.json();
@@ -76,11 +76,11 @@ describe("Feishu Adapter (WebSocket mode)", () => {
   it("adapter manager reloads on config delete", async () => {
     const app = await appPromise;
     const req = await authedRequest(app);
-    const { agent } = await createTestAgent(app, { id: "feishu-del-reload-agent" });
+    const { agent } = await createTestAgent(app, { name: "feishu-del-reload-agent" });
 
     const createRes = await req("POST", "/api/v1/admin/adapters", {
       platform: "feishu",
-      agentId: agent.id,
+      agentId: agent.uuid,
       credentials: { app_id: "cli_delete_reload", app_secret: "secret_d" },
     });
     const created = createRes.json();

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -34,15 +34,15 @@ export async function createTestApp(): Promise<FastifyInstance> {
 /** Create an agent via direct DB insert and return its bearer token. */
 export async function createTestAgent(
   app: FastifyInstance,
-  opts: { id?: string; type?: AgentType; displayName?: string } = {},
+  opts: { name?: string; type?: AgentType; displayName?: string } = {},
 ) {
   const { createAgent, createToken } = await import("../services/agent.js");
   const agent = await createAgent(app.db, {
-    id: opts.id ?? `test-agent-${crypto.randomUUID().slice(0, 8)}`,
+    name: opts.name ?? `test-agent-${crypto.randomUUID().slice(0, 8)}`,
     type: opts.type ?? "autonomous_agent",
     displayName: opts.displayName ?? "Test Agent",
   });
-  const token = await createToken(app.db, agent.id, { name: "test" });
+  const token = await createToken(app.db, agent.uuid, { name: "test" });
   return { agent, token: token.token };
 }
 

--- a/packages/server/src/__tests__/inbox-renew.test.ts
+++ b/packages/server/src/__tests__/inbox-renew.test.ts
@@ -7,15 +7,15 @@ describe("Inbox Renew & Timeout API", () => {
 
   async function setupInboxEntry(app: Awaited<ReturnType<typeof createTestApp>>) {
     const uid = crypto.randomUUID().slice(0, 6);
-    const { token: t1 } = await createTestAgent(app, { id: `renew-a1-${uid}` });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: `renew-a2-${uid}` });
+    const { token: t1 } = await createTestAgent(app, { name: `renew-a1-${uid}` });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: `renew-a2-${uid}` });
 
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chatId = chatRes.json().id;
 

--- a/packages/server/src/__tests__/inbox-timeout.test.ts
+++ b/packages/server/src/__tests__/inbox-timeout.test.ts
@@ -9,15 +9,15 @@ describe("Inbox Timeout Reset", () => {
 
   it("resets timed-out delivered entries to pending", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "timeout-a1" });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "timeout-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "timeout-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: "timeout-a2" });
 
     // Create chat and send message
     const chatRes = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chatId = chatRes.json().id;
 
@@ -60,14 +60,14 @@ describe("Inbox Timeout Reset", () => {
 
   it("marks entries as failed after max retries", async () => {
     const app = await appPromise;
-    const { token: t1 } = await createTestAgent(app, { id: "maxretry-a1" });
-    const { agent: a2, token: t2 } = await createTestAgent(app, { id: "maxretry-a2" });
+    const { token: t1 } = await createTestAgent(app, { name: "maxretry-a1" });
+    const { agent: a2, token: t2 } = await createTestAgent(app, { name: "maxretry-a2" });
 
     const chatRes = await app.inject({
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chatId = chatRes.json().id;
 

--- a/packages/server/src/__tests__/kael-runtime.test.ts
+++ b/packages/server/src/__tests__/kael-runtime.test.ts
@@ -145,8 +145,8 @@ describe("KaelRuntime", () => {
 
   describe("reload()", () => {
     it("loads active kael adapter configs from DB", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-reload-1" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-reload-1" });
+      await insertKaelConfig(agent.uuid);
 
       const log = createMockLogger();
       const runtime = createKaelRuntime(app.db, ENCRYPTION_KEY, KAEL_ENDPOINT, KAEL_API_KEY, SERVER_URL, log);
@@ -156,7 +156,7 @@ describe("KaelRuntime", () => {
       expect(log.info).toHaveBeenCalled();
       const infoMock = log.info as unknown as { mock: { calls: unknown[][] } };
       const infoArgs = infoMock.mock.calls.map((c) => (c[0] as Record<string, unknown>)?.agentId);
-      expect(infoArgs).toContain(agent.id);
+      expect(infoArgs).toContain(agent.uuid);
 
       // Verify config was loaded by sending a message through processOutbound
       const chatId = `chat-reload-1-${Date.now()}`;
@@ -176,8 +176,8 @@ describe("KaelRuntime", () => {
     });
 
     it("ignores non-kael configs", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-ignore-feishu" });
-      await insertFeishuConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-ignore-feishu" });
+      await insertFeishuConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -196,8 +196,8 @@ describe("KaelRuntime", () => {
     });
 
     it("ignores inactive configs", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-inactive" });
-      await insertKaelConfig(agent.id, { status: "inactive" });
+      const { agent } = await createTestAgent(app, { name: "kael-inactive" });
+      await insertKaelConfig(agent.uuid, { status: "inactive" });
 
       const runtime = createKaelRuntime(
         app.db,
@@ -215,8 +215,8 @@ describe("KaelRuntime", () => {
     });
 
     it("clears configs when KAEL_ENDPOINT is not set", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-no-endpoint" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-no-endpoint" });
+      await insertKaelConfig(agent.uuid);
 
       // First load with endpoint
       const runtime = createKaelRuntime(
@@ -246,9 +246,9 @@ describe("KaelRuntime", () => {
     });
 
     it("handles decryption failures gracefully (logs error, skips config)", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-bad-creds" });
+      const { agent } = await createTestAgent(app, { name: "kael-bad-creds" });
       // Insert with invalid (non-encrypted) credentials
-      await insertKaelConfig(agent.id, { credentials: "not-valid-encrypted-data" });
+      await insertKaelConfig(agent.uuid, { credentials: "not-valid-encrypted-data" });
 
       const log = createMockLogger();
       const runtime = createKaelRuntime(app.db, ENCRYPTION_KEY, KAEL_ENDPOINT, KAEL_API_KEY, SERVER_URL, log);
@@ -282,8 +282,8 @@ describe("KaelRuntime", () => {
     });
 
     it("claims pending inbox entries for kael-bound agents", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-claim" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-claim" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -317,9 +317,9 @@ describe("KaelRuntime", () => {
     });
 
     it("POSTs correct payload to Kael API (verify URL, headers, body shape)", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-payload" });
+      const { agent } = await createTestAgent(app, { name: "kael-payload" });
       const kaelCreds = { kaelUserId: "u-123", kaelProjectId: "p-456", agentToken: "tok-789" };
-      await insertKaelConfig(agent.id, {
+      await insertKaelConfig(agent.uuid, {
         credentials: encryptCredentials(kaelCreds, ENCRYPTION_KEY),
       });
 
@@ -359,7 +359,7 @@ describe("KaelRuntime", () => {
       // Verify body shape
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
       expect(body.hub_chat_id).toBe(chatId);
-      expect(body.hub_agent_id).toBe(agent.id);
+      expect(body.hub_agent_id).toBe(agent.uuid);
       expect(body.hub_server_url).toBe(SERVER_URL);
       expect(body.hub_agent_token).toBe(kaelCreds.agentToken);
       expect(body.user_id).toBe(kaelCreds.kaelUserId);
@@ -372,8 +372,8 @@ describe("KaelRuntime", () => {
     });
 
     it("ACKs entry on successful POST", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-ack-ok" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-ack-ok" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -406,8 +406,8 @@ describe("KaelRuntime", () => {
     });
 
     it("NACKs entry on HTTP error (4xx, 5xx)", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-nack-http" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-nack-http" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -449,8 +449,8 @@ describe("KaelRuntime", () => {
     });
 
     it("NACKs entry on network error", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-nack-net" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-nack-net" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -484,8 +484,8 @@ describe("KaelRuntime", () => {
     });
 
     it("marks entry as failed after MAX_RETRY_COUNT (3) retries", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-max-retry" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-max-retry" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -531,12 +531,12 @@ describe("KaelRuntime", () => {
 
     it("does not claim entries for non-kael agents", async () => {
       // Create agent with feishu adapter only (no kael)
-      const { agent } = await createTestAgent(app, { id: "kael-non-kael-agent" });
-      await insertFeishuConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-non-kael-agent" });
+      await insertFeishuConfig(agent.uuid);
 
       // Create a kael-bound agent to load configs
-      const { agent: kaelAgent } = await createTestAgent(app, { id: "kael-actual-agent" });
-      await insertKaelConfig(kaelAgent.id);
+      const { agent: kaelAgent } = await createTestAgent(app, { name: "kael-actual-agent" });
+      await insertKaelConfig(kaelAgent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -571,8 +571,8 @@ describe("KaelRuntime", () => {
     });
 
     it("uses X-Internal-API-Key header (not Authorization: Bearer)", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-header-check" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-header-check" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -612,8 +612,8 @@ describe("KaelRuntime", () => {
 
   describe("shutdown()", () => {
     it("clears agent configs", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-shutdown-clear" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-shutdown-clear" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,
@@ -633,8 +633,8 @@ describe("KaelRuntime", () => {
     });
 
     it("processOutbound returns immediately after shutdown", async () => {
-      const { agent } = await createTestAgent(app, { id: "kael-shutdown-noop" });
-      await insertKaelConfig(agent.id);
+      const { agent } = await createTestAgent(app, { name: "kael-shutdown-noop" });
+      await insertKaelConfig(agent.uuid);
 
       const runtime = createKaelRuntime(
         app.db,

--- a/packages/server/src/__tests__/message-recipients.test.ts
+++ b/packages/server/src/__tests__/message-recipients.test.ts
@@ -9,15 +9,15 @@ describe("sendMessage returns recipients", () => {
 
   it("returns recipient inboxIds excluding sender", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: `recip-a1-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a2 } = await createTestAgent(app, { id: `recip-a2-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1 } = await createTestAgent(app, { name: `recip-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `recip-a2-${crypto.randomUUID().slice(0, 6)}` });
 
-    const chat = await createChat(app.db, a1.id, {
+    const chat = await createChat(app.db, a1.uuid, {
       type: "direct",
-      participantIds: [a2.id],
+      participantIds: [a2.uuid],
     });
 
-    const result = await sendMessage(app.db, chat.id, a1.id, {
+    const result = await sendMessage(app.db, chat.id, a1.uuid, {
       format: "text",
       content: "hello",
     });
@@ -30,14 +30,14 @@ describe("sendMessage returns recipients", () => {
 
   it("returns empty recipients when no other participants", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: `recip-solo-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1 } = await createTestAgent(app, { name: `recip-solo-${crypto.randomUUID().slice(0, 6)}` });
 
-    const chat = await createChat(app.db, a1.id, {
+    const chat = await createChat(app.db, a1.uuid, {
       type: "group",
       participantIds: [],
     });
 
-    const result = await sendMessage(app.db, chat.id, a1.id, {
+    const result = await sendMessage(app.db, chat.id, a1.uuid, {
       format: "text",
       content: "talking to myself",
     });
@@ -47,16 +47,16 @@ describe("sendMessage returns recipients", () => {
 
   it("returns multiple recipients in group chat", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: `recip-g1-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a2 } = await createTestAgent(app, { id: `recip-g2-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a3 } = await createTestAgent(app, { id: `recip-g3-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1 } = await createTestAgent(app, { name: `recip-g1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `recip-g2-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a3 } = await createTestAgent(app, { name: `recip-g3-${crypto.randomUUID().slice(0, 6)}` });
 
-    const chat = await createChat(app.db, a1.id, {
+    const chat = await createChat(app.db, a1.uuid, {
       type: "group",
-      participantIds: [a2.id, a3.id],
+      participantIds: [a2.uuid, a3.uuid],
     });
 
-    const result = await sendMessage(app.db, chat.id, a1.id, {
+    const result = await sendMessage(app.db, chat.id, a1.uuid, {
       format: "text",
       content: "group msg",
     });
@@ -70,17 +70,17 @@ describe("sendMessage returns recipients", () => {
 
   it("includes replyTo recipient in recipients", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: `recip-rt1-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a2 } = await createTestAgent(app, { id: `recip-rt2-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a3 } = await createTestAgent(app, { id: `recip-rt3-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1 } = await createTestAgent(app, { name: `recip-rt1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `recip-rt2-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a3 } = await createTestAgent(app, { name: `recip-rt3-${crypto.randomUUID().slice(0, 6)}` });
 
-    const chat = await createChat(app.db, a1.id, {
+    const chat = await createChat(app.db, a1.uuid, {
       type: "group",
-      participantIds: [a2.id],
+      participantIds: [a2.uuid],
     });
 
     // a1 sends a message with replyTo pointing to a3
-    const original = await sendMessage(app.db, chat.id, a1.id, {
+    const original = await sendMessage(app.db, chat.id, a1.uuid, {
       format: "text",
       content: "original message",
       replyToInbox: a3.inboxId,
@@ -88,7 +88,7 @@ describe("sendMessage returns recipients", () => {
     });
 
     // a2 replies to the original message
-    const reply = await sendMessage(app.db, chat.id, a2.id, {
+    const reply = await sendMessage(app.db, chat.id, a2.uuid, {
       format: "text",
       content: "reply",
       inReplyTo: original.message.id,
@@ -101,10 +101,11 @@ describe("sendMessage returns recipients", () => {
 
   it("sendToAgent returns recipients", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: `recip-dm1-${crypto.randomUUID().slice(0, 6)}` });
-    const { agent: a2 } = await createTestAgent(app, { id: `recip-dm2-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a1 } = await createTestAgent(app, { name: `recip-dm1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `recip-dm2-${crypto.randomUUID().slice(0, 6)}` });
+    if (!a2.name) throw new Error("Expected a2.name to be set");
 
-    const result = await sendToAgent(app.db, a1.id, a2.id, {
+    const result = await sendToAgent(app.db, a1.uuid, a2.name, {
       format: "text",
       content: "direct message",
     });

--- a/packages/server/src/__tests__/notify-on-send.test.ts
+++ b/packages/server/src/__tests__/notify-on-send.test.ts
@@ -16,10 +16,10 @@ describe("WebSocket notification on message send", () => {
   it("recipient receives WS notification when message is sent via API", async () => {
     const app = await appPromise;
     const { token: t1 } = await createTestAgent(app, {
-      id: `ntf-a1-${crypto.randomUUID().slice(0, 6)}`,
+      name: `ntf-a1-${crypto.randomUUID().slice(0, 6)}`,
     });
     const { agent: a2, token: t2 } = await createTestAgent(app, {
-      id: `ntf-a2-${crypto.randomUUID().slice(0, 6)}`,
+      name: `ntf-a2-${crypto.randomUUID().slice(0, 6)}`,
     });
 
     // Create a chat
@@ -27,7 +27,7 @@ describe("WebSocket notification on message send", () => {
       method: "POST",
       url: "/api/v1/agent/chats",
       headers: { authorization: `Bearer ${t1}` },
-      payload: { type: "direct", participantIds: [a2.id] },
+      payload: { type: "direct", participantIds: [a2.uuid] },
     });
     const chatId = chatRes.json().id;
 
@@ -86,10 +86,10 @@ describe("WebSocket notification on message send", () => {
   it("recipient receives WS notification on sendToAgent", async () => {
     const app = await appPromise;
     const { token: t1 } = await createTestAgent(app, {
-      id: `ntf-dm1-${crypto.randomUUID().slice(0, 6)}`,
+      name: `ntf-dm1-${crypto.randomUUID().slice(0, 6)}`,
     });
     const { agent: a2, token: t2 } = await createTestAgent(app, {
-      id: `ntf-dm2-${crypto.randomUUID().slice(0, 6)}`,
+      name: `ntf-dm2-${crypto.randomUUID().slice(0, 6)}`,
     });
 
     // Connect a2 via WS
@@ -115,7 +115,7 @@ describe("WebSocket notification on message send", () => {
     // Send via sendToAgent API
     const sendRes = await app.inject({
       method: "POST",
-      url: `/api/v1/agent/agents/${a2.id}/messages`,
+      url: `/api/v1/agent/agents/${a2.name}/messages`,
       headers: { authorization: `Bearer ${t1}` },
       payload: { format: "text", content: "DM via WS!" },
     });

--- a/packages/server/src/__tests__/presence.test.ts
+++ b/packages/server/src/__tests__/presence.test.ts
@@ -8,54 +8,54 @@ describe("Presence Service", () => {
 
   it("sets agent online and offline", async () => {
     const app = await appPromise;
-    const { agent } = await createTestAgent(app, { id: "pres-a1" });
+    const { agent } = await createTestAgent(app, { name: "pres-a1" });
 
     // Set online
-    await presenceService.setOnline(app.db, agent.id, "test-instance");
-    let presence = await presenceService.getPresence(app.db, agent.id);
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    let presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence).not.toBeNull();
     expect(presence?.status).toBe("online");
     expect(presence?.instanceId).toBe("test-instance");
 
     // Set offline
-    await presenceService.setOffline(app.db, agent.id);
-    presence = await presenceService.getPresence(app.db, agent.id);
+    await presenceService.setOffline(app.db, agent.uuid);
+    presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence?.status).toBe("offline");
     expect(presence?.instanceId).toBeNull();
   });
 
   it("counts online agents", async () => {
     const app = await appPromise;
-    const { agent: a1 } = await createTestAgent(app, { id: "count-a1" });
-    const { agent: a2 } = await createTestAgent(app, { id: "count-a2" });
+    const { agent: a1 } = await createTestAgent(app, { name: "count-a1" });
+    const { agent: a2 } = await createTestAgent(app, { name: "count-a2" });
 
-    await presenceService.setOnline(app.db, a1.id, "inst-1");
-    await presenceService.setOnline(app.db, a2.id, "inst-1");
+    await presenceService.setOnline(app.db, a1.uuid, "inst-1");
+    await presenceService.setOnline(app.db, a2.uuid, "inst-1");
 
     const count = await presenceService.getOnlineCount(app.db);
     expect(count).toBe(2);
 
-    await presenceService.setOffline(app.db, a1.id);
+    await presenceService.setOffline(app.db, a1.uuid);
     const count2 = await presenceService.getOnlineCount(app.db);
     expect(count2).toBe(1);
   });
 
   it("upserts presence on repeated setOnline", async () => {
     const app = await appPromise;
-    const { agent } = await createTestAgent(app, { id: "upsert-a1" });
+    const { agent } = await createTestAgent(app, { name: "upsert-a1" });
 
-    await presenceService.setOnline(app.db, agent.id, "inst-1");
-    await presenceService.setOnline(app.db, agent.id, "inst-2");
+    await presenceService.setOnline(app.db, agent.uuid, "inst-1");
+    await presenceService.setOnline(app.db, agent.uuid, "inst-2");
 
-    const presence = await presenceService.getPresence(app.db, agent.id);
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence?.instanceId).toBe("inst-2");
   });
 
   it("returns null for agent without presence record", async () => {
     const app = await appPromise;
-    const { agent } = await createTestAgent(app, { id: "nopres-a1" });
+    const { agent } = await createTestAgent(app, { name: "nopres-a1" });
 
-    const presence = await presenceService.getPresence(app.db, agent.id);
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence).toBeNull();
   });
 
@@ -69,10 +69,10 @@ describe("Presence Service", () => {
 
   it("cleans up stale presence", async () => {
     const app = await appPromise;
-    const { agent } = await createTestAgent(app, { id: "stale-a1" });
+    const { agent } = await createTestAgent(app, { name: "stale-a1" });
 
     // Set online with a stale instance
-    await presenceService.setOnline(app.db, agent.id, "stale-instance");
+    await presenceService.setOnline(app.db, agent.uuid, "stale-instance");
 
     // Register stale instance with old heartbeat
     const { sql } = await import("drizzle-orm");
@@ -86,7 +86,7 @@ describe("Presence Service", () => {
     const cleaned = await presenceService.cleanupStalePresence(app.db, 60);
     expect(cleaned).toBe(1);
 
-    const presence = await presenceService.getPresence(app.db, agent.id);
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
     expect(presence?.status).toBe("offline");
   });
 });

--- a/packages/server/src/__tests__/ws-single-connection.test.ts
+++ b/packages/server/src/__tests__/ws-single-connection.test.ts
@@ -34,7 +34,7 @@ describe("WebSocket single-connection constraint", () => {
 
   it("allows first WebSocket connection", async () => {
     const app = await appPromise;
-    const { token } = await createTestAgent(app, { id: `ws-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { token } = await createTestAgent(app, { name: `ws-a1-${crypto.randomUUID().slice(0, 6)}` });
     const ws = await connectWs(token);
     expect(ws.readyState).toBe(WebSocket.OPEN);
     ws.close();
@@ -43,7 +43,7 @@ describe("WebSocket single-connection constraint", () => {
 
   it("rejects second WebSocket connection with 4009", async () => {
     const app = await appPromise;
-    const { token } = await createTestAgent(app, { id: `ws-a2-${crypto.randomUUID().slice(0, 6)}` });
+    const { token } = await createTestAgent(app, { name: `ws-a2-${crypto.randomUUID().slice(0, 6)}` });
 
     // First connection
     const first = await connectWs(token);
@@ -61,7 +61,7 @@ describe("WebSocket single-connection constraint", () => {
 
   it("allows reconnection after first WS is closed", async () => {
     const app = await appPromise;
-    const { token } = await createTestAgent(app, { id: `ws-a3-${crypto.randomUUID().slice(0, 6)}` });
+    const { token } = await createTestAgent(app, { name: `ws-a3-${crypto.randomUUID().slice(0, 6)}` });
 
     // First connection
     const first = await connectWs(token);

--- a/packages/server/src/api/admin/adapter-mappings.ts
+++ b/packages/server/src/api/admin/adapter-mappings.ts
@@ -33,9 +33,9 @@ export async function adminAdapterMappingRoutes(app: FastifyInstance): Promise<v
 
     // Validate agent exists and is human type
     const [agent] = await app.db
-      .select({ id: agents.id, type: agents.type, status: agents.status })
+      .select({ id: agents.uuid, type: agents.type, status: agents.status })
       .from(agents)
-      .where(eq(agents.id, body.agentId))
+      .where(eq(agents.uuid, body.agentId))
       .limit(1);
     if (!agent || agent.status === "deleted") {
       throw new NotFoundError(`Agent "${body.agentId}" not found`);

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -27,7 +27,8 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   app.get("/", async (request) => {
     const query = paginationQuerySchema.parse(request.query);
     const { type } = listAgentsFilterSchema.parse(request.query);
-    const result = await agentService.listAgents(app.db, query.limit, query.cursor, type);
+    const org = (request.query as Record<string, string>).org ?? "default";
+    const result = await agentService.listAgents(app.db, org, query.limit, query.cursor, type);
     return {
       items: result.items.map((a) => ({
         ...a,
@@ -49,9 +50,9 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  app.patch<{ Params: { agentId: string } }>("/:agentId", async (request) => {
+  app.patch<{ Params: { uuid: string } }>("/:uuid", async (request) => {
     const body = updateAgentSchema.parse(request.body);
-    const agent = await agentService.updateAgent(app.db, request.params.agentId, body);
+    const agent = await agentService.updateAgent(app.db, request.params.uuid, body);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
@@ -59,8 +60,8 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  app.get<{ Params: { agentId: string } }>("/:agentId", async (request) => {
-    const agent = await agentService.getAgent(app.db, request.params.agentId);
+  app.get<{ Params: { uuid: string } }>("/:uuid", async (request) => {
+    const agent = await agentService.getAgent(app.db, request.params.uuid);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
@@ -69,9 +70,9 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // Token management
-  app.post<{ Params: { agentId: string } }>("/:agentId/tokens", async (request, reply) => {
+  app.post<{ Params: { uuid: string } }>("/:uuid/tokens", async (request, reply) => {
     const body = createAgentTokenSchema.parse(request.body);
-    const result = await agentService.createToken(app.db, request.params.agentId, body);
+    const result = await agentService.createToken(app.db, request.params.uuid, body);
     return reply.status(201).send({
       ...result,
       expiresAt: serializeDate(result.expiresAt),
@@ -81,8 +82,8 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  app.get<{ Params: { agentId: string } }>("/:agentId/tokens", async (request) => {
-    const tokens = await agentService.listTokens(app.db, request.params.agentId);
+  app.get<{ Params: { uuid: string } }>("/:uuid/tokens", async (request) => {
+    const tokens = await agentService.listTokens(app.db, request.params.uuid);
     return tokens.map((t) => ({
       ...t,
       expiresAt: serializeDate(t.expiresAt),
@@ -92,24 +93,24 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     }));
   });
 
-  app.delete<{ Params: { agentId: string; tokenId: string } }>("/:agentId/tokens/:tokenId", async (request, reply) => {
-    await agentService.revokeToken(app.db, request.params.agentId, request.params.tokenId);
+  app.delete<{ Params: { uuid: string; tokenId: string } }>("/:uuid/tokens/:tokenId", async (request, reply) => {
+    await agentService.revokeToken(app.db, request.params.uuid, request.params.tokenId);
     return reply.status(204).send();
   });
 
   // Force-disconnect an agent's WebSocket connection
-  app.post<{ Params: { agentId: string } }>("/:agentId/disconnect", async (request, reply) => {
-    const { agentId } = request.params;
+  app.post<{ Params: { uuid: string } }>("/:uuid/disconnect", async (request, reply) => {
+    const { uuid } = request.params;
     // Verify agent exists
-    await agentService.getAgent(app.db, agentId);
+    await agentService.getAgent(app.db, uuid);
     // Close WebSocket and set presence offline
-    const wasConnected = forceDisconnect(agentId);
-    await presenceService.setOffline(app.db, agentId);
+    const wasConnected = forceDisconnect(uuid);
+    await presenceService.setOffline(app.db, uuid);
     return reply.status(200).send({ disconnected: wasConnected });
   });
 
-  app.post<{ Params: { agentId: string } }>("/:agentId/suspend", async (request) => {
-    const agent = await agentService.suspendAgent(app.db, request.params.agentId);
+  app.post<{ Params: { uuid: string } }>("/:uuid/suspend", async (request) => {
+    const agent = await agentService.suspendAgent(app.db, request.params.uuid);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
@@ -117,8 +118,8 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  app.post<{ Params: { agentId: string } }>("/:agentId/reactivate", async (request) => {
-    const agent = await agentService.reactivateAgent(app.db, request.params.agentId);
+  app.post<{ Params: { uuid: string } }>("/:uuid/reactivate", async (request) => {
+    const agent = await agentService.reactivateAgent(app.db, request.params.uuid);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
@@ -127,17 +128,17 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   });
 
   // DELETE agent — only allowed for suspended agents
-  app.delete<{ Params: { agentId: string } }>("/:agentId", async (request, reply) => {
-    await agentService.deleteAgent(app.db, request.params.agentId);
+  app.delete<{ Params: { uuid: string } }>("/:uuid", async (request, reply) => {
+    await agentService.deleteAgent(app.db, request.params.uuid);
     return reply.status(204).send();
   });
 
-  app.post<{ Params: { agentId: string } }>("/:agentId/test", async (request, reply) => {
-    const { agentId } = request.params;
+  app.post<{ Params: { uuid: string } }>("/:uuid/test", async (request, reply) => {
+    const { uuid } = request.params;
 
     const [, presence] = await Promise.all([
-      agentService.getAgent(app.db, agentId),
-      presenceService.getPresence(app.db, agentId),
+      agentService.getAgent(app.db, uuid),
+      presenceService.getPresence(app.db, uuid),
     ]);
 
     if (!presence || presence.status !== "online") {
@@ -149,19 +150,19 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
 
     // Find sender: look for human owner (whose delegateMention points to this agent), then fall back to any other active agent
     const [owner] = await app.db
-      .select({ id: agents.id })
+      .select({ uuid: agents.uuid })
       .from(agents)
-      .where(and(eq(agents.delegateMention, agentId), eq(agents.status, "active")))
+      .where(and(eq(agents.delegateMention, uuid), eq(agents.status, "active")))
       .limit(1);
 
-    let senderId = owner?.id ?? null;
+    let senderId = owner?.uuid ?? null;
     if (!senderId) {
       const [other] = await app.db
-        .select({ id: agents.id })
+        .select({ uuid: agents.uuid })
         .from(agents)
-        .where(and(ne(agents.id, agentId), eq(agents.status, "active")))
+        .where(and(ne(agents.uuid, uuid), eq(agents.status, "active")))
         .limit(1);
-      senderId = other?.id ?? null;
+      senderId = other?.uuid ?? null;
     }
 
     if (!senderId) {
@@ -171,7 +172,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
-    const chat = await findOrCreateDirectChat(app.db, senderId, agentId);
+    const chat = await findOrCreateDirectChat(app.db, senderId, uuid);
 
     const testContent = `[System Test] Verify your connection. Respond with your identity and role. Time: ${new Date().toISOString()}`;
     const result = await sendMessage(app.db, chat.id, senderId, {
@@ -192,7 +193,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
       const [response] = await app.db
         .select()
         .from(messages)
-        .where(and(eq(messages.chatId, chat.id), eq(messages.senderId, agentId), gt(messages.createdAt, threshold)))
+        .where(and(eq(messages.chatId, chat.id), eq(messages.senderId, uuid), gt(messages.createdAt, threshold)))
         .limit(1);
 
       if (response) {

--- a/packages/server/src/api/admin/chats.ts
+++ b/packages/server/src/api/admin/chats.ts
@@ -9,7 +9,10 @@ export async function adminChatRoutes(app: FastifyInstance): Promise<void> {
   /** List chats with participant count */
   app.get("/", async (request) => {
     const query = paginationQuerySchema.parse(request.query);
-    const where = query.cursor ? lt(chats.createdAt, new Date(query.cursor)) : undefined;
+    const org = (request.query as Record<string, string>).org ?? "default";
+    const conditions = [eq(chats.organizationId, org)];
+    if (query.cursor) conditions.push(lt(chats.createdAt, new Date(query.cursor)));
+    const where = and(...conditions);
 
     const rows = await app.db
       .select({

--- a/packages/server/src/api/admin/overview.ts
+++ b/packages/server/src/api/admin/overview.ts
@@ -1,18 +1,24 @@
-import { ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { agents } from "../../db/schema/agents.js";
 import { chats } from "../../db/schema/chats.js";
 import * as presenceService from "../../services/presence.js";
 
 export async function adminOverviewRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/", async () => {
+  app.get("/", async (request) => {
+    const org = ((request.query ?? {}) as Record<string, string>).org ?? "default";
+
     const [agentCount] = await app.db
       .select({ count: sql<number>`count(*)::int` })
       .from(agents)
-      .where(ne(agents.status, "deleted"));
+      .where(and(ne(agents.status, "deleted"), eq(agents.organizationId, org)));
 
-    const [chatCount] = await app.db.select({ count: sql<number>`count(*)::int` }).from(chats);
+    const [chatCount] = await app.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(chats)
+      .where(eq(chats.organizationId, org));
 
+    // TODO(multi-org): getOnlineCount is global — JOIN agents to filter by org when MULTI_ORG is implemented
     const onlineCount = await presenceService.getOnlineCount(app.db);
 
     return {

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -15,7 +15,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
   app.post("/", async (request, reply) => {
     const identity = requireAgent(request);
     const body = createChatSchema.parse(request.body);
-    const result = await chatService.createChat(app.db, identity.id, body);
+    const result = await chatService.createChat(app.db, identity.uuid, body);
     return reply.status(201).send({
       ...serializeChat(result),
       participants: result.participants.map((p) => ({
@@ -28,7 +28,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
   app.get("/", async (request) => {
     const identity = requireAgent(request);
     const query = paginationQuerySchema.parse(request.query);
-    const result = await chatService.listChats(app.db, identity.id, query.limit, query.cursor);
+    const result = await chatService.listChats(app.db, identity.uuid, query.limit, query.cursor);
     return {
       items: result.items.map(serializeChat),
       nextCursor: result.nextCursor,
@@ -37,7 +37,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
 
   app.get<{ Params: { chatId: string } }>("/:chatId", async (request) => {
     const identity = requireAgent(request);
-    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const detail = await chatService.getChatDetail(app.db, request.params.chatId);
     return {
       ...serializeChat(detail),
@@ -52,7 +52,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { chatId: string } }>("/:chatId/participants", async (request, reply) => {
     const identity = requireAgent(request);
     const body = addParticipantSchema.parse(request.body);
-    const participants = await chatService.addParticipant(app.db, request.params.chatId, identity.id, body);
+    const participants = await chatService.addParticipant(app.db, request.params.chatId, identity.uuid, body);
     return reply.status(201).send(
       participants.map((p) => ({
         ...p,
@@ -65,7 +65,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
     "/:chatId/participants/:agentId",
     async (request, reply) => {
       const identity = requireAgent(request);
-      await chatService.removeParticipant(app.db, request.params.chatId, identity.id, request.params.agentId);
+      await chatService.removeParticipant(app.db, request.params.chatId, identity.uuid, request.params.agentId);
       return reply.status(204).send();
     },
   );

--- a/packages/server/src/api/agent/feishu-bot.ts
+++ b/packages/server/src/api/agent/feishu-bot.ts
@@ -15,14 +15,14 @@ export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> 
     const body = selfServiceFeishuBotSchema.parse(request.body);
 
     // Verify agent is not human
-    const agent = await agentService.getAgent(app.db, identity.id);
+    const agent = await agentService.getAgent(app.db, identity.uuid);
     if (agent.type === "human") {
       throw new BadRequestError("Human agents cannot bind Feishu bots. Use bind-user instead.");
     }
 
     // Try update existing, otherwise create
     const existing = await adapterService.listAdapterConfigs(app.db);
-    const current = existing.find((c) => c.agentId === identity.id && c.platform === "feishu");
+    const current = existing.find((c) => c.agentId === identity.uuid && c.platform === "feishu");
 
     let config: Awaited<ReturnType<typeof adapterService.updateAdapterConfig>>;
     if (current) {
@@ -37,7 +37,7 @@ export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> 
         app.db,
         {
           platform: "feishu",
-          agentId: identity.id,
+          agentId: identity.uuid,
           credentials: { app_id: body.appId, app_secret: body.appSecret },
           status: "active",
         },
@@ -64,7 +64,7 @@ export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> 
     const identity = requireAgent(request);
 
     const existing = await adapterService.listAdapterConfigs(app.db);
-    const current = existing.find((c) => c.agentId === identity.id && c.platform === "feishu");
+    const current = existing.find((c) => c.agentId === identity.uuid && c.platform === "feishu");
 
     if (!current) {
       return reply.status(204).send();

--- a/packages/server/src/api/agent/feishu-user.ts
+++ b/packages/server/src/api/agent/feishu-user.ts
@@ -24,10 +24,10 @@ export async function agentFeishuUserRoutes(app: FastifyInstance): Promise<void>
     }
 
     // 2. Check delegate_mention authorization
-    if (humanAgent.delegateMention !== identity.id) {
+    if (humanAgent.delegateMention !== identity.uuid) {
       throw new ForbiddenError(
-        `Agent "${identity.id}" is not the delegate of "${humanAgentId}". ` +
-          `Expected delegate_mention="${identity.id}" but found "${humanAgent.delegateMention ?? "(none)"}".`,
+        `Agent "${identity.uuid}" is not the delegate of "${humanAgentId}". ` +
+          `Expected delegate_mention="${identity.uuid}" but found "${humanAgent.delegateMention ?? "(none)"}".`,
       );
     }
 
@@ -63,8 +63,8 @@ export async function agentFeishuUserRoutes(app: FastifyInstance): Promise<void>
     const humanAgent = await agentService.getAgent(app.db, humanAgentId);
 
     // 2. Check delegate_mention authorization
-    if (humanAgent.delegateMention !== identity.id) {
-      throw new ForbiddenError(`Agent "${identity.id}" is not the delegate of "${humanAgentId}"`);
+    if (humanAgent.delegateMention !== identity.uuid) {
+      throw new ForbiddenError(`Agent "${identity.uuid}" is not the delegate of "${humanAgentId}"`);
     }
 
     // 3. Delete mapping

--- a/packages/server/src/api/agent/me.ts
+++ b/packages/server/src/api/agent/me.ts
@@ -5,7 +5,7 @@ import * as agentService from "../../services/agent.js";
 export async function agentMeRoutes(app: FastifyInstance): Promise<void> {
   app.get("/me", async (request) => {
     const identity = requireAgent(request);
-    const agent = await agentService.getAgent(app.db, identity.id);
+    const agent = await agentService.getAgent(app.db, identity.uuid);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -14,12 +14,12 @@ const editMessageSchema = z.object({
 export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { chatId: string } }>("/:chatId/messages", async (request, reply) => {
     const identity = requireAgent(request);
-    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const body = sendMessageSchema.parse(request.body);
     const { message: msg, recipients } = await messageService.sendMessage(
       app.db,
       request.params.chatId,
-      identity.id,
+      identity.uuid,
       body,
     );
 
@@ -33,13 +33,13 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
 
   app.patch<{ Params: { chatId: string; messageId: string } }>("/:chatId/messages/:messageId", async (request) => {
     const identity = requireAgent(request);
-    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const body = editMessageSchema.parse(request.body);
     const msg = await messageService.editMessage(
       app.db,
       request.params.chatId,
       request.params.messageId,
-      identity.id,
+      identity.uuid,
       body,
     );
 
@@ -55,7 +55,7 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
 
   app.get<{ Params: { chatId: string } }>("/:chatId/messages", async (request) => {
     const identity = requireAgent(request);
-    await chatService.assertParticipant(app.db, request.params.chatId, identity.id);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const query = paginationQuerySchema.parse(request.query);
     const result = await messageService.listMessages(app.db, request.params.chatId, query.limit, query.cursor);
     return {
@@ -69,13 +69,13 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
 }
 
 export async function agentSendToAgentRoutes(app: FastifyInstance): Promise<void> {
-  app.post<{ Params: { agentId: string } }>("/:agentId/messages", async (request, reply) => {
+  app.post<{ Params: { name: string } }>("/:name/messages", async (request, reply) => {
     const identity = requireAgent(request);
     const body = sendToAgentSchema.parse(request.body);
     const { message: msg, recipients } = await messageService.sendToAgent(
       app.db,
-      identity.id,
-      request.params.agentId,
+      identity.uuid,
+      request.params.name,
       body,
     );
 

--- a/packages/server/src/api/agent/ws.ts
+++ b/packages/server/src/api/agent/ws.ts
@@ -12,25 +12,25 @@ export function agentWsRoutes(notifier: Notifier, instanceId: string) {
         return;
       }
 
-      if (connectionManager.hasActiveConnection(agent.id)) {
+      if (connectionManager.hasActiveConnection(agent.uuid)) {
         socket.close(connectionManager.WS_CLOSE_ALREADY_CONNECTED, "Agent already connected");
         return;
       }
 
       const inboxId = agent.inboxId;
 
-      await presenceService.setOnline(app.db, agent.id, instanceId);
-      connectionManager.setConnection(agent.id, socket);
+      await presenceService.setOnline(app.db, agent.uuid, instanceId);
+      connectionManager.setConnection(agent.uuid, socket);
       notifier.subscribe(inboxId, socket);
 
       socket.on("close", async () => {
         notifier.unsubscribe(inboxId, socket);
-        const wasActive = connectionManager.removeConnection(agent.id, socket);
+        const wasActive = connectionManager.removeConnection(agent.uuid, socket);
         // Only set offline if this socket was still the active connection.
         // A newer socket may have replaced it — avoid overwriting its online status.
         if (wasActive) {
           try {
-            await presenceService.setOffline(app.db, agent.id);
+            await presenceService.setOffline(app.db, agent.uuid);
           } catch {
             // best-effort
           }

--- a/packages/server/src/api/bootstrap/token.ts
+++ b/packages/server/src/api/bootstrap/token.ts
@@ -5,13 +5,13 @@ import * as agentService from "../../services/agent.js";
 
 export async function bootstrapRoutes(app: FastifyInstance): Promise<void> {
   /**
-   * POST /bootstrap/:agentId/token
+   * POST /bootstrap/:name/token
    * GitHub identity → Agent token.
    * Auto-creates the agent if it does not exist.
    * Only works when the agent has no active tokens.
    */
-  app.post<{ Params: { agentId: string } }>("/:agentId/token", async (request, reply) => {
-    const { agentId } = request.params;
+  app.post<{ Params: { name: string } }>("/:name/token", async (request, reply) => {
+    const { name } = request.params;
     const githubUser = request.githubUser;
     if (!githubUser) {
       throw new ForbiddenError("GitHub authentication required");
@@ -32,7 +32,7 @@ export async function bootstrapRoutes(app: FastifyInstance): Promise<void> {
     }
 
     const body = bootstrapTokenRequestSchema.parse(request.body ?? {});
-    const result = await agentService.bootstrapToken(app.db, agentId, githubUser.username, {
+    const result = await agentService.bootstrapToken(app.db, name, "default", githubUser.username, {
       tokenName: body.name,
       type: body.type,
       displayName: body.displayName,
@@ -52,25 +52,23 @@ export async function bootstrapRoutes(app: FastifyInstance): Promise<void> {
   });
 
   /**
-   * GET /bootstrap/:agentId/status
+   * GET /bootstrap/:name/status
    * Check if an agent exists and its status (for polling).
    */
-  app.get<{ Params: { agentId: string } }>("/:agentId/status", async (request) => {
-    const { agentId } = request.params;
+  app.get<{ Params: { name: string } }>("/:name/status", async (request) => {
+    const { name } = request.params;
     const githubUser = request.githubUser;
     if (!githubUser) {
       throw new ForbiddenError("GitHub authentication required");
     }
 
     try {
-      const agent = await agentService.getAgent(app.db, agentId);
+      const agent = await agentService.getAgentByName(app.db, "default", name);
 
       // Verify caller is in owners
       const owners: string[] = Array.isArray(agent.metadata?.owners) ? (agent.metadata.owners as string[]) : [];
       if (!owners.includes(githubUser.username)) {
-        throw new ForbiddenError(
-          `GitHub user "${githubUser.username}" is not in the owners list for agent "${agentId}"`,
-        );
+        throw new ForbiddenError(`GitHub user "${githubUser.username}" is not in the owners list for agent "${name}"`);
       }
 
       return {

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -5,7 +5,8 @@ import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
 import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
 import { createAgent } from "../../services/agent.js";
-import { sendToAgent } from "../../services/message.js";
+import { findOrCreateDirectChat } from "../../services/chat.js";
+import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 
 // ── GitHub payload types ────────────────────────────────────────────
@@ -63,29 +64,33 @@ function verifySignature(secret: string, rawBody: Buffer, signatureHeader: strin
 }
 
 async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
-  const [existing] = await db.select({ id: agents.id }).from(agents).where(eq(agents.id, GITHUB_ADAPTER_ID)).limit(1);
+  const [existing] = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(and(eq(agents.organizationId, "default"), eq(agents.name, GITHUB_ADAPTER_ID)))
+    .limit(1);
 
   if (existing) {
-    return existing.id;
+    return existing.uuid;
   }
 
   try {
     const agent = await createAgent(db, {
-      id: GITHUB_ADAPTER_ID,
+      name: GITHUB_ADAPTER_ID,
       type: "autonomous_agent",
       displayName: "GitHub Adapter",
       metadata: { source: "github", managed: true },
     });
-    return agent.id;
+    return agent.uuid;
   } catch (err) {
     if (err instanceof ConflictError) {
       // Another concurrent request created it first
       const [created] = await db
-        .select({ id: agents.id })
+        .select({ uuid: agents.uuid })
         .from(agents)
-        .where(eq(agents.id, GITHUB_ADAPTER_ID))
+        .where(and(eq(agents.organizationId, "default"), eq(agents.name, GITHUB_ADAPTER_ID)))
         .limit(1);
-      if (created) return created.id;
+      if (created) return created.uuid;
     }
     throw err;
   }
@@ -94,12 +99,12 @@ async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
 async function findTargetAgent(db: Database, repoFullName: string): Promise<string | null> {
   // First: look for an agent whose metadata has github.repos containing the repo full_name
   const allAgents = await db
-    .select({ id: agents.id, metadata: agents.metadata, type: agents.type })
+    .select({ id: agents.uuid, name: agents.name, metadata: agents.metadata, type: agents.type })
     .from(agents)
     .where(eq(agents.status, "active"));
 
   for (const agent of allAgents) {
-    if (agent.id === GITHUB_ADAPTER_ID) continue;
+    if (agent.name === GITHUB_ADAPTER_ID) continue;
     const meta = agent.metadata;
     if (meta && typeof meta === "object" && "github" in meta) {
       const github = meta.github;
@@ -155,38 +160,40 @@ async function routeMentionDelegations(
 ): Promise<number> {
   if (mentionedNames.length === 0) return 0;
 
-  // Batch lookup: find agents with delegate_mention set
+  // Batch lookup: find agents with delegate_mention set (match by name)
   const delegates = await app.db
     .select({
-      id: agents.id,
+      id: agents.uuid,
+      name: agents.name,
       delegateMention: agents.delegateMention,
       status: agents.status,
     })
     .from(agents)
-    .where(and(inArray(agents.id, mentionedNames), isNotNull(agents.delegateMention)));
+    .where(and(inArray(agents.name, mentionedNames), isNotNull(agents.delegateMention)));
 
   let routed = 0;
   for (const agent of delegates) {
     if (agent.status !== "active" || !agent.delegateMention) continue;
 
-    // Verify delegate target exists and is active
+    // Verify delegate target exists and is active (delegateMention stores a UUID)
     const [target] = await app.db
-      .select({ id: agents.id, status: agents.status })
+      .select({ id: agents.uuid, status: agents.status })
       .from(agents)
-      .where(eq(agents.id, agent.delegateMention))
+      .where(eq(agents.uuid, agent.delegateMention))
       .limit(1);
 
     if (!target || target.status !== "active") {
-      app.log.warn(`delegate_mention target "${agent.delegateMention}" for "${agent.id}" is not active, skipping`);
+      app.log.warn(`delegate_mention target "${agent.delegateMention}" for "${agent.name}" is not active, skipping`);
       continue;
     }
 
     try {
-      const { message: msg, recipients } = await sendToAgent(app.db, agent.id, agent.delegateMention, {
+      const chat = await findOrCreateDirectChat(app.db, agent.id, agent.delegateMention);
+      const { message: msg, recipients } = await sendMessage(app.db, chat.id, agent.id, {
         format: "card",
         content: {
           type: "github_mention",
-          mentionedUser: agent.id,
+          mentionedUser: agent.name,
           event: ctx.event,
           repository: ctx.repository,
           sender: ctx.sender,
@@ -197,13 +204,13 @@ async function routeMentionDelegations(
         metadata: {
           source: "github",
           event: "mention_delegation",
-          mentionedUser: agent.id,
+          mentionedUser: agent.name,
         },
       });
       notifyRecipients(app.notifier, recipients, msg.id);
       routed++;
     } catch (err) {
-      app.log.error(err, `Failed to route mention delegation from "${agent.id}" to "${agent.delegateMention}"`);
+      app.log.error(err, `Failed to route mention delegation from "${agent.name}" to "${agent.delegateMention}"`);
     }
   }
 
@@ -561,7 +568,8 @@ async function handleIssuesEvent(
     action: data.action,
   };
 
-  const { message: msg, recipients } = await sendToAgent(app.db, senderId, targetAgentId, {
+  const chat = await findOrCreateDirectChat(app.db, senderId, targetAgentId);
+  const { message: msg, recipients } = await sendMessage(app.db, chat.id, senderId, {
     format: "card",
     content,
     metadata,
@@ -625,7 +633,8 @@ async function handleIssueCommentEvent(
     action: data.action,
   };
 
-  const { message: msg, recipients } = await sendToAgent(app.db, senderId, targetAgentId, {
+  const chat = await findOrCreateDirectChat(app.db, senderId, targetAgentId);
+  const { message: msg, recipients } = await sendMessage(app.db, chat.id, senderId, {
     format: "card",
     content,
     metadata,

--- a/packages/server/src/db/schema/adapter-agent-mappings.ts
+++ b/packages/server/src/db/schema/adapter-agent-mappings.ts
@@ -10,7 +10,7 @@ export const adapterAgentMappings = pgTable(
     externalUserId: text("external_user_id").notNull(),
     agentId: text("agent_id")
       .notNull()
-      .references(() => agents.id),
+      .references(() => agents.uuid),
     /** "code" | "reverse_token" | "oauth" | "manual" */
     boundVia: text("bound_via"),
     displayName: text("display_name"),

--- a/packages/server/src/db/schema/adapter-configs.ts
+++ b/packages/server/src/db/schema/adapter-configs.ts
@@ -10,7 +10,7 @@ export const adapterConfigs = pgTable(
     platform: text("platform").notNull(),
     agentId: text("agent_id")
       .notNull()
-      .references(() => agents.id),
+      .references(() => agents.uuid),
     /** Encrypted JSONB — application-layer AES-256-GCM */
     credentials: jsonb("credentials").$type<unknown>().notNull(),
     /** "active" | "inactive" */

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -5,7 +5,7 @@ import { agents } from "./agents.js";
 export const agentPresence = pgTable("agent_presence", {
   agentId: text("agent_id")
     .primaryKey()
-    .references(() => agents.id, { onDelete: "cascade" }),
+    .references(() => agents.uuid, { onDelete: "cascade" }),
   /** "online" | "offline" */
   status: text("status").notNull().default("offline"),
   /** Server instance ID that holds this agent's WebSocket connection */

--- a/packages/server/src/db/schema/agent-tokens.ts
+++ b/packages/server/src/db/schema/agent-tokens.ts
@@ -8,7 +8,7 @@ export const agentTokens = pgTable(
     id: text("id").primaryKey(),
     agentId: text("agent_id")
       .notNull()
-      .references(() => agents.id, { onDelete: "cascade" }),
+      .references(() => agents.uuid, { onDelete: "cascade" }),
     /** SHA-256 hash; plaintext is returned only once at creation */
     tokenHash: text("token_hash").notNull(),
     /** Optional label, e.g. "production", "dev" */

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -1,25 +1,30 @@
-import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { index, jsonb, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
 
 /** Agent registration. Each agent owns a unique inboxId for message delivery. */
 export const agents = pgTable(
   "agents",
   {
-    id: text("id").primaryKey(),
+    uuid: text("uuid").primaryKey(),
+    /** Human-readable identifier. UNIQUE per org. NULL when deleted (releases the name). */
+    name: text("name"),
     organizationId: text("organization_id").notNull().default("default"),
     /** "human" | "personal_assistant" | "autonomous_agent" */
     type: text("type").notNull(),
     displayName: text("display_name"),
-    /** Agent ID to forward @mentions to (e.g. personal assistant) */
+    /** Agent UUID to forward @mentions to (e.g. personal assistant) */
     delegateMention: text("delegate_mention"),
     /** Agent self-description and instructions (markdown) */
     profile: text("profile"),
-    /** Delivery address, auto-generated as inbox_{id} */
+    /** Delivery address, auto-generated as inbox_{uuid} */
     inboxId: text("inbox_id").unique().notNull(),
-    /** "active" | "suspended". Suspended agents have all API requests rejected. */
+    /** "active" | "suspended" | "deleted". Suspended agents have all API requests rejected. */
     status: text("status").notNull().default("active"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("idx_agents_org").on(table.organizationId)],
+  (table) => [
+    index("idx_agents_org").on(table.organizationId),
+    unique("uq_agents_org_name").on(table.organizationId, table.name),
+  ],
 );

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -25,7 +25,7 @@ export const chatParticipants = pgTable(
       .references(() => chats.id, { onDelete: "cascade" }),
     agentId: text("agent_id")
       .notNull()
-      .references(() => agents.id),
+      .references(() => agents.uuid),
     /** "owner" | "member" */
     role: text("role").notNull().default("member"),
     /** "full" = receive all messages; "mention_only" = consumer-side behavior, does not affect fan-out */

--- a/packages/server/src/middleware/agent-auth.ts
+++ b/packages/server/src/middleware/agent-auth.ts
@@ -48,12 +48,13 @@ export function agentAuthHook(db: Database) {
 
     const [agent] = await db
       .select({
-        id: agents.id,
+        uuid: agents.uuid,
+        name: agents.name,
         organizationId: agents.organizationId,
         inboxId: agents.inboxId,
       })
       .from(agents)
-      .where(and(eq(agents.id, tokenRow.agentId), eq(agents.status, "active")))
+      .where(and(eq(agents.uuid, tokenRow.agentId), eq(agents.status, "active")))
       .limit(1);
 
     if (!agent) {

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -480,9 +480,9 @@ async function handleBindCommand(
 
   // 2. Check if target agent exists
   const [agent] = await db
-    .select({ id: agents.id, type: agents.type, status: agents.status })
+    .select({ id: agents.uuid, type: agents.type, status: agents.status })
     .from(agents)
-    .where(eq(agents.id, agentId))
+    .where(eq(agents.uuid, agentId))
     .limit(1);
 
   if (!agent) {
@@ -557,7 +557,7 @@ async function processFeishuOutbound(
     WHERE id IN (
       SELECT ie.id FROM inbox_entries ie
       JOIN agents a ON ie.inbox_id = a.inbox_id
-      JOIN adapter_agent_mappings aam ON a.id = aam.agent_id
+      JOIN adapter_agent_mappings aam ON a.uuid = aam.agent_id
       WHERE aam.platform = 'feishu' AND ie.status = 'pending'
       ORDER BY ie.created_at
       LIMIT ${OUTBOUND_BATCH_SIZE}

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -182,7 +182,7 @@ export async function findOrCreateChatForChannel(
     const [botAgent] = await tx
       .select({ organizationId: agents.organizationId })
       .from(agents)
-      .where(eq(agents.id, data.botAgentId))
+      .where(eq(agents.uuid, data.botAgentId))
       .limit(1);
 
     const orgId = botAgent?.organizationId ?? "default";

--- a/packages/server/src/services/adapter.ts
+++ b/packages/server/src/services/adapter.ts
@@ -23,9 +23,9 @@ function requireEncryptionKey(key: string | undefined): string {
 
 async function validateAgentId(db: Database, agentId: string): Promise<void> {
   const [agent] = await db
-    .select({ id: agents.id, type: agents.type })
+    .select({ id: agents.uuid, type: agents.type })
     .from(agents)
-    .where(and(eq(agents.id, agentId), ne(agents.status, "deleted")))
+    .where(and(eq(agents.uuid, agentId), ne(agents.status, "deleted")))
     .limit(1);
   if (!agent) {
     throw new NotFoundError(`Agent "${agentId}" not found`);

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@first-tree-hub/shared";
 import { AGENT_STATUSES } from "@first-tree-hub/shared";
 import { and, desc, eq, isNull, lt, ne } from "drizzle-orm";
@@ -9,84 +9,80 @@ import { agentPresence } from "../db/schema/agent-presence.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { uuidv7 } from "../uuid.js";
 
 function hashToken(raw: string): string {
   return createHash("sha256").update(raw).digest("hex");
 }
 
 export async function createAgent(db: Database, data: CreateAgent) {
-  const id = data.id ?? randomUUID();
-  const inboxId = `inbox_${id}`;
+  const uuid = uuidv7();
+  const name = data.name ?? null;
+  const inboxId = `inbox_${uuid}`;
+  const orgId = data.organizationId ?? "default";
 
-  const [existing] = await db
-    .select({ id: agents.id, status: agents.status })
-    .from(agents)
-    .where(eq(agents.id, id))
-    .limit(1);
-
-  if (existing) {
-    if (existing.status !== AGENT_STATUSES.DELETED) {
-      throw new ConflictError(`Agent "${id}" already exists`);
-    }
-    // Overwrite deleted agent — reuse the row
+  try {
     const [agent] = await db
-      .update(agents)
-      .set({
-        organizationId: data.organizationId ?? "default",
+      .insert(agents)
+      .values({
+        uuid,
+        name,
+        organizationId: orgId,
         type: data.type,
         displayName: data.displayName ?? null,
         delegateMention: data.delegateMention ?? null,
         profile: data.profile ?? null,
-        status: "active",
+        inboxId,
         metadata: data.metadata ?? {},
-        updatedAt: new Date(),
       })
-      .where(eq(agents.id, id))
       .returning();
-    if (!agent) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+
+    if (!agent) throw new Error("Unexpected: INSERT RETURNING produced no row");
     return agent;
+  } catch (err) {
+    // PostgreSQL unique_violation (23505) on UNIQUE(organization_id, name)
+    const pgCode = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code ?? "";
+    if (pgCode === "23505" && name) {
+      throw new ConflictError(`Agent name "${name}" already exists in organization "${orgId}"`);
+    }
+    throw err;
   }
-
-  const [agent] = await db
-    .insert(agents)
-    .values({
-      id,
-      organizationId: data.organizationId ?? "default",
-      type: data.type,
-      displayName: data.displayName ?? null,
-      delegateMention: data.delegateMention ?? null,
-      profile: data.profile ?? null,
-      inboxId,
-      metadata: data.metadata ?? {},
-    })
-    .returning();
-
-  // INSERT ... RETURNING always returns a row
-  if (!agent) throw new Error("Unexpected: INSERT RETURNING produced no row");
-  return agent;
 }
 
-export async function getAgent(db: Database, id: string) {
+export async function getAgent(db: Database, uuid: string) {
   const [agent] = await db
     .select()
     .from(agents)
-    .where(and(eq(agents.id, id), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
     .limit(1);
   if (!agent) {
-    throw new NotFoundError(`Agent "${id}" not found`);
+    throw new NotFoundError(`Agent "${uuid}" not found`);
   }
   return agent;
 }
 
-export async function listAgents(db: Database, limit: number, cursor?: string, type?: string) {
-  const conditions = [ne(agents.status, AGENT_STATUSES.DELETED)];
+export async function getAgentByName(db: Database, orgId: string, name: string) {
+  const [agent] = await db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.organizationId, orgId), eq(agents.name, name), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .limit(1);
+  if (!agent) {
+    throw new NotFoundError(`Agent "${name}" not found in organization "${orgId}"`);
+  }
+  return agent;
+}
+
+export async function listAgents(db: Database, orgId: string, limit: number, cursor?: string, type?: string) {
+  const conditions = [ne(agents.status, AGENT_STATUSES.DELETED), eq(agents.organizationId, orgId)];
   if (cursor) conditions.push(lt(agents.createdAt, new Date(cursor)));
   if (type) conditions.push(eq(agents.type, type));
   const where = and(...conditions);
 
   const rows = await db
     .select({
-      id: agents.id,
+      uuid: agents.uuid,
+      name: agents.name,
       organizationId: agents.organizationId,
       type: agents.type,
       displayName: agents.displayName,
@@ -100,7 +96,7 @@ export async function listAgents(db: Database, limit: number, cursor?: string, t
       presenceStatus: agentPresence.status,
     })
     .from(agents)
-    .leftJoin(agentPresence, eq(agents.id, agentPresence.agentId))
+    .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
     .where(where)
     .orderBy(desc(agents.createdAt))
     .limit(limit + 1);
@@ -113,8 +109,8 @@ export async function listAgents(db: Database, limit: number, cursor?: string, t
   return { items, nextCursor };
 }
 
-export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
-  const agent = await getAgent(db, id);
+export async function updateAgent(db: Database, uuid: string, data: UpdateAgent) {
+  const agent = await getAgent(db, uuid);
 
   const updates: Record<string, unknown> = { updatedAt: new Date() };
   if (data.type !== undefined) updates.type = data.type;
@@ -123,7 +119,7 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
   if (data.profile !== undefined) updates.profile = data.profile;
   if (data.metadata !== undefined) updates.metadata = data.metadata;
 
-  const [updated] = await db.update(agents).set(updates).where(eq(agents.id, agent.id)).returning();
+  const [updated] = await db.update(agents).set(updates).where(eq(agents.uuid, agent.uuid)).returning();
 
   if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
   return updated;
@@ -132,14 +128,14 @@ export async function updateAgent(db: Database, id: string, data: UpdateAgent) {
 /**
  * Reactivate a suspended agent.
  */
-export async function reactivateAgent(db: Database, id: string) {
+export async function reactivateAgent(db: Database, uuid: string) {
   const [existing] = await db
-    .select({ id: agents.id, status: agents.status })
+    .select({ uuid: agents.uuid, status: agents.status })
     .from(agents)
-    .where(eq(agents.id, id))
+    .where(eq(agents.uuid, uuid))
     .limit(1);
   if (!existing || existing.status === AGENT_STATUSES.DELETED) {
-    throw new NotFoundError(`Agent "${id}" not found`);
+    throw new NotFoundError(`Agent "${uuid}" not found`);
   }
   if (existing.status !== AGENT_STATUSES.SUSPENDED) {
     throw new BadRequestError("Only suspended agents can be reactivated.");
@@ -148,7 +144,7 @@ export async function reactivateAgent(db: Database, id: string) {
   const [agent] = await db
     .update(agents)
     .set({ status: AGENT_STATUSES.ACTIVE, updatedAt: new Date() })
-    .where(eq(agents.id, id))
+    .where(eq(agents.uuid, uuid))
     .returning();
 
   if (!agent) throw new Error("Unexpected: UPDATE RETURNING produced no row");
@@ -158,22 +154,22 @@ export async function reactivateAgent(db: Database, id: string) {
 /**
  * Suspend an agent. Revokes all active tokens so the agent can no longer authenticate.
  */
-export async function suspendAgent(db: Database, id: string) {
+export async function suspendAgent(db: Database, uuid: string) {
   const [agent] = await db
     .update(agents)
     .set({ status: AGENT_STATUSES.SUSPENDED, updatedAt: new Date() })
-    .where(and(eq(agents.id, id), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
     .returning();
 
   if (!agent) {
-    throw new NotFoundError(`Agent "${id}" not found`);
+    throw new NotFoundError(`Agent "${uuid}" not found`);
   }
 
   // Revoke all active tokens
   await db
     .update(agentTokens)
     .set({ revokedAt: new Date() })
-    .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
+    .where(and(eq(agentTokens.agentId, uuid), isNull(agentTokens.revokedAt)));
 
   return agent;
 }
@@ -181,36 +177,37 @@ export async function suspendAgent(db: Database, id: string) {
 /**
  * Delete an agent. Only allowed when status is "suspended".
  * Suspend the agent first to revoke tokens, then delete.
+ * Sets name to NULL to release the name for reuse.
  */
-export async function deleteAgent(db: Database, id: string) {
+export async function deleteAgent(db: Database, uuid: string) {
   const [existing] = await db
-    .select({ id: agents.id, status: agents.status })
+    .select({ uuid: agents.uuid, status: agents.status })
     .from(agents)
-    .where(eq(agents.id, id))
+    .where(eq(agents.uuid, uuid))
     .limit(1);
   if (!existing || existing.status === AGENT_STATUSES.DELETED) {
-    throw new NotFoundError(`Agent "${id}" not found`);
+    throw new NotFoundError(`Agent "${uuid}" not found`);
   }
   if (existing.status !== AGENT_STATUSES.SUSPENDED) {
     throw new BadRequestError("Only suspended agents can be deleted. Suspend the agent first.");
   }
 
-  // 1. Set status to deleted
+  // 1. Set status to deleted, release name
   const [agent] = await db
     .update(agents)
-    .set({ status: AGENT_STATUSES.DELETED, updatedAt: new Date() })
-    .where(eq(agents.id, id))
+    .set({ status: AGENT_STATUSES.DELETED, name: null, updatedAt: new Date() })
+    .where(eq(agents.uuid, uuid))
     .returning();
 
   // 2. Revoke all active tokens (may already be revoked by suspend, but be safe)
   await db
     .update(agentTokens)
     .set({ revokedAt: new Date() })
-    .where(and(eq(agentTokens.agentId, id), isNull(agentTokens.revokedAt)));
+    .where(and(eq(agentTokens.agentId, uuid), isNull(agentTokens.revokedAt)));
 
   // 3. Clean up adapter bindings (bot credentials + user mappings)
-  await db.delete(adapterConfigs).where(eq(adapterConfigs.agentId, id));
-  await db.delete(adapterAgentMappings).where(eq(adapterAgentMappings.agentId, id));
+  await db.delete(adapterConfigs).where(eq(adapterConfigs.agentId, uuid));
+  await db.delete(adapterAgentMappings).where(eq(adapterAgentMappings.agentId, uuid));
 
   if (!agent) throw new Error("Unexpected: UPDATE RETURNING produced no row");
   return agent;
@@ -232,24 +229,26 @@ export type BootstrapOptions = {
 
 export async function bootstrapToken(
   db: Database,
-  agentId: string,
+  agentName: string,
+  orgId: string,
   githubUsername: string,
   options?: BootstrapOptions,
 ) {
   // 1. Get or create agent
-  let agent: { id: string; metadata: Record<string, unknown> | null };
+  let agent: { uuid: string; metadata: Record<string, unknown> | null };
   try {
-    agent = await getAgent(db, agentId);
+    agent = await getAgentByName(db, orgId, agentName);
   } catch (err) {
     if (err instanceof NotFoundError) {
       // Auto-create agent with the GitHub user as owner
       const metadata = { ...options?.metadata, owners: [githubUsername] };
       agent = await createAgent(db, {
-        id: agentId,
+        name: agentName,
         type: (options?.type as "human" | "personal_assistant" | "autonomous_agent") ?? "autonomous_agent",
-        displayName: options?.displayName ?? agentId,
+        displayName: options?.displayName ?? agentName,
         delegateMention: options?.delegateMention,
         profile: options?.profile,
+        organizationId: orgId,
         metadata,
       });
     } else {
@@ -260,23 +259,23 @@ export async function bootstrapToken(
   // 2. Check agent has owners in metadata
   const owners: string[] = Array.isArray(agent.metadata?.owners) ? (agent.metadata.owners as string[]) : [];
   if (!owners.includes(githubUsername)) {
-    throw new ForbiddenError(`GitHub user "${githubUsername}" is not in the owners list for agent "${agentId}"`);
+    throw new ForbiddenError(`GitHub user "${githubUsername}" is not in the owners list for agent "${agentName}"`);
   }
 
   // 3. Check no active tokens exist (non-revoked = active for bootstrap purposes)
   const activeTokens = await db
     .select({ id: agentTokens.id })
     .from(agentTokens)
-    .where(and(eq(agentTokens.agentId, agentId), isNull(agentTokens.revokedAt)));
+    .where(and(eq(agentTokens.agentId, agent.uuid), isNull(agentTokens.revokedAt)));
 
   if (activeTokens.length > 0) {
     throw new ConflictError(
-      `Agent "${agentId}" already has ${activeTokens.length} active token(s). Revoke all tokens first to re-bootstrap.`,
+      `Agent "${agentName}" already has ${activeTokens.length} active token(s). Revoke all tokens first to re-bootstrap.`,
     );
   }
 
   // 4. Create token
-  return createToken(db, agentId, { name: options?.tokenName ?? "bootstrap" });
+  return createToken(db, agent.uuid, { name: options?.tokenName ?? "bootstrap" });
 }
 
 /**
@@ -294,19 +293,19 @@ export async function checkGitHubOrgMembership(githubToken: string, org: string)
   return orgs.some((o) => o.login.toLowerCase() === org.toLowerCase());
 }
 
-export async function createToken(db: Database, agentId: string, data: CreateAgentToken) {
+export async function createToken(db: Database, agentUuid: string, data: CreateAgentToken) {
   // Verify agent exists
-  await getAgent(db, agentId);
+  await getAgent(db, agentUuid);
 
   const raw = `aghub_${randomBytes(32).toString("hex")}`;
   const tokenHash = hashToken(raw);
-  const tokenId = randomUUID();
+  const tokenId = uuidv7();
 
   const [token] = await db
     .insert(agentTokens)
     .values({
       id: tokenId,
-      agentId,
+      agentId: agentUuid,
       tokenHash,
       name: data.name ?? null,
       expiresAt: data.expiresAt ? new Date(data.expiresAt) : null,
@@ -326,7 +325,7 @@ export async function createToken(db: Database, agentId: string, data: CreateAge
   };
 }
 
-export async function listTokens(db: Database, agentId: string) {
+export async function listTokens(db: Database, agentUuid: string) {
   return db
     .select({
       id: agentTokens.id,
@@ -338,15 +337,15 @@ export async function listTokens(db: Database, agentId: string) {
       lastUsedAt: agentTokens.lastUsedAt,
     })
     .from(agentTokens)
-    .where(eq(agentTokens.agentId, agentId))
+    .where(eq(agentTokens.agentId, agentUuid))
     .orderBy(desc(agentTokens.createdAt));
 }
 
-export async function revokeToken(db: Database, agentId: string, tokenId: string) {
+export async function revokeToken(db: Database, agentUuid: string, tokenId: string) {
   const [token] = await db
     .update(agentTokens)
     .set({ revokedAt: new Date() })
-    .where(and(eq(agentTokens.id, tokenId), eq(agentTokens.agentId, agentId), isNull(agentTokens.revokedAt)))
+    .where(and(eq(agentTokens.id, tokenId), eq(agentTokens.agentId, agentUuid), isNull(agentTokens.revokedAt)))
     .returning();
 
   if (!token) {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -14,9 +14,9 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
 
   // Verify all participants exist and belong to the same organization
   const existingAgents = await db
-    .select({ id: agents.id, organizationId: agents.organizationId })
+    .select({ id: agents.uuid, organizationId: agents.organizationId })
     .from(agents)
-    .where(inArray(agents.id, [...allParticipantIds]));
+    .where(inArray(agents.uuid, [...allParticipantIds]));
 
   if (existingAgents.length !== allParticipantIds.size) {
     const found = new Set(existingAgents.map((a) => a.id));
@@ -128,9 +128,9 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
 
   // Verify target agent exists and is in the same org
   const [targetAgent] = await db
-    .select({ id: agents.id, organizationId: agents.organizationId })
+    .select({ id: agents.uuid, organizationId: agents.organizationId })
     .from(agents)
-    .where(eq(agents.id, data.agentId))
+    .where(eq(agents.uuid, data.agentId))
     .limit(1);
 
   if (!targetAgent) {
@@ -213,7 +213,7 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
   const [agentA] = await db
     .select({ organizationId: agents.organizationId })
     .from(agents)
-    .where(eq(agents.id, agentAId))
+    .where(eq(agents.uuid, agentAId))
     .limit(1);
 
   if (!agentA) throw new NotFoundError(`Agent "${agentAId}" not found`);

--- a/packages/server/src/services/kael-runtime.ts
+++ b/packages/server/src/services/kael-runtime.ts
@@ -64,14 +64,14 @@ export function createKaelRuntime(
       const configAgentIds = configs.filter((c) => c.credentials).map((c) => c.agentId);
       const agentRows =
         configAgentIds.length > 0
-          ? await db.execute<{ id: string; inbox_id: string }>(
-              sql`SELECT id, inbox_id FROM agents WHERE id IN (${sql.join(
+          ? await db.execute<{ uuid: string; inbox_id: string }>(
+              sql`SELECT uuid, inbox_id FROM agents WHERE uuid IN (${sql.join(
                 configAgentIds.map((id) => sql`${id}`),
                 sql`, `,
               )}) AND status = 'active'`,
             )
           : [];
-      const agentInboxMap = new Map(agentRows.map((a) => [a.id, a.inbox_id]));
+      const agentInboxMap = new Map(agentRows.map((a) => [a.uuid, a.inbox_id]));
 
       const seen = new Set<string>();
 
@@ -141,10 +141,10 @@ export function createKaelRuntime(
           WHERE id IN (
             SELECT ie.id FROM inbox_entries ie
             JOIN agents a ON ie.inbox_id = a.inbox_id
-            JOIN adapter_configs ac ON a.id = ac.agent_id
+            JOIN adapter_configs ac ON a.uuid = ac.agent_id
             WHERE ac.platform = 'kael' AND ac.status = 'active'
               AND ie.status = 'pending'
-              AND a.id IN (${sql.join(
+              AND a.uuid IN (${sql.join(
                 agentIds.map((id) => sql`${id}`),
                 sql`, `,
               )})

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { SendMessage, SendToAgent } from "@first-tree-hub/shared";
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, lt, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatParticipants, chats } from "../db/schema/chats.js";
@@ -46,7 +46,7 @@ export async function sendMessage(
         inboxId: agents.inboxId,
       })
       .from(chatParticipants)
-      .innerJoin(agents, eq(chatParticipants.agentId, agents.id))
+      .innerJoin(agents, eq(chatParticipants.agentId, agents.uuid))
       .where(eq(chatParticipants.chatId, chatId));
 
     // 3. Fan-out: create inbox entries for all participants (except sender)
@@ -104,32 +104,35 @@ export async function sendMessage(
 
 export async function sendToAgent(
   db: Database,
-  senderId: string,
-  targetAgentId: string,
+  senderUuid: string,
+  targetName: string,
   data: SendToAgent,
 ): Promise<SendMessageResult> {
-  // Verify target agent exists and is in the same org
+  // Verify sender exists
   const [sender] = await db
-    .select({ id: agents.id, organizationId: agents.organizationId })
+    .select({ uuid: agents.uuid, organizationId: agents.organizationId })
     .from(agents)
-    .where(eq(agents.id, senderId))
+    .where(eq(agents.uuid, senderUuid))
     .limit(1);
 
-  if (!sender) throw new NotFoundError(`Agent "${senderId}" not found`);
+  if (!sender) throw new NotFoundError(`Agent "${senderUuid}" not found`);
 
+  // Resolve target by name within sender's org (natural cross-org isolation)
   const [target] = await db
-    .select({ id: agents.id, organizationId: agents.organizationId })
+    .select({ uuid: agents.uuid })
     .from(agents)
-    .where(eq(agents.id, targetAgentId))
+    .where(
+      and(eq(agents.organizationId, sender.organizationId), eq(agents.name, targetName), ne(agents.status, "deleted")),
+    )
     .limit(1);
 
-  if (!target) throw new NotFoundError(`Agent "${targetAgentId}" not found`);
+  if (!target) throw new NotFoundError(`Agent "${targetName}" not found`);
 
   // Find or create direct chat
-  const chat = await findOrCreateDirectChat(db, senderId, targetAgentId);
+  const chat = await findOrCreateDirectChat(db, senderUuid, target.uuid);
 
   // Send message via existing sendMessage
-  return sendMessage(db, chat.id, senderId, {
+  return sendMessage(db, chat.id, senderUuid, {
     format: data.format,
     content: data.content,
     metadata: data.metadata,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,7 +3,8 @@ import type { AdapterManager } from "./services/adapter-manager.js";
 import type { Notifier } from "./services/notifier.js";
 
 export type AgentIdentity = {
-  id: string;
+  uuid: string;
+  name: string | null;
   organizationId: string;
   inboxId: string;
 };

--- a/packages/server/src/uuid.ts
+++ b/packages/server/src/uuid.ts
@@ -1,0 +1,28 @@
+import { randomBytes } from "node:crypto";
+
+/** Generate a UUID v7 (time-ordered). No external dependency. */
+export function uuidv7(): string {
+  const now = BigInt(Date.now());
+  const bytes = new Uint8Array(16);
+
+  bytes[0] = Number((now >> 40n) & 0xffn);
+  bytes[1] = Number((now >> 32n) & 0xffn);
+  bytes[2] = Number((now >> 24n) & 0xffn);
+  bytes[3] = Number((now >> 16n) & 0xffn);
+  bytes[4] = Number((now >> 8n) & 0xffn);
+  bytes[5] = Number(now & 0xffn);
+
+  const rand = randomBytes(10);
+  for (let i = 0; i < 10; i++) {
+    const b = rand[i];
+    if (b !== undefined) bytes[6 + i] = b;
+  }
+
+  // Version 7
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x70;
+  // Variant 10xx
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -20,7 +20,7 @@ export const agentStatusSchema = z.enum(["active", "suspended"]);
 export type AgentStatus = z.infer<typeof agentStatusSchema>;
 
 export const createAgentSchema = z.object({
-  id: z
+  name: z
     .string()
     .min(1)
     .max(100)
@@ -45,7 +45,8 @@ export const updateAgentSchema = z.object({
 export type UpdateAgent = z.infer<typeof updateAgentSchema>;
 
 export const agentSchema = z.object({
-  id: z.string(),
+  uuid: z.string(),
+  name: z.string().nullable(),
   organizationId: z.string(),
   type: agentTypeSchema,
   displayName: z.string().nullable(),

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -15,28 +15,28 @@ export function listAgents(params?: { limit?: number; cursor?: string; type?: st
   return api.get<PaginatedAgents>(`/admin/agents${query ? `?${query}` : ""}`);
 }
 
-export function getAgent(agentId: string): Promise<Agent> {
-  return api.get<Agent>(`/admin/agents/${encodeURIComponent(agentId)}`);
+export function getAgent(uuid: string): Promise<Agent> {
+  return api.get<Agent>(`/admin/agents/${encodeURIComponent(uuid)}`);
 }
 
 export function createAgent(data: CreateAgent): Promise<Agent> {
   return api.post<Agent>("/admin/agents", data);
 }
 
-export function updateAgent(agentId: string, data: UpdateAgent): Promise<Agent> {
-  return api.patch<Agent>(`/admin/agents/${encodeURIComponent(agentId)}`, data);
+export function updateAgent(uuid: string, data: UpdateAgent): Promise<Agent> {
+  return api.patch<Agent>(`/admin/agents/${encodeURIComponent(uuid)}`, data);
 }
 
-export function deleteAgent(agentId: string): Promise<void> {
-  return api.delete<void>(`/admin/agents/${encodeURIComponent(agentId)}`);
+export function deleteAgent(uuid: string): Promise<void> {
+  return api.delete<void>(`/admin/agents/${encodeURIComponent(uuid)}`);
 }
 
-export function suspendAgent(agentId: string): Promise<Agent> {
-  return api.post<Agent>(`/admin/agents/${encodeURIComponent(agentId)}/suspend`, {});
+export function suspendAgent(uuid: string): Promise<Agent> {
+  return api.post<Agent>(`/admin/agents/${encodeURIComponent(uuid)}/suspend`, {});
 }
 
-export function reactivateAgent(agentId: string): Promise<Agent> {
-  return api.post<Agent>(`/admin/agents/${encodeURIComponent(agentId)}/reactivate`, {});
+export function reactivateAgent(uuid: string): Promise<Agent> {
+  return api.post<Agent>(`/admin/agents/${encodeURIComponent(uuid)}/reactivate`, {});
 }
 
 // -- Test Connection --
@@ -49,6 +49,6 @@ export type TestResult = {
   responseTime?: number;
 };
 
-export function testAgentConnection(agentId: string): Promise<TestResult> {
-  return api.post<TestResult>(`/admin/agents/${encodeURIComponent(agentId)}/test`, {});
+export function testAgentConnection(uuid: string): Promise<TestResult> {
+  return api.post<TestResult>(`/admin/agents/${encodeURIComponent(uuid)}/test`, {});
 }

--- a/packages/web/src/api/tokens.ts
+++ b/packages/web/src/api/tokens.ts
@@ -1,14 +1,14 @@
 import type { AgentToken, AgentTokenCreated, CreateAgentToken } from "@first-tree-hub/shared";
 import { api } from "./client.js";
 
-export function listTokens(agentId: string): Promise<AgentToken[]> {
-  return api.get<AgentToken[]>(`/admin/agents/${encodeURIComponent(agentId)}/tokens`);
+export function listTokens(uuid: string): Promise<AgentToken[]> {
+  return api.get<AgentToken[]>(`/admin/agents/${encodeURIComponent(uuid)}/tokens`);
 }
 
-export function createToken(agentId: string, data: CreateAgentToken): Promise<AgentTokenCreated> {
-  return api.post<AgentTokenCreated>(`/admin/agents/${encodeURIComponent(agentId)}/tokens`, data);
+export function createToken(uuid: string, data: CreateAgentToken): Promise<AgentTokenCreated> {
+  return api.post<AgentTokenCreated>(`/admin/agents/${encodeURIComponent(uuid)}/tokens`, data);
 }
 
-export function revokeToken(agentId: string, tokenId: string): Promise<void> {
-  return api.delete<void>(`/admin/agents/${encodeURIComponent(agentId)}/tokens/${encodeURIComponent(tokenId)}`);
+export function revokeToken(uuid: string, tokenId: string): Promise<void> {
+  return api.delete<void>(`/admin/agents/${encodeURIComponent(uuid)}/tokens/${encodeURIComponent(tokenId)}`);
 }

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -32,7 +32,7 @@ export function App() {
               <Route element={<Layout />}>
                 <Route index element={<OverviewPage />} />
                 <Route path="agents" element={<AgentsPage />} />
-                <Route path="agents/:agentId" element={<AgentDetailPage />} />
+                <Route path="agents/:uuid" element={<AgentDetailPage />} />
                 <Route path="bindings" element={<BindingsPage />} />
                 <Route path="chats" element={<ChatsPage />} />
                 <Route path="admin-users" element={<AdminUsersPage />} />

--- a/packages/web/src/components/agent-form-dialog.tsx
+++ b/packages/web/src/components/agent-form-dialog.tsx
@@ -18,7 +18,7 @@ type AgentFormProps = {
 } & ({ mode: "create"; agent?: undefined } | { mode: "edit"; agent: Agent });
 
 export type AgentFormData = {
-  id?: string;
+  name?: string;
   type: AgentType;
   displayName: string | null;
   delegateMention: string | null;
@@ -28,7 +28,7 @@ export function AgentFormDialog(props: AgentFormProps) {
   const { open, onOpenChange, onSubmit, isPending, error, mode } = props;
   const agent = mode === "edit" ? props.agent : undefined;
 
-  const [formId, setFormId] = useState("");
+  const [formName, setFormName] = useState("");
   const [formType, setFormType] = useState<AgentType>("personal_assistant");
   const [formDisplayName, setFormDisplayName] = useState("");
   const [formDelegateMention, setFormDelegateMention] = useState("");
@@ -48,12 +48,12 @@ export function AgentFormDialog(props: AgentFormProps) {
   useEffect(() => {
     if (open) {
       if (agent) {
-        setFormId(agent.id);
+        setFormName(agent.name ?? "");
         setFormType(agent.type);
         setFormDisplayName(agent.displayName ?? "");
         setFormDelegateMention(agent.delegateMention ?? "");
       } else {
-        setFormId("");
+        setFormName("");
         setFormType("personal_assistant");
         setFormDisplayName("");
         setFormDelegateMention("");
@@ -64,7 +64,7 @@ export function AgentFormDialog(props: AgentFormProps) {
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     onSubmit({
-      id: mode === "create" && formId ? formId : undefined,
+      name: mode === "create" && formName ? formName : undefined,
       type: formType,
       displayName: formDisplayName || null,
       delegateMention: formDelegateMention || null,
@@ -80,16 +80,16 @@ export function AgentFormDialog(props: AgentFormProps) {
           <DialogTitle>{isEdit ? "Edit Agent" : "New Agent"}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* ID */}
+          {/* Name */}
           <div className="space-y-2">
-            <Label htmlFor="agent-id">ID</Label>
+            <Label htmlFor="agent-name">Name</Label>
             {isEdit ? (
-              <Input id="agent-id" value={formId} disabled className="font-mono" />
+              <Input id="agent-name" value={formName} disabled className="font-mono" />
             ) : (
               <Input
-                id="agent-id"
-                value={formId}
-                onChange={(e) => setFormId(e.target.value)}
+                id="agent-name"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
                 placeholder="Leave empty to auto-generate"
                 pattern="^[a-z0-9_-]*$"
                 title="Only lowercase alphanumeric, hyphens, and underscores"
@@ -144,8 +144,8 @@ export function AgentFormDialog(props: AgentFormProps) {
               >
                 <option value="">None</option>
                 {assistantsQuery.data?.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.displayName ? `${a.displayName} (${a.id})` : a.id}
+                  <option key={a.uuid} value={a.uuid}>
+                    {a.displayName ? `${a.displayName} (${a.name ?? a.uuid})` : (a.name ?? a.uuid)}
                   </option>
                 ))}
               </select>

--- a/packages/web/src/lib/use-agent-name-map.ts
+++ b/packages/web/src/lib/use-agent-name-map.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { listAgents } from "../api/agents.js";
+
+/**
+ * Shared hook that builds a UUID → name lookup map from the agents list.
+ * Used by pages that display agent UUIDs (delegate mentions, participants, senders, bindings).
+ *
+ * Note: limited to 100 agents (API max). For deployments with more agents,
+ * this should be replaced with a paginated fetch or a dedicated lookup endpoint.
+ */
+export function useAgentNameMap(): (uuid: string | null | undefined) => string {
+  const { data } = useQuery({
+    queryKey: ["agents", "name-map"],
+    queryFn: () => listAgents({ limit: 100 }),
+    staleTime: 30_000,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, string>();
+    if (data?.items) {
+      for (const a of data.items) {
+        map.set(a.uuid, a.name ?? a.displayName ?? a.uuid);
+      }
+    }
+    return (uuid: string | null | undefined) => {
+      if (!uuid) return "\u2014";
+      return map.get(uuid) ?? uuid;
+    };
+  }, [data]);
+}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -25,28 +25,30 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "../components/ui/input.js";
 import { Label } from "../components/ui/label.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { cn, formatDate } from "../lib/utils.js";
 
 const platformValues = Object.values(ADAPTER_PLATFORMS);
 
 export function AgentDetailPage() {
-  const params = useParams<{ agentId: string }>();
-  const agentId = params.agentId ?? "";
+  const params = useParams<{ uuid: string }>();
+  const uuid = params.uuid ?? "";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const resolveAgentName = useAgentNameMap();
 
   // Agent data
   const agentQuery = useQuery({
-    queryKey: ["agent", agentId],
-    queryFn: () => getAgent(agentId),
-    enabled: !!agentId,
+    queryKey: ["agent", uuid],
+    queryFn: () => getAgent(uuid),
+    enabled: !!uuid,
   });
 
   // Tokens data (only for non-human agents)
   const tokensQuery = useQuery({
-    queryKey: ["tokens", agentId],
-    queryFn: () => listTokens(agentId),
-    enabled: !!agentId && agentQuery.isSuccess && agentQuery.data?.type !== "human",
+    queryKey: ["tokens", uuid],
+    queryFn: () => listTokens(uuid),
+    enabled: !!uuid && agentQuery.isSuccess && agentQuery.data?.type !== "human",
   });
 
   // Adapter bindings for this agent
@@ -58,8 +60,8 @@ export function AgentDetailPage() {
     refetchInterval: 15_000,
   });
 
-  const agentAdapters = adaptersQuery.data?.filter((a) => a.agentId === agentId) ?? [];
-  const agentMappings = mappingsQuery.data?.filter((m) => m.agentId === agentId) ?? [];
+  const agentAdapters = adaptersQuery.data?.filter((a) => a.agentId === uuid) ?? [];
+  const agentMappings = mappingsQuery.data?.filter((m) => m.agentId === uuid) ?? [];
 
   // Token dialog
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
@@ -85,33 +87,33 @@ export function AgentDetailPage() {
 
   // Mutations — agent lifecycle
   const suspendMutation = useMutation({
-    mutationFn: () => suspendAgent(agentId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agent", agentId] }),
+    mutationFn: () => suspendAgent(uuid),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agent", uuid] }),
   });
 
   const reactivateMutation = useMutation({
-    mutationFn: () => reactivateAgent(agentId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agent", agentId] }),
+    mutationFn: () => reactivateAgent(uuid),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agent", uuid] }),
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteAgent(agentId),
+    mutationFn: () => deleteAgent(uuid),
     onSuccess: () => navigate("/agents"),
   });
 
   // Mutations — tokens
   const createTokenMutation = useMutation({
-    mutationFn: (name: string) => createToken(agentId, { name: name || undefined }),
+    mutationFn: (name: string) => createToken(uuid, { name: name || undefined }),
     onSuccess: (data) => {
       setCreatedToken(data.token);
       setTokenName("");
-      queryClient.invalidateQueries({ queryKey: ["tokens", agentId] });
+      queryClient.invalidateQueries({ queryKey: ["tokens", uuid] });
     },
   });
 
   const revokeTokenMutation = useMutation({
-    mutationFn: (tokenId: string) => revokeToken(agentId, tokenId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["tokens", agentId] }),
+    mutationFn: (tokenId: string) => revokeToken(uuid, tokenId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["tokens", uuid] }),
   });
 
   // Mutations — bot binding (non-human agents)
@@ -122,20 +124,20 @@ export function AgentDetailPage() {
 
       // For Kael: auto-create a dedicated agent token
       if (bindingForm.platform === "kael" && !creds.agentToken) {
-        const tokenResult = await createToken(agentId, { name: "kael-hub-binding" });
+        const tokenResult = await createToken(uuid, { name: "kael-hub-binding" });
         creds = { ...creds, agentToken: tokenResult.token };
       }
 
       return createAdapter({
         platform: bindingForm.platform as "feishu" | "slack" | "kael",
-        agentId,
+        agentId: uuid,
         credentials: creds,
         status: bindingForm.status as "active" | "inactive",
       });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["adapters"] });
-      queryClient.invalidateQueries({ queryKey: ["tokens", agentId] });
+      queryClient.invalidateQueries({ queryKey: ["tokens", uuid] });
       closeBindingDialog();
     },
   });
@@ -165,7 +167,7 @@ export function AgentDetailPage() {
       createAdapterMapping({
         platform: bindingForm.platform as "feishu" | "slack" | "kael",
         externalUserId: bindingForm.externalUserId,
-        agentId,
+        agentId: uuid,
         boundVia: "manual",
         displayName: bindingForm.displayName || undefined,
       }),
@@ -184,30 +186,30 @@ export function AgentDetailPage() {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const updateMutation = useMutation({
     mutationFn: (formData: AgentFormData) =>
-      updateAgent(agentId, {
+      updateAgent(uuid, {
         displayName: formData.displayName,
         delegateMention: formData.delegateMention,
       }),
     onSuccess: () => {
       setEditDialogOpen(false);
-      queryClient.invalidateQueries({ queryKey: ["agent", agentId] });
+      queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },
   });
 
   // Test connection
   const testMutation = useMutation({
-    mutationFn: () => testAgentConnection(agentId),
+    mutationFn: () => testAgentConnection(uuid),
   });
 
   // Profile editing
   const [profileDialogOpen, setProfileDialogOpen] = useState(false);
   const [profileDraft, setProfileDraft] = useState("");
   const profileMutation = useMutation({
-    mutationFn: (profile: string) => updateAgent(agentId, { profile: profile || null }),
+    mutationFn: (profile: string) => updateAgent(uuid, { profile: profile || null }),
     onSuccess: () => {
       setProfileDialogOpen(false);
-      queryClient.invalidateQueries({ queryKey: ["agent", agentId] });
+      queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
     },
   });
 
@@ -340,8 +342,8 @@ export function AgentDetailPage() {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <div className="flex-1">
-          <h1 className="text-2xl font-semibold">{agent.displayName ?? agent.id}</h1>
-          <p className="text-sm text-muted-foreground font-mono">{agent.id}</p>
+          <h1 className="text-2xl font-semibold">{agent.displayName ?? agent.name}</h1>
+          <p className="text-sm text-muted-foreground font-mono">{agent.name}</p>
         </div>
         {agent.status === "active" && (
           <Button variant="outline" size="sm" onClick={() => setEditDialogOpen(true)}>
@@ -433,7 +435,7 @@ export function AgentDetailPage() {
             {agent.delegateMention && (
               <div>
                 <dt className="text-muted-foreground mb-1">Delegate Mention</dt>
-                <dd className="font-mono">{agent.delegateMention}</dd>
+                <dd className="font-mono">{resolveAgentName(agent.delegateMention)}</dd>
               </div>
             )}
             {role && (

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -8,6 +8,7 @@ import { type AgentFormData, AgentFormDialog } from "../components/agent-form-di
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { cn, formatDate } from "../lib/utils.js";
 
 const agentTypeValues = Object.values(AGENT_TYPES);
@@ -18,6 +19,7 @@ export function AgentsPage() {
   const [cursor, setCursor] = useState<string | undefined>();
   const [typeFilter, setTypeFilter] = useState<string>("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const resolveAgentName = useAgentNameMap();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["agents", cursor, typeFilter],
@@ -27,7 +29,7 @@ export function AgentsPage() {
   const createMutation = useMutation({
     mutationFn: (formData: AgentFormData) =>
       createAgent({
-        id: formData.id,
+        name: formData.name,
         type: formData.type,
         displayName: formData.displayName ?? undefined,
         delegateMention: formData.delegateMention ?? undefined,
@@ -35,7 +37,7 @@ export function AgentsPage() {
     onSuccess: (agent) => {
       setCreateDialogOpen(false);
       queryClient.invalidateQueries({ queryKey: ["agents"] });
-      navigate(`/agents/${agent.id}`);
+      navigate(`/agents/${agent.uuid}`);
     },
   });
 
@@ -70,7 +72,7 @@ export function AgentsPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>ID</TableHead>
+              <TableHead>Name</TableHead>
               <TableHead>Display Name</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Delegate</TableHead>
@@ -100,14 +102,14 @@ export function AgentsPage() {
               </TableRow>
             ) : (
               data.items.map((agent) => (
-                <TableRow key={agent.id} className="cursor-pointer" onClick={() => navigate(`/agents/${agent.id}`)}>
-                  <TableCell className="font-mono text-sm">{agent.id}</TableCell>
+                <TableRow key={agent.uuid} className="cursor-pointer" onClick={() => navigate(`/agents/${agent.uuid}`)}>
+                  <TableCell className="font-mono text-sm">{agent.name}</TableCell>
                   <TableCell>{agent.displayName ?? "\u2014"}</TableCell>
                   <TableCell>
                     <Badge variant="secondary">{agent.type}</Badge>
                   </TableCell>
                   <TableCell className="font-mono text-sm text-muted-foreground">
-                    {agent.delegateMention ?? "\u2014"}
+                    {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "\u2014"}
                   </TableCell>
                   <TableCell>
                     <span

--- a/packages/web/src/pages/bindings.tsx
+++ b/packages/web/src/pages/bindings.tsx
@@ -6,10 +6,12 @@ import { listAdapters } from "../api/adapters.js";
 import { Badge } from "../components/ui/badge.js";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { cn, formatDate } from "../lib/utils.js";
 
 export function BindingsPage() {
   const navigate = useNavigate();
+  const resolveAgentName = useAgentNameMap();
 
   const { data: adapters, isLoading: loadingAdapters } = useQuery({
     queryKey: ["adapters"],
@@ -72,7 +74,7 @@ export function BindingsPage() {
                   const status = botStatuses?.find((s) => s.configId === a.id);
                   return (
                     <TableRow key={a.id} className="cursor-pointer" onClick={() => navigate(`/agents/${a.agentId}`)}>
-                      <TableCell className="font-mono text-sm">{a.agentId}</TableCell>
+                      <TableCell className="font-mono text-sm">{resolveAgentName(a.agentId)}</TableCell>
                       <TableCell>
                         <Badge variant="secondary">{a.platform}</Badge>
                       </TableCell>
@@ -135,7 +137,7 @@ export function BindingsPage() {
               ) : (
                 mappings.map((m) => (
                   <TableRow key={m.id} className="cursor-pointer" onClick={() => navigate(`/agents/${m.agentId}`)}>
-                    <TableCell className="font-mono text-sm">{m.agentId}</TableCell>
+                    <TableCell className="font-mono text-sm">{resolveAgentName(m.agentId)}</TableCell>
                     <TableCell>
                       <Badge variant="secondary">{m.platform}</Badge>
                     </TableCell>

--- a/packages/web/src/pages/chats.tsx
+++ b/packages/web/src/pages/chats.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { formatDate } from "../lib/utils.js";
 
 export function ChatsPage() {
@@ -104,6 +105,7 @@ function ChatListView({
 
 function ChatDetailView({ chatId, onBack }: { chatId: string; onBack: () => void }) {
   const [msgCursor, setMsgCursor] = useState<string | undefined>();
+  const resolveAgentName = useAgentNameMap();
 
   const chatQuery = useQuery({
     queryKey: ["chat", chatId],
@@ -139,7 +141,7 @@ function ChatDetailView({ chatId, onBack }: { chatId: string; onBack: () => void
             <div className="flex flex-wrap gap-2">
               {chat.participants.map((p) => (
                 <Badge key={p.agentId} variant="outline">
-                  {p.agentId} ({p.role})
+                  {resolveAgentName(p.agentId)} ({p.role})
                 </Badge>
               ))}
             </div>
@@ -164,7 +166,7 @@ function ChatDetailView({ chatId, onBack }: { chatId: string; onBack: () => void
               {messagesData?.items.map((msg) => (
                 <div key={msg.id} className="border rounded-md p-3">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="font-mono text-sm font-medium">{msg.senderId}</span>
+                    <span className="font-mono text-sm font-medium">{resolveAgentName(msg.senderId)}</span>
                     <span className="text-xs text-muted-foreground">{formatDate(msg.createdAt)}</span>
                   </div>
                   <div className="text-sm">


### PR DESCRIPTION
## Summary

- Split `agents.id` into `uuid` (UUID v7 PK, system-generated, immutable) and `name` (human-readable, per-org unique, recyclable on delete)
- Delete sets `name=NULL` to release for reuse while preserving `uuid` for historical message attribution
- Org internalized as server-side concept: agent routes resolve org from token, admin routes use `?org=` query param
- `sendToAgent` resolves target by name within sender's org, providing natural cross-org isolation
- `delegate_mention` stores uuid (not name) to prevent stale references after name recycling
- Web: `useAgentNameMap` hook resolves uuid→name for all display locations (delegates, bindings, participants, senders)
- Bump command package to 0.5.0 (breaking: bootstrap API path `/bootstrap/:agentId/token` → `/bootstrap/:name/token`)

## Migration

After merging, existing databases need a one-time data migration (not included in this PR):

```bash
pnpm --filter @first-tree-hub/server db:migrate          # DDL
psql "$DATABASE_URL" -f packages/server/scripts/migrate-uuid.sql  # data
```

## Test plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm typecheck` — 9/9 tasks pass
- [x] `pnpm test` — 182/182 tests pass (28 test files)
- [x] New `agent-identity.test.ts` — 12 cases covering name recycling, getAgentByName, org filtering, UUID generation, name uniqueness
- [x] Manual verification: Web dashboard displays agent names correctly in all locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)