### PR TITLE
fix(client): isolate git worktree sessions with per-branch mirror refs

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@first-tree-hub/client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "First Tree Hub SDK — programmatic client for First Tree Hub server",

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -1,10 +1,13 @@
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   createGitMirrorManager,
+  deriveSessionBranchName,
+  GitMirrorError,
   type GitMirrorManager,
   GitMirrorWorktreeConflictError,
 } from "../runtime/git-mirror-manager.js";
@@ -12,11 +15,11 @@ import {
 let workRoot: string;
 let fixtureRepo: string;
 let fixtureUrl: string;
+let initialMainSha: string;
 
 beforeAll(() => {
   workRoot = mkdtempSync(join(tmpdir(), "ftt-mirror-"));
   fixtureRepo = join(workRoot, "fixture-bare.git");
-  // Create a tiny fixture repo with two commits.
   const seed = join(workRoot, "fixture-seed");
   mkdirSync(seed, { recursive: true });
   execSync("git init -q -b main", { cwd: seed });
@@ -25,9 +28,9 @@ beforeAll(() => {
   execSync("git add . && git commit -q -m initial", { cwd: seed });
   writeFileSync(join(seed, "README.md"), "hello v2");
   execSync("git add . && git commit -q -m second", { cwd: seed });
-  // Make a bare clone we can reference as the upstream URL.
   execSync(`git clone -q --bare ${seed} ${fixtureRepo}`);
-  fixtureUrl = fixtureRepo; // file:// works too, but a plain path is simpler
+  fixtureUrl = fixtureRepo;
+  initialMainSha = execSync("git rev-parse main", { cwd: fixtureRepo }).toString().trim();
 });
 
 afterAll(() => {
@@ -41,8 +44,25 @@ function makeManager(): GitMirrorManager {
   });
 }
 
-describe("GitMirrorManager (Step 5)", () => {
-  it("ensureMirror clones once and is idempotent", async () => {
+function gitIn(cwd: string, args: string): string {
+  return execSync(`git ${args}`, { cwd }).toString().trim();
+}
+
+function tryGitIn(cwd: string, args: string): { ok: boolean; stdout: string } {
+  try {
+    return {
+      ok: true,
+      stdout: execSync(`git ${args}`, { cwd, stdio: ["ignore", "pipe", "pipe"] })
+        .toString()
+        .trim(),
+    };
+  } catch (err) {
+    return { ok: false, stdout: (err as { stdout?: Buffer }).stdout?.toString() ?? "" };
+  }
+}
+
+describe("GitMirrorManager — lifecycle", () => {
+  it("ensureMirror bootstraps once and is idempotent", async () => {
     const m = makeManager();
     const first = await m.ensureMirror(fixtureUrl);
     expect(first.cloned).toBe(true);
@@ -53,62 +73,78 @@ describe("GitMirrorManager (Step 5)", () => {
     expect(second.mirrorPath).toBe(first.mirrorPath);
   });
 
-  it("createWorktree adds a detached worktree at HEAD", async () => {
+  it("ensureMirror configures the mirror with remote-tracking fetch refspec (no mirror flag)", async () => {
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    expect(gitIn(mirrorPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
+    expect(tryGitIn(mirrorPath, "config --get remote.origin.mirror").ok).toBe(false);
+    expect(gitIn(mirrorPath, "config --get remote.origin.url")).toBe(fixtureUrl);
+  });
+
+  it("createWorktree creates a session branch, attached (not detached)", async () => {
     const m = makeManager();
     await m.ensureMirror(fixtureUrl);
-    const target = mkdtempSync(join(tmpdir(), "ftt-wt-"));
-    rmSync(target, { recursive: true, force: true }); // ensure target path is free
-    const wt = await m.createWorktree({ url: fixtureUrl, targetPath: target });
-    expect(wt.worktreePath).toBe(target);
-    expect(wt.headCommit).toMatch(/^[0-9a-f]{40}$/);
+    const target = join(workRoot, "wt-attached");
+    const { worktreePath, headCommit, branchName } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "chat-1",
+    });
+    expect(worktreePath).toBe(target);
+    expect(headCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(branchName).toBe(deriveSessionBranchName("chat-1", fixtureUrl));
+    // HEAD should be a symbolic ref to the session branch (not detached).
+    expect(gitIn(target, "symbolic-ref HEAD")).toBe(`refs/heads/${branchName}`);
     expect(existsSync(join(target, "README.md"))).toBe(true);
   });
 
-  it("two worktrees from same URL coexist independently", async () => {
+  it("different session keys produce disjoint branches on the same mirror", async () => {
     const m = makeManager();
     await m.ensureMirror(fixtureUrl);
-    const a = join(workRoot, "two-wt-a");
-    const b = join(workRoot, "two-wt-b");
-    await m.createWorktree({ url: fixtureUrl, targetPath: a });
-    await m.createWorktree({ url: fixtureUrl, targetPath: b });
+    const a = join(workRoot, "two-sess-a");
+    const b = join(workRoot, "two-sess-b");
+    const ra = await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "chat-A" });
+    const rb = await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "chat-B" });
+    expect(ra.branchName).not.toBe(rb.branchName);
     writeFileSync(join(a, "scratch.txt"), "in A only");
     expect(existsSync(join(a, "scratch.txt"))).toBe(true);
     expect(existsSync(join(b, "scratch.txt"))).toBe(false);
   });
 
-  it("createWorktree reports conflict when target is a non-Hub directory (D13)", async () => {
+  it("createWorktree rejects a non-Hub occupant (D13)", async () => {
     const m = makeManager();
     await m.ensureMirror(fixtureUrl);
     const occupied = join(workRoot, "occupied");
     mkdirSync(occupied, { recursive: true });
     writeFileSync(join(occupied, "user-data.txt"), "important");
-    await expect(m.createWorktree({ url: fixtureUrl, targetPath: occupied })).rejects.toBeInstanceOf(
-      GitMirrorWorktreeConflictError,
-    );
-    // Original data must survive the failed call.
+    await expect(
+      m.createWorktree({ url: fixtureUrl, targetPath: occupied, sessionKey: "chat-C" }),
+    ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
     expect(existsSync(join(occupied, "user-data.txt"))).toBe(true);
   });
 
-  it("removeWorktree clears the worktree but keeps the mirror", async () => {
+  it("removeWorktree deletes both the worktree and the session branch", async () => {
     const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
     const target = join(workRoot, "remove-target");
-    await m.createWorktree({ url: fixtureUrl, targetPath: target });
-    await m.removeWorktree(target);
+    const { branchName } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "chat-rm",
+    });
+    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(true);
+    await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
     expect(existsSync(target)).toBe(false);
-    expect(existsSync(join(m.mirrorsRoot, m.mirrorsRoot ? "" : ""))).toBeDefined(); // mirrors dir still there
+    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(false);
   });
 
   it("gcMirrors removes mirrors not in the referenced set", async () => {
     const m = makeManager();
     await m.ensureMirror(fixtureUrl);
-    // Mirror exists; gc with empty set should drop it.
-    const before = readdirSync(m.mirrorsRoot).length;
-    expect(before).toBe(1);
+    expect(readdirSync(m.mirrorsRoot).length).toBe(1);
     const { removed } = await m.gcMirrors(new Set());
     expect(removed).toHaveLength(1);
-    const after = readdirSync(m.mirrorsRoot).length;
-    expect(after).toBe(0);
+    expect(readdirSync(m.mirrorsRoot).length).toBe(0);
   });
 
   it("gcMirrors keeps mirrors still referenced", async () => {
@@ -116,5 +152,169 @@ describe("GitMirrorManager (Step 5)", () => {
     await m.ensureMirror(fixtureUrl);
     const { removed } = await m.gcMirrors(new Set([fixtureUrl]));
     expect(removed).toEqual([]);
+  });
+});
+
+describe("GitMirrorManager — session isolation regressions", () => {
+  it("incident 1: fetch does not mutate session branches when upstream advances", async () => {
+    // Reproduce the original data-loss scenario: session branch is attached in
+    // a worktree, upstream force-moves main to a new commit, fetch runs — the
+    // session branch and the worktree's HEAD must survive untouched.
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    const target = join(workRoot, "incident-1");
+    const { branchName, headCommit } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "incident-1",
+    });
+
+    // Advance upstream by one commit (plain commit, not force-push — good enough
+    // because the old mirror refspec would still force-overwrite local main).
+    const upstreamClone = mkdtempSync(join(tmpdir(), "ftt-upstream-"));
+    execSync(`git clone -q ${fixtureUrl} ${upstreamClone}`);
+    execSync("git config user.email test@example.com && git config user.name test", { cwd: upstreamClone });
+    writeFileSync(join(upstreamClone, "README.md"), "advanced");
+    execSync("git add . && git commit -q -m advance", { cwd: upstreamClone });
+    execSync("git push -q origin main", { cwd: upstreamClone });
+
+    await m.fetchMirror(fixtureUrl);
+
+    expect(gitIn(mirrorPath, `rev-parse refs/heads/${branchName}`)).toBe(headCommit);
+    expect(gitIn(target, "rev-parse HEAD")).toBe(headCommit);
+    expect(gitIn(mirrorPath, "rev-parse refs/remotes/origin/main")).not.toBe(headCommit);
+
+    // Restore fixture upstream to its original HEAD so later tests see the
+    // expected baseline state.
+    execSync(`git reset --hard ${initialMainSha}`, { cwd: upstreamClone });
+    execSync("git push -q --force origin main", { cwd: upstreamClone });
+    rmSync(upstreamClone, { recursive: true, force: true });
+  });
+
+  it("incident 2: fetch --prune does not remove local heads that never had an upstream counterpart", async () => {
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    // Create a local branch directly in the mirror that upstream never had.
+    const localOnlySha = gitIn(mirrorPath, "rev-parse refs/remotes/origin/main");
+    execSync(`git branch local-only ${localOnlySha}`, { cwd: mirrorPath });
+    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/local-only").ok).toBe(true);
+
+    await m.fetchMirror(fixtureUrl);
+
+    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/local-only").ok).toBe(true);
+  });
+
+  it("incident 3: fetchMirror succeeds even when multiple session branches are checked out", async () => {
+    const m = makeManager();
+    await m.ensureMirror(fixtureUrl);
+    const a = join(workRoot, "incident-3-a");
+    const b = join(workRoot, "incident-3-b");
+    await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "incident-3-A" });
+    await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "incident-3-B" });
+    await expect(m.fetchMirror(fixtureUrl)).resolves.toBeDefined();
+  });
+});
+
+describe("GitMirrorManager — migration from legacy mirror config", () => {
+  it("ensureMirror rewrites legacy --mirror config to the safe refspec", async () => {
+    const tmpData = mkdtempSync(join(tmpdir(), "ftt-legacy-"));
+    const m = createGitMirrorManager({ dataDir: tmpData, cloneTimeoutMs: 30_000 });
+
+    // Hand-roll a legacy mirror: `git clone --mirror` sets
+    // `fetch = +refs/*:refs/*` and `mirror = true`.
+    const legacyPath = join(tmpData, "git-mirrors", createHash("sha256").update(fixtureUrl).digest("hex").slice(0, 32));
+    mkdirSync(join(tmpData, "git-mirrors"), { recursive: true });
+    execSync(`git clone -q --mirror ${fixtureUrl} ${legacyPath}`);
+    expect(gitIn(legacyPath, "config --get remote.origin.mirror")).toBe("true");
+
+    // Run ensureMirror — should rewrite the config in-place.
+    const result = await m.ensureMirror(fixtureUrl);
+    expect(result.cloned).toBe(false);
+    expect(gitIn(legacyPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
+    expect(tryGitIn(legacyPath, "config --get remote.origin.mirror").ok).toBe(false);
+
+    // Second call is a no-op (idempotent).
+    await m.ensureMirror(fixtureUrl);
+    expect(gitIn(legacyPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
+  });
+});
+
+describe("GitMirrorManager — crash recovery", () => {
+  it("reattaches to an existing session branch when the worktree directory is missing", async () => {
+    // Simulate a crashed session: branch exists in the mirror, path has been
+    // manually cleaned up. Next session start must attach the branch to a new
+    // worktree path rather than failing because the branch already exists.
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    const firstTarget = join(workRoot, "crash-first");
+    const { branchName, headCommit } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: firstTarget,
+      sessionKey: "crashy",
+    });
+    // User or an external process removed the worktree dir without running
+    // `git worktree remove`. Git marks it prunable on next access.
+    rmSync(firstTarget, { recursive: true, force: true });
+    execSync("git worktree prune", { cwd: mirrorPath });
+    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(true);
+
+    const reopened = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: firstTarget,
+      sessionKey: "crashy",
+    });
+    expect(reopened.branchName).toBe(branchName);
+    expect(reopened.headCommit).toBe(headCommit);
+    expect(existsSync(join(firstTarget, "README.md"))).toBe(true);
+  });
+
+  it("refuses to proceed when the worktree path exists but the session branch is missing", async () => {
+    // Simulates ref-level corruption: the worktree directory survives on disk,
+    // but the session branch in the mirror has vanished (manual ref tampering,
+    // disk restore from a partial backup, etc.). createWorktree must refuse
+    // rather than silently recreate an unrelated branch at the same path.
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    const target = join(workRoot, "crash-ghost");
+    const { branchName } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "ghosty",
+    });
+    // Bypass git's safety net and delete the ref file directly. Works against
+    // loose refs; a freshly-created branch never reaches packed-refs.
+    const refPath = join(mirrorPath, "refs", "heads", branchName);
+    rmSync(refPath, { force: true });
+
+    await expect(
+      m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "ghosty" }),
+    ).rejects.toBeInstanceOf(GitMirrorError);
+  });
+});
+
+describe("GitMirrorManager — concurrency", () => {
+  it("collapses parallel ensureMirror calls onto a single bootstrap", async () => {
+    const m = makeManager();
+    const [a, b] = await Promise.all([m.ensureMirror(fixtureUrl), m.ensureMirror(fixtureUrl)]);
+    // Exactly one of the two saw the cold path.
+    expect([a.cloned, b.cloned].sort()).toEqual([false, true]);
+    expect(a.mirrorPath).toBe(b.mirrorPath);
+  });
+
+  it("serialises parallel createWorktree calls on the same URL (config-lock contention)", async () => {
+    // `git worktree add -b` writes to the mirror's `config` file to set
+    // upstream tracking. Running two adds in parallel without a lock causes
+    // the second to fail with "could not lock config file" (found via E2E).
+    const m = makeManager();
+    await m.ensureMirror(fixtureUrl);
+    const a = join(workRoot, "conc-a");
+    const b = join(workRoot, "conc-b");
+    const [ra, rb] = await Promise.all([
+      m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "conc-A" }),
+      m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "conc-B" }),
+    ]);
+    expect(ra.branchName).not.toBe(rb.branchName);
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
   });
 });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -7,7 +7,7 @@ import type { McpServerConfig, PermissionMode, Query, SDKUserMessage } from "@an
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { bootstrapWorkspace } from "../runtime/bootstrap.js";
-import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
+import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type {
   AgentHandler,
   AgentIdentity,
@@ -209,8 +209,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let appliedConfigVersion = 0;
   let appliedModel = "";
   let appliedPayload: AgentRuntimeConfigPayload | null = null;
-  /** Worktree paths materialised for this session — removed on shutdown. */
-  const ownedWorktrees: string[] = [];
+  /** Worktrees materialised for this session — each entry removed on shutdown. */
+  const ownedWorktrees: Array<{ url: string; path: string; branchName: string }> = [];
 
   function toSDKUserMessage(message: SessionMessage, sessionId: string): SDKUserMessage {
     const rawContent = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
@@ -494,20 +494,27 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       await gitMirrorManager.fetchMirror(repo.url);
 
       // If a prior session left a worktree behind at the same path, reuse it
-      // rather than fighting the `git worktree add` lock.
+      // rather than fighting the `git worktree add` lock. The matching session
+      // branch is re-derived deterministically from (chatId, url) so cleanup
+      // later can still drop it.
       if (existsSync(targetPath) && isHubWorktreeMarker(targetPath)) {
         sessionCtx.log(`Git: reusing existing worktree at ${localPath}`);
-        ownedWorktrees.push(targetPath);
+        ownedWorktrees.push({
+          url: repo.url,
+          path: targetPath,
+          branchName: deriveSessionBranchName(sessionCtx.chatId, repo.url),
+        });
         continue;
       }
 
-      const { headCommit } = await gitMirrorManager.createWorktree({
+      const { headCommit, branchName } = await gitMirrorManager.createWorktree({
         url: repo.url,
         ref: repo.ref,
         targetPath,
+        sessionKey: sessionCtx.chatId,
       });
-      ownedWorktrees.push(targetPath);
-      sessionCtx.log(`Git: worktree at ${localPath} @ ${headCommit.slice(0, 7)}`);
+      ownedWorktrees.push({ url: repo.url, path: targetPath, branchName });
+      sessionCtx.log(`Git: worktree at ${localPath} @ ${headCommit.slice(0, 7)} on ${branchName}`);
     }
   }
 
@@ -515,12 +522,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   async function cleanupGitWorktrees(sessionCtx: SessionContext): Promise<void> {
     if (!gitMirrorManager) return;
     while (ownedWorktrees.length > 0) {
-      const path = ownedWorktrees.pop();
-      if (!path) continue;
+      const entry = ownedWorktrees.pop();
+      if (!entry) continue;
       try {
-        await gitMirrorManager.removeWorktree(path);
+        await gitMirrorManager.removeWorktree(entry);
       } catch (err) {
-        sessionCtx.log(`Git: removeWorktree(${path}) failed — ${err instanceof Error ? err.message : String(err)}`);
+        sessionCtx.log(
+          `Git: removeWorktree(${entry.path}) failed — ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
   }

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -3,29 +3,32 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — overridable via env
+const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const FETCH_REFSPEC = "+refs/heads/*:refs/remotes/origin/*";
+const SESSION_BRANCH_PREFIX = "hub-session";
 
 /**
- * Per-URL bare mirror manager (Step 5).
+ * Per-URL bare mirror manager.
  *
  * Layout:
- *   <dataDir>/git-mirrors/<sha256(url)>/  ← bare clone
+ *   <dataDir>/git-mirrors/<sha256(url)>/  ← bare repo (shared object store)
  *
- * - `ensureMirror` is idempotent: clones only when the directory is absent.
- * - `fetchMirror` runs `git fetch --prune` against an existing mirror.
- * - `createWorktree` allocates a `--detach`'d worktree at `targetPath`.
- * - `removeWorktree` reverses the above.
- * - `gcMirrors` keeps only mirrors whose URL appears in the supplied set —
- *   used by Step 7 on agent unbind / delete.
+ * Isolation model:
+ * - The mirror is configured with `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`
+ *   and `remote.origin.mirror` unset. `git fetch` therefore writes only to
+ *   `refs/remotes/origin/*` and never touches `refs/heads/*`.
+ * - Each session owns a dedicated local branch `hub-session-<sessionHash>-<urlHash>`
+ *   in the mirror. Worktrees attach to that branch, not to a remote-tracking ref,
+ *   so two sessions on the same URL get disjoint branch names and cannot
+ *   collide on `git worktree add` or on `git fetch` ref locks.
  *
- * Authentication is delegated to the host Git environment (PRD §D12) — no
- * env vars or credential helpers are injected.
+ * Authentication is delegated to the host Git environment — no env vars or
+ * credential helpers are injected.
  */
 export type GitMirrorManagerOptions = {
   dataDir: string;
-  /** Override clone timeout (ms). Defaults to env `FIRST_TREE_HUB_GIT_CLONE_TIMEOUT_MS` or 5 minutes. */
   cloneTimeoutMs?: number;
-  /** Optional structured logger — see plan §5.5. */
   log?: (event: string, fields: Record<string, unknown>) => void;
 };
 
@@ -36,10 +39,10 @@ export interface GitMirrorManager {
     url: string;
     ref?: string;
     targetPath: string;
-  }): Promise<{ worktreePath: string; headCommit: string }>;
-  removeWorktree(path: string): Promise<void>;
+    sessionKey: string;
+  }): Promise<{ worktreePath: string; headCommit: string; branchName: string }>;
+  removeWorktree(args: { url: string; path: string; branchName: string }): Promise<void>;
   gcMirrors(stillReferencedUrls: Set<string>): Promise<{ removed: string[] }>;
-  /** Internal: directory holding all mirrors (test helper). */
   readonly mirrorsRoot: string;
 }
 
@@ -47,11 +50,51 @@ export function hashUrl(url: string): string {
   return createHash("sha256").update(url).digest("hex").slice(0, 32);
 }
 
+function shortHash(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 8);
+}
+
+export function deriveSessionBranchName(sessionKey: string, url: string): string {
+  return `${SESSION_BRANCH_PREFIX}-${shortHash(sessionKey)}-${shortHash(url)}`;
+}
+
+/**
+ * A value is SHA-like when it's a 7–40 character hex string. Used to decide
+ * whether `ref` should be resolved via the remote namespace (branch name) or
+ * used as-is (commit hash).
+ */
+function looksLikeCommitSha(ref: string): boolean {
+  return /^[0-9a-f]{7,40}$/i.test(ref);
+}
+
 export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirrorManager {
   const mirrorsRoot = join(opts.dataDir, "git-mirrors");
   const cloneTimeoutMs =
     opts.cloneTimeoutMs ?? Number(process.env.FIRST_TREE_HUB_GIT_CLONE_TIMEOUT_MS ?? DEFAULT_CLONE_TIMEOUT_MS);
   const log = opts.log ?? (() => {});
+
+  // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /
+  // gcMirrors for the same URL from racing on the same directory.
+  const urlLocks = new Map<string, Promise<unknown>>();
+
+  function withUrlLock<T>(url: string, op: () => Promise<T>): Promise<T> {
+    const key = hashUrl(url);
+    const prev = urlLocks.get(key) ?? Promise.resolve();
+    const next = prev.then(op, op);
+    urlLocks.set(key, next);
+    // Drop the map entry once the tail resolves so a long-lived manager doesn't
+    // leak one entry per URL forever. Silently swallow errors on this side
+    // channel — the real rejection is delivered via the returned `next`.
+    next.then(
+      () => {
+        if (urlLocks.get(key) === next) urlLocks.delete(key);
+      },
+      () => {
+        if (urlLocks.get(key) === next) urlLocks.delete(key);
+      },
+    );
+    return next;
+  }
 
   function mirrorDir(url: string): string {
     return join(mirrorsRoot, hashUrl(url));
@@ -90,98 +133,253 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     });
   }
 
+  async function gitOk(args: string[], cwd: string, timeoutMs: number): Promise<boolean> {
+    try {
+      await git(args, cwd, timeoutMs);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Bring the mirror's config to the invariant expected by this module:
+   * fetch refspec = `+refs/heads/*:refs/remotes/origin/*`, `remote.origin.mirror`
+   * absent, `refs/remotes/origin/HEAD` resolvable.
+   *
+   * Called from `ensureMirror` on every invocation — both the fresh-clone path
+   * (ensures our own bootstrap wrote the right values) and the pre-existing
+   * mirror path (repairs drift from the legacy `--mirror` config).
+   */
+  async function assertMirrorConfig(mirrorPath: string, url: string): Promise<{ migrated: boolean }> {
+    let migrated = false;
+
+    // Read current fetch spec. `--get-all` returns every value on its own line;
+    // empty stdout means the key is absent.
+    let currentFetch = "";
+    try {
+      const { stdout } = await git(["config", "--get-all", "remote.origin.fetch"], mirrorPath, 10_000);
+      currentFetch = stdout.trim();
+    } catch {
+      currentFetch = "";
+    }
+
+    if (currentFetch !== FETCH_REFSPEC) {
+      // Replace whatever is there with exactly our refspec.
+      await git(["config", "--replace-all", "remote.origin.fetch", FETCH_REFSPEC], mirrorPath, 10_000);
+      migrated = true;
+    }
+
+    // `mirror = true` forces every fetch to prune & force-update every ref —
+    // must be unset for our refspec to behave as intended.
+    const mirrorFlag = await gitOk(["config", "--get", "remote.origin.mirror"], mirrorPath, 10_000);
+    if (mirrorFlag) {
+      await git(["config", "--unset-all", "remote.origin.mirror"], mirrorPath, 10_000);
+      migrated = true;
+    }
+
+    // Ensure origin URL matches (a mismatched URL would make migration silently
+    // pick up from the wrong upstream — refuse).
+    try {
+      const { stdout } = await git(["config", "--get", "remote.origin.url"], mirrorPath, 10_000);
+      const currentUrl = stdout.trim();
+      if (currentUrl !== url) {
+        await git(["config", "--replace-all", "remote.origin.url", url], mirrorPath, 10_000);
+        migrated = true;
+      }
+    } catch {
+      await git(["remote", "add", "origin", url], mirrorPath, 10_000);
+      migrated = true;
+    }
+
+    if (migrated) {
+      // Populate `refs/remotes/origin/*` and set `origin/HEAD`. Without this,
+      // newly-migrated mirrors have no remote-tracking refs to base worktrees on.
+      await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+      // Failing `set-head --auto` is non-fatal — callers that pass an explicit
+      // `ref` don't need origin/HEAD, and fallbacks below handle its absence.
+      await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000);
+      log("mirrorConfigMigrated", { gitUrl: url });
+    }
+
+    return { migrated };
+  }
+
+  /**
+   * Bootstrap a fresh mirror at `mirrorPath`. Uses `git init --bare` +
+   * manual remote setup rather than `git clone --mirror` / `git clone --bare`,
+   * so we never transiently have the mirror configured to force-write
+   * `refs/heads/*` on fetch.
+   */
+  async function bootstrapMirror(mirrorPath: string, url: string): Promise<void> {
+    mkdirSync(dirname(mirrorPath), { recursive: true });
+    await git(["init", "--bare", mirrorPath], null, cloneTimeoutMs);
+    await git(["remote", "add", "origin", url], mirrorPath, 10_000);
+    await git(["config", "--replace-all", "remote.origin.fetch", FETCH_REFSPEC], mirrorPath, 10_000);
+    await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+    await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000);
+  }
+
+  async function branchExists(mirrorPath: string, branchName: string): Promise<boolean> {
+    return await gitOk(["rev-parse", "--verify", "--quiet", `refs/heads/${branchName}`], mirrorPath, 10_000);
+  }
+
+  /**
+   * Resolve the commit-ish to base a new session branch on.
+   *
+   * - explicit SHA → use as-is
+   * - explicit branch name → prefer `refs/remotes/origin/<ref>`, fall back to
+   *   a literal SHA resolution in case the caller handed us a short commit
+   * - `ref` absent → `refs/remotes/origin/HEAD`
+   */
+  async function resolveBase(mirrorPath: string, ref: string | undefined): Promise<string> {
+    if (!ref) {
+      if (await gitOk(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD"], mirrorPath, 10_000)) {
+        return "refs/remotes/origin/HEAD";
+      }
+      throw new GitMirrorError(
+        "Cannot resolve default branch: refs/remotes/origin/HEAD is missing. Re-run with an explicit `ref`.",
+      );
+    }
+    if (looksLikeCommitSha(ref)) {
+      if (await gitOk(["cat-file", "-e", ref], mirrorPath, 10_000)) return ref;
+    }
+    const remoteRef = `refs/remotes/origin/${ref}`;
+    if (await gitOk(["rev-parse", "--verify", "--quiet", remoteRef], mirrorPath, 10_000)) {
+      return remoteRef;
+    }
+    // Last resort: let git resolve `ref` against whatever it can find (tags,
+    // local heads, etc.). If this fails the error surfaces to the caller.
+    return ref;
+  }
+
   return {
     get mirrorsRoot() {
       return mirrorsRoot;
     },
 
-    async ensureMirror(url) {
-      mkdirSync(mirrorsRoot, { recursive: true });
-      const path = mirrorDir(url);
-      if (existsSync(join(path, "HEAD"))) {
-        // Already a bare repo — fast return.
-        return { mirrorPath: path, elapsedMs: 0, cloned: false };
-      }
-      try {
-        const { elapsedMs } = await git(["clone", "--mirror", url, path], null, cloneTimeoutMs);
-        log("ensureMirror", { gitUrl: url, elapsedMs, cloned: true });
-        return { mirrorPath: path, elapsedMs, cloned: true };
-      } catch (err) {
-        if (err instanceof GitMirrorTimeoutError) {
-          log("mirrorCloneTimeout", { gitUrl: url, timeoutMs: cloneTimeoutMs, elapsedMs: cloneTimeoutMs });
+    ensureMirror(url) {
+      return withUrlLock(url, async () => {
+        mkdirSync(mirrorsRoot, { recursive: true });
+        const path = mirrorDir(url);
+        if (existsSync(join(path, "HEAD"))) {
+          const { migrated } = await assertMirrorConfig(path, url);
+          if (migrated) {
+            // migration fetched already; report elapsed as 0 to preserve the
+            // existing "cloned === false => fast path" contract.
+          }
+          return { mirrorPath: path, elapsedMs: 0, cloned: false };
         }
-        // Clean up partial clone on failure to keep `ensureMirror` idempotent
-        // on the next attempt.
-        if (existsSync(path)) rmSync(path, { recursive: true, force: true });
-        throw err;
-      }
-    },
-
-    async fetchMirror(url) {
-      const path = mirrorDir(url);
-      if (!existsSync(join(path, "HEAD"))) {
-        throw new GitMirrorError(`Cannot fetch — no mirror exists for "${url}"`);
-      }
-      try {
-        const { elapsedMs } = await git(["fetch", "--prune"], path, cloneTimeoutMs);
-        return { elapsedMs };
-      } catch (err) {
-        log("mirrorFetchFailed", {
-          gitUrl: url,
-          errorCode: err instanceof GitMirrorError ? "git-failed" : "unknown",
-          stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
-        });
-        throw err;
-      }
-    },
-
-    async createWorktree({ url, ref, targetPath }) {
-      const mirror = mirrorDir(url);
-      if (!existsSync(join(mirror, "HEAD"))) {
-        throw new GitMirrorError(`Cannot create worktree — no mirror exists for "${url}"`);
-      }
-      const absTarget = resolve(targetPath);
-      // D13: target path must be free OR a Hub-managed worktree we can reuse.
-      if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {
-        log("worktreeCreateConflict", {
-          gitUrl: url,
-          targetPath: absTarget,
-          occupantKind: classifyOccupant(absTarget),
-        });
-        throw new GitMirrorWorktreeConflictError(
-          `Worktree target "${absTarget}" is already occupied by ${classifyOccupant(absTarget)} — aborting (D13)`,
-        );
-      }
-      mkdirSync(dirname(absTarget), { recursive: true });
-      const args = ["worktree", "add", "--detach", absTarget];
-      if (ref) args.push(ref);
-      await git(args, mirror, cloneTimeoutMs);
-      const head = await git(["rev-parse", "HEAD"], absTarget, 30_000);
-      return { worktreePath: absTarget, headCommit: head.stdout.trim() };
-    },
-
-    async removeWorktree(path) {
-      const absTarget = resolve(path);
-      if (!existsSync(absTarget)) return;
-      // Find the mirror that owns this worktree by walking each mirror's
-      // `worktree list` — cheap because the set of mirrors is small.
-      if (!existsSync(mirrorsRoot)) return;
-      let removed = false;
-      for (const entry of readdirSync(mirrorsRoot)) {
-        const mirror = join(mirrorsRoot, entry);
-        if (!isBareRepo(mirror)) continue;
+        const start = Date.now();
         try {
-          await git(["worktree", "remove", "--force", absTarget], mirror, 30_000);
-          removed = true;
-          break;
-        } catch {
-          // Try the next mirror — only one will own this worktree path.
+          await bootstrapMirror(path, url);
+          const elapsedMs = Date.now() - start;
+          log("ensureMirror", { gitUrl: url, elapsedMs, cloned: true });
+          return { mirrorPath: path, elapsedMs, cloned: true };
+        } catch (err) {
+          if (err instanceof GitMirrorTimeoutError) {
+            log("mirrorCloneTimeout", { gitUrl: url, timeoutMs: cloneTimeoutMs, elapsedMs: cloneTimeoutMs });
+          }
+          if (existsSync(path)) rmSync(path, { recursive: true, force: true });
+          throw err;
         }
-      }
-      if (!removed && existsSync(absTarget)) {
-        // Worktree was never registered (e.g. orphan); just rm.
-        rmSync(absTarget, { recursive: true, force: true });
-      }
+      });
+    },
+
+    fetchMirror(url) {
+      return withUrlLock(url, async () => {
+        const path = mirrorDir(url);
+        if (!existsSync(join(path, "HEAD"))) {
+          throw new GitMirrorError(`Cannot fetch — no mirror exists for "${url}"`);
+        }
+        try {
+          const { elapsedMs } = await git(["fetch", "--prune", "origin"], path, cloneTimeoutMs);
+          return { elapsedMs };
+        } catch (err) {
+          log("mirrorFetchFailed", {
+            gitUrl: url,
+            errorCode: err instanceof GitMirrorError ? "git-failed" : "unknown",
+            stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
+          });
+          throw err;
+        }
+      });
+    },
+
+    createWorktree({ url, ref, targetPath, sessionKey }) {
+      return withUrlLock(url, async () => {
+        const mirror = mirrorDir(url);
+        if (!existsSync(join(mirror, "HEAD"))) {
+          throw new GitMirrorError(`Cannot create worktree — no mirror exists for "${url}"`);
+        }
+        const absTarget = resolve(targetPath);
+        const branchName = deriveSessionBranchName(sessionKey, url);
+
+        // D13: target path must be free OR a Hub-managed worktree we can reuse.
+        if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {
+          log("worktreeCreateConflict", {
+            gitUrl: url,
+            targetPath: absTarget,
+            occupantKind: classifyOccupant(absTarget),
+          });
+          throw new GitMirrorWorktreeConflictError(
+            `Worktree target "${absTarget}" is already occupied by ${classifyOccupant(absTarget)} — aborting (D13)`,
+          );
+        }
+
+        const pathExists = existsSync(absTarget);
+        const hasBranch = await branchExists(mirror, branchName);
+
+        mkdirSync(dirname(absTarget), { recursive: true });
+
+        // Crash-recovery matrix (see refactor plan §5.3):
+        //   path + branch    → reuse (short-circuit here even though callers also
+        //                       short-circuit; defensive, cheap)
+        //   !path + !branch  → `worktree add -b <branch> <path> <base>`
+        //   !path + branch   → `worktree add <path> <branch>` (attach existing)
+        //   path + !branch   → corruption; refuse rather than guess
+        if (pathExists && hasBranch) {
+          // Already wired up — treat as successful reuse.
+        } else if (pathExists && !hasBranch) {
+          throw new GitMirrorError(
+            `Worktree directory "${absTarget}" exists as a Hub worktree but the expected session branch "${branchName}" is missing in the mirror — manual cleanup required`,
+          );
+        } else if (!pathExists && hasBranch) {
+          await git(["worktree", "add", absTarget, branchName], mirror, cloneTimeoutMs);
+        } else {
+          const base = await resolveBase(mirror, ref);
+          await git(["worktree", "add", "-b", branchName, absTarget, base], mirror, cloneTimeoutMs);
+        }
+
+        const head = await git(["rev-parse", "HEAD"], absTarget, 30_000);
+        return { worktreePath: absTarget, headCommit: head.stdout.trim(), branchName };
+      });
+    },
+
+    removeWorktree({ url, path, branchName }) {
+      return withUrlLock(url, async () => {
+        const absTarget = resolve(path);
+        const mirror = mirrorDir(url);
+        if (!isBareRepo(mirror)) {
+          // Mirror was already GC'd; just rm the orphan dir if it exists.
+          if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });
+          return;
+        }
+        if (existsSync(absTarget)) {
+          await gitOk(["worktree", "remove", "--force", absTarget], mirror, 30_000);
+        } else {
+          // Path is already gone — let git prune its bookkeeping so later
+          // worktree-add calls don't hit the stale admin record.
+          await gitOk(["worktree", "prune"], mirror, 30_000);
+        }
+        if (existsSync(absTarget)) {
+          // Worktree wasn't git-registered (orphan dir) — rm for tidiness.
+          rmSync(absTarget, { recursive: true, force: true });
+        }
+        if (await branchExists(mirror, branchName)) {
+          await gitOk(["branch", "-D", branchName], mirror, 10_000);
+        }
+      });
     },
 
     async gcMirrors(stillReferencedUrls) {
@@ -205,8 +403,6 @@ function isBareRepo(p: string): boolean {
 }
 
 function isHubManagedWorktree(p: string): boolean {
-  // A Hub-managed worktree has a `.git` file (not directory) pointing back
-  // into the bare mirror's `worktrees/` dir.
   const gitMarker = join(p, ".git");
   if (!existsSync(gitMarker)) return false;
   try {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {


### PR DESCRIPTION
## Summary

Three field incidents shared a root cause in `GitMirrorManager`: cloning with `--mirror` and fetching with `+refs/*:refs/*` let every `git fetch` force-overwrite and prune `refs/heads/*` under active worktrees.

- Incident 1 — uncommitted agent work overwritten when upstream main advanced.
- Incident 2 — un-pushed local branch ref pruned because upstream had no matching branch.
- Incident 3 — session resume failing with `git fetch --prune` exit 128 while another session's worktree held the branch.

### Fix

- Bootstrap the mirror with `git init --bare` and set `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*` with `remote.origin.mirror` unset. Legacy mirrors repair their config on the next `ensureMirror` call — no manual migration required.
- Each session owns a dedicated branch `hub-session-<sessionHash>-<urlHash>`. Worktrees attach to that branch, so upstream fetches land in `refs/remotes/origin/*` only and two sessions can't collide on a shared name.
- `ensureMirror`, `fetchMirror`, `createWorktree`, and `removeWorktree` all serialise per URL via an in-process async mutex. Required because `git worktree add -b` writes to the mirror's config file — a parallel creator hits "could not lock config file" without this.
- `removeWorktree` deletes both the worktree and the session branch on cleanup.

## Impact on existing state

- Active sessions continue to work. Their current worktrees (detached or on a user-named branch) survive the lazy config migration untouched.
- The stuck session from incident 3 self-heals on next resume attempt: the migration rewrites the fetch refspec before the fetch runs.
- User-created branches in existing mirrors are never pruned by Hub cleanup (only `hub-session-*` branches are).

## Test plan

- [x] `pnpm check`, `pnpm typecheck`, `pnpm test` — green
- [x] 16 unit tests in `git-mirror-manager.test.ts`: one regression per incident, legacy-config migration, crash recovery path+branch matrix, parallel `createWorktree` contention
- [x] End-to-end run against a real `git clone --mirror` seed + real bare remote, covering migration + three-incident regressions + cleanup (kept as a local script, not checked in)
- [ ] Smoke-test on a local isolated Hub home before land