### PR TITLE
fix: set password state before invalidating queries in member creation

### DIFF
--- a/packages/web/src/pages/members.tsx
+++ b/packages/web/src/pages/members.tsx
@@ -43,8 +43,8 @@ export function MembersPage() {
         role: form.role as "admin" | "member",
       }),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["members"] });
       setCreatedPassword(data.password);
+      queryClient.invalidateQueries({ queryKey: ["members"] });
     },
   });
 


### PR DESCRIPTION
## Summary

- Swap order of `setCreatedPassword` and `invalidateQueries` in member creation `onSuccess` callback
- Ensures password dialog renders before the member list refetch triggers a re-render

One-line fix in `packages/web/src/pages/members.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)