### PR TITLE
feat: multiplexed client connections and activity monitoring (runtime M1)

### DIFF
--- a/packages/client/src/__tests__/client-connection.test.ts
+++ b/packages/client/src/__tests__/client-connection.test.ts
@@ -1,0 +1,313 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for ClientConnection — mock WebSocket, no real server.
+ *
+ * Focus:
+ * - ref-based correlation for bind responses (P1-1)
+ * - error responses matched to correct pending bind via ref (P1-3)
+ * - pending binds rejected on WS close (P2-3)
+ * - pending binds rejected on disconnect() (P2-4)
+ * - reconnect triggers rebind for all boundAgents (P2-1)
+ * - connect() fast-fails on early socket closure (P2-2)
+ */
+
+// -- Mock WebSocket --
+
+class MockWebSocket extends EventEmitter {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState: number = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close(_code?: number, _reason?: string) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  terminate() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  removeAllListeners() {
+    super.removeAllListeners();
+    return this;
+  }
+
+  receiveMessage(msg: Record<string, unknown>) {
+    this.emit("message", Buffer.from(JSON.stringify(msg)));
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open");
+  }
+}
+
+// Track the latest mock WS instance
+let latestMockWs: MockWebSocket;
+
+vi.mock("ws", () => {
+  // Must use Reflect.construct to return a custom object from `new WebSocket(url)`
+  // while satisfying biome's no-constructor-return rule.
+  function createMockWs() {
+    const instance = new MockWebSocket();
+    latestMockWs = instance;
+    setTimeout(() => {
+      if (instance.readyState === MockWebSocket.CONNECTING) {
+        instance.simulateOpen();
+      }
+    }, 0);
+    return instance;
+  }
+  const MockWS = new Proxy(createMockWs, {
+    construct: () => createMockWs() as object,
+  });
+  Object.assign(MockWS, { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 });
+  return { default: MockWS, __esModule: true };
+});
+
+// Must import AFTER vi.mock
+const { ClientConnection } = await import("../client-connection.js");
+
+/** Parse a sent message by index. Throws if missing. */
+function parseSent(ws: MockWebSocket, idx: number): Record<string, string> {
+  const raw = ws.sent[idx];
+  if (!raw) throw new Error(`No message at index ${idx}`);
+  return JSON.parse(raw) as Record<string, string>;
+}
+
+function createConn() {
+  return new ClientConnection({ serverUrl: "http://localhost:9999" });
+}
+
+/** Connect and register (simulates full server handshake). */
+async function connectAndRegister(conn: ReturnType<typeof createConn>) {
+  const connectPromise = conn.connect();
+  await vi.waitFor(() => {
+    expect(latestMockWs.sent.length).toBeGreaterThanOrEqual(1);
+  });
+  latestMockWs.receiveMessage({ type: "client:registered", clientId: conn.clientId });
+  await connectPromise;
+  return latestMockWs;
+}
+
+describe("ClientConnection: ref-based bind correlation", () => {
+  it("bindAgent sends ref in the request", async () => {
+    const conn = createConn();
+    const ws = await connectAndRegister(conn);
+
+    const bindPromise = conn.bindAgent("aghub_test123", "claude-code");
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThanOrEqual(2);
+    });
+
+    const bindMsg = parseSent(ws, 1);
+    expect(bindMsg.type).toBe("agent:bind");
+    expect(bindMsg.ref).toBeDefined();
+    expect(typeof bindMsg.ref).toBe("string");
+    expect(bindMsg.token).toBe("aghub_test123");
+
+    ws.receiveMessage({
+      type: "agent:bound",
+      ref: bindMsg.ref,
+      agentId: "agent-uuid-1",
+      displayName: "Test Agent",
+      agentType: "autonomous_agent",
+    });
+
+    const bound = await bindPromise;
+    expect(bound.agentId).toBe("agent-uuid-1");
+    expect(bound.token).toBe("aghub_test123");
+
+    await conn.disconnect();
+  });
+
+  it("matches out-of-order responses correctly via ref", async () => {
+    const conn = createConn();
+    const ws = await connectAndRegister(conn);
+
+    const bind1 = conn.bindAgent("aghub_token_A", "type-a");
+    const bind2 = conn.bindAgent("aghub_token_B", "type-b");
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThanOrEqual(3);
+    });
+
+    const msg1 = parseSent(ws, 1);
+    const msg2 = parseSent(ws, 2);
+
+    // Respond in REVERSE order
+    ws.receiveMessage({ type: "agent:bound", ref: msg2.ref, agentId: "agent-B", agentType: "type-b" });
+    ws.receiveMessage({ type: "agent:bound", ref: msg1.ref, agentId: "agent-A", agentType: "type-a" });
+
+    const [result1, result2] = await Promise.all([bind1, bind2]);
+
+    expect(result1.agentId).toBe("agent-A");
+    expect(result1.token).toBe("aghub_token_A");
+    expect(result2.agentId).toBe("agent-B");
+    expect(result2.token).toBe("aghub_token_B");
+
+    await conn.disconnect();
+  });
+});
+
+describe("ClientConnection: error response matched via ref", () => {
+  it("rejects the correct pending bind when error carries ref", async () => {
+    const conn = createConn();
+    const ws = await connectAndRegister(conn);
+
+    const bind1 = conn.bindAgent("aghub_good", "type-a");
+    const bind2 = conn.bindAgent("aghub_bad", "type-b");
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThanOrEqual(3);
+    });
+
+    const msg1 = parseSent(ws, 1);
+    const msg2 = parseSent(ws, 2);
+
+    ws.receiveMessage({ type: "error", ref: msg2.ref, message: "Invalid token" });
+    ws.receiveMessage({ type: "agent:bound", ref: msg1.ref, agentId: "agent-good" });
+
+    const result1 = await bind1;
+    expect(result1.agentId).toBe("agent-good");
+    expect(result1.token).toBe("aghub_good");
+
+    await expect(bind2).rejects.toThrow("Invalid token");
+
+    await conn.disconnect();
+  });
+});
+
+describe("ClientConnection: pending binds rejected on WS close", () => {
+  it("rejects all pending binds when WebSocket closes", async () => {
+    const conn = createConn();
+    await connectAndRegister(conn);
+
+    const bind1 = conn.bindAgent("aghub_t1", "type-a");
+    const bind2 = conn.bindAgent("aghub_t2", "type-b");
+
+    await vi.waitFor(() => {
+      expect(latestMockWs.sent.length).toBeGreaterThanOrEqual(3);
+    });
+
+    // Simulate WS drop — disconnect first to prevent reconnect timer leak
+    await conn.disconnect();
+
+    await expect(bind1).rejects.toThrow("Client disconnected");
+    await expect(bind2).rejects.toThrow("Client disconnected");
+  });
+});
+
+describe("ClientConnection: pending binds rejected on disconnect()", () => {
+  it("rejects all pending binds when disconnect() is called", async () => {
+    const conn = createConn();
+    await connectAndRegister(conn);
+
+    const bind1 = conn.bindAgent("aghub_d1", "type-a");
+
+    await vi.waitFor(() => {
+      expect(latestMockWs.sent.length).toBeGreaterThanOrEqual(2);
+    });
+
+    await conn.disconnect();
+
+    await expect(bind1).rejects.toThrow("Client disconnected");
+  });
+});
+
+describe("ClientConnection: reconnect triggers rebind", () => {
+  it("re-sends agent:bind for all boundAgents after reconnection", async () => {
+    const conn = createConn();
+    const ws1 = await connectAndRegister(conn);
+
+    // Bind an agent
+    const bindPromise = conn.bindAgent("aghub_recon", "claude-code");
+
+    await vi.waitFor(() => {
+      expect(ws1.sent.length).toBeGreaterThanOrEqual(2);
+    });
+
+    const bindMsg = parseSent(ws1, 1);
+    ws1.receiveMessage({
+      type: "agent:bound",
+      ref: bindMsg.ref,
+      agentId: "agent-recon-1",
+      agentType: "claude-code",
+    });
+    await bindPromise;
+    expect(conn.agents.size).toBe(1);
+
+    // Simulate WS drop — triggers reconnect
+    ws1.readyState = MockWebSocket.CLOSED;
+    ws1.emit("close");
+
+    // Wait for reconnect timer (1s) to create a new WS
+    await vi.waitFor(
+      () => {
+        expect(latestMockWs).not.toBe(ws1);
+      },
+      { timeout: 5000 },
+    );
+
+    const ws2 = latestMockWs;
+
+    // Wait for ws2 to open and send client:register
+    await vi.waitFor(() => {
+      expect(ws2.sent.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const registerMsg = parseSent(ws2, 0);
+    expect(registerMsg.type).toBe("client:register");
+    expect(registerMsg.clientId).toBe(conn.clientId);
+
+    // Server responds with client:registered — triggers rebind
+    ws2.receiveMessage({ type: "client:registered", clientId: conn.clientId });
+
+    // rebindAgents runs synchronously within handleMessage
+    expect(ws2.sent.length).toBeGreaterThanOrEqual(2);
+
+    const rebindMsg = parseSent(ws2, 1);
+    expect(rebindMsg.type).toBe("agent:bind");
+    expect(rebindMsg.token).toBe("aghub_recon");
+    expect(rebindMsg.ref).toBeDefined();
+
+    // Complete the rebind handshake before disconnecting
+    ws2.receiveMessage({
+      type: "agent:bound",
+      ref: rebindMsg.ref,
+      agentId: "agent-recon-1",
+      agentType: "claude-code",
+    });
+
+    await conn.disconnect();
+  });
+});
+
+describe("ClientConnection: connect() fast-fail", () => {
+  it("rejects if WS closes before registration", async () => {
+    const conn = createConn();
+
+    const connectPromise = conn.connect();
+
+    await vi.waitFor(() => {
+      expect(latestMockWs).toBeDefined();
+    });
+
+    // Close before auto-open fires
+    latestMockWs.readyState = MockWebSocket.CLOSED;
+    latestMockWs.emit("close");
+
+    await expect(connectPromise).rejects.toThrow("WebSocket closed before registration");
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -1,0 +1,371 @@
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { hostname as getHostname, platform } from "node:os";
+import type { AgentActivity } from "@first-tree-hub/shared";
+import WebSocket from "ws";
+import { FirstTreeHubSDK } from "./sdk.js";
+
+export type ClientConnectionConfig = {
+  serverUrl: string;
+  clientId?: string;
+  sdkVersion?: string;
+};
+
+export type BoundAgent = {
+  agentId: string;
+  displayName: string | null;
+  agentType: string;
+  token: string;
+  sdk: FirstTreeHubSDK;
+};
+
+type ClientConnectionEvents = {
+  connected: [];
+  disconnected: [];
+  reconnecting: [attempt: number];
+  reconnected: [];
+  error: [error: Error];
+  "agent:bound": [agent: BoundAgent];
+  "agent:unbound": [agentId: string];
+  "agent:message": [agentId: string, data: unknown];
+};
+
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+const WS_CONNECT_TIMEOUT_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * M1 Client Connection: one WebSocket per client process, multiple agents multiplexed.
+ *
+ * Protocol:
+ *   1. connect() → WS to /api/v1/agent/ws/client
+ *   2. client:register → register with env info
+ *   3. bindAgent(token, runtimeType) → agent:bind per agent (with ref for correlation)
+ *   4. reportActivity(agentId, activity) → agent:activity
+ *   5. heartbeat → client-level keepalive
+ */
+export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
+  readonly clientId: string;
+  private readonly serverUrl: string;
+  private readonly sdkVersion: string | undefined;
+
+  private ws: WebSocket | null = null;
+  private wsConnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private closing = false;
+  private registered = false;
+
+  private readonly boundAgents = new Map<string, BoundAgent>();
+
+  /** Pending bind requests keyed by correlation ref. */
+  private pendingBinds = new Map<
+    string,
+    {
+      token: string;
+      runtimeType: string;
+      runtimeVersion?: string;
+      resolve: (agent: BoundAgent) => void;
+      reject: (err: Error) => void;
+    }
+  >();
+
+  constructor(config: ClientConnectionConfig) {
+    super();
+    this.clientId = config.clientId ?? `client_${randomUUID().slice(0, 8)}`;
+    this.serverUrl = config.serverUrl.replace(/\/+$/, "");
+    this.sdkVersion = config.sdkVersion;
+  }
+
+  get isConnected(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN && this.registered;
+  }
+
+  get agents(): ReadonlyMap<string, BoundAgent> {
+    return this.boundAgents;
+  }
+
+  /** Connect the client WS and register. */
+  async connect(): Promise<void> {
+    this.closing = false;
+    await this.openWebSocket();
+  }
+
+  /** Bind an agent to this client connection. */
+  async bindAgent(token: string, runtimeType: string, runtimeVersion?: string): Promise<BoundAgent> {
+    if (!this.isConnected) {
+      throw new Error("Client not connected");
+    }
+
+    return new Promise<BoundAgent>((resolve, reject) => {
+      const ref = randomUUID().slice(0, 12);
+      this.pendingBinds.set(ref, { token, runtimeType, runtimeVersion, resolve, reject });
+      this.ws?.send(
+        JSON.stringify({
+          type: "agent:bind",
+          ref,
+          token,
+          runtimeType,
+          runtimeVersion,
+        }),
+      );
+    });
+  }
+
+  /** Unbind an agent. */
+  async unbindAgent(agentId: string): Promise<void> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "agent:unbind", agentId }));
+    this.boundAgents.delete(agentId);
+  }
+
+  /** Report runtime state for a bound agent. */
+  reportActivity(agentId: string, activity: AgentActivity): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(
+      JSON.stringify({
+        type: "agent:activity",
+        agentId,
+        ...activity,
+      }),
+    );
+  }
+
+  /** Gracefully disconnect. */
+  async disconnect(): Promise<void> {
+    this.closing = true;
+    this.clearTimers();
+    this.rejectAllPendingBinds("Client disconnected");
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      if (this.ws.readyState === WebSocket.OPEN) {
+        this.ws.close(1000, "Client disconnect");
+      }
+      this.ws = null;
+    }
+    this.registered = false;
+    this.boundAgents.clear();
+    this.emit("disconnected");
+  }
+
+  // ---- WebSocket management --
+
+  private openWebSocket(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const wsUrl = `${this.serverUrl.replace(/^http/, "ws")}/api/v1/agent/ws/client`;
+      const ws = new WebSocket(wsUrl);
+      let settled = false;
+
+      const settle = (fn: typeof resolve | typeof reject, value?: unknown) => {
+        if (settled) return;
+        settled = true;
+        if (this.wsConnectTimer) {
+          clearTimeout(this.wsConnectTimer);
+          this.wsConnectTimer = null;
+        }
+        if (fn === resolve) {
+          (fn as typeof resolve)();
+        } else {
+          (fn as typeof reject)(value);
+        }
+      };
+
+      this.wsConnectTimer = setTimeout(() => {
+        this.wsConnectTimer = null;
+        ws.terminate();
+        settle(reject, new Error("WebSocket connect timeout"));
+      }, WS_CONNECT_TIMEOUT_MS);
+
+      ws.on("open", () => {
+        this.reconnectAttempt = 0;
+        this.ws = ws;
+
+        // Send client:register
+        ws.send(
+          JSON.stringify({
+            type: "client:register",
+            clientId: this.clientId,
+            hostname: getHostname(),
+            os: platform(),
+            sdkVersion: this.sdkVersion,
+          }),
+        );
+      });
+
+      ws.on("message", (data) => {
+        try {
+          const msg = JSON.parse(data.toString()) as Record<string, unknown>;
+          this.handleMessage(msg, () => settle(resolve));
+        } catch {
+          // ignore malformed messages
+        }
+      });
+
+      ws.on("close", () => {
+        this.stopHeartbeat();
+        this.registered = false;
+        this.rejectAllPendingBinds("WebSocket closed");
+
+        if (!settled) {
+          // Initial connect failed before registration — reject immediately
+          settle(reject, new Error("WebSocket closed before registration"));
+          return;
+        }
+
+        // Already connected before — this is a drop, schedule reconnect
+        if (!this.closing) {
+          this.emit("disconnected");
+          this.scheduleReconnect();
+        }
+      });
+
+      ws.on("error", (err) => {
+        this.emit("error", err);
+        // Don't settle here — let close handler do it (error always fires before close)
+      });
+    });
+  }
+
+  private handleMessage(msg: Record<string, unknown>, connectResolve?: () => void): void {
+    const type = msg.type as string;
+
+    if (type === "client:registered") {
+      const isReconnect = this.boundAgents.size > 0;
+      this.registered = true;
+      this.startHeartbeat();
+      this.emit("connected");
+      connectResolve?.();
+
+      // After reconnection, re-bind all previously bound agents
+      if (isReconnect) {
+        this.rebindAgents();
+      }
+    } else if (type === "agent:bound") {
+      const agentId = msg.agentId as string;
+      const ref = msg.ref as string | undefined;
+      const pending = ref ? this.pendingBinds.get(ref) : undefined;
+      if (ref) this.pendingBinds.delete(ref);
+      if (pending) {
+        const sdk = new FirstTreeHubSDK({ serverUrl: this.serverUrl, token: pending.token });
+        const agent: BoundAgent = {
+          agentId,
+          displayName: (msg.displayName as string) ?? null,
+          agentType: (msg.agentType as string) ?? "personal_assistant",
+          token: pending.token,
+          sdk,
+        };
+        this.boundAgents.set(agentId, agent);
+        this.emit("agent:bound", agent);
+        pending.resolve(agent);
+      }
+    } else if (type === "agent:unbound") {
+      const agentId = msg.agentId as string;
+      this.boundAgents.delete(agentId);
+      this.emit("agent:unbound", agentId);
+    } else if (type === "new_message") {
+      // Route to the correct agent
+      const inboxId = msg.inboxId as string | undefined;
+      if (inboxId) {
+        this.emit("agent:message", inboxId, msg);
+      }
+    } else if (type === "error") {
+      const errorMsg = msg.message as string;
+      const ref = msg.ref as string | undefined;
+      // Match error to pending bind via ref
+      const pending = ref ? this.pendingBinds.get(ref) : undefined;
+      if (pending && ref) {
+        this.pendingBinds.delete(ref);
+        pending.reject(new Error(errorMsg));
+      } else {
+        this.emit("error", new Error(errorMsg));
+      }
+    }
+  }
+
+  /** Re-bind all agents after reconnection. */
+  private rebindAgents(): void {
+    this.emit("reconnected");
+    for (const [, agent] of this.boundAgents) {
+      const ref = randomUUID().slice(0, 12);
+      // Re-bind with a new pending entry; on failure, remove from boundAgents
+      this.pendingBinds.set(ref, {
+        token: agent.token,
+        runtimeType: agent.agentType,
+        resolve: (rebound) => {
+          // Update the entry in case agentId or displayName changed
+          this.boundAgents.set(rebound.agentId, rebound);
+        },
+        reject: (err) => {
+          // Agent couldn't be re-bound (e.g., token revoked during disconnect)
+          this.boundAgents.delete(agent.agentId);
+          this.emit("agent:unbound", agent.agentId);
+          this.emit("error", err);
+        },
+      });
+      this.ws?.send(
+        JSON.stringify({
+          type: "agent:bind",
+          ref,
+          token: agent.token,
+          runtimeType: agent.agentType,
+        }),
+      );
+    }
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectAttempt++;
+    this.emit("reconnecting", this.reconnectAttempt);
+
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** (this.reconnectAttempt - 1), RECONNECT_MAX_MS);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.closing) {
+        this.openWebSocket().catch((err) => {
+          this.emit("error", err instanceof Error ? err : new Error(String(err)));
+        });
+      }
+    }, delay);
+  }
+
+  // ---- Heartbeat --
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: "heartbeat" }));
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  // ---- Cleanup --
+
+  private rejectAllPendingBinds(reason: string): void {
+    for (const [, pending] of this.pendingBinds) {
+      pending.reject(new Error(reason));
+    }
+    this.pendingBinds.clear();
+  }
+
+  private clearTimers(): void {
+    this.stopHeartbeat();
+    if (this.wsConnectTimer) {
+      clearTimeout(this.wsConnectTimer);
+      this.wsConnectTimer = null;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -264,6 +264,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       const agentId = msg.agentId as string;
       this.boundAgents.delete(agentId);
       this.emit("agent:unbound", agentId);
+    } else if (type === "agent:force_disconnect") {
+      const agentId = msg.agentId as string;
+      if (agentId && this.boundAgents.has(agentId)) {
+        this.boundAgents.delete(agentId);
+        this.emit("agent:unbound", agentId);
+      }
     } else if (type === "new_message") {
       // Route to the correct agent
       const inboxId = msg.inboxId as string | undefined;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,5 @@
+export type { BoundAgent, ClientConnectionConfig } from "./client-connection.js";
+export { ClientConnection } from "./client-connection.js";
 export type { AgentConnectionConfig, ConnectionState, MessageHandler } from "./connection.js";
 export { AgentConnection } from "./connection.js";
 // Handlers

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
-import type { InboxEntryWithMessage } from "@first-tree-hub/shared";
+import type { InboxEntryWithMessage, RuntimeState } from "@first-tree-hub/shared";
 import { DEFAULT_DATA_DIR } from "@first-tree-hub/shared/config";
+import type { ClientConnection } from "../client-connection.js";
 import { AgentConnection } from "../connection.js";
 import type { RegisterResult } from "../sdk.js";
 import type { SessionConfig } from "./config.js";
@@ -15,32 +16,74 @@ export type AgentSlotConfig = {
   handlerFactory: HandlerFactory;
   session: SessionConfig;
   concurrency: number;
+  /** M1: optional shared client connection */
+  clientConnection?: ClientConnection;
+  /** M1: runtime type for activity reporting */
+  runtimeType?: string;
+  /** M1: runtime version for activity reporting */
+  runtimeVersion?: string;
 };
 
 export class AgentSlot {
-  private readonly connection: AgentConnection;
+  private readonly legacyConnection: AgentConnection | null;
+  private readonly clientConnection: ClientConnection | null;
   private sessionManager: SessionManager | null = null;
   private readonly config: AgentSlotConfig;
   private readonly logFn: (msg: string) => void;
+  private agentId: string | null = null;
+  private sdk: import("../sdk.js").FirstTreeHubSDK | null = null;
+  private pollingTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(config: AgentSlotConfig) {
     this.config = config;
     this.logFn = (msg: string) => {
       process.stderr.write(`[${config.name}] ${msg}\n`);
     };
-    this.connection = new AgentConnection({
-      serverUrl: config.serverUrl,
-      token: config.token,
-    });
 
-    this.connection.on("connected", () => this.logFn("Connected"));
-    this.connection.on("reconnecting", (attempt) => this.logFn(`Reconnecting (attempt ${attempt})...`));
-    this.connection.on("error", (err) => this.logFn(`Error: ${err.message}`));
+    if (config.clientConnection) {
+      this.clientConnection = config.clientConnection;
+      this.legacyConnection = null;
+    } else {
+      this.legacyConnection = new AgentConnection({
+        serverUrl: config.serverUrl,
+        token: config.token,
+      });
+      this.clientConnection = null;
+
+      this.legacyConnection.on("connected", () => this.logFn("Connected"));
+      this.legacyConnection.on("reconnecting", (attempt) => this.logFn(`Reconnecting (attempt ${attempt})...`));
+      this.legacyConnection.on("error", (err) => this.logFn(`Error: ${err.message}`));
+    }
   }
 
   async start(contextTreePath?: string | null): Promise<RegisterResult> {
-    const agent = await this.connection.connect();
-    this.logFn(`Registered as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+    let agent: RegisterResult;
+    let sdk: import("../sdk.js").FirstTreeHubSDK;
+
+    if (this.clientConnection) {
+      const bound = await this.clientConnection.bindAgent(
+        this.config.token,
+        this.config.runtimeType ?? this.config.type,
+        this.config.runtimeVersion,
+      );
+      this.agentId = bound.agentId;
+      sdk = bound.sdk;
+      this.sdk = sdk;
+      agent = await sdk.register();
+
+      this.logFn(`Bound as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+
+      this.clientConnection.on("agent:message", () => {
+        this.pullAndDispatch();
+      });
+    } else {
+      const conn = this.legacyConnection as AgentConnection;
+      agent = await conn.connect();
+      this.agentId = agent.agentId;
+      sdk = conn.sdk;
+
+      this.logFn(`Registered as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+    }
 
     const registryPath = join(DEFAULT_DATA_DIR, "sessions", `${this.config.name}.json`);
 
@@ -60,21 +103,69 @@ export class AgentSlot {
         profile: agent.profile,
         metadata: agent.metadata,
       },
-      sdk: this.connection.sdk,
+      sdk,
       log: this.logFn,
       registryPath,
+      onStateChange: this.clientConnection
+        ? (state, description) => this.reportActivity(state, description)
+        : undefined,
     });
 
-    this.connection.onMessage(async (entry: InboxEntryWithMessage) => {
-      await this.sessionManager?.dispatch(entry);
-    });
+    if (this.clientConnection) {
+      this.startPolling();
+      this.reportActivity("idle");
+    } else {
+      const conn = this.legacyConnection as AgentConnection;
+      conn.onMessage(async (entry: InboxEntryWithMessage) => {
+        await this.sessionManager?.dispatch(entry);
+      });
+    }
 
     return agent;
   }
 
   async stop(): Promise<void> {
+    if (this.pollingTimer) {
+      clearInterval(this.pollingTimer);
+      this.pollingTimer = null;
+    }
+    if (this.clientConnection && this.agentId) {
+      this.reportActivity("idle");
+      await this.clientConnection.unbindAgent(this.agentId);
+    }
     await this.sessionManager?.shutdown();
-    await this.connection.disconnect();
+    if (this.legacyConnection) {
+      await this.legacyConnection.disconnect();
+    }
     this.logFn("Stopped");
+  }
+
+  private reportActivity(state: RuntimeState, description?: string): void {
+    if (!this.clientConnection || !this.agentId) return;
+    this.clientConnection.reportActivity(this.agentId, {
+      state,
+      description,
+      activeSessions: this.sessionManager?.activeCount ?? 0,
+      totalSessions: this.sessionManager?.totalCount ?? 0,
+    });
+  }
+
+  private startPolling(): void {
+    this.pollingTimer = setInterval(() => {
+      this.pullAndDispatch();
+    }, 5000);
+    this.pullAndDispatch();
+  }
+
+  private async pullAndDispatch(): Promise<void> {
+    if (!this.sdk) return;
+    try {
+      const { entries } = await this.sdk.pull(10);
+      for (const entry of entries) {
+        await this.sessionManager?.dispatch(entry);
+      }
+    } catch {
+      // ignore polling errors
+    }
   }
 }

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -1,3 +1,4 @@
+import { ClientConnection } from "../client-connection.js";
 import { AgentSlot } from "./agent-slot.js";
 import { syncContextTree } from "./bootstrap.js";
 import type { RuntimeConfig } from "./config.js";
@@ -6,6 +7,8 @@ import { getHandlerFactory } from "./handler.js";
 export type AgentRuntimeOptions = {
   config: RuntimeConfig;
   shutdownTimeout?: number;
+  /** M1: use shared client connection (default: true if multiple agents) */
+  useClientConnection?: boolean;
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 30_000;
@@ -14,13 +17,23 @@ export class AgentRuntime {
   private readonly slots: AgentSlot[] = [];
   private readonly config: RuntimeConfig;
   private readonly shutdownTimeout: number;
+  private clientConnection: ClientConnection | null = null;
   private stopping = false;
 
   constructor(options: AgentRuntimeOptions) {
     this.config = options.config;
     this.shutdownTimeout = options.shutdownTimeout ?? DEFAULT_SHUTDOWN_TIMEOUT;
 
-    for (const [name, agentConfig] of Object.entries(this.config.agents)) {
+    const agentEntries = Object.entries(this.config.agents);
+    const useClientConn = options.useClientConnection ?? agentEntries.length > 1;
+
+    if (useClientConn) {
+      this.clientConnection = new ClientConnection({
+        serverUrl: this.config.server,
+      });
+    }
+
+    for (const [name, agentConfig] of agentEntries) {
       const handlerFactory = getHandlerFactory(agentConfig.type);
       this.slots.push(
         new AgentSlot({
@@ -31,6 +44,8 @@ export class AgentRuntime {
           handlerFactory,
           session: agentConfig.session,
           concurrency: agentConfig.concurrency,
+          clientConnection: this.clientConnection ?? undefined,
+          runtimeType: agentConfig.type,
         }),
       );
     }
@@ -48,6 +63,13 @@ export class AgentRuntime {
     }
     if (!contextTreePath) {
       log("Context Tree not configured or sync skipped — agents will start without organizational context");
+    }
+
+    // M1: Connect shared client connection first
+    if (this.clientConnection) {
+      log(`Connecting client (${this.clientConnection.clientId})...`);
+      await this.clientConnection.connect();
+      log(`Client connected (${this.clientConnection.clientId})`);
     }
 
     log(`Starting ${this.slots.length} agent(s)...`);
@@ -94,5 +116,8 @@ export class AgentRuntime {
   /** Stop all slots. */
   async stop(): Promise<void> {
     await Promise.allSettled(this.slots.map((slot) => slot.stop()));
+    if (this.clientConnection) {
+      await this.clientConnection.disconnect();
+    }
   }
 }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1,4 +1,4 @@
-import type { InboxEntryWithMessage } from "@first-tree-hub/shared";
+import type { InboxEntryWithMessage, RuntimeState } from "@first-tree-hub/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { SessionConfig } from "./config.js";
 import { Deduplicator } from "./deduplicator.js";
@@ -38,6 +38,8 @@ type SessionManagerConfig = {
   sdk: FirstTreeHubSDK;
   log: (msg: string) => void;
   registryPath?: string;
+  /** M1: callback when runtime state should change */
+  onStateChange?: (state: RuntimeState, description?: string) => void;
 };
 
 /**
@@ -62,6 +64,7 @@ export class SessionManager {
   private readonly pendingQueue: PendingMessage[] = [];
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private _activeCount = 0;
+  private _lastReportedState: RuntimeState | null = null;
 
   constructor(config: SessionManagerConfig) {
     this.config = config;
@@ -190,12 +193,14 @@ export class SessionManager {
         this.config.log(`Session ${chatId}: created (${sessionId})`);
       }
       this.persistRegistry();
+      this.notifyStateChange();
     } catch (err) {
       this.config.log(
         `Session ${chatId}: ${evicted ? "resume" : "start"} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       this.sessions.delete(chatId);
       this._activeCount--;
+      this.notifyStateChange();
     }
   }
 
@@ -217,10 +222,12 @@ export class SessionManager {
       await entry.handler.resume(message, entry.claudeSessionId, ctx);
       this.config.log(`Session ${entry.chatId}: resumed (${entry.claudeSessionId})`);
       this.persistRegistry();
+      this.notifyStateChange();
     } catch (err) {
       this.config.log(`Session ${entry.chatId}: resume failed: ${err instanceof Error ? err.message : String(err)}`);
       entry.status = "suspended";
       this._activeCount--;
+      this.notifyStateChange();
     }
   }
 
@@ -268,6 +275,7 @@ export class SessionManager {
         entry.suspending = null;
       });
     this.persistRegistry();
+    this.notifyStateChange();
 
     // Drain pending queue
     this.drainPendingQueue();
@@ -343,6 +351,14 @@ export class SessionManager {
       const oldest = this.evictedMappings.keys().next().value;
       if (oldest !== undefined) this.evictedMappings.delete(oldest);
     }
+  }
+
+  private notifyStateChange(): void {
+    if (!this.config.onStateChange) return;
+    const state: RuntimeState = this._activeCount > 0 ? "working" : "idle";
+    if (state === this._lastReportedState) return;
+    this._lastReportedState = state;
+    this.config.onStateChange(state);
   }
 
   private buildSessionContext(chatId: string): SessionContext {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -12,7 +12,7 @@ import {
 } from "@first-tree-hub/shared/config";
 import type { Command } from "commander";
 import { fail, success } from "../cli/output.js";
-import { bootstrapToken, resolveAgentToken, resolveServerUrl } from "../core/bootstrap.js";
+import { bootstrapToken, resolveAdminToken, resolveAgentToken, resolveServerUrl } from "../core/bootstrap.js";
 import { bindFeishuBot, bindFeishuUser } from "../core/feishu.js";
 import { promptAddAgent } from "../core/index.js";
 
@@ -373,6 +373,124 @@ export function registerAgentCommands(program: Command): void {
         success(result);
       } catch (error) {
         handleSdkError(error);
+      }
+    });
+
+  // ── M1: Runtime status & management ─────────────────────────────────
+
+  agent
+    .command("status [name]")
+    .description("Show agent runtime status from Hub server")
+    .option("--server <url>", "Hub server URL")
+    .action(async (name?: string, options?: { server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options?.server);
+        const response = await fetch(`${serverUrl}/api/v1/admin/agents/activity`, {
+          headers: { Authorization: `Bearer ${resolveAdminToken()}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          fail("FETCH_ERROR", `Server returned ${response.status}`, 1);
+        }
+        const data = (await response.json()) as {
+          total: number;
+          running: number;
+          byState: { idle: number; working: number; error: number };
+          clients: number;
+          agents: Array<{
+            agentId: string;
+            clientId: string | null;
+            runtimeType: string | null;
+            runtimeState: string | null;
+            runtimeDescription: string | null;
+            activeSessions: number | null;
+            totalSessions: number | null;
+            errorMessage: string | null;
+          }>;
+        };
+
+        if (name) {
+          const agent = data.agents.find((a) => a.agentId === name);
+          if (!agent) {
+            process.stderr.write(`\n  Agent "${name}" is not running.\n\n`);
+            return;
+          }
+          process.stderr.write(`\n  Agent: ${agent.agentId}\n`);
+          process.stderr.write(`  Runtime: ${agent.runtimeType ?? "—"}\n`);
+          process.stderr.write(`  State: ${agent.runtimeState ?? "—"}\n`);
+          if (agent.runtimeDescription) {
+            process.stderr.write(`  Description: ${agent.runtimeDescription}\n`);
+          }
+          if (agent.activeSessions !== null) {
+            process.stderr.write(`  Sessions: ${agent.activeSessions} active / ${agent.totalSessions ?? 0} total\n`);
+          }
+          if (agent.errorMessage) {
+            process.stderr.write(`  Error: ${agent.errorMessage}\n`);
+          }
+          if (agent.clientId) {
+            process.stderr.write(`  Client: ${agent.clientId}\n`);
+          }
+          process.stderr.write("\n");
+          return;
+        }
+
+        process.stderr.write(`\n  Hub: ${serverUrl}\n\n`);
+        process.stderr.write(`  Clients: ${data.clients} connected\n`);
+        process.stderr.write(`  Agents: ${data.running} running / ${data.total} total\n`);
+        process.stderr.write(
+          `  Errors: ${data.byState.error} | Working: ${data.byState.working} | Idle: ${data.byState.idle}\n\n`,
+        );
+
+        if (data.agents.length > 0) {
+          const header = `  ${"AGENT".padEnd(18)} ${"RUNTIME".padEnd(14)} ${"STATE".padEnd(10)} ${"SESSIONS".padEnd(10)} DESCRIPTION`;
+          process.stderr.write(`${header}\n`);
+          process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
+          for (const a of data.agents) {
+            const sessions = a.activeSessions !== null ? `${a.activeSessions}/${a.totalSessions ?? 0}` : "—";
+            const desc = a.runtimeDescription ?? (a.errorMessage ? `Error: ${a.errorMessage.slice(0, 40)}` : "—");
+            process.stderr.write(
+              `  ${(a.agentId ?? "").padEnd(18)} ${(a.runtimeType ?? "—").padEnd(14)} ${(a.runtimeState ?? "—").padEnd(10)} ${sessions.padEnd(10)} ${desc}\n`,
+            );
+          }
+          process.stderr.write("\n");
+        }
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("ADMIN_TOKEN")) {
+          try {
+            const sdk = createSdk();
+            const me = await sdk.register();
+            process.stderr.write(`\n  Agent: ${me.agentId} (${me.displayName ?? "no name"})\n`);
+            process.stderr.write(`  Type: ${me.type}\n`);
+            process.stderr.write(`  Status: ${me.status}\n\n`);
+          } catch (sdkError) {
+            handleSdkError(sdkError);
+          }
+          return;
+        }
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("STATUS_ERROR", msg);
+      }
+    });
+
+  agent
+    .command("reset <name>")
+    .description("Reset agent error state to idle")
+    .option("--server <url>", "Hub server URL")
+    .action(async (name: string, options: { server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options.server);
+        const response = await fetch(`${serverUrl}/api/v1/admin/agents/activity/${name}/reset-activity`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${resolveAdminToken()}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          fail("RESET_ERROR", `Server returned ${response.status}`, 1);
+        }
+        process.stderr.write(`  Agent "${name}" reset to idle.\n`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("RESET_ERROR", msg);
       }
     });
 

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -9,6 +9,7 @@ import {
   resetConfigMeta,
 } from "@first-tree-hub/shared/config";
 import type { Command } from "commander";
+import { fail } from "../cli/output.js";
 import {
   ClientRuntime,
   checkAgentConfigs,
@@ -19,6 +20,8 @@ import {
   checkWebSocket,
   printResults,
   promptMissingFields,
+  resolveAdminToken,
+  resolveServerUrl,
 } from "../core/index.js";
 
 export function registerClientCommands(program: Command): void {
@@ -128,4 +131,86 @@ export function registerClientCommands(program: Command): void {
         process.stderr.write("  No agents directory found.\n");
       }
     });
+
+  // ── M1: Hub-level client management ────────────────────────────────
+
+  client
+    .command("hub-list")
+    .description("List connected clients on the Hub server")
+    .option("--server <url>", "Hub server URL")
+    .action(async (options: { server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options.server);
+        const token = resolveAdminToken();
+        const response = await fetch(`${serverUrl}/api/v1/admin/clients`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          fail("FETCH_ERROR", `Server returned ${response.status}`, 1);
+        }
+        const clients = (await response.json()) as Array<{
+          id: string;
+          hostname: string | null;
+          agentCount: number;
+          connectedAt: string | null;
+          lastSeenAt: string;
+        }>;
+
+        if (clients.length === 0) {
+          process.stderr.write("  No connected clients.\n");
+          return;
+        }
+
+        process.stderr.write(`\n  Connected Clients: ${clients.length}\n\n`);
+        const header = `  ${"CLIENT".padEnd(20)} ${"HOST".padEnd(25)} ${"AGENTS".padEnd(8)} CONNECTED`;
+        process.stderr.write(`${header}\n`);
+        process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
+        for (const c of clients) {
+          const since = c.connectedAt ? timeSince(c.connectedAt) : "—";
+          process.stderr.write(
+            `  ${c.id.padEnd(20)} ${(c.hostname ?? "—").padEnd(25)} ${String(c.agentCount).padEnd(8)} ${since}\n`,
+          );
+        }
+        process.stderr.write("\n");
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("CLIENT_LIST_ERROR", msg);
+      }
+    });
+
+  client
+    .command("hub-disconnect <clientId>")
+    .description("Force-disconnect a client from the Hub server")
+    .option("--server <url>", "Hub server URL")
+    .action(async (clientId: string, options: { server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options.server);
+        const token = resolveAdminToken();
+        const response = await fetch(`${serverUrl}/api/v1/admin/clients/${clientId}/disconnect`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!response.ok) {
+          fail("DISCONNECT_ERROR", `Server returned ${response.status}`, 1);
+        }
+        process.stderr.write(`  Client "${clientId}" disconnected.\n`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("DISCONNECT_ERROR", msg);
+      }
+    });
+}
+
+function timeSince(isoDate: string): string {
+  const ms = Date.now() - new Date(isoDate).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
 }

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -123,6 +123,18 @@ export function resolveAgentToken(): string {
 }
 
 /**
+ * Resolve admin JWT token from FIRST_TREE_HUB_ADMIN_TOKEN env var.
+ * Throws if not set.
+ */
+export function resolveAdminToken(): string {
+  const token = process.env.FIRST_TREE_HUB_ADMIN_TOKEN;
+  if (!token) {
+    throw new Error("FIRST_TREE_HUB_ADMIN_TOKEN environment variable is required.");
+  }
+  return token;
+}
+
+/**
  * Check if an agent exists and is synced.
  */
 export async function checkBootstrapStatus(

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -8,6 +8,7 @@ export {
   checkBootstrapStatus,
   getGitHubToken,
   getGitHubUsername,
+  resolveAdminToken,
   resolveAgentToken,
   resolveServerUrl,
 } from "./bootstrap.js";

--- a/packages/server/drizzle/0009_agent_runtime_m1.sql
+++ b/packages/server/drizzle/0009_agent_runtime_m1.sql
@@ -1,0 +1,31 @@
+-- M1: Agent Runtime — Process Awareness
+-- New clients table + agent_presence runtime columns
+
+CREATE TABLE IF NOT EXISTS "clients" (
+	"id" text PRIMARY KEY NOT NULL,
+	"status" text DEFAULT 'disconnected' NOT NULL,
+	"sdk_version" text,
+	"hostname" text,
+	"os" text,
+	"instance_id" text,
+	"connected_at" timestamp with time zone,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb
+);
+
+ALTER TABLE "agent_presence" ADD COLUMN "client_id" text;
+ALTER TABLE "agent_presence" ADD COLUMN "runtime_type" text;
+ALTER TABLE "agent_presence" ADD COLUMN "runtime_version" text;
+ALTER TABLE "agent_presence" ADD COLUMN "runtime_state" text;
+ALTER TABLE "agent_presence" ADD COLUMN "runtime_description" text;
+ALTER TABLE "agent_presence" ADD COLUMN "active_sessions" integer;
+ALTER TABLE "agent_presence" ADD COLUMN "total_sessions" integer;
+ALTER TABLE "agent_presence" ADD COLUMN "error_message" text;
+ALTER TABLE "agent_presence" ADD COLUMN "task_ref" text;
+ALTER TABLE "agent_presence" ADD COLUMN "runtime_updated_at" timestamp with time zone;
+
+DO $$ BEGIN
+  ALTER TABLE "agent_presence" ADD CONSTRAINT "agent_presence_client_id_clients_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."clients"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775952000000,
       "tag": "0008_uuid_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776019200000,
+      "tag": "0009_agent_runtime_m1",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/client-service.test.ts
+++ b/packages/server/src/__tests__/client-service.test.ts
@@ -1,0 +1,102 @@
+import { eq } from "drizzle-orm";
+import { afterAll, describe, expect, it } from "vitest";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import * as clientService from "../services/client.js";
+import * as presenceService from "../services/presence.js";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+/**
+ * Unit tests for client.ts service layer — DB-backed.
+ *
+ * Focus: disconnectClient must not corrupt agents that were re-bound
+ * to a different client.
+ */
+
+describe("client service: disconnectClient", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("sets agents with matching clientId to offline", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: `cs-dc-1-${crypto.randomUUID().slice(0, 6)}` });
+
+    const clientId = `client-dc-1-${Date.now()}`;
+    await clientService.registerClient(app.db, { clientId, instanceId: "test" });
+    await presenceService.bindAgent(app.db, agent.uuid, {
+      clientId,
+      instanceId: "test",
+      runtimeType: "test",
+    });
+
+    await clientService.disconnectClient(app.db, clientId);
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("offline");
+    expect(presence?.clientId).toBeNull();
+    expect(presence?.runtimeState).toBeNull();
+  });
+
+  it("does not affect agents re-bound to a different client", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: `cs-dc-2-${crypto.randomUUID().slice(0, 6)}` });
+
+    const oldClient = `client-dc-old-${Date.now()}`;
+    const newClient = `client-dc-new-${Date.now()}`;
+    await clientService.registerClient(app.db, { clientId: oldClient, instanceId: "test" });
+    await clientService.registerClient(app.db, { clientId: newClient, instanceId: "test" });
+
+    // Bind to old client first
+    await presenceService.bindAgent(app.db, agent.uuid, {
+      clientId: oldClient,
+      instanceId: "test",
+      runtimeType: "test",
+    });
+
+    // Re-bind to new client (upsert overwrites clientId)
+    await presenceService.bindAgent(app.db, agent.uuid, {
+      clientId: newClient,
+      instanceId: "test",
+      runtimeType: "test",
+    });
+
+    // Disconnect old client — agent's clientId is now newClient, so it must NOT be affected
+    await clientService.disconnectClient(app.db, oldClient);
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("online");
+    expect(presence?.clientId).toBe(newClient);
+    expect(presence?.runtimeState).toBe("idle");
+  });
+
+  it("only affects agents of the disconnected client, not others", async () => {
+    const app = await appPromise;
+    const { agent: agentA } = await createTestAgent(app, { name: `cs-dc-3a-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: agentB } = await createTestAgent(app, { name: `cs-dc-3b-${crypto.randomUUID().slice(0, 6)}` });
+
+    const clientX = `client-dc-x-${Date.now()}`;
+    const clientY = `client-dc-y-${Date.now()}`;
+    await clientService.registerClient(app.db, { clientId: clientX, instanceId: "test" });
+    await clientService.registerClient(app.db, { clientId: clientY, instanceId: "test" });
+
+    await presenceService.bindAgent(app.db, agentA.uuid, {
+      clientId: clientX,
+      instanceId: "test",
+      runtimeType: "test",
+    });
+    await presenceService.bindAgent(app.db, agentB.uuid, {
+      clientId: clientY,
+      instanceId: "test",
+      runtimeType: "test",
+    });
+
+    // Disconnect clientX — agentB on clientY must not be affected
+    await clientService.disconnectClient(app.db, clientX);
+
+    const [presA] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentA.uuid));
+    const [presB] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentB.uuid));
+
+    expect(presA?.status).toBe("offline");
+    expect(presB?.status).toBe("online");
+    expect(presB?.clientId).toBe(clientY);
+  });
+});

--- a/packages/server/src/__tests__/connection-manager.test.ts
+++ b/packages/server/src/__tests__/connection-manager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 import {
   bindAgentToClient,
+  forceDisconnect,
   forceDisconnectClient,
   getAgentClientId,
   getClientAgentIds,
@@ -20,7 +21,7 @@ import {
 
 /** Create a minimal mock WebSocket (only readyState matters here). */
 function mockWs(readyState = WebSocket.OPEN): WebSocket {
-  return { readyState, close: () => {} } as unknown as WebSocket;
+  return { readyState, close: () => {}, send: () => {} } as unknown as WebSocket;
 }
 
 // connection-manager uses module-level Maps, so we need to clean up
@@ -133,5 +134,93 @@ describe("connection-manager: forceDisconnectClient", () => {
     const removed = forceDisconnectClient(clientA);
     expect(removed).toEqual([agent1]);
     expect(getAgentClientId(agent1)).toBeUndefined();
+  });
+});
+
+describe("connection-manager: setClientConnection takeover protection", () => {
+  it("closes existing active connection when new WS registers with same clientId", () => {
+    const clientId = "client-takeover";
+    const agent1 = "agent-takeover-1";
+    let closeCalled = false;
+    const ws1 = {
+      readyState: WebSocket.OPEN,
+      close: () => {
+        closeCalled = true;
+      },
+      send: () => {},
+    } as unknown as WebSocket;
+    const ws2 = mockWs();
+
+    setClientConnection(clientId, ws1);
+    bindAgentToClient(clientId, agent1);
+
+    // New connection with same clientId should close the old one
+    setClientConnection(clientId, ws2);
+
+    expect(closeCalled).toBe(true);
+    // Old agent bindings should be cleaned up
+    expect(getAgentClientId(agent1)).toBeUndefined();
+
+    // Cleanup
+    forceDisconnectClient(clientId);
+  });
+
+  it("does not close if same WS instance re-registers", () => {
+    const clientId = "client-same-ws";
+    let closeCalled = false;
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: () => {
+        closeCalled = true;
+      },
+      send: () => {},
+    } as unknown as WebSocket;
+
+    setClientConnection(clientId, ws);
+    setClientConnection(clientId, ws);
+
+    expect(closeCalled).toBe(false);
+
+    forceDisconnectClient(clientId);
+  });
+});
+
+describe("connection-manager: forceDisconnect M1 mode", () => {
+  it("unbinds single agent without closing the shared client WS", () => {
+    const clientId = "client-m1-force";
+    const agent1 = "agent-m1-1";
+    const agent2 = "agent-m1-2";
+    let closeCalled = false;
+    const sentMessages: string[] = [];
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: () => {
+        closeCalled = true;
+      },
+      send: (data: string) => {
+        sentMessages.push(data);
+      },
+    } as unknown as WebSocket;
+
+    setClientConnection(clientId, ws);
+    bindAgentToClient(clientId, agent1);
+    bindAgentToClient(clientId, agent2);
+
+    // Force disconnect only agent1
+    const result = forceDisconnect(agent1);
+
+    expect(result).toBe(true);
+    // WS should NOT be closed
+    expect(closeCalled).toBe(false);
+    // Should have sent force_disconnect message
+    expect(sentMessages).toHaveLength(1);
+    expect(JSON.parse(sentMessages[0] as string)).toEqual({ type: "agent:force_disconnect", agentId: agent1 });
+    // agent1 unbound, agent2 still bound
+    expect(getAgentClientId(agent1)).toBeUndefined();
+    expect(getAgentClientId(agent2)).toBe(clientId);
+    expect(getClientAgentIds(clientId)).toEqual([agent2]);
+
+    // Cleanup
+    forceDisconnectClient(clientId);
   });
 });

--- a/packages/server/src/__tests__/connection-manager.test.ts
+++ b/packages/server/src/__tests__/connection-manager.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import {
+  bindAgentToClient,
+  forceDisconnectClient,
+  getAgentClientId,
+  getClientAgentIds,
+  hasClientConnection,
+  removeClientConnection,
+  setClientConnection,
+  unbindAgentFromClient,
+} from "../services/connection-manager.js";
+
+/**
+ * Unit tests for connection-manager.ts — pure in-memory state management.
+ *
+ * Focus: the bindAgentToClient fix that removes agent from old client,
+ * plus general map consistency between agentToClient and clientConnections.
+ */
+
+/** Create a minimal mock WebSocket (only readyState matters here). */
+function mockWs(readyState = WebSocket.OPEN): WebSocket {
+  return { readyState, close: () => {} } as unknown as WebSocket;
+}
+
+// connection-manager uses module-level Maps, so we need to clean up
+// between tests by removing all known entries.
+function cleanup(clientIds: string[], agentIds: string[]) {
+  for (const aid of agentIds) {
+    unbindAgentFromClient(aid);
+  }
+  for (const cid of clientIds) {
+    forceDisconnectClient(cid);
+  }
+}
+
+describe("connection-manager: bindAgentToClient", () => {
+  const clientA = "client-A";
+  const clientB = "client-B";
+  const agent1 = "agent-1";
+  const agent2 = "agent-2";
+  const wsA = mockWs();
+  const wsB = mockWs();
+
+  beforeEach(() => {
+    cleanup([clientA, clientB], [agent1, agent2]);
+    setClientConnection(clientA, wsA);
+    setClientConnection(clientB, wsB);
+  });
+
+  it("binds agent to client and updates both maps", () => {
+    bindAgentToClient(clientA, agent1);
+
+    expect(getAgentClientId(agent1)).toBe(clientA);
+    expect(getClientAgentIds(clientA)).toContain(agent1);
+  });
+
+  it("rebind to new client removes agent from old client agentIds", () => {
+    bindAgentToClient(clientA, agent1);
+    expect(getClientAgentIds(clientA)).toContain(agent1);
+
+    // Rebind agent1 to clientB
+    bindAgentToClient(clientB, agent1);
+
+    // agent1 should be in clientB, NOT in clientA
+    expect(getAgentClientId(agent1)).toBe(clientB);
+    expect(getClientAgentIds(clientB)).toContain(agent1);
+    expect(getClientAgentIds(clientA)).not.toContain(agent1);
+  });
+
+  it("rebind does not affect other agents on old client", () => {
+    bindAgentToClient(clientA, agent1);
+    bindAgentToClient(clientA, agent2);
+    expect(getClientAgentIds(clientA)).toEqual(expect.arrayContaining([agent1, agent2]));
+
+    // Move only agent1 to clientB
+    bindAgentToClient(clientB, agent1);
+
+    // agent2 stays on clientA
+    expect(getClientAgentIds(clientA)).toContain(agent2);
+    expect(getClientAgentIds(clientA)).not.toContain(agent1);
+  });
+
+  it("binding same agent to same client is idempotent", () => {
+    bindAgentToClient(clientA, agent1);
+    bindAgentToClient(clientA, agent1);
+
+    expect(getAgentClientId(agent1)).toBe(clientA);
+    expect(getClientAgentIds(clientA)).toEqual([agent1]);
+  });
+});
+
+describe("connection-manager: removeClientConnection", () => {
+  const clientA = "client-rm-A";
+  const agent1 = "agent-rm-1";
+  const agent2 = "agent-rm-2";
+
+  it("removes all agents bound to the client", () => {
+    const ws = mockWs();
+    setClientConnection(clientA, ws);
+    bindAgentToClient(clientA, agent1);
+    bindAgentToClient(clientA, agent2);
+
+    const removed = removeClientConnection(clientA, ws);
+
+    expect(removed.sort()).toEqual([agent1, agent2].sort());
+    expect(getAgentClientId(agent1)).toBeUndefined();
+    expect(getAgentClientId(agent2)).toBeUndefined();
+    expect(hasClientConnection(clientA)).toBe(false);
+  });
+
+  it("returns empty array if ws does not match", () => {
+    const ws1 = mockWs();
+    const ws2 = mockWs();
+    setClientConnection(clientA, ws1);
+    bindAgentToClient(clientA, agent1);
+
+    const removed = removeClientConnection(clientA, ws2);
+    expect(removed).toEqual([]);
+    // Original binding should still exist
+    expect(getAgentClientId(agent1)).toBe(clientA);
+  });
+});
+
+describe("connection-manager: forceDisconnectClient", () => {
+  it("cleans up all agent bindings", () => {
+    const clientA = "client-force-A";
+    const agent1 = "agent-force-1";
+    const ws = mockWs();
+    setClientConnection(clientA, ws);
+    bindAgentToClient(clientA, agent1);
+
+    const removed = forceDisconnectClient(clientA);
+    expect(removed).toEqual([agent1]);
+    expect(getAgentClientId(agent1)).toBeUndefined();
+  });
+});

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -16,10 +16,7 @@ import { forceDisconnect } from "../../services/connection-manager.js";
 import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
-
-function serializeDate(d: Date | null): string | null {
-  return d ? d.toISOString() : null;
-}
+import { serializeDate } from "../../utils.js";
 
 export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   const listAgentsFilterSchema = z.object({ type: agentTypeSchema.optional() });
@@ -35,6 +32,13 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
         presenceStatus: a.presenceStatus ?? "offline",
         createdAt: a.createdAt.toISOString(),
         updatedAt: a.updatedAt.toISOString(),
+        // M1: runtime fields
+        clientId: a.clientId ?? null,
+        runtimeType: a.runtimeType ?? null,
+        runtimeState: a.runtimeState ?? null,
+        runtimeDescription: a.runtimeDescription ?? null,
+        activeSessions: a.activeSessions ?? null,
+        errorMessage: a.errorMessage ?? null,
       })),
       nextCursor: result.nextCursor,
     };

--- a/packages/server/src/api/admin/clients.ts
+++ b/packages/server/src/api/admin/clients.ts
@@ -1,0 +1,84 @@
+import type { FastifyInstance } from "fastify";
+import { AppError } from "../../errors.js";
+import * as activityService from "../../services/activity.js";
+import * as clientService from "../../services/client.js";
+import { forceDisconnectClient } from "../../services/connection-manager.js";
+import { serializeDate } from "../../utils.js";
+
+export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
+  // GET /admin/clients — all connected clients
+  app.get("/", async () => {
+    const clients = await clientService.listClients(app.db);
+    return clients.map((c) => ({
+      id: c.id,
+      status: c.status,
+      sdkVersion: c.sdkVersion,
+      hostname: c.hostname,
+      os: c.os,
+      agentCount: c.agentCount,
+      connectedAt: serializeDate(c.connectedAt),
+      lastSeenAt: c.lastSeenAt.toISOString(),
+    }));
+  });
+
+  // GET /admin/clients/:clientId — single client with agent list
+  app.get<{ Params: { clientId: string } }>("/:clientId", async (request) => {
+    const client = await clientService.getClient(app.db, request.params.clientId);
+    if (!client) {
+      throw new AppError(404, "Client not found");
+    }
+    return {
+      id: client.id,
+      status: client.status,
+      sdkVersion: client.sdkVersion,
+      hostname: client.hostname,
+      os: client.os,
+      connectedAt: serializeDate(client.connectedAt),
+      lastSeenAt: client.lastSeenAt.toISOString(),
+    };
+  });
+
+  // POST /admin/clients/:clientId/disconnect — force disconnect a client
+  app.post<{ Params: { clientId: string } }>("/:clientId/disconnect", async (request) => {
+    const { clientId } = request.params;
+    const client = await clientService.getClient(app.db, clientId);
+    if (!client) {
+      throw new AppError(404, "Client not found");
+    }
+
+    const agentIds = forceDisconnectClient(clientId);
+    await clientService.disconnectClient(app.db, clientId);
+
+    return { disconnected: true, agentIds };
+  });
+}
+
+export async function adminActivityRoutes(app: FastifyInstance): Promise<void> {
+  // GET /admin/agents/activity — activity overview
+  app.get("/", async () => {
+    const overview = await activityService.getActivityOverview(app.db);
+    const runningAgents = await activityService.listAgentsWithRuntime(app.db);
+
+    return {
+      ...overview,
+      agents: runningAgents.map((a) => ({
+        agentId: a.agentId,
+        clientId: a.clientId,
+        runtimeType: a.runtimeType,
+        runtimeState: a.runtimeState,
+        runtimeDescription: a.runtimeDescription,
+        activeSessions: a.activeSessions,
+        totalSessions: a.totalSessions,
+        errorMessage: a.errorMessage,
+        taskRef: a.taskRef,
+        runtimeUpdatedAt: a.runtimeUpdatedAt?.toISOString() ?? null,
+      })),
+    };
+  });
+
+  // POST /admin/agents/:agentId/reset-activity — reset error state to idle
+  app.post<{ Params: { agentId: string } }>("/:agentId/reset-activity", async (request) => {
+    await activityService.resetActivity(app.db, request.params.agentId);
+    return { reset: true };
+  });
+}

--- a/packages/server/src/api/agent/me.ts
+++ b/packages/server/src/api/agent/me.ts
@@ -1,15 +1,39 @@
+import { agentActivitySchema } from "@first-tree-hub/shared";
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
+import * as activityService from "../../services/activity.js";
 import * as agentService from "../../services/agent.js";
+import * as presenceService from "../../services/presence.js";
 
 export async function agentMeRoutes(app: FastifyInstance): Promise<void> {
   app.get("/me", async (request) => {
     const identity = requireAgent(request);
-    const agent = await agentService.getAgent(app.db, identity.uuid);
+    const [agent, presence] = await Promise.all([
+      agentService.getAgent(app.db, identity.uuid),
+      presenceService.getPresence(app.db, identity.uuid),
+    ]);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),
       updatedAt: agent.updatedAt.toISOString(),
+      // M1: runtime fields
+      clientId: presence?.clientId ?? null,
+      runtimeType: presence?.runtimeType ?? null,
+      runtimeVersion: presence?.runtimeVersion ?? null,
+      runtimeState: presence?.runtimeState ?? null,
+      runtimeDescription: presence?.runtimeDescription ?? null,
+      activeSessions: presence?.activeSessions ?? null,
+      totalSessions: presence?.totalSessions ?? null,
+      errorMessage: presence?.errorMessage ?? null,
+      taskRef: presence?.taskRef ?? null,
     };
+  });
+
+  // PUT /agent/me/activity — report runtime state
+  app.put("/me/activity", async (request) => {
+    const identity = requireAgent(request);
+    const body = agentActivitySchema.parse(request.body);
+    await activityService.updateActivity(app.db, identity.uuid, body);
+    return { ok: true };
   });
 }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1,0 +1,203 @@
+import { agentActivitySchema, agentBindSchema, clientRegisterSchema } from "@first-tree-hub/shared";
+import { and, eq, isNull } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { agentTokens } from "../../db/schema/agent-tokens.js";
+import { agents } from "../../db/schema/agents.js";
+import * as activityService from "../../services/activity.js";
+import * as clientService from "../../services/client.js";
+import * as connectionManager from "../../services/connection-manager.js";
+import type { Notifier } from "../../services/notifier.js";
+import * as presenceService from "../../services/presence.js";
+import { hashToken } from "../../utils.js";
+
+const wsMessageSchema = z.object({
+  type: z.string(),
+  agentId: z.string().optional(),
+  ref: z.string().optional(),
+});
+
+/**
+ * M1 Client WebSocket: one WS per client, multiple agents multiplexed.
+ *
+ * Protocol:
+ *   1. Client connects (no auth required at WS level)
+ *   2. client:register — register client with env info
+ *   3. agent:bind — bind agent to this client (authenticates via token)
+ *   4. agent:activity — report runtime state changes
+ *   5. heartbeat — client-level heartbeat
+ *   6. agent:unbind — unbind agent
+ */
+export function clientWsRoutes(notifier: Notifier, instanceId: string) {
+  return async (app: FastifyInstance): Promise<void> => {
+    app.get("/client", { websocket: true }, async (socket) => {
+      let clientId: string | null = null;
+      const boundAgents = new Map<string, { agentId: string; inboxId: string }>();
+
+      socket.on("message", async (raw) => {
+        let msg: unknown;
+        try {
+          msg = JSON.parse(String(raw));
+        } catch {
+          socket.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+          return;
+        }
+
+        const parsed = wsMessageSchema.safeParse(msg);
+        if (!parsed.success) {
+          socket.send(JSON.stringify({ type: "error", message: "Invalid message format" }));
+          return;
+        }
+
+        const { type, ref } = parsed.data;
+
+        try {
+          if (type === "client:register") {
+            const data = clientRegisterSchema.parse(msg);
+            clientId = data.clientId;
+
+            await clientService.registerClient(app.db, {
+              clientId: data.clientId,
+              instanceId,
+              hostname: data.hostname,
+              os: data.os,
+              sdkVersion: data.sdkVersion,
+            });
+
+            connectionManager.setClientConnection(data.clientId, socket);
+
+            socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
+          } else if (type === "agent:bind") {
+            if (!clientId) {
+              socket.send(JSON.stringify({ type: "error", ref, message: "Must register client first" }));
+              return;
+            }
+
+            const data = agentBindSchema.parse(msg);
+
+            // Authenticate agent via token
+            const raw = data.token;
+            if (!raw.startsWith("aghub_")) {
+              socket.send(JSON.stringify({ type: "error", ref, message: "Invalid token format" }));
+              return;
+            }
+
+            const hash = hashToken(raw);
+            const [tokenRow] = await app.db
+              .select({ agentId: agentTokens.agentId })
+              .from(agentTokens)
+              .where(and(eq(agentTokens.tokenHash, hash), isNull(agentTokens.revokedAt)))
+              .limit(1);
+
+            if (!tokenRow) {
+              socket.send(JSON.stringify({ type: "error", ref, message: "Invalid or revoked token" }));
+              return;
+            }
+
+            const [agent] = await app.db
+              .select({
+                id: agents.uuid,
+                displayName: agents.displayName,
+                type: agents.type,
+                organizationId: agents.organizationId,
+                inboxId: agents.inboxId,
+              })
+              .from(agents)
+              .where(and(eq(agents.uuid, tokenRow.agentId), eq(agents.status, "active")))
+              .limit(1);
+
+            if (!agent) {
+              socket.send(JSON.stringify({ type: "error", ref, message: "Agent is suspended or not found" }));
+              return;
+            }
+
+            // Bind agent to this client
+            await presenceService.bindAgent(app.db, agent.id, {
+              clientId,
+              instanceId,
+              runtimeType: data.runtimeType,
+              runtimeVersion: data.runtimeVersion,
+            });
+
+            connectionManager.bindAgentToClient(clientId, agent.id);
+            boundAgents.set(agent.id, { agentId: agent.id, inboxId: agent.inboxId });
+
+            // Subscribe to inbox notifications
+            notifier.subscribe(agent.inboxId, socket);
+
+            socket.send(
+              JSON.stringify({
+                type: "agent:bound",
+                ref,
+                agentId: agent.id,
+                displayName: agent.displayName,
+                agentType: agent.type,
+              }),
+            );
+          } else if (type === "agent:unbind") {
+            const agentId = parsed.data.agentId;
+            if (!agentId || !boundAgents.has(agentId)) {
+              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+              return;
+            }
+
+            const info = boundAgents.get(agentId);
+            if (info) {
+              notifier.unsubscribe(info.inboxId, socket);
+            }
+
+            await presenceService.unbindAgent(app.db, agentId);
+            connectionManager.unbindAgentFromClient(agentId);
+            boundAgents.delete(agentId);
+
+            socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
+          } else if (type === "agent:activity") {
+            const agentId = parsed.data.agentId;
+            if (!agentId || !boundAgents.has(agentId)) {
+              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+              return;
+            }
+
+            const activityPayload = agentActivitySchema.parse(msg);
+            await activityService.updateActivity(app.db, agentId, activityPayload);
+          } else if (type === "heartbeat") {
+            if (clientId) {
+              await clientService.heartbeatClient(app.db, clientId);
+            }
+            socket.send(JSON.stringify({ type: "heartbeat:ack" }));
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Internal error";
+          socket.send(JSON.stringify({ type: "error", message }));
+        }
+      });
+
+      socket.on("close", async () => {
+        // Unbind agents that are still owned by this client.
+        // If an agent was re-bound to a different client while this socket was alive,
+        // we must NOT unbind it (that would corrupt the new binding).
+        for (const [agentId, info] of boundAgents) {
+          notifier.unsubscribe(info.inboxId, socket);
+          const currentOwner = connectionManager.getAgentClientId(agentId);
+          if (currentOwner === clientId) {
+            try {
+              await presenceService.unbindAgent(app.db, agentId);
+            } catch {
+              // best-effort
+            }
+          }
+        }
+        boundAgents.clear();
+
+        if (clientId) {
+          connectionManager.removeClientConnection(clientId, socket);
+          try {
+            await clientService.disconnectClient(app.db, clientId);
+          } catch {
+            // best-effort
+          }
+        }
+      });
+    });
+  };
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -14,6 +14,7 @@ import { adminAdapterRoutes } from "./api/admin/adapters.js";
 import { adminAgentRoutes } from "./api/admin/agents.js";
 import { adminAuthRoutes } from "./api/admin/auth.js";
 import { adminChatRoutes } from "./api/admin/chats.js";
+import { adminActivityRoutes, adminClientRoutes } from "./api/admin/clients.js";
 import { adminOverviewRoutes } from "./api/admin/overview.js";
 import { adminSystemConfigRoutes } from "./api/admin/system-config.js";
 import { adminUserRoutes } from "./api/admin/users.js";
@@ -25,6 +26,7 @@ import { agentInboxRoutes } from "./api/agent/inbox.js";
 import { agentMeRoutes } from "./api/agent/me.js";
 import { agentMessageRoutes, agentSendToAgentRoutes } from "./api/agent/messages.js";
 import { agentWsRoutes } from "./api/agent/ws.js";
+import { clientWsRoutes } from "./api/agent/ws-client.js";
 import { bootstrapConfigRoutes } from "./api/bootstrap/config.js";
 import { bootstrapRoutes } from "./api/bootstrap/token.js";
 import { contextTreeInfoRoutes } from "./api/context-tree-info.js";
@@ -186,6 +188,24 @@ export async function buildApp(config: Config) {
         { prefix: "/admin/chats" },
       );
 
+      // M1: Client management routes
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminClientRoutes);
+        },
+        { prefix: "/admin/clients" },
+      );
+
+      // M1: Agent activity routes
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", adminAuth);
+          await adminApp.register(adminActivityRoutes);
+        },
+        { prefix: "/admin/agents/activity" },
+      );
+
       // Agent routes (Bearer token protected)
       await api.register(
         async (agentApp) => {
@@ -202,6 +222,9 @@ export async function buildApp(config: Config) {
         },
         { prefix: "/agent" },
       );
+
+      // M1: Client WebSocket (no auth at WS level — auth via agent:bind message)
+      await api.register(clientWsRoutes(notifier, config.instanceId), { prefix: "/agent/ws" });
     },
     { prefix: "/api/v1" },
   );

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -1,15 +1,39 @@
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
+import { clients } from "./clients.js";
 
-/** Agent online status. Tracked via WebSocket connections; stale entries are cleaned up using server_instances heartbeat. */
+/** Agent presence and runtime state. Tracked via WebSocket connections; stale entries are cleaned up using server_instances heartbeat. */
 export const agentPresence = pgTable("agent_presence", {
   agentId: text("agent_id")
     .primaryKey()
     .references(() => agents.uuid, { onDelete: "cascade" }),
-  /** "online" | "offline" */
+  /** Legacy: "online" | "offline". Kept for backward compat; runtime_state is the authority for M1+. */
   status: text("status").notNull().default("offline"),
-  /** Server instance ID that holds this agent's WebSocket connection */
+  /** Server instance ID that holds this agent's WebSocket connection (migrating to clients table) */
   instanceId: text("instance_id"),
   connectedAt: timestamp("connected_at", { withTimezone: true }),
   lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+
+  // -- M1: Client & Runtime fields --
+
+  /** FK to clients table. Non-null = agent is bound to a running client. */
+  clientId: text("client_id").references(() => clients.id, { onDelete: "set null" }),
+  /** Runtime type: "claude-code" | "codex" | "devin" | "custom" etc. */
+  runtimeType: text("runtime_type"),
+  /** Runtime version. */
+  runtimeVersion: text("runtime_version"),
+  /** idle | working | error. NULL = agent not running. THE authority for whether agent is running. */
+  runtimeState: text("runtime_state"),
+  /** Human-readable description of current work */
+  runtimeDescription: text("runtime_description"),
+  /** Number of active sessions */
+  activeSessions: integer("active_sessions"),
+  /** Total sessions (including suspended/evicted) */
+  totalSessions: integer("total_sessions"),
+  /** Error summary when runtime_state = "error" */
+  errorMessage: text("error_message"),
+  /** External task reference (e.g. GitHub Issue URL) */
+  taskRef: text("task_ref"),
+  /** When runtime_state was last updated */
+  runtimeUpdatedAt: timestamp("runtime_updated_at", { withTimezone: true }),
 });

--- a/packages/server/src/db/schema/clients.ts
+++ b/packages/server/src/db/schema/clients.ts
@@ -1,0 +1,16 @@
+import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/** Client connections. A client is a single SDK process (AgentRuntime) that may host multiple agents. */
+export const clients = pgTable("clients", {
+  id: text("id").primaryKey(),
+  /** "connected" | "disconnected" */
+  status: text("status").notNull().default("disconnected"),
+  sdkVersion: text("sdk_version"),
+  hostname: text("hostname"),
+  os: text("os"),
+  /** Server instance ID that holds this client's WebSocket connection */
+  instanceId: text("instance_id"),
+  connectedAt: timestamp("connected_at", { withTimezone: true }),
+  lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -7,6 +7,7 @@ export { agentPresence } from "./agent-presence.js";
 export { agentTokens } from "./agent-tokens.js";
 export { agents } from "./agents.js";
 export { chatParticipants, chats } from "./chats.js";
+export { clients } from "./clients.js";
 export { inboxEntries } from "./inbox-entries.js";
 export { messages } from "./messages.js";
 export { serverInstances } from "./server-instances.js";

--- a/packages/server/src/middleware/agent-auth.ts
+++ b/packages/server/src/middleware/agent-auth.ts
@@ -1,14 +1,10 @@
-import { createHash } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import type { Database } from "../db/connection.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
 import { UnauthorizedError } from "../errors.js";
-
-function hashToken(raw: string): string {
-  return createHash("sha256").update(raw).digest("hex");
-}
+import { hashToken } from "../utils.js";
 
 export function agentAuthHook(db: Database) {
   return async (request: FastifyRequest, _reply: FastifyReply): Promise<void> => {

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -1,0 +1,73 @@
+import type { AgentActivity } from "@first-tree-hub/shared";
+import { eq, isNotNull, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { clients } from "../db/schema/clients.js";
+
+export async function updateActivity(db: Database, agentId: string, activity: AgentActivity) {
+  const now = new Date();
+  await db
+    .update(agentPresence)
+    .set({
+      runtimeState: activity.state,
+      runtimeDescription: activity.description ?? null,
+      activeSessions: activity.activeSessions ?? null,
+      totalSessions: activity.totalSessions ?? null,
+      errorMessage: activity.errorMessage ?? null,
+      taskRef: activity.taskRef ?? null,
+      runtimeUpdatedAt: now,
+      lastSeenAt: now,
+    })
+    .where(eq(agentPresence.agentId, agentId));
+}
+
+export async function resetActivity(db: Database, agentId: string) {
+  const now = new Date();
+  await db
+    .update(agentPresence)
+    .set({
+      runtimeState: "idle",
+      runtimeDescription: null,
+      errorMessage: null,
+      taskRef: null,
+      runtimeUpdatedAt: now,
+    })
+    .where(eq(agentPresence.agentId, agentId));
+}
+
+export async function getActivityOverview(db: Database) {
+  const [agentCounts] = await db
+    .select({
+      total: sql<number>`count(*)::int`,
+      running: sql<number>`count(*) FILTER (WHERE ${agentPresence.runtimeState} IS NOT NULL)::int`,
+      idle: sql<number>`count(*) FILTER (WHERE ${agentPresence.runtimeState} = 'idle')::int`,
+      working: sql<number>`count(*) FILTER (WHERE ${agentPresence.runtimeState} = 'working')::int`,
+      error: sql<number>`count(*) FILTER (WHERE ${agentPresence.runtimeState} = 'error')::int`,
+    })
+    .from(agentPresence);
+
+  const [clientCounts] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(clients)
+    .where(eq(clients.status, "connected"));
+
+  return {
+    total: agentCounts?.total ?? 0,
+    running: agentCounts?.running ?? 0,
+    byState: {
+      idle: agentCounts?.idle ?? 0,
+      working: agentCounts?.working ?? 0,
+      error: agentCounts?.error ?? 0,
+    },
+    clients: clientCounts?.count ?? 0,
+  };
+}
+
+export async function getAgentWithRuntime(db: Database, agentId: string) {
+  const [row] = await db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId)).limit(1);
+  return row ?? null;
+}
+
+export async function listAgentsWithRuntime(db: Database) {
+  return db.select().from(agentPresence).where(isNotNull(agentPresence.runtimeState));
+}

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import type { CreateAgent, CreateAgentToken, UpdateAgent } from "@first-tree-hub/shared";
 import { AGENT_STATUSES } from "@first-tree-hub/shared";
 import { and, desc, eq, isNull, lt, ne } from "drizzle-orm";
@@ -9,11 +9,8 @@ import { agentPresence } from "../db/schema/agent-presence.js";
 import { agentTokens } from "../db/schema/agent-tokens.js";
 import { agents } from "../db/schema/agents.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { hashToken } from "../utils.js";
 import { uuidv7 } from "../uuid.js";
-
-function hashToken(raw: string): string {
-  return createHash("sha256").update(raw).digest("hex");
-}
 
 export async function createAgent(db: Database, data: CreateAgent) {
   const uuid = uuidv7();
@@ -94,6 +91,13 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
       createdAt: agents.createdAt,
       updatedAt: agents.updatedAt,
       presenceStatus: agentPresence.status,
+      // M1: runtime fields
+      clientId: agentPresence.clientId,
+      runtimeType: agentPresence.runtimeType,
+      runtimeState: agentPresence.runtimeState,
+      runtimeDescription: agentPresence.runtimeDescription,
+      activeSessions: agentPresence.activeSessions,
+      errorMessage: agentPresence.errorMessage,
     })
     .from(agents)
     .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import type { AdapterManager } from "./adapter-manager.js";
+import * as clientService from "./client.js";
 import * as inboxService from "./inbox.js";
 import type { KaelRuntime } from "./kael-runtime.js";
 import * as presenceService from "./presence.js";
@@ -42,6 +43,7 @@ export function createBackgroundTasks(
           const configs = await systemConfigService.getAllConfigs(app.db);
           const staleSeconds = (configs.presence_cleanup_seconds as number) ?? 60;
           await presenceService.cleanupStalePresence(app.db, staleSeconds);
+          await clientService.cleanupStaleClients(app.db, staleSeconds);
         } catch (err) {
           app.log.error(err, "Failed to heartbeat / cleanup presence");
         }

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -1,0 +1,111 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { clients } from "../db/schema/clients.js";
+import { runtimeFieldsReset } from "./presence.js";
+
+export async function registerClient(
+  db: Database,
+  data: {
+    clientId: string;
+    instanceId: string;
+    hostname?: string;
+    os?: string;
+    sdkVersion?: string;
+  },
+) {
+  const now = new Date();
+  await db
+    .insert(clients)
+    .values({
+      id: data.clientId,
+      status: "connected",
+      instanceId: data.instanceId,
+      hostname: data.hostname ?? null,
+      os: data.os ?? null,
+      sdkVersion: data.sdkVersion ?? null,
+      connectedAt: now,
+      lastSeenAt: now,
+    })
+    .onConflictDoUpdate({
+      target: clients.id,
+      set: {
+        status: "connected",
+        instanceId: data.instanceId,
+        hostname: data.hostname ?? null,
+        os: data.os ?? null,
+        sdkVersion: data.sdkVersion ?? null,
+        connectedAt: now,
+        lastSeenAt: now,
+      },
+    });
+}
+
+export async function disconnectClient(db: Database, clientId: string) {
+  const now = new Date();
+
+  // Only reset agents still bound to this client.
+  // Agents that were re-bound to a different client must not be affected.
+  await db
+    .update(agentPresence)
+    .set({ status: "offline", clientId: null, ...runtimeFieldsReset(now) })
+    .where(eq(agentPresence.clientId, clientId));
+
+  await db.update(clients).set({ status: "disconnected", lastSeenAt: now }).where(eq(clients.id, clientId));
+}
+
+export async function heartbeatClient(db: Database, clientId: string) {
+  await db.update(clients).set({ lastSeenAt: new Date() }).where(eq(clients.id, clientId));
+}
+
+export async function getClient(db: Database, clientId: string) {
+  const [row] = await db.select().from(clients).where(eq(clients.id, clientId)).limit(1);
+  return row ?? null;
+}
+
+export async function listClients(db: Database) {
+  const rows = await db.select().from(clients).where(eq(clients.status, "connected"));
+  // Attach agent counts
+  const counts = await db
+    .select({
+      clientId: agentPresence.clientId,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(agentPresence)
+    .where(sql`${agentPresence.clientId} IS NOT NULL AND ${agentPresence.runtimeState} IS NOT NULL`)
+    .groupBy(agentPresence.clientId);
+
+  const countMap = new Map(counts.map((c) => [c.clientId, c.count]));
+
+  return rows.map((row) => ({
+    ...row,
+    agentCount: countMap.get(row.id) ?? 0,
+  }));
+}
+
+export async function cleanupStaleClients(db: Database, staleSeconds = 60): Promise<number> {
+  const result = await db.execute<{ id: string }>(sql`
+    UPDATE clients SET status = 'disconnected'
+    WHERE instance_id IN (
+      SELECT instance_id FROM server_instances
+      WHERE last_heartbeat < NOW() - make_interval(secs => ${staleSeconds})
+    )
+    AND status = 'connected'
+    RETURNING id
+  `);
+
+  if (result.length > 0) {
+    const staleIds = result.map((r) => r.id);
+    await db.execute(sql`
+      UPDATE agent_presence SET
+        status = 'offline',
+        runtime_state = NULL, runtime_description = NULL,
+        active_sessions = NULL, total_sessions = NULL,
+        error_message = NULL, task_ref = NULL,
+        runtime_updated_at = NOW()
+      WHERE client_id = ANY(${staleIds})
+    `);
+  }
+
+  return result.length;
+}

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -28,6 +28,18 @@ export function removeConnection(agentId: string, ws: WebSocket): boolean {
 
 /** Force-disconnect an agent's active WS connection. Returns true if a connection was closed. */
 export function forceDisconnect(agentId: string): boolean {
+  const clientId = agentToClient.get(agentId);
+  if (clientId) {
+    // M1 mode: unbind the single agent without closing the shared client WS
+    const entry = clientConnections.get(clientId);
+    if (entry && entry.ws.readyState <= 1) {
+      entry.ws.send(JSON.stringify({ type: "agent:force_disconnect", agentId }));
+    }
+    unbindAgentFromClient(agentId);
+    return true;
+  }
+
+  // Legacy mode: close the per-agent WS
   const ws = activeConnections.get(agentId);
   if (!ws) return false;
   ws.close(WS_CLOSE_ALREADY_CONNECTED, "Disconnected by admin");
@@ -46,6 +58,16 @@ const clientConnections = new Map<string, ClientEntry>();
 const agentToClient = new Map<string, string>();
 
 export function setClientConnection(clientId: string, ws: WebSocket): void {
+  const existing = clientConnections.get(clientId);
+  if (existing && existing.ws !== ws && existing.ws.readyState <= 1) {
+    // Close the previous connection to prevent clientId takeover
+    existing.ws.close(WS_CLOSE_ALREADY_CONNECTED, "Replaced by new connection");
+    // Clean up agent bindings from the old connection
+    for (const agentId of existing.agentIds) {
+      agentToClient.delete(agentId);
+      activeConnections.delete(agentId);
+    }
+  }
   clientConnections.set(clientId, { ws, agentIds: new Set() });
 }
 

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -34,3 +34,94 @@ export function forceDisconnect(agentId: string): boolean {
   activeConnections.delete(agentId);
   return true;
 }
+
+// -- M1: Per-client connections (one WS per client, multiple agents) --
+
+type ClientEntry = {
+  ws: WebSocket;
+  agentIds: Set<string>;
+};
+
+const clientConnections = new Map<string, ClientEntry>();
+const agentToClient = new Map<string, string>();
+
+export function setClientConnection(clientId: string, ws: WebSocket): void {
+  clientConnections.set(clientId, { ws, agentIds: new Set() });
+}
+
+export function getClientConnection(clientId: string): WebSocket | undefined {
+  const entry = clientConnections.get(clientId);
+  return entry?.ws.readyState === 1 ? entry.ws : undefined;
+}
+
+export function hasClientConnection(clientId: string): boolean {
+  const entry = clientConnections.get(clientId);
+  return entry !== undefined && entry.ws.readyState <= 1;
+}
+
+export function bindAgentToClient(clientId: string, agentId: string): void {
+  // Remove agent from previous client if it was bound elsewhere
+  const prevClientId = agentToClient.get(agentId);
+  if (prevClientId && prevClientId !== clientId) {
+    const prevEntry = clientConnections.get(prevClientId);
+    if (prevEntry) {
+      prevEntry.agentIds.delete(agentId);
+    }
+  }
+
+  const entry = clientConnections.get(clientId);
+  if (entry) {
+    entry.agentIds.add(agentId);
+    activeConnections.set(agentId, entry.ws);
+  }
+  agentToClient.set(agentId, clientId);
+}
+
+export function unbindAgentFromClient(agentId: string): void {
+  const clientId = agentToClient.get(agentId);
+  if (clientId) {
+    const entry = clientConnections.get(clientId);
+    if (entry) {
+      entry.agentIds.delete(agentId);
+    }
+    agentToClient.delete(agentId);
+  }
+  activeConnections.delete(agentId);
+}
+
+export function getClientAgentIds(clientId: string): string[] {
+  const entry = clientConnections.get(clientId);
+  return entry ? [...entry.agentIds] : [];
+}
+
+export function getAgentClientId(agentId: string): string | undefined {
+  return agentToClient.get(agentId);
+}
+
+export function removeClientConnection(clientId: string, ws: WebSocket): string[] {
+  const entry = clientConnections.get(clientId);
+  if (!entry || entry.ws !== ws) return [];
+
+  const agentIds = [...entry.agentIds];
+  for (const agentId of agentIds) {
+    agentToClient.delete(agentId);
+    activeConnections.delete(agentId);
+  }
+  clientConnections.delete(clientId);
+  return agentIds;
+}
+
+export function forceDisconnectClient(clientId: string): string[] {
+  const entry = clientConnections.get(clientId);
+  if (!entry) return [];
+
+  const agentIds = [...entry.agentIds];
+  entry.ws.close(WS_CLOSE_ALREADY_CONNECTED, "Client disconnected by admin");
+
+  for (const agentId of agentIds) {
+    agentToClient.delete(agentId);
+    activeConnections.delete(agentId);
+  }
+  clientConnections.delete(clientId);
+  return agentIds;
+}

--- a/packages/server/src/services/presence.ts
+++ b/packages/server/src/services/presence.ts
@@ -3,6 +3,22 @@ import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { serverInstances } from "../db/schema/server-instances.js";
 
+/** Common field reset when agent goes offline or is unbound. */
+export function runtimeFieldsReset(now: Date) {
+  return {
+    runtimeState: null,
+    runtimeDescription: null,
+    activeSessions: null,
+    totalSessions: null,
+    errorMessage: null,
+    taskRef: null,
+    runtimeUpdatedAt: now,
+    lastSeenAt: now,
+  } as const;
+}
+
+// -- Legacy presence (kept for backward compat + non-M1 clients) --
+
 export async function setOnline(db: Database, agentId: string, instanceId: string) {
   const now = new Date();
   await db
@@ -26,12 +42,13 @@ export async function setOnline(db: Database, agentId: string, instanceId: strin
 }
 
 export async function setOffline(db: Database, agentId: string) {
+  const now = new Date();
   await db
     .update(agentPresence)
     .set({
       status: "offline",
       instanceId: null,
-      lastSeenAt: new Date(),
+      ...runtimeFieldsReset(now),
     })
     .where(eq(agentPresence.agentId, agentId));
 }
@@ -49,6 +66,68 @@ export async function getOnlineCount(db: Database): Promise<number> {
   return result?.count ?? 0;
 }
 
+// -- M1: Agent bind/unbind (client-aware) --
+
+export async function bindAgent(
+  db: Database,
+  agentId: string,
+  data: {
+    clientId: string;
+    instanceId: string;
+    runtimeType: string;
+    runtimeVersion?: string;
+  },
+) {
+  const now = new Date();
+  await db
+    .insert(agentPresence)
+    .values({
+      agentId,
+      status: "online",
+      instanceId: data.instanceId,
+      clientId: data.clientId,
+      runtimeType: data.runtimeType,
+      runtimeVersion: data.runtimeVersion ?? null,
+      runtimeState: "idle",
+      connectedAt: now,
+      lastSeenAt: now,
+      runtimeUpdatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: agentPresence.agentId,
+      set: {
+        status: "online",
+        instanceId: data.instanceId,
+        clientId: data.clientId,
+        runtimeType: data.runtimeType,
+        runtimeVersion: data.runtimeVersion ?? null,
+        runtimeState: "idle",
+        runtimeDescription: null,
+        activeSessions: null,
+        totalSessions: null,
+        errorMessage: null,
+        taskRef: null,
+        connectedAt: now,
+        lastSeenAt: now,
+        runtimeUpdatedAt: now,
+      },
+    });
+}
+
+export async function unbindAgent(db: Database, agentId: string) {
+  const now = new Date();
+  await db
+    .update(agentPresence)
+    .set({
+      status: "offline",
+      clientId: null,
+      ...runtimeFieldsReset(now),
+    })
+    .where(eq(agentPresence.agentId, agentId));
+}
+
+// -- Server instance heartbeat --
+
 export async function heartbeatInstance(db: Database, instanceId: string) {
   await db
     .insert(serverInstances)
@@ -61,7 +140,11 @@ export async function heartbeatInstance(db: Database, instanceId: string) {
 
 export async function cleanupStalePresence(db: Database, staleSeconds = 60): Promise<number> {
   const result = await db.execute<{ agent_id: string }>(sql`
-    UPDATE agent_presence SET status = 'offline', instance_id = NULL
+    UPDATE agent_presence SET status = 'offline', instance_id = NULL,
+      runtime_state = NULL, runtime_description = NULL,
+      active_sessions = NULL, total_sessions = NULL,
+      error_message = NULL, task_ref = NULL,
+      runtime_updated_at = NOW()
     WHERE instance_id IN (
       SELECT instance_id FROM server_instances
       WHERE last_heartbeat < NOW() - make_interval(secs => ${staleSeconds})

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -1,0 +1,11 @@
+import { createHash } from "node:crypto";
+
+/** SHA-256 hash for agent token verification. */
+export function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+/** Serialize a Date to ISO string, or null. */
+export function serializeDate(d: Date | null): string | null {
+  return d ? d.toISOString() : null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -96,6 +96,15 @@ export {
   removeParticipantSchema,
 } from "./schemas/chat.js";
 export {
+  CLIENT_STATUSES,
+  type Client,
+  type ClientRegister,
+  type ClientStatus,
+  clientRegisterSchema,
+  clientSchema,
+  clientStatusSchema,
+} from "./schemas/client.js";
+export {
   type PaginationQuery,
   paginatedResponse,
   paginationQuerySchema,
@@ -123,11 +132,22 @@ export {
   sendToAgentSchema,
 } from "./schemas/message.js";
 export {
+  type ActivityOverview,
+  type AgentActivity,
+  type AgentBind,
   type AgentPresence,
+  activityOverviewSchema,
+  agentActivitySchema,
+  agentBindSchema,
   agentPresenceSchema,
   PRESENCE_STATUSES,
   type PresenceStatus,
   presenceStatusSchema,
+  RUNTIME_STATES,
+  type RuntimeState,
+  runtimeStateSchema,
+  type SessionInfo,
+  sessionInfoSchema,
 } from "./schemas/presence.js";
 export {
   SYSTEM_CONFIG_DEFAULTS,

--- a/packages/shared/src/schemas/client.ts
+++ b/packages/shared/src/schemas/client.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// -- Client Status --
+
+export const CLIENT_STATUSES = {
+  CONNECTED: "connected",
+  DISCONNECTED: "disconnected",
+} as const;
+
+export const clientStatusSchema = z.enum(["connected", "disconnected"]);
+export type ClientStatus = z.infer<typeof clientStatusSchema>;
+
+// -- Client --
+
+export const clientSchema = z.object({
+  id: z.string(),
+  status: clientStatusSchema,
+  sdkVersion: z.string().max(50).nullable(),
+  hostname: z.string().max(100).nullable(),
+  os: z.string().max(50).nullable(),
+  agentCount: z.number().int().min(0),
+  connectedAt: z.string().nullable(),
+  lastSeenAt: z.string(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+});
+export type Client = z.infer<typeof clientSchema>;
+
+// -- Client Register (WS payload from client SDK) --
+
+export const clientRegisterSchema = z.object({
+  clientId: z.string().min(1).max(100),
+  hostname: z.string().max(100).optional(),
+  os: z.string().max(50).optional(),
+  sdkVersion: z.string().max(50).optional(),
+});
+export type ClientRegister = z.infer<typeof clientRegisterSchema>;

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -8,10 +8,79 @@ export const PRESENCE_STATUSES = {
 export const presenceStatusSchema = z.enum(["online", "offline"]);
 export type PresenceStatus = z.infer<typeof presenceStatusSchema>;
 
+// -- Runtime State --
+
+export const RUNTIME_STATES = {
+  IDLE: "idle",
+  WORKING: "working",
+  ERROR: "error",
+} as const;
+
+export const runtimeStateSchema = z.enum(["idle", "working", "error"]);
+export type RuntimeState = z.infer<typeof runtimeStateSchema>;
+
+// -- Agent Activity Payload (client → server) --
+
+export const agentActivitySchema = z.object({
+  state: runtimeStateSchema,
+  description: z.string().max(500).optional(),
+  activeSessions: z.number().int().min(0).optional(),
+  totalSessions: z.number().int().min(0).optional(),
+  errorMessage: z.string().max(1000).optional(),
+  taskRef: z.string().max(200).optional(),
+});
+export type AgentActivity = z.infer<typeof agentActivitySchema>;
+
+// -- Agent Bind Payload (client → server) --
+
+export const agentBindSchema = z.object({
+  token: z.string().min(1),
+  runtimeType: z.string().max(50),
+  runtimeVersion: z.string().max(50).optional(),
+});
+export type AgentBind = z.infer<typeof agentBindSchema>;
+
+// -- Session Info (reported with activity, not persisted to DB) --
+
+export const sessionInfoSchema = z.object({
+  chatId: z.string(),
+  status: z.enum(["active", "suspended", "evicted"]),
+  claudeSessionId: z.string().nullable(),
+  startedAt: z.string(),
+  lastActiveAt: z.string(),
+});
+export type SessionInfo = z.infer<typeof sessionInfoSchema>;
+
+// -- Extended Agent Presence --
+
 export const agentPresenceSchema = z.object({
   agentId: z.string(),
   status: presenceStatusSchema,
   connectedAt: z.string().nullable(),
   lastSeenAt: z.string(),
+  clientId: z.string().nullable().optional(),
+  runtimeType: z.string().nullable().optional(),
+  runtimeVersion: z.string().nullable().optional(),
+  runtimeState: runtimeStateSchema.nullable().optional(),
+  runtimeDescription: z.string().nullable().optional(),
+  activeSessions: z.number().int().nullable().optional(),
+  totalSessions: z.number().int().nullable().optional(),
+  errorMessage: z.string().nullable().optional(),
+  taskRef: z.string().nullable().optional(),
+  runtimeUpdatedAt: z.string().nullable().optional(),
 });
 export type AgentPresence = z.infer<typeof agentPresenceSchema>;
+
+// -- Activity Overview (admin response) --
+
+export const activityOverviewSchema = z.object({
+  total: z.number().int(),
+  running: z.number().int(),
+  byState: z.object({
+    idle: z.number().int(),
+    working: z.number().int(),
+    error: z.number().int(),
+  }),
+  clients: z.number().int(),
+});
+export type ActivityOverview = z.infer<typeof activityOverviewSchema>;

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -1,0 +1,57 @@
+import { api } from "./client.js";
+
+export type RuntimeAgent = {
+  agentId: string;
+  clientId: string | null;
+  runtimeType: string | null;
+  runtimeState: string | null;
+  runtimeDescription: string | null;
+  activeSessions: number | null;
+  totalSessions: number | null;
+  errorMessage: string | null;
+  taskRef: string | null;
+  runtimeUpdatedAt: string | null;
+};
+
+export type ActivityOverview = {
+  total: number;
+  running: number;
+  byState: {
+    idle: number;
+    working: number;
+    error: number;
+  };
+  clients: number;
+  agents: RuntimeAgent[];
+};
+
+export type HubClient = {
+  id: string;
+  status: string;
+  sdkVersion: string | null;
+  hostname: string | null;
+  os: string | null;
+  agentCount: number;
+  connectedAt: string | null;
+  lastSeenAt: string;
+};
+
+export function getActivityOverview(): Promise<ActivityOverview> {
+  return api.get<ActivityOverview>("/admin/agents/activity");
+}
+
+export function listClients(): Promise<HubClient[]> {
+  return api.get<HubClient[]>("/admin/clients");
+}
+
+export function getClient(clientId: string): Promise<HubClient> {
+  return api.get<HubClient>(`/admin/clients/${clientId}`);
+}
+
+export function disconnectClient(clientId: string): Promise<{ disconnected: boolean; agentIds: string[] }> {
+  return api.post(`/admin/clients/${clientId}/disconnect`);
+}
+
+export function resetAgentActivity(agentId: string): Promise<{ reset: boolean }> {
+  return api.post(`/admin/agents/activity/${agentId}/reset-activity`);
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
 import { Layout } from "./components/layout.js";
+import { ActivityPage } from "./pages/activity.js";
 import { AdminUsersPage } from "./pages/admin-users.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { AgentsPage } from "./pages/agents.js";
@@ -31,6 +32,7 @@ export function App() {
             <Route element={<RequireAuth />}>
               <Route element={<Layout />}>
                 <Route index element={<OverviewPage />} />
+                <Route path="activity" element={<ActivityPage />} />
                 <Route path="agents" element={<AgentsPage />} />
                 <Route path="agents/:uuid" element={<AgentDetailPage />} />
                 <Route path="bindings" element={<BindingsPage />} />

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,10 +1,11 @@
-import { Bot, Cable, LayoutDashboard, LogOut, MessageSquare, Settings, Shield } from "lucide-react";
+import { Activity, Bot, Cable, LayoutDashboard, LogOut, MessageSquare, Settings, Shield } from "lucide-react";
 import { NavLink, Outlet } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
 
 const navItems = [
   { to: "/", icon: LayoutDashboard, label: "Overview" },
+  { to: "/activity", icon: Activity, label: "Activity" },
   { to: "/agents", icon: Bot, label: "Agents" },
   { to: "/bindings", icon: Cable, label: "Bindings" },
   { to: "/chats", icon: MessageSquare, label: "Chats" },

--- a/packages/web/src/pages/activity.tsx
+++ b/packages/web/src/pages/activity.tsx
@@ -1,0 +1,212 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Activity, AlertTriangle, Monitor, Pause, Play, RefreshCw, Server, Unplug } from "lucide-react";
+import { useState } from "react";
+import {
+  disconnectClient,
+  getActivityOverview,
+  type HubClient,
+  listClients,
+  type RuntimeAgent,
+  resetAgentActivity,
+} from "../api/activity.js";
+import { Badge } from "../components/ui/badge.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+
+function stateColor(state: string | null): string {
+  switch (state) {
+    case "idle":
+      return "text-green-600 bg-green-50";
+    case "working":
+      return "text-blue-600 bg-blue-50";
+    case "error":
+      return "text-red-600 bg-red-50";
+    default:
+      return "text-muted-foreground bg-muted";
+  }
+}
+
+function StateBadge({ state }: { state: string | null }) {
+  if (!state) return <span className="text-muted-foreground text-sm">—</span>;
+  return <Badge className={stateColor(state)}>{state}</Badge>;
+}
+
+export function ActivityPage() {
+  const queryClient = useQueryClient();
+  const [view, setView] = useState<"agents" | "clients">("agents");
+
+  const { data: activity, isLoading: activityLoading } = useQuery({
+    queryKey: ["activity"],
+    queryFn: getActivityOverview,
+    refetchInterval: 5_000,
+  });
+
+  const { data: clients } = useQuery({
+    queryKey: ["clients"],
+    queryFn: listClients,
+    refetchInterval: 10_000,
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: resetAgentActivity,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["activity"] }),
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: disconnectClient,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+      queryClient.invalidateQueries({ queryKey: ["clients"] });
+    },
+  });
+
+  const stats = [
+    { label: "Clients", value: activity?.clients, icon: Server },
+    { label: "Running", value: activity?.running, icon: Play },
+    { label: "Working", value: activity?.byState.working, icon: Activity },
+    { label: "Idle", value: activity?.byState.idle, icon: Pause },
+    { label: "Error", value: activity?.byState.error, icon: AlertTriangle },
+  ];
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-6">Agent Activity</h1>
+
+      {/* Stat cards */}
+      <div className="grid gap-4 md:grid-cols-5 mb-6">
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">{stat.label}</CardTitle>
+              <stat.icon className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{activityLoading ? "..." : (stat.value ?? 0)}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* View toggle */}
+      <div className="flex gap-2 mb-4">
+        <Button variant={view === "agents" ? "default" : "outline"} size="sm" onClick={() => setView("agents")}>
+          <Monitor className="h-4 w-4 mr-2" />
+          Agent View
+        </Button>
+        <Button variant={view === "clients" ? "default" : "outline"} size="sm" onClick={() => setView("clients")}>
+          <Server className="h-4 w-4 mr-2" />
+          Client View
+        </Button>
+      </div>
+
+      {/* Agent view */}
+      {view === "agents" && (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Runtime</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Sessions</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(!activity?.agents || activity.agents.length === 0) && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                      No running agents
+                    </TableCell>
+                  </TableRow>
+                )}
+                {activity?.agents.map((agent: RuntimeAgent) => (
+                  <TableRow key={agent.agentId}>
+                    <TableCell className="font-medium">{agent.agentId}</TableCell>
+                    <TableCell>{agent.runtimeType ?? "—"}</TableCell>
+                    <TableCell>
+                      <StateBadge state={agent.runtimeState} />
+                    </TableCell>
+                    <TableCell>
+                      {agent.activeSessions !== null ? `${agent.activeSessions}/${agent.totalSessions ?? 0}` : "—"}
+                    </TableCell>
+                    <TableCell className="max-w-[200px] truncate">
+                      {agent.runtimeDescription ?? agent.errorMessage ?? "—"}
+                    </TableCell>
+                    <TableCell>
+                      {agent.runtimeState === "error" && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => resetMutation.mutate(agent.agentId)}
+                          disabled={resetMutation.isPending}
+                        >
+                          <RefreshCw className="h-3 w-3 mr-1" />
+                          Reset
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Client view */}
+      {view === "clients" && (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Client ID</TableHead>
+                  <TableHead>Host</TableHead>
+                  <TableHead>OS</TableHead>
+                  <TableHead>Agents</TableHead>
+                  <TableHead>Connected</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(!clients || clients.length === 0) && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                      No connected clients
+                    </TableCell>
+                  </TableRow>
+                )}
+                {clients?.map((client: HubClient) => (
+                  <TableRow key={client.id}>
+                    <TableCell className="font-mono text-sm">{client.id}</TableCell>
+                    <TableCell>{client.hostname ?? "—"}</TableCell>
+                    <TableCell>{client.os ?? "—"}</TableCell>
+                    <TableCell>{client.agentCount}</TableCell>
+                    <TableCell>
+                      {client.connectedAt ? new Date(client.connectedAt).toLocaleString("zh-CN") : "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => disconnectMutation.mutate(client.id)}
+                        disabled={disconnectMutation.isPending}
+                      >
+                        <Unplug className="h-3 w-3 mr-1" />
+                        Disconnect
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -468,6 +468,67 @@ export function AgentDetailPage() {
         </CardContent>
       </Card>
 
+      {/* M1: Runtime Info */}
+      {(() => {
+        const ext = agent as Record<string, unknown>;
+        const rState = ext.runtimeState as string | null;
+        const rType = ext.runtimeType as string | null;
+        const rDesc = ext.runtimeDescription as string | null;
+        const rSessions = ext.activeSessions as number | null;
+        const rClientId = ext.clientId as string | null;
+        const rError = ext.errorMessage as string | null;
+        if (!rState) return null;
+        return (
+          <Card>
+            <CardHeader>
+              <CardTitle>Runtime</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <dt className="text-muted-foreground mb-1">Runtime Type</dt>
+                  <dd>{rType ?? "—"}</dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground mb-1">State</dt>
+                  <dd>
+                    <Badge
+                      variant={rState === "error" ? "destructive" : rState === "working" ? "default" : "secondary"}
+                    >
+                      {rState}
+                    </Badge>
+                  </dd>
+                </div>
+                {rDesc && (
+                  <div className="col-span-2">
+                    <dt className="text-muted-foreground mb-1">Current Work</dt>
+                    <dd>{rDesc}</dd>
+                  </div>
+                )}
+                {rSessions !== null && (
+                  <div>
+                    <dt className="text-muted-foreground mb-1">Sessions</dt>
+                    <dd>{rSessions} active</dd>
+                  </div>
+                )}
+                {rClientId && (
+                  <div>
+                    <dt className="text-muted-foreground mb-1">Client</dt>
+                    <dd className="font-mono text-xs">{rClientId}</dd>
+                  </div>
+                )}
+                {rError && (
+                  <div className="col-span-2">
+                    <dt className="text-muted-foreground mb-1">Error</dt>
+                    <dd className="text-destructive">{rError}</dd>
+                  </div>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+        );
+      })()}
+
       {/* Profile */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -76,7 +76,7 @@ export function AgentsPage() {
               <TableHead>Display Name</TableHead>
               <TableHead>Type</TableHead>
               <TableHead>Delegate</TableHead>
-              <TableHead>Online</TableHead>
+              <TableHead>Runtime</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Created</TableHead>
             </TableRow>
@@ -112,13 +112,24 @@ export function AgentsPage() {
                     {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "\u2014"}
                   </TableCell>
                   <TableCell>
-                    <span
-                      className={cn(
-                        "inline-block h-2 w-2 rounded-full",
-                        agent.presenceStatus === "online" ? "bg-green-500" : "bg-gray-300",
-                      )}
-                      title={agent.presenceStatus ?? "offline"}
-                    />
+                    {(() => {
+                      const a = agent as Record<string, unknown>;
+                      const state = a.runtimeState as string | null;
+                      if (!state) {
+                        return <span className="inline-block h-2 w-2 rounded-full bg-gray-300" title="not running" />;
+                      }
+                      const colors: Record<string, string> = {
+                        idle: "bg-green-500",
+                        working: "bg-blue-500",
+                        error: "bg-red-500",
+                      };
+                      return (
+                        <span className="flex items-center gap-1.5">
+                          <span className={cn("inline-block h-2 w-2 rounded-full", colors[state] ?? "bg-gray-300")} />
+                          <span className="text-xs text-muted-foreground">{state}</span>
+                        </span>
+                      );
+                    })()}
                   </TableCell>
                   <TableCell>
                     <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>


### PR DESCRIPTION
## Summary

- **Multiplexed client model**: Shift from 1:1 agent→server WebSocket to one persistent connection per SDK process (`ClientConnection`), supporting multiple agents via `agent:bind`/`agent:unbind` protocol
- **Client tracking**: New `clients` table, `ClientService`, and admin API (`/admin/clients`) for connection lifecycle management with heartbeat and stale cleanup
- **Activity monitoring**: New `ActivityService` tracks per-agent runtime state (idle/working/error), session counts, errors, and task references — exposed via `/admin/agents/activity` and a new dashboard Activity page with agent/client dual-view tabs
- **Presence enrichment**: `agent_presence` extended with `clientId`, runtime fields (`runtimeType`, `runtimeVersion`, `runtimeState`, `runtimeDescription`), and activity counters
- **Dashboard**: Activity page with 5s agent / 10s client auto-refresh, state badges, reset-error and force-disconnect actions

## Test plan

- [ ] `pnpm test` — new tests for `ClientService`, `ConnectionManager`, and `ClientConnection`
- [ ] `pnpm typecheck && pnpm check` — full type and lint pass
- [ ] Manual: start server, connect a client SDK, verify `client:register` → `agent:bind` flow
- [ ] Manual: verify Activity page shows connected agents and clients with live refresh
- [ ] Manual: test force-disconnect and reset-activity admin actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)