### PR TITLE
feat(command): onboarding polish — fix launchd race, surface install errors, prompt on account switch

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.9.0",
+  "version": "0.8.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -9,10 +9,136 @@ import {
   resetConfigMeta,
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { input, password } from "@inquirer/prompts";
+import { input, password, select } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
-import { ClientRuntime, installClientService, isServiceSupported, saveCredentials } from "../core/index.js";
+import {
+  ClientRuntime,
+  getClientServiceStatus,
+  installClientService,
+  isServiceSupported,
+  loadCredentials,
+  saveCredentials,
+} from "../core/index.js";
+
+type JwtPayload = {
+  memberId?: unknown;
+  organizationId?: unknown;
+  role?: unknown;
+  iat?: unknown;
+};
+
+/** Decode a JWT payload without signature verification. For UI purposes only. */
+function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3 || !parts[1]) return null;
+    const raw = Buffer.from(parts[1], "base64url").toString();
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj !== "object" || obj === null) return null;
+    return obj as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect if the current home already holds a setup for a *different* account,
+ * and give the operator a chance to back out before we overwrite credentials.
+ *
+ * Why this gate exists: running `client connect` implicitly overwrites
+ * `~/.first-tree-hub/config/credentials.json`. Without this prompt, someone
+ * onboarding a second account on their own machine silently logs themselves
+ * out of the first account — they'd only notice when their "main" agents
+ * appeared offline later. We treat single-account-per-machine as the product
+ * default; the `FIRST_TREE_HUB_HOME` env var remains the advanced escape
+ * hatch for power users who want parallel setups.
+ *
+ * The caller passes the *new* memberId directly so this gate can run BEFORE
+ * auth. That matters for the `--token` path: connect tokens are single-use;
+ * if we auth first and the user picks Cancel, the token is burned even
+ * though nothing changed on disk. Decoding the connect token locally lets
+ * us return early without spending it.
+ *
+ * Behavior:
+ *   - No existing credentials → proceed silently (first-time install).
+ *   - Existing credentials, same memberId → proceed silently (reconnect /
+ *     token refresh — common + safe).
+ *   - Existing credentials, memberId indeterminate → proceed silently (we
+ *     can't tell; don't interrupt a flow we might be wrong about).
+ *   - Existing credentials, different memberId → prompt [Replace / Cancel].
+ *     Cancel prints the isolation guide and returns "cancel".
+ */
+async function promptReplaceOrCancel(newMemberId: string, newServerUrl: string): Promise<"proceed" | "cancel"> {
+  const existing = loadCredentials();
+  if (!existing) return "proceed";
+
+  const existingPayload = decodeJwtPayload(existing.accessToken);
+  const existingMemberId = typeof existingPayload?.memberId === "string" ? existingPayload.memberId : null;
+
+  // Same account reconnecting (token refresh, re-install) — no prompt.
+  if (existingMemberId && existingMemberId === newMemberId) {
+    return "proceed";
+  }
+
+  // Can't identify the existing account (corrupted creds, older schema) —
+  // fall through to prompt with an "unknown" label so the user can still
+  // make the call.
+
+  const existingMember = existingMemberId ? `member ${existingMemberId.slice(0, 8)}` : "unknown account";
+  const existingOrg = typeof existingPayload?.organizationId === "string" ? existingPayload.organizationId : null;
+  const serviceStatus = getClientServiceStatus();
+  const serviceLine =
+    serviceStatus.state === "active"
+      ? `running (${serviceStatus.detail ?? "live"})`
+      : serviceStatus.state === "inactive"
+        ? `installed but not running${serviceStatus.detail ? ` — ${serviceStatus.detail}` : ""}`
+        : "not installed";
+
+  process.stderr.write("\n");
+  process.stderr.write("  \u26a0\ufe0f  This computer is already connected to the Hub under another account.\n\n");
+  process.stderr.write(`       Existing account:  ${existingMember}\n`);
+  if (existingOrg) {
+    process.stderr.write(`       Organization:      ${existingOrg.slice(0, 8)}\n`);
+  }
+  process.stderr.write(`       Server:            ${existing.serverUrl}\n`);
+  process.stderr.write(`       Background service: ${serviceLine}\n\n`);
+  process.stderr.write("     Replacing only affects THIS computer. Your agents, messages, and\n");
+  process.stderr.write("     settings on the Hub itself are untouched.\n\n");
+
+  const choice = await select<"replace" | "cancel">({
+    message: "How would you like to continue?",
+    choices: [
+      {
+        name: "Replace — log out the other account and set up this one",
+        value: "replace",
+      },
+      {
+        name: "Cancel  — keep the existing setup on this computer",
+        value: "cancel",
+      },
+    ],
+  });
+
+  if (choice === "cancel") {
+    printIsolationGuide(newServerUrl);
+    return "cancel";
+  }
+
+  return "proceed";
+}
+
+function printIsolationGuide(newServerUrl: string): void {
+  process.stderr.write("\n  Cancelled. The existing account on this computer is untouched.\n\n");
+  process.stderr.write("  To run this new account alongside it (advanced — no background service):\n\n");
+  process.stderr.write('    export FIRST_TREE_HUB_HOME="$HOME/.first-tree-hub-<label>"\n');
+  process.stderr.write(`    first-tree-hub client connect ${newServerUrl} --token <token>\n`);
+  process.stderr.write("    first-tree-hub client start\n\n");
+  process.stderr.write("  Notes:\n");
+  process.stderr.write("    - Run the commands in a FRESH terminal (the isolated home must be set first).\n");
+  process.stderr.write("    - In isolated mode the client stays online only while that terminal runs.\n");
+  process.stderr.write("    - The main account's background service is not affected.\n\n");
+}
 
 /**
  * Authenticate via connect token — exchange for full JWT credentials.
@@ -70,15 +196,49 @@ export function registerConnectCommand(parent: Command): void {
       try {
         const url = serverUrl.replace(/\/+$/, "");
 
-        // 1. Write server URL to client.yaml
-        const clientConfigPath = join(DEFAULT_CONFIG_DIR, "client.yaml");
-        setConfigValue(clientConfigPath, "server.url", url);
-        process.stderr.write(`\n  \u2713 Server configured: ${url}\n`);
+        // 1. Pre-auth account-switch gate (token path).
+        //
+        // Connect tokens are single-use. If we authed first and the user
+        // picked Cancel, the token would be burned even though nothing
+        // changed on disk — forcing them to re-Generate a new one for a
+        // second attempt. Decoding the connect token's JWT payload locally
+        // lets the prompt run BEFORE we spend the token.
+        //
+        // Interactive login doesn't have this concern (user re-enters
+        // username/password trivially) — we defer that check to after auth.
+        let preAuthDecided = false;
+        if (options.token) {
+          const connectPayload = decodeJwtPayload(options.token);
+          const newMemberId = typeof connectPayload?.memberId === "string" ? connectPayload.memberId : null;
+          if (newMemberId !== null) {
+            const decision = await promptReplaceOrCancel(newMemberId, url);
+            if (decision === "cancel") return;
+            preAuthDecided = true;
+          }
+        }
 
-        // 2. Authenticate — token or interactive
+        // 2. Authenticate — token or interactive.
         const tokens = options.token
           ? await authenticateWithToken(url, options.token)
           : await authenticateInteractive(url);
+
+        // 3. Post-auth fallback gate. Fires only when we couldn't decide in
+        // step 1 (interactive login, or connect token that didn't carry a
+        // memberId claim). Token is already spent here, but creds haven't
+        // hit disk yet so Cancel still leaves the prior setup intact.
+        if (!preAuthDecided) {
+          const newPayload = decodeJwtPayload(tokens.accessToken);
+          const newMemberId = typeof newPayload?.memberId === "string" ? newPayload.memberId : null;
+          if (newMemberId !== null) {
+            const decision = await promptReplaceOrCancel(newMemberId, url);
+            if (decision === "cancel") return;
+          }
+        }
+
+        // 4. Write server URL and credentials.
+        const clientConfigPath = join(DEFAULT_CONFIG_DIR, "client.yaml");
+        setConfigValue(clientConfigPath, "server.url", url);
+        process.stderr.write(`\n  \u2713 Server configured: ${url}\n`);
 
         saveCredentials({ ...tokens, serverUrl: url });
         process.stderr.write("  \u2713 Authenticated\n");

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -64,8 +64,8 @@ function decodeJwtPayload(token: string): JwtPayload | null {
  *   - No existing credentials → proceed silently (first-time install).
  *   - Existing credentials, same memberId → proceed silently (reconnect /
  *     token refresh — common + safe).
- *   - Existing credentials, memberId indeterminate → proceed silently (we
- *     can't tell; don't interrupt a flow we might be wrong about).
+ *   - Existing credentials, memberId indeterminate → prompt with
+ *     "unknown account" label so the user can decide.
  *   - Existing credentials, different memberId → prompt [Replace / Cancel].
  *     Cancel prints the isolation guide and returns "cancel".
  */
@@ -253,7 +253,7 @@ export function registerConnectCommand(parent: Command): void {
         });
         process.stderr.write(`  \u2713 Connected as this computer (id: ${config.client.id})\n`);
 
-        // 3. Install background service (default) OR run inline (--no-service).
+        // 5. Install background service (default) OR run inline (--no-service).
         const shouldInstallService = options.service !== false && isServiceSupported();
 
         if (shouldInstallService) {

--- a/packages/command/src/core/service-install.ts
+++ b/packages/command/src/core/service-install.ts
@@ -1,10 +1,36 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { DEFAULT_HOME_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 
 export type ServiceState = "active" | "inactive" | "not-installed" | "unknown";
+
+type ShellResult = { ok: true } | { ok: false; stderr: string; code: number | null };
+
+/**
+ * Run a subprocess capturing stderr so failures surface a meaningful error
+ * instead of Node's opaque "Command failed". Used for launchctl/systemctl —
+ * anywhere the stderr message is diagnostically crucial.
+ */
+function runCapture(program: string, args: string[], timeoutMs: number): ShellResult {
+  const res = spawnSync(program, args, {
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status === 0) return { ok: true };
+  return {
+    ok: false,
+    stderr: (res.stderr ?? "").trim(),
+    code: res.status,
+  };
+}
+
+function sleepSync(ms: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
 
 export type ServiceInfo = {
   platform: "launchd" | "systemd" | "unsupported";
@@ -127,21 +153,46 @@ function launchctlDomainTarget(): string {
 function launchdState(): { state: ServiceState; detail?: string } {
   const plist = launchdPlistPath();
   if (!existsSync(plist)) return { state: "not-installed" };
-  try {
-    const out = execFileSync("launchctl", ["print", `${launchctlDomainTarget()}/${LAUNCHD_LABEL}`], {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    const stateLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("state ="));
-    const pidLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("pid ="));
-    if (stateLine?.includes("running")) {
-      const pid = pidLine?.split("=")[1]?.trim();
-      return { state: "active", detail: pid ? `pid ${pid}` : "running" };
-    }
-    return { state: "inactive", detail: stateLine?.trim() ?? "loaded" };
-  } catch {
+  // Use spawnSync with explicit stderr:"pipe" so launchctl's "Could not
+  // find service" message doesn't leak onto the user's terminal when the
+  // label isn't currently loaded. execFileSync defaults stderr to inherit.
+  const res = spawnSync("launchctl", ["print", `${launchctlDomainTarget()}/${LAUNCHD_LABEL}`], {
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) {
     return { state: "inactive", detail: "plist present but not loaded" };
   }
+  const out = res.stdout ?? "";
+  const stateLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("state ="));
+  const pidLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("pid ="));
+  if (stateLine?.includes("running")) {
+    const pid = pidLine?.split("=")[1]?.trim();
+    return { state: "active", detail: pid ? `pid ${pid}` : "running" };
+  }
+  return { state: "inactive", detail: stateLine?.trim() ?? "loaded" };
+}
+
+/**
+ * Poll `launchctl print` until the label disappears, confirming launchd has
+ * finished the async eviction kicked off by `bootout`. Required because
+ * `bootout` returns before the actual unload completes when the service has
+ * active WebSocket connections — a follow-up `bootstrap` against a still-
+ * registered label fails with `Bootstrap failed: 5: Input/output error`.
+ */
+function waitForLabelEvicted(target: string, label: string, timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = spawnSync("launchctl", ["print", `${target}/${label}`], {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (res.status !== 0) return true;
+    sleepSync(200);
+  }
+  return false;
 }
 
 function installLaunchd(): ServiceInfo {
@@ -152,20 +203,53 @@ function installLaunchd(): ServiceInfo {
   writeFileSync(plistPath, renderPlist(invocation), { mode: 0o644 });
 
   const target = launchctlDomainTarget();
-  // Bootout if already loaded (ignore errors — may not be loaded).
-  try {
-    execFileSync("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], {
-      stdio: "ignore",
-      timeout: 5000,
-    });
-  } catch {
-    // Not loaded — fine.
+
+  // Step 1: bootout any existing registration. Generous timeout because
+  // tearing down an active service (SIGTERM → WS close → process exit)
+  // routinely takes several seconds when there are live connections.
+  const bootoutRes = runCapture("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], 15_000);
+  if (!bootoutRes.ok) {
+    const notLoaded = /not find|no such|not loaded/i.test(bootoutRes.stderr);
+    if (!notLoaded) {
+      // Unexpected bootout error — surface it but don't fail; waitForLabelEvicted
+      // will give it a final chance to clear.
+      process.stderr.write(
+        `    warning: launchctl bootout: ${bootoutRes.stderr || `exit ${bootoutRes.code ?? "unknown"}`}\n`,
+      );
+    }
   }
-  execFileSync("launchctl", ["bootstrap", target, plistPath], { stdio: "ignore", timeout: 5000 });
-  execFileSync("launchctl", ["enable", `${target}/${LAUNCHD_LABEL}`], {
-    stdio: "ignore",
-    timeout: 5000,
-  });
+
+  // Step 2: poll until launchd has actually evicted the label. Without this,
+  // `bootstrap` collides with the still-unloading registration.
+  waitForLabelEvicted(target, LAUNCHD_LABEL, 10_000);
+
+  // Step 3: bootstrap with one retry. If the poll missed a late eviction,
+  // a 1s wait + retry recovers instead of exploding with a cryptic error.
+  let lastBootstrapErr: ShellResult | null = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const res = runCapture("launchctl", ["bootstrap", target, plistPath], 10_000);
+    if (res.ok) {
+      lastBootstrapErr = null;
+      break;
+    }
+    lastBootstrapErr = res;
+    if (attempt < 2) sleepSync(1_000);
+  }
+  if (lastBootstrapErr) {
+    throw new Error(
+      `launchctl bootstrap failed: ${lastBootstrapErr.stderr || `exit ${lastBootstrapErr.code ?? "unknown"}`}\n` +
+        `    Command: launchctl bootstrap ${target} ${plistPath}\n` +
+        `    Recovery: \`launchctl bootout ${target}/${LAUNCHD_LABEL}\` then \`first-tree-hub service install\`.`,
+    );
+  }
+
+  // Step 4: enable. Non-fatal if it fails (service already bootstrapped).
+  const enableRes = runCapture("launchctl", ["enable", `${target}/${LAUNCHD_LABEL}`], 5_000);
+  if (!enableRes.ok) {
+    process.stderr.write(
+      `    warning: launchctl enable: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n`,
+    );
+  }
 
   const { state, detail } = launchdState();
   return {
@@ -239,20 +323,16 @@ function shellQuote(value: string): string {
 function systemdState(): { state: ServiceState; detail?: string } {
   const unitPath = systemdUnitPath();
   if (!existsSync(unitPath)) return { state: "not-installed" };
-  try {
-    const out = execFileSync("systemctl", ["--user", "is-active", SYSTEMD_UNIT], {
-      encoding: "utf-8",
-      timeout: 5000,
-    }).trim();
-    if (out === "active") return { state: "active", detail: "running" };
-    return { state: "inactive", detail: out };
-  } catch (err) {
-    const stdout =
-      typeof (err as { stdout?: unknown }).stdout === "string"
-        ? ((err as { stdout?: string }).stdout ?? "").trim()
-        : "";
-    return { state: "inactive", detail: stdout || "unit present but not active" };
-  }
+  // Mirror the launchctl fix: keep stderr piped so systemctl's error text
+  // ("Failed to connect to bus..." etc.) doesn't leak to the user's terminal.
+  const res = spawnSync("systemctl", ["--user", "is-active", SYSTEMD_UNIT], {
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const out = (res.stdout ?? "").trim();
+  if (res.status === 0 && out === "active") return { state: "active", detail: "running" };
+  return { state: "inactive", detail: out || "unit present but not active" };
 }
 
 function installSystemd(): ServiceInfo {
@@ -262,11 +342,20 @@ function installSystemd(): ServiceInfo {
   mkdirSync(dirname(unitPath), { recursive: true });
   writeFileSync(unitPath, renderSystemdUnit(invocation), { mode: 0o644 });
 
-  execFileSync("systemctl", ["--user", "daemon-reload"], { stdio: "ignore", timeout: 5000 });
-  execFileSync("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT], {
-    stdio: "ignore",
-    timeout: 10_000,
-  });
+  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  if (!reloadRes.ok) {
+    throw new Error(
+      `systemctl --user daemon-reload failed: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}`,
+    );
+  }
+
+  const enableRes = runCapture("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT], 10_000);
+  if (!enableRes.ok) {
+    throw new Error(
+      `systemctl --user enable --now ${SYSTEMD_UNIT} failed: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n` +
+        `    Recovery: \`systemctl --user stop ${SYSTEMD_UNIT}\` then \`first-tree-hub service install\`.`,
+    );
+  }
 
   const { state, detail } = systemdState();
   return {

--- a/packages/command/src/core/service-install.ts
+++ b/packages/command/src/core/service-install.ts
@@ -265,13 +265,9 @@ function installLaunchd(): ServiceInfo {
 function uninstallLaunchd(): ServiceInfo {
   const plistPath = launchdPlistPath();
   const target = launchctlDomainTarget();
-  try {
-    execFileSync("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], {
-      stdio: "ignore",
-      timeout: 5000,
-    });
-  } catch {
-    // Already gone.
+  const res = runCapture("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], 15_000);
+  if (!res.ok && !/not find|no such|not loaded/i.test(res.stderr)) {
+    process.stderr.write(`    warning: bootout during uninstall: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
   }
   if (existsSync(plistPath)) rmSync(plistPath);
   return {
@@ -370,19 +366,18 @@ function installSystemd(): ServiceInfo {
 
 function uninstallSystemd(): ServiceInfo {
   const unitPath = systemdUnitPath();
-  try {
-    execFileSync("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], {
-      stdio: "ignore",
-      timeout: 10_000,
-    });
-  } catch {
-    // Unit not loaded — fine.
+  const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000);
+  if (!disableRes.ok && !/not found|no such|not loaded/i.test(disableRes.stderr)) {
+    process.stderr.write(
+      `    warning: systemctl disable during uninstall: ${disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`}\n`,
+    );
   }
   if (existsSync(unitPath)) rmSync(unitPath);
-  try {
-    execFileSync("systemctl", ["--user", "daemon-reload"], { stdio: "ignore", timeout: 5000 });
-  } catch {
-    // systemd may not be reachable — fine for cleanup.
+  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  if (!reloadRes.ok) {
+    process.stderr.write(
+      `    warning: systemctl daemon-reload during uninstall: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}\n`,
+    );
   }
   return {
     platform: "systemd",


### PR DESCRIPTION
## Summary

Closes the "onboarding succeeds 95% and then throws a cryptic `launchctl bootstrap failed` error" failure mode. Four CLI-only fixes in `packages/command`:

1. **launchd async race** — `bootout` + `bootstrap` collided when the old service had active WS connections. Fix: bigger bootout timeout (15s), poll until the label is actually evicted, retry bootstrap once.
2. **Swallowed launchctl stderr** — CLI only showed Node's generic `Command failed: launchctl bootstrap ...`. Now captures the real message (e.g. `Bootstrap failed: 5: Input/output error`) and includes a recovery hint. Also fixes a separate leak where `launchdState`/`systemdState` printed `Could not find service in domain` directly to the terminal.
3. **Silent account overwrite** — `client connect` unconditionally overwrote `credentials.json`. Added a prompt `[Replace / Cancel]` when the machine already belongs to a different account; Cancel prints an actionable `FIRST_TREE_HUB_HOME` isolation recipe.
4. **Cancel no longer burns the connect token** — the account-switch gate decodes the connect token locally (pre-auth), so Cancel returns without spending the single-use token.

Mirrors the defensive changes on the systemd branch (capture stderr + real error messages).

## Version
`@agent-team-foundation/first-tree-hub` 0.8.0 → **0.9.0** (minor, feat). Auto-publishes on merge via `npm-publish.yml`.

## Scope excluded
- Auto-reconnect behavior — already multi-layered and healthy (WS backoff, proactive token refresh, server-pushed `auth:expired`, launchd/systemd keepalive). Not touched.
- Orphan `agent.yaml` when the user Cancels after running `agent add` — `agent add` has no account awareness today; separate concern.
- True parallel multi-account install — product model remains single-account-per-machine. `FIRST_TREE_HUB_HOME` stays as the advanced escape hatch.

## Verification
- `pnpm check` / `pnpm typecheck` / `pnpm --filter @agent-team-foundation/first-tree-hub test` — all green (15/15 tests).
- Manual repro against staging, reproducing the original failure report:
  - **Test A** (same account reconnect, live service pid running): race fix kicks in, bootstrap succeeds on first try, no error leak. ✓
  - **Test B Cancel** (different-account connect): prompt renders with correct identifiers, Cancel exits cleanly with isolation-mode guide, no `Bad request` leak. ✓

## Test plan
- [x] Clean install (fresh machine) — no prompt, silent success.
- [x] Same-account reconnect — no prompt, race fix verified.
- [x] Different-account + Cancel — prompt renders, token not burned, no stderr leak.
- [ ] Different-account + Replace — prompt renders, full switch completes. *(Code path identical to Test A's "proceed" branch; considered covered by A + Cancel.)*
- [ ] Linux systemd path — defensive changes mirrored but not manually verified (no Linux machine in the loop today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)