### PR TITLE
feat(web): agent owner display with My/Team split

### DIFF
--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -37,6 +37,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     return {
       items: result.items.map((a) => ({
         ...a,
+        managerId: a.managerId ?? null,
         presenceStatus: a.presenceStatus ?? "offline",
         createdAt: a.createdAt.toISOString(),
         updatedAt: a.updatedAt.toISOString(),

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -129,6 +129,7 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
       cloudUserId: agents.cloudUserId,
       public: agents.public,
       metadata: agents.metadata,
+      managerId: agents.managerId,
       createdAt: agents.createdAt,
       updatedAt: agents.updatedAt,
       presenceStatus: agentPresence.status,

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -3,12 +3,13 @@ import { login as loginApi } from "../api/auth.js";
 import { api, clearStoredTokens, getStoredTokens, setStoredTokens } from "../api/client.js";
 
 type MeResponse = {
-  member: { role: string };
+  member: { id: string; role: string };
 };
 
 type AuthContextValue = {
   isAuthenticated: boolean;
   role: string | null;
+  memberId: string | null;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 };
@@ -18,17 +19,20 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(() => !!getStoredTokens());
   const [role, setRole] = useState<string | null>(null);
+  const [memberId, setMemberId] = useState<string | null>(null);
 
   const logout = useCallback(() => {
     clearStoredTokens();
     setIsAuthenticated(false);
     setRole(null);
+    setMemberId(null);
   }, []);
 
-  const fetchRole = useCallback(async () => {
+  const fetchMe = useCallback(async () => {
     try {
       const data = await api.get<MeResponse>("/me");
       setRole(data.member.role);
+      setMemberId(data.member.id);
     } catch {
       // If /me fails, role stays null — UI falls back to hiding admin features
     }
@@ -38,19 +42,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const tokens = await loginApi(username, password);
     setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
     setIsAuthenticated(true);
-    // Fetch role immediately after login
+    // Fetch member info immediately after login
     await api
       .get<MeResponse>("/me")
-      .then((data) => setRole(data.member.role))
+      .then((data) => {
+        setRole(data.member.role);
+        setMemberId(data.member.id);
+      })
       .catch(() => {});
   }, []);
 
-  // Fetch role on initial load if already authenticated
+  // Fetch member info on initial load if already authenticated
   useEffect(() => {
     if (isAuthenticated && !role) {
-      fetchRole();
+      fetchMe();
     }
-  }, [isAuthenticated, role, fetchRole]);
+  }, [isAuthenticated, role, fetchMe]);
 
   // Listen for auth failure dispatched by the API client
   useEffect(() => {
@@ -59,7 +66,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("auth:logout", handler);
   }, [logout]);
 
-  return <AuthContext.Provider value={{ isAuthenticated, role, login, logout }}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, role, memberId, login, logout }}>{children}</AuthContext.Provider>
+  );
 }
 
 export function useAuth(): AuthContextValue {

--- a/packages/web/src/lib/use-member-name-map.ts
+++ b/packages/web/src/lib/use-member-name-map.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { listMembers } from "../api/members.js";
+
+/**
+ * Shared hook that builds a member ID → display name lookup map.
+ * Used by pages that display managerId references on agents.
+ */
+export function useMemberNameMap(): (memberId: string | null | undefined) => string {
+  const { data } = useQuery({
+    queryKey: ["members", "name-map"],
+    queryFn: listMembers,
+    staleTime: 30_000,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, string>();
+    if (data) {
+      for (const m of data) {
+        map.set(m.id, m.displayName || m.username);
+      }
+    }
+    return (memberId: string | null | undefined) => {
+      if (!memberId) return "\u2014";
+      return map.get(memberId) ?? memberId;
+    };
+  }, [data]);
+}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -26,6 +26,7 @@ import { Input } from "../components/ui/input.js";
 import { Label } from "../components/ui/label.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
+import { useMemberNameMap } from "../lib/use-member-name-map.js";
 import { cn, formatDate } from "../lib/utils.js";
 
 const platformValues = Object.values(ADAPTER_PLATFORMS);
@@ -36,6 +37,7 @@ export function AgentDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const resolveAgentName = useAgentNameMap();
+  const resolveMemberName = useMemberNameMap();
 
   // Agent data
   const agentQuery = useQuery({
@@ -436,6 +438,12 @@ export function AgentDetailPage() {
               <div>
                 <dt className="text-muted-foreground mb-1">Delegate Mention</dt>
                 <dd className="font-mono">{resolveAgentName(agent.delegateMention)}</dd>
+              </div>
+            )}
+            {agent.managerId && (
+              <div>
+                <dt className="text-muted-foreground mb-1">Owner</dt>
+                <dd>{resolveMemberName(agent.managerId)}</dd>
               </div>
             )}
             {role && (

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -1,30 +1,57 @@
+import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
 import { AGENT_TYPES } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { createAgent, listAgents } from "../api/agents.js";
+import { useAuth } from "../auth/auth-context.js";
 import { type AgentFormData, AgentFormDialog } from "../components/agent-form-dialog.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
+import { useMemberNameMap } from "../lib/use-member-name-map.js";
 import { cn, formatDate } from "../lib/utils.js";
 
 const agentTypeValues = Object.values(AGENT_TYPES);
 
+function sortByName(agents: Agent[]): Agent[] {
+  return [...agents].sort((a, b) => {
+    const nameA = (a.name ?? a.displayName ?? "").toLowerCase();
+    const nameB = (b.name ?? b.displayName ?? "").toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+}
+
 export function AgentsPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { memberId } = useAuth();
   const [cursor, setCursor] = useState<string | undefined>();
   const [typeFilter, setTypeFilter] = useState<string>("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const resolveAgentName = useAgentNameMap();
+  const resolveMemberName = useMemberNameMap();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["agents", cursor, typeFilter],
-    queryFn: () => listAgents({ limit: 20, cursor, type: typeFilter || undefined }),
+    queryFn: () => listAgents({ limit: 100, cursor, type: typeFilter || undefined }),
   });
+
+  const { myAgents, teamAgents } = useMemo(() => {
+    if (!data?.items) return { myAgents: [], teamAgents: [] };
+    const my: Agent[] = [];
+    const team: Agent[] = [];
+    for (const agent of data.items) {
+      if (memberId && agent.managerId === memberId) {
+        my.push(agent);
+      } else {
+        team.push(agent);
+      }
+    }
+    return { myAgents: sortByName(my), teamAgents: sortByName(team) };
+  }, [data, memberId]);
 
   const createMutation = useMutation({
     mutationFn: (formData: AgentFormData) =>
@@ -41,109 +68,140 @@ export function AgentsPage() {
     },
   });
 
+  function renderAgentRow(agent: Agent) {
+    const ext = agent as Record<string, unknown>;
+    const runtimeState = ext.runtimeState as string | null;
+    const runtimeColors: Record<string, string> = {
+      idle: "bg-green-500",
+      working: "bg-blue-500",
+      error: "bg-red-500",
+    };
+
+    return (
+      <TableRow key={agent.uuid} className="cursor-pointer" onClick={() => navigate(`/agents/${agent.uuid}`)}>
+        <TableCell className="font-mono text-sm">{agent.name}</TableCell>
+        <TableCell>{agent.displayName ?? "\u2014"}</TableCell>
+        <TableCell>
+          <Badge variant="secondary">{agent.type}</Badge>
+        </TableCell>
+        <TableCell className="font-mono text-sm text-muted-foreground">
+          {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "\u2014"}
+        </TableCell>
+        <TableCell className="text-sm text-muted-foreground">{resolveMemberName(agent.managerId)}</TableCell>
+        <TableCell>
+          {runtimeState ? (
+            <span className="flex items-center gap-1.5">
+              <span className={cn("inline-block h-2 w-2 rounded-full", runtimeColors[runtimeState] ?? "bg-gray-300")} />
+              <span className="text-xs text-muted-foreground">{runtimeState}</span>
+            </span>
+          ) : (
+            <span className="inline-block h-2 w-2 rounded-full bg-gray-300" title="not running" />
+          )}
+        </TableCell>
+        <TableCell>
+          <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>
+        </TableCell>
+        <TableCell className="text-muted-foreground">{formatDate(agent.createdAt)}</TableCell>
+      </TableRow>
+    );
+  }
+
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-semibold">Agents</h1>
-          <select
-            value={typeFilter}
-            onChange={(e) => {
-              setTypeFilter(e.target.value);
-              setCursor(undefined);
-            }}
-            className="h-8 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <option value="">All types</option>
-            {agentTypeValues.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </div>
-        <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
-          <Plus className="h-4 w-4 mr-2" />
-          New Agent
-        </Button>
+    <div className="space-y-8">
+      {/* Page header with type filter */}
+      <div className="flex items-center gap-4">
+        <h1 className="text-2xl font-semibold">Agents</h1>
+        <select
+          value={typeFilter}
+          onChange={(e) => {
+            setTypeFilter(e.target.value);
+            setCursor(undefined);
+          }}
+          className="h-8 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <option value="">All types</option>
+          {agentTypeValues.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
       </div>
 
-      <div className="border rounded-lg">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Display Name</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Delegate</TableHead>
-              <TableHead>Runtime</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Created</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  Loading...
-                </TableCell>
-              </TableRow>
-            ) : error ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-destructive">
-                  Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
-                </TableCell>
-              </TableRow>
-            ) : !data?.items.length ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  {typeFilter ? `No ${typeFilter} agents` : "No agents yet"}
-                </TableCell>
-              </TableRow>
-            ) : (
-              data.items.map((agent) => (
-                <TableRow key={agent.uuid} className="cursor-pointer" onClick={() => navigate(`/agents/${agent.uuid}`)}>
-                  <TableCell className="font-mono text-sm">{agent.name}</TableCell>
-                  <TableCell>{agent.displayName ?? "\u2014"}</TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">{agent.type}</Badge>
-                  </TableCell>
-                  <TableCell className="font-mono text-sm text-muted-foreground">
-                    {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "\u2014"}
-                  </TableCell>
-                  <TableCell>
-                    {(() => {
-                      const a = agent as Record<string, unknown>;
-                      const state = a.runtimeState as string | null;
-                      if (!state) {
-                        return <span className="inline-block h-2 w-2 rounded-full bg-gray-300" title="not running" />;
-                      }
-                      const colors: Record<string, string> = {
-                        idle: "bg-green-500",
-                        working: "bg-blue-500",
-                        error: "bg-red-500",
-                      };
-                      return (
-                        <span className="flex items-center gap-1.5">
-                          <span className={cn("inline-block h-2 w-2 rounded-full", colors[state] ?? "bg-gray-300")} />
-                          <span className="text-xs text-muted-foreground">{state}</span>
-                        </span>
-                      );
-                    })()}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">{formatDate(agent.createdAt)}</TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      {isLoading ? (
+        <div className="text-center py-8 text-muted-foreground">Loading...</div>
+      ) : error ? (
+        <div className="text-center py-8 text-destructive">
+          Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
+        </div>
+      ) : (
+        <>
+          {/* My Agents */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-medium">My Agents</h2>
+              <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                New Agent
+              </Button>
+            </div>
+            <div className="border rounded-lg">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Display Name</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Delegate</TableHead>
+                    <TableHead>Owner</TableHead>
+                    <TableHead>Runtime</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {myAgents.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                        No agents yet — create one to get started
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    myAgents.map((agent) => renderAgentRow(agent))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </section>
+
+          {/* Team Agents */}
+          {teamAgents.length > 0 && (
+            <section>
+              <h2 className="text-lg font-medium mb-3">Team Agents</h2>
+              <div className="border rounded-lg">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Display Name</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Delegate</TableHead>
+                      <TableHead>Owner</TableHead>
+                      <TableHead>Runtime</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Created</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>{teamAgents.map((agent) => renderAgentRow(agent))}</TableBody>
+                </Table>
+              </div>
+            </section>
+          )}
+        </>
+      )}
 
       {data?.nextCursor && (
-        <div className="flex justify-end mt-4">
+        <div className="flex justify-end">
           <Button variant="outline" onClick={() => setCursor(data.nextCursor ?? undefined)}>
             Next Page
           </Button>


### PR DESCRIPTION
## Summary
- Server: include `managerId` in agent list API response
- Web Agents page split into **My Agents** (current user's) and **Team Agents** (others), both sorted alphabetically by name
- Owner column displayed in both tables; agent detail page also shows Owner
- Auth context extended to store `memberId` for client-side ownership filtering

## Test plan
- [ ] Log in as admin — verify "My Agents" shows agents with `managerId` matching current member
- [ ] Log in as member — verify same split behavior
- [ ] Verify both tables have aligned columns (Owner column in both)
- [ ] Verify alphabetical sort within each group
- [ ] Verify empty "My Agents" shows guidance text
- [ ] Verify agent detail page shows Owner field
- [ ] `pnpm check && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)