### PR TITLE
chore: bump command package version to 0.6.0

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump `@agent-team-foundation/first-tree-hub` CLI package version from 0.5.0 to 0.6.0
- Required for clients to pick up the new multiplexed client connection with application-level heartbeat, fixing the "Agent is unresponsive" false positives

## Test plan
- [ ] `pnpm install` succeeds
- [ ] Publish 0.6.0 to npm
- [ ] Verify client heartbeat works correctly after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)