### PR TITLE
feat(kael-runtime): inject Context Tree AGENT.md into Kael outbound payload

### DIFF
--- a/packages/server/src/__tests__/kael-runtime.test.ts
+++ b/packages/server/src/__tests__/kael-runtime.test.ts
@@ -1,3 +1,6 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
@@ -632,7 +635,7 @@ describe("KaelRuntime", () => {
       expect(result).toEqual({ sent: 0, errors: 0 });
     });
 
-    it("processOutbound returns immediately after shutdown", async () => {
+    it("processOutbound returns immediately after shutdown (no fetch calls)", async () => {
       const { agent } = await createTestAgent(app, { name: "kael-shutdown-noop" });
       await insertKaelConfig(agent.uuid);
 
@@ -671,6 +674,291 @@ describe("KaelRuntime", () => {
       expect(defined(unchanged).status).toBe("pending");
 
       vi.unstubAllGlobals();
+    });
+  });
+
+  // ---- Context Tree AGENT.md injection ----
+
+  describe("Context Tree AGENT.md injection", () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "kael-ctx-"));
+    });
+
+    afterAll(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("reload() reads AGENT.md and processOutbound() includes agents_md in payload", async () => {
+      const agentMdContent = "# Team Instructions\nAlways respond in English.";
+      writeFileSync(join(tmpDir, "AGENT.md"), agentMdContent, "utf-8");
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-inject" });
+      await insertKaelConfig(agent.uuid);
+
+      const log = createMockLogger();
+      const runtime = createKaelRuntime(app.db, ENCRYPTION_KEY, KAEL_ENDPOINT, KAEL_API_KEY, SERVER_URL, log, tmpDir);
+      await runtime.reload();
+
+      // Verify AGENT.md was loaded (logged)
+      const infoMock = log.info as unknown as { mock: { calls: unknown[][] } };
+      const loadedLog = infoMock.mock.calls.some((c) => typeof c[0] === "string" && c[0].includes("Loaded AGENT.md"));
+      expect(loadedLog).toBe(true);
+
+      // Send a message and verify payload includes agents_md
+      const chatId = `chat-ctx-inject-${Date.now()}`;
+      const msgId = `msg-ctx-inject-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "ctx test" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBe(agentMdContent);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("payload omits agents_md when AGENT.md does not exist", async () => {
+      const emptyDir = mkdtempSync(join(tmpdir(), "kael-ctx-empty-"));
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-no-file" });
+      await insertKaelConfig(agent.uuid);
+
+      const runtime = createKaelRuntime(
+        app.db,
+        ENCRYPTION_KEY,
+        KAEL_ENDPOINT,
+        KAEL_API_KEY,
+        SERVER_URL,
+        createMockLogger(),
+        emptyDir,
+      );
+      await runtime.reload();
+
+      const chatId = `chat-ctx-nofile-${Date.now()}`;
+      const msgId = `msg-ctx-nofile-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "no ctx" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBeUndefined();
+
+      vi.unstubAllGlobals();
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+
+    it("payload omits agents_md when contextTreeDir is not provided", async () => {
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-no-dir" });
+      await insertKaelConfig(agent.uuid);
+
+      const runtime = createKaelRuntime(
+        app.db,
+        ENCRYPTION_KEY,
+        KAEL_ENDPOINT,
+        KAEL_API_KEY,
+        SERVER_URL,
+        createMockLogger(),
+      );
+      await runtime.reload();
+
+      const chatId = `chat-ctx-nodir-${Date.now()}`;
+      const msgId = `msg-ctx-nodir-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "no dir" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBeUndefined();
+
+      vi.unstubAllGlobals();
+    });
+
+    it("reload() refreshes agents_md when AGENT.md content changes", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "kael-ctx-refresh-"));
+      writeFileSync(join(dir, "AGENT.md"), "# Version 1", "utf-8");
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-refresh" });
+      await insertKaelConfig(agent.uuid);
+
+      const runtime = createKaelRuntime(
+        app.db,
+        ENCRYPTION_KEY,
+        KAEL_ENDPOINT,
+        KAEL_API_KEY,
+        SERVER_URL,
+        createMockLogger(),
+        dir,
+      );
+      await runtime.reload();
+
+      // Update AGENT.md content
+      writeFileSync(join(dir, "AGENT.md"), "# Version 2 — updated instructions", "utf-8");
+      await runtime.reload();
+
+      const chatId = `chat-ctx-refresh-${Date.now()}`;
+      const msgId = `msg-ctx-refresh-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "refresh" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBe("# Version 2 — updated instructions");
+
+      vi.unstubAllGlobals();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("reload() clears agents_md when AGENT.md is deleted between reloads", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "kael-ctx-delete-"));
+      const agentMdPath = join(dir, "AGENT.md");
+      writeFileSync(agentMdPath, "# Will be deleted", "utf-8");
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-delete" });
+      await insertKaelConfig(agent.uuid);
+
+      const runtime = createKaelRuntime(
+        app.db,
+        ENCRYPTION_KEY,
+        KAEL_ENDPOINT,
+        KAEL_API_KEY,
+        SERVER_URL,
+        createMockLogger(),
+        dir,
+      );
+      await runtime.reload();
+
+      // Delete AGENT.md and reload
+      rmSync(agentMdPath);
+      await runtime.reload();
+
+      const chatId = `chat-ctx-delete-${Date.now()}`;
+      const msgId = `msg-ctx-delete-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "deleted" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBeUndefined();
+
+      vi.unstubAllGlobals();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("reload() handles readFileSync error gracefully (logs warning, clears agentsMd)", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "kael-ctx-readerr-"));
+      const agentMdPath = join(dir, "AGENT.md");
+      writeFileSync(agentMdPath, "# Readable initially", "utf-8");
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-readerr" });
+      await insertKaelConfig(agent.uuid);
+
+      const log = createMockLogger();
+      const runtime = createKaelRuntime(app.db, ENCRYPTION_KEY, KAEL_ENDPOINT, KAEL_API_KEY, SERVER_URL, log, dir);
+
+      // First reload succeeds
+      await runtime.reload();
+
+      // Make file unreadable and reload — should catch error, clear agentsMd
+      chmodSync(agentMdPath, 0o000);
+      await runtime.reload();
+
+      expect(log.warn).toHaveBeenCalled();
+
+      // Payload should not include agents_md
+      const chatId = `chat-ctx-readerr-${Date.now()}`;
+      const msgId = `msg-ctx-readerr-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "err" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.agents_md).toBeUndefined();
+
+      vi.unstubAllGlobals();
+      // Restore permission before cleanup
+      chmodSync(agentMdPath, 0o644);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("payload omits agents_md when AGENT.md is empty (falsy check)", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "kael-ctx-empty-file-"));
+      writeFileSync(join(dir, "AGENT.md"), "", "utf-8");
+
+      const { agent } = await createTestAgent(app, { name: "kael-ctx-empty-file" });
+      await insertKaelConfig(agent.uuid);
+
+      const runtime = createKaelRuntime(
+        app.db,
+        ENCRYPTION_KEY,
+        KAEL_ENDPOINT,
+        KAEL_API_KEY,
+        SERVER_URL,
+        createMockLogger(),
+        dir,
+      );
+      await runtime.reload();
+
+      const chatId = `chat-ctx-emptyfile-${Date.now()}`;
+      const msgId = `msg-ctx-emptyfile-${Date.now()}`;
+      await createChat(chatId);
+      await insertMessage({ id: msgId, chatId, senderId: "s", content: "empty file" });
+      await insertInboxEntry({ inboxId: agent.inboxId, messageId: msgId, chatId });
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("") });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await runtime.processOutbound();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      // Empty string is falsy, so agents_md should not be included
+      expect(body.agents_md).toBeUndefined();
+
+      vi.unstubAllGlobals();
+      rmSync(dir, { recursive: true, force: true });
     });
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
+import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
@@ -275,6 +276,7 @@ export async function buildApp(config: Config) {
   app.decorate("adapterManager", adapterManager);
 
   // Kael runtime — server-embedded forwarding to Kael API
+  const contextTreeDir = join(DEFAULT_DATA_DIR, "context-tree");
   const kaelRuntime = config.kael?.endpoint
     ? createKaelRuntime(
         db,
@@ -283,6 +285,7 @@ export async function buildApp(config: Config) {
         config.kael.apiKey,
         config.kael.hubPublicUrl,
         app.log,
+        contextTreeDir,
       )
     : undefined;
 

--- a/packages/server/src/services/kael-runtime.ts
+++ b/packages/server/src/services/kael-runtime.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
 import type { Database } from "../db/connection.js";
@@ -36,10 +38,12 @@ export function createKaelRuntime(
   kaelApiKey: string | undefined,
   serverUrl: string,
   log: FastifyBaseLogger,
+  contextTreeDir?: string,
 ): KaelRuntime {
   const agentConfigs = new Map<string, KaelAgentConfig>();
   const inboxToConfig = new Map<string, KaelAgentConfig>();
   let aborted = false;
+  let agentsMd: string | null = null;
 
   return {
     async reload(): Promise<void> {
@@ -117,6 +121,22 @@ export function createKaelRuntime(
           log.info({ agentId }, "Removed inactive Kael adapter config");
         }
       }
+
+      // Read AGENT.md from Context Tree clone (shared with client syncContextTree)
+      if (contextTreeDir) {
+        const agentMdPath = join(contextTreeDir, "AGENT.md");
+        if (existsSync(agentMdPath)) {
+          try {
+            agentsMd = readFileSync(agentMdPath, "utf-8");
+            log.info("Loaded AGENT.md from Context Tree (%d chars)", agentsMd.length);
+          } catch (err) {
+            log.warn({ err }, "Failed to read AGENT.md from Context Tree");
+            agentsMd = null;
+          }
+        } else {
+          agentsMd = null;
+        }
+      }
     },
 
     async processOutbound(): Promise<{ sent: number; errors: number }> {
@@ -174,7 +194,7 @@ export function createKaelRuntime(
             // Resolve message content to string
             const messageContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
 
-            const payload = {
+            const payload: Record<string, unknown> = {
               hub_chat_id: entry.chat_id ?? msg.chatId,
               hub_agent_id: config.agentId,
               hub_server_url: serverUrl,
@@ -185,6 +205,9 @@ export function createKaelRuntime(
               sender_id: msg.senderId,
               format: msg.format,
             };
+            if (agentsMd) {
+              payload.agents_md = agentsMd;
+            }
 
             const response = await fetch(`${kaelEndpoint}/api/v1/hub/messages`, {
               method: "POST",


### PR DESCRIPTION
## Summary

- Kael runtime reads `AGENT.md` from the Context Tree clone on each `reload()` and includes it as `agents_md` in Kael outbound payloads
- Enables workspace-level context injection consistent with the client-side pattern (client writes AGENT.md to workspace files, Kael receives it via payload → workspace config)
- Always passes `contextTreeDir` to runtime (no startup-time `existsSync` gate), so late clone creation is supported without server restart

## Changes

- `kael-runtime.ts`: add `contextTreeDir` parameter, read AGENT.md on reload, conditionally include `agents_md` in payload
- `app.ts`: construct `contextTreeDir` path and pass to `createKaelRuntime`
- `kael-runtime.test.ts`: 7 new integration tests (injection, missing file/dir, refresh, deletion, read error, empty file)

## Companion PR

Kael-side changes (accept `agents_md`, write to project workspace config) are in a separate PR on the kael-agent repo.

## Test plan

- [x] `pnpm check` — no lint errors
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm --filter @first-tree-hub/server test` — 34 files, 222 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)