### PR TITLE
fix: prevent human agent handler loop — skip runtime for identity-only agents

### DIFF
--- a/packages/client/src/__tests__/agent-slot-human.test.ts
+++ b/packages/client/src/__tests__/agent-slot-human.test.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import type { ClientConnection } from "../client-connection.js";
+import { AgentSlot } from "../runtime/agent-slot.js";
+import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import type { RegisterResult } from "../sdk.js";
+
+function createMockHandler(): AgentHandler {
+  return {
+    start: vi.fn().mockResolvedValue("session-id"),
+    resume: vi.fn().mockResolvedValue("session-id"),
+    inject: vi.fn(),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Create a mock ClientConnection that resolves bindAgent with the given register result. */
+function createMockClientConnection(registerResult: RegisterResult) {
+  const mockSdk = {
+    register: vi.fn().mockResolvedValue(registerResult),
+    pull: vi.fn().mockResolvedValue({ entries: [] }),
+    ack: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn(),
+    sendToAgent: vi.fn(),
+    renew: vi.fn(),
+    serverUrl: "http://localhost:8000",
+    agentToken: "test-token",
+  };
+
+  const emitter = new EventEmitter();
+  const conn = Object.assign(emitter, {
+    clientId: "test-client",
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    bindAgent: vi.fn().mockResolvedValue({
+      agentId: registerResult.agentId,
+      sdk: mockSdk,
+    }),
+    unbindAgent: vi.fn().mockResolvedValue(undefined),
+    reportSessionState: vi.fn(),
+    reportRuntimeState: vi.fn(),
+    reportSessionOutput: vi.fn(),
+    removeListener: vi.fn(),
+  }) as unknown as ClientConnection;
+
+  return { conn, mockSdk };
+}
+
+describe("AgentSlot human agent guard", () => {
+  it("skips SessionManager and event listeners when server reports type=human", async () => {
+    const humanResult: RegisterResult = {
+      agentId: "agent-human-1",
+      inboxId: "inbox-1",
+      status: "active",
+      displayName: "Human User",
+      type: "human",
+      delegateMention: null,
+      profile: null,
+      metadata: {},
+    };
+
+    const { conn, mockSdk } = createMockClientConnection(humanResult);
+    const handler = createMockHandler();
+    const handlerFactory: HandlerFactory = () => handler;
+
+    const slot = new AgentSlot({
+      name: "test-human",
+      serverUrl: "http://localhost:8000",
+      token: "test-token",
+      type: "claude-code",
+      handlerFactory,
+      session: { idle_timeout: 300, max_sessions: 10 },
+      concurrency: 5,
+      clientConnection: conn,
+    });
+
+    const result = await slot.start();
+
+    // Should return the register result
+    expect(result.agentId).toBe("agent-human-1");
+    expect(result.type).toBe("human");
+
+    // Handler should NOT have been called — no SessionManager created
+    expect(handler.start).not.toHaveBeenCalled();
+
+    // No event listeners should be registered on the connection
+    // (agent:message, agent:bound are registered AFTER the human check)
+    expect(conn.listenerCount("agent:message")).toBe(0);
+    expect(conn.listenerCount("agent:bound")).toBe(0);
+
+    // SDK pull should NOT have been called (no polling started)
+    expect(mockSdk.pull).not.toHaveBeenCalled();
+
+    await slot.stop();
+  });
+
+  it("initializes SessionManager and listeners for non-human agents", async () => {
+    const assistantResult: RegisterResult = {
+      agentId: "agent-assistant-1",
+      inboxId: "inbox-1",
+      status: "active",
+      displayName: "Assistant",
+      type: "personal_assistant",
+      delegateMention: null,
+      profile: null,
+      metadata: {},
+    };
+
+    const { conn } = createMockClientConnection(assistantResult);
+    const handler = createMockHandler();
+    const handlerFactory: HandlerFactory = () => handler;
+
+    const slot = new AgentSlot({
+      name: "test-assistant",
+      serverUrl: "http://localhost:8000",
+      token: "test-token",
+      type: "claude-code",
+      handlerFactory,
+      session: { idle_timeout: 300, max_sessions: 10 },
+      concurrency: 5,
+      clientConnection: conn,
+    });
+
+    const result = await slot.start();
+
+    expect(result.type).toBe("personal_assistant");
+
+    // Event listeners SHOULD be registered for non-human agents
+    expect(conn.listenerCount("agent:message")).toBeGreaterThan(0);
+    expect(conn.listenerCount("agent:bound")).toBeGreaterThan(0);
+
+    await slot.stop();
+  });
+});

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -73,7 +73,25 @@ export class AgentSlot {
       agent = await sdk.register();
 
       this.logFn(`Bound as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+    } else {
+      const conn = this.legacyConnection as AgentConnection;
+      agent = await conn.connect();
+      this.agentId = agent.agentId;
+      sdk = conn.sdk;
 
+      this.logFn(`Registered as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+    }
+
+    // Defensive check: if server reports this is a human agent, skip message
+    // processing entirely — prevents infinite reply loops even if the agent
+    // was misconfigured into the agents/ directory with a runtime handler.
+    if (agent.type === "human") {
+      this.logFn("Server reports type=human — message processing disabled");
+      return agent;
+    }
+
+    // Register event listeners AFTER the human check to avoid unnecessary polling
+    if (this.clientConnection) {
       const onMessage = (agentId: string) => {
         if (agentId === this.agentId) this.pullAndDispatch();
       };
@@ -86,13 +104,6 @@ export class AgentSlot {
         { event: "agent:message", fn: onMessage as (...args: unknown[]) => void },
         { event: "agent:bound", fn: onBound as (...args: unknown[]) => void },
       );
-    } else {
-      const conn = this.legacyConnection as AgentConnection;
-      agent = await conn.connect();
-      this.agentId = agent.agentId;
-      sdk = conn.sdk;
-
-      this.logFn(`Registered as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
     }
 
     const registryPath = join(DEFAULT_DATA_DIR, "sessions", `${this.config.name}.json`);

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -103,14 +103,17 @@ export async function bootstrapToken(
 
   const data = (await res.json()) as { token: string; agentId: string };
 
-  // Save token to agent config if requested
-  if (options.saveTo === "agent" || !options.saveTo) {
+  // Save token to agent config if requested.
+  // Human agents are identity-only (managed by adapter); they don't need a client
+  // runtime config, so skip writing to the agents/ directory.
+  const isHuman = options.type === "human";
+  if ((options.saveTo === "agent" || !options.saveTo) && !isHuman) {
     const configDir = join(DEFAULT_CONFIG_DIR, "agents", agentName);
     const configPath = `${configDir}/agent.yaml`;
     mkdirSync(configDir, { recursive: true, mode: 0o700 });
     writeFileSync(configPath, `token: "${data.token}"\nruntime: claude-code\n`, { mode: 0o600 });
     chmodSync(configDir, 0o700);
-  } else if (options.saveTo) {
+  } else if (options.saveTo && options.saveTo !== "agent") {
     mkdirSync(dirname(options.saveTo), { recursive: true });
     writeFileSync(options.saveTo, data.token, { mode: 0o600 });
   }

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -139,7 +139,13 @@ export class ClientRuntime {
 
     process.stderr.write(`\n  Provisioned by Hub: ${agentName} (${agentType})\n`);
 
-    // Save agent config to disk — runtime defaults to claude-code (agentType is the business type, not the handler)
+    // Human agents are identity-only; skip runtime config and handler
+    if (agentType === "human") {
+      process.stderr.write(`  - ${agentName}: human agent — no runtime needed\n`);
+      return;
+    }
+
+    // Save agent config to disk — runtime defaults to claude-code
     const runtime = "claude-code";
     saveAgentConfig(agentName, token, runtime);
 

--- a/packages/command/src/core/migrate.ts
+++ b/packages/command/src/core/migrate.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -22,10 +22,42 @@ function resolveMigrationsFolder(): string {
 }
 
 /**
+ * Validate that migration journal timestamps are strictly increasing.
+ * Drizzle silently skips migrations whose `when` is <= the last applied
+ * timestamp, which causes missing columns/tables with no error.
+ */
+function validateJournalOrder(migrationsFolder: string): void {
+  const journalPath = join(migrationsFolder, "meta", "_journal.json");
+  if (!existsSync(journalPath)) return;
+
+  const journal = JSON.parse(readFileSync(journalPath, "utf-8")) as {
+    entries: Array<{ idx: number; when: number; tag: string }>;
+  };
+
+  let prevWhen = 0;
+  let prevTag = "";
+  for (const entry of journal.entries) {
+    if (entry.when <= prevWhen) {
+      throw new Error(
+        `Migration journal timestamps are not monotonically increasing:\n` +
+          `  "${prevTag}" (when: ${prevWhen}) >= "${entry.tag}" (when: ${entry.when})\n` +
+          `  Drizzle will silently skip "${entry.tag}". Fix the 'when' values in:\n` +
+          `  ${journalPath}`,
+      );
+    }
+    prevWhen = entry.when;
+    prevTag = entry.tag;
+  }
+}
+
+/**
  * Run Drizzle database migrations.
  */
 export async function runMigrations(databaseUrl: string): Promise<number> {
   const migrationsFolder = resolveMigrationsFolder();
+
+  // Fail fast if journal timestamps are out of order
+  validateJournalOrder(migrationsFolder);
 
   const client = postgres(databaseUrl, { max: 1 });
   const db = drizzle(client);

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -212,8 +212,12 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
     }
   }
 
-  const agentToBootstrap = args.assistant ?? args.id;
-  process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${agentToBootstrap}/agent.yaml\n`);
+  // Token path: human agents are not saved to agents/ (identity-only);
+  // only the assistant (or non-human agent) gets a runtime config.
+  const runtimeAgent = args.type === "human" ? args.assistant : args.id;
+  if (runtimeAgent) {
+    process.stderr.write(`Token saved to ${DEFAULT_HOME_DIR}/config/agents/${runtimeAgent}/agent.yaml\n`);
+  }
 
   // 3. Bind Feishu bot (if requested)
   if (args.feishuBotAppId && args.feishuBotAppSecret) {
@@ -242,7 +246,9 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
   if (args.assistant) {
     process.stderr.write(`  Assistant: ${args.assistant}\n`);
   }
-  process.stderr.write(`  Token:     ${DEFAULT_HOME_DIR}/config/agents/${agentToBootstrap}/agent.yaml\n`);
+  if (runtimeAgent) {
+    process.stderr.write(`  Token:     ${DEFAULT_HOME_DIR}/config/agents/${runtimeAgent}/agent.yaml\n`);
+  }
   if (args.feishuBotAppId) {
     process.stderr.write(`  Feishu:    bot bound (${args.feishuBotAppId})\n`);
   }
@@ -255,7 +261,10 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
     }
   }
 
-  process.stderr.write("\n  Start the agent:\n");
-  process.stderr.write("    first-tree-hub client start\n");
+  // Only show "client start" hint when there's an agent that needs a runtime
+  if (runtimeAgent) {
+    process.stderr.write("\n  Start the agent:\n");
+    process.stderr.write("    first-tree-hub client start\n");
+  }
   process.stderr.write("\n");
 }

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -117,14 +117,14 @@
     {
       "idx": 16,
       "version": "7",
-      "when": 1776160292779,
+      "when": 1776643200000,
       "tag": "0016_strange_havok",
       "breakpoints": true
     },
     {
       "idx": 17,
       "version": "7",
-      "when": 1776309300000,
+      "when": 1776729600000,
       "tag": "0017_session_outputs_unique",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

- **Bug**: Human agents received `runtime: claude-code` in their config, causing `client start` to assign them a Claude Code handler. When a Feishu message triggered an assistant reply, the human agent auto-replied back, creating an infinite reply loop.
- **Root cause**: `bootstrapToken` hardcoded `runtime: claude-code` for all agent types including human.
- **Fix**: Human agents are identity-only — they don't get written to the `agents/` config directory, and `AgentSlot.start()` has a defensive server-type check as a safety net.
- **Bonus**: Fixed Drizzle migration journal timestamp ordering (0016/0017 had non-monotonic `when` values, causing silent migration skips) and added a `validateJournalOrder()` pre-flight check.

## Test plan

- [x] `pnpm check` — lint passes
- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm test` — all tests pass (including new `agent-slot-human.test.ts`)
- [ ] Manual: `onboard --type human --assistant <name>` — verify only assistant config is saved to `agents/`
- [ ] Manual: Send Feishu message → assistant replies → no infinite loop
- [ ] Manual: Existing agent configs with `runtime: claude-code` continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)