### PR TITLE
Revert "docs: disambiguate breeze naming in agents guide" (#118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,22 +12,6 @@ First Tree Hub ≠ Orchestration framework
 First Tree Hub ≠ Context Tree
 ```
 
-## Breeze Naming
-
-In this repo, **Breeze** means the Hub-hosted GitHub delivery surface inside
-`first-tree-hub`, not the local `first-tree breeze` daemon shipped by the
-`first-tree` npm package.
-
-- Hub-hosted Breeze: lives here; built on top of Hub messaging,
-  notifications, and Gardener review logic.
-- Local CLI Breeze: lives in the `first-tree` repo; owns `first-tree breeze`,
-  launchd wiring, `~/.breeze/`, local GitHub notification polling, and local
-  agent workspaces.
-
-If a task is about `first-tree breeze`, launchd, `~/.breeze/`, local daemon
-lifecycle, or Codex/Claude runner behavior, switch to the `first-tree` repo
-and the shared Context Tree nodes before editing Hub code here.
-
 ## Tech Stack
 
 **Server:** Fastify / Drizzle ORM / PostgreSQL / Zod / bcrypt / jose / @fastify/websocket / @fastify/rate-limit


### PR DESCRIPTION
## Summary
- Reverts #118. The Hub-hosted Breeze surface doesn't exist in this repo yet — the only mention of "Breeze" here is the disambiguation block itself, which makes it self-referential with nothing to point agents at.
- Context Tree (`agent-hub/breeze.md`) already records the 2026-04-16 decision that Breeze will live in Hub; we can re-add the AGENTS.md pointer when real Hub-side Breeze code lands and can be referenced concretely.

## Test plan
- [x] Docs-only revert; no code paths touched