### PR TITLE
docs(agents): document version-bump policy — only command + shared are published

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,55 @@ External CLI projects (e.g. context-tree) can `import { startServer, checkDataba
 - **Releases**: tag + GitHub Release
 - Do not auto-commit; wait for user to test and confirm before committing
 
+### Versioning & Publishing
+
+A release reaches downstream consumers only when the published package's
+`version` advances. The npm registry refuses to overwrite an existing
+version, and `npm ci` resolves strictly by the version pin — so a new
+build that ships under an unchanged version is invisible to anyone
+running `npm ci` / `npm install`. Treat the version bump as a required
+part of every shipped change, not a release-time afterthought.
+
+#### Which package's version actually ships
+
+Two packages are published to npm; the rest are `private: true` and
+bundled into the published artifacts at build time via `tsdown`. The
+private packages' `version` fields are inert — bumping them has no
+effect on what downstream consumers receive.
+
+| Package | Path | Published | Bump rule |
+|---|---|---|---|
+| `@agent-team-foundation/first-tree-hub` | `packages/command` | Yes (`publishConfig.access: public`) | **Bump on every PR that changes any source file in `command`, `client`, `server`, `web`, or `shared`.** This tarball is the unified CLI consumers install; without a new version the bundled change cannot reach `npm ci`. |
+| `@agent-team-foundation/first-tree-hub-shared` | `packages/shared` | Yes | **Bump when the externally-importable surface of `shared` changes** — exported Zod schemas, types, or constants that another npm package could consume. Internal-only edits to `shared` still require the `command` bump above; they do not require a `shared` bump. |
+| `@first-tree-hub/client` | `packages/client` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
+| `@first-tree-hub/server` | `packages/server` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
+| `@first-tree-hub/web` | `packages/web` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
+
+#### Choosing the next version
+
+1. Read the **published** `latest` from the registry — it may be ahead of
+   `main` if a release shipped between PRs:
+   ```bash
+   npm view @agent-team-foundation/first-tree-hub version
+   ```
+2. Pick `max(npm latest, current main) + 1` patch — never reuse a
+   version that already exists on npm.
+3. Default to **patch** bumps for additive changes, fixes, and internal
+   refactors. Reserve **minor** bumps for breaking changes to the CLI's
+   public surface (commands, flags, exit codes, on-disk file layouts
+   under `~/.first-tree-hub/`).
+4. Apply the same rule to `shared`: query npm, pick the next available
+   patch, prefer patch over minor.
+
+#### Anti-pattern
+
+Bumping a `private: true` package (`client` / `server` / `web`) on a PR
+that changes its source. pnpm publish only ships `command` and `shared`,
+and `tsdown` inlines the private packages into the `command` tarball at
+build time — so the private package's `version` field never reaches the
+registry. Bump **`packages/command`** instead; that is the artifact
+whose version pins the release downstream `npm ci` will see.
+
 <!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->
 ## First Tree integration
 


### PR DESCRIPTION
## Summary
Codify the npm publishing contract as a working norm in `AGENTS.md`, so the `client` ↔ `command` version-bump confusion (which has cost two revert cycles already) doesn't keep recurring.

Key rules added to a new "Versioning & Publishing" section under Development Workflow:

- **Lead with the mechanism**: the npm registry refuses to overwrite existing versions, and `npm ci` resolves strictly by version pin, so the bump *is* what makes a change reach downstream installs.
- **Per-package table**: only `@agent-team-foundation/first-tree-hub` (`packages/command`) and `@agent-team-foundation/first-tree-hub-shared` (`packages/shared`) are published. `client` / `server` / `web` are `private: true` and bundled into `command` at build time via `tsdown` — their `version` fields are inert.
- **Trigger**: bump `packages/command` on every PR that changes source in any of `command` / `client` / `server` / `web` / `shared`, regardless of whether the change is "user-visible". The bundled tarball differs and `npm ci` only sees the version.
- **Process**: always `npm view @agent-team-foundation/first-tree-hub version` first — `main` can lag the published `latest` if a release shipped between PRs. Pick `max(npm latest, main) + 1` patch.
- **Default**: patch bumps for additive / fix / refactor; minor only for breaking CLI surface changes (commands, flags, exit codes, on-disk file layouts).
- **Anti-pattern callout**: bumping a `private: true` package has no effect — `tsdown` inlines those packages into the `command` tarball, so their `version` field never reaches the registry.

## Test plan
- [x] `AGENTS.md` renders correctly on GitHub (markdown table + code block + headings)
- [x] `CLAUDE.md` symlink still resolves (no file content change beyond `AGENTS.md`)
- [x] No commit hashes or PR-specific references in the documentation — written purely as a normative spec
- [x] No code changes; no test/typecheck impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)