### PR TITLE
fix(command): persist client.id and nest connect under client

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,7 +87,11 @@ first-tree-hub server admin:create -u admin -p mypassword
 Client runtime — connects all configured agents to the server.
 
 ```bash
-# Start all configured agents
+# First-time setup: authenticate and start (use the command shown in the web
+# "Connect a machine" dialog, which includes a one-time token)
+first-tree-hub client connect <server-url> --token <token>
+
+# Start all configured agents (uses saved credentials)
 first-tree-hub client start
 
 # Check environment readiness

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -43,7 +43,7 @@ function warnLegacyFields(agentName: string, raw: unknown): void {
   if (warnedAgents.has(agentName) || typeof raw !== "object" || raw === null) return;
   const r = raw as Record<string, unknown>;
   const legacy: string[] = [];
-  if ("token" in r) legacy.push("token (removed — authenticate via `first-tree-hub connect`)");
+  if ("token" in r) legacy.push("token (removed — authenticate via `first-tree-hub client connect`)");
   if ("concurrency" in r) legacy.push("concurrency");
   if (r.session) {
     const parsed = legacySessionConfigShape.safeParse(r.session);

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -5,7 +5,6 @@ import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent.js";
 import { registerClientCommands } from "../commands/client.js";
 import { registerConfigCommands } from "../commands/config.js";
-import { registerConnectCommand } from "../commands/connect.js";
 import { registerOnboardCommand } from "../commands/onboard.js";
 import { registerServerCommands } from "../commands/server.js";
 import { registerStatusCommand } from "../commands/status.js";
@@ -20,7 +19,7 @@ program
   .description("First Tree Hub — centralized collaboration platform for agent teams")
   .version(version);
 
-// Core subsystems
+// Core subsystems — `client` group mounts `connect` too.
 registerServerCommands(program);
 registerClientCommands(program);
 
@@ -32,9 +31,6 @@ registerConfigCommands(program);
 
 // Global status overview
 registerStatusCommand(program);
-
-// Connect (first-time setup)
-registerConnectCommand(program);
 
 // Onboarding
 registerOnboardCommand(program);

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -227,7 +227,7 @@ export function registerAgentCommands(program: Command): void {
     .requiredOption("--type <type>", "Agent type (human, personal_assistant, autonomous_agent)")
     .requiredOption(
       "--client-id <id>",
-      "Client (machine) that will run this agent — must be owned by you. Run `first-tree-hub connect` on that machine first.",
+      "Client (machine) that will run this agent — must be owned by you. Run `first-tree-hub client connect` on that machine first.",
     )
     .option("--runtime <runtime>", "Runtime handler (default: claude-code)", "claude-code")
     .option("--display-name <name>", "Display name")

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -22,9 +22,15 @@ import {
   promptMissingFields,
   resolveServerUrl,
 } from "../core/index.js";
+import { registerConnectCommand } from "./connect.js";
 
 export function registerClientCommands(program: Command): void {
   const client = program.command("client").description("Client runtime — connect agents to the server");
+
+  // `client connect` — first-time setup: configure server URL, authenticate,
+  // and start the runtime. Registered here so all machine-level commands live
+  // under a single `client` subcommand group.
+  registerConnectCommand(client);
 
   client
     .command("start")
@@ -48,9 +54,9 @@ export function registerClientCommands(program: Command): void {
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
-        process.stderr.write(`\n  Connecting to ${config.server.url}...\n`);
+        process.stderr.write(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
 
-        const runtime = new ClientRuntime(config.server.url);
+        const runtime = new ClientRuntime(config.server.url, config.client.id);
         for (const [name, agentConfig] of agents) {
           runtime.addAgent(name, agentConfig);
         }

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -60,8 +60,8 @@ async function authenticateInteractive(url: string): Promise<{ accessToken: stri
   return (await loginRes.json()) as { accessToken: string; refreshToken: string };
 }
 
-export function registerConnectCommand(program: Command): void {
-  program
+export function registerConnectCommand(parent: Command): void {
+  parent
     .command("connect <server-url>")
     .description("Connect to a Hub server — configure, authenticate, and start client")
     .option("--token <token>", "Connect token (from Hub web console) — skips interactive login")
@@ -94,9 +94,9 @@ export function registerConnectCommand(program: Command): void {
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
-        process.stderr.write(`\n  Starting client...\n`);
+        process.stderr.write(`\n  Starting client (id: ${config.client.id})...\n`);
 
-        const runtime = new ClientRuntime(config.server.url);
+        const runtime = new ClientRuntime(config.server.url, config.client.id);
         for (const [name, agentConfig] of agents) {
           runtime.addAgent(name, agentConfig);
         }

--- a/packages/command/src/commands/onboard.ts
+++ b/packages/command/src/commands/onboard.ts
@@ -16,10 +16,10 @@ async function promptMissing(args: Record<string, unknown>): Promise<void> {
     }
   }
 
-  // 2. Require that the user has already run `first-tree-hub connect`
+  // 2. Require that the user has already run `first-tree-hub client connect`
   const { loadCredentials } = await import("../core/bootstrap.js");
   if (!loadCredentials()) {
-    throw new Error("No saved credentials. Run `first-tree-hub connect <server-url>` before onboarding.");
+    throw new Error("No saved credentials. Run `first-tree-hub client connect <server-url>` before onboarding.");
   }
 
   if (!args.id) {

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -42,14 +42,14 @@ export function resolveServerUrl(flagValue?: string): string {
  * Resolve the current member access JWT from persisted credentials.
  *
  * Unified-user-token milestone: the CLI has a single credential store and a
- * single onboarding path (`first-tree-hub connect`). The legacy
+ * single onboarding path (`first-tree-hub client connect`). The legacy
  * `FIRST_TREE_HUB_TOKEN` env var is no longer read — callers get a clear
- * error pointing at `connect` instead.
+ * error pointing at `client connect` instead.
  */
 export function resolveAccessToken(): string {
   const creds = loadCredentials();
   if (!creds) {
-    throw new Error("No credentials found. Run `first-tree-hub connect <server-url>` to sign in.");
+    throw new Error("No credentials found. Run `first-tree-hub client connect <server-url>` to sign in.");
   }
   return creds.accessToken;
 }
@@ -62,7 +62,7 @@ export function resolveAccessToken(): string {
 export async function ensureFreshAccessToken(): Promise<string> {
   const creds = loadCredentials();
   if (!creds) {
-    throw new Error("No credentials found. Run `first-tree-hub connect <server-url>` to sign in.");
+    throw new Error("No credentials found. Run `first-tree-hub client connect <server-url>` to sign in.");
   }
 
   if (!isTokenExpired(creds.accessToken)) {
@@ -77,7 +77,7 @@ export async function ensureFreshAccessToken(): Promise<string> {
   });
 
   if (!res.ok) {
-    throw new Error("Access token expired and refresh failed. Run `first-tree-hub connect <server-url>`.");
+    throw new Error("Access token expired and refresh failed. Run `first-tree-hub client connect <server-url>`.");
   }
 
   const data = (await res.json()) as { accessToken: string };

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -30,10 +30,11 @@ export class ClientRuntime {
   private watcher: FSWatcher | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(serverUrl: string) {
+  constructor(serverUrl: string, clientId: string) {
     this.serverUrl = serverUrl;
     this.connection = new ClientConnection({
       serverUrl,
+      clientId,
       getAccessToken: () => ensureFreshAccessToken(),
     });
     registerBuiltinHandlers();

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -62,7 +62,7 @@ export async function onboardCheck(args: OnboardArgs): Promise<CheckItem[]> {
       key: "connect",
       label: "Signed in",
       status: "missing_required",
-      hint: "Run `first-tree-hub connect <server-url>` first",
+      hint: "Run `first-tree-hub client connect <server-url>` first",
     });
   }
 

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -180,7 +180,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     if (health === "disconnected") {
       return reply.status(200).send({
         status: "offline",
-        message: "Agent is not connected. Start the client with: first-tree-hub connect <server-url>",
+        message: "Agent is not connected. Start the client with: first-tree-hub client connect <server-url>",
         connection,
       });
     }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -59,7 +59,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
     const proto = request.headers["x-forwarded-proto"] ?? request.protocol;
     const host = request.headers["x-forwarded-host"] ?? request.headers.host ?? request.hostname;
     const serverUrl = `${proto}://${host}`;
-    const command = `first-tree-hub connect ${serverUrl} --token ${token}`;
+    const command = `first-tree-hub client connect ${serverUrl} --token ${token}`;
 
     return { token, expiresIn, command };
   });

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -92,7 +92,7 @@ async function resolveAgentClient(
   if (!client.userId) {
     throw new BadRequestError(
       `Client "${data.clientId}" has not been claimed by a user yet. Have the operator run ` +
-        "`first-tree-hub connect` on that machine before pinning an agent to it.",
+        "`first-tree-hub client connect` on that machine before pinning an agent to it.",
     );
   }
   if (client.userId !== manager.userId) {

--- a/packages/shared/src/config/client-config.ts
+++ b/packages/shared/src/config/client-config.ts
@@ -10,6 +10,16 @@ export const clientConfigSchema = defineConfig({
       prompt: { message: "Server URL:", default: "http://localhost:8000" },
     }),
   },
+  client: {
+    // Stable per-machine client identifier. Auto-generated on first start and
+    // written back to client.yaml so the SDK keeps the same id across
+    // restarts — agents pin to `clients.id` on the server, so a fresh random
+    // id every run would orphan every pinned agent (Rule R-RUN WRONG_CLIENT).
+    id: field(z.string().regex(/^client_[a-f0-9]{8}$/), {
+      auto: "client-id",
+      env: "FIRST_TREE_HUB_CLIENT_ID",
+    }),
+  },
   logLevel: field(z.enum(["debug", "info", "warn", "error"]).default("info"), { env: "FIRST_TREE_HUB_LOG_LEVEL" }),
 });
 

--- a/packages/shared/src/config/resolver.ts
+++ b/packages/shared/src/config/resolver.ts
@@ -91,6 +91,9 @@ function coerceEnvValue(value: string, schema: z.ZodType): unknown {
 // ── Auto-generation ──────────────────────────────────────────────────
 
 function builtinAutoGenerate(strategy: string): string {
+  if (strategy === "client-id") {
+    return `client_${randomBytes(4).toString("hex")}`;
+  }
   const match = /^random:(\w+):(\d+)$/.exec(strategy);
   if (!match) {
     throw new Error(`Unknown auto-generation strategy: ${strategy}`);

--- a/packages/web/src/components/agent-form-dialog.tsx
+++ b/packages/web/src/components/agent-form-dialog.tsx
@@ -239,7 +239,7 @@ export function AgentFormDialog(props: AgentFormProps) {
                 <p className="text-xs text-muted-foreground">
                   {isAdmin && !formManagerId
                     ? "Pick a manager first to see their clients."
-                    : "No eligible clients. Run `first-tree-hub connect` on the target machine to register one."}
+                    : "No eligible clients. Run `first-tree-hub client connect` on the target machine to register one."}
                 </p>
               )}
               <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

- **Persist client.id across restarts** — auto-generated on first use, written to `client.yaml`, reused on subsequent runs. Fixes the orphaned-pin bug where every `connect`/`client start` created a fresh random `clients.id` row and any agent pinned to the previous id was rejected at bind with \`WRONG_CLIENT\`.
- **Move \`connect\` under \`client\`** — `first-tree-hub client connect <url>` replaces the top-level `first-tree-hub connect <url>`. All per-machine commands now live in one group. Updated web's /api/me command string, CLI help, error hints, and docs.

## Test plan

- [x] `pnpm check && pnpm typecheck` pass
- [x] `pnpm test` — 291 server + 29 shared + 11 command tests pass
- [x] Local smoke: auto-generation + persistence + env-var override all verified
  - Fresh run writes `client.id` to `client.yaml`, same id on subsequent runs
  - `FIRST_TREE_HUB_CLIENT_ID` env var wins and is not persisted
- [ ] Manual: run `pnpm --filter @agent-team-foundation/first-tree-hub dev -- client connect https://<hub> --token <...>`, confirm `client.yaml` contains `client.id: client_xxxxxxxx` and a second connect reuses the same id
- [ ] Manual: web "Connect a machine" dialog emits `first-tree-hub client connect ...`

## Notes

- Version bumped to 0.6.3.
- `client-connection.ts`'s random fallback is kept as defensive default for library consumers; all CLI paths now pass a persistent id from config.
- Backwards-incompatible UX: existing `first-tree-hub connect` script invocations must switch to `first-tree-hub client connect`.