### PR TITLE
feat: session-level state reporting

### DIFF
--- a/packages/client/src/__tests__/client-connection.test.ts
+++ b/packages/client/src/__tests__/client-connection.test.ts
@@ -294,6 +294,49 @@ describe("ClientConnection: reconnect triggers rebind", () => {
   });
 });
 
+describe("ClientConnection: reportSessionState", () => {
+  it("sends correctly formatted session:state WS message", async () => {
+    const conn = createConn();
+    const ws = await connectAndRegister(conn);
+
+    // Bind an agent first
+    const bindPromise = conn.bindAgent("aghub_state", "claude-code");
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThanOrEqual(2);
+    });
+    const bindMsg = parseSent(ws, 1);
+    ws.receiveMessage({
+      type: "agent:bound",
+      ref: bindMsg.ref,
+      agentId: "agent-state-1",
+      agentType: "claude-code",
+    });
+    await bindPromise;
+
+    // Report session state
+    conn.reportSessionState("agent-state-1", "chat-123", "active");
+
+    await vi.waitFor(() => {
+      expect(ws.sent.length).toBeGreaterThanOrEqual(3);
+    });
+
+    const stateMsg = parseSent(ws, 2);
+    expect(stateMsg.type).toBe("session:state");
+    expect(stateMsg.agentId).toBe("agent-state-1");
+    expect(stateMsg.chatId).toBe("chat-123");
+    expect(stateMsg.state).toBe("active");
+
+    await conn.disconnect();
+  });
+
+  it("silently drops message when WS is not open", async () => {
+    const conn = createConn();
+    // Don't connect — WS is null
+    // Should not throw
+    conn.reportSessionState("agent-1", "chat-1", "active");
+  });
+});
+
 describe("ClientConnection: connect() fast-fail", () => {
   it("rejects if WS closes before registration", async () => {
     const conn = createConn();

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -1,0 +1,288 @@
+import type { InboxEntryWithMessage, SessionState } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import { SessionManager } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+
+/**
+ * Tests for per-session state notifications (onStateChange callback),
+ * deduplication via lastReportedStates, getSessionStates(), and shutdown reporting.
+ */
+
+function mockEntry(opts: { id?: number; chatId?: string; content?: string } = {}): InboxEntryWithMessage {
+  const chatId = opts.chatId ?? "chat-1";
+  return {
+    id: opts.id ?? 1,
+    inboxId: "inbox-test",
+    messageId: `msg-${opts.id ?? 1}`,
+    chatId,
+    status: "delivered",
+    retryCount: 0,
+    createdAt: new Date().toISOString(),
+    deliveredAt: new Date().toISOString(),
+    ackedAt: null,
+    message: {
+      id: `msg-${opts.id ?? 1}`,
+      chatId,
+      senderId: "sender-1",
+      format: "text",
+      content: opts.content ?? "hello",
+      metadata: {},
+      replyToInbox: null,
+      replyToChat: null,
+      inReplyTo: null,
+      createdAt: new Date().toISOString(),
+    },
+  };
+}
+
+function mockSdk(): FirstTreeHubSDK {
+  return {
+    register: vi.fn(),
+    pull: vi.fn(),
+    ack: vi.fn().mockResolvedValue(undefined),
+    renew: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue({ id: "msg-reply" }),
+    sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+  } as unknown as FirstTreeHubSDK;
+}
+
+function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
+  return {
+    start: vi.fn().mockResolvedValue("session-id-mock"),
+    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    inject: vi.fn(),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createSessionManager(opts: {
+  sdk?: FirstTreeHubSDK;
+  handler?: AgentHandler;
+  handlerFactory?: HandlerFactory;
+  session?: { idle_timeout: number; max_sessions: number };
+  concurrency?: number;
+  log?: (msg: string) => void;
+  onStateChange?: (chatId: string, state: SessionState) => void;
+}) {
+  const handler = opts.handler ?? createMockHandler();
+  const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
+  const sdk = opts.sdk ?? mockSdk();
+
+  return new SessionManager({
+    session: opts.session ?? { idle_timeout: 300, max_sessions: 10 },
+    concurrency: opts.concurrency ?? 5,
+    handlerFactory: factory,
+    handlerConfig: { workspaceRoot: "/tmp/test" },
+    agentIdentity: {
+      agentId: "agent-1",
+      displayName: "Agent",
+      type: "autonomous_agent",
+      delegateMention: null,
+      profile: null,
+      metadata: {},
+    },
+    sdk,
+    log: opts.log ?? (() => {}),
+    onStateChange: opts.onStateChange,
+  });
+}
+
+describe("SessionManager: state notifications", () => {
+  it("fires onStateChange('active') when a new session starts", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+
+    expect(stateChanges).toHaveLength(1);
+    expect(stateChanges[0]).toEqual({ chatId: "chat-a", state: "active" });
+
+    await sm.shutdown();
+  });
+
+  it("fires onStateChange('suspended') when a session is preempted", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      concurrency: 1,
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+
+    // chat-a: active, then suspended (preempted); chat-b: active
+    const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
+    const chatBChanges = stateChanges.filter((c) => c.chatId === "chat-b");
+
+    expect(chatAChanges).toEqual([
+      { chatId: "chat-a", state: "active" },
+      { chatId: "chat-a", state: "suspended" },
+    ]);
+    expect(chatBChanges).toEqual([{ chatId: "chat-b", state: "active" }]);
+
+    await sm.shutdown();
+  });
+
+  it("fires onStateChange('evicted') when a session is evicted", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const handlers: AgentHandler[] = [];
+    const sm = createSessionManager({
+      session: { idle_timeout: 300, max_sessions: 2 },
+      handlerFactory: () => {
+        const h = createMockHandler();
+        handlers.push(h);
+        return h;
+      },
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    // Third chat triggers eviction of chat-a (LRU)
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
+
+    const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
+    expect(chatAChanges).toContainEqual({ chatId: "chat-a", state: "evicted" });
+
+    await sm.shutdown();
+  });
+
+  it("fires onStateChange('active') on resume after suspension", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      concurrency: 1,
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    // chat-a starts (active), chat-b preempts chat-a (suspended → active)
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    // chat-a resumes, preempting chat-b
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a" }));
+
+    const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
+    expect(chatAChanges).toEqual([
+      { chatId: "chat-a", state: "active" },
+      { chatId: "chat-a", state: "suspended" },
+      { chatId: "chat-a", state: "active" },
+    ]);
+
+    await sm.shutdown();
+  });
+
+  it("does not fire onStateChange when no callback is provided", async () => {
+    // Should not throw
+    const sm = createSessionManager({});
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager: state deduplication", () => {
+  it("does not fire duplicate 'active' notifications for the same session", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+
+    // Concurrency 1: chat-a starts, chat-b preempts, chat-a resumes, chat-b preempts again
+    const sm = createSessionManager({
+      concurrency: 1,
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" })); // active
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" })); // a→suspended, b→active
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a" })); // b→suspended, a→active
+    await sm.dispatch(mockEntry({ id: 4, chatId: "chat-b" })); // a→suspended, b→active
+
+    // Each chat should alternate active/suspended with no duplicates
+    const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
+    const chatBChanges = stateChanges.filter((c) => c.chatId === "chat-b");
+
+    // No two consecutive identical states
+    for (const changes of [chatAChanges, chatBChanges]) {
+      for (let i = 1; i < changes.length; i++) {
+        expect(changes[i]?.state).not.toBe(changes[i - 1]?.state);
+      }
+    }
+
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager: getSessionStates()", () => {
+  it("returns all current session states", async () => {
+    const sm = createSessionManager({
+      concurrency: 1,
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+
+    const states = sm.getSessionStates();
+    expect(states).toHaveLength(2);
+
+    const chatA = states.find((s) => s.chatId === "chat-a");
+    const chatB = states.find((s) => s.chatId === "chat-b");
+
+    // chat-b preempted chat-a, so chat-a is suspended, chat-b is active
+    expect(chatA?.state).toBe("suspended");
+    expect(chatB?.state).toBe("active");
+
+    await sm.shutdown();
+  });
+
+  it("returns empty array when no sessions exist", async () => {
+    const sm = createSessionManager({});
+    expect(sm.getSessionStates()).toEqual([]);
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager: shutdown state reporting", () => {
+  it("reports active sessions as 'suspended' on shutdown", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+
+    // Clear state changes from start phase
+    stateChanges.length = 0;
+
+    await sm.shutdown();
+
+    // Both active sessions should be reported as suspended
+    expect(stateChanges).toContainEqual({ chatId: "chat-a", state: "suspended" });
+    expect(stateChanges).toContainEqual({ chatId: "chat-b", state: "suspended" });
+  });
+
+  it("does not report already-suspended sessions on shutdown", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      concurrency: 1,
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+
+    // chat-a is already suspended (preempted by chat-b)
+    stateChanges.length = 0;
+
+    await sm.shutdown();
+
+    // Only chat-b (active) should get a suspended notification
+    // chat-a was already suspended (and dedup prevents re-notification)
+    const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
+    expect(chatAChanges).toHaveLength(0);
+
+    const chatBChanges = stateChanges.filter((c) => c.chatId === "chat-b");
+    expect(chatBChanges).toEqual([{ chatId: "chat-b", state: "suspended" }]);
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { hostname as getHostname, platform } from "node:os";
-import type { AgentActivity } from "@agent-team-foundation/first-tree-hub-shared";
+import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
 import WebSocket from "ws";
 import { FirstTreeHubSDK } from "./sdk.js";
 
@@ -42,7 +42,7 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
  *   1. connect() → WS to /api/v1/agent/ws/client
  *   2. client:register → register with env info
  *   3. bindAgent(token, runtimeType) → agent:bind per agent (with ref for correlation)
- *   4. reportActivity(agentId, activity) → agent:activity
+ *   4. reportSessionState(agentId, chatId, state) → session:state
  *   5. heartbeat → client-level keepalive
  */
 export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
@@ -121,14 +121,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.boundAgents.delete(agentId);
   }
 
-  /** Report runtime state for a bound agent. */
-  reportActivity(agentId: string, activity: AgentActivity): void {
+  /** Report a per-session state change for a bound agent. */
+  reportSessionState(agentId: string, chatId: string, state: SessionState): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(
       JSON.stringify({
-        type: "agent:activity",
+        type: "session:state",
         agentId,
-        ...activity,
+        chatId,
+        state,
       }),
     );
   }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import type { InboxEntryWithMessage, RuntimeState } from "@agent-team-foundation/first-tree-hub-shared";
+import type { InboxEntryWithMessage, SessionState } from "@agent-team-foundation/first-tree-hub-shared";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { ClientConnection } from "../client-connection.js";
 import { AgentConnection } from "../connection.js";
@@ -76,6 +76,12 @@ export class AgentSlot {
       this.clientConnection.on("agent:message", () => {
         this.pullAndDispatch();
       });
+
+      this.clientConnection.on("agent:bound", (boundAgent) => {
+        if (boundAgent.agentId === this.agentId) {
+          this.fullStateSync();
+        }
+      });
     } else {
       const conn = this.legacyConnection as AgentConnection;
       agent = await conn.connect();
@@ -106,14 +112,11 @@ export class AgentSlot {
       sdk,
       log: this.logFn,
       registryPath,
-      onStateChange: this.clientConnection
-        ? (state, description) => this.reportActivity(state, description)
-        : undefined,
+      onStateChange: this.clientConnection ? (chatId, state) => this.reportSessionState(chatId, state) : undefined,
     });
 
     if (this.clientConnection) {
       this.startPolling();
-      this.reportActivity("idle");
     } else {
       const conn = this.legacyConnection as AgentConnection;
       conn.onMessage(async (entry: InboxEntryWithMessage) => {
@@ -130,7 +133,6 @@ export class AgentSlot {
       this.pollingTimer = null;
     }
     if (this.clientConnection && this.agentId) {
-      this.reportActivity("idle");
       await this.clientConnection.unbindAgent(this.agentId);
     }
     await this.sessionManager?.shutdown();
@@ -140,14 +142,16 @@ export class AgentSlot {
     this.logFn("Stopped");
   }
 
-  private reportActivity(state: RuntimeState, description?: string): void {
+  private reportSessionState(chatId: string, state: SessionState): void {
     if (!this.clientConnection || !this.agentId) return;
-    this.clientConnection.reportActivity(this.agentId, {
-      state,
-      description,
-      activeSessions: this.sessionManager?.activeCount ?? 0,
-      totalSessions: this.sessionManager?.totalCount ?? 0,
-    });
+    this.clientConnection.reportSessionState(this.agentId, chatId, state);
+  }
+
+  private fullStateSync(): void {
+    if (!this.sessionManager || !this.clientConnection || !this.agentId) return;
+    for (const { chatId, state } of this.sessionManager.getSessionStates()) {
+      this.clientConnection.reportSessionState(this.agentId, chatId, state);
+    }
   }
 
   private startPolling(): void {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1,4 +1,4 @@
-import type { InboxEntryWithMessage, RuntimeState } from "@agent-team-foundation/first-tree-hub-shared";
+import type { InboxEntryWithMessage, SessionState } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { SessionConfig } from "./config.js";
 import { Deduplicator } from "./deduplicator.js";
@@ -12,13 +12,11 @@ import type {
 } from "./handler.js";
 import { SessionRegistry } from "./session-registry.js";
 
-type SessionStatus = "active" | "suspended" | "evicted";
-
 type SessionEntry = {
   chatId: string;
   claudeSessionId: string;
   handler: AgentHandler;
-  status: SessionStatus;
+  status: SessionState;
   lastActivity: number;
   /** In-flight suspend promise; awaited before resume to avoid race conditions. */
   suspending: Promise<void> | null;
@@ -38,8 +36,8 @@ type SessionManagerConfig = {
   sdk: FirstTreeHubSDK;
   log: (msg: string) => void;
   registryPath?: string;
-  /** M1: callback when runtime state should change */
-  onStateChange?: (state: RuntimeState, description?: string) => void;
+  /** M1: callback when a session state changes (per-session granularity) */
+  onStateChange?: (chatId: string, state: SessionState) => void;
 };
 
 /**
@@ -62,9 +60,9 @@ export class SessionManager {
   private readonly deduplicator = new Deduplicator(1000);
   private readonly registry: SessionRegistry | null;
   private readonly pendingQueue: PendingMessage[] = [];
+  private readonly lastReportedStates = new Map<string, SessionState>();
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private _activeCount = 0;
-  private _lastReportedState: RuntimeState | null = null;
 
   constructor(config: SessionManagerConfig) {
     this.config = config;
@@ -113,12 +111,20 @@ export class SessionManager {
     );
     await Promise.allSettled(shutdowns);
 
+    // Report active sessions as suspended before clearing
+    for (const [chatId, session] of this.sessions) {
+      if (session.status === "active") {
+        this.notifySessionState(chatId, "suspended");
+      }
+    }
+
     // Persist final state
     this.persistRegistry();
     this.registry?.dispose();
 
     this.sessions.clear();
     this.evictedMappings.clear();
+    this.lastReportedStates.clear();
     this._activeCount = 0;
   }
 
@@ -128,6 +134,14 @@ export class SessionManager {
 
   get totalCount(): number {
     return this.sessions.size;
+  }
+
+  /** Return all current session states for full state sync after reconnect. */
+  getSessionStates(): Array<{ chatId: string; state: SessionState }> {
+    return [...this.sessions.entries()].map(([chatId, entry]) => ({
+      chatId,
+      state: entry.status,
+    }));
   }
 
   // ---- Internal -----------------------------------------------------------
@@ -193,14 +207,13 @@ export class SessionManager {
         this.config.log(`Session ${chatId}: created (${sessionId})`);
       }
       this.persistRegistry();
-      this.notifyStateChange();
+      this.notifySessionState(chatId, "active");
     } catch (err) {
       this.config.log(
         `Session ${chatId}: ${evicted ? "resume" : "start"} failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       this.sessions.delete(chatId);
       this._activeCount--;
-      this.notifyStateChange();
     }
   }
 
@@ -222,12 +235,11 @@ export class SessionManager {
       await entry.handler.resume(message, entry.claudeSessionId, ctx);
       this.config.log(`Session ${entry.chatId}: resumed (${entry.claudeSessionId})`);
       this.persistRegistry();
-      this.notifyStateChange();
+      this.notifySessionState(entry.chatId, "active");
     } catch (err) {
       this.config.log(`Session ${entry.chatId}: resume failed: ${err instanceof Error ? err.message : String(err)}`);
       entry.status = "suspended";
       this._activeCount--;
-      this.notifyStateChange();
     }
   }
 
@@ -275,7 +287,7 @@ export class SessionManager {
         entry.suspending = null;
       });
     this.persistRegistry();
-    this.notifyStateChange();
+    this.notifySessionState(entry.chatId, "suspended");
 
     // Drain pending queue
     this.drainPendingQueue();
@@ -326,6 +338,7 @@ export class SessionManager {
         candidate.session.handler.shutdown().catch(() => {});
       }
       candidate.session.status = "evicted";
+      this.notifySessionState(candidate.key, "evicted");
       this.sessions.delete(candidate.key);
       this.persistRegistry();
     }
@@ -353,12 +366,12 @@ export class SessionManager {
     }
   }
 
-  private notifyStateChange(): void {
+  /** Notify per-session state change to the server via callback. Deduplicates redundant reports. */
+  private notifySessionState(chatId: string, state: SessionState): void {
     if (!this.config.onStateChange) return;
-    const state: RuntimeState = this._activeCount > 0 ? "working" : "idle";
-    if (state === this._lastReportedState) return;
-    this._lastReportedState = state;
-    this.config.onStateChange(state);
+    if (this.lastReportedStates.get(chatId) === state) return;
+    this.lastReportedStates.set(chatId, state);
+    this.config.onStateChange(chatId, state);
   }
 
   private buildSessionContext(chatId: string): SessionContext {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -402,10 +402,8 @@ export function registerAgentCommands(program: Command): void {
             clientId: string | null;
             runtimeType: string | null;
             runtimeState: string | null;
-            runtimeDescription: string | null;
             activeSessions: number | null;
             totalSessions: number | null;
-            errorMessage: string | null;
           }>;
         };
 
@@ -418,14 +416,8 @@ export function registerAgentCommands(program: Command): void {
           process.stderr.write(`\n  Agent: ${agent.agentId}\n`);
           process.stderr.write(`  Runtime: ${agent.runtimeType ?? "—"}\n`);
           process.stderr.write(`  State: ${agent.runtimeState ?? "—"}\n`);
-          if (agent.runtimeDescription) {
-            process.stderr.write(`  Description: ${agent.runtimeDescription}\n`);
-          }
           if (agent.activeSessions !== null) {
             process.stderr.write(`  Sessions: ${agent.activeSessions} active / ${agent.totalSessions ?? 0} total\n`);
-          }
-          if (agent.errorMessage) {
-            process.stderr.write(`  Error: ${agent.errorMessage}\n`);
           }
           if (agent.clientId) {
             process.stderr.write(`  Client: ${agent.clientId}\n`);
@@ -442,14 +434,13 @@ export function registerAgentCommands(program: Command): void {
         );
 
         if (data.agents.length > 0) {
-          const header = `  ${"AGENT".padEnd(18)} ${"RUNTIME".padEnd(14)} ${"STATE".padEnd(10)} ${"SESSIONS".padEnd(10)} DESCRIPTION`;
+          const header = `  ${"AGENT".padEnd(18)} ${"RUNTIME".padEnd(14)} ${"STATE".padEnd(10)} SESSIONS`;
           process.stderr.write(`${header}\n`);
           process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
           for (const a of data.agents) {
             const sessions = a.activeSessions !== null ? `${a.activeSessions}/${a.totalSessions ?? 0}` : "—";
-            const desc = a.runtimeDescription ?? (a.errorMessage ? `Error: ${a.errorMessage.slice(0, 40)}` : "—");
             process.stderr.write(
-              `  ${(a.agentId ?? "").padEnd(18)} ${(a.runtimeType ?? "—").padEnd(14)} ${(a.runtimeState ?? "—").padEnd(10)} ${sessions.padEnd(10)} ${desc}\n`,
+              `  ${(a.agentId ?? "").padEnd(18)} ${(a.runtimeType ?? "—").padEnd(14)} ${(a.runtimeState ?? "—").padEnd(10)} ${sessions}\n`,
             );
           }
           process.stderr.write("\n");

--- a/packages/server/drizzle/0012_session_level_state.sql
+++ b/packages/server/drizzle/0012_session_level_state.sql
@@ -1,0 +1,19 @@
+-- Session-level state reporting: new session table + drop unused presence columns
+
+CREATE TABLE "agent_chat_sessions" (
+	"agent_id" text NOT NULL,
+	"chat_id" text NOT NULL,
+	"state" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_chat_sessions_agent_id_chat_id_pk" PRIMARY KEY("agent_id","chat_id")
+);
+--> statement-breakpoint
+ALTER TABLE "agent_chat_sessions" ADD CONSTRAINT "agent_chat_sessions_agent_id_agents_uuid_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("uuid") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "agent_chat_sessions" ADD CONSTRAINT "agent_chat_sessions_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "agent_presence" DROP COLUMN IF EXISTS "runtime_description";
+--> statement-breakpoint
+ALTER TABLE "agent_presence" DROP COLUMN IF EXISTS "error_message";
+--> statement-breakpoint
+ALTER TABLE "agent_presence" DROP COLUMN IF EXISTS "task_ref";

--- a/packages/server/drizzle/meta/0012_snapshot.json
+++ b/packages/server/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1451 @@
+{
+  "id": "9a12714c-7ded-4a41-9fd8-8e2aa92a647e",
+  "prevId": "be78162b-42e3-4a83-9972-06b1dd19b7d4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.adapter_agent_mappings": {
+      "name": "adapter_agent_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adapter_agent_mappings_agent_id_agents_uuid_fk": {
+          "name": "adapter_agent_mappings_agent_id_agents_uuid_fk",
+          "tableFrom": "adapter_agent_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_adapter_agent_mapping": {
+          "name": "uq_adapter_agent_mapping",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "external_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adapter_chat_mappings": {
+      "name": "adapter_chat_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adapter_chat_mappings_chat_id_chats_id_fk": {
+          "name": "adapter_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "adapter_chat_mappings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adapter_configs": {
+      "name": "adapter_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adapter_configs_agent_id_agents_uuid_fk": {
+          "name": "adapter_configs_agent_id_agents_uuid_fk",
+          "tableFrom": "adapter_configs",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_adapter_configs_agent_platform": {
+          "name": "uq_adapter_configs_agent_platform",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "platform"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adapter_message_references": {
+      "name": "adapter_message_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_message_id": {
+          "name": "external_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_channel_id": {
+          "name": "external_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adapter_message_references_message_id_messages_id_fk": {
+          "name": "adapter_message_references_message_id_messages_id_fk",
+          "tableFrom": "adapter_message_references",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_adapter_message_ref": {
+          "name": "uq_adapter_message_ref",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "platform"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_users": {
+      "name": "admin_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_users_username_unique": {
+          "name": "admin_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_tokens": {
+      "name": "agent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_tokens_agent": {
+          "name": "idx_agent_tokens_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_tokens_hash": {
+          "name": "idx_agent_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_tokens_agent_id_agents_uuid_fk": {
+          "name": "agent_tokens_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_tokens",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cloud_user_id": {
+          "name": "cloud_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id"
+          ]
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_participants": {
+      "name": "chat_participants",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_participants_agent": {
+          "name": "idx_participants_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_participants_chat_id_chats_id_fk": {
+          "name": "chat_participants_chat_id_chats_id_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_participants_agent_id_agents_uuid_fk": {
+          "name": "chat_participants_agent_id_agents_uuid_fk",
+          "tableFrom": "chat_participants",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_participants_chat_id_agent_id_pk": {
+          "name": "chat_participants_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_configs": {
+      "name": "system_configs",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776211200000,
       "tag": "0011_org_uuid_pk",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776297600000,
+      "tag": "0012_session_level_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/session-state.test.ts
+++ b/packages/server/src/__tests__/session-state.test.ts
@@ -1,0 +1,261 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { chats } from "../db/schema/chats.js";
+import * as activityService from "../services/activity.js";
+import * as presenceService from "../services/presence.js";
+import { createTestAgent, createTestApp } from "./helpers.js";
+
+/**
+ * Integration tests for session-level state reporting:
+ *
+ * 1. upsertSessionState — upsert + aggregate + presence update
+ * 2. WS session:state — end-to-end through WebSocket handler
+ */
+
+/** Create a chat row in the DB for FK satisfaction. */
+async function createTestChat(app: Awaited<ReturnType<typeof createTestApp>>, chatId: string, organizationId: string) {
+  await app.db.insert(chats).values({ id: chatId, organizationId, type: "direct" }).onConflictDoNothing();
+}
+
+// -- Integration: upsertSessionState ------------------------------------------
+
+describe("upsertSessionState", () => {
+  const appPromise = createTestApp();
+  afterAll(async () => (await appPromise).close());
+
+  it("creates session row and updates presence aggregates", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: "state-a1" });
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    await createTestChat(app, "chat-s1", agent.organizationId);
+
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s1", "active");
+
+    // Verify agent_chat_sessions row
+    const [session] = await app.db.select().from(agentChatSessions).where(eq(agentChatSessions.agentId, agent.uuid));
+    expect(session).toBeDefined();
+    expect(session?.chatId).toBe("chat-s1");
+    expect(session?.state).toBe("active");
+
+    // Verify presence aggregates
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence?.runtimeState).toBe("working");
+    expect(presence?.activeSessions).toBe(1);
+    expect(presence?.totalSessions).toBe(1);
+  });
+
+  it("updates existing session state on conflict", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: "state-a2" });
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    await createTestChat(app, "chat-s2", agent.organizationId);
+
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s2", "active");
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s2", "suspended");
+
+    const [session] = await app.db.select().from(agentChatSessions).where(eq(agentChatSessions.agentId, agent.uuid));
+    expect(session?.state).toBe("suspended");
+
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence?.runtimeState).toBe("idle");
+    expect(presence?.activeSessions).toBe(0);
+    expect(presence?.totalSessions).toBe(1);
+  });
+
+  it("correctly aggregates multiple sessions", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: "state-a3" });
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    await createTestChat(app, "chat-s3a", agent.organizationId);
+    await createTestChat(app, "chat-s3b", agent.organizationId);
+    await createTestChat(app, "chat-s3c", agent.organizationId);
+
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s3a", "active");
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s3b", "active");
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s3c", "suspended");
+
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence?.runtimeState).toBe("working");
+    expect(presence?.activeSessions).toBe(2);
+    expect(presence?.totalSessions).toBe(3);
+
+    // Suspend one active
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s3a", "suspended");
+    const presence2 = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence2?.activeSessions).toBe(1);
+    expect(presence2?.totalSessions).toBe(3);
+
+    // Suspend the last active
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s3b", "suspended");
+    const presence3 = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence3?.runtimeState).toBe("idle");
+    expect(presence3?.activeSessions).toBe(0);
+  });
+
+  it("handles evicted state", async () => {
+    const app = await appPromise;
+    const { agent } = await createTestAgent(app, { name: "state-a4" });
+    await presenceService.setOnline(app.db, agent.uuid, "test-instance");
+    await createTestChat(app, "chat-s4", agent.organizationId);
+
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s4", "active");
+    await activityService.upsertSessionState(app.db, agent.uuid, "chat-s4", "evicted");
+
+    const [session] = await app.db.select().from(agentChatSessions).where(eq(agentChatSessions.agentId, agent.uuid));
+    expect(session?.state).toBe("evicted");
+
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence?.runtimeState).toBe("idle");
+    expect(presence?.activeSessions).toBe(0);
+  });
+});
+
+// -- E2E: WS session:state ---------------------------------------------------
+
+describe("WS session:state message", () => {
+  let app: Awaited<ReturnType<typeof createTestApp>>;
+  let addr: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    addr = await app.listen({ port: 0, host: "127.0.0.1" });
+  });
+
+  afterAll(async () => app?.close());
+
+  /** Helper: open a client WS and complete registration + bind handshake. */
+  async function connectAndBind(token: string): Promise<{
+    ws: WebSocket;
+    agentId: string;
+    clientId: string;
+  }> {
+    if (!app) {
+      app = await createTestApp();
+      addr = await app.listen({ port: 0, host: "127.0.0.1" });
+    }
+
+    const wsUrl = `${addr.replace(/^http/, "ws")}/api/v1/agent/ws/client`;
+    const ws = new WebSocket(wsUrl);
+    const clientId = `test-client-${crypto.randomUUID().slice(0, 8)}`;
+
+    await new Promise<void>((resolve, reject) => {
+      ws.on("open", () => resolve());
+      ws.on("error", reject);
+    });
+
+    // Register
+    ws.send(JSON.stringify({ type: "client:register", clientId }));
+    await waitForMessage(ws, "client:registered");
+
+    // Bind
+    const ref = crypto.randomUUID().slice(0, 12);
+    ws.send(JSON.stringify({ type: "agent:bind", ref, token, runtimeType: "claude-code" }));
+    const boundMsg = await waitForMessage(ws, "agent:bound");
+    const agentId = (boundMsg as { agentId: string }).agentId;
+
+    return { ws, agentId, clientId };
+  }
+
+  /** Wait for a specific WS message type. */
+  function waitForMessage(ws: WebSocket, type: string, timeoutMs = 5000): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Timeout waiting for ${type}`)), timeoutMs);
+      const handler = (data: WebSocket.Data) => {
+        const msg = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (msg.type === type) {
+          clearTimeout(timer);
+          ws.off("message", handler);
+          resolve(msg);
+        }
+      };
+      ws.on("message", handler);
+    });
+  }
+
+  it("session:state message updates agent_chat_sessions and presence", async () => {
+    if (!app) {
+      app = await createTestApp();
+      addr = await app.listen({ port: 0, host: "127.0.0.1" });
+    }
+
+    const { agent, token } = await createTestAgent(app, {
+      name: `ws-state-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    // Create a real chat via the API (sendToAgent creates one)
+    const { token: senderToken } = await createTestAgent(app, {
+      name: `ws-sender-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    const { FirstTreeHubSDK } = await import("@first-tree-hub/client");
+    const senderSdk = new FirstTreeHubSDK({ serverUrl: addr, token: senderToken });
+    const agentName = agent.name ?? agent.uuid;
+    const msg = await senderSdk.sendToAgent(agentName, {
+      format: "text",
+      content: "test message",
+    });
+    const chatId = msg.chatId;
+
+    // Connect and bind the receiver agent
+    const { ws, agentId } = await connectAndBind(token);
+
+    // Send session:state
+    ws.send(JSON.stringify({ type: "session:state", agentId, chatId, state: "active" }));
+
+    // Wait for server processing
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Verify DB state
+    const [session] = await app.db.select().from(agentChatSessions).where(eq(agentChatSessions.agentId, agentId));
+    expect(session).toBeDefined();
+    expect(session?.chatId).toBe(chatId);
+    expect(session?.state).toBe("active");
+
+    // Verify presence updated
+    const presence = await presenceService.getPresence(app.db, agentId);
+    expect(presence?.runtimeState).toBe("working");
+    expect(presence?.activeSessions).toBe(1);
+
+    // Now suspend
+    ws.send(JSON.stringify({ type: "session:state", agentId, chatId, state: "suspended" }));
+    await new Promise((r) => setTimeout(r, 500));
+
+    const presence2 = await presenceService.getPresence(app.db, agentId);
+    expect(presence2?.runtimeState).toBe("idle");
+    expect(presence2?.activeSessions).toBe(0);
+
+    ws.close();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("rejects session:state for unbound agent", async () => {
+    if (!app) {
+      app = await createTestApp();
+      addr = await app.listen({ port: 0, host: "127.0.0.1" });
+    }
+
+    const { token } = await createTestAgent(app, {
+      name: `ws-unbound-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    const { ws } = await connectAndBind(token);
+
+    // Try to send session:state for a different (unbound) agent
+    ws.send(
+      JSON.stringify({
+        type: "session:state",
+        agentId: "nonexistent-agent",
+        chatId: "chat-fake",
+        state: "active",
+      }),
+    );
+
+    const errorMsg = await waitForMessage(ws, "error");
+    expect(errorMsg.message).toBe("Agent not bound");
+
+    ws.close();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+});

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -44,9 +44,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
         clientId: a.clientId ?? null,
         runtimeType: a.runtimeType ?? null,
         runtimeState: a.runtimeState ?? null,
-        runtimeDescription: a.runtimeDescription ?? null,
         activeSessions: a.activeSessions ?? null,
-        errorMessage: a.errorMessage ?? null,
       })),
       nextCursor: result.nextCursor,
     };

--- a/packages/server/src/api/admin/clients.ts
+++ b/packages/server/src/api/admin/clients.ts
@@ -66,11 +66,8 @@ export async function adminActivityRoutes(app: FastifyInstance): Promise<void> {
         clientId: a.clientId,
         runtimeType: a.runtimeType,
         runtimeState: a.runtimeState,
-        runtimeDescription: a.runtimeDescription,
         activeSessions: a.activeSessions,
         totalSessions: a.totalSessions,
-        errorMessage: a.errorMessage,
-        taskRef: a.taskRef,
         runtimeUpdatedAt: a.runtimeUpdatedAt?.toISOString() ?? null,
       })),
     };

--- a/packages/server/src/api/agent/me.ts
+++ b/packages/server/src/api/agent/me.ts
@@ -1,7 +1,5 @@
-import { agentActivitySchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
-import * as activityService from "../../services/activity.js";
 import * as agentService from "../../services/agent.js";
 import * as presenceService from "../../services/presence.js";
 
@@ -21,19 +19,8 @@ export async function agentMeRoutes(app: FastifyInstance): Promise<void> {
       runtimeType: presence?.runtimeType ?? null,
       runtimeVersion: presence?.runtimeVersion ?? null,
       runtimeState: presence?.runtimeState ?? null,
-      runtimeDescription: presence?.runtimeDescription ?? null,
       activeSessions: presence?.activeSessions ?? null,
       totalSessions: presence?.totalSessions ?? null,
-      errorMessage: presence?.errorMessage ?? null,
-      taskRef: presence?.taskRef ?? null,
     };
-  });
-
-  // PUT /agent/me/activity — report runtime state
-  app.put("/me/activity", async (request) => {
-    const identity = requireAgent(request);
-    const body = agentActivitySchema.parse(request.body);
-    await activityService.updateActivity(app.db, identity.uuid, body);
-    return { ok: true };
   });
 }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1,7 +1,7 @@
 import {
-  agentActivitySchema,
   agentBindSchema,
   clientRegisterSchema,
+  sessionStateMessageSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
@@ -28,7 +28,7 @@ const wsMessageSchema = z.object({
  *   1. Client connects (no auth required at WS level)
  *   2. client:register — register client with env info
  *   3. agent:bind — bind agent to this client (authenticates via token)
- *   4. agent:activity — report runtime state changes
+ *   4. session:state — report per-session state changes
  *   5. heartbeat — client-level heartbeat
  *   6. agent:unbind — unbind agent
  */
@@ -155,15 +155,15 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             boundAgents.delete(agentId);
 
             socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
-          } else if (type === "agent:activity") {
+          } else if (type === "session:state") {
             const agentId = parsed.data.agentId;
             if (!agentId || !boundAgents.has(agentId)) {
               socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
               return;
             }
 
-            const activityPayload = agentActivitySchema.parse(msg);
-            await activityService.updateActivity(app.db, agentId, activityPayload);
+            const payload = sessionStateMessageSchema.parse(msg);
+            await activityService.upsertSessionState(app.db, agentId, payload.chatId, payload.state);
           } else if (type === "heartbeat") {
             if (clientId) {
               await clientService.heartbeatClient(app.db, clientId);

--- a/packages/server/src/db/schema/agent-chat-sessions.ts
+++ b/packages/server/src/db/schema/agent-chat-sessions.ts
@@ -1,0 +1,19 @@
+import { pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+import { chats } from "./chats.js";
+
+/** Per-session state snapshot. One row per (agent, chat) pair, upserted on each session:state message. */
+export const agentChatSessions = pgTable(
+  "agent_chat_sessions",
+  {
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.uuid, { onDelete: "cascade" }),
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    state: text("state").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.agentId, table.chatId] })],
+);

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -24,16 +24,10 @@ export const agentPresence = pgTable("agent_presence", {
   runtimeVersion: text("runtime_version"),
   /** idle | working | error. NULL = agent not running. THE authority for whether agent is running. */
   runtimeState: text("runtime_state"),
-  /** Human-readable description of current work */
-  runtimeDescription: text("runtime_description"),
-  /** Number of active sessions */
+  /** Number of active sessions (materialized from agent_chat_sessions) */
   activeSessions: integer("active_sessions"),
-  /** Total sessions (including suspended/evicted) */
+  /** Total sessions including suspended/evicted (materialized from agent_chat_sessions) */
   totalSessions: integer("total_sessions"),
-  /** Error summary when runtime_state = "error" */
-  errorMessage: text("error_message"),
-  /** External task reference (e.g. GitHub Issue URL) */
-  taskRef: text("task_ref"),
   /** When runtime_state was last updated */
   runtimeUpdatedAt: timestamp("runtime_updated_at", { withTimezone: true }),
 });

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -3,6 +3,7 @@ export { adapterChatMappings } from "./adapter-chat-mappings.js";
 export { adapterConfigs } from "./adapter-configs.js";
 export { adapterMessageReferences } from "./adapter-message-references.js";
 export { adminUsers } from "./admin-users.js";
+export { agentChatSessions } from "./agent-chat-sessions.js";
 export { agentPresence } from "./agent-presence.js";
 export { agentTokens } from "./agent-tokens.js";
 export { agents } from "./agents.js";

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -1,24 +1,47 @@
-import type { AgentActivity } from "@agent-team-foundation/first-tree-hub-shared";
+import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
 import { eq, isNotNull, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { clients } from "../db/schema/clients.js";
 
-export async function updateActivity(db: Database, agentId: string, activity: AgentActivity) {
+/** Upsert a session state and update materialized aggregates on agent_presence. */
+export async function upsertSessionState(db: Database, agentId: string, chatId: string, state: SessionState) {
   const now = new Date();
-  await db
-    .update(agentPresence)
-    .set({
-      runtimeState: activity.state,
-      runtimeDescription: activity.description ?? null,
-      activeSessions: activity.activeSessions ?? null,
-      totalSessions: activity.totalSessions ?? null,
-      errorMessage: activity.errorMessage ?? null,
-      taskRef: activity.taskRef ?? null,
-      runtimeUpdatedAt: now,
-      lastSeenAt: now,
-    })
-    .where(eq(agentPresence.agentId, agentId));
+  await db.transaction(async (tx) => {
+    // 1. Upsert session row
+    await tx
+      .insert(agentChatSessions)
+      .values({ agentId, chatId, state, updatedAt: now })
+      .onConflictDoUpdate({
+        target: [agentChatSessions.agentId, agentChatSessions.chatId],
+        set: { state, updatedAt: now },
+      });
+
+    // 2. Aggregate and update presence
+    const [counts] = await tx
+      .select({
+        active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
+        total: sql<number>`count(*)::int`,
+      })
+      .from(agentChatSessions)
+      .where(eq(agentChatSessions.agentId, agentId));
+
+    const activeSessions = counts?.active ?? 0;
+    const totalSessions = counts?.total ?? 0;
+    const runtimeState = activeSessions > 0 ? "working" : "idle";
+
+    await tx
+      .update(agentPresence)
+      .set({
+        runtimeState,
+        activeSessions,
+        totalSessions,
+        runtimeUpdatedAt: now,
+        lastSeenAt: now,
+      })
+      .where(eq(agentPresence.agentId, agentId));
+  });
 }
 
 export async function resetActivity(db: Database, agentId: string) {
@@ -27,9 +50,6 @@ export async function resetActivity(db: Database, agentId: string) {
     .update(agentPresence)
     .set({
       runtimeState: "idle",
-      runtimeDescription: null,
-      errorMessage: null,
-      taskRef: null,
       runtimeUpdatedAt: now,
     })
     .where(eq(agentPresence.agentId, agentId));

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -122,9 +122,7 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
       clientId: agentPresence.clientId,
       runtimeType: agentPresence.runtimeType,
       runtimeState: agentPresence.runtimeState,
-      runtimeDescription: agentPresence.runtimeDescription,
       activeSessions: agentPresence.activeSessions,
-      errorMessage: agentPresence.errorMessage,
     })
     .from(agents)
     .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -99,9 +99,8 @@ export async function cleanupStaleClients(db: Database, staleSeconds = 60): Prom
     await db.execute(sql`
       UPDATE agent_presence SET
         status = 'offline',
-        runtime_state = NULL, runtime_description = NULL,
+        runtime_state = NULL,
         active_sessions = NULL, total_sessions = NULL,
-        error_message = NULL, task_ref = NULL,
         runtime_updated_at = NOW()
       WHERE client_id = ANY(${staleIds})
     `);

--- a/packages/server/src/services/presence.ts
+++ b/packages/server/src/services/presence.ts
@@ -7,11 +7,8 @@ import { serverInstances } from "../db/schema/server-instances.js";
 export function runtimeFieldsReset(now: Date) {
   return {
     runtimeState: null,
-    runtimeDescription: null,
     activeSessions: null,
     totalSessions: null,
-    errorMessage: null,
-    taskRef: null,
     runtimeUpdatedAt: now,
     lastSeenAt: now,
   } as const;
@@ -102,11 +99,8 @@ export async function bindAgent(
         runtimeType: data.runtimeType,
         runtimeVersion: data.runtimeVersion ?? null,
         runtimeState: "idle",
-        runtimeDescription: null,
         activeSessions: null,
         totalSessions: null,
-        errorMessage: null,
-        taskRef: null,
         connectedAt: now,
         lastSeenAt: now,
         runtimeUpdatedAt: now,
@@ -141,9 +135,8 @@ export async function heartbeatInstance(db: Database, instanceId: string) {
 export async function cleanupStalePresence(db: Database, staleSeconds = 60): Promise<number> {
   const result = await db.execute<{ agent_id: string }>(sql`
     UPDATE agent_presence SET status = 'offline', instance_id = NULL,
-      runtime_state = NULL, runtime_description = NULL,
+      runtime_state = NULL,
       active_sessions = NULL, total_sessions = NULL,
-      error_message = NULL, task_ref = NULL,
       runtime_updated_at = NOW()
     WHERE instance_id IN (
       SELECT instance_id FROM server_instances

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -145,11 +145,9 @@ export {
 } from "./schemas/organization.js";
 export {
   type ActivityOverview,
-  type AgentActivity,
   type AgentBind,
   type AgentPresence,
   activityOverviewSchema,
-  agentActivitySchema,
   agentBindSchema,
   agentPresenceSchema,
   PRESENCE_STATUSES,
@@ -158,8 +156,11 @@ export {
   RUNTIME_STATES,
   type RuntimeState,
   runtimeStateSchema,
-  type SessionInfo,
-  sessionInfoSchema,
+  SESSION_STATES,
+  type SessionState,
+  type SessionStateMessage,
+  sessionStateMessageSchema,
+  sessionStateSchema,
 } from "./schemas/presence.js";
 export {
   type OrgStats,

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -19,17 +19,22 @@ export const RUNTIME_STATES = {
 export const runtimeStateSchema = z.enum(["idle", "working", "error"]);
 export type RuntimeState = z.infer<typeof runtimeStateSchema>;
 
-// -- Agent Activity Payload (client → server) --
+// -- Session State (client → server, per-session) --
 
-export const agentActivitySchema = z.object({
-  state: runtimeStateSchema,
-  description: z.string().max(500).optional(),
-  activeSessions: z.number().int().min(0).optional(),
-  totalSessions: z.number().int().min(0).optional(),
-  errorMessage: z.string().max(1000).optional(),
-  taskRef: z.string().max(200).optional(),
+export const SESSION_STATES = {
+  ACTIVE: "active",
+  SUSPENDED: "suspended",
+  EVICTED: "evicted",
+} as const;
+
+export const sessionStateSchema = z.enum(["active", "suspended", "evicted"]);
+export type SessionState = z.infer<typeof sessionStateSchema>;
+
+export const sessionStateMessageSchema = z.object({
+  chatId: z.string().min(1),
+  state: sessionStateSchema,
 });
-export type AgentActivity = z.infer<typeof agentActivitySchema>;
+export type SessionStateMessage = z.infer<typeof sessionStateMessageSchema>;
 
 // -- Agent Bind Payload (client → server) --
 
@@ -39,17 +44,6 @@ export const agentBindSchema = z.object({
   runtimeVersion: z.string().max(50).optional(),
 });
 export type AgentBind = z.infer<typeof agentBindSchema>;
-
-// -- Session Info (reported with activity, not persisted to DB) --
-
-export const sessionInfoSchema = z.object({
-  chatId: z.string(),
-  status: z.enum(["active", "suspended", "evicted"]),
-  claudeSessionId: z.string().nullable(),
-  startedAt: z.string(),
-  lastActiveAt: z.string(),
-});
-export type SessionInfo = z.infer<typeof sessionInfoSchema>;
 
 // -- Extended Agent Presence --
 
@@ -62,11 +56,8 @@ export const agentPresenceSchema = z.object({
   runtimeType: z.string().nullable().optional(),
   runtimeVersion: z.string().nullable().optional(),
   runtimeState: runtimeStateSchema.nullable().optional(),
-  runtimeDescription: z.string().nullable().optional(),
   activeSessions: z.number().int().nullable().optional(),
   totalSessions: z.number().int().nullable().optional(),
-  errorMessage: z.string().nullable().optional(),
-  taskRef: z.string().nullable().optional(),
   runtimeUpdatedAt: z.string().nullable().optional(),
 });
 export type AgentPresence = z.infer<typeof agentPresenceSchema>;

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -5,11 +5,8 @@ export type RuntimeAgent = {
   clientId: string | null;
   runtimeType: string | null;
   runtimeState: string | null;
-  runtimeDescription: string | null;
   activeSessions: number | null;
   totalSessions: number | null;
-  errorMessage: string | null;
-  taskRef: string | null;
   runtimeUpdatedAt: string | null;
 };
 

--- a/packages/web/src/pages/activity.tsx
+++ b/packages/web/src/pages/activity.tsx
@@ -111,14 +111,13 @@ export function ActivityPage() {
                   <TableHead>Runtime</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead>Sessions</TableHead>
-                  <TableHead>Description</TableHead>
                   <TableHead />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {(!activity?.agents || activity.agents.length === 0) && (
                   <TableRow>
-                    <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
                       No running agents
                     </TableCell>
                   </TableRow>
@@ -132,9 +131,6 @@ export function ActivityPage() {
                     </TableCell>
                     <TableCell>
                       {agent.activeSessions !== null ? `${agent.activeSessions}/${agent.totalSessions ?? 0}` : "—"}
-                    </TableCell>
-                    <TableCell className="max-w-[200px] truncate">
-                      {agent.runtimeDescription ?? agent.errorMessage ?? "—"}
                     </TableCell>
                     <TableCell>
                       {agent.runtimeState === "error" && (
@@ -175,7 +171,7 @@ export function ActivityPage() {
               <TableBody>
                 {(!clients || clients.length === 0) && (
                   <TableRow>
-                    <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
                       No connected clients
                     </TableCell>
                   </TableRow>

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -469,10 +469,8 @@ export function AgentDetailPage() {
         const ext = agent as Record<string, unknown>;
         const rState = ext.runtimeState as string | null;
         const rType = ext.runtimeType as string | null;
-        const rDesc = ext.runtimeDescription as string | null;
         const rSessions = ext.activeSessions as number | null;
         const rClientId = ext.clientId as string | null;
-        const rError = ext.errorMessage as string | null;
         if (!rState) return null;
         return (
           <Card>
@@ -495,12 +493,6 @@ export function AgentDetailPage() {
                     </Badge>
                   </dd>
                 </div>
-                {rDesc && (
-                  <div className="col-span-2">
-                    <dt className="text-muted-foreground mb-1">Current Work</dt>
-                    <dd>{rDesc}</dd>
-                  </div>
-                )}
                 {rSessions !== null && (
                   <div>
                     <dt className="text-muted-foreground mb-1">Sessions</dt>
@@ -511,12 +503,6 @@ export function AgentDetailPage() {
                   <div>
                     <dt className="text-muted-foreground mb-1">Client</dt>
                     <dd className="font-mono text-xs">{rClientId}</dd>
-                  </div>
-                )}
-                {rError && (
-                  <div className="col-span-2">
-                    <dt className="text-muted-foreground mb-1">Error</dt>
-                    <dd className="text-destructive">{rError}</dd>
                   </div>
                 )}
               </dl>


### PR DESCRIPTION
## Summary

- Replace coarse agent-level activity reporting (`idle`/`working`) with per-session state reporting (`active`/`suspended`/`evicted` per chat)
- New `agent_chat_sessions` table stores one row per (agent, chat) pair; server derives `agent_presence` aggregates via materialized aggregation
- New WS `session:state` message replaces `agent:activity`; removes unused presence columns (`runtimeDescription`, `errorMessage`, `taskRef`)

## Design

Per [session-level-state-reporting proposal](../first-tree-context/proposals/session-level-state-reporting.20260410.md):

- **Client reports per-session transitions**, no longer aggregates — server computes agent-level state from session data
- **State dedup** via `lastReportedStates` map prevents redundant WS + DB work
- **Full state sync on reconnect** — `agent:bound` event triggers re-report of all session states
- **Connection drop ≠ session stop** — `agent_chat_sessions` rows are NOT cleared on disconnect; reconnecting client overwrites via fullStateSync
- **No backward compat layer** for `agent:activity` — old clients lose dashboard status display but not functionality

## Changed files

| Package | Files | What |
|---------|-------|------|
| shared | `schemas/presence.ts`, `index.ts` | New `SessionState` schema, remove `AgentActivity` |
| client | `session-manager.ts`, `agent-slot.ts`, `client-connection.ts` | Per-session callbacks, fullStateSync, typed `SessionState` |
| server | `activity.ts`, `ws-client.ts`, `agent-chat-sessions.ts`, `agent-presence.ts`, `presence.ts`, `client.ts` | Upsert + aggregate, new table, drop columns |
| server | `me.ts`, `agents.ts`, `clients.ts` | Remove deleted fields from API responses |
| command | `agent.ts` | Remove description/error from CLI status |
| web | `activity.tsx`, `agent-detail.tsx`, `activity.ts` | Remove description/error columns from UI |

## Test plan

- [x] `pnpm typecheck` — all 5 packages pass
- [x] `pnpm --filter @first-tree-hub/client test` — 90 tests (12 new: session state notifications, dedup, getSessionStates, shutdown reporting, reportSessionState WS format)
- [x] `pnpm --filter @first-tree-hub/server test` — 228 tests (6 new: upsertSessionState integration, WS session:state e2e, unbound agent rejection)
- [x] `pnpm check` — Biome lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)