### PR TITLE
feat(workspace): install first-tree skill + SOURCE-INTEGRATION block on bootstrap

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -23,6 +23,12 @@ RUN pnpm install --frozen-lockfile --prod
 FROM node:24-alpine
 WORKDIR /app
 
+# git is required by syncContextTree (clone/pull) and `first-tree tree integrate`
+# (reading the tree checkout's remote URL). Pre-installing first-tree avoids a
+# per-session `npx` cold-start when bootstrapping workspaces.
+RUN apk add --no-cache git \
+    && npm install -g first-tree@latest
+
 # Production node_modules
 COPY --from=prod-deps /app ./
 

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -1,7 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { bootstrapWorkspace } from "../runtime/bootstrap.js";
+import {
+  bootstrapWorkspace,
+  installFirstTreeIntegration,
+  type InstallFirstTreeIntegrationExec,
+} from "../runtime/bootstrap.js";
 import type { AgentIdentity } from "../runtime/handler.js";
 
 // Use a real temp directory for file-based tests
@@ -202,5 +206,142 @@ describe("bootstrapWorkspace", () => {
 
     const data = JSON.parse(readFileSync(join(workspace, ".agent", "identity.json"), "utf-8"));
     expect(data.agentId).toBe("new-agent");
+  });
+});
+
+type ExecCall = {
+  command: string;
+  args: string[];
+  options: { cwd: string; timeout: number };
+};
+
+function makeRecordingExec(
+  impl: (call: ExecCall) => void = () => {},
+): { exec: InstallFirstTreeIntegrationExec; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const exec: InstallFirstTreeIntegrationExec = (command, args, options) => {
+    const call: ExecCall = { command, args, options };
+    calls.push(call);
+    impl(call);
+  };
+  return { exec, calls };
+}
+
+describe("installFirstTreeIntegration", () => {
+  it("shells out to `first-tree tree integrate` with the expected arguments", () => {
+    const workspace = join(tmpBase, "integrate-happy");
+    const treePath = join(tmpBase, "ctx-tree");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(treePath, { recursive: true });
+
+    const { exec, calls } = makeRecordingExec();
+    const logs: string[] = [];
+
+    const result = installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath: treePath,
+      workspaceId: "chat-xyz",
+      treeRepoUrl: "https://github.com/org/tree",
+      log: (m) => logs.push(m),
+      exec,
+    });
+
+    expect(result).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("first-tree");
+    expect(calls[0]?.args).toEqual([
+      "tree",
+      "integrate",
+      "--source-path",
+      workspace,
+      "--tree-path",
+      treePath,
+      "--mode",
+      "workspace-root",
+      "--workspace-id",
+      "chat-xyz",
+      "--tree-url",
+      "https://github.com/org/tree",
+    ]);
+    expect(calls[0]?.options.cwd).toBe(workspace);
+    expect(logs.join("\n")).toContain("first-tree (PATH)");
+  });
+
+  it("falls back to `npx first-tree@latest` when the binary is missing from PATH", () => {
+    const workspace = join(tmpBase, "integrate-fallback");
+    const treePath = join(tmpBase, "ctx-fb");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(treePath, { recursive: true });
+
+    let call = 0;
+    const { exec, calls } = makeRecordingExec(() => {
+      call += 1;
+      if (call === 1) {
+        const err = new Error("spawn first-tree ENOENT") as Error & { code?: string };
+        err.code = "ENOENT";
+        throw err;
+      }
+    });
+
+    const logs: string[] = [];
+    const result = installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath: treePath,
+      workspaceId: "chat-fb",
+      log: (m) => logs.push(m),
+      exec,
+    });
+
+    expect(result).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.command).toBe("npx");
+    expect(calls[1]?.args.slice(0, 3)).toEqual([
+      "-y",
+      "first-tree@latest",
+      "tree",
+    ]);
+    expect(logs.join("\n")).toContain("npx first-tree@latest");
+  });
+
+  it("returns false and logs without throwing when both attempts fail", () => {
+    const workspace = join(tmpBase, "integrate-fail");
+    const treePath = join(tmpBase, "ctx-fail");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(treePath, { recursive: true });
+
+    const { exec } = makeRecordingExec(() => {
+      throw new Error("spawn npx ENOENT");
+    });
+
+    const logs: string[] = [];
+    const result = installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath: treePath,
+      workspaceId: "chat-fail",
+      log: (m) => logs.push(m),
+      exec,
+    });
+
+    expect(result).toBe(false);
+    expect(logs.join("\n")).toContain("First-tree integration skipped");
+  });
+
+  it("omits --tree-url when no URL is provided", () => {
+    const workspace = join(tmpBase, "integrate-no-url");
+    const treePath = join(tmpBase, "ctx-no-url");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(treePath, { recursive: true });
+
+    const { exec, calls } = makeRecordingExec();
+
+    installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath: treePath,
+      workspaceId: "chat-no-url",
+      log: () => {},
+      exec,
+    });
+
+    expect(calls[0]?.args).not.toContain("--tree-url");
   });
 });

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -3,8 +3,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bootstrapWorkspace,
-  installFirstTreeIntegration,
   type InstallFirstTreeIntegrationExec,
+  installFirstTreeIntegration,
 } from "../runtime/bootstrap.js";
 import type { AgentIdentity } from "../runtime/handler.js";
 
@@ -215,9 +215,10 @@ type ExecCall = {
   options: { cwd: string; timeout: number };
 };
 
-function makeRecordingExec(
-  impl: (call: ExecCall) => void = () => {},
-): { exec: InstallFirstTreeIntegrationExec; calls: ExecCall[] } {
+function makeRecordingExec(impl: (call: ExecCall) => void = () => {}): {
+  exec: InstallFirstTreeIntegrationExec;
+  calls: ExecCall[];
+} {
   const calls: ExecCall[] = [];
   const exec: InstallFirstTreeIntegrationExec = (command, args, options) => {
     const call: ExecCall = { command, args, options };
@@ -295,11 +296,7 @@ describe("installFirstTreeIntegration", () => {
     expect(result).toBe(true);
     expect(calls).toHaveLength(2);
     expect(calls[1]?.command).toBe("npx");
-    expect(calls[1]?.args.slice(0, 3)).toEqual([
-      "-y",
-      "first-tree@latest",
-      "tree",
-    ]);
+    expect(calls[1]?.args.slice(0, 3)).toEqual(["-y", "first-tree@latest", "tree"]);
     expect(logs.join("\n")).toContain("npx first-tree@latest");
   });
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -6,7 +6,7 @@ import { deriveRepoLocalPath } from "@agent-team-foundation/first-tree-hub-share
 import type { McpServerConfig, PermissionMode, Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import { bootstrapWorkspace } from "../runtime/bootstrap.js";
+import { bootstrapWorkspace, installFirstTreeIntegration } from "../runtime/bootstrap.js";
 import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type {
   AgentHandler,
@@ -544,6 +544,18 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       chatId: sessionCtx.chatId,
     });
     generateClaudeMd(workspace, sessionCtx.agent, contextTreePath);
+
+    // Install the first-tree skill + FIRST-TREE-SOURCE-INTEGRATION block into
+    // the workspace by shelling out to `first-tree tree integrate`. Best-effort:
+    // integrate failures do not abort session start.
+    if (contextTreePath) {
+      installFirstTreeIntegration({
+        workspacePath: workspace,
+        contextTreePath,
+        workspaceId: sessionCtx.chatId,
+        log: (msg) => sessionCtx.log(msg),
+      });
+    }
   }
 
   const handler: AgentHandler = {

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -195,11 +195,7 @@ export type InstallFirstTreeIntegrationOptions = {
   exec?: InstallFirstTreeIntegrationExec;
 };
 
-function defaultInstallExec(
-  command: string,
-  args: string[],
-  options: { cwd: string; timeout: number },
-): void {
+function defaultInstallExec(command: string, args: string[], options: { cwd: string; timeout: number }): void {
   execFileSync(command, args, {
     cwd: options.cwd,
     stdio: "pipe",
@@ -219,11 +215,8 @@ function defaultInstallExec(
  * Graceful degradation: returns false on failure and logs. The session still
  * starts; the agent just doesn't have the first-tree skill wired up.
  */
-export function installFirstTreeIntegration(
-  options: InstallFirstTreeIntegrationOptions,
-): boolean {
-  const { workspacePath, contextTreePath, workspaceId, treeRepoUrl, log } =
-    options;
+export function installFirstTreeIntegration(options: InstallFirstTreeIntegrationOptions): boolean {
+  const { workspacePath, contextTreePath, workspaceId, treeRepoUrl, log } = options;
   const exec = options.exec ?? defaultInstallExec;
 
   const integrateArgs = [
@@ -267,9 +260,7 @@ export function installFirstTreeIntegration(
         // Try the next attempt (e.g. `first-tree` not on PATH → try npx).
         continue;
       }
-      log(
-        `First-tree integration skipped (${attempt.label}): ${msg.slice(0, 200)}`,
-      );
+      log(`First-tree integration skipped (${attempt.label}): ${msg.slice(0, 200)}`);
       return false;
     }
   }

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -176,6 +176,107 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
   writeFileSync(join(agentDir, "tools.md"), generateToolsDoc(), "utf-8");
 }
 
+export type InstallFirstTreeIntegrationExec = (
+  command: string,
+  args: string[],
+  options: { cwd: string; timeout: number },
+) => void;
+
+export type InstallFirstTreeIntegrationOptions = {
+  workspacePath: string;
+  contextTreePath: string;
+  workspaceId: string;
+  treeRepoUrl?: string;
+  log: (msg: string) => void;
+  /**
+   * Exec backend. Defaults to `execFileSync`. Override in tests to avoid
+   * ESM-module spying limitations.
+   */
+  exec?: InstallFirstTreeIntegrationExec;
+};
+
+function defaultInstallExec(
+  command: string,
+  args: string[],
+  options: { cwd: string; timeout: number },
+): void {
+  execFileSync(command, args, {
+    cwd: options.cwd,
+    stdio: "pipe",
+    timeout: options.timeout,
+    encoding: "utf-8",
+  });
+}
+
+/**
+ * Install the first-tree skill and FIRST-TREE-SOURCE-INTEGRATION block into
+ * the workspace by shelling out to `first-tree tree integrate`.
+ *
+ * Resolution order for the CLI binary:
+ *   1. `first-tree` on PATH — preferred for runtime images that pre-install it.
+ *   2. `npx -y first-tree@latest` — fallback that downloads on first run.
+ *
+ * Graceful degradation: returns false on failure and logs. The session still
+ * starts; the agent just doesn't have the first-tree skill wired up.
+ */
+export function installFirstTreeIntegration(
+  options: InstallFirstTreeIntegrationOptions,
+): boolean {
+  const { workspacePath, contextTreePath, workspaceId, treeRepoUrl, log } =
+    options;
+  const exec = options.exec ?? defaultInstallExec;
+
+  const integrateArgs = [
+    "tree",
+    "integrate",
+    "--source-path",
+    workspacePath,
+    "--tree-path",
+    contextTreePath,
+    "--mode",
+    "workspace-root",
+    "--workspace-id",
+    workspaceId,
+    ...(treeRepoUrl ? ["--tree-url", treeRepoUrl] : []),
+  ];
+
+  const attempts: Array<{ command: string; args: string[]; label: string }> = [
+    { command: "first-tree", args: integrateArgs, label: "first-tree (PATH)" },
+    {
+      command: "npx",
+      args: ["-y", "first-tree@latest", ...integrateArgs],
+      label: "npx first-tree@latest",
+    },
+  ];
+
+  for (let index = 0; index < attempts.length; index += 1) {
+    const attempt = attempts[index];
+    if (!attempt) continue;
+    try {
+      exec(attempt.command, attempt.args, {
+        cwd: workspacePath,
+        timeout: 120_000,
+      });
+      log(`First-tree integration installed via ${attempt.label}`);
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const binaryMissing = /ENOENT|not found|command not found/i.test(msg);
+      const isLastAttempt = index === attempts.length - 1;
+      if (binaryMissing && !isLastAttempt) {
+        // Try the next attempt (e.g. `first-tree` not on PATH → try npx).
+        continue;
+      }
+      log(
+        `First-tree integration skipped (${attempt.label}): ${msg.slice(0, 200)}`,
+      );
+      return false;
+    }
+  }
+
+  return false;
+}
+
 function generateToolsDoc(): string {
   return `# Agent Hub SDK
 


### PR DESCRIPTION
## Summary

- Each session workspace now shells out to `first-tree tree integrate` right after `bootstrapWorkspace()` to install the first-tree skill, upsert the FIRST-TREE-SOURCE-INTEGRATION block into `CLAUDE.md` / `AGENTS.md`, and write `.first-tree/source.json` (workspace-root binding).
- Added `apk add git` + `npm install -g first-tree@latest` to `Dockerfile.client` so the CLI is hot in production and per-session bootstraps skip npx cold-starts.

## Motivation

Previously Hub produced a hand-crafted `CLAUDE.md` with inline copies of `AGENT.md` / `NODE.md` from the shared Context Tree — effectively a lookalike of first-tree's binding system. Switching to the real binding block (via the new [`first-tree tree integrate` command](https://github.com/agent-team-foundation/first-tree/pull/234)) lets agents launched by Hub:

- Discover and invoke the first-tree skill (`.claude/skills/first-tree/`)
- Follow the standard **Before every task / After every task** workflow the Context Tree methodology expects
- Reference `.first-tree/source.json` as the source of truth for tree binding metadata

## Implementation notes

- **CLI resolution**: `installFirstTreeIntegration` tries `first-tree` on PATH first (for runtime images that pre-install it), then `npx -y first-tree@latest` as a fallback.
- **Graceful degradation**: integrate failures are logged but never block session start. The workspace just doesn't get the skill wired up.
- **Testability**: `InstallFirstTreeIntegrationExec` is injectable so unit tests don't need to spy on Node's ESM `child_process` namespace (which vitest can't patch).
- **Conservative scope**: the existing `.agent/context/*.md` copies + inline `CLAUDE.md` sections are left in place. Once this runs in production and first-tree integrate proves reliable end-to-end, we can remove the redundant inline content in a follow-up.

## Depends on

- [first-tree#234](https://github.com/agent-team-foundation/first-tree/pull/234) — adds the `first-tree tree integrate` command. Merged; published as `first-tree@latest`.

## Test plan

- [x] 4 new unit tests in `bootstrap.test.ts` cover:
  - Happy path arg list
  - Fallback from `first-tree` to `npx` when PATH binary is missing
  - Both-attempts-fail graceful degradation
  - `--tree-url` omitted when not provided
- [x] `pnpm typecheck` — 9/9 tasks pass
- [x] `pnpm test` — full suite passes (client + server + shared)
- [ ] Smoke test in a live environment with an actual agent session (post-merge, once first-tree@latest propagates through npm)