### PR TITLE
feat: first-class client management (bind-unbound + top-level Clients tab)

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -361,9 +361,44 @@ export function registerAgentCommands(program: Command): void {
       process.stderr.write(`  ${totalRemoved} workspace(s) cleaned.\n`);
     });
 
-  // ── Bind (Feishu bot / user) ────────────────────────────────────────
+  // ── Bind (client machine / Feishu bot / user) ───────────────────────
 
-  const bind = agent.command("bind").description("Bind external IM accounts to agents");
+  const bind = agent.command("bind").description("Bind an agent to a client machine or external IM account");
+
+  bind
+    .command("client <agentName>")
+    .description("Bind an unbound agent to a client machine (first-time bind only — ID is immutable once set)")
+    .requiredOption(
+      "--client-id <id>",
+      "Client (machine) ID — must be owned by you. Run `first-tree-hub client connect` on that machine first.",
+    )
+    .option("--server <url>", "Hub server URL")
+    .action(async (agentName: string, options: { clientId: string; server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options.server);
+        const accessToken = await ensureFreshAccessToken();
+        const target = await resolveAgent(serverUrl, accessToken, agentName);
+
+        const patchRes = await fetch(`${serverUrl}/api/v1/admin/agents/${target.uuid}`, {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ clientId: options.clientId }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!patchRes.ok) {
+          const body = (await patchRes.json().catch(() => ({}))) as { error?: string };
+          fail("BIND_CLIENT_ERROR", body.error ?? `Bind failed (HTTP ${patchRes.status})`, 1);
+        }
+        process.stderr.write(`  \u2713 Bound "${target.name ?? target.uuid}" to client ${options.clientId}.\n`);
+        success({ agentId: target.uuid, clientId: options.clientId });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("BIND_CLIENT_ERROR", msg);
+      }
+    });
 
   bind
     .command("bot")

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -139,13 +139,13 @@ export function registerClientCommands(program: Command): void {
 
   client
     .command("hub-list")
-    .description("List connected clients on the Hub server")
+    .description("List clients on the Hub server")
     .option("--server <url>", "Hub server URL")
     .action(async (options: { server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);
         const token = await ensureFreshAccessToken();
-        const response = await fetch(`${serverUrl}/api/v1/admin/clients`, {
+        const response = await fetch(`${serverUrl}/api/v1/clients`, {
           headers: { Authorization: `Bearer ${token}` },
           signal: AbortSignal.timeout(10_000),
         });
@@ -161,11 +161,11 @@ export function registerClientCommands(program: Command): void {
         }>;
 
         if (clients.length === 0) {
-          process.stderr.write("  No connected clients.\n");
+          process.stderr.write("  No clients.\n");
           return;
         }
 
-        process.stderr.write(`\n  Connected Clients: ${clients.length}\n\n`);
+        process.stderr.write(`\n  Clients: ${clients.length}\n\n`);
         const header = `  ${"CLIENT".padEnd(20)} ${"HOST".padEnd(25)} ${"AGENTS".padEnd(8)} CONNECTED`;
         process.stderr.write(`${header}\n`);
         process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
@@ -190,7 +190,7 @@ export function registerClientCommands(program: Command): void {
       try {
         const serverUrl = resolveServerUrl(options.server);
         const token = await ensureFreshAccessToken();
-        const response = await fetch(`${serverUrl}/api/v1/admin/clients/${clientId}/disconnect`, {
+        const response = await fetch(`${serverUrl}/api/v1/clients/${clientId}/disconnect`, {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },
           signal: AbortSignal.timeout(10_000),

--- a/packages/server/src/api/admin/clients.ts
+++ b/packages/server/src/api/admin/clients.ts
@@ -6,7 +6,7 @@ import { forceDisconnectClient } from "../../services/connection-manager.js";
 import { serializeDate } from "../../utils.js";
 
 export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
-  // GET /admin/clients — clients owned by the caller. Every `clients.user_id`
+  // GET /clients — clients owned by the caller. Every `clients.user_id`
   // is the authoritative owner (Rule R-RUN); routes are scoped to that user
   // so a cross-org or cross-user caller can't see or touch clients that
   // aren't theirs.
@@ -26,7 +26,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
     }));
   });
 
-  // GET /admin/clients/:clientId — single client, owner-scoped.
+  // GET /clients/:clientId — single client, owner-scoped.
   app.get<{ Params: { clientId: string } }>("/:clientId", async (request) => {
     const scope = memberScope(request);
     await clientService.assertClientOwner(app.db, request.params.clientId, scope.userId);
@@ -45,7 +45,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  // POST /admin/clients/:clientId/disconnect — force disconnect, owner-scoped.
+  // POST /clients/:clientId/disconnect — force disconnect, owner-scoped.
   app.post<{ Params: { clientId: string } }>("/:clientId/disconnect", async (request) => {
     const scope = memberScope(request);
     const { clientId } = request.params;
@@ -57,7 +57,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
     return { disconnected: true, agentIds };
   });
 
-  // DELETE /admin/clients/:clientId — retire, owner-scoped. Refuses while
+  // DELETE /clients/:clientId — retire, owner-scoped. Refuses while
   // agents are still pinned (proposal M12); the service layer surfaces a 409
   // with the pinned agent list so the UI can display it.
   app.delete<{ Params: { clientId: string } }>("/:clientId", async (request, reply) => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -228,7 +228,7 @@ export async function buildApp(config: Config) {
           adminApp.addHook("onRequest", memberAuth);
           await adminApp.register(adminClientRoutes);
         },
-        { prefix: "/admin/clients" },
+        { prefix: "/clients" },
       );
 
       // M1: Agent activity routes

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -108,13 +108,8 @@ export async function getClient(db: Database, clientId: string) {
   return row ?? null;
 }
 
-export async function listClients(db: Database, userId?: string) {
-  const conditions = [eq(clients.status, "connected")];
-  if (userId) conditions.push(eq(clients.userId, userId));
-  const rows = await db
-    .select()
-    .from(clients)
-    .where(conditions.length === 1 ? conditions[0] : and(...conditions));
+export async function listClients(db: Database, userId: string) {
+  const rows = await db.select().from(clients).where(eq(clients.userId, userId));
   const counts = await db
     .select({
       clientId: agents.clientId,

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -39,7 +39,7 @@ export type HubClient = {
 };
 
 export function retireClient(clientId: string): Promise<void> {
-  return api.delete<void>(`/admin/clients/${encodeURIComponent(clientId)}`);
+  return api.delete<void>(`/clients/${encodeURIComponent(clientId)}`);
 }
 
 export function getActivityOverview(): Promise<ActivityOverview> {
@@ -47,15 +47,15 @@ export function getActivityOverview(): Promise<ActivityOverview> {
 }
 
 export function listClients(): Promise<HubClient[]> {
-  return api.get<HubClient[]>("/admin/clients");
+  return api.get<HubClient[]>("/clients");
 }
 
 export function getClient(clientId: string): Promise<HubClient> {
-  return api.get<HubClient>(`/admin/clients/${clientId}`);
+  return api.get<HubClient>(`/clients/${clientId}`);
 }
 
 export function disconnectClient(clientId: string): Promise<{ disconnected: boolean; agentIds: string[] }> {
-  return api.post(`/admin/clients/${clientId}/disconnect`);
+  return api.post(`/clients/${clientId}/disconnect`);
 }
 
 export function resetAgentActivity(agentId: string): Promise<{ reset: boolean }> {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -7,6 +7,7 @@ import { PulseProvider } from "./hooks/pulse-context.js";
 import { AdminPage } from "./pages/admin.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { AgentsPage } from "./pages/agents.js";
+import { ClientsPage } from "./pages/clients.js";
 import { LoginPage } from "./pages/login.js";
 import { WorkspacePage } from "./pages/workspace/index.js";
 
@@ -37,6 +38,7 @@ export function App() {
                 <Route index element={<WorkspacePage />} />
                 <Route path="agents" element={<AgentsPage />} />
                 <Route path="agents/:uuid" element={<AgentDetailPage />} />
+                <Route path="clients" element={<ClientsPage />} />
                 <Route path="admin" element={<AdminPage />} />
               </Route>
             </Route>

--- a/packages/web/src/components/agent-form-dialog.tsx
+++ b/packages/web/src/components/agent-form-dialog.tsx
@@ -69,8 +69,10 @@ export function AgentFormDialog(props: AgentFormProps) {
   // Filter clients by the selected manager's user_id. The manager dropdown
   // is admin-only; members auto-pin under their own user, so their options
   // are already filtered server-side by clients the user owns.
+  // Only connected clients are pin-eligible — disconnected ones surface in
+  // the Clients page but cannot accept new agent bindings.
   const visibleClients = useMemo(() => {
-    const all = clientsQuery.data ?? [];
+    const all = (clientsQuery.data ?? []).filter((c) => c.status === "connected");
     if (!showClient) return all;
     if (!isAdmin) {
       // Server should only return clients owned by the caller for non-admins.

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -10,9 +10,10 @@ import { ThemeToggle } from "./ui/theme-toggle.js";
 const navTabs = [
   { to: "/", label: "Workspace", end: true, kbd: "⌘1" },
   { to: "/agents", label: "Agents", end: false, kbd: "⌘2" },
+  { to: "/clients", label: "Clients", end: false, kbd: "⌘3" },
 ];
 
-const adminTab = { to: "/admin", label: "Admin", end: false, kbd: "⌘3" };
+const adminTab = { to: "/admin", label: "Admin", end: false, kbd: "⌘4" };
 
 export function Layout() {
   const { role, logout } = useAuth();

--- a/packages/web/src/pages/admin.tsx
+++ b/packages/web/src/pages/admin.tsx
@@ -1,13 +1,11 @@
 import { useLocation, useNavigate } from "react-router";
 import { cn } from "../lib/utils.js";
 import { BindingsPage } from "./bindings.js";
-import { ClientsPage } from "./clients.js";
 import { MembersPage } from "./members.js";
 import { SettingsPage } from "./settings.js";
 
 const tabs = [
   { key: "members", label: "Members" },
-  { key: "clients", label: "Clients" },
   { key: "settings", label: "Settings" },
   { key: "bindings", label: "Bindings" },
 ] as const;
@@ -45,7 +43,6 @@ export function AdminPage() {
         ))}
       </div>
       {active === "members" && <MembersPage />}
-      {active === "clients" && <ClientsPage />}
       {active === "settings" && <SettingsPage />}
       {active === "bindings" && <BindingsPage />}
     </div>

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1027,12 +1027,13 @@ function BindClientList({
   selected: string;
   onSelect: (id: string) => void;
 }) {
-  const bindable = clients.filter((c) => c.status !== "retired");
+  const bindable = clients.filter((c) => c.status === "connected");
   if (bindable.length === 0) {
     return (
       <div className="rounded border bg-muted/40 px-3 py-4 text-sm text-muted-foreground">
-        No clients available. Run <code className="font-mono text-xs">first-tree-hub client connect &lt;url&gt;</code>{" "}
-        on the machine that should run this agent, then reopen this dialog.
+        No connected clients available. Run{" "}
+        <code className="font-mono text-xs">first-tree-hub client connect &lt;url&gt;</code> on the machine that should
+        run this agent, then reopen this dialog.
       </div>
     );
   }

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Cable, Link2, MoreHorizontal, Play, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import { type HubClient, listClients } from "./../api/activity.js";
 import { createAdapterMapping, deleteAdapterMapping, listAdapterMappings } from "./../api/adapter-mappings.js";
 import { getAdapterStatuses } from "./../api/adapter-status.js";
 import { createAdapter, deleteAdapter, listAdapters, updateAdapter } from "./../api/adapters.js";
@@ -162,6 +163,28 @@ export function AgentDetailPage() {
     window.addEventListener("mousedown", onClickAway);
     return () => window.removeEventListener("mousedown", onClickAway);
   }, [moreOpen]);
+
+  // Bind-client (agent ↔ client first-time binding) dialog state
+  const [bindClientOpen, setBindClientOpen] = useState(false);
+  const [bindClientSelected, setBindClientSelected] = useState<string>("");
+  const [bindClientError, setBindClientError] = useState<string | null>(null);
+  const clientsQuery = useQuery({
+    queryKey: ["clients"],
+    queryFn: listClients,
+    enabled: bindClientOpen,
+  });
+  const bindClientMutation = useMutation({
+    mutationFn: (clientId: string) => updateAgent(uuid, { clientId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
+      queryClient.invalidateQueries({ queryKey: ["agent-client-status", uuid] });
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      setBindClientOpen(false);
+      setBindClientSelected("");
+      setBindClientError(null);
+    },
+    onError: (err) => setBindClientError(err instanceof Error ? err.message : String(err)),
+  });
 
   // Binding dialog state (unchanged from previous)
   const [bindingDialogOpen, setBindingDialogOpen] = useState(false);
@@ -445,6 +468,21 @@ export function AgentDetailPage() {
         isHuman={isHuman}
       />
 
+      {isUnclaimed && agent.status === "active" && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 flex items-center justify-between gap-3">
+          <div className="text-sm text-amber-900">
+            <div className="font-medium">No client bound</div>
+            <div className="text-xs text-amber-800/80">
+              Bind this agent to a client machine so it can run. A client will also claim it on first WebSocket connect.
+            </div>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setBindClientOpen(true)}>
+            <Link2 className="h-4 w-4 mr-2" />
+            Bind Client
+          </Button>
+        </div>
+      )}
+
       {/* Identity */}
       <IdentitySection
         agent={agent}
@@ -696,6 +734,59 @@ export function AgentDetailPage() {
         </div>
       )}
 
+      {/* Bind Client Dialog — first-time NULL → ID bind only */}
+      <Dialog
+        open={bindClientOpen}
+        onOpenChange={(open) => {
+          setBindClientOpen(open);
+          if (!open) {
+            setBindClientSelected("");
+            setBindClientError(null);
+            bindClientMutation.reset();
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Bind client</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Pick a client machine you own to pin this agent to. The bind is one-shot — once set, moving the agent
+              requires deleting and re-creating it on the target client.
+            </p>
+            {clientsQuery.isLoading ? (
+              <div className="text-sm text-muted-foreground">Loading clients…</div>
+            ) : clientsQuery.error ? (
+              <div className="text-sm text-destructive">
+                Failed to load clients: {clientsQuery.error instanceof Error ? clientsQuery.error.message : "Unknown"}
+              </div>
+            ) : (
+              <BindClientList
+                clients={clientsQuery.data ?? []}
+                selected={bindClientSelected}
+                onSelect={setBindClientSelected}
+              />
+            )}
+            {bindClientError && <div className="text-sm text-destructive">{bindClientError}</div>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBindClientOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!bindClientSelected || bindClientMutation.isPending}
+              onClick={() => {
+                setBindClientError(null);
+                bindClientMutation.mutate(bindClientSelected);
+              }}
+            >
+              {bindClientMutation.isPending ? "Binding…" : "Bind"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Binding Dialog */}
       <Dialog
         open={bindingDialogOpen}
@@ -923,6 +1014,62 @@ function buildCredentials(form: {
   const trimmed = form.credentialsJson.trim();
   if (!trimmed) return null;
   return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+// ─── bind-client picker ──────────────────────────────────────────────
+
+function BindClientList({
+  clients,
+  selected,
+  onSelect,
+}: {
+  clients: HubClient[];
+  selected: string;
+  onSelect: (id: string) => void;
+}) {
+  const bindable = clients.filter((c) => c.status !== "retired");
+  if (bindable.length === 0) {
+    return (
+      <div className="rounded border bg-muted/40 px-3 py-4 text-sm text-muted-foreground">
+        No clients available. Run <code className="font-mono text-xs">first-tree-hub client connect &lt;url&gt;</code>{" "}
+        on the machine that should run this agent, then reopen this dialog.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y rounded border max-h-64 overflow-y-auto">
+      {bindable.map((c) => {
+        const picked = c.id === selected;
+        const online = c.status === "online" || c.status === "active";
+        return (
+          <li key={c.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(c.id)}
+              className={cn(
+                "w-full text-left px-3 py-2 flex items-center gap-3 hover:bg-gray-50",
+                picked && "bg-blue-50",
+              )}
+            >
+              <span
+                className={cn("inline-block h-2 w-2 rounded-full", online ? "bg-green-500" : "bg-gray-400")}
+                aria-hidden
+              />
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium truncate">{c.hostname ?? c.id}</span>
+                <span className="block text-xs text-muted-foreground font-mono truncate">
+                  {c.id}
+                  {c.os ? ` · ${c.os}` : ""}
+                  {c.sdkVersion ? ` · SDK ${c.sdkVersion}` : ""}
+                </span>
+              </span>
+              <span className="text-xs text-muted-foreground">{c.status}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
 }
 
 // ─── test connection card ────────────────────────────────────────────

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -130,6 +130,7 @@ export function ClientsPage() {
 
   return (
     <div>
+      <h1 className="text-2xl font-semibold mb-4">Clients</h1>
       <ConnectCommandBanner />
 
       {/* Confirm retire dialog */}
@@ -231,7 +232,7 @@ export function ClientsPage() {
 
       {!clients || clients.length === 0 ? (
         <div className="text-center text-muted-foreground py-12">
-          No connected clients. Use the button above to generate a connect command.
+          No clients. Use the button above to generate a connect command.
         </div>
       ) : (
         <div className="border rounded-lg overflow-hidden">


### PR DESCRIPTION
## Summary

Two related improvements that surface client operations to every member instead of gating them behind admin-only UI.

- **Bind-to-client entry for unclaimed agents** (b0e00d3). Migration 0020 allowed `agents.client_id` to be NULL until the first WS bind, but the NULL → ID claim path had no UI or CLI surface. Adds an amber banner on the agent detail page that opens a picker over the caller's owned clients, and a new `first-tree-hub agent bind client <name> --client-id <id>` CLI subcommand. Both issue `PATCH /admin/agents/:uuid { clientId }`; the service-layer one-shot rule (NULL → ID only) is unchanged — re-pinning a running agent still requires delete + recreate.
- **Decouple Clients from Admin** (e33430d). The `/admin/clients` routes were already `memberAuth`-only and user-scoped by `clients.user_id`, so the `/admin` prefix and placement under AdminPage were naming artifacts that locked non-admin members out of their own clients. Moves the routes to `/clients`, adds a top-level `/clients` page with a topbar entry at ⌘3 (Admin shifts to ⌘4), and drops the Clients sub-tab from AdminPage.
- **Keep disconnected clients visible.** `listClients` previously filtered `status = "connected"`, so a client disappeared from the page the moment it went offline. Removes that filter so the Clients page shows the full history; tightens the `listClients` signature to require `userId` so the scope can't be accidentally widened. Create/bind dropdowns filter connected-only on the client side.

API path migration covers web (`api/activity.ts`) and CLI (`hub-list`, `hub-disconnect`) in the same commit.

## Test plan

- [ ] Log in as a non-admin member → Clients tab appears at ⌘3, Admin is hidden; the list shows the user's own clients including any disconnected ones.
- [ ] Generate a connect command as a non-admin → register the client; it shows up on the Clients page under the caller's `user_id`.
- [ ] Disconnect a client from the UI → row stays on the page with the `disconnected` badge instead of disappearing.
- [ ] Retire a client with no pinned agents → row is removed. Retire with pinned agents → 409 listing the pinned agent names.
- [ ] Create an agent → the client dropdown only offers `connected` clients.
- [ ] Open an agent detail page for an agent with `clientId IS NULL` → amber "Bind client" banner appears; picker lists only connected clients; bind completes and the banner clears.
- [ ] `first-tree-hub client hub-list` → lists all clients (including disconnected) against `/api/v1/clients`. `first-tree-hub client hub-disconnect <id>` still works.
- [ ] `first-tree-hub agent bind client <name> --client-id <id>` against an unbound agent → succeeds; against a bound agent → ConflictError from the service layer.
- [ ] Log in as admin → Clients tab at ⌘3, Admin at ⌘4; Admin page no longer shows a Clients sub-tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)