### PR TITLE
fix(server): allow agents.client_id NULL until first WS bind

### DIFF
--- a/packages/command/src/commands/onboard.ts
+++ b/packages/command/src/commands/onboard.ts
@@ -39,11 +39,11 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
     saveOnboardState(args);
   }
 
-  if (args.type !== "human" && !args.clientId) {
+  if (args.type !== "human" && args.clientId === undefined) {
     args.clientId = await input({
-      message: "Client ID (machine that will run this agent — must be owned by you):",
-      validate: (v) => (v.length > 0 ? true : "clientId is required for non-human agents"),
+      message: "Client ID (Enter to leave unbound — first WS connect will claim it):",
     });
+    if (!args.clientId) args.clientId = undefined;
     saveOnboardState(args);
   }
 
@@ -78,11 +78,11 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
         message: "Assistant ID:",
         default: `${args.id as string}-assistant`,
       });
-      if (!args.clientId) {
-        args.clientId = await input({
-          message: "Client ID for the assistant (must be owned by you):",
-          validate: (v) => (v.length > 0 ? true : "clientId is required"),
+      if (args.clientId === undefined) {
+        const v = await input({
+          message: "Client ID for the assistant (Enter to leave unbound):",
         });
+        args.clientId = v || undefined;
       }
       saveOnboardState(args);
     }

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -107,13 +107,17 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
     items.push({ key: "type", label: "Agent type", status: "missing_required", hint: "Provide via --type" });
   }
 
-  if (args.type && args.type !== "human" && !args.clientId) {
-    items.push({
-      key: "client",
-      label: "Target client",
-      status: "missing_required",
-      hint: "Non-human agents must pin a client via --client-id <id>",
-    });
+  if (args.type && args.type !== "human") {
+    if (args.clientId) {
+      items.push({ key: "client", label: "Target client", status: "ok", value: args.clientId });
+    } else {
+      items.push({
+        key: "client",
+        label: "Target client",
+        status: "ok",
+        value: "(unbound — claimed on first WS connect)",
+      });
+    }
   }
 
   return items;

--- a/packages/server/drizzle/0020_unified_user_token.sql
+++ b/packages/server/drizzle/0020_unified_user_token.sql
@@ -6,9 +6,14 @@
 --   1. Drop `agent_tokens` (table + FK cascade).
 --   2. Add `clients.user_id` (nullable) — owning user of the physical client.
 --   3. Add `agents.client_id` (nullable FK) — pin an agent to the client that
---      runs it. `client_id` is backfilled from `agent_presence` and is
---      required for every non-human agent (enforced in the service layer per
---      CLAUDE.md "integrity in service layer"; no DB CHECK/trigger).
+--      runs it. `client_id` is backfilled from `agent_presence`. Rows that
+--      cannot be backfilled stay NULL and bind on first WS connect (see
+--      `api/agent/ws-client.ts` first-bind path). Originally this migration
+--      raised an exception when any non-human agent was unbacked — that
+--      gated startup on a data state the operator usually can't fix until
+--      the server is up. Relaxed to NOTICE so the loop is broken; runtime
+--      enforcement (Rule R-RUN in `services/agent.ts` + `agent-selector.ts`)
+--      still rejects unclaimed agents on the request path.
 --   4. Make `agents.manager_id` NOT NULL after backfilling the first admin
 --      member of each org onto the unmanaged rows.
 --
@@ -53,11 +58,11 @@ WHERE ap."agent_id" = a."uuid"
   AND a."client_id" IS NULL;
 --> statement-breakpoint
 
--- Fail loudly if any non-deleted non-human agent is missing a client_id.
--- These rows would pass migration but surface at runtime as `WRONG_CLIENT` /
--- `assertClientOwner` 404 — which looks like "installed but broken" to the
--- operator. Admins must either soft-delete the orphans or re-register their
--- client via `first-tree-hub connect` and manually UPDATE before retrying.
+-- Surface (do not block) any non-deleted non-human agent still missing a
+-- client_id after the backfill. They will sit in an "unclaimed" state until
+-- a client connects via WS and the first-bind path in
+-- `api/agent/ws-client.ts` claims them. Runtime guards reject HTTP / WS
+-- requests for those agents in the meantime.
 DO $$
 DECLARE
   unpinned_count integer;
@@ -69,10 +74,9 @@ BEGIN
     AND "status" <> 'deleted';
 
   IF unpinned_count > 0 THEN
-    RAISE EXCEPTION
+    RAISE NOTICE
       'unified-user-token migration: % non-human agents have no client_id after backfill; '
-      're-register their client via `first-tree-hub connect` (which will update agent_presence) '
-      'or soft-delete the orphan agents, then retry',
+      'they will be claimed on first WS bind (see ws-client.ts first-bind path)',
       unpinned_count;
   END IF;
 END $$;

--- a/packages/server/src/__tests__/agent-client-immutable.test.ts
+++ b/packages/server/src/__tests__/agent-client-immutable.test.ts
@@ -1,16 +1,18 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 /**
- * Unified-user-token T6 (proposal M7 / Q4): `agents.client_id` is immutable
- * once set. PATCH /admin/agents/:uuid { clientId } must reject with 400 so
- * operators are told the field cannot move, instead of silently dropping the
- * field (the schema-only approach).
+ * `agents.client_id` is one-shot:
+ *   - NULL → ID is allowed (admin claims an unbound agent for a known client).
+ *   - ID → another ID is rejected (would orphan the running runtime).
+ *   - ID → null is rejected (no point exposing an unbind path).
  */
-describe("PATCH /admin/agents/:uuid { clientId } — immutable", () => {
+describe("PATCH /admin/agents/:uuid { clientId } — one-shot", () => {
   const getApp = useTestApp();
 
-  it("returns 400 when clientId is present in the body", async () => {
+  it("returns 400 when changing an already-set clientId", async () => {
     const app = getApp();
     const { agent, accessToken } = await createTestAgent(app, { name: `imm-${Date.now()}` });
 
@@ -23,6 +25,38 @@ describe("PATCH /admin/agents/:uuid { clientId } — immutable", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json<{ error: string }>().error).toMatch(/immutable/i);
+  });
+
+  it("returns 400 when clearing clientId to null", async () => {
+    const app = getApp();
+    const { agent, accessToken } = await createTestAgent(app, { name: `clr-${Date.now()}` });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/agents/${agent.uuid}`,
+      headers: { Authorization: `Bearer ${accessToken}` },
+      payload: { clientId: null },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/cannot be cleared/i);
+  });
+
+  it("accepts NULL → ID first-set when the client is owned by the manager", async () => {
+    const app = getApp();
+    const { agent, accessToken, clientId } = await createTestAgent(app, { name: `set-${Date.now()}` });
+    // Detach the agent so the row matches the post-migration "unclaimed" shape.
+    await app.db.update(agents).set({ clientId: null }).where(eq(agents.uuid, agent.uuid));
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/agents/${agent.uuid}`,
+      headers: { Authorization: `Bearer ${accessToken}` },
+      payload: { clientId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ clientId: string }>().clientId).toBe(clientId);
   });
 
   it("still accepts legitimate updates (e.g. displayName) without side-effects on clientId", async () => {

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -9,7 +9,7 @@ import {
   WS_AUTH_FRAME_TIMEOUT_MS,
   wsAuthFrameSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { jwtVerify } from "jose";
 import type { WebSocket } from "ws";
@@ -237,9 +237,11 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 status: agents.status,
                 clientId: agents.clientId,
                 clientUserId: clients.userId,
+                managerUserId: members.userId,
               })
               .from(agents)
               .leftJoin(clients, eq(agents.clientId, clients.id))
+              .leftJoin(members, eq(agents.managerId, members.id))
               .where(and(eq(agents.uuid, bindRequest.agentId)))
               .limit(1);
 
@@ -255,11 +257,31 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.AGENT_SUSPENDED);
               return;
             }
-            if (!agent.clientId || agent.clientId !== clientId) {
+
+            // First-bind path: agent.clientId is NULL (e.g. created before
+            // the operator brought up a client, or migrated from pre-M1 with
+            // no presence record). Claim it for the connecting client iff
+            // the manager and the connecting session belong to the same
+            // user. The race-safe UPDATE returns 0 rows if another bind
+            // claimed it first — surface as WRONG_CLIENT.
+            if (agent.clientId === null) {
+              if (!agent.managerUserId || agent.managerUserId !== session.userId) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
+                return;
+              }
+              const claim = await app.db
+                .update(agents)
+                .set({ clientId, updatedAt: new Date() })
+                .where(and(eq(agents.uuid, agent.id), isNull(agents.clientId)))
+                .returning({ uuid: agents.uuid });
+              if (claim.length === 0) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
+                return;
+              }
+            } else if (agent.clientId !== clientId) {
               sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
               return;
-            }
-            if (!agent.clientUserId || agent.clientUserId !== session.userId) {
+            } else if (!agent.clientUserId || agent.clientUserId !== session.userId) {
               sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
               return;
             }

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -48,11 +48,13 @@ function defaultVisibility(type: AgentType): AgentVisibility {
 /**
  * Resolve + validate the client that will own the new agent.
  *
- * Rule (unified-user-token M1):
- *   - Non-human agents MUST pin a client at creation time. The pinned client
- *     must belong to the manager's user (Rule R-RUN upstream).
- *   - Human agents represent the member themselves and have no runtime, so a
- *     missing `clientId` is allowed and the column stays NULL.
+ * Rule (unified-user-token, post-first-bind relaxation):
+ *   - Human agents represent the member themselves and have no runtime; a
+ *     missing `clientId` is required and the column stays NULL.
+ *   - Non-human agents MAY omit `clientId` at creation; the row stays NULL
+ *     and is claimed on the first WS bind (see `api/agent/ws-client.ts`).
+ *   - When a non-human agent IS created with a `clientId`, the pinned client
+ *     must already be owned by the manager's user (Rule R-RUN).
  */
 async function resolveAgentClient(
   db: Database,
@@ -66,10 +68,7 @@ async function resolveAgentClient(
   }
 
   if (!data.clientId) {
-    throw new BadRequestError(
-      "clientId is required — every non-human agent must be pinned to a client at creation time. " +
-        "Run `first-tree-hub connect` on the target machine first.",
-    );
+    return null;
   }
 
   const [manager] = await db
@@ -334,16 +333,21 @@ export async function listAgentsForMember(
 }
 
 export async function updateAgent(db: Database, uuid: string, data: UpdateAgent) {
-  // `clientId` is immutable post-creation in this milestone (unified-user-token
-  // M7). The schema tolerates the field so we can 400 explicitly instead of
-  // silently dropping a caller's update.
-  if (data.clientId !== undefined) {
-    throw new BadRequestError(
-      "clientId is immutable in this milestone — delete and re-create the agent on the target client to move it",
-    );
-  }
-
   const agent = await getAgent(db, uuid);
+
+  // `clientId` is one-shot: NULL → ID is allowed (admin claiming an unbound
+  // agent for a known client). ID → null and ID → another ID are not —
+  // moving a running agent requires delete + recreate.
+  if (data.clientId !== undefined) {
+    if (data.clientId === null) {
+      throw new BadRequestError("clientId cannot be cleared — once bound, an agent stays bound to its client");
+    }
+    if (agent.clientId !== null && agent.clientId !== data.clientId) {
+      throw new BadRequestError(
+        "clientId is immutable once set — delete and re-create the agent on the target client to move it",
+      );
+    }
+  }
 
   const updates: Partial<typeof agents.$inferInsert> = { updatedAt: new Date() };
   if (data.type !== undefined) updates.type = data.type;
@@ -368,6 +372,20 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
       throw new BadRequestError("Manager must belong to the same organization as the agent");
     }
     updates.managerId = data.managerId;
+  }
+
+  // First-set clientId (NULL → ID): validate ownership against the agent's
+  // current manager. Reuses the resolveAgentClient ownership check so the
+  // semantics match agent creation.
+  if (data.clientId !== undefined && data.clientId !== null && agent.clientId === null) {
+    const resolvedClientId = await resolveAgentClient(db, {
+      clientId: data.clientId,
+      managerId: updates.managerId ?? agent.managerId,
+      type: agent.type,
+    });
+    if (resolvedClientId !== null) {
+      updates.clientId = resolvedClientId;
+    }
   }
 
   const [updated] = await db.update(agents).set(updates).where(eq(agents.uuid, agent.uuid)).returning();

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -54,9 +54,9 @@ export const createAgentSchema = z.object({
   /** Member who manages this agent */
   managerId: z.string().optional(),
   /**
-   * Physical client this agent is pinned to. REQUIRED for non-human agents —
-   * the pinned client is the only one authorised to run the agent (Rule R-RUN).
-   * Human agents (no runtime) may omit it.
+   * Physical client this agent is pinned to. Optional — when omitted for a
+   * non-human agent the row stays NULL and is claimed on the first WS bind
+   * (see `api/agent/ws-client.ts`). Human agents must omit it.
    */
   clientId: z.string().min(1).max(100).optional(),
 });
@@ -71,12 +71,11 @@ export const updateAgentSchema = z.object({
   /** Admin-only: reassign the manager */
   managerId: z.string().nullable().optional(),
   /**
-   * Present only so the API returns an explicit 400 when a caller tries to
-   * move a pinned agent. `clientId` is immutable post-creation in this
-   * milestone (unified-user-token M7 / Q4). The service layer inspects this
-   * field and rejects; it is never written to the DB.
+   * One-shot bind. NULL → ID is allowed (admin claims an unbound agent for
+   * a known client); ID → another ID and ID → null are rejected by the
+   * service layer with explicit 400s.
    */
-  clientId: z.string().optional(),
+  clientId: z.string().min(1).max(100).nullable().optional(),
 });
 export type UpdateAgent = z.infer<typeof updateAgentSchema>;
 


### PR DESCRIPTION
## Why

PR #97 fixed the transaction boundary in migration 0020, exposing the next blocker:
the migration's `RAISE EXCEPTION` (lines 56-79) gates startup on every non-human
agent already having `client_id` set. Real staging data had 10 unbound agents
(`agent_presence.client_id IS NULL`), so the migration aborted, the process
exited, the orchestrator restarted — restart loop continued.

The original contract — "every non-human agent must pin a client at create time" —
is wrong for the actual operator workflow: an agent is created in admin UI / CLI,
then a runtime is brought up later with `first-tree-hub connect`. Forcing the pin
upfront made the system unrunnable on common data shapes.

## What

Shift the contract from **"must pin at create"** to **"claim on first WS bind"**.

| Layer | Change |
|---|---|
| `drizzle/0020_unified_user_token.sql` | `RAISE EXCEPTION` → `RAISE NOTICE` for the unpinned check. Manager check (4c) intentionally untouched. |
| `services/agent.ts:resolveAgentClient` | Drop hard error when `clientId` omitted for non-human agents — return null. Ownership checks still run when `clientId` IS provided. |
| `services/agent.ts:updateAgent` | `clientId` is now **one-shot**: `NULL → ID` accepted, `ID → other ID` and `ID → null` rejected with explicit 400s. |
| `api/agent/ws-client.ts` | New **first-bind** path: when `agent.clientId IS NULL` on `agent:bind`, validate `manager.userId == session.userId`, then race-safe `UPDATE ... WHERE clientId IS NULL`. Lost race → `WRONG_CLIENT`. |
| `shared/schemas/agent.ts` | `updateAgentSchema.clientId` accepts nullable so service layer returns the explicit error (not Zod's generic "Validation error"). |
| `command/onboard.ts` | Drop the `missing_required` prompt for `clientId`; CLI lets you leave it blank. |
| `__tests__/agent-client-immutable.test.ts` | Renamed conceptually to "one-shot": keep `ID→ID` reject, add `ID→null` reject, add `NULL→ID` accept. |

## Migration safety

0020 was audited statement-by-statement against three states (never run / partially run / already run); all DDL is idempotent (`IF [NOT] EXISTS`, `SET NOT NULL` is no-op when already NOT NULL on PG ≥11, `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT`). The new `RAISE NOTICE` won't abort. drizzle treats this as a new hash → re-runs on every environment, all paths converge.

**Out of scope**: The `manager_id` `RAISE EXCEPTION` (4c at lines 119-134) is preserved. If a staging org has agents with no admin member, that block can still abort. **Operator must run the pre-deploy SQL in the test plan to verify.**

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — clean across all 9 packages
- [x] `pnpm test` — 291/291 tests pass (including 3 new one-shot scenarios + 4 existing R-RUN HTTP middleware tests)
- [ ] **Pre-deploy SQL** on staging — verify no manager_id orphans:
  ```sql
  WITH human_fixable AS (
    SELECT a.uuid FROM agents a JOIN members m ON m.agent_id = a.uuid
     WHERE a.manager_id IS NULL AND a.type = 'human' AND a.status <> 'deleted'
  ), nonhuman_fixable AS (
    SELECT DISTINCT a.uuid FROM agents a
      JOIN members m ON m.organization_id = a.organization_id AND m.role = 'admin'
     WHERE a.manager_id IS NULL AND a.type <> 'human' AND a.status <> 'deleted'
  )
  SELECT COUNT(*) AS will_orphan_after_4b
    FROM agents
   WHERE manager_id IS NULL AND status <> 'deleted'
     AND uuid NOT IN (SELECT uuid FROM human_fixable UNION SELECT uuid FROM nonhuman_fixable);
  ```
  Result must be 0 before deploy.
- [ ] Deploy to staging and confirm: server starts past migrations; the 10 known orphan agents stay in `client_id IS NULL` state; first `first-tree-hub connect` from any of those agent's machines auto-claims the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)