### PR TITLE
fix(command): agent send silently connects to localhost instead of configured server

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/resolve-server-url.test.ts
+++ b/packages/command/src/__tests__/resolve-server-url.test.ts
@@ -26,9 +26,9 @@ describe("resolveServerUrl without prior initConfig", () => {
     mkdirSync(join(testHome, "config"), { recursive: true });
 
     originalHome = process.env.FIRST_TREE_HUB_HOME;
-    originalServerUrl = process.env.FIRST_TREE_HUB_SERVER;
+    originalServerUrl = process.env.FIRST_TREE_HUB_SERVER_URL;
     process.env.FIRST_TREE_HUB_HOME = testHome;
-    delete process.env.FIRST_TREE_HUB_SERVER;
+    delete process.env.FIRST_TREE_HUB_SERVER_URL;
 
     // Force module-level constants (DEFAULT_HOME_DIR / DEFAULT_CONFIG_DIR) to
     // be re-evaluated from the updated env in the dynamic import below.
@@ -41,8 +41,8 @@ describe("resolveServerUrl without prior initConfig", () => {
     if (originalHome === undefined) delete process.env.FIRST_TREE_HUB_HOME;
     else process.env.FIRST_TREE_HUB_HOME = originalHome;
 
-    if (originalServerUrl === undefined) delete process.env.FIRST_TREE_HUB_SERVER;
-    else process.env.FIRST_TREE_HUB_SERVER = originalServerUrl;
+    if (originalServerUrl === undefined) delete process.env.FIRST_TREE_HUB_SERVER_URL;
+    else process.env.FIRST_TREE_HUB_SERVER_URL = originalServerUrl;
   });
 
   it("returns server.url from client.yaml when initConfig was never called", async () => {
@@ -62,9 +62,9 @@ describe("resolveServerUrl without prior initConfig", () => {
     expect(resolveServerUrl("https://flag.example.com")).toBe("https://flag.example.com");
   });
 
-  it("prefers FIRST_TREE_HUB_SERVER env var over yaml", async () => {
+  it("prefers FIRST_TREE_HUB_SERVER_URL env var over yaml", async () => {
     writeFileSync(join(testHome, "config", "client.yaml"), "server:\n  url: https://yaml.example.com\n");
-    process.env.FIRST_TREE_HUB_SERVER = "https://env.example.com";
+    process.env.FIRST_TREE_HUB_SERVER_URL = "https://env.example.com";
 
     const { resolveServerUrl } = await import("../core/bootstrap.js");
     expect(resolveServerUrl()).toBe("https://env.example.com");

--- a/packages/command/src/__tests__/resolve-server-url.test.ts
+++ b/packages/command/src/__tests__/resolve-server-url.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for the CLI's `agent send` (and any other SDK-using command)
+ * silently falling back to http://localhost:8000 when client.yaml points elsewhere.
+ *
+ * Root cause: resolveServerUrl() internally calls getClientConfig(), which reads
+ * a singleton that is only populated by initConfig(). The `agent` subcommand
+ * never calls initConfig, so getClientConfig() throws "Config not initialized",
+ * and the catch in agent.ts defaults to http://localhost:8000 — diverging from
+ * doctor/status which use resolveConfigReadonly and work correctly.
+ *
+ * Fix: resolveServerUrl should read the yaml via resolveConfigReadonly (no
+ * singleton dependency), same as doctor/status.
+ */
+describe("resolveServerUrl without prior initConfig", () => {
+  let testHome: string;
+  let originalHome: string | undefined;
+  let originalServerUrl: string | undefined;
+
+  beforeEach(() => {
+    testHome = join(tmpdir(), `ft-hub-resolve-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(testHome, "config"), { recursive: true });
+
+    originalHome = process.env.FIRST_TREE_HUB_HOME;
+    originalServerUrl = process.env.FIRST_TREE_HUB_SERVER;
+    process.env.FIRST_TREE_HUB_HOME = testHome;
+    delete process.env.FIRST_TREE_HUB_SERVER;
+
+    // Force module-level constants (DEFAULT_HOME_DIR / DEFAULT_CONFIG_DIR) to
+    // be re-evaluated from the updated env in the dynamic import below.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });
+
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HUB_HOME;
+    else process.env.FIRST_TREE_HUB_HOME = originalHome;
+
+    if (originalServerUrl === undefined) delete process.env.FIRST_TREE_HUB_SERVER;
+    else process.env.FIRST_TREE_HUB_SERVER = originalServerUrl;
+  });
+
+  it("returns server.url from client.yaml when initConfig was never called", async () => {
+    writeFileSync(join(testHome, "config", "client.yaml"), "server:\n  url: https://test-staging.example.com\n");
+
+    const { resolveServerUrl } = await import("../core/bootstrap.js");
+
+    // Before the fix this throws "Config not initialized. Call initConfig() first."
+    // After the fix it should return the URL from the yaml file.
+    expect(resolveServerUrl()).toBe("https://test-staging.example.com");
+  });
+
+  it("prefers flag argument over yaml", async () => {
+    writeFileSync(join(testHome, "config", "client.yaml"), "server:\n  url: https://yaml.example.com\n");
+
+    const { resolveServerUrl } = await import("../core/bootstrap.js");
+    expect(resolveServerUrl("https://flag.example.com")).toBe("https://flag.example.com");
+  });
+
+  it("prefers FIRST_TREE_HUB_SERVER env var over yaml", async () => {
+    writeFileSync(join(testHome, "config", "client.yaml"), "server:\n  url: https://yaml.example.com\n");
+    process.env.FIRST_TREE_HUB_SERVER = "https://env.example.com";
+
+    const { resolveServerUrl } = await import("../core/bootstrap.js");
+    expect(resolveServerUrl()).toBe("https://env.example.com");
+  });
+
+  it("throws a clear error when neither env, flag, nor yaml provides a URL", async () => {
+    // No client.yaml written — directory is empty.
+    const { resolveServerUrl } = await import("../core/bootstrap.js");
+
+    expect(() => resolveServerUrl()).toThrow(/Server URL not configured/);
+  });
+
+  it("throws a clear error when yaml exists but server.url is absent", async () => {
+    // yaml file is well-formed but missing the server.url field — must not
+    // silently return undefined or fall through to a default.
+    writeFileSync(join(testHome, "config", "client.yaml"), "logLevel: info\nserver: {}\n");
+
+    const { resolveServerUrl } = await import("../core/bootstrap.js");
+    expect(() => resolveServerUrl()).toThrow(/Server URL not configured/);
+  });
+});

--- a/packages/command/src/commands/agent-config.ts
+++ b/packages/command/src/commands/agent-config.ts
@@ -101,7 +101,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .command("get <agent>")
     .description("Print the current runtime config for an agent")
     .action(async (agentName: string) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       const cfg = await getCurrent(serverUrl, adminToken, uuid);
@@ -112,7 +112,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .command("set-model <agent> <model>")
     .description("Replace the model field (e.g. claude-opus-4-6)")
     .action(async (agentName: string, model: string) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       const current = await getCurrent(serverUrl, adminToken, uuid);
@@ -125,7 +125,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .description("Replace the systemPrompt append text — reads from -f file or stdin")
     .option("-f, --file <path>", "Read prompt text from this file")
     .action(async (agentName: string, opts: { file?: string }) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       let text: string;
@@ -161,7 +161,7 @@ export function registerAgentConfigCommands(parent: Command): void {
         agentName: string,
         opts: { name: string; transport: string; command?: string; args?: string[]; url?: string },
       ) => {
-        const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+        const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
         const adminToken = await ensureFreshAdminToken();
         const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
         const current = await getCurrent(serverUrl, adminToken, uuid);
@@ -190,7 +190,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .description("Set an env variable: KEY=VALUE. Use --sensitive for secrets.")
     .option("--sensitive", "Mark this value as sensitive (encrypted at rest, masked in echo)")
     .action(async (agentName: string, kv: string, opts: { sensitive?: boolean }) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       const eqIdx = kv.indexOf("=");
@@ -211,7 +211,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .option("--ref <ref>", "branch / tag / commit (defaults to repo HEAD)")
     .option("--path <path>", "local path relative to session cwd")
     .action(async (agentName: string, url: string, opts: { ref?: string; path?: string }) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       const current = await getCurrent(serverUrl, adminToken, uuid);
@@ -227,7 +227,7 @@ export function registerAgentConfigCommands(parent: Command): void {
     .description("Validate a JSON patch and print the diff without persisting")
     .requiredOption("-f, --file <path>", "JSON file with the partial payload to apply")
     .action(async (agentName: string, opts: { file: string }) => {
-      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();
       const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
       const patch = JSON.parse(readFileSync(opts.file, "utf-8")) as Partial<AgentRuntimeConfigPayload>;

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -60,7 +60,7 @@ function resolveLocalAgent(agentName?: string): ResolvedAgentConfig {
 
   let serverUrl: string;
   try {
-    serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
+    serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     fail("MISSING_SERVER_URL", msg, 2);

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -61,8 +61,9 @@ function resolveLocalAgent(agentName?: string): ResolvedAgentConfig {
   let serverUrl: string;
   try {
     serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER);
-  } catch {
-    serverUrl = "http://localhost:8000";
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail("MISSING_SERVER_URL", msg, 2);
   }
 
   return { serverUrl, agentId: cfg.agentId };

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -1,6 +1,10 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { DEFAULT_CONFIG_DIR, getClientConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import {
+  clientConfigSchema,
+  DEFAULT_CONFIG_DIR,
+  resolveConfigReadonly,
+} from "@agent-team-foundation/first-tree-hub-shared/config";
 
 const CREDENTIALS_PATH = join(DEFAULT_CONFIG_DIR, "credentials.json");
 
@@ -12,16 +16,19 @@ type StoredCredentials = {
 
 /**
  * Resolve Hub server URL from flag, env, or config.
+ *
+ * Uses resolveConfigReadonly (not the singleton getClientConfig) so CLI entry
+ * points don't have to remember to call initConfig() first.
  */
 export function resolveServerUrl(flagValue?: string): string {
   if (flagValue) return flagValue;
   if (process.env.FIRST_TREE_HUB_SERVER) return process.env.FIRST_TREE_HUB_SERVER;
 
-  try {
-    const config = getClientConfig();
-    if (config.server?.url) return config.server.url;
-  } catch {
-    // Config not available
+  const config = resolveConfigReadonly({ schema: clientConfigSchema, role: "client" });
+  const server = config.server;
+  if (server !== null && typeof server === "object") {
+    const url = Reflect.get(server, "url");
+    if (typeof url === "string" && url.length > 0) return url;
   }
 
   throw new Error(

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -22,7 +22,7 @@ type StoredCredentials = {
  */
 export function resolveServerUrl(flagValue?: string): string {
   if (flagValue) return flagValue;
-  if (process.env.FIRST_TREE_HUB_SERVER) return process.env.FIRST_TREE_HUB_SERVER;
+  if (process.env.FIRST_TREE_HUB_SERVER_URL) return process.env.FIRST_TREE_HUB_SERVER_URL;
 
   const config = resolveConfigReadonly({ schema: clientConfigSchema, role: "client" });
   const server = config.server;
@@ -33,7 +33,7 @@ export function resolveServerUrl(flagValue?: string): string {
 
   throw new Error(
     "Server URL not configured.\n" +
-      "  Provide via: --server <url>, FIRST_TREE_HUB_SERVER env var, or\n" +
+      "  Provide via: --server <url>, FIRST_TREE_HUB_SERVER_URL env var, or\n" +
       "  first-tree-hub config set -c server.url <url>",
   );
 }


### PR DESCRIPTION
## Summary

- `first-tree-hub agent send` (and every SDK-using `agent` subcommand) was ignoring `client.yaml` and connecting to `http://localhost:8000` regardless of user config. The divergence was silent — `status` / `doctor` showed the correct staging URL, but `send` went elsewhere.
- Root cause: `resolveServerUrl()` read from the shared-config **singleton** (`getClientConfig()`), which requires `initConfig()` to have run. The `agent` command group never calls `initConfig`, so the singleton throws "Config not initialized" — swallowed by two layers of silent `try/catch` that ultimately defaulted to `localhost:8000`.
- Fix: switch `resolveServerUrl` to `resolveConfigReadonly` (no singleton dependency, matching `doctor` / `status`) and remove both silent catches so genuine misconfig is loud.

## Why local dev didn't catch this

Local dev environments typically have `client.yaml` pointing at `http://localhost:8000` already — which happens to match the hard-coded fallback. So the two branches (correct read vs. silent fallback) produce identical results and the bug is invisible. It only surfaces when `client.yaml` points at a remote server (e.g. staging).

## Test plan

- [x] New unit tests in `packages/command/src/__tests__/resolve-server-url.test.ts`:
  - [x] Returns `server.url` from `client.yaml` when `initConfig` was never called (the actual bug)
  - [x] `--server` flag argument takes precedence over yaml
  - [x] `FIRST_TREE_HUB_SERVER_URL` env var takes precedence over yaml
  - [x] Throws a clear error when no source provides a URL
  - [x] Throws a clear error when yaml is present but `server.url` field is missing
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` — 8/8 pass
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub typecheck` — clean
- [x] `biome check` on changed files — clean
- [ ] Manual: `first-tree-hub agent send <target> "hi"` with `client.yaml` pointing at staging — connects to staging (not localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)