### PR TITLE
feat: add claude-opus-4-7 to agent model selection

### DIFF
--- a/packages/client/src/__tests__/claude-code-config.test.ts
+++ b/packages/client/src/__tests__/claude-code-config.test.ts
@@ -62,6 +62,7 @@ describe("claude-code handler helpers (Step 6)", () => {
 
     it("returns true for same family different rev", () => {
       expect(isSameModelFamily("claude-opus-4-5", "claude-opus-4-6")).toBe(true);
+      expect(isSameModelFamily("claude-opus-4-6", "claude-opus-4-7")).toBe(true);
     });
 
     it("returns false across families (opus ↔ haiku)", () => {

--- a/packages/command/src/commands/agent-config.ts
+++ b/packages/command/src/commands/agent-config.ts
@@ -110,7 +110,7 @@ export function registerAgentConfigCommands(parent: Command): void {
 
   config
     .command("set-model <agent> <model>")
-    .description("Replace the model field (e.g. claude-opus-4-6)")
+    .description("Replace the model field (e.g. claude-opus-4-7)")
     .action(async (agentName: string, model: string) => {
       const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
       const adminToken = await ensureFreshAdminToken();

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -8,7 +8,8 @@ import { Button } from "../../components/ui/button.js";
 export type ModelOption = { value: string; label: string; hint?: string };
 
 export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
-  { value: "claude-opus-4-6", label: "claude-opus-4-6", hint: "most capable" },
+  { value: "claude-opus-4-7", label: "claude-opus-4-7", hint: "most capable" },
+  { value: "claude-opus-4-6", label: "claude-opus-4-6" },
   { value: "claude-sonnet-4-6", label: "claude-sonnet-4-6", hint: "default" },
   { value: "claude-haiku-4-5", label: "claude-haiku-4-5", hint: "fastest" },
 ];


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-7` to the agent-detail Model dropdown as the new "most capable" option; keep `claude-opus-4-6` as a selectable fallback so operators can pin older revisions
- Refresh the CLI `agent config set-model` help example to reference `claude-opus-4-7`
- Extend the `isSameModelFamily` test to cover the 4-6 ↔ 4-7 swap path (ensures in-flight `setModel` is used, not a full session restart)

No schema, validator, or DB changes — the runtime config already accepts any model id string, and the Claude SDK validates at query time. Cross-family swaps (opus ↔ haiku) still restart; within-family (4-6 ↔ 4-7) continues to use `query.setModel()`.

Closes #114

## Test plan

- [x] `pnpm check` — Biome lint/format
- [x] `pnpm typecheck` — full monorepo tsc + build
- [x] `pnpm --filter @first-tree-hub/client test` — 132/132 passing (includes the new opus-4-6 ↔ opus-4-7 same-family assertion)
- [ ] Manual: open an agent detail page, confirm `claude-opus-4-7 — most capable` appears as the first option in the Model dropdown and saving persists the value
- [ ] Manual: switch an active session from opus-4-6 → opus-4-7 and confirm it swaps mid-stream (no cold restart) by watching client logs for `setModel` vs `resume`

🤖 Generated with [Claude Code](https://claude.com/claude-code)