### PR TITLE
docs(skills): rewrite first-tree-hub-cli to match current CLI

### DIFF
--- a/skills/first-tree-hub-cli/SKILL.md
+++ b/skills/first-tree-hub-cli/SKILL.md
@@ -1,133 +1,186 @@
 ---
 name: first-tree-hub-cli
-description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `server`, `client`, `agent`, `config`, `status`, and `onboard` workflows, and the repo's collaboration model around agent management, inbox delivery, and workspace bootstrap. Use when Codex needs to install or verify the CLI on a fresh machine, run or debug Hub commands, choose the right CLI flow for a user request, explain how First Tree Hub works, or change code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` that affects CLI behavior.
+description: Install, operate, deploy, and modify First Tree Hub with emphasis on the unified `first-tree-hub` CLI, its `client connect`/`client service`/`server`/`agent`/`agent config`/`config`/`status`/`onboard` workflows, the JWT credential model, and the repo's collaboration surface for agent identity, inbox delivery, workspace bootstrap, and background-service operation. Use whenever the user mentions First Tree Hub, connecting a machine to a Hub server, installing or running the Hub as a background service (launchd/systemd), managing agent runtime configuration (model, prompt, MCP, env, git repos), onboarding a member, or changing code in `packages/command`, `packages/client`, `packages/server`, or `packages/shared` — even if they don't say "CLI".
 ---
 
 # First Tree Hub CLI
 
 ## Overview
 
-Use this skill to map user intent onto the correct First Tree Hub command or code path without re-discovering the whole monorepo each time.
-Keep the central mental model straight: First Tree Hub is the communication backbone for agent teams. It is not the agent framework, not the orchestration engine, and not the Context Tree itself.
+Use this skill to map user intent onto the right First Tree Hub command or code path without re-discovering the repo each time.
+
+Keep the mental model straight: First Tree Hub is the communication and identity backbone for agent teams. It is **not** the agent framework, not the orchestration engine, and not the Context Tree. A Hub deployment has three principals:
+
+- **Server** — one per deployment. Owns identity, persistence, admin surface, and the inbox.
+- **Client** — one per computer. A machine signs in with a Hub member's credentials once, then runs every agent pinned to it.
+- **Agent** — many per Hub. Lives in the server's database; is bound to exactly one client machine.
+
+This shape drives almost every command: `server` targets the deployment, `client` targets a machine, `agent` targets a row in the server's database (usually acting as the member via their own JWT).
 
 ## Start Here
 
-1. Classify the task before acting.
-   - Install or sanity-check the CLI on a fresh machine: read `references/command-surface.md` first, then `README.md` or `docs/claim-agent-guide.md`
-   - Operate or diagnose a Hub deployment: read `references/command-surface.md`
-   - Map a natural-language request to an end-to-end CLI flow: read `references/scenario-playbooks.md`
-   - Execute or automate member onboarding from an external agent prompt: read `references/onboarding-operator.md`
-   - Explain product or architecture concepts: read `references/core-concepts.md`
-   - Modify CLI or related behavior in code: read `references/developer-map.md`
-3. Prefer existing CLI workflows over manual edits when the repo already has a supported path.
-   - Use `onboard` for member onboarding
-   - Use `config` for config inspection and updates
-   - Use `server start` or `client start` instead of stitching together ad hoc boot flows
-4. Read the canonical repo docs directly when the task becomes specialized.
-   - `docs/cli-reference.md` for exact flags and environment variables
-   - `docs/onboarding-guide.md` for the full onboarding flow
-   - `docs/claim-agent-guide.md` when claim or binding flows matter
-   - `docs/deployment-guide.md` for Docker, cloud deploy, HTTPS, and production setup
-5. On a fresh machine, verify prerequisites before proposing a flow.
+1. **Classify the task before acting.** Most requests fall into one of these buckets. Pick the bucket, then go to the reference it names.
+   - Install or sanity-check the CLI on a fresh machine → `references/command-surface.md`
+   - Run, diagnose, or deploy a Hub server → `references/command-surface.md`
+   - Connect a computer to a Hub server (first time) → the **`client connect`** section below, then `references/scenario-playbooks.md`
+   - Make a computer stay online permanently → the **Background service** section below
+   - Map a natural-language request to an end-to-end CLI flow → `references/scenario-playbooks.md`
+   - Operate `onboard` from an external agent prompt → `references/onboarding-operator.md`
+   - Explain product or architecture concepts → `references/core-concepts.md`
+   - Modify CLI or adjacent package behavior → `references/developer-map.md`
+2. **Prefer the supported CLI path over hand-rolled API calls or YAML edits.** The CLI already wires up auth, refresh, config layering, and retries for you.
+   - `client connect` for first-time auth on a new machine
+   - `client service install` to keep the machine online after reboot
+   - `agent config ...` to change a running agent's model / prompt / MCP / env / repos
+   - `onboard` to add a member end-to-end
+   - `config set/get/list` to read or write YAML, instead of hand-editing it
+3. **Read the canonical repo docs when the task becomes specialized.**
+   - `docs/cli-reference.md` — every flag and env var in one place
+   - `docs/onboarding-guide.md` — full onboarding walkthrough
+   - `docs/claim-agent-guide.md` — agent claim + Feishu binding
+   - `docs/deployment-guide.md` — Docker, Railway/Render, HTTPS, production
+4. **On a fresh machine, verify prerequisites before proposing a flow.**
    - Node.js `>= 22.16`
-   - Install with `npm install -g @agent-team-foundation/first-tree-hub`
-   - Verify with `first-tree-hub --version`
-   - If using `onboard` or `agent token bootstrap`, make sure `gh` is installed and authenticated
-6. If you are maintaining the skill inside the live repo, `.agents/skills/` and `.claude/skills/` are symlinks to `skills/` — no sync step is needed.
+   - Install: `npm install -g @agent-team-foundation/first-tree-hub`
+   - Verify: `first-tree-hub --version`
+   - For agent creation via GitHub identity, also: `gh auth status`
+5. **The skill lives inside the repo.** `.agents/skills/` and `.claude/skills/` are symlinks to `skills/` — when you edit `skills/first-tree-hub-cli/`, every runtime sees the change immediately. No sync step.
+
+## The Credential Model (read this once)
+
+The CLI stores a single **member access JWT + refresh token** at `~/.first-tree-hub/credentials.json` (mode `0600`). Every command that talks to the Hub runs through `ensureFreshAccessToken()`, which refreshes 30s before expiry via `/api/v1/auth/refresh` and re-persists the token silently.
+
+Implications:
+
+- There is **one** way to sign in: `first-tree-hub client connect <server-url>`. It accepts either a one-time `--token` (from the web "Connect a machine" dialog) or falls back to interactive username/password.
+- There is **no** standalone admin login, service-user token, or per-agent bearer token in the current CLI. Admin actions, agent-owner actions, and low-level SDK calls all use the signed-in member's JWT. The legacy `FIRST_TREE_HUB_AGENT_TOKEN` / `FIRST_TREE_HUB_AGENT` env vars and the old `agent token bootstrap` command have been removed.
+- `FIRST_TREE_HUB_SERVER_URL` still works for overriding the server URL per command, but auth itself is file-based.
+- Agents are database rows, owned by members. They do not hold their own tokens anymore — the client that runs them authenticates as the owning member.
+
+If a flow looks like "get an agent token, set an env var, then run the agent" — that flow is outdated. Point the user at `client connect` instead.
+
+## First-Time Setup on a New Machine
+
+The happy path is three commands, in this order:
+
+```bash
+npm install -g @agent-team-foundation/first-tree-hub            # install
+first-tree-hub client connect https://hub.example.com --token <one-time>   # sign in + register the machine
+# (service auto-installs on macOS/Linux — you can close the terminal)
+```
+
+If the user does not have a one-time connect token, omit `--token` and the command prompts for username/password. Pass `--no-service` when the user wants to run inline (useful in containers or for quick tests).
+
+After `client connect` succeeds:
+
+- `~/.first-tree-hub/credentials.json` exists
+- `~/.first-tree-hub/config/client.yaml` has `server.url` and a generated `client.id`
+- On macOS/Linux, the background service is installed and already running
+- Any agent pinned to this client (via the Hub UI or `agent create --client-id ...`) is automatically picked up by the running service
+
+## Background Service (keep the machine online)
+
+The client runtime is normally a foreground process. For production or day-to-day desktop use, install it as a user-level service so it survives logout/reboot:
+
+```bash
+first-tree-hub client service install      # launchd on macOS, systemd --user on Linux
+first-tree-hub client service status       # running? installed?
+first-tree-hub client service uninstall
+```
+
+`client connect` installs the service automatically unless `--no-service` is passed. Logs land in `~/.first-tree-hub/logs/`. Windows is currently unsupported — on Windows, fall back to running `first-tree-hub client start` manually or inside a user-managed process supervisor.
 
 ## Operating Rules
 
-- Keep subsystem boundaries clear.
-  - `server` manages Hub server lifecycle, database setup, migrations, and admin users.
-  - `client` runs configured agents and hydrates their local workspaces and context.
-  - `agent` manages local agent configs, tokens, bindings, workspace cleanup, and debug messaging.
-  - `config` edits YAML-backed config by scope.
-  - `status` is read-only overview.
-  - `onboard` is the high-level member onboarding flow.
-- Remember the identity model.
-  - Agent identities are managed by Hub via Admin API.
-  - Context Tree integration is optional — when configured, Client injects organizational context into agent workspaces.
-- Respect auth isolation.
-  - Admin JWT and agent Bearer token are separate paths.
-  - Messaging and low-level agent commands require an agent token: either `FIRST_TREE_HUB_AGENT_TOKEN` directly, or `FIRST_TREE_HUB_AGENT=<name>` to look up a token from the local agent config.
-- Keep the server URL knobs straight.
-  - `FIRST_TREE_HUB_SERVER_URL` is the canonical environment variable across client config, agent runtime injection, onboard, and low-level agent debugging commands.
-- Respect config layering.
-  - CLI args override env vars, env vars override YAML config, YAML overrides auto-generated values, auto-generated values override defaults.
-- Distinguish config scopes and paths.
-  - Home defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` can relocate it.
-  - Server: `$FIRST_TREE_HUB_HOME/config/server.yaml`
-  - Client: `$FIRST_TREE_HUB_HOME/config/client.yaml`
-  - Agent: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+- **Keep subsystem boundaries clear.**
+  - `server ...` — server lifecycle (start, stop, doctor, status, migrations, admin creation).
+  - `client ...` — everything that happens on a specific computer: first-time auth (`connect`), the foreground runtime (`start`), the background service, and Hub-side client inventory (`hub-list`, `hub-disconnect`).
+  - `agent ...` — everything that is "about an agent record": local alias config (`add`/`remove`/`list`), creation and claiming, workspace cleanup, bindings, **runtime configuration via `agent config`**, messaging, sessions, and interactive chat.
+  - `config ...` — scope-aware YAML editing for `server.yaml`, `client.yaml`, or a specific agent's `agent.yaml`.
+  - `status` — top-level overview across server health, database, client config, and local agent count.
+  - `onboard` — the guided "add a new member" flow; composes multiple low-level operations behind one command.
+- **Distinguish `agent config` (server-side runtime) from `config -a <name>` (local YAML).** `agent config set-model` or `append-prompt` mutates the Hub database via the admin API and affects the running agent everywhere. `config -a <name> set` edits the local `agent.yaml`, which only names the agent locally and tells the client which `agentId` to load.
+- **Respect config layering.** CLI args override env vars → env vars override YAML → YAML overrides auto-generated → auto-generated overrides defaults.
+- **Distinguish config scopes and paths.**
+  - Home defaults to `~/.first-tree-hub`; `FIRST_TREE_HUB_HOME` relocates it.
+  - Server config: `$FIRST_TREE_HUB_HOME/config/server.yaml`
+  - Client config: `$FIRST_TREE_HUB_HOME/config/client.yaml`
+  - Per-agent local alias: `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+  - Credentials: `$FIRST_TREE_HUB_HOME/credentials.json`
   - Onboard resume state: `$FIRST_TREE_HUB_HOME/.onboard-state.json`
-- Do not describe Hub as "the agents" or "the Context Tree". It sits between them.
+  - Service logs: `$FIRST_TREE_HUB_HOME/logs/`
+- **Do not describe Hub as "the agents" or "the Context Tree".** It sits between them.
 
 ## Common Workflows
 
 ### Choose a Command
 
-- First local boot or quick demo: `first-tree-hub server start`
-- Fresh machine install or verification: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`
-- Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or top-level `first-tree-hub status`
-- Add a local runtime agent config: `first-tree-hub agent add`, then `first-tree-hub client start`
-- Bootstrap or recover agent access: `first-tree-hub agent token bootstrap`
-- Debug agent messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`
-- Clean stale chat workspaces: `first-tree-hub agent workspace clean`
-- Onboard a new human or autonomous agent end to end: `first-tree-hub onboard`
+- Install + verify: `npm install -g @agent-team-foundation/first-tree-hub`, then `first-tree-hub --version`.
+- First local boot or quick demo: `first-tree-hub server start`.
+- Environment readiness: `first-tree-hub server doctor`, `first-tree-hub client doctor`, or `first-tree-hub status` for a compact summary.
+- Connect a computer to a Hub server: `first-tree-hub client connect <url>` (add `--token <connect-token>` to skip interactive login).
+- Keep the computer online across reboots: `first-tree-hub client service install`.
+- Run the runtime inline (no service): `first-tree-hub client start`.
+- See which machines the Hub currently sees: `first-tree-hub client hub-list`; force-drop one with `first-tree-hub client hub-disconnect <clientId>`.
+- Create an agent from the CLI: `first-tree-hub agent create <name> --type <t> --client-id <id>`.
+- Change a running agent's configuration (model, prompt, MCP, env, repos): `first-tree-hub agent config ...`.
+- Onboard a new human or autonomous agent end-to-end: `first-tree-hub onboard` (or `onboard --check` first to validate inputs).
+- Debug messaging manually: `first-tree-hub agent send`, `agent chats`, `agent history`, `agent pull`, or `agent chat <agent>` for an interactive REPL.
+- Inspect or fix session state: `first-tree-hub agent status`, `agent reset`, `agent sessions`, `agent session suspend|resume|terminate`.
+- Clean stale chat workspaces: `first-tree-hub agent workspace clean`.
 
 ### Run Onboarding From an Agent Prompt
 
-- Treat onboarding as a supported CLI workflow, not as a manual repo-edit task.
-- If the environment does not already have the repo checked out or the CLI installed:
-  - Ensure `gh` is available and authenticated.
-  - Install the published package.
-    - Prefer `npm install -g @agent-team-foundation/first-tree-hub` when you need the `first-tree-hub` binary on `PATH`.
-    - If the caller explicitly used `npm i @agent-team-foundation/first-tree-hub`, run the CLI with `npx first-tree-hub ...`.
-  - Read the canonical onboarding guide with `gh` before acting, for example:
+- Treat onboarding as a supported CLI workflow, not a manual repo-edit task.
+- If the machine does not yet have the CLI or credentials:
+  - Ensure `gh` is authenticated (`gh auth login`) — required for GitHub-identity agent creation.
+  - Install `@agent-team-foundation/first-tree-hub` globally (or use `npx` when the caller installed it locally).
+  - Run `first-tree-hub client connect <server-url>` first. Onboarding depends on a valid credential file — without it, `onboard` exits with a clear error pointing at `client connect`.
+  - When you need to read the canonical guide from the repo without a local checkout:
 
-```bash
-gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
-```
+    ```bash
+    gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
+    ```
 
-- Use any server URL supplied by the user or automation in every onboarding step via `--server <url>` when available.
+- Thread any server URL the user supplies through `--server <url>` in every onboarding step.
 - Default operator flow:
 
-```bash
-first-tree-hub onboard --check ...
-first-tree-hub onboard --server <url> ...
-first-tree-hub client start
-```
+  ```bash
+  first-tree-hub client connect <server-url>         # one-time, if not done already
+  first-tree-hub onboard --check --server <url> --id <id> --type <type> ...
+  first-tree-hub onboard --server <url> --id <id> --type <type> ...
+  first-tree-hub client start                        # only if no service is installed
+  ```
 
-- Prefer `onboard --check` before asking follow-up questions or creating the agent.
-- Ensure `gh` is authenticated (`gh auth login`).
+- Always prefer `onboard --check` before asking follow-up questions — the checklist tells you which fields are actually missing.
 
 ### Modify Code Safely
 
 - For new or changed CLI behavior, inspect:
-  - `packages/command/src/commands/*.ts` for command registration and args
-  - `packages/command/src/core/*.ts` for reusable logic
-  - `packages/shared/src/config/*` if flags, env vars, or config schema change
-  - `docs/cli-reference.md` and `docs/onboarding-guide.md` if user-facing behavior changes
-- Keep command modules thin. Reusable business logic belongs in `packages/command/src/core/`.
-- Re-export new reusable core functions from `packages/command/src/core/index.ts` and `packages/command/src/index.ts` when external callers should be able to import them.
+  - `packages/command/src/commands/*.ts` — command registration and argument shape.
+  - `packages/command/src/core/*.ts` — reusable logic (auth, service install, doctor, onboard, Docker Postgres, Feishu, etc.).
+  - `packages/shared/src/config/*.ts` — if flags, env vars, or schema change.
+  - `docs/cli-reference.md` and `docs/onboarding-guide.md` — whenever user-facing behavior changes.
+- Keep command modules thin. Reusable business logic belongs in `packages/command/src/core/`. Re-export new reusable functions from `packages/command/src/core/index.ts` and `packages/command/src/index.ts` when external callers should be able to import them.
+- See `references/developer-map.md` for the full source layout.
 
 ## Validation
 
-- For skill-only documentation work, run `pnpm validate:skill` from the repo root and inspect `agents/openai.yaml`.
-- For CLI or behavior changes, prefer:
+- Skill-only edits: `pnpm validate:skill` from the repo root, and inspect `agents/openai.yaml`.
+- CLI or behavior changes:
 
-```bash
-pnpm check
-pnpm typecheck
-pnpm --filter @agent-team-foundation/first-tree-hub test
-```
+  ```bash
+  pnpm check
+  pnpm typecheck
+  pnpm --filter @agent-team-foundation/first-tree-hub test
+  ```
 
-- Add more targeted package tests when you change runtime behavior.
+- Add targeted package tests when you change runtime behavior.
 
 ## References
 
-- `references/command-surface.md` for command selection, command semantics, env vars, and common workflows
-- `references/scenario-playbooks.md` for request-to-command playbooks and end-to-end operator flows
-- `references/onboarding-operator.md` for automation-friendly onboarding instructions that start from a prompt instead of a local repo checkout
-- `references/core-concepts.md` for product boundaries, architecture invariants, and runtime mental models
-- `references/developer-map.md` for package ownership, source-file entry points, and change workflows
+- `references/command-surface.md` — exhaustive command catalog, including the credential model, scopes, env vars, and admin API endpoints the CLI calls.
+- `references/scenario-playbooks.md` — request-to-command playbooks (install, connect, onboard, debug, deploy).
+- `references/onboarding-operator.md` — automation-friendly onboarding instructions that start from a prompt, not a local checkout.
+- `references/core-concepts.md` — product boundaries, architecture invariants, runtime mental models.
+- `references/developer-map.md` — package ownership, source-file entry points, change workflows.

--- a/skills/first-tree-hub-cli/evals/evals.json
+++ b/skills/first-tree-hub-cli/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "first-tree-hub-cli",
+  "evals": [
+    {
+      "id": 0,
+      "name": "new-machine",
+      "prompt": "I just bought a new Mac and want it to run as a Hub client, permanently connected to our team's Hub at https://hub.example.com/. Walk me through it from zero. One more thing — previously I always set FIRST_TREE_HUB_AGENT_TOKEN and ran `first-tree-hub agent token bootstrap` to get my agent running. Do I still do that on the new machine?",
+      "expected_output": "Should recommend npm install → first-tree-hub client connect <url> (mentioning --token for one-time connect tokens), explain that the background service is installed automatically on macOS (launchd), and explicitly correct the user's outdated assumption: FIRST_TREE_HUB_AGENT_TOKEN and `agent token bootstrap` are gone; auth is now a single member JWT stored in credentials.json written by client connect.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "agent-config",
+      "prompt": "I want to switch my 'alice' agent to use claude-opus-4-7 and also add a GitHub MCP server to it. Walk me through it via the first-tree-hub CLI.",
+      "expected_output": "Should use `first-tree-hub agent config set-model alice claude-opus-4-7` and `first-tree-hub agent config add-mcp alice --name <n> --transport stdio --command gh --args mcp`. Must NOT suggest hand-editing ~/.first-tree-hub/config/agents/alice/agent.yaml (that's the local alias, not the runtime config). Bonus: mentions `agent config get alice` to verify, or `agent config dry-run` for preview.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "stuck-session",
+      "prompt": "Our 'code-reviewer' autonomous agent seems stuck — it stopped responding in its chat about an hour ago. I need to figure out what's wrong and recover it without redeploying. What's the CLI flow?",
+      "expected_output": "Should suggest inspecting with `first-tree-hub agent status code-reviewer` (and/or top-level `agent status`), listing sessions via `agent sessions code-reviewer`, then recovering with `agent session suspend/resume/terminate <name> <chat-id>` as appropriate, and `agent reset code-reviewer` if it's in error state. May also mention `agent workspace clean` for stale workspaces. Should NOT suggest restarting the whole client or redeploying.",
+      "files": []
+    }
+  ]
+}

--- a/skills/first-tree-hub-cli/references/command-surface.md
+++ b/skills/first-tree-hub-cli/references/command-surface.md
@@ -4,158 +4,211 @@
 
 | User intent | Preferred entry point | Non-obvious note |
 | --- | --- | --- |
-| Install or verify the CLI on a fresh machine | `npm install -g @agent-team-foundation/first-tree-hub` then `first-tree-hub --version` | Requires Node.js `>= 22.16`; use this before proposing runtime commands on a machine that may not have the CLI yet |
-| Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; can auto-provision PostgreSQL with Docker, run migrations, create the default admin, and serve the embedded web UI |
-| Check whether a machine is ready for Hub | `first-tree-hub server doctor` or `first-tree-hub client doctor` | `doctor` is readiness-oriented; top-level `status` is a current-state summary |
+| Install or verify the CLI on a fresh machine | `npm install -g @agent-team-foundation/first-tree-hub` then `first-tree-hub --version` | Requires Node.js `>= 22.16` |
+| Bring up a full local Hub quickly | `first-tree-hub server start` | Interactive on first run; auto-provisions PostgreSQL with Docker, runs migrations, creates the default admin, and serves the web UI |
+| Check whether a machine is ready for Hub | `first-tree-hub server doctor` / `client doctor` | `doctor` = readiness; top-level `status` = current state summary |
 | See if the server is alive | `first-tree-hub server status` | Hits `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set |
-| Start all configured agents | `first-tree-hub client start` | Loads every agent config under `~/.first-tree-hub/config/agents/` |
-| Manage local config files | `first-tree-hub config ...` | Scope defaults to server unless `-c` or `-a <name>` is passed |
-| Add or remove a local agent config | `first-tree-hub agent add/remove/list` | This is local configuration, not Context Tree identity management |
-| Bootstrap an agent token from GitHub identity | `first-tree-hub agent token bootstrap <agentId>` | Requires `gh` auth and a Hub server that already knows the agent |
-| Send or inspect debug messages as an agent | `first-tree-hub agent send/chats/history/pull/register` | Requires `FIRST_TREE_HUB_AGENT_TOKEN` (or `FIRST_TREE_HUB_AGENT=<name>` to look up from local config); these are low-level debugging utilities |
-| Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Removes stale workspaces only when there is no active non-evicted session |
-| Onboard a new human or autonomous agent | `first-tree-hub onboard` | Creates a PR in the Context Tree repo, not in `first-tree-hub` itself |
+| Sign this computer into a Hub server | `first-tree-hub client connect <server-url> [--token <t>] [--no-service]` | Stores a member JWT at `~/.first-tree-hub/credentials.json`, writes `client.yaml`, and (by default) installs the background service |
+| Run the client inline instead of via service | `first-tree-hub client start` | Loads credentials written by `connect`; fails if there are none or if no agents are pinned to this client |
+| Keep the computer online across reboots | `first-tree-hub client service install` | launchd on macOS, `systemd --user` on Linux; Windows unsupported |
+| List machines the Hub currently sees | `first-tree-hub client hub-list` | Server-side inventory of connected clients |
+| Forcibly drop a machine from the Hub | `first-tree-hub client hub-disconnect <clientId>` | Server-side admin action |
+| Register a local alias for a Hub agent on this machine | `first-tree-hub agent add [name] [--agent-id <uuid>]` | Local-only; a running client auto-registers any agent an admin pins to this `clientId`, so `agent add` is mostly for scripted or unattended setups |
+| Create a fresh agent from the CLI | `first-tree-hub agent create <name> --type <t> --client-id <id>` | Writes to the Hub via Admin API and saves the local alias in one step |
+| Take ownership of an existing agent | `first-tree-hub agent claim <agentName>` | Sets `managerId` to the signed-in member |
+| Change an agent's runtime config (model, prompt, MCP, env, repos) | `first-tree-hub agent config <sub>` | Server-side edit via `/api/v1/admin/agents/:id/config` — affects the running agent everywhere |
+| Debug messaging as an agent | `first-tree-hub agent send/chats/history/pull/register/chat` | Low-level; authenticates as the signed-in member (no agent-specific token) |
+| Inspect session runtime state | `first-tree-hub agent status [name]`, `agent sessions <name>`, `agent session <suspend\|resume\|terminate>` | Reads `/api/v1/admin/agents/activity`, `/admin/sessions/agents/...` |
+| Reset an agent stuck in `error` state | `first-tree-hub agent reset <name>` | POSTs `reset-activity` |
+| Clean old isolated chat workspaces | `first-tree-hub agent workspace clean` | Respects the session registry — only removes evicted or untracked chats |
+| Onboard a new human or autonomous agent | `first-tree-hub onboard` | Guided flow; requires prior `client connect` for credentials |
+
+## The Credential Model
+
+Every CLI command that talks to the Hub reaches for `~/.first-tree-hub/credentials.json`. The file is written by `client connect` and contains `{ accessToken, refreshToken, serverUrl }` (mode `0600`). `ensureFreshAccessToken()` auto-refreshes against `/api/v1/auth/refresh` when the token is within 30 seconds of expiry, silently re-persists the result, and then returns the fresh access token.
+
+There are no separate admin or agent tokens. The member's JWT is used for every authenticated call — admin endpoints, Feishu binding, agent creation, agent config, messaging, SDK debugging, everything. The old `FIRST_TREE_HUB_AGENT_TOKEN` / `FIRST_TREE_HUB_AGENT` environment variables and the `agent token bootstrap` subcommand have been removed.
+
+If `credentials.json` is missing or refresh fails, the CLI exits with a message pointing at `first-tree-hub client connect <server-url>`. Do not paper over this with manual env vars — run `client connect`.
 
 ## Command Families
 
 ### `server`
 
-- `server start`
-  - Best default for first-run local usage.
-  - Prompts for missing required server config unless `--no-interactive` is used.
-  - If no database URL is provided, it can auto-start a managed PostgreSQL container via Docker.
-  - Runs migrations automatically.
-  - Creates the default `admin` user if the database has none.
-  - Resolves or builds the web dist so the server can host the admin UI.
-- `server stop`
-  - Only stops the managed PostgreSQL container used by the CLI workflow.
-  - It does not stop an already-running standalone Fastify process.
-- `server doctor`
-  - Checks Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, and server health.
-- `server status`
-  - Performs a health request against `/api/v1/health`.
-  - Uses `FIRST_TREE_HUB_SERVER_URL` when set; otherwise defaults to `http://localhost:8000`.
-- `server db:migrate`
-  - Uses the configured database and applies migrations.
-- `server admin:create`
-  - Creates an admin user directly against the configured database.
+Lifecycle for the Hub server process and its PostgreSQL backing store.
+
+- `server start` — best default for first-run local usage. Prompts for missing config unless `--no-interactive` is set; can auto-start a Docker-managed PostgreSQL if no `--database-url` is provided; runs migrations; creates the default `admin` user on an empty database; resolves/builds the web dist so the admin UI is served.
+- `server stop` — stops the CLI-managed PostgreSQL container only. It does **not** stop a standalone Fastify process.
+- `server doctor` — Node version, Docker availability, server config, database connectivity, GitHub token, Context Tree access, server health.
+- `server status` — simple health probe against `/api/v1/health`; defaults to `http://localhost:8000` unless `FIRST_TREE_HUB_SERVER_URL` is set.
+- `server db:migrate` — applies migrations against the configured database.
+- `server admin:create` — creates a new owner/admin against the configured database (not via HTTP — direct DB access).
 
 ### `client`
 
-- `client start`
-  - Initializes client config, loads all configured agents, creates a `ClientRuntime`, and keeps it alive until interrupted.
-  - Fails if there are no configured agents.
-- `client doctor`
-  - Checks Node version, client config, server reachability, agent configs, token validity, and WebSocket reachability.
-- `client status`
-  - Lists configured local agents and masked tokens.
-- `client stop`
-  - Currently informational only; there is no daemon manager yet.
+Everything that is "this computer and its relationship to a Hub server".
+
+- `client connect <server-url>` — first-time setup. Writes `server.url` into `client.yaml`, exchanges a connect token (or interactive login) for a member JWT, persists `credentials.json`, generates a stable `client.id`, and by default installs the background service so the machine stays online. Options: `--token <connect-token>`, `--no-service`.
+- `client start` — foreground runtime loop. Loads credentials, initializes config, spins up `ClientRuntime`, watches the agents config directory for hot-add, and stays alive until SIGINT/SIGTERM.
+- `client stop` — currently informational; prints the right Ctrl+C / `kill` hint. No daemon PID management yet.
+- `client status` — lists locally configured agent aliases with their runtime and agent UUID.
+- `client doctor` — Node version, client config, server reachability, agent configs, credential validity, WebSocket reachability.
+- `client service install` / `status` / `uninstall` — user-level launchd (macOS) or systemd (Linux) unit that runs `first-tree-hub client start --no-interactive` in the background. Logs go to `~/.first-tree-hub/logs/`. Use `isServiceSupported()` semantics — platform is `unsupported` on Windows and other OSes.
+- `client hub-list [--server <url>]` — enumerates clients currently known to the Hub server (`GET /api/v1/clients`), with hostname, agent count, and last-seen timestamp.
+- `client hub-disconnect <clientId> [--server <url>]` — POSTs `/api/v1/clients/:id/disconnect` to force-drop a WebSocket connection on the server side.
 
 ### `agent`
 
-- `agent add [name]`
-  - Writes `~/.first-tree-hub/config/agents/<name>/agent.yaml`.
-  - Prompts interactively if name or token is missing.
-- `agent remove <name>`
-  - Deletes the agent config and also removes runtime workspaces and the saved session registry for that agent.
-- `agent list`
-  - Reads local configured agents and masks tokens in output.
-- `agent workspace clean [agent-name] [--ttl <days>]`
-  - Cleans stale workspace directories under `~/.first-tree-hub/data/workspaces/`.
-  - Skips chat workspaces that still have an active session in the session registry.
-- `agent token bootstrap <agentId>`
-  - Uses GitHub identity and the server's bootstrap endpoint to create or retrieve an agent token.
-  - `--save-to agent` stores the token in the local agent config by default.
-- `agent bind ...`
-  - Used for Feishu bindings. Read `docs/claim-agent-guide.md` when claim/bind flows matter.
-- `agent send/chats/history/register/pull`
-  - These are SDK-style debugging commands.
-  - Auth resolution: `FIRST_TREE_HUB_AGENT_TOKEN` (explicit) → `FIRST_TREE_HUB_AGENT` env var lookup in `~/.first-tree-hub/agents/<name>/agent.yaml`.
-  - `send` supports direct target vs `--chat`, stdin piping, and reply metadata.
-  - `pull` is the low-level inbox polling path.
+Everything that is "about one or more agent records". Subcommands split into several groups.
+
+**Local aliases**
+
+- `agent add [name] [--agent-id <uuid>]` — writes `~/.first-tree-hub/config/agents/<name>/agent.yaml`. Prompts interactively when arguments are missing. Local-only; does not create an agent on the Hub.
+- `agent remove <name>` — deletes the local alias, its workspaces under `data/workspaces/<name>/`, and its session registry file.
+- `agent list` — prints every locally configured alias.
+
+**Hub-side creation / ownership**
+
+- `agent create <name> --type <human|personal_assistant|autonomous_agent> --client-id <id> [--runtime <r>] [--display-name <n>] [--server <url>]` — calls `POST /api/v1/admin/agents` then saves the local alias. Requires the target `client-id` to be a machine you own (run `client connect` on that machine first).
+- `agent claim <agentName>` — sets `managerId` to the signed-in member via `PATCH /api/v1/admin/agents/:id`. Admins can claim any agent; non-admins can only self-claim unmanaged ones.
+
+**Runtime configuration** (server-side — see also `agent-config.ts`)
+
+- `agent config get <agent>` — prints the current `AgentRuntimeConfig` (model, prompt.append, mcpServers, env, gitRepos) with secrets masked.
+- `agent config set-model <agent> <model>` — replaces the `model` field (e.g. `claude-opus-4-7`).
+- `agent config append-prompt <agent> [-f <file>]` — replaces the `prompt.append` text; reads stdin if `-f` is absent.
+- `agent config add-mcp <agent> --name <n> --transport <stdio|http|sse> [--command / --args] [--url]` — replace-by-name semantics; use `stdio` for `--command`/`--args`, or `http`/`sse` for `--url`.
+- `agent config set-env <agent> <KEY=VALUE> [--sensitive]` — replace-by-key semantics. `--sensitive` encrypts at rest and masks in echo.
+- `agent config add-repo <agent> <url> [--ref <r>] [--path <p>]` — adds (or replaces by URL) a Git repo for the agent's worktree set.
+- `agent config dry-run <agent> -f <patch.json>` — validates a partial payload against the current version and prints the diff without persisting.
+
+All `agent config` subcommands call `GET`/`PATCH`/`POST dry-run` on `/api/v1/admin/agents/:id/config`, enforce optimistic concurrency by sending `expectedVersion`, and require the signed-in member to have admin scope on the target.
+
+**Workspaces**
+
+- `agent workspace clean [agent-name] [--ttl <days>]` — removes workspace directories under `~/.first-tree-hub/data/workspaces/<name>/` that are older than TTL (default 7 days) and not currently referenced by an active session in the registry.
+
+**Bindings**
+
+- `agent bind client <agentName> --client-id <id>` — first-time bind of an agent to a client machine. The `clientId` field on the agent is immutable once set, so this is a one-shot operation; use it for seeding, scripting, or recovery.
+- `agent bind bot --platform feishu --app-id <id> --app-secret <s>` — binds a Feishu bot to this agent (self-service via the adapter API).
+- `agent bind user <humanAgentId> --platform feishu --feishu-id <ou_xxx>` — binds a Feishu user to a human agent for `delegate_mention` routing.
+
+**Messaging & sessions**
+
+- `agent send <target> [message]` — sends a message to an agent ID or (with `--chat`) a chat ID. Supports `-f <text|markdown|card>`, `-m '<json>'`, and reply routing via `--reply-to`, `--reply-to-inbox`, `--reply-to-chat`. Reads from stdin when `[message]` is omitted.
+- `agent chats` / `agent history <chatId>` — list chats / show history (cursor-paginated, 1–100 per page).
+- `agent status [name]` — reads `/api/v1/admin/agents/activity` for a live snapshot (running count, state breakdown, per-agent runtime + session count).
+- `agent reset <name>` — POSTs `reset-activity` to move an agent out of `error` state.
+- `agent sessions <agent-name> [--state <s>]` — lists sessions via `/api/v1/admin/sessions/agents/:id`.
+- `agent session suspend|resume|terminate <agent-name> <chat-id>` — POSTs the corresponding session lifecycle endpoint.
+- `agent chat <agent-name>` — opens an admin-scoped REPL against the agent: creates a DM chat, polls messages every 2s, writes to the chat, exits on Ctrl+C.
+
+**Low-level SDK debug**
+
+- `agent register` — proxies `sdk.register()` for identity confirmation.
+- `agent pull [-l] [--ack]` — low-level inbox polling; `--ack` acknowledges all returned entries.
+
+All messaging / session / chat commands accept `--agent <name>` (local alias) when multiple agents are configured; with a single configured agent the flag is optional.
 
 ### `config`
 
-- `config setup`
-  - Runs schema-driven interactive prompts for server or client config.
-- `config set/get/list`
-  - Supports `-s/--server`, `-c/--client`, and `-a <name>/--agent <name>`.
-  - Defaults to server scope if no scope flag is provided.
-  - `list` and `get` hide secret fields unless `--show-secrets` is passed.
+Scope-aware YAML editing. Scopes:
 
-### Top-Level `status`
+- `-s` / `--server` (default) → `$FIRST_TREE_HUB_HOME/config/server.yaml`
+- `-c` / `--client` → `$FIRST_TREE_HUB_HOME/config/client.yaml`
+- `-a <name>` / `--agent <name>` → `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
 
-- Summarizes:
-  - Current server health
-  - Database config presence
-  - Number of local configured agents
-  - Whether client config exists and what server URL it points to
-- Use this when the user asks for a compact overall state, not a deep readiness diagnosis.
+Subcommands:
+
+- `config setup` — schema-driven interactive wizard for the server or client config.
+- `config set <key> <value>` — sets a dotted key. Values matching `^\d+$`, `true`, or `false` are auto-coerced.
+- `config get <key> [--show-secrets]` — reads a dotted key; secret fields are masked unless `--show-secrets` is passed.
+- `config list [--show-secrets]` — flat dump of the selected config file.
+
+`agent config ...` is a different surface — it mutates server-side runtime configuration, not a local YAML file.
+
+### `status` (top-level)
+
+One compact overview:
+
+- Server health (probes `/api/v1/health` on the configured port)
+- Database configuration presence and provider
+- Count of locally configured agents
+- Client config presence and the server URL it points to
+
+Use this for a fast "is my machine connected and does the server answer" check; use `doctor` when you need to see *which* component is broken.
 
 ### `onboard`
 
-- `onboard --check`
-  - Shows readiness and missing inputs without making changes.
-- `onboard`
-  - Auto-creates the agent and bootstraps a token using GitHub identity.
-  - Optionally binds a Feishu bot.
-  - Writes `client.yaml` so `client start` works without extra setup.
-  - Only requires `gh` authentication — no admin credentials needed.
+High-level guided onboarding flow. Composes agent creation, optional assistant creation, and optional Feishu bot binding into one command. Supports a `--check` dry-run that prints the readiness checklist, and persists partial state to `~/.first-tree-hub/.onboard-state.json` so interactive re-runs pick up where they left off.
+
+Important: `onboard` depends on a valid credential file. If `loadCredentials()` returns null, the command errors out and points at `first-tree-hub client connect <server-url>`. It does **not** try to log the user in itself.
 
 ## Config and Environment Model
 
-### Config priority
+### Priority
 
 1. CLI args
 2. Environment variables
 3. YAML config files
-4. Auto-generated values
+4. Auto-generated values (secrets, Docker PG URL, `client.id`)
 5. Built-in defaults
 
-### Default config paths
+### Paths
 
-- Home root defaults to `~/.first-tree-hub`, but `FIRST_TREE_HUB_HOME` overrides it.
-- `$FIRST_TREE_HUB_HOME/config/server.yaml`
-- `$FIRST_TREE_HUB_HOME/config/client.yaml`
-- `$FIRST_TREE_HUB_HOME/config/agents/<name>/agent.yaml`
+- Home: `~/.first-tree-hub` by default; override with `FIRST_TREE_HUB_HOME`.
+- `$HOME/credentials.json` — member JWT + refresh token.
+- `$HOME/config/server.yaml`
+- `$HOME/config/client.yaml`
+- `$HOME/config/agents/<name>/agent.yaml`
+- `$HOME/.onboard-state.json`
+- `$HOME/logs/` — background service stdout/stderr
+- `$HOME/context-tree/` — optional organizational clone
+- `$HOME/data/sessions/`, `$HOME/data/workspaces/<agent>/<chatId>/`, `$HOME/data/postgres/`
 
-### Default runtime paths
+### Environment variables
 
-- `$FIRST_TREE_HUB_HOME/.onboard-state.json`
-- `$FIRST_TREE_HUB_HOME/context-tree/`
-- `$FIRST_TREE_HUB_HOME/data/sessions/`
-- `$FIRST_TREE_HUB_HOME/data/workspaces/`
-- `$FIRST_TREE_HUB_HOME/data/postgres/`
+**Global**
+- `FIRST_TREE_HUB_HOME`
 
-### Important environment variables
+**Server**
+- `FIRST_TREE_HUB_DATABASE_URL`
+- `FIRST_TREE_HUB_PORT`
+- `FIRST_TREE_HUB_HOST`
+- `FIRST_TREE_HUB_JWT_SECRET`
+- `FIRST_TREE_HUB_ENCRYPTION_KEY`
+- `FIRST_TREE_HUB_CONTEXT_TREE_REPO`
+- `FIRST_TREE_HUB_GITHUB_TOKEN`
+- `FIRST_TREE_HUB_WEB_DIST_PATH`
 
-- Global:
-  - `FIRST_TREE_HUB_HOME`
-- Server:
-  - `FIRST_TREE_HUB_DATABASE_URL`
-  - `FIRST_TREE_HUB_PORT`
-  - `FIRST_TREE_HUB_HOST`
-  - `FIRST_TREE_HUB_JWT_SECRET`
-  - `FIRST_TREE_HUB_ENCRYPTION_KEY`
-  - `FIRST_TREE_HUB_CONTEXT_TREE_REPO`
-  - `FIRST_TREE_HUB_GITHUB_TOKEN`
-  - `FIRST_TREE_HUB_WEB_DIST_PATH`
-- Client:
-  - `FIRST_TREE_HUB_SERVER_URL`
-  - `FIRST_TREE_HUB_LOG_LEVEL`
-- Agent runtime / debugging:
-  - `FIRST_TREE_HUB_AGENT_TOKEN` (explicit token)
-  - `FIRST_TREE_HUB_AGENT` (agent name → looks up token from local config)
-  - `FIRST_TREE_HUB_SERVER_URL`
-- Onboard:
-  - `FIRST_TREE_HUB_SERVER_URL`
-  - `FEISHU_APP_ID`
-  - `FEISHU_APP_SECRET`
+**Client**
+- `FIRST_TREE_HUB_SERVER_URL` — overrides `client.yaml`'s `server.url` at call time.
+- `FIRST_TREE_HUB_LOG_LEVEL`
+
+**Onboard**
+- `FIRST_TREE_HUB_SERVER_URL`
+- `FEISHU_APP_ID`, `FEISHU_APP_SECRET`
+
+No agent-specific token env vars exist anymore. If you see a guide or old script setting `FIRST_TREE_HUB_AGENT_TOKEN` or `FIRST_TREE_HUB_AGENT`, it's stale — the CLI ignores both.
+
+## Admin API Endpoints the CLI Calls
+
+Useful when debugging or when a user wants to script around the CLI. All calls authenticate with the member JWT.
+
+- Auth: `POST /api/v1/auth/connect-token`, `POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`
+- Me: `GET /api/v1/me`
+- Clients: `GET /api/v1/clients`, `POST /api/v1/clients/:id/disconnect`
+- Agents (admin): `GET /api/v1/admin/agents`, `POST /api/v1/admin/agents`, `PATCH /api/v1/admin/agents/:id`
+- Agent config: `GET|PATCH /api/v1/admin/agents/:id/config`, `POST /api/v1/admin/agents/:id/config/dry-run`
+- Agent activity: `GET /api/v1/admin/agents/activity`, `POST /api/v1/admin/agents/activity/:name/reset-activity`
+- Sessions: `GET /api/v1/admin/sessions/agents/:id`, `POST /admin/sessions/agents/:id/:chatId/{suspend|resume|terminate}`
+- Admin chat: `POST /api/v1/admin/agents/:id/chats`, `GET|POST /api/v1/admin/chats/:id/messages`
+- Health: `GET /api/v1/health`
 
 ## When to Read Other Docs
 
-- Read `docs/cli-reference.md` for the full public command reference.
-- Read `docs/onboarding-guide.md` for onboarding examples and type-specific behavior.
-- Read `docs/claim-agent-guide.md` for claim-agent and Feishu user binding flows.
-- Read `docs/deployment-guide.md` when the request is about Docker, Railway, Render, Supabase, HTTPS, or multi-machine deployment.
+- `docs/cli-reference.md` — the canonical public flag/env reference.
+- `docs/onboarding-guide.md` — end-to-end onboarding walkthrough and type-specific notes.
+- `docs/claim-agent-guide.md` — claim + Feishu binding details.
+- `docs/deployment-guide.md` — Docker, Railway, Render, Supabase, HTTPS, multi-machine.

--- a/skills/first-tree-hub-cli/references/core-concepts.md
+++ b/skills/first-tree-hub-cli/references/core-concepts.md
@@ -4,27 +4,22 @@
 
 First Tree Hub is shared infrastructure for agent teams.
 
-- It provides agent identity management, authentication, messaging, adapter bridges, and the admin dashboard.
-- It is not the LLM agent runtime itself.
-- It is not the orchestration framework.
-- It is not the Context Tree.
+- It provides agent identity management, authentication, messaging, adapter bridges, background agent runtime, and the admin dashboard.
+- It is **not** the LLM agent runtime itself.
+- It is **not** the orchestration framework.
+- It is **not** the Context Tree.
 
 Use this distinction consistently when explaining the system or choosing where a change belongs.
 
 ## Package Roles
 
-- `packages/server`
-  - Fastify API server, admin APIs, agent APIs, database access, adapters, notifications
-- `packages/client`
-  - Agent SDK, runtime, WebSocket connection management, workspace/session handling
-- `packages/command`
-  - Unified CLI entry point plus reusable core orchestration helpers
-- `packages/shared`
-  - Zod schemas, TypeScript types, and schema-driven config system shared across packages
-- `packages/web`
-  - React admin dashboard served by the server
+- `packages/server` — Fastify API server, admin APIs, agent APIs, database access, adapters, notifications.
+- `packages/client` — Agent SDK, client runtime, WebSocket connection management, workspace/session handling.
+- `packages/command` — Unified CLI entry point plus reusable core orchestration helpers (auth, service install, onboard, doctor, Docker Postgres, Feishu binding).
+- `packages/shared` — Zod schemas, TypeScript types, and the schema-driven config system shared across packages.
+- `packages/web` — React admin dashboard served by the server.
 
-The command package depends on server and client packages, but it is still an entry layer. Keep business logic in reusable core modules instead of duplicating it in Commander handlers.
+The command package depends on server and client packages, but it is still an entry layer — keep business logic in reusable `core/*` modules instead of duplicating it in Commander handlers.
 
 ## Architecture Invariants
 
@@ -36,22 +31,24 @@ The command package depends on server and client packages, but it is still an en
 
 ### Agent identity is managed by Hub
 
-- Agent identities are created, updated, and managed via Admin API.
+- Agent identities are created, updated, and owned via Admin API (used both by the web UI and by the CLI's `agent create` / `agent claim` / `onboard`).
 - Agent profile (markdown self-description) is stored in the `agents.profile` column.
-- Context Tree integration is optional — when configured, Client injects organizational context (AGENT.md, root NODE.md) into agent workspaces at startup.
+- Each agent has exactly one `clientId` — the machine that runs it. Bind with `agent bind client <name> --client-id <id>`; the field is immutable once set.
+- Context Tree integration is optional — when configured, the client injects organizational context (`AGENT.md`, root `NODE.md`) into agent workspaces at startup.
 
 ### Inbox is the server-client boundary
 
 - The server writes messages to inbox rows.
-- Delivery is fan-out on write and at-least-once.
-- Clients receive WebSocket notifications and can also pull.
+- Delivery is fan-out on write and **at-least-once**.
+- Clients receive WebSocket notifications and can also pull via SDK.
 - The client side is responsible for deduplication and session/workspace management.
 
-### Auth paths are isolated
+### Auth uses one credential, everywhere
 
-- Agent API uses agent Bearer tokens.
-- Admin API uses admin JWT.
-- These are separate security domains even on localhost.
+- Clients sign in once via `client connect`, which persists a member access JWT + refresh token in `~/.first-tree-hub/credentials.json`.
+- Every subsequent CLI call runs through `ensureFreshAccessToken()`, which auto-refreshes 30s before expiry via `/api/v1/auth/refresh`.
+- Admin actions, agent-owner actions, Feishu binding, `agent config` mutations, and SDK debug calls all use the same member JWT. Server enforcement is role-based.
+- There is no separate admin JWT or per-agent bearer token in the current model. The legacy `FIRST_TREE_HUB_AGENT_TOKEN` / `FIRST_TREE_HUB_AGENT` env vars and `agent token bootstrap` command are gone.
 
 ### Messages are immutable and time-ordered
 
@@ -67,29 +64,33 @@ The command package depends on server and client packages, but it is still an en
 It can:
 
 - collect missing config interactively
-- provision PostgreSQL if the user did not provide one
+- provision PostgreSQL via Docker if the user did not provide one
 - run migrations
-- create the first admin account
+- create the first admin account on an empty database
 - discover or build the web dist
 - start the server with a generated instance ID
 
 ### Client startup
 
-`client start` runs all locally configured agents against one Hub server.
+`client start` runs every locally configured agent against one Hub server.
 
 The client runtime:
 
-- reads `client.yaml`
-- reads all configured agent YAML files
-- establishes WebSocket and HTTP communication
+- loads `~/.first-tree-hub/credentials.json` (member JWT + refresh)
+- reads `client.yaml` for `server.url` and `client.id`
+- reads every agent's local alias YAML to resolve `name → agentId`
+- establishes WebSocket and HTTP communication, refreshing the access token on demand
+- watches the agents config directory for hot-add
 - manages session state and isolated chat workspaces
 - optionally syncs a shared Context Tree clone for organizational context
 
+The **background service** (`client service install`, typically triggered automatically by `client connect`) runs `client start --no-interactive` under launchd (macOS) or `systemd --user` (Linux), with logs at `~/.first-tree-hub/logs/`. This is how a machine stays online across reboots without a terminal.
+
 ### Workspace bootstrap
 
-When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files.
+When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files:
 
-- `self.md` from the agent's `profile` field (stored in Hub)
+- `self.md` from the agent's `profile` field (stored in Hub).
 - If Context Tree is configured:
   - `agent-instructions.md` from the root `AGENT.md`
   - `domain-map.md` from the root `NODE.md`
@@ -98,16 +99,17 @@ When a handler starts, the client runtime bootstraps a per-chat workspace and wr
 
 `onboard` is intentionally higher-level than the rest of the CLI.
 
-- It auto-creates the agent and bootstraps the token in a single step via GitHub identity.
-- Only `gh` authentication is required — no admin credentials needed.
-- This is the supported path for creating new members.
+- It creates the agent via Admin API, optionally creates a personal assistant, optionally binds a Feishu bot, and saves the local alias — all in one step.
+- It uses the signed-in member's JWT (from `credentials.json`). If no credentials exist, it exits with a clear pointer to `client connect`.
+- `--check` performs a dry-run that surfaces exactly which fields are missing, using the same check logic as the real path.
 
-Do not replace this with ad hoc API calls unless the user explicitly wants to bypass the normal flow for development or debugging.
+Do not replace `onboard` with ad hoc Admin API calls unless the user explicitly wants to bypass the supported flow for development or debugging.
 
 ## Common Misunderstandings to Avoid
 
-- Do not say that `agent add` creates an identity in Hub. It only creates local client config.
-- Do not say that `client start` starts the server. It only runs configured agent clients.
-- Do not say that the Context Tree owns agent identity. Hub does. Context Tree is an optional organizational knowledge source.
+- Do not say `agent add` creates an agent on the Hub. It only writes a local alias (`agents/<name>/agent.yaml`) mapping a friendly name to an existing `agentId`. Use `agent create` to create a server-side row.
+- Do not say `client start` starts the server. It only runs configured agent clients against a server that must already be running.
+- Do not say the Context Tree owns agent identity. Hub does. Context Tree is an optional organizational knowledge source.
 - Do not frame the inbox as exactly-once delivery. The contract is at-least-once with client-side deduplication.
-- Do not mix up admin and agent credentials.
+- Do not reach for `FIRST_TREE_HUB_AGENT_TOKEN` or `FIRST_TREE_HUB_AGENT`. Neither env var is read by the CLI anymore; all auth flows through `credentials.json`.
+- Do not conflate `agent config ...` (server-side runtime configuration) with `config -a <name> ...` (local YAML editing for the alias file). Both are legitimate; they operate on different state.

--- a/skills/first-tree-hub-cli/references/developer-map.md
+++ b/skills/first-tree-hub-cli/references/developer-map.md
@@ -2,95 +2,91 @@
 
 ## Repo Entry Points
 
-- `AGENTS.md`
-  - Architecture rules, conventions, package map, and development workflow
-- `README.md`
-  - Product framing, quick start, and top-level documentation links
-- `docs/cli-reference.md`
-  - Public command and environment variable reference
-- `docs/onboarding-guide.md`
-  - End-to-end onboarding flow
-- `docs/claim-agent-guide.md`
-  - Claim and Feishu binding details
+- `AGENTS.md` — architecture rules, conventions, package map, development workflow.
+- `README.md` — product framing, quick start, top-level documentation links.
+- `docs/cli-reference.md` — public command and environment variable reference.
+- `docs/onboarding-guide.md` — end-to-end onboarding flow.
+- `docs/claim-agent-guide.md` — claim + Feishu binding details.
+- `docs/deployment-guide.md` — Docker, Railway, Render, Supabase, HTTPS, production.
 
 ## CLI Source Map
 
-- `packages/command/src/cli/index.ts`
-  - Top-level Commander program and command registration
-- `packages/command/src/commands/server.ts`
-  - `server` subcommands
-- `packages/command/src/commands/client.ts`
-  - `client` subcommands
-- `packages/command/src/commands/agent.ts`
-  - local agent management, bindings, workspace cleanup, messaging utilities
-- `packages/command/src/commands/config.ts`
-  - scope-aware config set/get/list/setup flows
-- `packages/command/src/commands/status.ts`
-  - top-level overview command
-- `packages/command/src/commands/onboard.ts`
-  - high-level interactive entry for onboarding
+- `packages/command/src/cli/index.ts` — top-level Commander program and command registration.
+- `packages/command/src/commands/server.ts` — `server start/stop/status/doctor/db:migrate/admin:create`.
+- `packages/command/src/commands/client.ts` — `client start/stop/status/doctor`, the `client service install/status/uninstall` subgroup, and the Hub-side `client hub-list/hub-disconnect` commands. Delegates `client connect` registration to `commands/connect.ts`.
+- `packages/command/src/commands/connect.ts` — `client connect <server-url>`: writes `server.url`, authenticates via connect token or interactive login, persists `credentials.json`, installs the background service by default.
+- `packages/command/src/commands/agent.ts` — local aliases (`add/remove/list`), `create`, `claim`, `workspace clean`, `bind client/bot/user`, messaging (`send/chats/history/register/pull`), runtime status (`status/reset/sessions/session/chat`). Delegates `agent config` registration to `commands/agent-config.ts`.
+- `packages/command/src/commands/agent-config.ts` — `agent config get/set-model/append-prompt/add-mcp/set-env/add-repo/dry-run`, all thin wrappers over `/api/v1/admin/agents/:id/config`.
+- `packages/command/src/commands/config.ts` — scope-aware `config setup/set/get/list` for `server.yaml`, `client.yaml`, and `agents/<name>/agent.yaml`.
+- `packages/command/src/commands/status.ts` — top-level overview command.
+- `packages/command/src/commands/onboard.ts` — guided onboarding, argument-shape only.
 
 ## Reusable Core Logic
 
-- `packages/command/src/core/server.ts`
-  - orchestration for `server start`, including config prompts, Docker PostgreSQL, migrations, admin creation, and web dist resolution
-- `packages/command/src/core/onboard.ts`
-  - agent creation via Admin API, token bootstrap, and Feishu binding
-- `packages/command/src/core/bootstrap.ts`
-  - token bootstrap helpers and server URL resolution
-- `packages/command/src/core/doctor.ts`
-  - readiness checks used by `server doctor` and `client doctor`
-- `packages/command/src/core/feishu.ts`
-  - Feishu binding helpers
-- `packages/command/src/core/prompt.ts`
-  - schema-driven prompting behavior
+- `packages/command/src/core/server.ts` — orchestration for `server start` (config prompts, Docker Postgres, migrations, admin creation, web dist resolution).
+- `packages/command/src/core/onboard.ts` — agent creation via Admin API, optional assistant creation, optional Feishu binding; provides `onboardCheck` / `onboardCreate` / `formatCheckReport` / `loadOnboardState` / `saveOnboardState`.
+- `packages/command/src/core/bootstrap.ts` — credential persistence (`saveCredentials`, `loadCredentials`) and token freshness (`resolveAccessToken`, `ensureFreshAccessToken`), plus `resolveServerUrl` and `saveAgentConfig`. `ensureFreshAdminToken` is a back-compat alias of `ensureFreshAccessToken`.
+- `packages/command/src/core/service-install.ts` — `installClientService`, `uninstallClientService`, `getClientServiceStatus`, `isServiceSupported`, `resolveCliInvocation`. Handles launchd (macOS) and `systemd --user` (Linux); marks other platforms as `unsupported`. Logs go to `~/.first-tree-hub/logs/`.
+- `packages/command/src/core/client-runtime.ts` — the long-lived `ClientRuntime` used by `client start` and `client connect --no-service`. Watches the agents config dir for hot-add and uses `ensureFreshAccessToken` on every WebSocket handshake.
+- `packages/command/src/core/doctor.ts` — readiness checks used by `server doctor` and `client doctor`: `checkNodeVersion`, `checkDocker`, `checkServerConfig`, `checkDatabase`, `checkServerHealth`, `checkServerReachable`, `checkClientConfig`, `checkAgentConfigs`, `checkWebSocket`.
+- `packages/command/src/core/feishu.ts` — `bindFeishuBot`, `bindFeishuUser`.
+- `packages/command/src/core/docker-postgres.ts` — `ensurePostgres`, `isDockerAvailable`, `stopPostgres` (CLI-managed Docker Postgres container).
+- `packages/command/src/core/migrate.ts` — `runMigrations`.
+- `packages/command/src/core/admin.ts` — `createOwner`, `hasUser` (direct DB access for seeding).
+- `packages/command/src/core/prompt.ts` — `isInteractive`, `promptAddAgent`, `promptMissingFields` (schema-driven prompting).
+- `packages/command/src/core/output.ts` — `fail`, `success`, `blank`, `status` helpers for consistent stderr/stdout output.
 
 If you change command behavior, there is a good chance the real logic belongs in one of these core modules rather than in the command handler itself.
 
 ## Shared Config and Schema Files
 
-- `packages/shared/src/config/server-config.ts`
-  - server config schema, defaults, prompts, env names
-- `packages/shared/src/config/client-config.ts`
-  - client config schema
-- `packages/shared/src/config/agent-config.ts`
-  - agent config schema
-- `packages/shared/src/config/resolver.ts`
-  - config priority resolution, YAML reading/writing, auto-generation
+- `packages/shared/src/config/server-config.ts` — server config schema, defaults, prompts, env names.
+- `packages/shared/src/config/client-config.ts` — client config schema.
+- `packages/shared/src/config/agent-config.ts` — agent (local alias) config schema.
+- `packages/shared/src/config/resolver.ts` — config priority resolution, YAML reading/writing, auto-generation.
+- `packages/shared/src/config/singleton.ts` — `initConfig`, `resetConfig`, `resetConfigMeta` (per-process singleton so command handlers can reinit between subcommands).
 
 If a flag, env var, or config key changes, inspect these files and update docs accordingly.
 
 ## Client and Server Runtime Files
 
-- `packages/client/src/sdk.ts`
-  - agent SDK surface used by debugging flows and runtime internals
-- `packages/client/src/runtime/runtime.ts`
-  - runtime orchestration for configured agents
-- `packages/client/src/runtime/bootstrap.ts`
-  - optional Context Tree clone sync and `.agent/` workspace bootstrap
-- `packages/client/src/runtime/session-manager.ts`
-  - session lifecycle and dedup-sensitive message dispatch
-- `packages/server/src/app.ts`
-  - server wiring, route registration, background jobs
-- `packages/server/src/services/inbox.ts`
-  - inbox poll/ack/renew behavior
+- `packages/client/src/sdk.ts` — the agent SDK surface used by debugging flows and runtime internals.
+- `packages/client/src/runtime/runtime.ts` — runtime orchestration for configured agents.
+- `packages/client/src/runtime/bootstrap.ts` — optional Context Tree clone sync and `.agent/` workspace bootstrap.
+- `packages/client/src/runtime/session-manager.ts` — session lifecycle and dedup-sensitive message dispatch.
+- `packages/server/src/app.ts` — server wiring, route registration, background jobs.
+- `packages/server/src/api/auth/` — login, connect-token, refresh endpoints consumed by `client connect` and `ensureFreshAccessToken`.
+- `packages/server/src/api/admin/` — agent admin, agent config, session, and client endpoints that the CLI calls.
+- `packages/server/src/services/inbox.ts` — inbox poll/ack/renew behavior.
 
 ## Change Patterns
 
 ### Add or change a CLI command
 
-1. Update or add the command handler in `packages/command/src/commands/`.
+1. Update or add the handler in `packages/command/src/commands/`.
 2. Move reusable logic into `packages/command/src/core/`.
 3. Register the command from `packages/command/src/cli/index.ts` if it is new.
-4. Update barrel exports if the functionality should be imported by external consumers.
+4. Update barrel exports (`packages/command/src/core/index.ts`, `packages/command/src/index.ts`) if the functionality should be importable by other tools.
 5. Update `docs/cli-reference.md`.
+
+### Change the credential / auth surface
+
+1. Changes to login or refresh behavior touch `core/bootstrap.ts` and the `/api/v1/auth/*` routes.
+2. Changes to `client connect` flow touch `commands/connect.ts` and (usually) `core/service-install.ts`.
+3. Any change that adds or removes an auth env var must update `docs/cli-reference.md` and `references/command-surface.md` in this skill.
 
 ### Change onboarding behavior
 
-1. Update `packages/command/src/commands/onboard.ts` only for argument shape or interaction flow.
-2. Put the real behavior in `packages/command/src/core/onboard.ts`.
-3. Update `docs/onboarding-guide.md`.
-4. Update `docs/claim-agent-guide.md` too if claim or binding behavior changes.
+1. `commands/onboard.ts` for argument shape or interaction flow only.
+2. `core/onboard.ts` for the actual behavior.
+3. `docs/onboarding-guide.md` for user-facing changes.
+4. `docs/claim-agent-guide.md` if claim / binding behavior changes.
+
+### Change the background service
+
+1. `core/service-install.ts` for platform-specific logic (launchd plist, systemd unit, log paths, CLI invocation resolution).
+2. `commands/client.ts` (the `service` subcommand group) for CLI surface.
+3. `commands/connect.ts` if `client connect` install-on-connect behavior changes.
 
 ### Change config behavior
 
@@ -122,16 +118,14 @@ Use the package-specific commands when only one area changed, but keep in mind t
 
 ## External Consumption
 
-The published CLI package is `@agent-team-foundation/first-tree-hub`.
-
-Its public CLI binary is:
+The published CLI package is `@agent-team-foundation/first-tree-hub`. Its public CLI binary is:
 
 ```bash
 first-tree-hub
 ```
 
-Its reusable code surface is also intended to be importable by other tools. When you add reusable CLI-adjacent behavior, preserve that separation:
+Reusable code is also importable. When adding reusable CLI-adjacent behavior, preserve the separation:
 
 - thin command handler for argument parsing
 - reusable `core/*` function for behavior
-- re-export through `packages/command/src/index.ts` when appropriate
+- re-export through `packages/command/src/index.ts` when external callers need the API

--- a/skills/first-tree-hub-cli/references/onboarding-operator.md
+++ b/skills/first-tree-hub-cli/references/onboarding-operator.md
@@ -1,45 +1,61 @@
 # First Tree Hub Onboarding Operator Playbook
 
-Use this file when an external agent receives an onboarding task such as "install First Tree Hub CLI, read the onboarding guide with `gh`, and add a member."
+Use this file when an external agent receives an onboarding task such as:
+
+> "Install First Tree Hub CLI, read the onboarding guide with `gh`, and add a member. Server URL is `https://hub.example.com`."
+
+The goal is to run the supported CLI workflow — not to manually create agents via API calls or YAML edits.
 
 ## Core Rule
 
-- Use `first-tree-hub onboard` for the workflow.
-- Ensure `gh` is installed and authenticated (`gh auth login`).
+- Use `first-tree-hub onboard` for the end-to-end flow.
+- `onboard` depends on a valid credential file; if this machine is not yet signed in, run `first-tree-hub client connect <server-url>` first.
+- Ensure `gh` is installed and authenticated (`gh auth login`) — required for GitHub-identity agent creation.
 
 ## When the Prompt Starts From Scratch
 
-If the task only gives you a package name, a docs URL, and a server URL, normalize it into this sequence:
+If the task only gives you a package name, a docs URL, and a server URL, translate it into this sequence:
 
-1. Confirm tooling:
-   - `gh` is installed and authenticated (used for agent registration and token bootstrap).
-   - Node is new enough to run the published CLI.
+1. Confirm tooling on the current machine:
+   - `gh auth status` — authenticated.
+   - `node --version` — `>= 22.16`.
 2. Install the CLI:
-   - Preferred: `npm install -g @agent-team-foundation/first-tree-hub`
-   - If the caller installed locally with `npm i @agent-team-foundation/first-tree-hub`, use `npx first-tree-hub ...`
-3. Read the canonical guide with `gh`:
+   - Preferred: `npm install -g @agent-team-foundation/first-tree-hub`.
+   - If the caller installed locally (`npm i @agent-team-foundation/first-tree-hub`), invoke via `npx first-tree-hub ...`.
+3. Read the canonical guide with `gh` (so you pick up any server-specific nuance):
 
-```bash
-gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main --jq .content | base64 --decode
-```
+   ```bash
+   gh api repos/agent-team-foundation/first-tree-hub/contents/docs/onboarding-guide.md?ref=main \
+     --jq .content | base64 --decode
+   ```
 
-4. Run readiness first:
+4. Sign this machine into the Hub:
 
-```bash
-first-tree-hub onboard --check --server <url> ...
-```
+   ```bash
+   first-tree-hub client connect <server-url>                       # interactive login
+   # or
+   first-tree-hub client connect <server-url> --token <connect-token>
+   # or, in a container / CI:
+   first-tree-hub client connect <server-url> --no-service
+   ```
 
-5. Execute onboarding (creates agent via Admin API + bootstraps token):
+5. Dry-run the onboarding to surface missing fields:
 
-```bash
-first-tree-hub onboard --server <url> ...
-```
+   ```bash
+   first-tree-hub onboard --check --server <url> --id <id> --type <type> ...
+   ```
 
-6. Start the runtime when this machine should host the configured agent:
+6. Execute onboarding (creates the agent via Admin API + optional assistant + optional Feishu bot):
 
-```bash
-first-tree-hub client start
-```
+   ```bash
+   first-tree-hub onboard --server <url> --id <id> --type <type> ...
+   ```
+
+7. Start the runtime if this machine should host the agent and no service is installed:
+
+   ```bash
+   first-tree-hub client start
+   ```
 
 ## Prompt Template Interpretation
 
@@ -48,50 +64,50 @@ If the automation says something like:
 ```text
 请先安装 npm i @agent-team-foundation/first-tree-hub
 然后使用 gh 命令阅读 docs/onboarding-guide.md，帮我添加成员。
-Server url 是 https://first-tree.staging.unispark.dev/
+Server URL 是 https://first-tree.staging.unispark.dev/
 ```
 
-interpret it as:
+Interpret it as:
 
-- Install or invoke the published CLI.
-- Fetch the guide with `gh` rather than relying on a browser-only read.
-- Use `https://first-tree.staging.unispark.dev/` as the Hub server URL in the onboarding commands.
-- Execute the supported `onboard` flow instead of manually calling APIs.
+- Install (or `npx`-invoke) the published CLI.
+- Fetch the onboarding guide with `gh` rather than relying on a browser.
+- If this machine has no `~/.first-tree-hub/credentials.json`, run `first-tree-hub client connect https://first-tree.staging.unispark.dev/` first.
+- Thread `https://first-tree.staging.unispark.dev/` through `--server` in every onboarding command.
+- Use the supported `onboard` flow instead of hand-rolling Admin API calls.
 
 ## Minimal Inputs to Collect
 
-- Required:
-  - member type: `human`, `personal_assistant`, or `autonomous_agent`
+- **Required**
+  - member `type`: `human`, `personal_assistant`, or `autonomous_agent`
   - `id`
   - `role`
   - `domains`
-  - `server` URL when it is not already configured
-- Optional:
-  - `display-name`
+  - `server` URL (unless already in `client.yaml` / env)
+- **Optional**
+  - `display-name` (defaults to `id`)
   - `profile` (agent self-description in markdown)
-  - `assistant` only for `human`
-  - Feishu bot credentials only when a bot binding should be created
+  - `assistant` (only valid when `type=human`)
+  - Feishu bot credentials (`--feishu-bot-app-id`, `--feishu-bot-app-secret`) when the bot should be bound
 
-Prefer `first-tree-hub onboard --check` to reveal missing fields instead of guessing.
+Always prefer `first-tree-hub onboard --check` to reveal missing fields instead of guessing.
 
 ## Type-Specific Notes
 
-- `human`
-  - May include `--assistant <id>` to create a personal assistant.
-  - If Feishu bot binding is configured, remind the human to send `/bind <id>` afterwards.
-- `autonomous_agent`
-  - Do not use `--assistant`.
-  - Feishu bot binding is optional.
-- `personal_assistant`
-  - Usually created through the human flow rather than as a separate top-level request.
+- **`human`**
+  - May include `--assistant <id>` to create a personal assistant in the same step.
+  - If a Feishu bot is bound, remind the human to send `/bind <id>` in Feishu after the command completes.
+- **`autonomous_agent`**
+  - Do **not** pass `--assistant`.
+  - Feishu bot binding is optional; no `/bind` follow-up.
+- **`personal_assistant`**
+  - Usually created via `--assistant` on a human onboard, not as a separate top-level request.
 
 ## Example Commands
 
 ### Human + assistant
 
 ```bash
-first-tree-hub onboard \
-  --check \
+first-tree-hub onboard --check \
   --server https://first-tree.staging.unispark.dev/ \
   --id alice \
   --type human \
@@ -113,8 +129,7 @@ first-tree-hub onboard \
 ### Autonomous agent
 
 ```bash
-first-tree-hub onboard \
-  --check \
+first-tree-hub onboard --check \
   --server https://first-tree.staging.unispark.dev/ \
   --id code-reviewer \
   --type autonomous_agent \
@@ -130,3 +145,10 @@ first-tree-hub onboard \
   --role "Code Review" \
   --domains "code-review"
 ```
+
+## Common Pitfalls
+
+- **"No credentials found" error** → run `first-tree-hub client connect <server-url>` before re-running `onboard`. Do not try to set an `AGENT_TOKEN` env var; that path no longer exists.
+- **`gh` not authenticated** → `gh auth login`. GitHub identity is what `onboard` uses to create the agent.
+- **Missing `--server`** → if the automation supplied a URL, thread it explicitly; do not rely on an unconfigured default. `onboard --check` will tell you when it's missing.
+- **Trying `onboard` twice with the same ID** → if the first run partially succeeded, `.onboard-state.json` has the previous args; re-running interactive mode picks up where it left off rather than starting over.

--- a/skills/first-tree-hub-cli/references/scenario-playbooks.md
+++ b/skills/first-tree-hub-cli/references/scenario-playbooks.md
@@ -1,27 +1,20 @@
 # First Tree Hub Scenario Playbooks
 
-Use this file when the user describes a goal in natural language and you need to translate it into the right First Tree Hub CLI sequence.
+Use this file when the user describes a goal in natural language and you need to translate it into a First Tree Hub CLI sequence.
 
-## 0. "I do not have first-tree-hub installed yet"
+## 0. "I do not have `first-tree-hub` installed yet"
 
-Use this before any operational flow when the machine may not have the CLI.
+Run this before any operational flow when the machine may not have the CLI.
 
-### Recommended flow
-
-1. Verify Node.js is supported:
+### Flow
 
 ```bash
-node --version
-```
-
-2. Install and verify the CLI:
-
-```bash
+node --version                                        # must be >= 22.16
 npm install -g @agent-team-foundation/first-tree-hub
 first-tree-hub --version
 ```
 
-3. If the user will use `onboard` or `agent token bootstrap`, make sure GitHub CLI is authenticated:
+For any task that creates agents via GitHub identity, also check:
 
 ```bash
 gh auth status
@@ -30,31 +23,24 @@ gh auth status
 ### What to remember
 
 - First Tree Hub requires Node.js `>= 22.16`.
-- Do not jump straight to `server start`, `client start`, or `onboard` on a machine where installation is still unknown.
+- Do not jump to `server start`, `client start`, `client connect`, or `onboard` on a machine where installation state is unknown.
+- If the user installed locally (`npm i`, not `npm i -g`), prefer `npx first-tree-hub ...` so they do not have to fight PATH.
 
-## 1. "Help me get First Tree Hub running locally"
+## 1. "Get First Tree Hub running locally"
 
-Use this when the user is setting up a local Hub for the first time.
+For a first-time local Hub.
 
-### Recommended flow
-
-1. If installation is unknown, do scenario 0 first.
-
-2. Start with:
+### Flow
 
 ```bash
-first-tree-hub server start
-```
-
-3. If the user wants a non-interactive setup, switch to:
-
-```bash
+first-tree-hub server start                     # interactive; provisions Docker Postgres + admin + web UI
+# or for CI / Docker:
 first-tree-hub server start --no-interactive
+# using an existing Postgres:
+first-tree-hub server start --database-url postgresql://user:pass@host:5432/db
 ```
 
-and make sure the required environment variables or config already exist.
-
-4. If startup fails, move to:
+If startup fails:
 
 ```bash
 first-tree-hub server doctor
@@ -63,224 +49,248 @@ first-tree-hub status
 
 ### What to remember
 
-- `server start` is the happy-path bootstrap command.
-- It can provision Docker PostgreSQL, run migrations, create the first admin, and serve the web UI.
-- If the user already has PostgreSQL, prefer `--database-url` instead of forcing Docker.
-- If the CLI is not installed yet, installation is part of the correct flow rather than a side detail.
+- `server start` is the happy-path bootstrap. It can run migrations, seed the first admin, and build/serve the web dist.
+- Prefer `--database-url` over forcing Docker when the user already has a Postgres.
+- First-run prints a generated admin password — capture it; it is shown only once.
 
-## 2. "Connect my local agent machine to an existing Hub"
+## 2. "Connect this computer to an existing Hub server"
 
-Use this when the Hub server already exists and the user wants a local client runtime.
+Use this when the Hub is already up and the user wants this machine to run agents against it.
 
-### Recommended flow
-
-1. Ensure client config points at the server:
+### Flow
 
 ```bash
-first-tree-hub config setup -c
+# Interactive login (prompts for username/password):
+first-tree-hub client connect https://hub.example.com
+
+# Or with a one-time connect token from the web "Connect a machine" dialog:
+first-tree-hub client connect https://hub.example.com --token <connect-token>
+
+# Skip the background service install (useful in containers):
+first-tree-hub client connect https://hub.example.com --no-service
 ```
 
-or:
+After `connect` succeeds, the machine is signed in and (by default on macOS/Linux) running as a background service.
+
+To verify:
 
 ```bash
-first-tree-hub config set -c server.url http://host:8000
+first-tree-hub client status          # local: configured agents
+first-tree-hub client doctor          # readiness checks
+first-tree-hub client service status  # service state (if installed)
+first-tree-hub client hub-list        # server-side: this client appears in the Hub
 ```
 
-2. Add the local agent config:
+If something breaks, `client doctor` usually points at the culprit (no credentials, wrong server URL, WebSocket blocked, etc.).
+
+### What to remember
+
+- `client connect` is the **only** supported way to sign in. There is no separate `login`, `token`, or manual credential setup.
+- It writes `~/.first-tree-hub/credentials.json` and a generated `client.id` in `client.yaml`.
+- Agents are not registered by this command. Admins pin agents to this machine's `client.id` from the Hub UI (or via `agent create --client-id ...`). A running client auto-picks them up.
+
+## 3. "Keep this machine online across reboots"
+
+Use this for a production desktop or a server that should run agents permanently.
+
+### Flow
 
 ```bash
-first-tree-hub agent add <name> --token <token>
+first-tree-hub client service install      # launchd (macOS) or systemd --user (Linux)
+first-tree-hub client service status
+first-tree-hub client service uninstall    # when decommissioning the machine
 ```
 
-3. Start the runtime:
+`client connect` installs the service by default. Only re-run `service install` when the user ran `connect --no-service` initially, or when re-installing after `uninstall`.
+
+Logs: `~/.first-tree-hub/logs/`.
+
+### What to remember
+
+- Windows is unsupported. Tell the user to use `first-tree-hub client start` inside a user-managed supervisor instead.
+- The service runs `client start --no-interactive`, so the machine must already have valid `credentials.json` — run `client connect` first.
+- `service install` is safe to re-run. It rewrites the unit file and reloads the supervisor.
+
+## 4. "Onboard a new human member"
+
+Add a real person to the team through the supported identity flow.
+
+### Flow
 
 ```bash
-first-tree-hub client start
+# 0. Prereq on this machine: CLI installed, logged in.
+first-tree-hub client connect <server-url>             # if credentials.json does not exist
+
+# 1. Dry-run to surface missing fields:
+first-tree-hub onboard --check \
+  --server <url> --id alice --type human \
+  --role "Engineer" --domains "backend,infrastructure"
+
+# 2. Create the member (and optionally a personal assistant):
+first-tree-hub onboard \
+  --server <url> --id alice --type human \
+  --role "Engineer" --domains "backend,infrastructure" \
+  --assistant alice-assistant
 ```
 
-4. If something looks wrong, inspect:
+If the machine should also run this human's personal assistant, run `client start` (or rely on the already-installed background service).
+
+### What to remember
+
+- `onboard` creates the agent via Admin API and wires up the local alias + optional Feishu bot in one step.
+- It **does not** log you in. If `credentials.json` is missing, it exits with a pointer to `client connect`.
+- Pass the server URL explicitly (`--server`) whenever the user / automation supplied one — do not silently fall back to defaults.
+- Humans with a Feishu bot configured still need to send `/bind <id>` in Feishu afterwards to attach the human user to the assistant.
+
+## 5. "Onboard a standalone autonomous agent"
+
+A bot with no human owner (code reviewer, monitor, pipeline agent).
+
+### Flow
 
 ```bash
-first-tree-hub client doctor
-first-tree-hub client status
+first-tree-hub onboard --check \
+  --server <url> --id code-reviewer --type autonomous_agent \
+  --role "Code Review" --domains "code-review"
+
+first-tree-hub onboard \
+  --server <url> --id code-reviewer --type autonomous_agent \
+  --role "Code Review" --domains "code-review"
 ```
 
 ### What to remember
 
-- `agent add` is local-only configuration.
-- `client start` runs all locally configured agents, not just one.
+- Do **not** pass `--assistant` for `autonomous_agent`.
+- Feishu bot binding is optional here (no `/bind` follow-up needed).
+- Thread through `--server <url>` whenever supplied.
 
-## 3. "Onboard a new human member"
+## 6. "Change an agent's model / prompt / MCP / env / repos"
 
-Use this when the user wants to add a real person to the team through the supported identity flow.
+Use this whenever the user wants the live agent to behave differently — *not* when they want to edit their local alias file.
 
-### Recommended flow
-
-1. If the task starts from an external agent prompt instead of a repo checkout:
-   - Install the CLI if needed.
-   - Read `references/onboarding-operator.md`.
-   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
-
-2. Dry-run requirements first:
+### Flow
 
 ```bash
-first-tree-hub onboard --check --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
-```
-
-3. Create the agent:
-
-```bash
-first-tree-hub onboard --server <url> --id <id> --type human --role "<role>" --domains "<d1,d2>"
-```
-
-4. Start the local runtime if this machine should run the assistant:
-
-```bash
-first-tree-hub client start
+first-tree-hub agent config get alice                                      # read current config
+first-tree-hub agent config set-model alice claude-opus-4-7                # swap model
+cat ./house-prompt.md | first-tree-hub agent config append-prompt alice    # replace prompt append
+first-tree-hub agent config add-mcp alice --name gh --transport stdio --command gh --args mcp
+first-tree-hub agent config set-env alice OPENAI_API_KEY=sk-... --sensitive
+first-tree-hub agent config add-repo alice https://github.com/acme/monorepo --ref main
+first-tree-hub agent config dry-run alice -f ./patch.json                  # preview + validate
 ```
 
 ### What to remember
 
-- `onboard` creates the agent via Admin API and bootstraps the token in one step.
-- Admin credentials are required (`FIRST_TREE_HUB_ADMIN_TOKEN` or `FIRST_TREE_HUB_ADMIN_USERNAME` + `FIRST_TREE_HUB_ADMIN_PASSWORD`).
-- For humans, a personal assistant is optional and may be created with `--assistant <id>`.
-- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
-- If a Feishu bot is configured for the assistant path, the human usually still needs to send `/bind <id>` in Feishu afterwards.
+- This surface mutates server-side runtime config via `/api/v1/admin/agents/:id/config` and affects the running agent everywhere.
+- Requests carry an `expectedVersion` — concurrent edits get a conflict, not silent overwrite. On conflict, re-fetch with `agent config get` and retry.
+- `--sensitive` env values are encrypted at rest and always masked in subsequent `get`/`list`.
+- `dry-run` is the safe way to preview a big patch before committing it.
+- Do not confuse this with `first-tree-hub config -a <name> set ...`, which edits the local `agent.yaml` (alias → UUID mapping), not server state.
 
-## 4. "Onboard a standalone autonomous agent"
+## 7. "Why can't the client connect?" / "Why does startup fail?"
 
-Use this when the new member is a bot with no human owner.
+Diagnose before editing code or YAML.
 
-### Recommended flow
-
-1. If the task starts from an external agent prompt instead of a repo checkout:
-   - Install the CLI if needed.
-   - Read `references/onboarding-operator.md`.
-   - Fetch `docs/onboarding-guide.md` with `gh` if you need the canonical public doc text.
-
-2. Check:
+### Flow
 
 ```bash
-first-tree-hub onboard --check --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
-```
-
-3. Create the agent:
-
-```bash
-first-tree-hub onboard --server <url> --id <id> --type autonomous_agent --role "<role>" --domains "<d1,d2>"
-```
-
-4. Start:
-
-```bash
-first-tree-hub client start
+first-tree-hub status                 # overall state: server, db, client, agents
+first-tree-hub client doctor          # or `server doctor` for the server side
+first-tree-hub client service status  # if running as a service
+first-tree-hub config list -c         # effective client YAML
+first-tree-hub config list -s         # effective server YAML
+first-tree-hub server status          # health-probe an already-running server
 ```
 
 ### What to remember
 
-- Do not use `--assistant` for `autonomous_agent`.
-- When a server URL is provided in the user prompt or automation payload, thread it through the onboarding commands instead of assuming local defaults.
-- Feishu bot binding is optional here, unlike the human `/bind` flow.
+- If `client doctor` flags "no credentials", the fix is `client connect`, not a YAML edit.
+- If `hub-list` shows the client but `client status` shows 0 agents, no agent is pinned to this machine — create one with `agent create --client-id <this-client-id>` or bind an existing agent with `agent bind client <name> --client-id <id>`.
+- Server and client issues look similar from a distance. Make the user goal explicit before debugging.
 
-## 5. "Why can't the client connect?" or "Why does startup fail?"
+## 8. "Debug messaging between agents"
 
-Use this for diagnosis before editing code.
+Verify delivery, inspect chats, send test messages manually.
 
-### Recommended flow
-
-1. Check top-level state:
+### Flow
 
 ```bash
-first-tree-hub status
-```
+# Prereq: this machine must have credentials.json (client connect).
 
-2. Run the relevant doctor:
+first-tree-hub agent send <agentId> "hello"                    # send to an agent
+first-tree-hub agent send <chatId> "hello" --chat              # send to an existing chat
+echo "piped" | first-tree-hub agent send <agentId>             # stdin
+first-tree-hub agent send <agentId> "hi" --metadata '{"priority":"high"}'
+first-tree-hub agent send <agentId> "follow-up" --reply-to-inbox <inboxId> --reply-to-chat <chatId>
 
-```bash
-first-tree-hub client doctor
-```
-
-or:
-
-```bash
-first-tree-hub server doctor
-```
-
-3. Inspect effective config:
-
-```bash
-first-tree-hub config list -c
-first-tree-hub config list -s
-```
-
-4. If the server should already be running, probe health directly:
-
-```bash
-first-tree-hub server status
-```
-
-### What to remember
-
-- Prefer diagnosis commands before changing YAML files by hand.
-- Server issues and client issues often look similar; make the user goal explicit before debugging.
-
-## 6. "Help me debug messaging between agents"
-
-Use this when the user wants to verify delivery, inspect chats, or send test messages manually.
-
-### Recommended flow
-
-1. Make sure agent debug auth is available (either set the token directly or point at a stored agent):
-
-```bash
-export FIRST_TREE_HUB_AGENT_TOKEN=...
-# Or, if the agent has a local config:
-export FIRST_TREE_HUB_AGENT=<agentName>
-```
-
-2. Send a message:
-
-```bash
-first-tree-hub agent send <agentId> "hello"
-```
-
-or to an existing chat:
-
-```bash
-first-tree-hub agent send <chatId> "hello" --chat
-```
-
-3. Inspect chats and history:
-
-```bash
 first-tree-hub agent chats
 first-tree-hub agent history <chatId>
+first-tree-hub agent pull --ack                                # low-level inbox polling
+first-tree-hub agent chat <agent-name>                         # interactive REPL
 ```
 
-4. Fall back to low-level inbox polling if needed:
+### What to remember
+
+- These are debugging / operator commands. For production, agents run under `client start` (or the service) and receive messages via WebSocket.
+- Use `--agent <name>` when multiple agent aliases are configured; with a single alias the flag is optional.
+
+## 9. "Inspect or recover session state"
+
+Use these when a user reports a stuck or misbehaving session.
+
+### Flow
 
 ```bash
-first-tree-hub agent pull
+first-tree-hub agent status                     # fleet-wide snapshot (runtime states, session counts)
+first-tree-hub agent status <name>              # single-agent detail
+first-tree-hub agent sessions <name>            # list sessions for one agent
+first-tree-hub agent sessions <name> --state suspended
+
+first-tree-hub agent session suspend <name> <chat-id>
+first-tree-hub agent session resume <name> <chat-id>
+first-tree-hub agent session terminate <name> <chat-id>
+
+first-tree-hub agent reset <name>               # move an error-state agent back to idle
+first-tree-hub agent workspace clean            # remove stale chat workspaces safely
 ```
 
 ### What to remember
 
-- These commands are for debugging and operator visibility, not the normal runtime path.
-- If a user only wants to run their agents normally, `client start` is the main flow.
+- `workspace clean` consults the session registry — it will not remove a chat that still has an active (non-evicted) session. Safe to run on a live machine.
+- `reset` only clears the error flag; it does not restart the agent.
 
-## 7. "Change how the CLI behaves"
+## 10. "Deploy First Tree Hub somewhere real"
 
-Use this when the user wants a code change rather than an operational action.
+Use this when the task goes beyond a local demo.
 
-### Recommended flow
+### Flow
 
-1. Find the matching command handler in `packages/command/src/commands/`.
-2. Move behavior into `packages/command/src/core/` if the logic is reusable.
-3. Update the corresponding docs in `docs/cli-reference.md` or `docs/onboarding-guide.md`.
-4. Validate with the smallest relevant command/package test set.
+1. Read `docs/deployment-guide.md` before proposing anything — it covers Docker, Railway, Render, Supabase, HTTPS, and multi-machine topology.
+2. Provision the backing Postgres externally and pass `--database-url` to `server start`; do not rely on the CLI's Docker-managed Postgres in production.
+3. Set secrets via env vars (`FIRST_TREE_HUB_JWT_SECRET`, `FIRST_TREE_HUB_ENCRYPTION_KEY`, `FIRST_TREE_HUB_GITHUB_TOKEN`, etc.) so they are not auto-generated on restart.
+4. On each client machine, run `client connect` once to sign in, then `client service install` so the runtime survives reboots.
 
 ### What to remember
 
-- Command handlers should stay thin.
-- Config changes usually require updates in `packages/shared/src/config/`.
-- Onboarding changes often touch both `commands/onboard.ts` and `core/onboard.ts`.
+- Production auto-generated secrets (JWT, encryption key) should be pinned in env so that restarts do not invalidate issued tokens or make encrypted adapter credentials unreadable.
+- `server stop` only stops the CLI-managed Docker Postgres container — it is not a generic "stop the running server" command.
+
+## 11. "Change how the CLI behaves" (code change)
+
+Use this when the task is a code change, not an operation.
+
+### Flow
+
+1. Find the matching command handler under `packages/command/src/commands/`.
+2. Move reusable logic into `packages/command/src/core/`.
+3. If flags / env vars / schema change, update `packages/shared/src/config/*.ts`.
+4. Register new top-level commands from `packages/command/src/cli/index.ts`.
+5. Update `docs/cli-reference.md` (and `docs/onboarding-guide.md` if onboarding flow changes).
+6. Run the smallest relevant validation first: `pnpm check`, `pnpm typecheck`, `pnpm --filter @agent-team-foundation/first-tree-hub test`.
+
+### What to remember
+
+- Command handlers stay thin; core modules carry the logic.
+- Onboarding changes usually touch both `commands/onboard.ts` (argument shape) and `core/onboard.ts` (actual behavior).
+- See `references/developer-map.md` for the full source layout.


### PR DESCRIPTION
## Summary

- Rewrites the bundled `first-tree-hub-cli` skill so its SKILL.md and all five references align with the current `packages/command` CLI surface.
- Removes stale content: the legacy `FIRST_TREE_HUB_AGENT_TOKEN` / `FIRST_TREE_HUB_AGENT` env vars and `agent token bootstrap` command, all gone from code.
- Adds coverage for the missing surface that the skill did not know about: `client connect`, `client service install/status/uninstall`, `client hub-list/hub-disconnect`, the full `agent config` family, `agent create/claim`, `agent status/reset/sessions/session/chat`, and `agent bind client`.
- Explains the single-member-JWT credential model (`credentials.json` + auto-refresh) and teaches the three-command first-time setup.

## Why

The skill was last written against an older auth model where each agent carried a static bearer token and the onboarding ritual was `agent token bootstrap` + `export FIRST_TREE_HUB_AGENT_TOKEN`. That surface no longer exists in the code. Agents reading the skill were therefore recommending commands users cannot run, and were completely missing the background-service, session-diagnostic, and runtime-config surfaces.

## Evidence

Benchmarked the rewritten skill against the prior skill (baseline = `origin/main` at the time of writing) on three representative prompts in `evals/evals.json`:

| | New skill | Prior skill | Delta |
|---|---|---|---|
| Pass rate | 100% (17/17) | 23.3% (4/17) | +76.7pp |
| Time | 51.9s ± 2.2 | 57.7s ± 7.6 | −5.8s |
| Tokens | 37,622 ± 847 | 39,154 ± 2,075 | −1,532 |

Per-eval:
- **new-machine setup**: 6/6 vs 3/6 — prior skill still teaches removed env var and removed bootstrap command.
- **agent config change (model + MCP)**: 5/5 vs 1/5 — prior skill invents `config set -a alice model ...` keys that don't exist; new skill uses the real `agent config set-model` / `add-mcp`.
- **stuck session recovery**: 6/6 vs 0/6 — prior skill has zero coverage of `agent status/sessions/session/reset`; new skill walks the full recovery flow.

## Test plan

- [x] `pnpm validate:skill` — `Skill is valid!`, `Skill symlinks are correct.`
- [x] `python3 skills/first-tree-hub-cli/scripts/quick_validate.py` — passes
- [x] SKILL.md under 200 lines (186); references each under 300 lines
- [x] `.claude/skills/first-tree-hub-cli` and `.agents/skills/first-tree-hub-cli` symlinks unchanged
- [x] Spot-checked every command named in the rewrite against `packages/command/src/commands/*.ts`

No code changes — docs-only.