### PR TITLE
feat(observability): unified pino logger + OpenTelemetry tracing

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -266,7 +266,6 @@ Resolution order for the agent token:
 | `FIRST_TREE_HUB_OTEL_ENDPOINT` | OTLP/HTTP traces endpoint. Non-empty value enables tracing | `""` (disabled) |
 | `FIRST_TREE_HUB_OTEL_HEADERS` | OTLP headers in `key1=val1,key2=val2` format (secret — typically holds the write token) | `""` |
 | `FIRST_TREE_HUB_OTEL_ENVIRONMENT` | Deployment environment label (`development` / `staging` / `production` / …) — emitted as `deployment.environment.name` | `development` |
-| `FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT` | Whether to include message bodies / prompts in span attrs | `false` |
 
 See [observability.md](observability.md) for the full config reference, backend cheat sheet, and troubleshooting recipes.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -258,6 +258,18 @@ Resolution order for the agent token:
 | `FEISHU_APP_ID` | Feishu bot App ID alternative to `--feishu-bot-app-id` |
 | `FEISHU_APP_SECRET` | Feishu bot App Secret alternative to `--feishu-bot-app-secret` |
 
+### Observability (server)
+
+| Variable | Purpose | Default |
+|---------|------|--------|
+| `FIRST_TREE_HUB_LOG_LEVEL` | Log level (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) | `info` |
+| `FIRST_TREE_HUB_OTEL_ENDPOINT` | OTLP/HTTP traces endpoint. Non-empty value enables tracing | `""` (disabled) |
+| `FIRST_TREE_HUB_OTEL_HEADERS` | OTLP headers in `key1=val1,key2=val2` format (secret — typically holds the write token) | `""` |
+| `FIRST_TREE_HUB_OTEL_ENVIRONMENT` | Deployment environment label (`development` / `staging` / `production` / …) — emitted as `deployment.environment.name` | `development` |
+| `FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT` | Whether to include message bodies / prompts in span attrs | `false` |
+
+See [observability.md](observability.md) for the full config reference, backend cheat sheet, and troubleshooting recipes.
+
 ## Directory Structure
 
 ```

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -57,7 +57,7 @@ These must be set for Docker / CI / `--no-interactive` deployments. Interactive 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FIRST_TREE_HUB_LOG_LEVEL` | `info` | Log level (`debug` / `info` / `warn` / `error`) |
+| `FIRST_TREE_HUB_LOG_LEVEL` | `info` | Log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`) |
 
 ## Docker Compose (HTTP)
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,8 +51,6 @@ in the startup log.
 | `observability.tracing.serviceName` | — | `first-tree-hub` | Shown in trace backends |
 | `observability.tracing.environment` | — | `development` | `deployment.environment.name` OTel attr |
 | `observability.tracing.sampleRate` | — | `1.0` | `0.0–1.0`, ratio applied at root |
-| `observability.tracing.captureContent` | `FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT` | `false` | Include message bodies / prompts in span attrs. **Opt-in** for privacy |
-| `observability.tracing.instrumentPostgres` | — | `false` | Wrap postgres queries with spans. Opt-in |
 
 ## Multi-environment setup (one backend, many environments)
 
@@ -312,10 +310,11 @@ Sampling is `ParentBased(TraceIdRatioBased(sampleRate))` — inbound
 - **No client-side tracing.** Client (`@first-tree-hub/client`) emits logs
   only. Agent-side work is observed indirectly via Hub-side spans
   (`ws.connection`, `ws.message`, inbox attrs).
-- **No PG span by default.** PostgreSQL query spans are opt-in via
-  `observability.tracing.instrumentPostgres: true`. For query performance
-  investigation, PostgreSQL's own `log_min_duration_statement` +
-  `pg_stat_statements` is usually sufficient.
+- **No PG span.** PostgreSQL queries are not wrapped in spans — for query
+  performance investigation, PostgreSQL's own `log_min_duration_statement` +
+  `pg_stat_statements` is typically sufficient. If cross-query correlation
+  becomes a need, this should be reconsidered as a dedicated feature, not a
+  flag-gated default.
 - **Server restart loses in-flight trace context.** Messages enqueued but
   not yet delivered keep their business state but lose the original
   request's trace linkage. Attribute search still works.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,321 @@
+# Observability
+
+First Tree Hub ships a vendor-neutral observability stack built on pino
+(logs) and OpenTelemetry (traces). Tracing is **off by default** — configure
+an OTLP endpoint to enable it.
+
+## Quick start
+
+### Logs only (default, zero config)
+
+No setup required. Hub emits structured logs to stdout in a human-readable
+format during development, and as NDJSON in production (`NODE_ENV=production`).
+
+### Logs + traces
+
+Configure an OTLP/HTTP endpoint and matching headers — any backend that
+speaks OTLP works (Logfire, Honeycomb, Jaeger, Tempo, SigNoz, Axiom, …).
+
+```yaml
+# ~/.first-tree-hub/config/server.yaml
+observability:
+  tracing:
+    endpoint: https://<your-otlp-endpoint>/v1/traces
+    headers:
+      Authorization: "Bearer <write-token>"
+    serviceName: first-tree-hub
+    environment: production
+    sampleRate: 1.0
+```
+
+Or via environment variables (preferred for secret tokens):
+
+```bash
+FIRST_TREE_HUB_OTEL_ENDPOINT=https://<your-otlp-endpoint>/v1/traces
+FIRST_TREE_HUB_OTEL_HEADERS="Authorization=Bearer <write-token>"
+```
+
+Restart the server. You should see `tracing enabled: exporter=otlp-http ...`
+in the startup log.
+
+## Configuration reference
+
+| Path | Env var | Default | Notes |
+|---|---|---|---|
+| `observability.logging.level` | `FIRST_TREE_HUB_LOG_LEVEL` | `info` | `trace` / `debug` / `info` / `warn` / `error` / `fatal` |
+| `observability.logging.format` | — | `pretty` (dev), `json` (prod) | Pretty for humans, JSON for log collectors |
+| `observability.logging.bridgeToSpanLevel` | — | `error` | Minimum pino level whose records are attached to the active span. `warn` / `error` / `off` |
+| `observability.tracing.endpoint` | `FIRST_TREE_HUB_OTEL_ENDPOINT` | `""` (disabled) | OTLP/HTTP traces URL |
+| `observability.tracing.headers` | `FIRST_TREE_HUB_OTEL_HEADERS` | `""` | `key1=val1,key2=val2` format |
+| `observability.tracing.exporter` | — | `otlp-http` | `otlp-http` or `otlp-grpc` |
+| `observability.tracing.serviceName` | — | `first-tree-hub` | Shown in trace backends |
+| `observability.tracing.environment` | — | `development` | `deployment.environment.name` OTel attr |
+| `observability.tracing.sampleRate` | — | `1.0` | `0.0–1.0`, ratio applied at root |
+| `observability.tracing.captureContent` | `FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT` | `false` | Include message bodies / prompts in span attrs. **Opt-in** for privacy |
+| `observability.tracing.instrumentPostgres` | — | `false` | Wrap postgres queries with spans. Opt-in |
+
+## Multi-environment setup (one backend, many environments)
+
+A common deployment pattern is to point **all** environments (dev, staging,
+prod, …) at the **same** Logfire / Honeycomb / … project, and rely on the
+UI's filter/group features to tell them apart. Hub supports this out of the
+box — no need to maintain multiple projects or tokens.
+
+### How it works
+
+Every span Hub emits carries three OTel resource attributes that trace
+backends treat as first-class:
+
+| Attribute | Value | Configured by |
+|---|---|---|
+| `service.name` | `first-tree-hub` (customizable) | `observability.tracing.serviceName` |
+| `deployment.environment.name` | `development` / `staging` / `production` / … | `observability.tracing.environment` or `FIRST_TREE_HUB_OTEL_ENVIRONMENT` |
+| `service.instance.id` | `srv_<8-char-hex>` — unique per process | auto-generated at startup |
+
+### Typical deployment
+
+```bash
+# Production instance
+FIRST_TREE_HUB_OTEL_ENDPOINT=https://logfire-us.pydantic.dev/v1/traces \
+FIRST_TREE_HUB_OTEL_HEADERS="Authorization=Bearer <token>" \
+FIRST_TREE_HUB_OTEL_ENVIRONMENT=production \
+  first-tree-hub server start
+
+# Staging instance (same token, different env label)
+FIRST_TREE_HUB_OTEL_ENDPOINT=https://logfire-us.pydantic.dev/v1/traces \
+FIRST_TREE_HUB_OTEL_HEADERS="Authorization=Bearer <token>" \
+FIRST_TREE_HUB_OTEL_ENVIRONMENT=staging \
+  first-tree-hub server start
+```
+
+### Filtering in the UI
+
+- **Logfire**: top filter bar → add `deployment.environment.name = production`
+- **Honeycomb**: dataset filter `deployment.environment.name = production`
+- **Jaeger / Tempo**: search → Tags → `deployment.environment.name=production`
+- **SigNoz / Axiom**: resource attribute filter with the same key
+
+### When to use separate projects instead
+
+One project-per-environment is only necessary if:
+
+- **Strict data isolation is required** (e.g. prod data must never commingle
+  with dev for compliance) — then use distinct tokens per environment and
+  rotate them independently.
+- **Retention policies differ** per environment — some backends apply
+  retention at the project level.
+- **Cost attribution** needs to be per environment — most backends bill
+  per-project.
+
+Otherwise, a single project with `deployment.environment.name` filtering is
+simpler to operate and makes cross-environment comparisons trivial.
+
+### Multi-replica deployment
+
+When you scale out to multiple Hub instances behind a load balancer, each
+process gets its own `service.instance.id` at startup. To drill into a
+specific replica in your trace backend, filter by that attribute — this is
+how you answer "which replica is spiking latency" without manual tagging.
+
+## Log message conventions
+
+All runtime logs — server *and* client — go through the same pino pipeline
+with the same pretty/json formats. To keep grep-ability and structured-
+search working across a growing codebase, follow these five rules when
+adding new log lines.
+
+### 1. English, lowercase, no trailing punctuation
+
+```ts
+// ✅
+log.error({ err }, "failed to reload adapter");
+log.info({ count }, "cleaned up stale sessions");
+
+// ❌
+log.error({ err }, "Failed to reload adapter.");
+log.info("CLEANUP DONE!");
+```
+
+### 2. Errors: `"failed to <verb> <object>"` form
+
+One shape for error messages makes skimming faster.
+
+```ts
+// ✅
+log.error({ err, entryId }, "failed to deliver inbox entry");
+
+// ❌
+log.error({ err }, "delivery failed");
+log.error({ err }, "inbox entry delivery error");
+```
+
+### 3. Info: past tense describing what happened
+
+```ts
+// ✅
+log.info({ agentId }, "bound agent");
+log.info({ count }, "marked agents as stale");
+
+// ❌
+log.info({ agentId }, "binding agent...");
+log.info({ agentId }, "agent will be bound");
+```
+
+### 4. Context goes in the attrs object, not interpolated into the message
+
+```ts
+// ✅  — structured, grep / Loki-filterable
+log.warn({ entryId, retries }, "retry budget exhausted");
+
+// ❌  — a needle in a haystack at scale
+log.warn(`entry ${entryId} gave up after ${retries} retries`);
+```
+
+Rule of thumb: if a downstream consumer (Loki / Datadog / a human running
+`grep`) might want to filter by a value, it belongs in attrs.
+
+### 5. Don't repeat the module name in the message
+
+The `[Module]` prefix is emitted automatically by the pretty formatter.
+
+```ts
+const log = createLogger("Inbox");
+
+// ✅  output:  INFO  [Inbox] entry expired
+log.info({ entryId }, "entry expired");
+
+// ❌  output:  INFO  [Inbox] inbox: entry expired
+log.info({ entryId }, "inbox: entry expired");
+```
+
+### What these rules do NOT cover
+
+- **CLI status output** (`first-tree-hub server start` banner, `status(...)`
+  helpers) is a different channel — it's interactive, user-facing, and can
+  use formatting / localized strings. It does *not* go through pino.
+- **Existing log lines that predate these rules**. Follow the style when
+  you touch a file; don't do bulk rewrites purely for style.
+- **Natural exceptions**: acronyms stay capitalized (`"failed to parse JWT"`),
+  proper nouns stay capitalized (`"connected to Logfire"`).
+
+## Backend cheat sheet
+
+Values below go into `observability.tracing.endpoint` / `.headers`.
+
+### Logfire (Pydantic)
+
+```
+endpoint: https://logfire-us.pydantic.dev/v1/traces   # or logfire-eu.*
+headers:
+  Authorization: "Bearer pylf_v1_us_xxxxxxxxxxxx"
+```
+
+Get a write token at Logfire → Settings → Write Tokens.
+
+### Honeycomb
+
+```
+endpoint: https://api.honeycomb.io:443/v1/traces
+headers:
+  x-honeycomb-team: "<ingest-key>"
+```
+
+### Jaeger (OTLP-enabled ≥1.35)
+
+```
+endpoint: http://<jaeger-host>:4318/v1/traces
+```
+
+### Grafana Tempo / Cloud
+
+```
+endpoint: https://tempo-us-central1.grafana.net/tempo/v1/traces
+headers:
+  Authorization: "Basic <base64(user:token)>"
+```
+
+### SigNoz self-hosted
+
+```
+endpoint: http://<signoz-host>:4318/v1/traces
+```
+
+### Axiom
+
+```
+endpoint: https://api.axiom.co/v1/traces
+headers:
+  Authorization: "Bearer <api-token>"
+  x-axiom-dataset: "<dataset-name>"
+```
+
+## Troubleshooting recipes
+
+### "Find the full story of one user message"
+
+Every delivery path stamps the same attribute set. Search in your trace
+backend for any of:
+
+- `inbox.entry.id = "<id>"` — single inbox entry, enqueue → deliver → ack
+- `message.id = "<id>"` — one business message across chats / fan-outs
+- `chat.id = "<id>"` — every span on a given chat
+- `agent.id = "<id>"` — all spans touching a specific agent
+
+### "Why did agent X disconnect?"
+
+Search `ws.connection` spans filtered by `client.id = "<id>"`. The span's
+duration shows connection lifetime; `ws.close.code` attribute shows the
+reason the socket closed.
+
+### "Correlate an error from logs to trace"
+
+Error responses return a `x-trace-id` header and include `traceId` in the
+body. Copy it into your trace backend to jump straight to the full tree.
+
+### "Turn on temporarily"
+
+```
+FIRST_TREE_HUB_LOG_LEVEL=debug \
+FIRST_TREE_HUB_OTEL_ENDPOINT=https://... \
+FIRST_TREE_HUB_OTEL_HEADERS="Authorization=Bearer ..." \
+  first-tree-hub server start
+```
+
+## Sampling guidance
+
+| Deployment | Sample rate | Rationale |
+|---|---|---|
+| Local dev | `1.0` | Full trace on every request, fast feedback |
+| Staging | `1.0` | Rare enough traffic that full sample is cheap |
+| Prod, low-traffic (<10 req/s) | `1.0` | Still cheap at this volume |
+| Prod, medium-traffic | `0.1`–`0.25` | Representative sample without overwhelming the backend |
+| Prod, high-traffic (>100 req/s) | `0.01`–`0.05` | Cap backend cost; relies on tail-based or attribute-biased sampling at the backend for error-path coverage |
+
+Sampling is `ParentBased(TraceIdRatioBased(sampleRate))` — inbound
+`traceparent` headers from upstream services are respected.
+
+## Known limitations
+
+- **WebSocket traces appear "Incomplete" while connected.** Our `ws.connection`
+  span is deliberately long-running (lives for the full socket lifetime),
+  so Logfire and other trace UIs will show it as "Incomplete" or "missing
+  root span" *until the client disconnects*. This is expected — the span
+  finalizes with attributes like `ws.close.code` once the socket closes.
+  For short-lived per-message visibility, search by `ws.message.type` or
+  the `client.id` / `agent.id` attributes directly.
+- **Orphan spans at async boundaries.** When a message is enqueued and
+  delivered in different async roots (later tick, different WS connection),
+  the deliver span is a new trace root rather than a child of the original
+  request. Use attribute-based search (see "Find the full story" above).
+  Fixing this requires persisting W3C `traceparent` on inbox rows and is
+  tracked as tech debt until multi-replica deployment makes it necessary.
+- **No client-side tracing.** Client (`@first-tree-hub/client`) emits logs
+  only. Agent-side work is observed indirectly via Hub-side spans
+  (`ws.connection`, `ws.message`, inbox attrs).
+- **No PG span by default.** PostgreSQL query spans are opt-in via
+  `observability.tracing.instrumentPostgres: true`. For query performance
+  investigation, PostgreSQL's own `log_min_duration_statement` +
+  `pg_stat_statements` is usually sufficient.
+- **Server restart loses in-flight trace context.** Messages enqueued but
+  not yet delivered keep their business state but lose the original
+  request's trace linkage. Attribute search still works.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,10 +8,14 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./dist/index.mjs"
+    },
+    "./observability": {
+      "types": "./src/observability/index.ts",
+      "import": "./dist/observability/index.mjs"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --no-dts",
+    "build": "tsdown src/index.ts src/observability/index.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
@@ -20,6 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "pino": "^9.5.0",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2,6 +2,7 @@ export type { BoundAgent, ClientConnectionConfig, SessionCommand } from "./clien
 export { ClientConnection } from "./client-connection.js";
 // Handlers
 export { registerBuiltinHandlers } from "./handlers/index.js";
+export { applyClientLoggerConfig, createLogger, rootLogger } from "./observability/index.js";
 // Runtime
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
 export { AgentSlot } from "./runtime/agent-slot.js";

--- a/packages/client/src/observability/index.ts
+++ b/packages/client/src/observability/index.ts
@@ -1,0 +1,1 @@
+export { applyClientLoggerConfig, createLogger, rootLogger } from "./logger.js";

--- a/packages/client/src/observability/logger.ts
+++ b/packages/client/src/observability/logger.ts
@@ -1,4 +1,10 @@
-import { Writable } from "node:stream";
+import {
+  createLoggerOutputStream,
+  formatLocalTime,
+  type LogFormat,
+  type LogLevel,
+  parseLogLevel,
+} from "@agent-team-foundation/first-tree-hub-shared/observability";
 import pino from "pino";
 
 /**
@@ -7,11 +13,9 @@ import pino from "pino";
  * so we skip tracing, context propagation, and error sinks.
  */
 
-type LogFormat = "pretty" | "json";
-type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
-
+const initialLevel = parseLogLevel(process.env.FIRST_TREE_HUB_LOG_LEVEL);
 let _format: LogFormat = process.env.NODE_ENV === "production" ? "json" : "pretty";
-let _level: LogLevel = ((process.env.FIRST_TREE_HUB_LOG_LEVEL as LogLevel | undefined) ?? "info") as LogLevel;
+let _level: LogLevel = initialLevel.level;
 
 export function applyClientLoggerConfig(options: { level?: LogLevel; format?: LogFormat } = {}): void {
   if (options.level) {
@@ -21,76 +25,22 @@ export function applyClientLoggerConfig(options: { level?: LogLevel; format?: Lo
   if (options.format) _format = options.format;
 }
 
-const LEVEL_LABELS: Record<number, string> = {
-  10: "TRACE",
-  20: "DEBUG",
-  30: "INFO",
-  40: "WARN",
-  50: "ERROR",
-  60: "FATAL",
-};
-const LEVEL_COLORS: Record<number, string> = {
-  10: "\x1b[90m",
-  20: "\x1b[36m",
-  30: "\x1b[32m",
-  40: "\x1b[33m",
-  50: "\x1b[31m",
-  60: "\x1b[35m",
-};
-const RESET = "\x1b[0m";
-const DIM = "\x1b[2m";
-const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
-
-function formatPretty(json: string): string {
-  const obj = JSON.parse(json) as Record<string, unknown>;
-  const level = obj.level as number;
-  const label = LEVEL_LABELS[level] ?? "???";
-  const color = LEVEL_COLORS[level] ?? "";
-  const time = (obj.time as string) ?? new Date().toISOString();
-  const module = obj.module ? `[${String(obj.module)}] ` : "";
-  const msg = (obj.msg as string) ?? "";
-  const extras: string[] = [];
-  let errStack = "";
-  for (const [k, v] of Object.entries(obj)) {
-    if (SKIP_KEYS.has(k)) continue;
-    if (k === "err" && v && typeof v === "object") {
-      const e = v as Record<string, unknown>;
-      if (e.message) extras.push(`err.message=${String(e.message)}`);
-      if (typeof e.stack === "string") errStack = `\n${DIM}${e.stack}${RESET}`;
-    } else {
-      extras.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
-    }
-  }
-  const extraStr = extras.length > 0 ? `  ${DIM}${extras.join(" ")}${RESET}` : "";
-  return `${DIM}${time}${RESET} ${color}${label.padEnd(5)}${RESET} ${module}${msg}${extraStr}${errStack}\n`;
-}
-
-function localTime(): string {
-  const d = new Date();
-  const date = d.toLocaleDateString("sv-SE");
-  const time = d.toLocaleTimeString("en-GB", { hour12: false });
-  return `${date} ${time}`;
-}
-
-const outputStream = new Writable({
-  write(chunk, _, callback) {
-    const text = chunk.toString();
-    try {
-      process.stdout.write(_format === "pretty" ? formatPretty(text) : text);
-    } catch {
-      process.stdout.write(text);
-    }
-    callback();
-  },
-});
+const outputStream = createLoggerOutputStream({ getFormat: () => _format });
 
 export const rootLogger = pino(
   {
     level: _level,
-    timestamp: () => `,"time":"${localTime()}"`,
+    timestamp: () => `,"time":"${formatLocalTime()}"`,
   },
   outputStream,
 );
+
+if (initialLevel.fellBack) {
+  rootLogger.warn(
+    { envValue: process.env.FIRST_TREE_HUB_LOG_LEVEL },
+    "invalid FIRST_TREE_HUB_LOG_LEVEL; falling back to info",
+  );
+}
 
 export function createLogger(module: string): pino.Logger {
   return rootLogger.child({ module });

--- a/packages/client/src/observability/logger.ts
+++ b/packages/client/src/observability/logger.ts
@@ -1,0 +1,97 @@
+import { Writable } from "node:stream";
+import pino from "pino";
+
+/**
+ * Client-side logger. Same pretty / NDJSON formats as the server logger, but
+ * intentionally lightweight — the client is deployed to agent user machines,
+ * so we skip tracing, context propagation, and error sinks.
+ */
+
+type LogFormat = "pretty" | "json";
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+let _format: LogFormat = process.env.NODE_ENV === "production" ? "json" : "pretty";
+let _level: LogLevel = ((process.env.FIRST_TREE_HUB_LOG_LEVEL as LogLevel | undefined) ?? "info") as LogLevel;
+
+export function applyClientLoggerConfig(options: { level?: LogLevel; format?: LogFormat } = {}): void {
+  if (options.level) {
+    _level = options.level;
+    rootLogger.level = options.level;
+  }
+  if (options.format) _format = options.format;
+}
+
+const LEVEL_LABELS: Record<number, string> = {
+  10: "TRACE",
+  20: "DEBUG",
+  30: "INFO",
+  40: "WARN",
+  50: "ERROR",
+  60: "FATAL",
+};
+const LEVEL_COLORS: Record<number, string> = {
+  10: "\x1b[90m",
+  20: "\x1b[36m",
+  30: "\x1b[32m",
+  40: "\x1b[33m",
+  50: "\x1b[31m",
+  60: "\x1b[35m",
+};
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m";
+const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
+
+function formatPretty(json: string): string {
+  const obj = JSON.parse(json) as Record<string, unknown>;
+  const level = obj.level as number;
+  const label = LEVEL_LABELS[level] ?? "???";
+  const color = LEVEL_COLORS[level] ?? "";
+  const time = (obj.time as string) ?? new Date().toISOString();
+  const module = obj.module ? `[${String(obj.module)}] ` : "";
+  const msg = (obj.msg as string) ?? "";
+  const extras: string[] = [];
+  let errStack = "";
+  for (const [k, v] of Object.entries(obj)) {
+    if (SKIP_KEYS.has(k)) continue;
+    if (k === "err" && v && typeof v === "object") {
+      const e = v as Record<string, unknown>;
+      if (e.message) extras.push(`err.message=${String(e.message)}`);
+      if (typeof e.stack === "string") errStack = `\n${DIM}${e.stack}${RESET}`;
+    } else {
+      extras.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
+    }
+  }
+  const extraStr = extras.length > 0 ? `  ${DIM}${extras.join(" ")}${RESET}` : "";
+  return `${DIM}${time}${RESET} ${color}${label.padEnd(5)}${RESET} ${module}${msg}${extraStr}${errStack}\n`;
+}
+
+function localTime(): string {
+  const d = new Date();
+  const date = d.toLocaleDateString("sv-SE");
+  const time = d.toLocaleTimeString("en-GB", { hour12: false });
+  return `${date} ${time}`;
+}
+
+const outputStream = new Writable({
+  write(chunk, _, callback) {
+    const text = chunk.toString();
+    try {
+      process.stdout.write(_format === "pretty" ? formatPretty(text) : text);
+    } catch {
+      process.stdout.write(text);
+    }
+    callback();
+  },
+});
+
+export const rootLogger = pino(
+  {
+    level: _level,
+    timestamp: () => `,"time":"${localTime()}"`,
+  },
+  outputStream,
+);
+
+export function createLogger(module: string): pino.Logger {
+  return rootLogger.child({ module });
+}

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -8,6 +8,7 @@ import {
   resetConfig,
   resetConfigMeta,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { applyClientLoggerConfig } from "@first-tree-hub/client";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import {
@@ -53,6 +54,10 @@ export function registerClientCommands(program: Command): void {
           schema: clientConfigSchema,
           role: "client",
         });
+
+        // Wire the resolved logLevel into the client logger — without this,
+        // `logLevel: debug` in client.yaml is parsed but never reaches pino.
+        applyClientLoggerConfig({ level: config.logLevel });
 
         // Load agents (may be empty — client can start without agents)
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");

--- a/packages/command/src/core/server.ts
+++ b/packages/command/src/core/server.ts
@@ -107,7 +107,7 @@ export async function startServer(options: StartOptions): Promise<void> {
   // passed as service.instance.id so replicas of the same service are
   // distinguishable in the trace backend.
   const { initTelemetry, shutdownTelemetry } = await import("@first-tree-hub/server/observability");
-  initTelemetry(serverConfig.observability.tracing, config.instanceId);
+  await initTelemetry(serverConfig.observability.tracing, config.instanceId);
 
   const app = await buildApp(config);
 

--- a/packages/command/src/core/server.ts
+++ b/packages/command/src/core/server.ts
@@ -100,15 +100,25 @@ export async function startServer(options: StartOptions): Promise<void> {
     ...serverConfig,
     webDistPath: webDistPath ?? undefined,
     instanceId: `srv_${randomUUID().slice(0, 8)}`,
-    logger: true,
   };
+
+  // Initialize telemetry from resolved config before server bootstrap, so that
+  // spans emitted during migrations / hot-reload are captured. instanceId is
+  // passed as service.instance.id so replicas of the same service are
+  // distinguishable in the trace backend.
+  const { initTelemetry, shutdownTelemetry } = await import("@first-tree-hub/server/observability");
+  initTelemetry(serverConfig.observability.tracing, config.instanceId);
 
   const app = await buildApp(config);
 
   // Graceful shutdown
   const shutdown = async () => {
     process.stderr.write("\n  Shutting down...\n");
-    await app.close();
+    try {
+      await app.close();
+    } finally {
+      await shutdownTelemetry();
+    }
     process.exit(0);
   };
   process.on("SIGINT", () => void shutdown());

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,11 +9,15 @@
       "import": "./dist/app.mjs"
     },
     "./config": "./src/config.ts",
+    "./observability": {
+      "types": "./src/observability/index.ts",
+      "import": "./dist/observability/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "tsx watch --env-file=../../.env src/index.ts",
-    "build": "tsdown src/index.ts src/app.ts --format esm --no-dts",
+    "build": "tsdown src/index.ts src/app.ts src/observability/index.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",
@@ -24,15 +28,22 @@
   "dependencies": {
     "@agent-team-foundation/first-tree-hub-shared": "workspace:*",
     "@fastify/cors": "^11.2.0",
+    "@fastify/otel": "^0.9.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",
     "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.30.0",
     "bcrypt": "^6.0.0",
     "drizzle-orm": "^0.44.0",
     "fastify": "^5.3.0",
     "gray-matter": "^4.0.3",
     "jose": "^6.0.0",
+    "pino": "^9.5.0",
     "postgres": "^3.4.0",
     "zod": "^4.0.0"
   },

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -32,8 +32,10 @@ export async function createTestApp(): Promise<FastifyInstance> {
       allowedOrg: "test-org",
     },
     rateLimit: { max: 10000, loginMax: 10000, webhookMax: 10000 },
+    observability: {
+      logging: { level: "error", format: "json", bridgeToSpanLevel: "off" },
+    },
     instanceId: "test-instance",
-    logger: false,
   };
   const app = await buildApp(config);
   await app.ready();

--- a/packages/server/src/api/admin/adapters.ts
+++ b/packages/server/src/api/admin/adapters.ts
@@ -1,8 +1,11 @@
 import { createAdapterConfigSchema, updateAdapterConfigSchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance } from "fastify";
 import { BadRequestError } from "../../errors.js";
+import { createLogger } from "../../observability/index.js";
 import { assertCanManage, memberScope } from "../../services/access-control.js";
 import * as adapterService from "../../services/adapter.js";
+
+const log = createLogger("AdminAdapters");
 
 function parseId(raw: string): number {
   const id = Number(raw);
@@ -28,7 +31,7 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
     await assertCanManage(app.db, scope, body.agentId);
     const config = await adapterService.createAdapterConfig(app.db, body, app.config.secrets.encryptionKey);
     // Fire-and-forget: reload local instance + notify others via PG NOTIFY
-    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after create"));
+    app.adapterManager.reload().catch((err) => log.error({ err }, "adapter reload failed after create"));
     app.notifier.notifyConfigChange("adapter_configs").catch(() => {});
     return reply.status(201).send({
       ...config,
@@ -54,7 +57,7 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
     const existing = await adapterService.getAdapterConfig(app.db, id);
     await assertCanManage(app.db, scope, existing.agentId);
     const config = await adapterService.updateAdapterConfig(app.db, id, body, app.config.secrets.encryptionKey);
-    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after update"));
+    app.adapterManager.reload().catch((err) => log.error({ err }, "adapter reload failed after update"));
     app.notifier.notifyConfigChange("adapter_configs").catch(() => {});
     return {
       ...config,
@@ -69,7 +72,7 @@ export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
     const existing = await adapterService.getAdapterConfig(app.db, id);
     await assertCanManage(app.db, scope, existing.agentId);
     await adapterService.deleteAdapterConfig(app.db, id);
-    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after delete"));
+    app.adapterManager.reload().catch((err) => log.error({ err }, "adapter reload failed after delete"));
     app.notifier.notifyConfigChange("adapter_configs").catch(() => {});
     return reply.status(204).send();
   });

--- a/packages/server/src/api/admin/ws-admin.ts
+++ b/packages/server/src/api/admin/ws-admin.ts
@@ -73,7 +73,8 @@ export function adminWsRoutes(notifier: Notifier, jwtSecret: string) {
   });
 
   return async (app: FastifyInstance): Promise<void> => {
-    app.get("/admin", { websocket: true }, async (socket, request) => {
+    // See ws-client.ts for why config.otel is disabled on WS upgrade routes.
+    app.get("/admin", { websocket: true, config: { otel: false } }, async (socket, request) => {
       const token = (request.query as Record<string, string>).token;
       if (!token) {
         socket.send(JSON.stringify({ type: "error", message: "Missing token query parameter" }));

--- a/packages/server/src/api/admin/ws-admin.ts
+++ b/packages/server/src/api/admin/ws-admin.ts
@@ -5,6 +5,7 @@ import { jwtVerify } from "jose";
 import type { WebSocket } from "ws";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
+import { endWsConnectionSpan, setWsConnectionAttrs, startWsConnectionSpan } from "../../observability/index.js";
 import { registerAdminBroadcaster } from "../../services/admin-broadcast.js";
 import type { Notifier } from "../../services/notifier.js";
 
@@ -75,10 +76,13 @@ export function adminWsRoutes(notifier: Notifier, jwtSecret: string) {
   return async (app: FastifyInstance): Promise<void> => {
     // See ws-client.ts for why config.otel is disabled on WS upgrade routes.
     app.get("/admin", { websocket: true, config: { otel: false } }, async (socket, request) => {
+      startWsConnectionSpan(socket, { remoteIp: request.ip });
+
       const token = (request.query as Record<string, string>).token;
       if (!token) {
         socket.send(JSON.stringify({ type: "error", message: "Missing token query parameter" }));
         socket.close(4001, "Missing token");
+        endWsConnectionSpan(socket, 4001);
         return;
       }
 
@@ -94,6 +98,7 @@ export function adminWsRoutes(notifier: Notifier, jwtSecret: string) {
         ) {
           socket.send(JSON.stringify({ type: "error", message: "Invalid token type" }));
           socket.close(4001, "Invalid token");
+          endWsConnectionSpan(socket, 4001);
           return;
         }
         organizationId = payload.organizationId;
@@ -101,8 +106,11 @@ export function adminWsRoutes(notifier: Notifier, jwtSecret: string) {
       } catch {
         socket.send(JSON.stringify({ type: "error", message: "Invalid or expired token" }));
         socket.close(4001, "Auth failed");
+        endWsConnectionSpan(socket, 4001);
         return;
       }
+
+      setWsConnectionAttrs(socket, { organizationId, memberId });
 
       // Visibility cached at connect time. New agents added mid-session won't
       // appear in pulses until the dashboard reconnects — acceptable trade-off
@@ -112,8 +120,9 @@ export function adminWsRoutes(notifier: Notifier, jwtSecret: string) {
       adminSockets.set(socket, { organizationId, memberId, visibleAgentIds });
       socket.send(JSON.stringify({ type: "admin:connected" }));
 
-      socket.on("close", () => {
+      socket.on("close", (code) => {
         adminSockets.delete(socket);
+        endWsConnectionSpan(socket, code);
       });
     });
   };

--- a/packages/server/src/api/agent/feishu-bot.ts
+++ b/packages/server/src/api/agent/feishu-bot.ts
@@ -2,8 +2,11 @@ import { selfServiceFeishuBotSchema } from "@agent-team-foundation/first-tree-hu
 import type { FastifyInstance } from "fastify";
 import { BadRequestError } from "../../errors.js";
 import { requireAgent } from "../../middleware/require-identity.js";
+import { createLogger } from "../../observability/index.js";
 import * as adapterService from "../../services/adapter.js";
 import * as agentService from "../../services/agent.js";
+
+const log = createLogger("AgentFeishuBot");
 
 export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> {
   /**
@@ -46,7 +49,7 @@ export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> 
     }
 
     // Trigger adapter reload
-    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after self-service bind"));
+    app.adapterManager.reload().catch((err) => log.error({ err }, "adapter reload failed after self-service bind"));
     app.notifier.notifyConfigChange("adapter_configs").catch(() => {});
 
     return reply.status(current ? 200 : 201).send({
@@ -71,7 +74,7 @@ export async function agentFeishuBotRoutes(app: FastifyInstance): Promise<void> 
     }
 
     await adapterService.deleteAdapterConfig(app.db, current.id);
-    app.adapterManager.reload().catch((err) => app.log.error(err, "Adapter reload failed after self-service unbind"));
+    app.adapterManager.reload().catch((err) => log.error({ err }, "adapter reload failed after self-service unbind"));
     app.notifier.notifyConfigChange("adapter_configs").catch(() => {});
 
     return reply.status(204).send();

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -6,9 +6,12 @@ import {
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAgent } from "../../middleware/require-identity.js";
+import { createLogger } from "../../observability/index.js";
 import * as chatService from "../../services/chat.js";
 import * as messageService from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
+
+const log = createLogger("AgentMessages");
 
 const editMessageSchema = z.object({
   format: z.string().optional(),
@@ -49,7 +52,7 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
 
     app.adapterManager
       .editOutboundMessage(msg.id, msg.format, msg.content)
-      .catch((err) => app.log.error({ err, messageId: msg.id }, "Failed to edit outbound message"));
+      .catch((err) => log.error({ err, messageId: msg.id }, "failed to edit outbound message"));
 
     return {
       ...msg,

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -20,6 +20,7 @@ import { agents } from "../../db/schema/agents.js";
 import { clients } from "../../db/schema/clients.js";
 import { members } from "../../db/schema/members.js";
 import { users } from "../../db/schema/users.js";
+import { endWsConnectionSpan, setWsConnectionAttrs, startWsConnectionSpan } from "../../observability/index.js";
 import * as activityService from "../../services/activity.js";
 import * as clientService from "../../services/client.js";
 import * as connectionManager from "../../services/connection-manager.js";
@@ -83,7 +84,12 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
   return async (app: FastifyInstance): Promise<void> => {
     const jwtSecretBytes = new TextEncoder().encode(app.config.secrets.jwtSecret);
 
-    app.get("/client", { websocket: true }, async (socket) => {
+    // config.otel=false skips @fastify/otel's HTTP instrumentation for the
+    // upgrade request. We already emit a long-running `ws.connection` span
+    // ourselves via startWsConnectionSpan — a parallel HTTP-style span for a
+    // protocol upgrade would double-report and never finish cleanly.
+    app.get("/client", { websocket: true, config: { otel: false } }, async (socket) => {
+      startWsConnectionSpan(socket);
       let session: AuthenticatedSession | null = null;
       let clientId: string | null = null;
       let authExpiryTimer: NodeJS.Timeout | null = null;
@@ -204,6 +210,10 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               organizationId: member.organizationId,
               role: member.role,
             };
+            setWsConnectionAttrs(socket, {
+              "organization.id": member.organizationId,
+              "member.id": member.id,
+            });
             clearTimeout(authTimeout);
             scheduleAuthExpiry(claims.exp);
             socket.send(JSON.stringify({ type: "auth:ok" }));
@@ -236,6 +246,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             }
 
             clientId = data.clientId;
+            setWsConnectionAttrs(socket, { "client.id": data.clientId });
             connectionManager.setClientConnection(data.clientId, socket);
             socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
 
@@ -476,7 +487,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         }
       });
 
-      socket.on("close", async () => {
+      socket.on("close", async (closeCode?: number) => {
+        endWsConnectionSpan(socket, closeCode);
         clearTimeout(authTimeout);
         if (authExpiryTimer) clearTimeout(authExpiryTimer);
 

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -20,7 +20,12 @@ import { agents } from "../../db/schema/agents.js";
 import { clients } from "../../db/schema/clients.js";
 import { members } from "../../db/schema/members.js";
 import { users } from "../../db/schema/users.js";
-import { endWsConnectionSpan, setWsConnectionAttrs, startWsConnectionSpan } from "../../observability/index.js";
+import {
+  endWsConnectionSpan,
+  setWsConnectionAttrs,
+  startWsConnectionSpan,
+  withWsMessageSpan,
+} from "../../observability/index.js";
 import * as activityService from "../../services/activity.js";
 import * as clientService from "../../services/client.js";
 import * as connectionManager from "../../services/connection-manager.js";
@@ -225,266 +230,271 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           return;
         }
 
-        try {
-          if (type === "client:register") {
-            const data = clientRegisterSchema.parse(msg);
+        const spanAttrs: Record<string, unknown> = ref !== undefined ? { "ws.message.ref": String(ref) } : {};
+        await withWsMessageSpan(socket, type, spanAttrs, async () => {
+          // Re-assert the outer auth-gate narrowing — TS drops it across the async closure boundary.
+          if (!session) return;
+          try {
+            if (type === "client:register") {
+              const data = clientRegisterSchema.parse(msg);
 
-            try {
-              await clientService.registerClient(app.db, {
-                clientId: data.clientId,
-                userId: session.userId,
-                instanceId,
-                hostname: data.hostname,
-                os: data.os,
-                sdkVersion: data.sdkVersion,
-              });
-            } catch (err) {
-              const message = err instanceof Error ? err.message : "client register failed";
-              socket.send(JSON.stringify({ type: "client:register:rejected", message }));
-              socket.close(4403, "client register rejected");
-              return;
-            }
-
-            clientId = data.clientId;
-            setWsConnectionAttrs(socket, { "client.id": data.clientId });
-            connectionManager.setClientConnection(data.clientId, socket);
-            socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
-
-            // Backfill `agent:pinned` for any agent already bound to this
-            // client at registration time. Without this, an admin who pins an
-            // agent while the client is offline would still need a manual
-            // `first-tree-hub agent add` after restart — the realtime push in
-            // admin/agents.ts only fires for live sockets. The client dedupes
-            // on agentId, so re-firing on every reconnect is safe.
-            try {
-              const pinned = await clientService.listActiveAgentsPinnedToClient(app.db, data.clientId);
-              for (const agent of pinned) {
-                const parsed = agentPinnedMessageSchema.safeParse({
-                  type: "agent:pinned",
-                  agentId: agent.uuid,
-                  name: agent.name,
-                  displayName: agent.displayName,
-                  agentType: agent.type,
+              try {
+                await clientService.registerClient(app.db, {
+                  clientId: data.clientId,
+                  userId: session.userId,
+                  instanceId,
+                  hostname: data.hostname,
+                  os: data.os,
+                  sdkVersion: data.sdkVersion,
                 });
-                if (!parsed.success) {
-                  app.log.warn(
-                    { err: parsed.error.flatten(), agentId: agent.uuid, clientId: data.clientId },
-                    "agent:pinned backfill frame failed schema validation — skipping",
-                  );
-                  continue;
-                }
-                socket.send(JSON.stringify(parsed.data));
+              } catch (err) {
+                const message = err instanceof Error ? err.message : "client register failed";
+                socket.send(JSON.stringify({ type: "client:register:rejected", message }));
+                socket.close(4403, "client register rejected");
+                return;
               }
-            } catch (err) {
-              app.log.error(
-                { err, clientId: data.clientId },
-                "agent:pinned backfill on client:register failed — client may need manual `agent add`",
-              );
-            }
-          } else if (type === "agent:bind") {
-            if (!clientId) {
-              socket.send(JSON.stringify({ type: "error", ref, message: "Must register client first" }));
-              return;
-            }
 
-            const bindRequest = agentBindRequestSchema.parse(msg);
+              clientId = data.clientId;
+              setWsConnectionAttrs(socket, { "client.id": data.clientId });
+              connectionManager.setClientConnection(data.clientId, socket);
+              socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
 
-            const [agent] = await app.db
-              .select({
-                id: agents.uuid,
-                displayName: agents.displayName,
-                type: agents.type,
-                organizationId: agents.organizationId,
-                inboxId: agents.inboxId,
-                status: agents.status,
-                clientId: agents.clientId,
-                clientUserId: clients.userId,
-                managerUserId: members.userId,
-              })
-              .from(agents)
-              .leftJoin(clients, eq(agents.clientId, clients.id))
-              .leftJoin(members, eq(agents.managerId, members.id))
-              .where(and(eq(agents.uuid, bindRequest.agentId)))
-              .limit(1);
+              // Backfill `agent:pinned` for any agent already bound to this
+              // client at registration time. Without this, an admin who pins an
+              // agent while the client is offline would still need a manual
+              // `first-tree-hub agent add` after restart — the realtime push in
+              // admin/agents.ts only fires for live sockets. The client dedupes
+              // on agentId, so re-firing on every reconnect is safe.
+              try {
+                const pinned = await clientService.listActiveAgentsPinnedToClient(app.db, data.clientId);
+                for (const agent of pinned) {
+                  const parsed = agentPinnedMessageSchema.safeParse({
+                    type: "agent:pinned",
+                    agentId: agent.uuid,
+                    name: agent.name,
+                    displayName: agent.displayName,
+                    agentType: agent.type,
+                  });
+                  if (!parsed.success) {
+                    app.log.warn(
+                      { err: parsed.error.flatten(), agentId: agent.uuid, clientId: data.clientId },
+                      "agent:pinned backfill frame failed schema validation — skipping",
+                    );
+                    continue;
+                  }
+                  socket.send(JSON.stringify(parsed.data));
+                }
+              } catch (err) {
+                app.log.error(
+                  { err, clientId: data.clientId },
+                  "agent:pinned backfill on client:register failed — client may need manual `agent add`",
+                );
+              }
+            } else if (type === "agent:bind") {
+              if (!clientId) {
+                socket.send(JSON.stringify({ type: "error", ref, message: "Must register client first" }));
+                return;
+              }
 
-            if (!agent) {
-              sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.UNKNOWN_AGENT);
-              return;
-            }
-            if (agent.organizationId !== session.organizationId) {
-              sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_ORG);
-              return;
-            }
-            if (agent.status !== "active") {
-              sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.AGENT_SUSPENDED);
-              return;
-            }
+              const bindRequest = agentBindRequestSchema.parse(msg);
 
-            // First-bind path: agent.clientId is NULL (e.g. created before
-            // the operator brought up a client, or migrated from pre-M1 with
-            // no presence record). Claim it for the connecting client iff
-            // the manager and the connecting session belong to the same
-            // user. The race-safe UPDATE returns 0 rows if another bind
-            // claimed it first — surface as WRONG_CLIENT.
-            if (agent.clientId === null) {
-              if (!agent.managerUserId || agent.managerUserId !== session.userId) {
+              const [agent] = await app.db
+                .select({
+                  id: agents.uuid,
+                  displayName: agents.displayName,
+                  type: agents.type,
+                  organizationId: agents.organizationId,
+                  inboxId: agents.inboxId,
+                  status: agents.status,
+                  clientId: agents.clientId,
+                  clientUserId: clients.userId,
+                  managerUserId: members.userId,
+                })
+                .from(agents)
+                .leftJoin(clients, eq(agents.clientId, clients.id))
+                .leftJoin(members, eq(agents.managerId, members.id))
+                .where(and(eq(agents.uuid, bindRequest.agentId)))
+                .limit(1);
+
+              if (!agent) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.UNKNOWN_AGENT);
+                return;
+              }
+              if (agent.organizationId !== session.organizationId) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_ORG);
+                return;
+              }
+              if (agent.status !== "active") {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.AGENT_SUSPENDED);
+                return;
+              }
+
+              // First-bind path: agent.clientId is NULL (e.g. created before
+              // the operator brought up a client, or migrated from pre-M1 with
+              // no presence record). Claim it for the connecting client iff
+              // the manager and the connecting session belong to the same
+              // user. The race-safe UPDATE returns 0 rows if another bind
+              // claimed it first — surface as WRONG_CLIENT.
+              if (agent.clientId === null) {
+                if (!agent.managerUserId || agent.managerUserId !== session.userId) {
+                  sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
+                  return;
+                }
+                const claim = await app.db
+                  .update(agents)
+                  .set({ clientId, updatedAt: new Date() })
+                  .where(and(eq(agents.uuid, agent.id), isNull(agents.clientId)))
+                  .returning({ uuid: agents.uuid });
+                if (claim.length === 0) {
+                  sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
+                  return;
+                }
+              } else if (agent.clientId !== clientId) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
+                return;
+              } else if (!agent.clientUserId || agent.clientUserId !== session.userId) {
                 sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
                 return;
               }
-              const claim = await app.db
-                .update(agents)
-                .set({ clientId, updatedAt: new Date() })
-                .where(and(eq(agents.uuid, agent.id), isNull(agents.clientId)))
-                .returning({ uuid: agents.uuid });
-              if (claim.length === 0) {
-                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
+
+              await presenceService.bindAgent(app.db, agent.id, {
+                clientId,
+                instanceId,
+                runtimeType: bindRequest.runtimeType,
+                runtimeVersion: bindRequest.runtimeVersion,
+              });
+
+              connectionManager.bindAgentToClient(clientId, agent.id);
+              boundAgents.set(agent.id, { agentId: agent.id, inboxId: agent.inboxId });
+
+              notifier.subscribe(agent.inboxId, socket);
+
+              socket.send(
+                JSON.stringify({
+                  type: "agent:bound",
+                  ref,
+                  agentId: agent.id,
+                  displayName: agent.displayName,
+                  agentType: agent.type,
+                }),
+              );
+            } else if (type === "agent:unbind") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
-            } else if (agent.clientId !== clientId) {
-              sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);
-              return;
-            } else if (!agent.clientUserId || agent.clientUserId !== session.userId) {
-              sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
-              return;
-            }
 
-            await presenceService.bindAgent(app.db, agent.id, {
-              clientId,
-              instanceId,
-              runtimeType: bindRequest.runtimeType,
-              runtimeVersion: bindRequest.runtimeVersion,
-            });
+              const info = boundAgents.get(agentId);
+              if (info) {
+                notifier.unsubscribe(info.inboxId, socket);
+              }
 
-            connectionManager.bindAgentToClient(clientId, agent.id);
-            boundAgents.set(agent.id, { agentId: agent.id, inboxId: agent.inboxId });
+              await presenceService.unbindAgent(app.db, agentId);
+              connectionManager.unbindAgentFromClient(agentId);
+              boundAgents.delete(agentId);
 
-            notifier.subscribe(agent.inboxId, socket);
+              socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
+            } else if (type === "session:state") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
 
-            socket.send(
-              JSON.stringify({
-                type: "agent:bound",
-                ref,
-                agentId: agent.id,
-                displayName: agent.displayName,
-                agentType: agent.type,
-              }),
-            );
-          } else if (type === "agent:unbind") {
-            const agentId = parsed.data.agentId;
-            if (!agentId || !boundAgents.has(agentId)) {
-              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
-              return;
-            }
+              const payload = sessionStateMessageSchema.parse(msg);
 
-            const info = boundAgents.get(agentId);
-            if (info) {
-              notifier.unsubscribe(info.inboxId, socket);
-            }
-
-            await presenceService.unbindAgent(app.db, agentId);
-            connectionManager.unbindAgentFromClient(agentId);
-            boundAgents.delete(agentId);
-
-            socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
-          } else if (type === "session:state") {
-            const agentId = parsed.data.agentId;
-            if (!agentId || !boundAgents.has(agentId)) {
-              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
-              return;
-            }
-
-            const payload = sessionStateMessageSchema.parse(msg);
-
-            // Drop persisted events on eviction. Chained through the per-session FIFO so any
-            // in-flight appendEvent finishes BEFORE clearEvents (otherwise late inserts resurrect rows).
-            if (payload.state === "evicted") {
-              chainSessionOp(agentId, payload.chatId, () =>
-                sessionEventService.clearEvents(app.db, agentId, payload.chatId).catch(() => {}),
-              );
-            }
-
-            await activityService.upsertSessionState(
-              app.db,
-              agentId,
-              payload.chatId,
-              payload.state,
-              session.organizationId,
-              notifier,
-            );
-          } else if (type === "runtime:state") {
-            const agentId = parsed.data.agentId;
-            if (!agentId || !boundAgents.has(agentId)) {
-              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
-              return;
-            }
-
-            const payload = runtimeStateMessageSchema.parse(msg);
-            await presenceService.setRuntimeState(app.db, agentId, payload.runtimeState, {
-              organizationId: session.organizationId,
-              notifier,
-            });
-
-            if (payload.runtimeState === "error" && shouldNotify(agentId, "agent_error")) {
-              notificationService
-                .notifyAgentEvent(app.db, agentId, "agent_error", "high", `Agent ${agentId} entered error state`)
-                .catch(() => {});
-            } else if (payload.runtimeState === "blocked" && shouldNotify(agentId, "agent_blocked")) {
-              notificationService
-                .notifyAgentEvent(app.db, agentId, "agent_blocked", "medium", `Agent ${agentId} is blocked`)
-                .catch(() => {});
-            }
-          } else if (type === "session:event") {
-            const agentId = parsed.data.agentId;
-            if (!agentId || !boundAgents.has(agentId)) {
-              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
-              return;
-            }
-
-            const payload = sessionEventMessageSchema.parse(msg);
-            chainSessionOp(agentId, payload.chatId, async () => {
-              try {
-                await sessionEventService.appendEvent(app.db, agentId, payload.chatId, payload.event);
-              } catch (err) {
-                socket.send(
-                  JSON.stringify({
-                    type: "error",
-                    message: `Failed to persist session event: ${err instanceof Error ? err.message : String(err)}`,
-                  }),
+              // Drop persisted events on eviction. Chained through the per-session FIFO so any
+              // in-flight appendEvent finishes BEFORE clearEvents (otherwise late inserts resurrect rows).
+              if (payload.state === "evicted") {
+                chainSessionOp(agentId, payload.chatId, () =>
+                  sessionEventService.clearEvents(app.db, agentId, payload.chatId).catch(() => {}),
                 );
               }
-            });
-          } else if (type === "session:completion") {
-            const agentId = parsed.data.agentId;
-            if (!agentId || !boundAgents.has(agentId)) {
-              socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
-              return;
-            }
 
-            const payload = sessionCompletionMessageSchema.parse(msg);
+              await activityService.upsertSessionState(
+                app.db,
+                agentId,
+                payload.chatId,
+                payload.state,
+                session.organizationId,
+                notifier,
+              );
+            } else if (type === "runtime:state") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
 
-            if (shouldNotify(agentId, `session_completed:${payload.chatId}`)) {
-              notificationService
-                .notifyAgentEvent(
-                  app.db,
-                  agentId,
-                  "session_completed",
-                  "low",
-                  `Agent ${agentId} completed a task`,
-                  payload.chatId,
-                )
-                .catch(() => {});
+              const payload = runtimeStateMessageSchema.parse(msg);
+              await presenceService.setRuntimeState(app.db, agentId, payload.runtimeState, {
+                organizationId: session.organizationId,
+                notifier,
+              });
+
+              if (payload.runtimeState === "error" && shouldNotify(agentId, "agent_error")) {
+                notificationService
+                  .notifyAgentEvent(app.db, agentId, "agent_error", "high", `Agent ${agentId} entered error state`)
+                  .catch(() => {});
+              } else if (payload.runtimeState === "blocked" && shouldNotify(agentId, "agent_blocked")) {
+                notificationService
+                  .notifyAgentEvent(app.db, agentId, "agent_blocked", "medium", `Agent ${agentId} is blocked`)
+                  .catch(() => {});
+              }
+            } else if (type === "session:event") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
+
+              const payload = sessionEventMessageSchema.parse(msg);
+              chainSessionOp(agentId, payload.chatId, async () => {
+                try {
+                  await sessionEventService.appendEvent(app.db, agentId, payload.chatId, payload.event);
+                } catch (err) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "error",
+                      message: `Failed to persist session event: ${err instanceof Error ? err.message : String(err)}`,
+                    }),
+                  );
+                }
+              });
+            } else if (type === "session:completion") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
+
+              const payload = sessionCompletionMessageSchema.parse(msg);
+
+              if (shouldNotify(agentId, `session_completed:${payload.chatId}`)) {
+                notificationService
+                  .notifyAgentEvent(
+                    app.db,
+                    agentId,
+                    "session_completed",
+                    "low",
+                    `Agent ${agentId} completed a task`,
+                    payload.chatId,
+                  )
+                  .catch(() => {});
+              }
+            } else if (type === "heartbeat") {
+              if (clientId) {
+                await clientService.heartbeatClient(app.db, clientId);
+                await Promise.all([...boundAgents.keys()].map((id) => presenceService.touchAgent(app.db, id)));
+              }
+              socket.send(JSON.stringify({ type: "heartbeat:ack" }));
             }
-          } else if (type === "heartbeat") {
-            if (clientId) {
-              await clientService.heartbeatClient(app.db, clientId);
-              await Promise.all([...boundAgents.keys()].map((id) => presenceService.touchAgent(app.db, id)));
-            }
-            socket.send(JSON.stringify({ type: "heartbeat:ack" }));
+          } catch (err) {
+            const message = err instanceof Error ? err.message : "Internal error";
+            socket.send(JSON.stringify({ type: "error", message }));
           }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : "Internal error";
-          socket.send(JSON.stringify({ type: "error", message }));
-        }
+        });
       });
 
       socket.on("close", async (closeCode?: number) => {

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -4,11 +4,14 @@ import type { FastifyInstance, FastifyReply } from "fastify";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
 import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
+import { createLogger } from "../../observability/index.js";
 import { createAgent } from "../../services/agent.js";
 import { findOrCreateDirectChat } from "../../services/chat.js";
 import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 import { resolveDefaultOrgId } from "../../services/organization.js";
+
+const log = createLogger("GithubWebhook");
 
 // ── GitHub payload types ────────────────────────────────────────────
 
@@ -186,7 +189,10 @@ async function routeMentionDelegations(
       .limit(1);
 
     if (!target || target.status !== "active") {
-      app.log.warn(`delegate_mention target "${agent.delegateMention}" for "${agent.name}" is not active, skipping`);
+      log.warn(
+        { targetAgent: agent.delegateMention, sourceAgent: agent.name },
+        "delegate_mention target not active, skipping",
+      );
       continue;
     }
 
@@ -213,7 +219,10 @@ async function routeMentionDelegations(
       notifyRecipients(app.notifier, recipients, msg.id);
       routed++;
     } catch (err) {
-      app.log.error(err, `Failed to route mention delegation from "${agent.name}" to "${agent.delegateMention}"`);
+      log.error(
+        { err, sourceAgent: agent.name, targetAgent: agent.delegateMention },
+        "failed to route mention delegation",
+      );
     }
   }
 
@@ -546,7 +555,7 @@ async function handleIssuesEvent(
   ]);
 
   if (!targetAgentId) {
-    app.log.warn(`No target agent found for GitHub issue event on ${data.repository.full_name}`);
+    log.warn({ repo: data.repository.full_name, event: "issue" }, "no target agent found for GitHub event");
     return reply.status(200).send({ ok: true, event: "issues", action: data.action, routed: false });
   }
 
@@ -607,7 +616,7 @@ async function handleIssueCommentEvent(
   ]);
 
   if (!targetAgentId) {
-    app.log.warn(`No target agent found for GitHub issue_comment event on ${data.repository.full_name}`);
+    log.warn({ repo: data.repository.full_name, event: "issue_comment" }, "no target agent found for GitHub event");
     return reply.status(200).send({ ok: true, event: "issue_comment", action: data.action, routed: false });
   }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -5,7 +5,7 @@ import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
-import Fastify from "fastify";
+import Fastify, { type FastifyBaseLogger } from "fastify";
 import postgres from "postgres";
 import { ZodError } from "zod";
 import { adminAdapterMappingRoutes } from "./api/admin/adapter-mappings.js";
@@ -48,6 +48,14 @@ import { connectDatabase } from "./db/connection.js";
 import { AppError } from "./errors.js";
 import { agentSelectorHook } from "./middleware/agent-selector.js";
 import { memberAuthHook, requireAdminRoleHook } from "./middleware/member-auth.js";
+import {
+  applyLoggerConfig,
+  createLogger,
+  currentTraceId,
+  getFastifyOtelPlugin,
+  observabilityPlugin,
+  rootLogger,
+} from "./observability/index.js";
 import { type AdapterManager, createAdapterManager } from "./services/adapter-manager.js";
 import { broadcastToAdmins } from "./services/admin-broadcast.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
@@ -68,7 +76,26 @@ export type AppContext = {
 };
 
 export async function buildApp(config: Config) {
-  const app = Fastify({ logger: config.logger ?? true });
+  applyLoggerConfig({
+    level: config.observability.logging.level,
+    format: config.observability.logging.format,
+    bridgeToSpanLevel: config.observability.logging.bridgeToSpanLevel,
+  });
+
+  // Cast widens pino.Logger<never, boolean> → FastifyBaseLogger so the
+  // returned FastifyInstance has the default generic and remains assignable
+  // in tests / callers that reference FastifyInstance without type args.
+  const app = Fastify({ loggerInstance: rootLogger as unknown as FastifyBaseLogger });
+
+  // Register @fastify/otel before any route — it wraps each request handler
+  // in an HTTP span that becomes the parent for business spans.
+  const otelPlugin = getFastifyOtelPlugin();
+  if (otelPlugin) {
+    await app.register(otelPlugin);
+  }
+
+  // Request-scoped logger + x-trace-id + error correlation
+  await app.register(observabilityPlugin);
 
   // Decorate with config and db
   const db = connectDatabase(config.database.url);
@@ -101,16 +128,19 @@ export async function buildApp(config: Config) {
   const adminOnly = requireAdminRoleHook();
   const agentSelector = agentSelectorHook(db);
 
-  // Error handler
-  app.setErrorHandler((error, _request, reply) => {
+  // Error handler — enriches error body with traceId so operators can search
+  // the trace backend by `x-trace-id` or body.traceId.
+  app.setErrorHandler((error, request, reply) => {
+    const traceId = currentTraceId();
+    const traceField = traceId ? { traceId } : {};
     if (error instanceof AppError) {
-      return reply.status(error.statusCode).send({ error: error.message });
+      return reply.status(error.statusCode).send({ error: error.message, ...traceField });
     }
     if (error instanceof ZodError) {
-      return reply.status(400).send({ error: "Validation error", details: error.issues });
+      return reply.status(400).send({ error: "Validation error", details: error.issues, ...traceField });
     }
-    app.log.error(error);
-    return reply.status(500).send({ error: "Internal server error" });
+    request.log.error({ err: error }, "unhandled request error");
+    return reply.status(500).send({ error: "Internal server error", ...traceField });
   });
 
   // Root-level health check for container orchestration (outside /api/v1)
@@ -369,10 +399,11 @@ export async function buildApp(config: Config) {
   const pulseAggregator = createPulseAggregator({ notifier, broadcast: broadcastToAdmins });
 
   // Register config change handler for hot reload
+  const hotReloadLog = createLogger("HotReload");
   notifier.onConfigChange((configType) => {
     if (configType === "adapter_configs") {
-      adapterManager.reload().catch((err) => app.log.error(err, "Adapter hot-reload failed (PG NOTIFY)"));
-      kaelRuntime?.reload().catch((err) => app.log.error(err, "Kael hot-reload failed (PG NOTIFY)"));
+      adapterManager.reload().catch((err) => hotReloadLog.error({ err }, "adapter hot-reload failed (PG NOTIFY)"));
+      kaelRuntime?.reload().catch((err) => hotReloadLog.error({ err }, "kael hot-reload failed (PG NOTIFY)"));
     }
   });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -7,8 +7,6 @@ import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/
 export type Config = ServerConfig & {
   /** Unique ID for this server instance — generated at startup */
   instanceId: string;
-  /** Fastify logger config */
-  logger?: boolean;
   /** Web static files dist path — resolved by CLI startup */
   webDistPath?: string;
 };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,9 @@ import { randomUUID } from "node:crypto";
 import { initConfig, serverConfigSchema } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { buildApp } from "./app.js";
 import type { Config } from "./config.js";
+import { applyLoggerConfig, createLogger, initTelemetry, shutdownTelemetry } from "./observability/index.js";
+
+const log = createLogger("Bootstrap");
 
 async function main() {
   const serverConfig = await initConfig({
@@ -9,17 +12,47 @@ async function main() {
     role: "server",
   });
 
+  // Apply logger config first so bootstrap logs use the right level / format.
+  applyLoggerConfig({
+    level: serverConfig.observability.logging.level,
+    format: serverConfig.observability.logging.format,
+    bridgeToSpanLevel: serverConfig.observability.logging.bridgeToSpanLevel,
+  });
+
   const config: Config = {
     ...serverConfig,
     instanceId: `srv_${randomUUID().slice(0, 8)}`,
-    logger: true,
   };
+
+  // Initialize telemetry before anything else — spans emitted during app
+  // bootstrap (e.g. notifier.start) will then be captured. instanceId is
+  // carried as service.instance.id so replicas are distinguishable in the
+  // trace backend.
+  initTelemetry(serverConfig.observability.tracing, config.instanceId);
 
   const app = await buildApp(config);
   await app.listen({ host: config.server.host, port: config.server.port });
+  log.info(`server listening on http://${config.server.host}:${config.server.port}`);
+
+  const shutdown = async (signal: string) => {
+    log.info(`received ${signal}, shutting down`);
+    try {
+      await app.close();
+    } finally {
+      await shutdownTelemetry();
+      process.exit(0);
+    }
+  };
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
+  });
 }
 
 main().catch((err) => {
-  console.error("Failed to start server:", err);
+  const bootLog = createLogger("Bootstrap");
+  bootLog.fatal({ err }, "failed to start server");
   process.exit(1);
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,7 +28,7 @@ async function main() {
   // bootstrap (e.g. notifier.start) will then be captured. instanceId is
   // carried as service.instance.id so replicas are distinguishable in the
   // trace backend.
-  initTelemetry(serverConfig.observability.tracing, config.instanceId);
+  await initTelemetry(serverConfig.observability.tracing, config.instanceId);
 
   const app = await buildApp(config);
   await app.listen({ host: config.server.host, port: config.server.port });

--- a/packages/server/src/observability/__tests__/logger.test.ts
+++ b/packages/server/src/observability/__tests__/logger.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyLoggerConfig, createLogger, setErrorSink } from "../logger.js";
+
+type SinkCall = { message: string; err: unknown; context: Record<string, unknown> };
+
+function installSpySink(): { calls: SinkCall[]; restore: () => void } {
+  const calls: SinkCall[] = [];
+  setErrorSink((message, err, context) => {
+    calls.push({ message, err, context });
+  });
+  return { calls, restore: () => setErrorSink(null) };
+}
+
+describe("logger ErrorSink bridging", () => {
+  // Silence stdout writes from the logger during tests.
+  // `vi.spyOn` on overloaded signatures (process.stdout.write) resists typing;
+  // the spy is only used to restore the mock so `unknown` is fine.
+  let writeSpy: { mockRestore(): void } | undefined;
+
+  afterEach(() => {
+    writeSpy?.mockRestore();
+    // Reset log config back to permissive defaults so other tests are unaffected.
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    setErrorSink(null);
+  });
+
+  function silenceStdout() {
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+  }
+
+  it("forwards error-level logs to the registered sink", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+
+    const log = createLogger("TestModule");
+    log.error({ err: new Error("boom"), userId: "u1" }, "something exploded");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.message).toBe("something exploded");
+    expect(calls[0]?.err).toMatchObject({ message: "boom" });
+    expect(calls[0]?.context.userId).toBe("u1");
+    expect(calls[0]?.context.module).toBe("TestModule");
+
+    restore();
+  });
+
+  it("forwards fatal-level logs to the sink", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+
+    createLogger("M").fatal("dying");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.message).toBe("dying");
+    restore();
+  });
+
+  it("does NOT forward warn-level logs when bridgeToSpanLevel=error", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+
+    createLogger("M").warn("non-fatal");
+
+    expect(calls).toHaveLength(0);
+    restore();
+  });
+
+  it("DOES forward warn-level logs when bridgeToSpanLevel=warn", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "warn" });
+    const { calls, restore } = installSpySink();
+
+    createLogger("M").warn("heads up");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.message).toBe("heads up");
+    restore();
+  });
+
+  it("does NOT forward any level when bridgeToSpanLevel=off", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "off" });
+    const { calls, restore } = installSpySink();
+
+    const log = createLogger("M");
+    log.error("boom1");
+    log.fatal("boom2");
+
+    expect(calls).toHaveLength(0);
+    restore();
+  });
+
+  it("does nothing when no sink is registered", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    setErrorSink(null);
+
+    // Should not throw when no sink is installed.
+    expect(() => createLogger("M").error("no-sink-registered")).not.toThrow();
+  });
+
+  it("swallows sink exceptions without breaking the logging path", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    setErrorSink(() => {
+      throw new Error("sink blew up");
+    });
+
+    expect(() => createLogger("M").error("boom")).not.toThrow();
+    setErrorSink(null);
+  });
+});
+
+describe("logger output format", () => {
+  // `vi.spyOn` on overloaded signatures (process.stdout.write) resists typing;
+  // the spy is only used to restore the mock so `unknown` is fine.
+  let writeSpy: { mockRestore(): void } | undefined;
+
+  afterEach(() => {
+    writeSpy?.mockRestore();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+  });
+
+  it("emits NDJSON when format=json", () => {
+    const chunks: string[] = [];
+    // process.stdout.write has multiple overloads; cast keeps the mock simple.
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as never);
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "off" });
+
+    createLogger("M").info({ k: "v" }, "hello");
+
+    const combined = chunks.join("");
+    // json format writes raw NDJSON from pino; should parse back.
+    const parsed = JSON.parse(combined.trim());
+    expect(parsed.module).toBe("M");
+    expect(parsed.msg).toBe("hello");
+    expect(parsed.k).toBe("v");
+  });
+
+  it("emits human-readable pretty output when format=pretty", () => {
+    const chunks: string[] = [];
+    // process.stdout.write has multiple overloads; cast keeps the mock simple.
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as never);
+    applyLoggerConfig({ level: "trace", format: "pretty", bridgeToSpanLevel: "off" });
+
+    createLogger("M").info("hello");
+
+    const combined = chunks.join("");
+    expect(combined).toContain("INFO");
+    expect(combined).toContain("[M]");
+    expect(combined).toContain("hello");
+  });
+});

--- a/packages/server/src/observability/__tests__/logger.test.ts
+++ b/packages/server/src/observability/__tests__/logger.test.ts
@@ -112,6 +112,40 @@ describe("logger ErrorSink bridging", () => {
     expect(() => createLogger("M").error("boom")).not.toThrow();
     setErrorSink(null);
   });
+
+  it("truncates overlong string values before handing them to the sink", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+
+    // 5000-char string — well above MAX_STRING_LEN (2048)
+    const huge = "x".repeat(5000);
+    createLogger("M").error({ payload: huge }, "big error");
+
+    expect(calls).toHaveLength(1);
+    const forwarded = calls[0]?.context.payload;
+    expect(typeof forwarded).toBe("string");
+    // Truncation marker must be appended; length is capped at MAX_STRING_LEN + marker
+    expect(forwarded).toMatch(/\.\.\.\[truncated \d+ chars\]$/);
+    expect((forwarded as string).length).toBeLessThan(huge.length);
+    restore();
+  });
+
+  it("JSON-stringifies and truncates oversized object values", () => {
+    silenceStdout();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+
+    // Object whose JSON will exceed MAX_JSON_LEN (8192)
+    const big = { items: Array.from({ length: 1000 }, (_, i) => ({ id: i, data: "x".repeat(50) })) };
+    createLogger("M").error({ state: big }, "bulky state");
+
+    expect(calls).toHaveLength(1);
+    const forwarded = calls[0]?.context.state;
+    expect(typeof forwarded).toBe("string");
+    expect(forwarded).toMatch(/\.\.\.\[truncated \d+ chars\]$/);
+    restore();
+  });
 });
 
 describe("logger output format", () => {

--- a/packages/server/src/observability/__tests__/span-attrs.test.ts
+++ b/packages/server/src/observability/__tests__/span-attrs.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { adapterAttrs, agentAttrs, chatAttrs, inboxAttrs, messageAttrs } from "../span-attrs.js";
+
+describe("span-attrs helpers", () => {
+  describe("messageAttrs", () => {
+    it("includes all provided fields with standard attribute names", () => {
+      const out = messageAttrs({ id: "m1", chatId: "c1", source: "feishu", senderAgentId: "a1" });
+      expect(out).toEqual({
+        "message.id": "m1",
+        "chat.id": "c1",
+        "message.source": "feishu",
+        "agent.id": "a1",
+      });
+    });
+
+    it("omits unset fields rather than emitting undefined", () => {
+      const out = messageAttrs({ id: "m1" });
+      expect(out).toEqual({ "message.id": "m1" });
+      expect("chat.id" in out).toBe(false);
+      expect("message.source" in out).toBe(false);
+    });
+
+    it("returns an empty object when nothing is provided", () => {
+      expect(messageAttrs({})).toEqual({});
+    });
+  });
+
+  describe("inboxAttrs", () => {
+    it("stringifies numeric entry ids (OTel prefers string for ids)", () => {
+      const out = inboxAttrs({ id: 42, messageId: "m1", agentId: "a1", status: "pending", retryCount: 2 });
+      expect(out).toEqual({
+        "inbox.entry.id": "42",
+        "message.id": "m1",
+        "agent.id": "a1",
+        "inbox.entry.status": "pending",
+        "inbox.delivery.attempt": 2,
+      });
+    });
+
+    it("handles retryCount=0 (not falsy-skipped)", () => {
+      const out = inboxAttrs({ id: 1, retryCount: 0 });
+      expect(out["inbox.delivery.attempt"]).toBe(0);
+    });
+
+    it("omits id when undefined or null", () => {
+      expect(inboxAttrs({})).toEqual({});
+      expect(inboxAttrs({ id: undefined })).toEqual({});
+    });
+  });
+
+  describe("chatAttrs", () => {
+    it("maps fields to namespaced attribute names", () => {
+      const out = chatAttrs({ id: "c1", type: "direct", organizationId: "org1" });
+      expect(out).toEqual({
+        "chat.id": "c1",
+        "chat.type": "direct",
+        "organization.id": "org1",
+      });
+    });
+  });
+
+  describe("agentAttrs", () => {
+    it("accepts either `uuid` or `id`, preferring uuid", () => {
+      expect(agentAttrs({ uuid: "u1", id: "fallback" })["agent.id"]).toBe("u1");
+      expect(agentAttrs({ id: "i1" })["agent.id"]).toBe("i1");
+    });
+
+    it("includes organization and client fields when present", () => {
+      const out = agentAttrs({ uuid: "u1", organizationId: "o1", clientId: "cli1" });
+      expect(out).toEqual({
+        "agent.id": "u1",
+        "organization.id": "o1",
+        "client.id": "cli1",
+      });
+    });
+  });
+
+  describe("adapterAttrs", () => {
+    it("stringifies numeric adapter ids", () => {
+      const out = adapterAttrs({ id: 7, platform: "feishu", externalChatId: "oc_abc", agentId: "a1" });
+      expect(out).toEqual({
+        "adapter.id": "7",
+        "adapter.platform": "feishu",
+        "adapter.external_chat_id": "oc_abc",
+        "agent.id": "a1",
+      });
+    });
+
+    it("accepts string ids unchanged", () => {
+      expect(adapterAttrs({ id: "github-adapter" })["adapter.id"]).toBe("github-adapter");
+    });
+  });
+
+  describe("stability of attribute keys (contract)", () => {
+    // These assertions guard the *string* keys that become queries in Logfire /
+    // Honeycomb. Changing them is a cross-span search-breaking event — the
+    // test is effectively a schema contract.
+    it("uses lowercase dot-separated keys under documented namespaces", () => {
+      const all = {
+        ...messageAttrs({ id: "x", chatId: "x", source: "x", senderAgentId: "x" }),
+        ...inboxAttrs({ id: 1, messageId: "x", agentId: "x", status: "x", retryCount: 1 }),
+        ...chatAttrs({ id: "x", type: "x", organizationId: "x" }),
+        ...agentAttrs({ uuid: "x", organizationId: "x", clientId: "x" }),
+        ...adapterAttrs({ id: 1, platform: "x", externalChatId: "x", agentId: "x" }),
+      };
+      const expectedKeys = [
+        "message.id",
+        "chat.id",
+        "message.source",
+        "agent.id",
+        "inbox.entry.id",
+        "inbox.entry.status",
+        "inbox.delivery.attempt",
+        "chat.type",
+        "organization.id",
+        "client.id",
+        "adapter.id",
+        "adapter.platform",
+        "adapter.external_chat_id",
+      ];
+      for (const key of expectedKeys) {
+        expect(all).toHaveProperty(key);
+      }
+    });
+  });
+});

--- a/packages/server/src/observability/__tests__/telemetry.test.ts
+++ b/packages/server/src/observability/__tests__/telemetry.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { normalizeAttrs, parseHeaderString } from "../telemetry.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initTelemetry,
+  isTelemetryEnabled,
+  normalizeAttrs,
+  parseHeaderString,
+  shutdownTelemetry,
+} from "../telemetry.js";
 
 describe("normalizeAttrs", () => {
   describe("sensitive key redaction", () => {
@@ -121,5 +127,67 @@ describe("parseHeaderString", () => {
   it("handles realistic Logfire-style token header", () => {
     const out = parseHeaderString("Authorization=Bearer pylf_v1_us_xyzABC123==");
     expect(out).toEqual({ Authorization: "Bearer pylf_v1_us_xyzABC123==" });
+  });
+});
+
+describe("initTelemetry / shutdownTelemetry lifecycle", () => {
+  afterEach(async () => {
+    // Make sure each test starts from a clean slate regardless of what the
+    // previous one left behind.
+    await shutdownTelemetry();
+  });
+
+  it("stays disabled when endpoint is empty", async () => {
+    await initTelemetry(undefined);
+    expect(isTelemetryEnabled()).toBe(false);
+
+    await initTelemetry({
+      endpoint: "",
+      headers: "",
+      exporter: "otlp-http",
+      serviceName: "test",
+      environment: "test",
+      sampleRate: 1,
+    });
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("enables after init and disables after shutdown", async () => {
+    await initTelemetry({
+      endpoint: "http://127.0.0.1:65535/v1/traces",
+      headers: "",
+      exporter: "otlp-http",
+      serviceName: "test",
+      environment: "test",
+      sampleRate: 1,
+    });
+    expect(isTelemetryEnabled()).toBe(true);
+
+    await shutdownTelemetry();
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+
+  it("is idempotent: double-init shuts down the first provider before creating the second", async () => {
+    const cfg = {
+      endpoint: "http://127.0.0.1:65535/v1/traces",
+      headers: "",
+      exporter: "otlp-http" as const,
+      serviceName: "test",
+      environment: "test",
+      sampleRate: 1,
+    };
+
+    await initTelemetry(cfg);
+    expect(isTelemetryEnabled()).toBe(true);
+
+    // Second call must not throw and must leave tracing enabled (not leak
+    // a zombie provider). The implementation tears the old one down first.
+    await expect(initTelemetry(cfg)).resolves.toBeUndefined();
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it("shutdownTelemetry on a never-initialized SDK is a no-op", async () => {
+    await expect(shutdownTelemetry()).resolves.toBeUndefined();
+    expect(isTelemetryEnabled()).toBe(false);
   });
 });

--- a/packages/server/src/observability/__tests__/telemetry.test.ts
+++ b/packages/server/src/observability/__tests__/telemetry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAttrs, parseHeaderString } from "../telemetry.js";
+
+describe("normalizeAttrs", () => {
+  describe("sensitive key redaction", () => {
+    it("redacts exact-match sensitive keys", () => {
+      const out = normalizeAttrs({
+        password: "hunter2",
+        token: "abc",
+        secret: "xyz",
+        apiKey: "key",
+      });
+      expect(out).toEqual({
+        password: "***",
+        token: "***",
+        secret: "***",
+        apiKey: "***",
+      });
+    });
+
+    it("redacts regardless of key casing", () => {
+      const out = normalizeAttrs({
+        Authorization: "Bearer xxx",
+        AUTHORIZATION: "Bearer yyy",
+        authorization: "Bearer zzz",
+      });
+      expect(out).toEqual({
+        Authorization: "***",
+        AUTHORIZATION: "***",
+        authorization: "***",
+      });
+    });
+
+    it("redacts keys where sensitive pattern is a substring", () => {
+      const out = normalizeAttrs({
+        userToken: "abc",
+        jwtSecret: "sign-key",
+        dbPassword: "pg",
+        encryptionKey: "aes",
+      });
+      expect(out.userToken).toBe("***");
+      expect(out.jwtSecret).toBe("***");
+      expect(out.dbPassword).toBe("***");
+      expect(out.encryptionKey).toBe("***");
+    });
+
+    it("does not redact benign keys that happen to look similar", () => {
+      const out = normalizeAttrs({
+        userId: "u123",
+        messageId: "m456",
+        "chat.id": "c789",
+      });
+      expect(out).toEqual({ userId: "u123", messageId: "m456", "chat.id": "c789" });
+    });
+  });
+
+  describe("type coercion", () => {
+    it("passes strings, numbers, booleans through", () => {
+      expect(normalizeAttrs({ s: "hi", n: 42, b: true })).toEqual({ s: "hi", n: 42, b: true });
+    });
+
+    it("preserves arrays of strings as arrays (OTel supports)", () => {
+      expect(normalizeAttrs({ tags: ["a", "b", "c"] })).toEqual({ tags: ["a", "b", "c"] });
+    });
+
+    it("JSON-stringifies objects and mixed arrays", () => {
+      const out = normalizeAttrs({
+        obj: { a: 1, b: "two" },
+        mixed: [1, "two", true],
+      });
+      expect(out.obj).toBe('{"a":1,"b":"two"}');
+      expect(out.mixed).toBe('[1,"two",true]');
+    });
+
+    it("drops null and undefined values", () => {
+      const out = normalizeAttrs({ keep: "yes", skip: null, gone: undefined });
+      expect(out).toEqual({ keep: "yes" });
+    });
+
+    it("returns empty object when input is undefined", () => {
+      expect(normalizeAttrs(undefined)).toEqual({});
+    });
+
+    it("falls back to String() when JSON.stringify throws", () => {
+      const circular: Record<string, unknown> = { name: "loop" };
+      circular.self = circular;
+      const out = normalizeAttrs({ circular });
+      expect(typeof out.circular).toBe("string");
+      // We don't care about the exact string — just that it didn't crash and produced something.
+      expect(out.circular).toBeTruthy();
+    });
+  });
+});
+
+describe("parseHeaderString", () => {
+  it("returns an empty object for empty input", () => {
+    expect(parseHeaderString("")).toEqual({});
+  });
+
+  it("parses simple key=value pairs", () => {
+    expect(parseHeaderString("a=1,b=2")).toEqual({ a: "1", b: "2" });
+  });
+
+  it("preserves values containing '=' (e.g. base64 padding)", () => {
+    const out = parseHeaderString("Authorization=Bearer abc==def");
+    expect(out).toEqual({ Authorization: "Bearer abc==def" });
+  });
+
+  it("trims whitespace around keys and values", () => {
+    expect(parseHeaderString("  a = 1 ,  b=2  ")).toEqual({ a: "1", b: "2" });
+  });
+
+  it("skips empty pairs and fragments without '='", () => {
+    expect(parseHeaderString("a=1,,b=2,invalid,c=3")).toEqual({ a: "1", b: "2", c: "3" });
+  });
+
+  it("skips fragments that start with '=' (no key)", () => {
+    expect(parseHeaderString("=nope,a=1")).toEqual({ a: "1" });
+  });
+
+  it("handles realistic Logfire-style token header", () => {
+    const out = parseHeaderString("Authorization=Bearer pylf_v1_us_xyzABC123==");
+    expect(out).toEqual({ Authorization: "Bearer pylf_v1_us_xyzABC123==" });
+  });
+});

--- a/packages/server/src/observability/__tests__/ws-tracing.test.ts
+++ b/packages/server/src/observability/__tests__/ws-tracing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { endWsConnectionSpan, setWsConnectionAttrs, startWsConnectionSpan, withWsMessageSpan } from "../ws-tracing.js";
+
+// When telemetry is disabled (default in unit tests — no initTelemetry call),
+// every ws-tracing function is supposed to be a no-op. A bug here would crash
+// the entire WS layer, not just the trace data — so these smoke tests exist
+// precisely to catch the regression where someone forgets the null check.
+
+describe("ws-tracing (telemetry disabled)", () => {
+  const fakeSocket = {} as unknown as WebSocket;
+
+  it("startWsConnectionSpan is a no-op when tracing is off", () => {
+    expect(() => startWsConnectionSpan(fakeSocket, { clientId: "c1" })).not.toThrow();
+  });
+
+  it("setWsConnectionAttrs on an untracked socket is a no-op", () => {
+    expect(() => setWsConnectionAttrs(fakeSocket, { "organization.id": "org1" })).not.toThrow();
+  });
+
+  it("endWsConnectionSpan on an untracked socket is a no-op", () => {
+    expect(() => endWsConnectionSpan(fakeSocket, 1000)).not.toThrow();
+  });
+
+  it("withWsMessageSpan runs the handler unwrapped", async () => {
+    let ran = false;
+    const result = await withWsMessageSpan(fakeSocket, "heartbeat", {}, async () => {
+      ran = true;
+      return "ok";
+    });
+    expect(ran).toBe(true);
+    expect(result).toBe("ok");
+  });
+
+  it("withWsMessageSpan propagates thrown errors", async () => {
+    await expect(
+      withWsMessageSpan(fakeSocket, "session:event", {}, async () => {
+        throw new Error("handler blew up");
+      }),
+    ).rejects.toThrow("handler blew up");
+  });
+
+  it("lifecycle start→setAttrs→end does not throw for sockets without spans", () => {
+    startWsConnectionSpan(fakeSocket, { clientId: "c1" });
+    setWsConnectionAttrs(fakeSocket, { "member.id": "m1" });
+    endWsConnectionSpan(fakeSocket, 1000);
+    // Second end should also be safe (idempotent no-op on cleared WeakMap entry)
+    endWsConnectionSpan(fakeSocket);
+  });
+});

--- a/packages/server/src/observability/fastify-plugin.ts
+++ b/packages/server/src/observability/fastify-plugin.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { createLogger } from "./logger.js";
-import { currentSpanId, currentTraceId } from "./telemetry.js";
+import { currentTraceId } from "./telemetry.js";
 
 /**
  * Fastify plugin that:
@@ -8,18 +8,20 @@ import { currentSpanId, currentTraceId } from "./telemetry.js";
  *    so request logs share the same format / output stream / errorSink.
  * 2. Stamps `x-trace-id` on every response when a trace id is available.
  * 3. Includes traceId in JSON error bodies emitted via `AppError`.
+ *
+ * We deliberately only bind `traceId` (stable for the whole request) — not
+ * `spanId`, which changes when handlers enter `withSpan(...)`. Binding it at
+ * onRequest would freeze it to the HTTP root span, mis-attributing later
+ * logs to the wrong span. Call sites that want the current span id can use
+ * `currentSpanId()` directly.
  */
 export const observabilityPlugin: FastifyPluginAsync = async (app: FastifyInstance) => {
   const log = createLogger("Http");
 
   app.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
     const traceId = currentTraceId();
-    const spanId = currentSpanId();
     const bindings: Record<string, unknown> = { requestId: request.id };
     if (traceId) bindings.traceId = traceId;
-    if (spanId) bindings.spanId = spanId;
-    // Replace Fastify's per-request logger with our module-scoped one so
-    // existing call sites (request.log.*) get our format + error sink.
     (request as FastifyRequest & { log: ReturnType<typeof log.child> }).log = log.child(bindings);
 
     if (traceId) {

--- a/packages/server/src/observability/fastify-plugin.ts
+++ b/packages/server/src/observability/fastify-plugin.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance, FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { createLogger } from "./logger.js";
+import { currentSpanId, currentTraceId } from "./telemetry.js";
+
+/**
+ * Fastify plugin that:
+ * 1. Swaps Fastify's request-scoped logger for a child of our createLogger
+ *    so request logs share the same format / output stream / errorSink.
+ * 2. Stamps `x-trace-id` on every response when a trace id is available.
+ * 3. Includes traceId in JSON error bodies emitted via `AppError`.
+ */
+export const observabilityPlugin: FastifyPluginAsync = async (app: FastifyInstance) => {
+  const log = createLogger("Http");
+
+  app.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
+    const traceId = currentTraceId();
+    const spanId = currentSpanId();
+    const bindings: Record<string, unknown> = { requestId: request.id };
+    if (traceId) bindings.traceId = traceId;
+    if (spanId) bindings.spanId = spanId;
+    // Replace Fastify's per-request logger with our module-scoped one so
+    // existing call sites (request.log.*) get our format + error sink.
+    (request as FastifyRequest & { log: ReturnType<typeof log.child> }).log = log.child(bindings);
+
+    if (traceId) {
+      reply.header("x-trace-id", traceId);
+    }
+  });
+
+  app.addHook("onResponse", async (request: FastifyRequest, reply: FastifyReply) => {
+    if (reply.statusCode >= 500) {
+      request.log.warn({ method: request.method, url: request.url, statusCode: reply.statusCode }, "request failed");
+    }
+  });
+};

--- a/packages/server/src/observability/index.ts
+++ b/packages/server/src/observability/index.ts
@@ -1,0 +1,32 @@
+export { FIRST_TREE_HUB_ATTR } from "@agent-team-foundation/first-tree-hub-shared/observability";
+export { observabilityPlugin } from "./fastify-plugin.js";
+export { applyLoggerConfig, createLogger, rootLogger, setErrorSink } from "./logger.js";
+export { adapterAttrs, agentAttrs, chatAttrs, inboxAttrs, messageAttrs } from "./span-attrs.js";
+export {
+  addSpanEvent,
+  context,
+  currentSpanId,
+  currentTraceId,
+  endSpan,
+  getFastifyOtelPlugin,
+  initTelemetry,
+  isContentCaptureEnabled,
+  isTelemetryEnabled,
+  normalizeAttrs,
+  propagation,
+  reportError,
+  SpanKind,
+  SpanStatusCode,
+  shutdownTelemetry,
+  startTrackedSpan,
+  type TracingConfig,
+  trace,
+  withSpan,
+} from "./telemetry.js";
+export {
+  endWsConnectionSpan,
+  getWsConnectionContext,
+  setWsConnectionAttrs,
+  startWsConnectionSpan,
+  withWsMessageSpan,
+} from "./ws-tracing.js";

--- a/packages/server/src/observability/index.ts
+++ b/packages/server/src/observability/index.ts
@@ -10,7 +10,6 @@ export {
   endSpan,
   getFastifyOtelPlugin,
   initTelemetry,
-  isContentCaptureEnabled,
   isTelemetryEnabled,
   normalizeAttrs,
   propagation,
@@ -25,7 +24,6 @@ export {
 } from "./telemetry.js";
 export {
   endWsConnectionSpan,
-  getWsConnectionContext,
   setWsConnectionAttrs,
   startWsConnectionSpan,
   withWsMessageSpan,

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -1,13 +1,18 @@
-import { Writable } from "node:stream";
+import {
+  createLoggerOutputStream,
+  formatLocalTime,
+  type LogFormat,
+  type LogLevel,
+  parseLogLevel,
+  SKIP_KEYS,
+} from "@agent-team-foundation/first-tree-hub-shared/observability";
 import pino from "pino";
 
 // ─── Config (late-initialized) ────────────────────────────────────────
 
-type LogFormat = "pretty" | "json";
-type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
-
+const initialLevel = parseLogLevel(process.env.FIRST_TREE_HUB_LOG_LEVEL);
 let _format: LogFormat = process.env.NODE_ENV === "production" ? "json" : "pretty";
-let _level: LogLevel = ((process.env.FIRST_TREE_HUB_LOG_LEVEL as LogLevel | undefined) ?? "info") as LogLevel;
+let _level: LogLevel = initialLevel.level;
 let _bridgeMinLevel = 50; // error
 
 /**
@@ -28,64 +33,6 @@ export function applyLoggerConfig(options: {
   rootLogger.level = options.level;
 }
 
-// ─── Pretty formatter ─────────────────────────────────────────────────
-
-const LEVEL_LABELS: Record<number, string> = {
-  10: "TRACE",
-  20: "DEBUG",
-  30: "INFO",
-  40: "WARN",
-  50: "ERROR",
-  60: "FATAL",
-};
-
-const LEVEL_COLORS: Record<number, string> = {
-  10: "\x1b[90m",
-  20: "\x1b[36m",
-  30: "\x1b[32m",
-  40: "\x1b[33m",
-  50: "\x1b[31m",
-  60: "\x1b[35m",
-};
-
-const RESET = "\x1b[0m";
-const DIM = "\x1b[2m";
-
-const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
-
-function formatPrettyEntry(json: string): string {
-  const obj = JSON.parse(json) as Record<string, unknown>;
-  const level = obj.level as number;
-  const label = LEVEL_LABELS[level] ?? "???";
-  const color = LEVEL_COLORS[level] ?? "";
-  const time = (obj.time as string) ?? new Date().toISOString();
-  const module = obj.module ? `[${String(obj.module)}] ` : "";
-  const msg = (obj.msg as string) ?? "";
-
-  const extras: string[] = [];
-  let errStack = "";
-  for (const [k, v] of Object.entries(obj)) {
-    if (SKIP_KEYS.has(k)) continue;
-    if (k === "err" && v && typeof v === "object") {
-      const e = v as Record<string, unknown>;
-      if (e.message) extras.push(`err.message=${String(e.message)}`);
-      if (typeof e.stack === "string") errStack = `\n${DIM}${e.stack}${RESET}`;
-    } else {
-      extras.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
-    }
-  }
-
-  const extraStr = extras.length > 0 ? `  ${DIM}${extras.join(" ")}${RESET}` : "";
-  return `${DIM}${time}${RESET} ${color}${label.padEnd(5)}${RESET} ${module}${msg}${extraStr}${errStack}\n`;
-}
-
-function formatLocalTime(): string {
-  const d = new Date();
-  const date = d.toLocaleDateString("sv-SE");
-  const time = d.toLocaleTimeString("en-GB", { hour12: false });
-  return `${date} ${time}`;
-}
-
 // ─── Error sink (bridges error/fatal logs onto active span) ───────────
 
 type ErrorSink = (message: string, err: unknown, context: Record<string, unknown>) => void;
@@ -93,6 +40,32 @@ let _errorSink: ErrorSink | null = null;
 
 export function setErrorSink(sink: ErrorSink | null): void {
   _errorSink = sink;
+}
+
+/**
+ * Truncate values before handing them to the sink. Strings over ~2KB get
+ * clipped with a marker; objects are JSON-stringified then clipped. Prevents
+ * an accidental 10MB log payload from becoming a 10MB span attribute.
+ */
+const MAX_STRING_LEN = 2048;
+const MAX_JSON_LEN = 8192;
+
+function truncateForAttr(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    if (value.length <= MAX_STRING_LEN) return value;
+    return `${value.slice(0, MAX_STRING_LEN)}...[truncated ${value.length - MAX_STRING_LEN} chars]`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value) && value.every((x) => typeof x === "string")) return value;
+  try {
+    const json = JSON.stringify(value);
+    if (!json) return undefined;
+    if (json.length <= MAX_JSON_LEN) return json;
+    return `${json.slice(0, MAX_JSON_LEN)}...[truncated ${json.length - MAX_JSON_LEN} chars]`;
+  } catch {
+    return String(value);
+  }
 }
 
 function forwardErrorIfNeeded(obj: Record<string, unknown>): void {
@@ -104,7 +77,8 @@ function forwardErrorIfNeeded(obj: Record<string, unknown>): void {
   const context: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {
     if (SKIP_KEYS.has(k) || k === "err") continue;
-    context[k] = v;
+    const truncated = truncateForAttr(v);
+    if (truncated !== undefined) context[k] = truncated;
   }
   if (typeof obj.module === "string") context.module = obj.module;
   try {
@@ -114,31 +88,12 @@ function forwardErrorIfNeeded(obj: Record<string, unknown>): void {
   }
 }
 
-// ─── Output stream ────────────────────────────────────────────────────
-
-const outputStream = new Writable({
-  write(chunk, _, callback) {
-    const text = chunk.toString();
-    try {
-      if (_format === "pretty") {
-        process.stdout.write(formatPrettyEntry(text));
-      } else {
-        process.stdout.write(text);
-      }
-      try {
-        const obj = JSON.parse(text) as Record<string, unknown>;
-        forwardErrorIfNeeded(obj);
-      } catch {
-        // non-JSON line, ignore
-      }
-    } catch {
-      process.stdout.write(text);
-    }
-    callback();
-  },
-});
-
 // ─── Root logger ──────────────────────────────────────────────────────
+
+const outputStream = createLoggerOutputStream({
+  getFormat: () => _format,
+  onJsonEntry: forwardErrorIfNeeded,
+});
 
 export const rootLogger = pino(
   {
@@ -147,6 +102,13 @@ export const rootLogger = pino(
   },
   outputStream,
 );
+
+if (initialLevel.fellBack) {
+  rootLogger.warn(
+    { envValue: process.env.FIRST_TREE_HUB_LOG_LEVEL },
+    "invalid FIRST_TREE_HUB_LOG_LEVEL; falling back to info",
+  );
+}
 
 /** Create a module-scoped child logger. Module name is shown as `[Module]` in pretty output. */
 export function createLogger(module: string): pino.Logger {

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -1,0 +1,156 @@
+import { Writable } from "node:stream";
+import pino from "pino";
+
+// ─── Config (late-initialized) ────────────────────────────────────────
+
+type LogFormat = "pretty" | "json";
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+let _format: LogFormat = process.env.NODE_ENV === "production" ? "json" : "pretty";
+let _level: LogLevel = ((process.env.FIRST_TREE_HUB_LOG_LEVEL as LogLevel | undefined) ?? "info") as LogLevel;
+let _bridgeMinLevel = 50; // error
+
+/**
+ * Apply resolved logging config to the singleton pino instance. Must be called
+ * once after `initConfig` and before any substantive logging happens. Loggers
+ * already created via `createLogger` keep working — child loggers share the
+ * root's level, which is updated here.
+ */
+export function applyLoggerConfig(options: {
+  level: LogLevel;
+  format: LogFormat;
+  bridgeToSpanLevel: "error" | "warn" | "off";
+}): void {
+  _level = options.level;
+  _format = options.format;
+  _bridgeMinLevel =
+    options.bridgeToSpanLevel === "off" ? Number.POSITIVE_INFINITY : options.bridgeToSpanLevel === "warn" ? 40 : 50;
+  rootLogger.level = options.level;
+}
+
+// ─── Pretty formatter ─────────────────────────────────────────────────
+
+const LEVEL_LABELS: Record<number, string> = {
+  10: "TRACE",
+  20: "DEBUG",
+  30: "INFO",
+  40: "WARN",
+  50: "ERROR",
+  60: "FATAL",
+};
+
+const LEVEL_COLORS: Record<number, string> = {
+  10: "\x1b[90m",
+  20: "\x1b[36m",
+  30: "\x1b[32m",
+  40: "\x1b[33m",
+  50: "\x1b[31m",
+  60: "\x1b[35m",
+};
+
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m";
+
+const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
+
+function formatPrettyEntry(json: string): string {
+  const obj = JSON.parse(json) as Record<string, unknown>;
+  const level = obj.level as number;
+  const label = LEVEL_LABELS[level] ?? "???";
+  const color = LEVEL_COLORS[level] ?? "";
+  const time = (obj.time as string) ?? new Date().toISOString();
+  const module = obj.module ? `[${String(obj.module)}] ` : "";
+  const msg = (obj.msg as string) ?? "";
+
+  const extras: string[] = [];
+  let errStack = "";
+  for (const [k, v] of Object.entries(obj)) {
+    if (SKIP_KEYS.has(k)) continue;
+    if (k === "err" && v && typeof v === "object") {
+      const e = v as Record<string, unknown>;
+      if (e.message) extras.push(`err.message=${String(e.message)}`);
+      if (typeof e.stack === "string") errStack = `\n${DIM}${e.stack}${RESET}`;
+    } else {
+      extras.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
+    }
+  }
+
+  const extraStr = extras.length > 0 ? `  ${DIM}${extras.join(" ")}${RESET}` : "";
+  return `${DIM}${time}${RESET} ${color}${label.padEnd(5)}${RESET} ${module}${msg}${extraStr}${errStack}\n`;
+}
+
+function formatLocalTime(): string {
+  const d = new Date();
+  const date = d.toLocaleDateString("sv-SE");
+  const time = d.toLocaleTimeString("en-GB", { hour12: false });
+  return `${date} ${time}`;
+}
+
+// ─── Error sink (bridges error/fatal logs onto active span) ───────────
+
+type ErrorSink = (message: string, err: unknown, context: Record<string, unknown>) => void;
+let _errorSink: ErrorSink | null = null;
+
+export function setErrorSink(sink: ErrorSink | null): void {
+  _errorSink = sink;
+}
+
+function forwardErrorIfNeeded(obj: Record<string, unknown>): void {
+  if (!_errorSink) return;
+  const level = obj.level as number;
+  if (level < _bridgeMinLevel) return;
+  const msg = typeof obj.msg === "string" ? obj.msg : "error";
+  const errField = obj.err;
+  const context: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (SKIP_KEYS.has(k) || k === "err") continue;
+    context[k] = v;
+  }
+  if (typeof obj.module === "string") context.module = obj.module;
+  try {
+    _errorSink(msg, errField, context);
+  } catch {
+    // sink errors must not break the logging path
+  }
+}
+
+// ─── Output stream ────────────────────────────────────────────────────
+
+const outputStream = new Writable({
+  write(chunk, _, callback) {
+    const text = chunk.toString();
+    try {
+      if (_format === "pretty") {
+        process.stdout.write(formatPrettyEntry(text));
+      } else {
+        process.stdout.write(text);
+      }
+      try {
+        const obj = JSON.parse(text) as Record<string, unknown>;
+        forwardErrorIfNeeded(obj);
+      } catch {
+        // non-JSON line, ignore
+      }
+    } catch {
+      process.stdout.write(text);
+    }
+    callback();
+  },
+});
+
+// ─── Root logger ──────────────────────────────────────────────────────
+
+export const rootLogger = pino(
+  {
+    level: _level,
+    timestamp: () => `,"time":"${formatLocalTime()}"`,
+  },
+  outputStream,
+);
+
+/** Create a module-scoped child logger. Module name is shown as `[Module]` in pretty output. */
+export function createLogger(module: string): pino.Logger {
+  return rootLogger.child({ module });
+}
+
+export type { pino };

--- a/packages/server/src/observability/span-attrs.ts
+++ b/packages/server/src/observability/span-attrs.ts
@@ -1,0 +1,73 @@
+/**
+ * Helpers that turn domain objects (messages, inbox entries, chats, agents,
+ * adapters) into a consistent set of span attribute records.
+ *
+ * Cross-async trace continuity in Hub relies on *attribute matching* in the
+ * trace backend rather than on parent-span linking (see
+ * `proposals/hub-observability.20260420.md` for rationale). These helpers
+ * guarantee that enqueue / deliver / push / adapter-outbound all stamp the
+ * same key set for the same domain object so a single query in Logfire /
+ * Honeycomb (e.g. `inbox.entry.id = "..."`) reconstructs the journey.
+ */
+
+import { FIRST_TREE_HUB_ATTR } from "@agent-team-foundation/first-tree-hub-shared/observability";
+
+type Attrs = Record<string, unknown>;
+
+export function messageAttrs(msg: { id?: string; chatId?: string; source?: string; senderAgentId?: string }): Attrs {
+  const out: Attrs = {};
+  if (msg.id) out[FIRST_TREE_HUB_ATTR.MESSAGE_ID] = msg.id;
+  if (msg.chatId) out[FIRST_TREE_HUB_ATTR.CHAT_ID] = msg.chatId;
+  if (msg.source) out[FIRST_TREE_HUB_ATTR.MESSAGE_SOURCE] = msg.source;
+  if (msg.senderAgentId) out[FIRST_TREE_HUB_ATTR.AGENT_ID] = msg.senderAgentId;
+  return out;
+}
+
+export function inboxAttrs(entry: {
+  id?: string | number;
+  messageId?: string;
+  agentId?: string;
+  status?: string;
+  retryCount?: number;
+}): Attrs {
+  const out: Attrs = {};
+  if (entry.id !== undefined && entry.id !== null) {
+    out[FIRST_TREE_HUB_ATTR.INBOX_ENTRY_ID] = String(entry.id);
+  }
+  if (entry.messageId) out[FIRST_TREE_HUB_ATTR.MESSAGE_ID] = entry.messageId;
+  if (entry.agentId) out[FIRST_TREE_HUB_ATTR.AGENT_ID] = entry.agentId;
+  if (entry.status) out[FIRST_TREE_HUB_ATTR.INBOX_STATUS] = entry.status;
+  if (entry.retryCount !== undefined) out[FIRST_TREE_HUB_ATTR.INBOX_ATTEMPT] = entry.retryCount;
+  return out;
+}
+
+export function chatAttrs(chat: { id?: string; type?: string; organizationId?: string }): Attrs {
+  const out: Attrs = {};
+  if (chat.id) out[FIRST_TREE_HUB_ATTR.CHAT_ID] = chat.id;
+  if (chat.type) out[FIRST_TREE_HUB_ATTR.CHAT_TYPE] = chat.type;
+  if (chat.organizationId) out[FIRST_TREE_HUB_ATTR.ORGANIZATION_ID] = chat.organizationId;
+  return out;
+}
+
+export function agentAttrs(agent: { uuid?: string; id?: string; organizationId?: string; clientId?: string }): Attrs {
+  const out: Attrs = {};
+  const id = agent.uuid ?? agent.id;
+  if (id) out[FIRST_TREE_HUB_ATTR.AGENT_ID] = id;
+  if (agent.organizationId) out[FIRST_TREE_HUB_ATTR.ORGANIZATION_ID] = agent.organizationId;
+  if (agent.clientId) out[FIRST_TREE_HUB_ATTR.CLIENT_ID] = agent.clientId;
+  return out;
+}
+
+export function adapterAttrs(a: {
+  id?: number | string;
+  platform?: string;
+  externalChatId?: string;
+  agentId?: string;
+}): Attrs {
+  const out: Attrs = {};
+  if (a.id !== undefined && a.id !== null) out[FIRST_TREE_HUB_ATTR.ADAPTER_ID] = String(a.id);
+  if (a.platform) out[FIRST_TREE_HUB_ATTR.ADAPTER_PLATFORM] = a.platform;
+  if (a.externalChatId) out[FIRST_TREE_HUB_ATTR.ADAPTER_EXTERNAL_CHAT_ID] = a.externalChatId;
+  if (a.agentId) out[FIRST_TREE_HUB_ATTR.AGENT_ID] = a.agentId;
+  return out;
+}

--- a/packages/server/src/observability/telemetry.ts
+++ b/packages/server/src/observability/telemetry.ts
@@ -1,0 +1,335 @@
+/**
+ * OpenTelemetry integration — vendor-neutral facade.
+ *
+ * Enable by configuring `observability.tracing.endpoint` (non-empty). All
+ * functions here are safe to call when tracing is disabled — they become
+ * no-ops so instrumented business code pays no cost.
+ */
+
+import { TRACING_SENSITIVE_KEY_PATTERNS } from "@agent-team-foundation/first-tree-hub-shared/observability";
+import otelModule from "@fastify/otel";
+import {
+  type Attributes,
+  type Context,
+  context,
+  propagation,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type Tracer,
+  trace,
+} from "@opentelemetry/api";
+import { OTLPTraceExporter as OTLPHttpExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchSpanProcessor,
+  NodeTracerProvider,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-node";
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+import { createLogger, setErrorSink } from "./logger.js";
+
+// CJS default-interop — `@fastify/otel` exports a class as the CJS default.
+const { FastifyOtelInstrumentation } = otelModule as unknown as {
+  FastifyOtelInstrumentation: new (opts?: {
+    servername?: string;
+    requestHook?: (span: Span, request: import("fastify").FastifyRequest) => void;
+  }) => {
+    plugin: () => import("fastify").FastifyPluginCallback;
+  };
+};
+
+const log = createLogger("Telemetry");
+
+export type TracingConfig = {
+  endpoint: string;
+  headers: string;
+  exporter: "otlp-http" | "otlp-grpc";
+  serviceName: string;
+  environment: string;
+  sampleRate: number;
+  captureContent: boolean;
+};
+
+let _enabled = false;
+let _captureContent = false;
+let _tracer: Tracer | null = null;
+let _provider: NodeTracerProvider | null = null;
+let _fastifyOtelPlugin: import("fastify").FastifyPluginCallback | null = null;
+
+const TRACER_NAME = "@first-tree-hub/server";
+const TRACER_VERSION = "0.1.0";
+
+/**
+ * Parse `key1=value1,key2=value2` into a header record. Preserves the first
+ * `=` only so values containing `=` (e.g. base64) survive. Exported for unit tests.
+ */
+export function parseHeaderString(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!raw) return out;
+  for (const pair of raw.split(",")) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const k = trimmed.slice(0, eq).trim();
+    const v = trimmed.slice(eq + 1).trim();
+    if (k) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Initialize the OpenTelemetry SDK. When `config.endpoint` is empty tracing
+ * stays disabled and every exported function becomes a no-op.
+ *
+ * `instanceId` — optional per-process identifier (Config.instanceId). When
+ * provided it becomes the OTel resource attribute `service.instance.id`,
+ * letting trace backends distinguish replicas of the same service even
+ * when they share environment / region / etc.
+ */
+export function initTelemetry(config: TracingConfig | undefined, instanceId?: string): void {
+  if (!config || !config.endpoint) {
+    log.info("tracing disabled (no endpoint configured)");
+    return;
+  }
+
+  if (config.exporter === "otlp-grpc") {
+    // Lazy: only require grpc package on demand; keeps it an optional dep.
+    log.warn("otlp-grpc exporter requested but not bundled; falling back to otlp-http");
+  }
+
+  const exporter = new OTLPHttpExporter({
+    url: config.endpoint,
+    headers: parseHeaderString(config.headers),
+  });
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: config.serviceName,
+    [ATTR_SERVICE_VERSION]: TRACER_VERSION,
+    "deployment.environment.name": config.environment,
+    ...(instanceId ? { "service.instance.id": instanceId } : {}),
+  });
+
+  const sampler = new ParentBasedSampler({
+    root: new TraceIdRatioBasedSampler(config.sampleRate),
+  });
+
+  const provider = new NodeTracerProvider({
+    resource,
+    sampler,
+    spanProcessors: [new BatchSpanProcessor(exporter)],
+  });
+
+  provider.register();
+
+  _provider = provider;
+  _tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
+  _enabled = true;
+  _captureContent = config.captureContent;
+
+  // Prepare Fastify HTTP instrumentation plugin; app.ts registers it
+  // conditionally via `getFastifyOtelPlugin()`.
+  //
+  // The `requestHook` is where we fix @fastify/otel's two default-behavior
+  // annoyances: (1) every span is named literally "request", and (2)
+  // `http.route` is set to the request URL (including path params) instead of
+  // the route pattern (`/api/v1/sessions/:id`). Both hurt discoverability in
+  // Logfire / Honeycomb / etc. We overwrite both here so spans render as
+  // `GET /api/v1/sessions/:id → 200` and aggregate-by-route works.
+  try {
+    const instrumentation = new FastifyOtelInstrumentation({
+      servername: config.serviceName,
+      requestHook: (span, request) => {
+        const route = request.routeOptions?.url;
+        if (route) {
+          span.updateName(`${request.method} ${route}`);
+          span.setAttribute("http.route", route);
+        } else {
+          // No route match (404 path); fall back to method + raw URL sans query.
+          const pathOnly = request.url.split("?")[0] ?? request.url;
+          span.updateName(`${request.method} ${pathOnly}`);
+        }
+      },
+    });
+    _fastifyOtelPlugin = instrumentation.plugin();
+  } catch (err) {
+    log.warn({ err }, "failed to initialize @fastify/otel plugin; HTTP spans disabled");
+  }
+
+  // Wire error log bridge: pino error/fatal → active span exception
+  setErrorSink((message, err, ctx) => {
+    const span = trace.getActiveSpan();
+    if (!span) return;
+    const error = err instanceof Error ? err : err !== undefined ? new Error(String(err)) : new Error(message);
+    span.recordException(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+    // Attach structured context as span attributes (redacted / normalized below)
+    const attrs = normalizeAttrs(ctx);
+    if (Object.keys(attrs).length > 0) span.setAttributes(attrs);
+  });
+
+  log.info(
+    `tracing enabled: exporter=${config.exporter} endpoint=${truncateEndpoint(config.endpoint)} service=${config.serviceName} env=${config.environment}${instanceId ? ` instance=${instanceId}` : ""} sampleRate=${config.sampleRate} captureContent=${config.captureContent}`,
+  );
+}
+
+function truncateEndpoint(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+export function isTelemetryEnabled(): boolean {
+  return _enabled;
+}
+
+export function isContentCaptureEnabled(): boolean {
+  return _enabled && _captureContent;
+}
+
+/** Flush all pending spans. Call before `process.exit()` in shutdown. */
+export async function shutdownTelemetry(): Promise<void> {
+  if (!_provider) return;
+  setErrorSink(null);
+  try {
+    await _provider.shutdown();
+  } catch {
+    // don't block shutdown on exporter errors
+  }
+  _enabled = false;
+  _tracer = null;
+  _provider = null;
+  _fastifyOtelPlugin = null;
+}
+
+/**
+ * Returns the `@fastify/otel` plugin instance or null when tracing is
+ * disabled. Consumers (app.ts) register this early so HTTP requests are
+ * wrapped in spans before any route handler runs.
+ */
+export function getFastifyOtelPlugin(): import("fastify").FastifyPluginCallback | null {
+  return _fastifyOtelPlugin;
+}
+
+// ─── Attribute normalization + redaction ──────────────────────────────
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return TRACING_SENSITIVE_KEY_PATTERNS.some((p) => lower.includes(p));
+}
+
+export function normalizeAttrs(attrs?: Record<string, unknown>): Attributes {
+  if (!attrs) return {};
+  const out: Attributes = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v === null || v === undefined) continue;
+    if (isSensitiveKey(k)) {
+      out[k] = "***";
+      continue;
+    }
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+      out[k] = v;
+    } else if (Array.isArray(v) && v.every((x) => typeof x === "string")) {
+      out[k] = v;
+    } else {
+      try {
+        out[k] = JSON.stringify(v);
+      } catch {
+        out[k] = String(v);
+      }
+    }
+  }
+  return out;
+}
+
+// ─── Span facade ──────────────────────────────────────────────────────
+
+/** Wrap an async function as a span. Records exceptions automatically. */
+export async function withSpan<T>(
+  name: string,
+  attrs: Record<string, unknown> | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!_tracer) return fn();
+  return _tracer.startActiveSpan(name, { attributes: normalizeAttrs(attrs) }, async (span) => {
+    try {
+      const result = await fn();
+      span.end();
+      return result;
+    } catch (err) {
+      if (err instanceof Error) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+      }
+      span.end();
+      throw err;
+    }
+  });
+}
+
+/**
+ * Start a span that must be ended manually. Useful for connection-lifecycle
+ * or hook-pair patterns where the end point is not a lexical callback.
+ *
+ * If the caller does not intend to make the span the active context for
+ * nested work, omit `makeActive`. When `makeActive=true`, pass the returned
+ * `context` to `context.with(...)` for nested spans to auto-parent.
+ */
+export function startTrackedSpan(
+  name: string,
+  attrs?: Record<string, unknown>,
+  options?: { kind?: SpanKind; parentContext?: Context },
+): Span | null {
+  if (!_tracer) return null;
+  const parent = options?.parentContext ?? context.active();
+  return _tracer.startSpan(name, { kind: options?.kind, attributes: normalizeAttrs(attrs) }, parent);
+}
+
+export function endSpan(span: Span | null, extraAttrs?: Record<string, unknown>, error?: Error): void {
+  if (!span) return;
+  if (extraAttrs) span.setAttributes(normalizeAttrs(extraAttrs));
+  if (error) {
+    span.recordException(error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  }
+  span.end();
+}
+
+export function addSpanEvent(span: Span | null, name: string, attrs?: Record<string, unknown>): void {
+  if (!span) return;
+  span.addEvent(name, normalizeAttrs(attrs));
+}
+
+/** Record an error onto the currently-active span. */
+export function reportError(message: string, err: unknown, extra?: Record<string, unknown>): void {
+  if (!_enabled) return;
+  const span = trace.getActiveSpan();
+  if (!span) return;
+  const error = err instanceof Error ? err : err !== undefined ? new Error(String(err)) : new Error(message);
+  span.recordException(error);
+  span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+  if (extra) span.setAttributes(normalizeAttrs(extra));
+}
+
+/** Current trace id, if any — used for `x-trace-id` response header. */
+export function currentTraceId(): string | undefined {
+  const span = trace.getActiveSpan();
+  const ctx = span?.spanContext();
+  if (!ctx || !ctx.traceId || ctx.traceId === "00000000000000000000000000000000") return undefined;
+  return ctx.traceId;
+}
+
+/** Current span id, if any — used for log correlation. */
+export function currentSpanId(): string | undefined {
+  const span = trace.getActiveSpan();
+  const ctx = span?.spanContext();
+  if (!ctx || !ctx.spanId || ctx.spanId === "0000000000000000") return undefined;
+  return ctx.spanId;
+}
+
+/** Re-export for consumers that want to drive `context.with(...)` themselves. */
+export { context, propagation, SpanKind, SpanStatusCode, trace };

--- a/packages/server/src/observability/telemetry.ts
+++ b/packages/server/src/observability/telemetry.ts
@@ -35,10 +35,18 @@ const { FastifyOtelInstrumentation } = otelModule as unknown as {
   FastifyOtelInstrumentation: new (opts?: {
     servername?: string;
     requestHook?: (span: Span, request: import("fastify").FastifyRequest) => void;
+    ignoreHeaders?: string[];
   }) => {
     plugin: () => import("fastify").FastifyPluginCallback;
   };
 };
+
+/**
+ * Headers the Fastify instrumentation must never capture. Even if upstream's
+ * default changes to opt-in capture, we want an explicit blocklist so a
+ * dependency bump can't quietly leak credentials into span attributes.
+ */
+const IGNORED_SPAN_HEADERS = ["authorization", "cookie", "set-cookie", "x-admin-token", "x-api-key"];
 
 const log = createLogger("Telemetry");
 
@@ -49,11 +57,9 @@ export type TracingConfig = {
   serviceName: string;
   environment: string;
   sampleRate: number;
-  captureContent: boolean;
 };
 
 let _enabled = false;
-let _captureContent = false;
 let _tracer: Tracer | null = null;
 let _provider: NodeTracerProvider | null = null;
 let _fastifyOtelPlugin: import("fastify").FastifyPluginCallback | null = null;
@@ -89,7 +95,14 @@ export function parseHeaderString(raw: string): Record<string, string> {
  * letting trace backends distinguish replicas of the same service even
  * when they share environment / region / etc.
  */
-export function initTelemetry(config: TracingConfig | undefined, instanceId?: string): void {
+export async function initTelemetry(config: TracingConfig | undefined, instanceId?: string): Promise<void> {
+  if (_provider) {
+    // Second call — tear down old processor first so we don't leak BatchSpanProcessor
+    // timers or pending export queues. Primarily guards tests and hot-reload code paths.
+    log.warn("initTelemetry called twice; shutting down previous provider");
+    await shutdownTelemetry();
+  }
+
   if (!config || !config.endpoint) {
     log.info("tracing disabled (no endpoint configured)");
     return;
@@ -127,7 +140,6 @@ export function initTelemetry(config: TracingConfig | undefined, instanceId?: st
   _provider = provider;
   _tracer = trace.getTracer(TRACER_NAME, TRACER_VERSION);
   _enabled = true;
-  _captureContent = config.captureContent;
 
   // Prepare Fastify HTTP instrumentation plugin; app.ts registers it
   // conditionally via `getFastifyOtelPlugin()`.
@@ -141,6 +153,7 @@ export function initTelemetry(config: TracingConfig | undefined, instanceId?: st
   try {
     const instrumentation = new FastifyOtelInstrumentation({
       servername: config.serviceName,
+      ignoreHeaders: IGNORED_SPAN_HEADERS,
       requestHook: (span, request) => {
         const route = request.routeOptions?.url;
         if (route) {
@@ -171,7 +184,7 @@ export function initTelemetry(config: TracingConfig | undefined, instanceId?: st
   });
 
   log.info(
-    `tracing enabled: exporter=${config.exporter} endpoint=${truncateEndpoint(config.endpoint)} service=${config.serviceName} env=${config.environment}${instanceId ? ` instance=${instanceId}` : ""} sampleRate=${config.sampleRate} captureContent=${config.captureContent}`,
+    `tracing enabled: exporter=${config.exporter} endpoint=${truncateEndpoint(config.endpoint)} service=${config.serviceName} env=${config.environment}${instanceId ? ` instance=${instanceId}` : ""} sampleRate=${config.sampleRate}`,
   );
 }
 
@@ -185,10 +198,6 @@ function truncateEndpoint(url: string): string {
 
 export function isTelemetryEnabled(): boolean {
   return _enabled;
-}
-
-export function isContentCaptureEnabled(): boolean {
-  return _enabled && _captureContent;
 }
 
 /** Flush all pending spans. Call before `process.exit()` in shutdown. */

--- a/packages/server/src/observability/ws-tracing.ts
+++ b/packages/server/src/observability/ws-tracing.ts
@@ -104,12 +104,3 @@ export async function withWsMessageSpan<T>(
     ),
   );
 }
-
-/**
- * Retrieve the OTel context captured at connection time. Useful for cases
- * like `notifier.onInbox(entryId)` dispatching a push that should parent to
- * the connection rather than to whatever was active in the notifier tick.
- */
-export function getWsConnectionContext(socket: WebSocket): Context | undefined {
-  return connections.get(socket)?.context;
-}

--- a/packages/server/src/observability/ws-tracing.ts
+++ b/packages/server/src/observability/ws-tracing.ts
@@ -1,0 +1,115 @@
+/**
+ * WebSocket trace helpers.
+ *
+ * WS doesn't fit cleanly into OTel's request/response model. We adopt two
+ * span lifecycles:
+ *
+ * 1. **Connection span** — one long-running span per WS connection, opened
+ *    when a socket is accepted and closed when the socket closes. Carries
+ *    `client.id`, `agent.id` and close code as attributes.
+ *
+ * 2. **Message span** — short span per inbound WS message, parented to the
+ *    connection span via an OTel Context captured at connect time. Use
+ *    `withWsMessageSpan()` around each message handler body.
+ *
+ * When tracing is disabled every function degrades to a transparent no-op.
+ */
+
+import { FIRST_TREE_HUB_ATTR } from "@agent-team-foundation/first-tree-hub-shared/observability";
+import type { Context, Span } from "@opentelemetry/api";
+import { context as otelContext, SpanStatusCode, trace } from "@opentelemetry/api";
+import type { WebSocket } from "ws";
+import { normalizeAttrs, startTrackedSpan } from "./telemetry.js";
+
+type ConnectionEntry = {
+  span: Span;
+  context: Context;
+};
+
+const connections = new WeakMap<WebSocket, ConnectionEntry>();
+
+/**
+ * Begin a connection-scoped span. Call once right after the socket is accepted.
+ * The returned handle is optional — callers that just want the
+ * `withWsMessageSpan` linkage don't need to hold onto it.
+ */
+export function startWsConnectionSpan(
+  socket: WebSocket,
+  attrs: {
+    clientId?: string;
+    organizationId?: string;
+    remoteIp?: string;
+  } = {},
+): void {
+  const span = startTrackedSpan("ws.connection", {
+    [FIRST_TREE_HUB_ATTR.CLIENT_ID]: attrs.clientId,
+    [FIRST_TREE_HUB_ATTR.ORGANIZATION_ID]: attrs.organizationId,
+    [FIRST_TREE_HUB_ATTR.WS_REMOTE_IP]: attrs.remoteIp,
+  });
+  if (!span) return;
+  const ctx = trace.setSpan(otelContext.active(), span);
+  connections.set(socket, { span, context: ctx });
+}
+
+/** Set additional attributes on the connection span (e.g. agentId discovered after bind). */
+export function setWsConnectionAttrs(socket: WebSocket, attrs: Record<string, unknown>): void {
+  const entry = connections.get(socket);
+  if (!entry) return;
+  entry.span.setAttributes(normalizeAttrs(attrs));
+}
+
+/** End the connection span with an optional close code. Safe to call on every close path. */
+export function endWsConnectionSpan(socket: WebSocket, closeCode?: number): void {
+  const entry = connections.get(socket);
+  if (!entry) return;
+  if (closeCode !== undefined) {
+    entry.span.setAttributes({ [FIRST_TREE_HUB_ATTR.WS_CLOSE_CODE]: closeCode });
+  }
+  entry.span.end();
+  connections.delete(socket);
+}
+
+/**
+ * Run a handler inside a span parented to the connection span. If tracing is
+ * disabled or no connection span exists, the handler runs unwrapped.
+ */
+export async function withWsMessageSpan<T>(
+  socket: WebSocket,
+  type: string,
+  attrs: Record<string, unknown>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const entry = connections.get(socket);
+  if (!entry) return fn();
+  const tracer = trace.getTracer("@first-tree-hub/server");
+  const spanName = `ws.message ${type}`;
+  return otelContext.with(entry.context, () =>
+    tracer.startActiveSpan(
+      spanName,
+      { attributes: normalizeAttrs({ [FIRST_TREE_HUB_ATTR.WS_MESSAGE_TYPE]: type, ...attrs }) },
+      async (span) => {
+        try {
+          const result = await fn();
+          span.end();
+          return result;
+        } catch (err) {
+          if (err instanceof Error) {
+            span.recordException(err);
+            span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          }
+          span.end();
+          throw err;
+        }
+      },
+    ),
+  );
+}
+
+/**
+ * Retrieve the OTel context captured at connection time. Useful for cases
+ * like `notifier.onInbox(entryId)` dispatching a push that should parent to
+ * the connection rather than to whatever was active in the notifier tick.
+ */
+export function getWsConnectionContext(socket: WebSocket): Context | undefined {
+  return connections.get(socket)?.context;
+}

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -6,6 +6,7 @@ import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agents } from "../db/schema/agents.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
+import { adapterAttrs, withSpan } from "../observability/index.js";
 import * as mappingService from "./adapter-mapping.js";
 import { decryptCredentials } from "./crypto.js";
 import type { FeishuBotCredentials, InboundEvent } from "./feishu/types.js";
@@ -122,7 +123,15 @@ export function createAdapterManager(
       if (!bot) return;
 
       try {
-        await processInboundMessage(db, event, bot, log, notifier);
+        await withSpan(
+          "adapter.inbound feishu",
+          adapterAttrs({
+            platform: "feishu",
+            externalChatId: event.externalChannelId,
+            agentId: bot.agentId,
+          }),
+          () => processInboundMessage(db, event, bot, log, notifier),
+        );
         bot.lastActiveAt = new Date();
       } catch (err) {
         // Unclaim the event so it can be retried on next delivery
@@ -221,12 +230,14 @@ export function createAdapterManager(
     async processOutbound() {
       if (bots.size === 0) return { sent: 0, errors: 0 };
 
-      try {
-        return await processFeishuOutbound(db, findBotByAgentId, log);
-      } catch (err) {
-        log.error({ err }, "Feishu outbound processing error");
-        return { sent: 0, errors: 1 };
-      }
+      return withSpan("adapter.outbound feishu", adapterAttrs({ platform: "feishu" }), async () => {
+        try {
+          return await processFeishuOutbound(db, findBotByAgentId, log);
+        } catch (err) {
+          log.error({ err }, "Feishu outbound processing error");
+          return { sent: 0, errors: 1 };
+        }
+      });
     },
 
     async editOutboundMessage(messageId: string, format: string, content: unknown): Promise<boolean> {

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { createLogger } from "../observability/index.js";
 import * as activityService from "./activity.js";
 import type { AdapterManager } from "./adapter-manager.js";
 import * as clientService from "./client.js";
@@ -7,6 +8,8 @@ import type { KaelRuntime } from "./kael-runtime.js";
 import * as notificationService from "./notification.js";
 import * as presenceService from "./presence.js";
 import * as systemConfigService from "./system-config.js";
+
+const log = createLogger("BackgroundTasks");
 
 export type BackgroundTasks = {
   start(): void;
@@ -35,7 +38,7 @@ export function createBackgroundTasks(
           const maxRetries = (configs.max_retry_count as number) ?? 3;
           await inboxService.resetTimedOutEntries(app.db, timeoutSeconds, maxRetries);
         } catch (err) {
-          app.log.error(err, "Failed to reset timed-out inbox entries");
+          log.error({ err }, "failed to reset timed-out inbox entries");
         }
       }, 60_000);
 
@@ -50,7 +53,7 @@ export function createBackgroundTasks(
           // M1: per-agent heartbeat staleness detection
           const staleAgents = await presenceService.markStaleAgents(app.db, staleSeconds);
           if (staleAgents.length > 0) {
-            app.log.info(`Marked ${staleAgents.length} agent(s) as stale: ${staleAgents.join(", ")}`);
+            log.info({ count: staleAgents.length, agentIds: staleAgents }, "marked agents as stale");
             // M1: Create notifications for stale agents
             for (const agentId of staleAgents) {
               notificationService
@@ -59,7 +62,7 @@ export function createBackgroundTasks(
             }
           }
         } catch (err) {
-          app.log.error(err, "Failed to heartbeat / cleanup presence");
+          log.error({ err }, "failed to heartbeat / cleanup presence");
         }
       }, 30_000);
 
@@ -68,7 +71,7 @@ export function createBackgroundTasks(
         try {
           await adapterManager.processOutbound();
         } catch (err) {
-          app.log.error(err, "Adapter outbound processing failed");
+          log.error({ err }, "adapter outbound processing failed");
         }
       }, 5_000);
 
@@ -78,7 +81,7 @@ export function createBackgroundTasks(
           try {
             await kaelRuntime.processOutbound();
           } catch (err) {
-            app.log.error(err, "Kael outbound processing failed");
+            log.error({ err }, "kael outbound processing failed");
           }
         }, 5_000);
       }
@@ -88,16 +91,16 @@ export function createBackgroundTasks(
         try {
           const deleted = await activityService.cleanupStaleSessions(app.db);
           if (deleted > 0) {
-            app.log.info(`Cleaned up ${deleted} stale session(s)`);
+            log.info({ count: deleted }, "cleaned up stale sessions");
           }
         } catch (err) {
-          app.log.error(err, "Failed to clean up stale sessions");
+          log.error({ err }, "failed to clean up stale sessions");
         }
       }, 3_600_000);
 
       // Initial heartbeat
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
-        app.log.error(err, "Failed initial heartbeat");
+        log.error({ err }, "failed initial heartbeat");
       });
     },
 

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -3,12 +3,19 @@ import type { Database } from "../db/connection.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { ForbiddenError, NotFoundError } from "../errors.js";
+import { FIRST_TREE_HUB_ATTR, withSpan } from "../observability/index.js";
 import { buildClientMessagePayloadsForInbox } from "./message-dispatcher.js";
 
 const DEFAULT_INBOX_TIMEOUT_SECONDS = 300;
 const DEFAULT_MAX_RETRY_COUNT = 3;
 
 export async function pollInbox(db: Database, inboxId: string, limit: number) {
+  return withSpan("inbox.deliver", { "inbox.id": inboxId, "inbox.poll.limit": limit }, () =>
+    pollInboxInner(db, inboxId, limit),
+  );
+}
+
+async function pollInboxInner(db: Database, inboxId: string, limit: number) {
   // Use raw SQL for SELECT ... FOR UPDATE SKIP LOCKED (not supported by Drizzle query builder)
   const result = await db.transaction(async (tx) => {
     // 1. Claim pending entries with SKIP LOCKED
@@ -93,17 +100,25 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
 }
 
 export async function ackEntry(db: Database, entryId: number, inboxId: string) {
-  const [entry] = await db
-    .update(inboxEntries)
-    .set({ status: "acked", ackedAt: new Date() })
-    .where(and(eq(inboxEntries.id, entryId), eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "delivered")))
-    .returning();
+  return withSpan(
+    "inbox.ack",
+    { [FIRST_TREE_HUB_ATTR.INBOX_ENTRY_ID]: String(entryId), "inbox.id": inboxId },
+    async () => {
+      const [entry] = await db
+        .update(inboxEntries)
+        .set({ status: "acked", ackedAt: new Date() })
+        .where(
+          and(eq(inboxEntries.id, entryId), eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "delivered")),
+        )
+        .returning();
 
-  if (!entry) {
-    throw new NotFoundError("Inbox entry not found or not in delivered status");
-  }
+      if (!entry) {
+        throw new NotFoundError("Inbox entry not found or not in delivered status");
+      }
 
-  return entry;
+      return entry;
+    },
+  );
 }
 
 export async function renewEntry(db: Database, entryId: number, inboxId: string) {

--- a/packages/server/src/services/kael-runtime.ts
+++ b/packages/server/src/services/kael-runtime.ts
@@ -6,6 +6,7 @@ import type { Database } from "../db/connection.js";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
+import { withSpan } from "../observability/index.js";
 import { decryptCredentials } from "./crypto.js";
 
 const OUTBOUND_BATCH_SIZE = 10;
@@ -144,18 +145,22 @@ export function createKaelRuntime(
         return { sent: 0, errors: 0 };
       }
 
-      let sent = 0;
-      let errorCount = 0;
+      return withSpan(
+        "kael.forward",
+        { "kael.endpoint": kaelEndpoint, "kael.agent_count": agentConfigs.size },
+        async () => {
+          let sent = 0;
+          let errorCount = 0;
 
-      try {
-        // Claim pending inbox entries for agents that have kael adapter_configs
-        const agentIds = [...agentConfigs.keys()];
-        const claimed = await db.execute<{
-          id: number;
-          inbox_id: string;
-          message_id: string;
-          chat_id: string | null;
-        }>(sql`
+          try {
+            // Claim pending inbox entries for agents that have kael adapter_configs
+            const agentIds = [...agentConfigs.keys()];
+            const claimed = await db.execute<{
+              id: number;
+              inbox_id: string;
+              message_id: string;
+              chat_id: string | null;
+            }>(sql`
           UPDATE inbox_entries
           SET status = 'delivered', delivered_at = NOW()
           WHERE id IN (
@@ -175,73 +180,75 @@ export function createKaelRuntime(
           RETURNING id, inbox_id, message_id, chat_id
         `);
 
-        for (const entry of claimed) {
-          try {
-            const [msg] = await db.select().from(messages).where(eq(messages.id, entry.message_id)).limit(1);
+            for (const entry of claimed) {
+              try {
+                const [msg] = await db.select().from(messages).where(eq(messages.id, entry.message_id)).limit(1);
 
-            if (!msg) {
-              await ackEntry(db, entry.id);
-              continue;
+                if (!msg) {
+                  await ackEntry(db, entry.id);
+                  continue;
+                }
+
+                // Find which agent this entry belongs to (O(1) reverse map lookup)
+                const config = inboxToConfig.get(entry.inbox_id);
+                if (!config) {
+                  await ackEntry(db, entry.id);
+                  continue;
+                }
+
+                // Resolve message content to string
+                const messageContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+
+                const payload: Record<string, unknown> = {
+                  hub_chat_id: entry.chat_id ?? msg.chatId,
+                  hub_agent_id: config.agentId,
+                  hub_server_url: serverUrl,
+                  hub_agent_token: config.agentToken,
+                  user_id: config.kaelUserId,
+                  project_id: config.kaelProjectId,
+                  message: messageContent,
+                  sender_id: msg.senderId,
+                  format: msg.format,
+                };
+                if (agentsMd) {
+                  payload.agents_md = agentsMd;
+                }
+
+                const response = await fetch(`${kaelEndpoint}/api/v1/hub/messages`, {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                    ...(kaelApiKey ? { "X-Internal-API-Key": kaelApiKey } : {}),
+                  },
+                  body: JSON.stringify(payload),
+                });
+
+                if (!response.ok) {
+                  const body = await response.text().catch(() => "");
+                  log.error({ entryId: entry.id, status: response.status, body }, "Kael API rejected outbound message");
+                  await nackEntry(db, entry.id);
+                  errorCount++;
+                  continue;
+                }
+
+                await ackEntry(db, entry.id);
+                sent++;
+              } catch (err) {
+                log.error({ entryId: entry.id, err }, "Failed to send outbound Kael message");
+                await nackEntry(db, entry.id).catch((nackErr) => {
+                  log.error({ entryId: entry.id, err: nackErr }, "Failed to NACK entry");
+                });
+                errorCount++;
+              }
             }
-
-            // Find which agent this entry belongs to (O(1) reverse map lookup)
-            const config = inboxToConfig.get(entry.inbox_id);
-            if (!config) {
-              await ackEntry(db, entry.id);
-              continue;
-            }
-
-            // Resolve message content to string
-            const messageContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
-
-            const payload: Record<string, unknown> = {
-              hub_chat_id: entry.chat_id ?? msg.chatId,
-              hub_agent_id: config.agentId,
-              hub_server_url: serverUrl,
-              hub_agent_token: config.agentToken,
-              user_id: config.kaelUserId,
-              project_id: config.kaelProjectId,
-              message: messageContent,
-              sender_id: msg.senderId,
-              format: msg.format,
-            };
-            if (agentsMd) {
-              payload.agents_md = agentsMd;
-            }
-
-            const response = await fetch(`${kaelEndpoint}/api/v1/hub/messages`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                ...(kaelApiKey ? { "X-Internal-API-Key": kaelApiKey } : {}),
-              },
-              body: JSON.stringify(payload),
-            });
-
-            if (!response.ok) {
-              const body = await response.text().catch(() => "");
-              log.error({ entryId: entry.id, status: response.status, body }, "Kael API rejected outbound message");
-              await nackEntry(db, entry.id);
-              errorCount++;
-              continue;
-            }
-
-            await ackEntry(db, entry.id);
-            sent++;
           } catch (err) {
-            log.error({ entryId: entry.id, err }, "Failed to send outbound Kael message");
-            await nackEntry(db, entry.id).catch((nackErr) => {
-              log.error({ entryId: entry.id, err: nackErr }, "Failed to NACK entry");
-            });
-            errorCount++;
+            log.error({ err }, "Kael outbound processing error");
+            return { sent: 0, errors: 1 };
           }
-        }
-      } catch (err) {
-        log.error({ err }, "Kael outbound processing error");
-        return { sent: 0, errors: 1 };
-      }
 
-      return { sent, errors: errorCount };
+          return { sent, errors: errorCount };
+        },
+      );
     },
 
     shutdown(): void {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -7,6 +7,7 @@ import { chatParticipants, chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { ForbiddenError, NotFoundError } from "../errors.js";
+import { messageAttrs, withSpan } from "../observability/index.js";
 import { findOrCreateDirectChat } from "./chat.js";
 
 export type SendMessageResult = {
@@ -16,6 +17,19 @@ export type SendMessageResult = {
 };
 
 export async function sendMessage(
+  db: Database,
+  chatId: string,
+  senderId: string,
+  data: SendMessage,
+): Promise<SendMessageResult> {
+  return withSpan(
+    "inbox.enqueue",
+    messageAttrs({ chatId, senderAgentId: senderId, source: data.source ?? undefined }),
+    () => sendMessageInner(db, chatId, senderId, data),
+  );
+}
+
+async function sendMessageInner(
   db: Database,
   chatId: string,
   senderId: string,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,10 +24,14 @@
     "./config": {
       "types": "./src/config/index.ts",
       "import": "./dist/config/index.mjs"
+    },
+    "./observability": {
+      "types": "./src/observability/index.ts",
+      "import": "./dist/observability/index.mjs"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/config/index.ts --format esm --dts",
+    "build": "tsdown src/index.ts src/config/index.ts src/observability/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/shared/src/config/client-config.ts
+++ b/packages/shared/src/config/client-config.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logLevelSchema } from "../observability/logger-core.js";
 import { defineConfig, field } from "./schema.js";
 import { getConfig } from "./singleton.js";
 import type { InferConfig } from "./types.js";
@@ -20,7 +21,7 @@ export const clientConfigSchema = defineConfig({
       env: "FIRST_TREE_HUB_CLIENT_ID",
     }),
   },
-  logLevel: field(z.enum(["debug", "info", "warn", "error"]).default("info"), { env: "FIRST_TREE_HUB_LOG_LEVEL" }),
+  logLevel: field(logLevelSchema.default("info"), { env: "FIRST_TREE_HUB_LOG_LEVEL" }),
 });
 
 export type ClientConfig = InferConfig<typeof clientConfigSchema>;

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { logFormatSchema, logLevelSchema } from "../observability/logger-core.js";
 import { defineConfig, field, optional } from "./schema.js";
 import { getConfig } from "./singleton.js";
 import type { InferConfig } from "./types.js";
@@ -67,14 +68,14 @@ export const serverConfigSchema = defineConfig({
   }),
   observability: {
     logging: {
-      level: field(z.enum(["trace", "debug", "info", "warn", "error", "fatal"]).default("info"), {
+      level: field(logLevelSchema.default("info"), {
         env: "FIRST_TREE_HUB_LOG_LEVEL",
       }),
       /**
        * Output format. Defaults to `json` in production and `pretty` elsewhere —
        * pretty is for humans, json is for log collectors (Loki, CloudWatch, Vector).
        */
-      format: field(z.enum(["pretty", "json"]).default(process.env.NODE_ENV === "production" ? "json" : "pretty")),
+      format: field(logFormatSchema.default(process.env.NODE_ENV === "production" ? "json" : "pretty")),
       /** Minimum pino level whose records are bridged onto the currently-active span. */
       bridgeToSpanLevel: field(z.enum(["error", "warn", "off"]).default("error")),
     },
@@ -101,10 +102,6 @@ export const serverConfigSchema = defineConfig({
         env: "FIRST_TREE_HUB_OTEL_ENVIRONMENT",
       }),
       sampleRate: field(z.number().min(0).max(1).default(1)),
-      /** Whether to include message bodies / prompts / LLM replies in span attrs. Opt-in. */
-      captureContent: field(z.boolean().default(false), { env: "FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT" }),
-      /** Whether to wrap postgres queries with spans. Opt-in. */
-      instrumentPostgres: field(z.boolean().default(false)),
     }),
   },
 });

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -65,6 +65,48 @@ export const serverConfigSchema = defineConfig({
     /** Public URL of this Hub server, reachable from Kael for API callbacks */
     hubPublicUrl: field(z.string(), { env: "FIRST_TREE_HUB_PUBLIC_URL" }),
   }),
+  observability: {
+    logging: {
+      level: field(z.enum(["trace", "debug", "info", "warn", "error", "fatal"]).default("info"), {
+        env: "FIRST_TREE_HUB_LOG_LEVEL",
+      }),
+      /**
+       * Output format. Defaults to `json` in production and `pretty` elsewhere —
+       * pretty is for humans, json is for log collectors (Loki, CloudWatch, Vector).
+       */
+      format: field(z.enum(["pretty", "json"]).default(process.env.NODE_ENV === "production" ? "json" : "pretty")),
+      /** Minimum pino level whose records are bridged onto the currently-active span. */
+      bridgeToSpanLevel: field(z.enum(["error", "warn", "off"]).default("error")),
+    },
+    tracing: optional({
+      /**
+       * OTLP endpoint. Non-empty value enables tracing; empty string disables it.
+       * There is deliberately no separate `enabled` flag — endpoint presence is the switch.
+       */
+      endpoint: field(z.string(), { env: "FIRST_TREE_HUB_OTEL_ENDPOINT" }),
+      /**
+       * Exporter headers, serialized as `key1=value1,key2=value2` (one string — avoids
+       * env-var record coercion issues). Secret because it typically holds the write token.
+       */
+      headers: field(z.string().default(""), { env: "FIRST_TREE_HUB_OTEL_HEADERS", secret: true }),
+      exporter: field(z.enum(["otlp-http", "otlp-grpc"]).default("otlp-http")),
+      serviceName: field(z.string().default("first-tree-hub")),
+      /**
+       * Deployment environment label. Emitted as the OTel resource attribute
+       * `deployment.environment.name` — trace backends (Logfire, Honeycomb, …)
+       * use this to let one project span many environments while still
+       * letting you filter by env in the UI.
+       */
+      environment: field(z.string().default("development"), {
+        env: "FIRST_TREE_HUB_OTEL_ENVIRONMENT",
+      }),
+      sampleRate: field(z.number().min(0).max(1).default(1)),
+      /** Whether to include message bodies / prompts / LLM replies in span attrs. Opt-in. */
+      captureContent: field(z.boolean().default(false), { env: "FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT" }),
+      /** Whether to wrap postgres queries with spans. Opt-in. */
+      instrumentPostgres: field(z.boolean().default(false)),
+    }),
+  },
 });
 
 export type ServerConfig = InferConfig<typeof serverConfigSchema>;

--- a/packages/shared/src/observability/index.ts
+++ b/packages/shared/src/observability/index.ts
@@ -1,4 +1,21 @@
 export {
+  createLoggerOutputStream,
+  DIM,
+  formatLocalTime,
+  formatPrettyEntry,
+  LEVEL_COLORS,
+  LEVEL_LABELS,
+  LOG_FORMATS,
+  LOG_LEVELS,
+  type LogFormat,
+  type LogLevel,
+  logFormatSchema,
+  logLevelSchema,
+  parseLogLevel,
+  RESET,
+  SKIP_KEYS,
+} from "./logger-core.js";
+export {
   FIRST_TREE_HUB_ATTR,
   type FirstTreeHubAttrKey,
   type FirstTreeHubAttrName,

--- a/packages/shared/src/observability/index.ts
+++ b/packages/shared/src/observability/index.ts
@@ -1,0 +1,6 @@
+export {
+  FIRST_TREE_HUB_ATTR,
+  type FirstTreeHubAttrKey,
+  type FirstTreeHubAttrName,
+  TRACING_SENSITIVE_KEY_PATTERNS,
+} from "./tracing-attrs.js";

--- a/packages/shared/src/observability/logger-core.ts
+++ b/packages/shared/src/observability/logger-core.ts
@@ -1,0 +1,128 @@
+/**
+ * Logger core — format / level primitives shared between server and client.
+ *
+ * This module intentionally has no dependency on `pino` so it can live in
+ * `@agent-team-foundation/first-tree-hub-shared`. Consumers construct their
+ * own pino instance and pass the output stream built here.
+ */
+
+import { Writable } from "node:stream";
+import { z } from "zod";
+
+export const LOG_LEVELS = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+export const LOG_FORMATS = ["pretty", "json"] as const;
+export type LogFormat = (typeof LOG_FORMATS)[number];
+
+export const logLevelSchema = z.enum(LOG_LEVELS);
+export const logFormatSchema = z.enum(LOG_FORMATS);
+
+/**
+ * Parse an env-var / config string into a LogLevel. Unknown values fall back
+ * to `info` so the process never fails to boot on a typo — the caller is
+ * responsible for emitting a warning when `fellBack` is true.
+ */
+export function parseLogLevel(raw: string | undefined | null): { level: LogLevel; fellBack: boolean } {
+  if (!raw) return { level: "info", fellBack: false };
+  const parsed = logLevelSchema.safeParse(raw);
+  if (parsed.success) return { level: parsed.data, fellBack: false };
+  return { level: "info", fellBack: true };
+}
+
+// ─── Pretty formatter ─────────────────────────────────────────────────
+
+export const LEVEL_LABELS: Record<number, string> = {
+  10: "TRACE",
+  20: "DEBUG",
+  30: "INFO",
+  40: "WARN",
+  50: "ERROR",
+  60: "FATAL",
+};
+
+export const LEVEL_COLORS: Record<number, string> = {
+  10: "\x1b[90m",
+  20: "\x1b[36m",
+  30: "\x1b[32m",
+  40: "\x1b[33m",
+  50: "\x1b[31m",
+  60: "\x1b[35m",
+};
+
+export const RESET = "\x1b[0m";
+export const DIM = "\x1b[2m";
+
+export const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
+
+export function formatPrettyEntry(json: string): string {
+  const obj = JSON.parse(json) as Record<string, unknown>;
+  const level = obj.level as number;
+  const label = LEVEL_LABELS[level] ?? "???";
+  const color = LEVEL_COLORS[level] ?? "";
+  const time = (obj.time as string) ?? new Date().toISOString();
+  const module = obj.module ? `[${String(obj.module)}] ` : "";
+  const msg = (obj.msg as string) ?? "";
+
+  const extras: string[] = [];
+  let errStack = "";
+  for (const [k, v] of Object.entries(obj)) {
+    if (SKIP_KEYS.has(k)) continue;
+    if (k === "err" && v && typeof v === "object") {
+      const e = v as Record<string, unknown>;
+      if (e.message) extras.push(`err.message=${String(e.message)}`);
+      if (typeof e.stack === "string") errStack = `\n${DIM}${e.stack}${RESET}`;
+    } else {
+      extras.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
+    }
+  }
+
+  const extraStr = extras.length > 0 ? `  ${DIM}${extras.join(" ")}${RESET}` : "";
+  return `${DIM}${time}${RESET} ${color}${label.padEnd(5)}${RESET} ${module}${msg}${extraStr}${errStack}\n`;
+}
+
+export function formatLocalTime(): string {
+  const d = new Date();
+  const date = d.toLocaleDateString("sv-SE");
+  const time = d.toLocaleTimeString("en-GB", { hour12: false });
+  return `${date} ${time}`;
+}
+
+// ─── Output stream factory ────────────────────────────────────────────
+
+type CreateStreamOptions = {
+  /** Getter so the format can change via applyConfig without rebuilding the stream. */
+  getFormat: () => LogFormat;
+  /**
+   * Optional hook invoked once per NDJSON record written by pino. Server uses
+   * this to bridge error/fatal logs onto the active OTel span; client leaves
+   * it undefined.
+   */
+  onJsonEntry?: (obj: Record<string, unknown>) => void;
+};
+
+export function createLoggerOutputStream(options: CreateStreamOptions): Writable {
+  return new Writable({
+    write(chunk, _, callback) {
+      const text = chunk.toString();
+      try {
+        if (options.getFormat() === "pretty") {
+          process.stdout.write(formatPrettyEntry(text));
+        } else {
+          process.stdout.write(text);
+        }
+        if (options.onJsonEntry) {
+          try {
+            const obj = JSON.parse(text) as Record<string, unknown>;
+            options.onJsonEntry(obj);
+          } catch {
+            // non-JSON line, ignore
+          }
+        }
+      } catch {
+        process.stdout.write(text);
+      }
+      callback();
+    },
+  });
+}

--- a/packages/shared/src/observability/tracing-attrs.ts
+++ b/packages/shared/src/observability/tracing-attrs.ts
@@ -1,0 +1,69 @@
+/**
+ * Standard span attribute names used across Hub tracing.
+ *
+ * Centralized to avoid typos (`inbox.entry.id` vs `inbox_entry_id`) and to
+ * make trace-backend queries consistent — operators can search by these keys
+ * to correlate spans across inbox enqueue / deliver / ws push / adapter flush
+ * without real parent links.
+ *
+ * Keys follow OTel convention: lowercase dot-separated namespaces.
+ */
+export const FIRST_TREE_HUB_ATTR = {
+  // Multi-tenancy
+  ORGANIZATION_ID: "organization.id",
+  MEMBER_ID: "member.id",
+  AGENT_ID: "agent.id",
+  CLIENT_ID: "client.id",
+
+  // Messaging domain
+  CHAT_ID: "chat.id",
+  CHAT_TYPE: "chat.type",
+  MESSAGE_ID: "message.id",
+  MESSAGE_SOURCE: "message.source",
+
+  // Inbox
+  INBOX_ENTRY_ID: "inbox.entry.id",
+  INBOX_ATTEMPT: "inbox.delivery.attempt",
+  INBOX_STATUS: "inbox.entry.status",
+
+  // WebSocket
+  WS_MESSAGE_TYPE: "ws.message.type",
+  WS_MESSAGE_REF: "ws.message.ref",
+  WS_CLOSE_CODE: "ws.close.code",
+  WS_REMOTE_IP: "ws.remote.ip",
+
+  // Adapter (external IM bridging)
+  ADAPTER_PLATFORM: "adapter.platform",
+  ADAPTER_ID: "adapter.id",
+  ADAPTER_EXTERNAL_CHAT_ID: "adapter.external_chat_id",
+
+  // Kael forwarding
+  KAEL_ENDPOINT: "kael.endpoint",
+
+  // Background tasks
+  BG_TASK_NAME: "bg_task.name",
+  BG_TASK_DURATION_MS: "bg_task.duration_ms",
+} as const;
+
+export type FirstTreeHubAttrKey = keyof typeof FIRST_TREE_HUB_ATTR;
+export type FirstTreeHubAttrName = (typeof FIRST_TREE_HUB_ATTR)[FirstTreeHubAttrKey];
+
+/**
+ * Attribute key patterns considered sensitive — automatically redacted by
+ * the telemetry facade when normalizing span attrs. Matched case-insensitively
+ * by substring.
+ */
+export const TRACING_SENSITIVE_KEY_PATTERNS: readonly string[] = [
+  "password",
+  "token",
+  "secret",
+  "authorization",
+  "apikey",
+  "api_key",
+  "encryptionkey",
+  "encryption_key",
+  "jwtsecret",
+  "jwt_secret",
+  "appsecret",
+  "app_secret",
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.84
         version: 0.2.84(zod@4.3.6)
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -80,7 +83,7 @@ importers:
         version: 13.1.0
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(postgres@3.4.8)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(postgres@3.4.8)
       fastify:
         specifier: ^5.3.0
         version: 5.8.2
@@ -139,6 +142,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/otel':
+        specifier: ^0.9.0
+        version: 0.9.4(@opentelemetry/api@1.9.1)
       '@fastify/rate-limit':
         specifier: ^10.3.0
         version: 10.3.0
@@ -151,12 +157,27 @@ importers:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.0.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.30.0
+        version: 1.40.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(postgres@3.4.8)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(postgres@3.4.8)
       fastify:
         specifier: ^5.3.0
         version: 5.8.2
@@ -166,6 +187,9 @@ importers:
       jose:
         specifier: ^6.0.0
         version: 6.2.2
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
@@ -952,6 +976,11 @@ packages:
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
 
+  '@fastify/otel@0.9.4':
+    resolution: {integrity: sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
@@ -1239,6 +1268,88 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@opentelemetry/api-logs@0.203.0':
+    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.215.0':
+    resolution: {integrity: sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0':
+    resolution: {integrity: sha512-k4J9ISeGpb0Bm/wCrlcrbroMFTkiWMrdhNxQGrlktxLy127Yzd4/7nrTawn5d/ApktYTknvdixsE6++34Qfi1w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.203.0':
+    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.215.0':
+    resolution: {integrity: sha512-lHrfbmeLSmesGSkkHiqDwOzfaEMSWXdc7q6UoLfbW8byONCb+bE/zkAr0kapN4US1baT/2nbpNT7Cn9XoB96Vg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.215.0':
+    resolution: {integrity: sha512-cWwBvaV+vkXHkSoTYR8hGw+AW03UlgTr6xtrUKOMeum3T+8vffYXIfXu6KY5MLu8O9QtoBKqaKWw9I5xoOepng==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.215.0':
+    resolution: {integrity: sha512-y3ucOmphzc4vgBTyIGchs+N/1rkACmoka8QalT2z1LBNM232Z17zMYayHcMl+dgMoOadZ0b72UZv7mDtqy1cFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.0':
+    resolution: {integrity: sha512-Vd7h95av/LYRsAVN7wbprvvJnHkq7swMXAo7Uad0Uxf9jl6NSReLa0JNivrcc5BVIx/vl2t+cgdVQQbnVhsR9w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.0':
+    resolution: {integrity: sha512-RrFHOXw0IYp/OThew6QORdybnnLitUAUMCJKcQNBYS0hDkCYarO2vTkVxfrGxCIqd5XHSMvbCpBd/T8ZMw8oSg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
@@ -1973,6 +2084,16 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2206,6 +2327,9 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -2710,6 +2834,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
@@ -2729,6 +2856,10 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -3045,6 +3176,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3099,6 +3233,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -3121,6 +3258,9 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -3129,6 +3269,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   postcss-selector-parser@6.0.10:
@@ -3168,6 +3312,10 @@ packages:
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@1.1.0:
@@ -3277,8 +3425,17 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
@@ -3488,6 +3645,10 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -3524,6 +3685,9 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -4308,6 +4472,16 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  '@fastify/otel@0.9.4(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      minimatch: 10.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@fastify/proxy-addr@5.1.0':
     dependencies:
       '@fastify/forwarded': 3.0.1
@@ -4603,6 +4777,96 @@ snapshots:
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@opentelemetry/api-logs@0.203.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api-logs@0.215.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@oxc-project/types@0.115.0': {}
 
@@ -5216,6 +5480,12 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -5441,6 +5711,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -5578,8 +5850,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.44.7(postgres@3.4.8):
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(postgres@3.4.8):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       postgres: 3.4.8
 
   dts-resolver@2.1.3: {}
@@ -5941,6 +6214,13 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   import-without-cache@0.2.5: {}
 
   inherits@2.0.4: {}
@@ -5955,6 +6235,10 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-decimal@2.0.1: {}
 
@@ -6344,6 +6628,8 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.1.3: {}
 
   mute-stream@3.0.0: {}
@@ -6385,6 +6671,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
@@ -6402,6 +6690,10 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -6422,6 +6714,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -6460,6 +6766,21 @@ snapshots:
   property-information@7.1.0: {}
 
   protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -6602,7 +6923,22 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   ret@0.5.0: {}
 
@@ -6848,6 +7184,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.2.2):
@@ -6931,6 +7269,10 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   thread-stream@4.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds a vendor-neutral observability stack — pino for structured logs,
  native `@opentelemetry/sdk-node` for traces — across server, client,
  command, and shared packages.
- Tracing is opt-in: set `FIRST_TREE_HUB_OTEL_ENDPOINT` to enable; otherwise
  every tracing call is a no-op so the default open-source path stays
  zero-cost.
- Compatible with Logfire, Honeycomb, Jaeger, Tempo, SigNoz, Axiom via OTLP.

## Key features

### Logging
- `createLogger("Module")` factory, pretty (dev) / json (prod) dual formats
- Per-request child logger with `requestId` + `traceId` via Fastify plugin
- Error/fatal logs auto-bridge onto the active span (ErrorSink), configurable
  via `observability.logging.bridgeToSpanLevel`
- Replaces 27 `app.log` / `console` call sites with module loggers

### Tracing
- OTLP/HTTP exporter; resource attrs include `service.name`,
  `service.version`, `deployment.environment.name`, `service.instance.id`
- `@fastify/otel` HTTP spans — requestHook renames to `{METHOD} {route}`
  and fixes `http.route` to the route pattern (not the raw URL)
- WebSocket `ws.connection` lifecycle span; `@fastify/otel` disabled on
  WS upgrade routes to avoid double-spanning
- Inbox enqueue / deliver / ack, adapter inbound / outbound, `kael.forward`
  all stamped with standard attrs (`inbox.entry.id`, `message.id`,
  `agent.id`, …) so cross-async flows are reconstructible by attribute
  search — **no persistent trace-context state required**
- Sensitive attr keys auto-redacted to `"***"`
- Every HTTP response carries `x-trace-id`; error bodies include `traceId`

### Configuration
Four env vars:
- `FIRST_TREE_HUB_OTEL_ENDPOINT` — OTLP URL (non-empty enables tracing)
- `FIRST_TREE_HUB_OTEL_HEADERS` — `Authorization=Bearer <token>,…`
- `FIRST_TREE_HUB_OTEL_ENVIRONMENT` — `development` / `staging` / `production` / …
- `FIRST_TREE_HUB_OTEL_CAPTURE_CONTENT` — opt-in message-body upload

Plus `FIRST_TREE_HUB_LOG_LEVEL`. Full schema under
`observability.{logging,tracing}` in `packages/shared/src/config/server-config.ts`.

### Client package
- Gains a matching pino logger (no tracing — stays lightweight for agent
  user machines)

## Test plan

- [x] `pnpm typecheck` — 9/9 packages pass
- [x] `pnpm check` (biome) — 329 files clean
- [x] `pnpm test` — 329 tests pass (was 291; +38 new observability tests
  covering redaction, header parsing, span-attr schema contract,
  ErrorSink bridging, formatter output)
- [ ] Manual smoke test: Logfire ingestion — HTTP spans render as
  `GET /api/v1/... → 200` with correct `http.route`
- [ ] Manual smoke test: multi-environment — different
  `FIRST_TREE_HUB_OTEL_ENVIRONMENT` values appear under
  `deployment.environment.name` in the backend UI
- [ ] Manual smoke test: `x-trace-id` response header present on every
  request; error responses include `traceId` in the body

## Docs

- `docs/observability.md` (new) — quick start, full config reference,
  backend setup cheat sheet (Logfire / Honeycomb / Jaeger / Tempo / SigNoz /
  Axiom), multi-environment pattern, log message conventions, known
  limitations
- `docs/cli-reference.md` — observability env var table

🤖 Generated with [Claude Code](https://claude.com/claude-code)