### PR TITLE
fix(client): reconnect after server pushes auth:expired

### DIFF
--- a/packages/client/src/__tests__/client-connection-auth-expired.test.ts
+++ b/packages/client/src/__tests__/client-connection-auth-expired.test.ts
@@ -1,0 +1,120 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { ClientConnection } from "../client-connection.js";
+
+// Regression: auth:expired must schedule a reconnect, not silently drop the socket.
+describe("ClientConnection — auth:expired reconnect", () => {
+  let httpServer: HttpServer;
+  let wss: WebSocketServer;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    httpServer = createServer();
+    wss = new WebSocketServer({ server: httpServer, path: "/api/v1/agent/ws/client" });
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") throw new Error("no server address");
+    serverUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("reconnects and refreshes the access token after server pushes auth:expired", async () => {
+    let socketCount = 0;
+
+    wss.on("connection", (ws: WebSocket) => {
+      const n = ++socketCount;
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          return;
+        }
+        if (msg.type === "client:register") {
+          ws.send(JSON.stringify({ type: "client:registered" }));
+          if (n === 1) {
+            setTimeout(() => {
+              ws.send(JSON.stringify({ type: "auth:expired" }));
+              ws.close(4401, "auth expired");
+            }, 20);
+          }
+        }
+      });
+    });
+
+    let tokenCalls = 0;
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_test",
+      getAccessToken: async () => {
+        tokenCalls++;
+        return `tok-${tokenCalls}`;
+      },
+    });
+
+    const events: string[] = [];
+    connection.on("auth:expired", () => events.push("auth:expired"));
+    connection.on("reconnecting", () => events.push("reconnecting"));
+    connection.on("connected", () => events.push("connected"));
+    connection.on("disconnected", () => events.push("disconnected"));
+
+    await connection.connect();
+    expect(connection.isConnected).toBe(true);
+
+    // The initial `connected` fired before the listener above was attached,
+    // so `once` here resolves only on the reconnect's `connected`.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("did not reconnect within 5s")), 5000);
+      connection.once("connected", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+
+    expect(events).toContain("auth:expired");
+    expect(events).toContain("reconnecting");
+    expect(socketCount).toBe(2);
+    expect(tokenCalls).toBeGreaterThanOrEqual(2);
+    expect(connection.isConnected).toBe(true);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("does not loop-reconnect when auth:rejected fires during initial handshake", async () => {
+    let socketCount = 0;
+    wss.on("connection", (ws: WebSocket) => {
+      socketCount++;
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:rejected", reason: "invalid" }));
+          ws.close(4401, "rejected");
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_rejected",
+      getAccessToken: async () => "bad-token",
+    });
+
+    const events: string[] = [];
+    connection.on("reconnecting", () => events.push("reconnecting"));
+    connection.on("error", () => {});
+
+    await expect(connection.connect()).rejects.toThrow();
+
+    // Deterministic assertion: initial-handshake rejection must never schedule
+    // a reconnect (wasRegistered is false at close). No need to wait on wall time.
+    expect(events).not.toContain("reconnecting");
+    expect(socketCount).toBe(1);
+    expect(connection.isConnected).toBe(false);
+
+    await connection.disconnect();
+  }, 10_000);
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -318,7 +318,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
 
     if (type === "auth:rejected" || type === "auth:expired") {
-      this.registered = false;
+      // The close handler reads `this.registered` to decide whether to
+      // reconnect; clearing it here would make that decision see post-close
+      // state and skip the reconnect after a mid-session auth:expired push.
       if (type === "auth:expired") this.emit("auth:expired");
       this.ws?.close(4401, type);
       return;

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary

- Fix silent hang where client's WS stopped reconnecting after the server pushed `auth:expired`. The handler cleared `this.registered = false` before `ws.close()`, so the close handler's `wasRegistered` check read `false` and `scheduleReconnect()` never fired — process stayed alive but idle until Hub timed out `lastSeenAt`.
- Leave state to the close handler so both paths are handled correctly: `auth:expired` (post-registration) reconnects with a refreshed JWT; `auth:rejected` (pre-registration) still fails the initial `connect()` promise without looping.
- Add a regression test (`client-connection-auth-expired.test.ts`) that reproduces the hang against an in-process mock WS server and verifies reconnect + token refresh; second test pins the no-loop-on-initial-reject invariant.
- Bump CLI package to 0.7.1.

## Observed symptom

A live client running v0.7.0 against staging ran fine for ~10 min, then logged `⚠️ Access token expired — reconnecting after refresh...` and went completely silent — no error, no exit, no reconnect. Hub marked it `disconnected` via lastSeenAt timeout. Manual restart restored normal operation.

## Test plan

- [x] `pnpm --filter @first-tree-hub/client test` — 19 suites / 123 tests pass
- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — all packages
- [x] Regression verified: reverting the fix makes the new test fail with "did not reconnect within 5s" (exactly the production symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)