### PR TITLE
refactor(command): align agent CLI env vars and add FIRST_TREE_HUB_AGENT lookup

### DIFF
--- a/docs/claim-agent-guide.md
+++ b/docs/claim-agent-guide.md
@@ -55,11 +55,13 @@ The response contains a `token` field (format: `aghub_...`). Save it immediately
 ## Step 3 — Set Environment Variables for Debugging / SDK Use
 
 ```bash
-export FIRST_TREE_HUB_TOKEN=aghub_your_token_here
-export FIRST_TREE_HUB_SERVER=http://localhost:8000   # optional, defaults to http://localhost:8000
+export FIRST_TREE_HUB_AGENT_TOKEN=aghub_your_token_here
+export FIRST_TREE_HUB_SERVER_URL=http://localhost:8000   # optional, defaults to http://localhost:8000
 ```
 
 For persistent configuration, add these to your shell profile or `.env` file.
+
+Alternatively, if you have multiple local agents, set `FIRST_TREE_HUB_AGENT=<agentName>` and the CLI will look up the token from `~/.first-tree-hub/agents/<agentName>/agent.yaml`.
 
 ## Step 4 — Verify Your Identity
 
@@ -82,7 +84,7 @@ Expected output:
 
 ```bash
 # Add agent to client config only if bootstrap or onboard has not already done it
-first-tree-hub agent add my-agent --token $FIRST_TREE_HUB_TOKEN
+first-tree-hub agent add my-agent --token $FIRST_TREE_HUB_AGENT_TOKEN
 
 # Configure server URL
 first-tree-hub config set -c server.url http://localhost:8000
@@ -123,8 +125,8 @@ first-tree-hub agent history <chat-id>             # view chat history
 import { FirstTreeHubSDK } from "@agent-team-foundation/first-tree-hub";
 
 const sdk = new FirstTreeHubSDK({
-  serverUrl: process.env.FIRST_TREE_HUB_SERVER ?? "http://localhost:8000",
-  token: process.env.FIRST_TREE_HUB_TOKEN!,
+  serverUrl: process.env.FIRST_TREE_HUB_SERVER_URL ?? "http://localhost:8000",
+  token: process.env.FIRST_TREE_HUB_AGENT_TOKEN!,
 });
 
 // Verify identity
@@ -149,10 +151,10 @@ await sdk.sendToAgent("target-agent-id", {
 
 | Error | Cause | Fix |
 |---|---|---|
-| `MISSING_TOKEN` | `FIRST_TREE_HUB_TOKEN` not set | Set the environment variable |
+| `MISSING_TOKEN` | Neither `FIRST_TREE_HUB_AGENT_TOKEN` nor `FIRST_TREE_HUB_AGENT` set | Set one of the environment variables |
 | `HTTP_401` | Invalid or revoked token | Ask admin to create a new token |
 | `HTTP_403` | Agent suspended or deleted | Check agent status in Admin UI |
-| `CONNECTION_ERROR` | Server unreachable | Verify `FIRST_TREE_HUB_SERVER` URL and server is running |
+| `CONNECTION_ERROR` | Server unreachable | Verify `FIRST_TREE_HUB_SERVER_URL` and server is running |
 
 ## See Also
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -159,7 +159,7 @@ first-tree-hub agent pull
 first-tree-hub agent pull --ack
 ```
 
-Messaging commands require `FIRST_TREE_HUB_TOKEN`. Use `FIRST_TREE_HUB_SERVER` to override the server URL for these low-level agent commands.
+Messaging commands require an agent token (see Agent env vars below). Use `FIRST_TREE_HUB_SERVER_URL` to override the server URL for these low-level agent commands.
 
 ## config
 
@@ -232,14 +232,21 @@ Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also acce
 
 | Variable | Purpose |
 |---------|------|
-| `FIRST_TREE_HUB_TOKEN` | Agent token (required for `agent send/chats/history/register/pull`) |
-| `FIRST_TREE_HUB_SERVER` | Server URL override for messaging commands |
+| `FIRST_TREE_HUB_AGENT_TOKEN` | Agent bearer token. Highest priority. Injected automatically when running inside a Hub agent runtime. |
+| `FIRST_TREE_HUB_AGENT` | Agent name. CLI looks up the token from `~/.first-tree-hub/agents/<name>/agent.yaml`. Used when token is not set explicitly. |
+| `FIRST_TREE_HUB_SERVER_URL` | Server URL override for messaging commands. Falls back to client config. |
+
+Resolution order for the agent token:
+
+1. `FIRST_TREE_HUB_AGENT_TOKEN` — explicit value
+2. `FIRST_TREE_HUB_AGENT` → lookup in `~/.first-tree-hub/agents/<name>/agent.yaml`
+3. Error
 
 ### Onboard
 
 | Variable | Purpose |
 |---------|------|
-| `FIRST_TREE_HUB_SERVER` | Hub server URL alternative to `--server` |
+| `FIRST_TREE_HUB_SERVER_URL` | Hub server URL alternative to `--server` |
 | `FEISHU_APP_ID` | Feishu bot App ID alternative to `--feishu-bot-app-id` |
 | `FEISHU_APP_SECRET` | Feishu bot App Secret alternative to `--feishu-bot-app-secret` |
 

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -128,7 +128,7 @@ When required parameters are missing, the same checklist is shown as an error.
 | Variable | Purpose |
 |----------|---------|
 | `FIRST_TREE_HUB_HOME` | Override config/data home directory (default: `~/.first-tree-hub`) |
-| `FIRST_TREE_HUB_SERVER` | Hub server URL (alternative to `--server`) |
+| `FIRST_TREE_HUB_SERVER_URL` | Hub server URL (alternative to `--server`) |
 | `FEISHU_APP_ID` | Feishu bot App ID (alternative to `--feishu-bot-app-id`) |
 | `FEISHU_APP_SECRET` | Feishu bot App Secret (alternative to `--feishu-bot-app-secret`) |
 

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -189,7 +189,7 @@ You are running inside **Agent Hub**, a messaging platform for agent teams.
 - Each message includes a \`[From: sender-id]\` header so you know who sent it
 - **Your final text response is automatically delivered** to the chat — just respond normally
 - For **proactive communication** (sending to other agents, other chats, or structured data),
-  use the curl API endpoints below
+  use the \`first-tree-hub\` CLI below
 - **Use your judgment about when to respond.** Not every message requires a reply.
   Your role and responsibilities (defined in your profile above) guide your behavior
 
@@ -204,22 +204,29 @@ These are injected automatically when the agent process starts:
 | \`FIRST_TREE_HUB_CHAT_ID\` | Current chat context ID |
 | \`FIRST_TREE_HUB_AGENT_ID\` | Your agent ID |
 
+The \`first-tree-hub\` CLI reads these automatically — no extra setup needed.
+
 ## Sending Messages
 
-Use curl or any HTTP client with the bearer token:
+Use the \`first-tree-hub agent send\` CLI:
 
 \`\`\`bash
-# Reply in current chat
-curl -X POST "$FIRST_TREE_HUB_SERVER_URL/api/v1/agent/chats/$FIRST_TREE_HUB_CHAT_ID/messages" \\
-  -H "Authorization: Bearer $FIRST_TREE_HUB_AGENT_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d '{"format": "text", "content": "your message"}'
+# Send to another agent (target = agent ID)
+first-tree-hub agent send <agentId> "your message"
 
-# Send to another agent directly
-curl -X POST "$FIRST_TREE_HUB_SERVER_URL/api/v1/agent/agents/{agentId}/messages" \\
-  -H "Authorization: Bearer $FIRST_TREE_HUB_AGENT_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d '{"format": "text", "content": "your message"}'
+# Send to a chat (target = chat ID)
+first-tree-hub agent send --chat <chatId> "your message"
+
+# Send markdown (default format is text)
+first-tree-hub agent send <agentId> -f markdown "**bold** message"
+
+# Reply to a specific message
+first-tree-hub agent send <agentId> --reply-to <messageId> "reply content"
+
+# Pipe long content via stdin (recommended for special characters)
+echo "long message body" | first-tree-hub agent send <agentId>
 \`\`\`
+
+For content with quotes, \`$\`, backticks, or newlines, prefer stdin to avoid shell escaping issues.
 `;
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -28,13 +28,16 @@ const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // ── SDK helpers (for send/chats/history/register/pull) ────────────────
 
 function resolveAgentConfig(): { serverUrl: string; token: string } {
-  const token = process.env.FIRST_TREE_HUB_TOKEN;
-  if (!token) {
-    fail("MISSING_TOKEN", "FIRST_TREE_HUB_TOKEN environment variable is required.", 2);
+  let token: string;
+  try {
+    token = resolveAgentToken();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail("MISSING_TOKEN", msg, 2);
   }
   let serverUrl: string;
   try {
-    serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+    serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
   } catch {
     serverUrl = "http://localhost:8000";
   }

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -1,7 +1,8 @@
 import { execSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { DEFAULT_CONFIG_DIR, getClientConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { parse as parseYaml } from "yaml";
 
 const CREDENTIALS_PATH = join(DEFAULT_CONFIG_DIR, "credentials.json");
 
@@ -46,7 +47,7 @@ export function getGitHubToken(): string {
  */
 export function resolveServerUrl(flagValue?: string): string {
   if (flagValue) return flagValue;
-  if (process.env.FIRST_TREE_HUB_SERVER) return process.env.FIRST_TREE_HUB_SERVER;
+  if (process.env.FIRST_TREE_HUB_SERVER_URL) return process.env.FIRST_TREE_HUB_SERVER_URL;
 
   try {
     const config = getClientConfig();
@@ -57,7 +58,7 @@ export function resolveServerUrl(flagValue?: string): string {
 
   throw new Error(
     "Server URL not configured.\n" +
-      "  Provide via: --server <url>, FIRST_TREE_HUB_SERVER env var, or\n" +
+      "  Provide via: --server <url>, FIRST_TREE_HUB_SERVER_URL env var, or\n" +
       "  first-tree-hub config set -c server.url <url>",
   );
 }
@@ -122,15 +123,46 @@ export async function bootstrapToken(
 }
 
 /**
- * Resolve agent token from FIRST_TREE_HUB_TOKEN env var.
- * Throws if not set.
+ * Load an agent's token from `~/.first-tree-hub/agents/<agentName>/agent.yaml`.
+ * Returns null if the file is missing or has no token.
+ */
+export function loadAgentTokenByName(agentName: string): string | null {
+  const configPath = join(DEFAULT_CONFIG_DIR, "agents", agentName, "agent.yaml");
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = parseYaml(readFileSync(configPath, "utf-8")) as { token?: unknown };
+    if (typeof raw.token === "string" && raw.token.length > 0) return raw.token;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve agent token with the following precedence:
+ *   1. FIRST_TREE_HUB_AGENT_TOKEN env var (explicit token; runtime or manual export)
+ *   2. FIRST_TREE_HUB_AGENT env var → lookup in ~/.first-tree-hub/agents/<name>/agent.yaml
+ * Throws if neither is configured or the named agent has no stored token.
  */
 export function resolveAgentToken(): string {
-  const token = process.env.FIRST_TREE_HUB_TOKEN;
-  if (!token) {
-    throw new Error("FIRST_TREE_HUB_TOKEN environment variable is required.");
+  const token = process.env.FIRST_TREE_HUB_AGENT_TOKEN;
+  if (token) return token;
+
+  const agentName = process.env.FIRST_TREE_HUB_AGENT;
+  if (agentName) {
+    const loaded = loadAgentTokenByName(agentName);
+    if (loaded) return loaded;
+    throw new Error(
+      `Agent "${agentName}" has no token in ${join(DEFAULT_CONFIG_DIR, "agents", agentName)}/agent.yaml.\n` +
+        `  Verify the agent exists locally or set FIRST_TREE_HUB_AGENT_TOKEN explicitly.`,
+    );
   }
-  return token;
+
+  throw new Error(
+    "No agent token configured.\n" +
+      "  Set FIRST_TREE_HUB_AGENT_TOKEN directly, or\n" +
+      "  set FIRST_TREE_HUB_AGENT=<agentName> to use a stored agent config.",
+  );
 }
 
 /**

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -9,6 +9,7 @@ export {
   ensureFreshAdminToken,
   getGitHubToken,
   getGitHubUsername,
+  loadAgentTokenByName,
   loadCredentials,
   maskToken,
   resolveAdminToken,

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -117,7 +117,7 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
       key: "server",
       label: "Server URL",
       status: "missing_required",
-      hint: "Provide via --server, FIRST_TREE_HUB_SERVER, or config",
+      hint: "Provide via --server, FIRST_TREE_HUB_SERVER_URL, or config",
     });
   }
 

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -36,6 +36,7 @@ export {
   // Docker PostgreSQL
   isDockerAvailable,
   isInteractive,
+  loadAgentTokenByName,
   onboardCheck,
   onboardCreate,
   printResults,

--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -49,10 +49,9 @@ Keep the central mental model straight: First Tree Hub is the communication back
   - Context Tree integration is optional — when configured, Client injects organizational context into agent workspaces.
 - Respect auth isolation.
   - Admin JWT and agent Bearer token are separate paths.
-  - Messaging and low-level agent commands usually require `FIRST_TREE_HUB_TOKEN`.
+  - Messaging and low-level agent commands require an agent token: either `FIRST_TREE_HUB_AGENT_TOKEN` directly, or `FIRST_TREE_HUB_AGENT=<name>` to look up a token from the local agent config.
 - Keep the server URL knobs straight.
-  - `FIRST_TREE_HUB_SERVER_URL` is the client-config environment variable and is what `client doctor` expects.
-  - `FIRST_TREE_HUB_SERVER` is the direct override for `onboard` and low-level agent debugging commands.
+  - `FIRST_TREE_HUB_SERVER_URL` is the canonical environment variable across client config, agent runtime injection, onboard, and low-level agent debugging commands.
 - Respect config layering.
   - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
 - Distinguish config scopes and paths.

--- a/skills/first-tree-hub-cli/references/command-surface.md
+++ b/skills/first-tree-hub-cli/references/command-surface.md
@@ -12,7 +12,7 @@
 | Manage local config files | `first-tree-hub config ...` | Scope defaults to server unless `-c` or `-a <name>` is passed |
 | Add or remove a local agent config | `first-tree-hub agent add/remove/list` | This is local configuration, not Context Tree identity management |
 | Bootstrap an agent token from GitHub identity | `first-tree-hub agent token bootstrap <agentId>` | Requires `gh` auth and a Hub server that already knows the agent |
-| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_TOKEN`; these are low-level debugging utilities |
+| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_AGENT_TOKEN` (or `FIRST_TREE_HUB_AGENT=<name>` to look up from local config); these are low-level debugging utilities |
 | Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Removes stale workspaces only when there is no active non-evicted session |
 | Onboard a new human or autonomous agent | `first-tree-hub onboard` | Creates a PR in the Context Tree repo, not in `first-tree-hub` itself |
 
@@ -71,7 +71,7 @@
   - Used for Feishu bindings. Read `docs/claim-agent-guide.md` when claim/bind flows matter.
 - `agent send/chats/history/register/pull`
   - These are SDK-style debugging commands.
-  - They require `FIRST_TREE_HUB_TOKEN`.
+  - Auth resolution: `FIRST_TREE_HUB_AGENT_TOKEN` (explicit) → `FIRST_TREE_HUB_AGENT` env var lookup in `~/.first-tree-hub/agents/<name>/agent.yaml`.
   - `send` supports direct target vs `--chat`, stdin piping, and reply metadata.
   - `pull` is the low-level inbox polling path.
 
@@ -144,9 +144,12 @@
 - Client:
   - `FIRST_TREE_HUB_SERVER_URL`
   - `FIRST_TREE_HUB_LOG_LEVEL`
-- Onboard and agent debugging:
-  - `FIRST_TREE_HUB_TOKEN`
-  - `FIRST_TREE_HUB_SERVER`
+- Agent runtime / debugging:
+  - `FIRST_TREE_HUB_AGENT_TOKEN` (explicit token)
+  - `FIRST_TREE_HUB_AGENT` (agent name → looks up token from local config)
+  - `FIRST_TREE_HUB_SERVER_URL`
+- Onboard:
+  - `FIRST_TREE_HUB_SERVER_URL`
   - `FEISHU_APP_ID`
   - `FEISHU_APP_SECRET`
 

--- a/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -230,10 +230,12 @@ Use this when the user wants to verify delivery, inspect chats, or send test mes
 
 ### Recommended flow
 
-1. Make sure agent debug auth is available:
+1. Make sure agent debug auth is available (either set the token directly or point at a stored agent):
 
 ```bash
-export FIRST_TREE_HUB_TOKEN=...
+export FIRST_TREE_HUB_AGENT_TOKEN=...
+# Or, if the agent has a local config:
+export FIRST_TREE_HUB_AGENT=<agentName>
 ```
 
 2. Send a message:


### PR DESCRIPTION
## Summary

- **Breaking**: Renamed CLI env vars to match the canonical names already used by shared client config and the agent runtime injection
  - `FIRST_TREE_HUB_TOKEN` → `FIRST_TREE_HUB_AGENT_TOKEN`
  - `FIRST_TREE_HUB_SERVER` → `FIRST_TREE_HUB_SERVER_URL`
- **New**: `FIRST_TREE_HUB_AGENT` env var lets the CLI look up an agent's token from `~/.first-tree-hub/agents/<name>/agent.yaml`, so humans with multiple local agents don't need to copy-paste tokens
- **UX**: Runtime-generated `tools.md` now documents `first-tree-hub agent send` instead of curl. The CLI works inside agent processes out of the box because the env vars are already injected.
- Bumps `@agent-team-foundation/first-tree-hub` to `0.6.1`

## Why

The CLI used to read `FIRST_TREE_HUB_TOKEN` / `FIRST_TREE_HUB_SERVER`, while the runtime injected `FIRST_TREE_HUB_AGENT_TOKEN` / `FIRST_TREE_HUB_SERVER_URL` into agent processes — the names didn't match, so the CLI couldn't be used from inside an agent without re-exporting env vars. Aligning to the canonical names (`AGENT_TOKEN` matches `ADMIN_TOKEN`; `SERVER_URL` is unambiguous and already in shared config) lets agent processes call `first-tree-hub agent send` directly.

## Token resolution order (CLI)

1. `FIRST_TREE_HUB_AGENT_TOKEN` — explicit token (runtime injection or manual export)
2. `FIRST_TREE_HUB_AGENT` → `~/.first-tree-hub/agents/<name>/agent.yaml`
3. Error

## Migration

Existing users with `FIRST_TREE_HUB_TOKEN` / `FIRST_TREE_HUB_SERVER` set in their shell rc need to rename them:

```bash
export FIRST_TREE_HUB_AGENT_TOKEN=...   # was FIRST_TREE_HUB_TOKEN
export FIRST_TREE_HUB_SERVER_URL=...    # was FIRST_TREE_HUB_SERVER
```

Or, if the agent has a local config under `~/.first-tree-hub/agents/<name>/`, just set:

```bash
export FIRST_TREE_HUB_AGENT=<name>
```

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (298 tests)
- [ ] Verify `first-tree-hub agent send` works inside an agent process (smoke test)
- [ ] Verify `FIRST_TREE_HUB_AGENT=<name>` resolves token from local config

🤖 Generated with [Claude Code](https://claude.com/claude-code)