### PR TITLE
fix(client): survive socket errors and dedupe token refresh

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@first-tree-hub/client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "description": "First Tree Hub SDK — programmatic client for First Tree Hub server",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@first-tree-hub/client",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "First Tree Hub SDK — programmatic client for First Tree Hub server",

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -142,6 +142,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.serverUrl = config.serverUrl.replace(/\/+$/, "");
     this.sdkVersion = config.sdkVersion;
     this.getAccessToken = config.getAccessToken;
+
+    // Tombstone listener: Node's EventEmitter re-throws `error` events that
+    // have no listener, so a stray ECONNRESET would crash the host. Consumers
+    // (AgentRuntime / ClientRuntime) attach their own listeners for logging —
+    // this one is the fallback for raw-SDK users who don't.
+    this.on("error", () => {});
   }
 
   get isConnected(): boolean {

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -39,6 +39,11 @@ export class AgentRuntime {
       getAccessToken: this.getAccessToken,
     });
 
+    // Surface transport-level errors (TLS resets, DNS hiccups, WS handshake
+    // failures) to operators. ClientConnection's own reconnect loop handles
+    // recovery; a process-wide crash guard lives in ClientConnection itself.
+    this.clientConnection.on("error", (err) => this.log(`client connection error: ${err.message}`));
+
     for (const [name, agentConfig] of Object.entries(this.config.agents)) {
       const handlerFactory = getHandlerFactory(agentConfig.type);
       this.slots.push(
@@ -57,8 +62,12 @@ export class AgentRuntime {
     }
   }
 
+  private log(msg: string): void {
+    process.stderr.write(`[runtime] ${msg}\n`);
+  }
+
   async start(): Promise<void> {
-    const log = (msg: string) => process.stderr.write(`[runtime] ${msg}\n`);
+    const log = (msg: string) => this.log(msg);
 
     const contextTreePath = await syncContextTree(this.config.server, this.getAccessToken, log);
     if (!contextTreePath) {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/ensure-fresh-access-token.test.ts
+++ b/packages/command/src/__tests__/ensure-fresh-access-token.test.ts
@@ -91,4 +91,53 @@ describe("ensureFreshAccessToken — safety margin", () => {
     const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
     await expect(ensureFreshAccessToken()).rejects.toThrow(/refresh failed/);
   });
+
+  it("deduplicates concurrent refresh calls into a single HTTP round-trip", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 5 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    // Delay the response so all concurrent callers pile onto the same inflight
+    // promise before the first fetch resolves.
+    let releaseFetch: (res: Response) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        releaseFetch = resolve;
+      }),
+    );
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const calls = Promise.all([
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+      ensureFreshAccessToken(),
+    ]);
+
+    releaseFetch(new Response(JSON.stringify({ accessToken: refreshed })));
+    const results = await calls;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    for (const r of results) expect(r).toBe(refreshed);
+  });
+
+  it("releases the inflight slot so subsequent expirations can refresh again", async () => {
+    const stale1 = makeJwt({ exp: Math.floor(Date.now() / 1000) - 5 });
+    const refreshed1 = makeJwt({ exp: Math.floor(Date.now() / 1000) + 10 }); // still within 30s lead
+    const refreshed2 = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale1);
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed1 })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: refreshed2 })));
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    const first = await ensureFreshAccessToken();
+    const second = await ensureFreshAccessToken();
+
+    expect(first).toBe(refreshed1);
+    expect(second).toBe(refreshed2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -55,6 +55,15 @@ export function resolveAccessToken(): string {
 }
 
 /**
+ * In-flight refresh promise. Multiple callers (WS handshake, proactive
+ * refresh timer, every SDK request) can see an expired token within the same
+ * millisecond — without dedupe each would fire an independent `/auth/refresh`
+ * round-trip and race to write `credentials.json`. Share one in-flight
+ * promise so N concurrent callers resolve from a single HTTP call.
+ */
+let inflightRefresh: Promise<string> | null = null;
+
+/**
  * Ensure the persisted access token is fresh. Call before any API request
  * when using persisted credentials. Returns the (possibly refreshed) access
  * token. Service-user API keys are out of scope for this milestone.
@@ -69,20 +78,32 @@ export async function ensureFreshAccessToken(): Promise<string> {
     return creds.accessToken;
   }
 
-  const res = await fetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken: creds.refreshToken }),
-    signal: AbortSignal.timeout(10_000),
-  });
-
-  if (!res.ok) {
-    throw new Error("Access token expired and refresh failed. Run `first-tree-hub client connect <server-url>`.");
+  if (inflightRefresh) {
+    return inflightRefresh;
   }
 
-  const data = (await res.json()) as { accessToken: string };
-  saveCredentials({ ...creds, accessToken: data.accessToken });
-  return data.accessToken;
+  inflightRefresh = (async () => {
+    const res = await fetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: creds.refreshToken }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      throw new Error("Access token expired and refresh failed. Run `first-tree-hub client connect <server-url>`.");
+    }
+
+    const data = (await res.json()) as { accessToken: string };
+    saveCredentials({ ...creds, accessToken: data.accessToken });
+    return data.accessToken;
+  })();
+
+  try {
+    return await inflightRefresh;
+  } finally {
+    inflightRefresh = null;
+  }
 }
 
 /** Back-compat alias retained so existing call sites keep compiling. */

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -53,6 +53,13 @@ export class ClientRuntime {
       process.stderr.write("  \u26A0\uFE0F  Access token expired — reconnecting after refresh...\n");
     });
 
+    // Surface transport-level errors (TLS resets, DNS hiccups, WS handshake
+    // failures) to the operator. ClientConnection's own reconnect loop handles
+    // recovery; the process-wide crash guard lives in ClientConnection itself.
+    this.connection.on("error", (err) => {
+      process.stderr.write(`  \u26A0\uFE0F  Client connection error: ${err.message}\n`);
+    });
+
     // Server tells us an agent has just been pinned to this client — mirror
     // what `first-tree-hub agent add` does (write local config) and let the
     // scanForNewAgents helper start the slot. The fs watcher, when active,


### PR DESCRIPTION
## Summary
- **Crash fix**: stray TLS/socket errors (e.g. `ECONNRESET` from a flaky network) propagated to an unhandled EventEmitter `error` event and killed the CLI. `ClientConnection` now attaches a tombstone listener, and `AgentRuntime` / `ClientRuntime` each log transport errors so recovery is left to the existing reconnect loop.
- **Refresh dedupe**: multiple callers (WS handshake, proactive refresh timer, every SDK request) can see an expired JWT in the same millisecond. Without dedupe each fires its own `/auth/refresh` and races to write `credentials.json`. A module-level in-flight promise now satisfies all concurrent waiters with a single HTTP round-trip.

## Background
Observed on a long-running client against staging: `read ECONNRESET` bubbled past `new WebSocket(...)` → `ClientConnection.emit('error', ...)` → unhandled on the host runtime → Node re-threw and the process exited. Logs also showed back-to-back `Access token expired — reconnecting after refresh...` lines, suggesting concurrent refresh attempts.

## Test plan
- [x] `pnpm check` clean (366 files)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 529 tests pass (shared 49, web 10, client 136, server 317, command 17; +2 new dedupe tests)
- [x] Local e2e: started server on :8000, ran the local-source client with `FIRST_TREE_HUB_HOME=~/.first-tree-hub-test`, `kill -9`'d the server to force RST. Before: process crashed with `Unhandled 'error' event`. After: client logged `⚠️  Client connection error: WebSocket closed before ready (code 1006)` and kept retrying. A fresh client process reconnected cleanly once the server was back up.
- [x] New unit tests in `packages/command/src/__tests__/ensure-fresh-access-token.test.ts` cover the dedupe behavior (one HTTP call for N concurrent waiters) and that the in-flight slot is released afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)