### PR TITLE
chore: refresh shared tree binding metadata

### DIFF
--- a/.agents/skills/first-tree/SKILL.md
+++ b/.agents/skills/first-tree/SKILL.md
@@ -75,6 +75,9 @@ Default onboarding workflow:
 5. If the current root is a workspace, run `first-tree workspace sync` so all
    child repos bind to the same shared tree.
 
+During `bind` / `init`, the CLI also ensures the tree repo has the bundled
+`first-tree` skill installed and refreshes binding metadata in both locations.
+
 ## CLI Commands
 
 | Command | Purpose |

--- a/.agents/skills/first-tree/references/onboarding.md
+++ b/.agents/skills/first-tree/references/onboarding.md
@@ -65,10 +65,11 @@ first-tree init
 
 The CLI will:
 
-- install `.agents/skills/first-tree/` and `.claude/skills/first-tree/`
+- install `.agents/skills/first-tree/` and `.claude/skills/first-tree/` in the source/workspace root
 - create `FIRST_TREE.md`
 - refresh `AGENTS.md` and `CLAUDE.md`
 - create or reuse a sibling `<repo>-tree` checkout
+- install the bundled `first-tree` skill in that tree repo if it is missing
 - scaffold the tree repo there
 - write binding metadata in both the source repo and the tree repo
 
@@ -95,6 +96,7 @@ first-tree bind --tree-url git@github.com:acme/org-context.git --tree-mode share
 `bind` will clone a local checkout if needed, then:
 
 - install local skill integration in the current repo
+- install the bundled `first-tree` skill in the tree repo if it is missing
 - refresh `AGENTS.md` and `CLAUDE.md`
 - write `.first-tree/source.json`
 - refresh `.first-tree/local-tree.json`

--- a/.agents/skills/first-tree/references/source-workspace-installation.md
+++ b/.agents/skills/first-tree/references/source-workspace-installation.md
@@ -20,8 +20,9 @@ workspace repo, or non-git workspace folder.
   - `.first-tree/workspace.json` when the root is a workspace
 - `NODE.md`, `members/`, and tree-scoped `AGENTS.md` / `CLAUDE.md` belong only
   in the tree repo.
-- The tree repo keeps its own metadata under `.first-tree/tree.json` and
-  `.first-tree/bindings/`.
+- The tree repo keeps its own installed skill under `.agents/skills/first-tree/`
+  and `.claude/skills/first-tree`, plus tree metadata under `.first-tree/tree.json`
+  and `.first-tree/bindings/`.
 
 ## Binding Modes
 
@@ -47,6 +48,8 @@ workspace repo, or non-git workspace folder.
     workspace.json          # workspace roots only
 
 <tree-repo>/
+  .agents/skills/first-tree/
+  .claude/skills/first-tree
   .first-tree/
     VERSION
     progress.md
@@ -74,6 +77,10 @@ When an agent is asked to install `first-tree`:
 Do not recreate a new sibling tree repo when the user already has a shared tree
 they want to keep using.
 
+Whenever a git-backed source/workspace root is bound, keep the binding metadata
+pointing at the tree checkout and published tree URL. Do not create hidden
+codebase mirrors in the tree repo by default.
+
 ## Workspace Rule
 
 If the current root contains many child repos or submodules:
@@ -90,7 +97,8 @@ package folders that are not repos do not get repo-level binding metadata.
 - Verify the tree repo with `first-tree verify`.
 - Use `first-tree upgrade` in a source/workspace root to refresh local
   integration.
-- Use `first-tree upgrade --tree-path ...` to refresh the tree repo metadata.
+- Use `first-tree upgrade --tree-path ...` to refresh the tree repo metadata
+  plus its installed tree-repo skill.
 
 ## Publish Rule
 

--- a/.agents/skills/first-tree/references/upgrade-contract.md
+++ b/.agents/skills/first-tree/references/upgrade-contract.md
@@ -43,6 +43,8 @@ CLAUDE.md
 In a tree repo, `first-tree init tree` produces:
 
 ```text
+.agents/skills/first-tree/
+.claude/skills/first-tree
 .first-tree/
   VERSION
   progress.md
@@ -69,8 +71,8 @@ members/
 6. preserves `.first-tree/local-tree.json`, `.first-tree/source.json`, and
    `.first-tree/workspace.json`
 
-`first-tree upgrade --tree-path ...` in a tree repo refreshes only tree-side
-metadata such as `.first-tree/VERSION`.
+`first-tree upgrade --tree-path ...` in a tree repo refreshes tree-side
+metadata such as `.first-tree/VERSION` plus the installed tree-repo skill.
 
 ## What Gets Preserved
 
@@ -108,3 +110,5 @@ metadata such as `.first-tree/VERSION`.
 - workspace child repos should share one tree, not create many parallel trees
 - shared tree bindings should live in `.first-tree/bindings/`, not in a single
   overwrite-prone bootstrap file
+- source/workspace roots should keep referencing the tree through binding
+  metadata and `.first-tree/local-tree.json`

--- a/.first-tree/source.json
+++ b/.first-tree/source.json
@@ -2,7 +2,7 @@
   "bindingMode": "workspace-member",
   "rootKind": "git-repo",
   "scope": "workspace",
-  "sourceId": "first-tree-hub-5fb86a1c",
+  "sourceId": "first-tree-hub-d5c2100e",
   "sourceName": "first-tree-hub",
   "tree": {
     "entrypoint": "/workspaces/first-tree-all/repos/first-tree-hub",


### PR DESCRIPTION
## Summary
- refresh the committed shared-tree binding metadata to match the latest first-tree workspace sync state
- keep this repo aligned with the shared `first-tree-context` tree after tree PR #116

## Verification
- `npx -p first-tree first-tree inspect --json --skip-version-check`