### PR TITLE
docs(agents): align auth text with unified user-token model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ pnpm --filter @first-tree-hub/server db:studio      # Drizzle Studio
 
 ## Local Testing Isolation
 
-When exercising the CLI against a live hub on the same machine, always relocate the client home so tests do not clobber the production client's config, agent tokens, workspaces, or cloned Context Tree:
+When exercising the CLI against a live hub on the same machine, always relocate the client home so tests do not clobber the production client's saved JWT credentials (`credentials.json`), client/agent config, workspaces, or cloned Context Tree:
 
 ```bash
 export FIRST_TREE_HUB_HOME=/Users/<you>/.first-tree-hub-test
@@ -111,10 +111,7 @@ first-tree-hub/
 
 **PostgreSQL only:** No Redis / MQ. PG covers storage, queuing (SKIP LOCKED), and notifications (LISTEN/NOTIFY).
 
-**Dual-track auth isolation:**
-- Agent Token (Bearer) → Agent API — machine credentials
-- Admin JWT → Admin API — human credentials
-- Two auth paths are **completely isolated**; localhost must authenticate too
+**Unified user-JWT auth:** A single member JWT — issued by `first-tree-hub client connect` and stored at `~/.first-tree-hub/config/credentials.json` — authorizes both the Web/Admin API and every agent the signed-in user manages on the Client WebSocket. Per-agent `aghub_*` tokens and the `agent_tokens` table were retired by migration [`0020_unified_user_token`](packages/server/drizzle/0020_unified_user_token.sql) ([#95](https://github.com/agent-team-foundation/first-tree-hub/pull/95)); agents now bind via `agents.client_id` plus a server-pushed `agent:pinned` frame on the first-bind path (auto-pin, [#108](https://github.com/agent-team-foundation/first-tree-hub/pull/108)), and scope is enforced by Rule **R-RUN** in `packages/server/src/services/agent.ts`. No default passwords; localhost must authenticate too.
 
 **Inbox is the Server/Client boundary:** Server writes to Inbox (fan-out on write), Client pulls / receives WebSocket notifications. At-least-once delivery; Client is responsible for deduplication.
 


### PR DESCRIPTION
## Summary

The **Architecture Rules** section of `AGENTS.md` (mirrored to `CLAUDE.md` via symlink) still described a two-track auth model — `Agent Token (Bearer)` for the Agent API and `Admin JWT` for the Admin API, "completely isolated". That text predates the **unified user-token milestone**: migration [`packages/server/drizzle/0020_unified_user_token.sql`](packages/server/drizzle/0020_unified_user_token.sql) (landed in #95) dropped the `agent_tokens` table, retired the per-agent `aghub_*` bearer, and collapsed auth onto a single member JWT issued by `first-tree-hub client connect`. Agents now bind via `agents.client_id` + the server-pushed `agent:pinned` frame (auto-pin, #108), with scope enforced by Rule **R-RUN** in `packages/server/src/services/agent.ts`.

This PR rewrites the stale bullet to match the current reality and the Context Tree's "Unified user-JWT auth" principle in `first-tree-context/agent-hub/NODE.md` + `agent-hub/claim-agent.md`.

## Changes

- **Architecture Rules** — Replace `**Dual-track auth isolation**` (Agent Token / Admin JWT split) with `**Unified user-JWT auth**`. Names the single member-JWT credential, its on-disk location (`~/.first-tree-hub/config/credentials.json`), how the WebSocket authorizes every managed agent, and links the migration + relevant PRs (#95, #108). Keeps the "no default passwords; localhost must authenticate" point.
- **Local Testing Isolation** — The intro sentence listed "agent tokens" among the things that `FIRST_TREE_HUB_HOME` relocation protects. That label no longer exists on disk; replaced with "saved JWT credentials (`credentials.json`), client/agent config".

Docs-only, one file changed (AGENTS.md; CLAUDE.md is a symlink to it).

## Test plan

- [x] `pnpm check` — clean on the docs change (Biome ignores `.md`; the only repo-wide findings are pre-existing warnings in TS sources, unrelated to this PR).
- [x] `pnpm typecheck` — green across all packages when scoped to this branch.
- [x] Cross-checked wording against `first-tree-context/agent-hub/NODE.md` "Unified user-JWT auth" principle and `agent-hub/claim-agent.md` so the hub and tree agree.
- [ ] CODEOWNER review (not admin-merged — this is a shared repo).