### PR TITLE
perf(server): speed up test suite by 61%

### DIFF
--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -53,7 +53,7 @@ export async function createTestAdmin(app: FastifyInstance, opts: { username?: s
 
   const username = opts.username ?? "admin";
   const password = opts.password ?? "testpassword123";
-  const passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await bcrypt.hash(password, 1);
 
   await app.db.insert(adminUsers).values({
     id: randomUUID(),

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -6,18 +6,37 @@ import { connectDatabase } from "../db/connection.js";
 // Fixed test fixture UUID — not a real org, recreated before each test
 export const DEFAULT_ORG_ID = "01961234-0000-7000-8000-000000000000";
 
+// Reuse a single DB connection across all beforeEach calls
+let cachedDb: ReturnType<typeof connectDatabase> | undefined;
+function getDb() {
+  if (!cachedDb) {
+    cachedDb = connectDatabase(process.env.DATABASE_URL ?? "");
+  }
+  return cachedDb;
+}
+
 beforeEach(async () => {
-  const db = connectDatabase(process.env.DATABASE_URL ?? "");
+  const db = getDb();
   await db.execute(sql`
-    SET client_min_messages TO WARNING;
-    DO $$ DECLARE t text;
-    BEGIN
-      FOR t IN
-        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
-      LOOP
-        EXECUTE 'TRUNCATE TABLE public.' || quote_ident(t) || ' CASCADE';
-      END LOOP;
-    END $$
+    TRUNCATE TABLE
+      adapter_message_references,
+      adapter_chat_mappings,
+      adapter_agent_mappings,
+      adapter_configs,
+      inbox_entries,
+      messages,
+      chat_participants,
+      chats,
+      agent_tokens,
+      agent_presence,
+      agents,
+      admin_users,
+      clients,
+      processed_events,
+      system_configs,
+      server_instances,
+      organizations
+    CASCADE
   `);
   // Re-insert default organization with UUID PK (required by agents/chats FK constraints)
   await db.execute(


### PR DESCRIPTION
## Summary

- Reduce bcrypt rounds from 10 → 1 in test helpers (cryptographic security is irrelevant in tests)
- Reuse a single DB connection across all `beforeEach` calls instead of creating a new one per test
- Replace dynamic PL/pgSQL `TRUNCATE` loop (queries `pg_tables` then truncates each table individually) with a single explicit `TRUNCATE` statement

## Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total time | 2m51s | 1m07s | **-61%** |
| Test execution | 129.4s | 29.3s | **-77%** |

All 225 tests pass, no behavior changes.

## Test plan

- [x] `pnpm --filter @first-tree-hub/server test` — 34 files, 225 tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)