### PR TITLE
feat(hub-ui-polish): T1-T9 UI polish + permission hardening

### DIFF
--- a/packages/server/src/api/admin/adapter-mappings.ts
+++ b/packages/server/src/api/admin/adapter-mappings.ts
@@ -1,5 +1,5 @@
 import { createAdapterMappingSchema } from "@agent-team-foundation/first-tree-hub-shared";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { adapterAgentMappings } from "../../db/schema/adapter-agent-mappings.js";
 import { agents } from "../../db/schema/agents.js";
@@ -20,7 +20,16 @@ export async function adminAdapterMappingRoutes(app: FastifyInstance): Promise<v
     // M2 org scope: adapter_agent_mappings has no organization_id column,
     // so we JOIN agents to filter by the caller's org. Without this JOIN,
     // a cross-tenant admin could list every other org's mappings.
+    //
+    // Post hub-ui-polish: non-admin callers see only mappings for agents
+    // they manage; admins see every mapping in the org. The backend has to
+    // enforce this even when the UI hides the edit button — admin-only
+    // has been removed from the route hook.
     const scope = memberScope(request);
+    const conditions = [eq(agents.organizationId, scope.organizationId)];
+    if (scope.role !== "admin") {
+      conditions.push(eq(agents.managerId, scope.memberId));
+    }
     const rows = await app.db
       .select({
         id: adapterAgentMappings.id,
@@ -33,7 +42,7 @@ export async function adminAdapterMappingRoutes(app: FastifyInstance): Promise<v
       })
       .from(adapterAgentMappings)
       .innerJoin(agents, eq(agents.uuid, adapterAgentMappings.agentId))
-      .where(eq(agents.organizationId, scope.organizationId))
+      .where(and(...conditions))
       .orderBy(desc(adapterAgentMappings.createdAt));
     return rows.map((r) => ({
       id: r.id,

--- a/packages/server/src/api/admin/adapter-status.ts
+++ b/packages/server/src/api/admin/adapter-status.ts
@@ -1,7 +1,28 @@
+import { and, eq, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import { adapterConfigs } from "../../db/schema/adapter-configs.js";
+import { agents } from "../../db/schema/agents.js";
+import { memberScope } from "../../services/access-control.js";
 
 export async function adminAdapterStatusRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/", async () => {
-    return app.adapterManager.getBotStatuses();
+  app.get("/", async (request) => {
+    // Bot runtime statuses are shared state in the AdapterManager singleton.
+    // Mask them to the set of configs the caller has scope for so a
+    // non-admin member can't see connection/health info for adapters bound
+    // to agents owned by another member.
+    const scope = memberScope(request);
+    const conditions = [eq(agents.organizationId, scope.organizationId), ne(agents.status, "deleted")];
+    if (scope.role !== "admin") {
+      conditions.push(eq(agents.managerId, scope.memberId));
+    }
+    const visibleRows = await app.db
+      .select({ id: adapterConfigs.id })
+      .from(adapterConfigs)
+      .innerJoin(agents, eq(agents.uuid, adapterConfigs.agentId))
+      .where(and(...conditions));
+    const visibleIds = new Set(visibleRows.map((r) => r.id));
+    if (visibleIds.size === 0) return [];
+    const all = app.adapterManager.getBotStatuses();
+    return all.filter((s) => visibleIds.has(s.configId));
   });
 }

--- a/packages/server/src/api/admin/adapters.ts
+++ b/packages/server/src/api/admin/adapters.ts
@@ -16,8 +16,9 @@ function parseId(raw: string): number {
 }
 
 export async function adminAdapterRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/", async () => {
-    const configs = await adapterService.listAdapterConfigs(app.db);
+  app.get("/", async (request) => {
+    const scope = memberScope(request);
+    const configs = await adapterService.listAdapterConfigsForMember(app.db, scope);
     return configs.map((c) => ({
       ...c,
       createdAt: c.createdAt.toISOString(),

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -88,6 +88,36 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
+  /**
+   * Admin-only: every agent in the caller's org, skipping the visibility
+   * filter applied on the regular `/agents` list. Private agents owned by
+   * other members show up here so an admin can reassign or troubleshoot.
+   * Role gating is enforced here — the parent route group does NOT add
+   * adminOnly because the member-facing `GET /` is shared.
+   */
+  app.get("/all", async (request) => {
+    const scope = memberScope(request);
+    if (scope.role !== "admin") {
+      throw new ForbiddenError("Admin role required");
+    }
+    const query = paginationQuerySchema.parse(request.query);
+    const result = await agentService.listAgentsForAdmin(app.db, scope, query.limit, query.cursor);
+    return {
+      items: result.items.map((a) => ({
+        ...a,
+        managerId: a.managerId ?? null,
+        presenceStatus: a.presenceStatus ?? "offline",
+        createdAt: a.createdAt.toISOString(),
+        updatedAt: a.updatedAt.toISOString(),
+        clientId: a.clientId ?? null,
+        runtimeType: a.runtimeType ?? null,
+        runtimeState: a.runtimeState ?? null,
+        activeSessions: a.activeSessions ?? null,
+      })),
+      nextCursor: result.nextCursor,
+    };
+  });
+
   app.post("/", async (request, reply) => {
     const scope = memberScope(request);
     const body = createAgentSchema.parse(request.body);

--- a/packages/server/src/api/admin/clients.ts
+++ b/packages/server/src/api/admin/clients.ts
@@ -6,13 +6,21 @@ import { forceDisconnectClient } from "../../services/connection-manager.js";
 import { serializeDate } from "../../utils.js";
 
 export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
-  // GET /clients — clients owned by the caller. Every `clients.user_id`
-  // is the authoritative owner (Rule R-RUN); routes are scoped to that user
-  // so a cross-org or cross-user caller can't see or touch clients that
-  // aren't theirs.
+  // GET /clients — clients visible to the caller.
+  //
+  //   - member: only their own (`clients.user_id == scope.userId`). The
+  //     `assertClientOwner` check on per-id routes continues to enforce
+  //     the write path.
+  //   - admin: every client belonging to a member of the caller's org
+  //     plus any legacy unclaimed (user_id NULL) rows. The `/clients` UI
+  //     surfaces the owner so admins can tell whose machine is whose.
   app.get("/", async (request) => {
     const scope = memberScope(request);
-    const clients = await clientService.listClients(app.db, scope.userId);
+    const clients = await clientService.listClients(app.db, {
+      userId: scope.userId,
+      organizationId: scope.organizationId,
+      role: scope.role,
+    });
     return clients.map((c) => ({
       id: c.id,
       userId: c.userId,
@@ -29,7 +37,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
   // GET /clients/:clientId — single client, owner-scoped.
   app.get<{ Params: { clientId: string } }>("/:clientId", async (request) => {
     const scope = memberScope(request);
-    await clientService.assertClientOwner(app.db, request.params.clientId, scope.userId);
+    await clientService.assertClientOwner(app.db, request.params.clientId, scope);
     const client = await clientService.getClient(app.db, request.params.clientId);
     // assertClientOwner already 404'd on missing/not-yours; the row is present.
     if (!client) throw new Error("unreachable: client missing after owner check");
@@ -49,7 +57,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { clientId: string } }>("/:clientId/disconnect", async (request) => {
     const scope = memberScope(request);
     const { clientId } = request.params;
-    await clientService.assertClientOwner(app.db, clientId, scope.userId);
+    await clientService.assertClientOwner(app.db, clientId, scope);
 
     const agentIds = forceDisconnectClient(clientId);
     await clientService.disconnectClient(app.db, clientId);
@@ -63,7 +71,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
   app.delete<{ Params: { clientId: string } }>("/:clientId", async (request, reply) => {
     const scope = memberScope(request);
     const { clientId } = request.params;
-    await clientService.assertClientOwner(app.db, clientId, scope.userId);
+    await clientService.assertClientOwner(app.db, clientId, scope);
 
     // retireClient verifies no non-deleted agents are pinned before deleting
     // the clients row; a refused retire throws 409 BEFORE we disconnect, so a

--- a/packages/server/src/api/members.ts
+++ b/packages/server/src/api/members.ts
@@ -28,7 +28,8 @@ export async function memberRoutes(app: FastifyInstance): Promise<void> {
   app.patch<{ Params: { id: string } }>("/:id", async (request) => {
     requireAdmin(request);
     const body = updateMemberSchema.parse(request.body);
-    return memberService.updateMember(app.db, request.params.id, body);
+    const m = requireMember(request);
+    return memberService.updateMember(app.db, request.params.id, body, m.organizationId);
   });
 
   app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -201,10 +201,14 @@ export async function buildApp(config: Config) {
         { prefix: "/admin/overview" },
       );
 
+      // Adapter bindings are scoped by role inside the handlers:
+      //   - admin: all configs/mappings in the org
+      //   - non-admin: only those bound to agents they manage
+      // That lets the shared /settings page surface each user's own
+      // bindings without an admin flag gating the entire route.
       await api.register(
         async (adminApp) => {
           adminApp.addHook("onRequest", memberAuth);
-          adminApp.addHook("onRequest", adminOnly);
           await adminApp.register(adminAdapterRoutes);
         },
         { prefix: "/admin/adapters" },
@@ -213,7 +217,6 @@ export async function buildApp(config: Config) {
       await api.register(
         async (adminApp) => {
           adminApp.addHook("onRequest", memberAuth);
-          adminApp.addHook("onRequest", adminOnly);
           await adminApp.register(adminAdapterMappingRoutes);
         },
         { prefix: "/admin/adapter-mappings" },
@@ -222,7 +225,6 @@ export async function buildApp(config: Config) {
       await api.register(
         async (adminApp) => {
           adminApp.addHook("onRequest", memberAuth);
-          adminApp.addHook("onRequest", adminOnly);
           await adminApp.register(adminAdapterStatusRoutes);
         },
         { prefix: "/admin/adapters/status" },

--- a/packages/server/src/services/adapter.ts
+++ b/packages/server/src/services/adapter.ts
@@ -4,6 +4,7 @@ import type { Database } from "../db/connection.js";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agents } from "../db/schema/agents.js";
 import { AppError, BadRequestError, ConflictError, NotFoundError } from "../errors.js";
+import type { MemberScope } from "./access-control.js";
 import { encryptCredentials } from "./crypto.js";
 
 /** Server misconfiguration — not a client error. */
@@ -49,6 +50,39 @@ function toResponse(row: typeof adapterConfigs.$inferSelect) {
 
 export async function listAdapterConfigs(db: Database) {
   const rows = await db.select().from(adapterConfigs).orderBy(desc(adapterConfigs.createdAt));
+  return rows.map(toResponse);
+}
+
+/**
+ * Scoped variant used by the member-facing admin route.
+ *
+ *   - admin: every adapter config whose agent belongs to the caller's org.
+ *   - non-admin: only adapter configs bound to agents the caller manages
+ *     (Rule: bindings follow manageability).
+ *
+ * Kept as a separate function so internal self-service callers
+ * (`agent/feishu-bot.ts`) that only need a raw read don't accidentally pay
+ * for the join.
+ */
+export async function listAdapterConfigsForMember(db: Database, scope: MemberScope) {
+  const conditions = [eq(agents.organizationId, scope.organizationId), ne(agents.status, "deleted")];
+  if (scope.role !== "admin") {
+    conditions.push(eq(agents.managerId, scope.memberId));
+  }
+  const rows = await db
+    .select({
+      id: adapterConfigs.id,
+      platform: adapterConfigs.platform,
+      agentId: adapterConfigs.agentId,
+      credentials: adapterConfigs.credentials,
+      status: adapterConfigs.status,
+      createdAt: adapterConfigs.createdAt,
+      updatedAt: adapterConfigs.updatedAt,
+    })
+    .from(adapterConfigs)
+    .innerJoin(agents, eq(agents.uuid, adapterConfigs.agentId))
+    .where(and(...conditions))
+    .orderBy(desc(adapterConfigs.createdAt));
   return rows.map(toResponse);
 }
 

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -318,6 +318,55 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
 }
 
 /**
+ * Admin-only variant: return every non-deleted agent in the org, ignoring
+ * the visibility filter. Used by the `/admin` "All Agents" view so a team
+ * admin can see and act on private agents owned by other members. The
+ * route layer is responsible for gating this to admin callers — the
+ * service does not enforce role by itself, but it does enforce org scope
+ * and the not-deleted predicate.
+ */
+export async function listAgentsForAdmin(db: Database, scope: MemberScope, limit: number, cursor?: string) {
+  const conditions = [eq(agents.organizationId, scope.organizationId), ne(agents.status, AGENT_STATUSES.DELETED)];
+  if (cursor) conditions.push(lt(agents.createdAt, new Date(cursor)));
+  const where = and(...conditions);
+
+  const rows = await db
+    .select({
+      uuid: agents.uuid,
+      name: agents.name,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      displayName: agents.displayName,
+      delegateMention: agents.delegateMention,
+      inboxId: agents.inboxId,
+      status: agents.status,
+      cloudUserId: agents.cloudUserId,
+      visibility: agents.visibility,
+      metadata: agents.metadata,
+      managerId: agents.managerId,
+      clientId: agents.clientId,
+      createdAt: agents.createdAt,
+      updatedAt: agents.updatedAt,
+      presenceStatus: agentPresence.status,
+      runtimeType: agentPresence.runtimeType,
+      runtimeState: agentPresence.runtimeState,
+      activeSessions: agentPresence.activeSessions,
+    })
+    .from(agents)
+    .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
+    .where(where)
+    .orderBy(desc(agents.createdAt))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items[items.length - 1];
+  const nextCursor = hasMore && last ? last.createdAt.toISOString() : null;
+
+  return { items, nextCursor };
+}
+
+/**
  * List agents visible to a specific member.
  * Uses agentVisibilityCondition from access-control (same rules for all roles).
  */

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -3,24 +3,47 @@ import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
 import { ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { runtimeFieldsReset } from "./presence.js";
 
 /**
- * Assert the caller's user owns this client. Throws 404 for both "not found"
+ * Assert the caller can act on this client. Throws 404 for both "not found"
  * and "not yours" to prevent UUID enumeration across org/user boundaries.
- * Used by management routes (disconnect, retire, single GET) so a cross-org
- * admin cannot operate on another user's client.
+ *
+ *   - member: owner match (`row.user_id == scope.userId`).
+ *   - admin: any client whose owner is a member of the admin's own org.
+ *
+ * Legacy unclaimed rows (`user_id IS NULL`) have no org association we can
+ * verify — we explicitly refuse to grant admin access to them so a
+ * cross-tenant admin can't operate on another org's orphan rows. These
+ * orphans are surfaced for self-service re-registration only; the owning
+ * operator must claim the row via `first-tree-hub connect` before any
+ * admin action becomes available.
  */
-export async function assertClientOwner(db: Database, clientId: string, userId: string): Promise<void> {
+export async function assertClientOwner(
+  db: Database,
+  clientId: string,
+  scope: { userId: string; organizationId: string; role: string },
+): Promise<void> {
   const [row] = await db
     .select({ id: clients.id, userId: clients.userId })
     .from(clients)
     .where(eq(clients.id, clientId))
     .limit(1);
-  if (!row || row.userId !== userId) {
+  if (!row) {
     throw new NotFoundError(`Client "${clientId}" not found`);
   }
+  if (row.userId === scope.userId) return;
+  if (scope.role === "admin" && row.userId !== null) {
+    const [sibling] = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(and(eq(members.userId, row.userId), eq(members.organizationId, scope.organizationId)))
+      .limit(1);
+    if (sibling) return;
+  }
+  throw new NotFoundError(`Client "${clientId}" not found`);
 }
 
 /**
@@ -129,8 +152,40 @@ export async function listActiveAgentsPinnedToClient(db: Database, clientId: str
     .where(and(eq(agents.clientId, clientId), ne(agents.status, "deleted")));
 }
 
-export async function listClients(db: Database, userId: string) {
-  const rows = await db.select().from(clients).where(eq(clients.userId, userId));
+/**
+ * Scope-aware client listing.
+ *
+ *   - member: only rows where `user_id = scope.userId`.
+ *   - admin: every claimed row whose owner is a member of the caller's
+ *     organization.
+ *
+ * Legacy unclaimed rows (`user_id IS NULL`) are intentionally hidden from
+ * both roles — the `clients` table has no org column, so we cannot verify
+ * which org an orphan belongs to. Exposing them to admin would leak
+ * orphans across tenants. The owning operator reclaims the row via
+ * `first-tree-hub connect`, after which it appears in their list.
+ */
+export async function listClients(db: Database, scope: { userId: string; organizationId: string; role: string }) {
+  const rows =
+    scope.role === "admin"
+      ? await db
+          .selectDistinct({
+            id: clients.id,
+            userId: clients.userId,
+            status: clients.status,
+            sdkVersion: clients.sdkVersion,
+            hostname: clients.hostname,
+            os: clients.os,
+            instanceId: clients.instanceId,
+            connectedAt: clients.connectedAt,
+            lastSeenAt: clients.lastSeenAt,
+            metadata: clients.metadata,
+          })
+          .from(clients)
+          .innerJoin(members, eq(members.userId, clients.userId))
+          .where(eq(members.organizationId, scope.organizationId))
+      : await db.select().from(clients).where(eq(clients.userId, scope.userId));
+
   const counts = await db
     .select({
       clientId: agents.clientId,

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -136,20 +136,40 @@ export async function getMember(db: Database, id: string) {
   return { ...row, createdAt: row.createdAt.toISOString() };
 }
 
-export async function updateMember(db: Database, id: string, data: UpdateMember) {
-  if (!data.role) return getMember(db, id);
-
-  // Prevent demoting the last admin
-  if (data.role === "member") {
-    const member = await getMember(db, id);
-    if (member.role === "admin") {
-      await assertNotLastAdmin(db, member.organizationId, id);
-    }
+export async function updateMember(db: Database, id: string, data: UpdateMember, callerOrgId?: string) {
+  if (data.role === undefined && data.displayName === undefined) {
+    return getMember(db, id);
   }
 
-  const [row] = await db.update(members).set({ role: data.role }).where(eq(members.id, id)).returning();
+  const current = await getMember(db, id);
+  // A cross-org admin should never be able to mutate a member in another
+  // tenant. The route layer supplies its own org id; without a match we
+  // 404 to avoid leaking that the member exists.
+  if (callerOrgId && current.organizationId !== callerOrgId) {
+    throw new NotFoundError(`Member "${id}" not found`);
+  }
 
-  if (!row) throw new NotFoundError(`Member "${id}" not found`);
+  // Prevent demoting the last admin — if the caller is turning the final
+  // admin into a member, the org would be locked out of admin operations.
+  if (data.role === "member" && current.role === "admin") {
+    await assertNotLastAdmin(db, current.organizationId, id);
+  }
+
+  await db.transaction(async (tx) => {
+    if (data.role !== undefined && data.role !== current.role) {
+      await tx.update(members).set({ role: data.role }).where(eq(members.id, id));
+    }
+    // Member displayName is stored on the member's human agent — there is no
+    // `members.display_name` column. Write to the agent directly so the two
+    // views (member list + agent detail) don't drift. `users.display_name`
+    // is treated as the authoritative field the `listMembers` join reads
+    // from, so update it too.
+    if (data.displayName !== undefined && data.displayName !== current.displayName) {
+      await tx.update(users).set({ displayName: data.displayName }).where(eq(users.id, current.userId));
+      await tx.update(agents).set({ displayName: data.displayName }).where(eq(agents.uuid, current.agentId));
+    }
+  });
+
   return getMember(db, id);
 }
 

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -28,6 +28,8 @@ export type CreateMember = z.infer<typeof createMemberSchema>;
 
 export const updateMemberSchema = z.object({
   role: memberRoleSchema.optional(),
+  /** Friendly display name; stored on the member's human agent (single source of truth). */
+  displayName: z.string().min(1).max(200).optional(),
 });
 export type UpdateMember = z.infer<typeof updateMemberSchema>;
 

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -15,6 +15,18 @@ export function listAgents(params?: { limit?: number; cursor?: string; type?: st
   return api.get<PaginatedAgents>(`/admin/agents${query ? `?${query}` : ""}`);
 }
 
+/**
+ * Admin-only: every agent in the caller's org, ignoring visibility. Used by
+ * the Admin → All Agents tab; the server 403s for non-admin callers.
+ */
+export function listAllAgentsForAdmin(params?: { limit?: number; cursor?: string }): Promise<PaginatedAgents> {
+  const qs = new URLSearchParams();
+  if (params?.limit) qs.set("limit", String(params.limit));
+  if (params?.cursor) qs.set("cursor", params.cursor);
+  const query = qs.toString();
+  return api.get<PaginatedAgents>(`/admin/agents/all${query ? `?${query}` : ""}`);
+}
+
 export function getAgent(uuid: string): Promise<Agent> {
   return api.get<Agent>(`/admin/agents/${encodeURIComponent(uuid)}`);
 }

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -9,6 +9,7 @@ import { AgentDetailPage } from "./pages/agent-detail.js";
 import { AgentsPage } from "./pages/agents.js";
 import { ClientsPage } from "./pages/clients.js";
 import { LoginPage } from "./pages/login.js";
+import { SettingsPage } from "./pages/settings.js";
 import { WorkspacePage } from "./pages/workspace/index.js";
 
 const queryClient = new QueryClient({
@@ -39,6 +40,7 @@ export function App() {
                 <Route path="agents" element={<AgentsPage />} />
                 <Route path="agents/:uuid" element={<AgentDetailPage />} />
                 <Route path="clients" element={<ClientsPage />} />
+                <Route path="settings" element={<SettingsPage />} />
                 <Route path="admin" element={<AdminPage />} />
               </Route>
             </Route>

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -11,9 +11,10 @@ const navTabs = [
   { to: "/", label: "Workspace", end: true, kbd: "⌘1" },
   { to: "/agents", label: "Agents", end: false, kbd: "⌘2" },
   { to: "/clients", label: "Computers", end: false, kbd: "⌘3" },
+  { to: "/settings", label: "Settings", end: false, kbd: "⌘4" },
 ];
 
-const adminTab = { to: "/admin", label: "Admin", end: false, kbd: "⌘4" };
+const adminTab = { to: "/admin", label: "Admin", end: false, kbd: "⌘5" };
 
 export function Layout() {
   const { role, logout } = useAuth();

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -45,8 +45,14 @@ function issuesToFieldErrors(issues: ValidationIssue[] | undefined): FieldErrors
  * Hidden defaults (see hub-onboarding-mvp proposal §2.2):
  *   - type = "personal_assistant" (Team agents go through a different path)
  *   - manager = current user (admin-assisted creation uses a separate UI)
- *   - displayName = Name, slug derived automatically
  *   - delegateMention, visibility, clientId = not surfaced
+ *
+ * Name vs. display name:
+ *   - `name` is the permanent hub ID (lowercase slug). Format help is shown
+ *     inline so the rule is visible before the user hits Submit.
+ *   - `displayName` is the friendly label and defaults to the user's raw
+ *     text input. We keep the two linked until the user edits `displayName`
+ *     directly — after that, editing `name` no longer touches it.
  *
  * Runtime choice:
  *   - "claude-code" — agent binds to the user's computer on first WS connect.
@@ -86,6 +92,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [nameDirty, setNameDirty] = useState(false);
+  const [displayName, setDisplayName] = useState("");
+  const [displayNameDirty, setDisplayNameDirty] = useState(false);
   const [runtime, setRuntime] = useState<Runtime>("claude-code");
 
   // Step 2 state — shown only when the user has multiple connected computers
@@ -100,6 +108,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
     if (open) {
       setName("");
       setNameDirty(false);
+      setDisplayName("");
+      setDisplayNameDirty(false);
       setRuntime("claude-code");
       setStep("form");
       setCandidateClients([]);
@@ -113,7 +123,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
 
   const createMut = useMutation({
     mutationFn: async (opts: { clientId?: string }) => {
-      const displayName = name.trim() || "Untitled assistant";
+      const effectiveDisplay = displayName.trim() || name.trim() || "Untitled assistant";
       const effectiveName = slug || undefined;
       // When a clientId is provided (scenario B), the server pins the agent
       // on create and emits an `agent:pinned` WebSocket frame to the
@@ -123,7 +133,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
       return createAgent({
         name: effectiveName,
         type: "personal_assistant",
-        displayName,
+        displayName: effectiveDisplay,
         clientId: opts.clientId,
       });
     },
@@ -136,13 +146,18 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
 
   // Translate a server validation error (Zod `issues[]` emitted by the server
   // `setErrorHandler` in `app.ts`) into per-field messages. Non-validation
-  // errors fall through to `_root` so they still render as a banner.
+  // errors fall through to `_root` so they still render as a banner —
+  // except the 409 uniqueness conflict, which we attach to the `name` field
+  // because "already exists" is specifically a name collision.
   const serverErrors = useMemo<FieldErrors>(() => {
     const err = createMut.error;
     if (!err) return {};
     if (err instanceof ApiError) {
       const fromIssues = issuesToFieldErrors(err.issues);
       if (Object.keys(fromIssues).length > 0) return fromIssues;
+      if (err.status === 409) {
+        return { name: "That hub ID is already in use in this organization. Pick a different one." };
+      }
       return { _root: err.message };
     }
     if (err instanceof Error) return { _root: err.message };
@@ -172,7 +187,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
       // Raw input had content but slugify() stripped it down to nothing —
       // e.g. pure-symbol input like "!!!". Server would auto-generate, but
       // the user probably didn't intend that; surface the issue.
-      errs.name = "Name must contain at least one letter or digit.";
+      errs.name = "Name must contain at least one letter or digit (e.g. a-z, 0-9).";
+    }
+    if (displayName.length > 200) {
+      errs.displayName = `Display name must be at most 200 characters (got ${displayName.length}).`;
     }
     return errs;
   }
@@ -305,19 +323,21 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
               id="new-agent-name"
               value={name}
               onChange={(e) => {
-                setName(e.target.value);
+                const next = e.target.value;
+                setName(next);
                 setNameDirty(true);
+                if (!displayNameDirty) setDisplayName(next);
                 if (clientErrors.name) setClientErrors((prev) => ({ ...prev, name: undefined }));
               }}
               placeholder="My Dev Assistant"
               autoFocus
-              maxLength={80}
+              maxLength={NAME_MAX}
               aria-invalid={fieldErrors.name ? true : undefined}
               aria-describedby="new-agent-name-help new-agent-name-error"
             />
             <p id="new-agent-name-help" className="text-xs text-muted-foreground">
-              Any text — we'll derive a hub ID (lowercase letters, digits, hyphens, underscores; up to {NAME_MAX} chars)
-              automatically.
+              Hub ID: lowercase letters, digits, hyphens (-), and underscores (_). Up to {NAME_MAX} characters.
+              Permanent after creation — you can't rename the agent later.
             </p>
             {nameDirty && slug && (
               <p className="text-xs text-muted-foreground">
@@ -327,6 +347,31 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
             {fieldErrors.name && (
               <p id="new-agent-name-error" className="text-xs text-destructive">
                 {fieldErrors.name}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="new-agent-display-name">Display name</Label>
+            <Input
+              id="new-agent-display-name"
+              value={displayName}
+              onChange={(e) => {
+                setDisplayName(e.target.value);
+                setDisplayNameDirty(true);
+                if (clientErrors.displayName) setClientErrors((prev) => ({ ...prev, displayName: undefined }));
+              }}
+              placeholder="How teammates see this agent"
+              maxLength={200}
+              aria-invalid={fieldErrors.displayName ? true : undefined}
+              aria-describedby="new-agent-display-name-help new-agent-display-name-error"
+            />
+            <p id="new-agent-display-name-help" className="text-xs text-muted-foreground">
+              Shown in chats and lists. Defaults to the Name above; you can change it anytime later.
+            </p>
+            {fieldErrors.displayName && (
+              <p id="new-agent-display-name-error" className="text-xs text-destructive">
+                {fieldErrors.displayName}
               </p>
             )}
           </div>

--- a/packages/web/src/components/notification-bell.tsx
+++ b/packages/web/src/components/notification-bell.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
@@ -29,9 +29,11 @@ function relativeTime(dateStr: string): string {
 
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
+  const [markAllError, setMarkAllError] = useState<string | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const agentName = useAgentNameMap();
+  const queryClient = useQueryClient();
 
   const { data } = useQuery({
     queryKey: ["notifications", "bell"],
@@ -63,9 +65,22 @@ export function NotificationBell() {
     [navigate],
   );
 
-  const handleMarkAll = useCallback(() => {
-    markAllNotificationsRead().catch(() => {});
-  }, []);
+  // Without an invalidate, the red badge stays up to 10s (refetchInterval)
+  // after the API succeeds — visually indistinguishable from "nothing
+  // happened". Broad-invalidate every `["notifications", …]` key so the
+  // bell list, unread count, and per-agent panels all refresh in lockstep
+  // — targeted invalidates miss any future consumer keyed on
+  // `["notifications", "agent", id]` or a yet-unbuilt list page. Surface
+  // failures inline since we don't have a toast system yet.
+  const handleMarkAll = useCallback(async () => {
+    setMarkAllError(null);
+    try {
+      await markAllNotificationsRead();
+      await queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    } catch (err) {
+      setMarkAllError(err instanceof Error ? err.message : "Failed to mark all as read");
+    }
+  }, [queryClient]);
 
   return (
     <div className="relative">
@@ -101,6 +116,11 @@ export function NotificationBell() {
                 </button>
               )}
             </div>
+            {markAllError && (
+              <div className="border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                {markAllError}
+              </div>
+            )}
             <div className="max-h-80 overflow-y-auto">
               {!data?.items || data.items.length === 0 ? (
                 <div className="py-6 text-center text-sm text-muted-foreground">No notifications</div>

--- a/packages/web/src/lib/use-agent-name-map.ts
+++ b/packages/web/src/lib/use-agent-name-map.ts
@@ -16,11 +16,17 @@ export function useAgentNameMap(): (uuid: string | null | undefined) => string {
     staleTime: 30_000,
   });
 
+  // Prefer `displayName` over `name` so chat/roster render friendly
+  // strings (e.g. "Alice Wang") instead of slug-form hub IDs
+  // (e.g. "alice"). The slug stays available as a fallback for agents
+  // with no display name set, and uuid as the last resort for soft-
+  // deleted rows (`name` is cleared on delete) or agents that never had
+  // either field populated.
   return useMemo(() => {
     const map = new Map<string, string>();
     if (data?.items) {
       for (const a of data.items) {
-        map.set(a.uuid, a.name ?? a.displayName ?? a.uuid);
+        map.set(a.uuid, a.displayName ?? a.name ?? a.uuid);
       }
     }
     return (uuid: string | null | undefined) => {

--- a/packages/web/src/lib/use-user-name-map.ts
+++ b/packages/web/src/lib/use-user-name-map.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { listMembers } from "../api/members.js";
+
+/**
+ * userId → display-name lookup. Clients carry `user_id`, not member_id, so
+ * listings that want to show "owner" need to cross a member row to surface
+ * the display name. Members-per-user is 1:1 in the current schema (one
+ * membership per user per org).
+ */
+export function useUserNameMap(): (userId: string | null | undefined) => string {
+  const { data } = useQuery({
+    queryKey: ["members", "user-name-map"],
+    queryFn: listMembers,
+    staleTime: 30_000,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, string>();
+    if (data) {
+      for (const m of data) {
+        map.set(m.userId, m.displayName || m.username);
+      }
+    }
+    return (userId: string | null | undefined) => {
+      if (!userId) return "—";
+      return map.get(userId) ?? userId;
+    };
+  }, [data]);
+}

--- a/packages/web/src/pages/admin-all-agents.tsx
+++ b/packages/web/src/pages/admin-all-agents.tsx
@@ -16,9 +16,12 @@ export function AdminAllAgentsPage() {
   const navigate = useNavigate();
   const resolveMember = useMemberNameMap();
 
+  // `paginationQuerySchema` caps `limit` at 100 server-side. Stay at the max
+  // here — if the org grows past 100 agents we'll need cursor pagination
+  // (same story as the rest of the admin list views).
   const { data, isLoading, error } = useQuery({
     queryKey: ["admin-all-agents"],
-    queryFn: () => listAllAgentsForAdmin({ limit: 200 }),
+    queryFn: () => listAllAgentsForAdmin({ limit: 100 }),
   });
 
   return (

--- a/packages/web/src/pages/admin-all-agents.tsx
+++ b/packages/web/src/pages/admin-all-agents.tsx
@@ -1,0 +1,91 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import { listAllAgentsForAdmin } from "../api/agents.js";
+import { Badge } from "../components/ui/badge.js";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { useMemberNameMap } from "../lib/use-member-name-map.js";
+import { formatDate } from "../lib/utils.js";
+
+/**
+ * Admin-only view of every agent in the organization, including private ones
+ * owned by other members. The default `/agents` list still applies the
+ * visibility filter (Rule: visibility != manageability); this page is the
+ * manageability-oriented view used to troubleshoot or reassign.
+ */
+export function AdminAllAgentsPage() {
+  const navigate = useNavigate();
+  const resolveMember = useMemberNameMap();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin-all-agents"],
+    queryFn: () => listAllAgentsForAdmin({ limit: 200 }),
+  });
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Every agent in the organization, including private agents owned by other members. Use this view to troubleshoot
+        or reassign — the regular Agents page still hides private agents you don't manage.
+      </p>
+
+      <div className="border rounded-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Display Name</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Visibility</TableHead>
+              <TableHead>Owner</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                  Loading...
+                </TableCell>
+              </TableRow>
+            ) : error ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-8 text-destructive">
+                  Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
+                </TableCell>
+              </TableRow>
+            ) : !data || data.items.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
+                  No agents
+                </TableCell>
+              </TableRow>
+            ) : (
+              data.items.map((a) => (
+                <TableRow
+                  key={a.uuid}
+                  className="cursor-pointer"
+                  onClick={() => navigate(`/agents/${encodeURIComponent(a.uuid)}`)}
+                >
+                  <TableCell className="font-mono text-sm">{a.name ?? a.uuid.slice(0, 8)}</TableCell>
+                  <TableCell>{a.displayName ?? "—"}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{a.type}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={a.visibility === "organization" ? "default" : "outline"}>{a.visibility}</Badge>
+                  </TableCell>
+                  <TableCell className="text-sm">{a.managerId ? resolveMember(a.managerId) : "—"}</TableCell>
+                  <TableCell>
+                    <Badge variant={a.status === "active" ? "default" : "secondary"}>{a.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">{formatDate(a.createdAt)}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/admin.tsx
+++ b/packages/web/src/pages/admin.tsx
@@ -1,20 +1,35 @@
-import { useLocation, useNavigate } from "react-router";
+import { Navigate, useLocation, useNavigate } from "react-router";
+import { useAuth } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
-import { BindingsPage } from "./bindings.js";
+import { AdminAllAgentsPage } from "./admin-all-agents.js";
 import { MembersPage } from "./members.js";
-import { SettingsPage } from "./settings.js";
+import { OrgSettingsPage } from "./org-settings.js";
 
 const tabs = [
   { key: "members", label: "Members" },
-  { key: "settings", label: "Settings" },
-  { key: "bindings", label: "Bindings" },
+  { key: "all-agents", label: "All Agents" },
+  { key: "settings", label: "Org Settings" },
 ] as const;
 
 type TabKey = (typeof tabs)[number]["key"];
 
 export function AdminPage() {
+  const { role } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
+
+  // `role` is null until the first `/me` response lands. Rendering the
+  // admin shell while we wait would flash admin-only UI to a non-admin
+  // for a tick — gate on role being resolved. Server-side enforcement
+  // still lives on the individual admin routes; this is only here to
+  // keep the UI honest during the loading window.
+  if (role === null) {
+    return <div className="text-sm text-muted-foreground">Loading…</div>;
+  }
+  if (role !== "admin") {
+    return <Navigate to="/settings" replace />;
+  }
+
   const hashTab = location.hash.replace("#", "") as TabKey;
   const active: TabKey = tabs.some((t) => t.key === hashTab) ? hashTab : "members";
 
@@ -43,8 +58,8 @@ export function AdminPage() {
         ))}
       </div>
       {active === "members" && <MembersPage />}
-      {active === "settings" && <SettingsPage />}
-      {active === "bindings" && <BindingsPage />}
+      {active === "all-agents" && <AdminAllAgentsPage />}
+      {active === "settings" && <OrgSettingsPage />}
     </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -1,8 +1,9 @@
-import type { Agent, UpdateAgent } from "@agent-team-foundation/first-tree-hub-shared";
+import { AGENT_VISIBILITY, type Agent, type UpdateAgent } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
 import { Pencil } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 import { listAgents } from "../../api/agents.js";
+import { useAuth } from "../../auth/auth-context.js";
 import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
@@ -100,8 +101,10 @@ type IdentityDialogProps = {
 };
 
 function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialogProps) {
+  const { memberId, role } = useAuth();
   const [displayName, setDisplayName] = useState(agent.displayName ?? "");
   const [delegateMention, setDelegateMention] = useState(agent.delegateMention ?? "");
+  const [visibility, setVisibility] = useState(agent.visibility);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -109,11 +112,16 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
     if (open) {
       setDisplayName(agent.displayName ?? "");
       setDelegateMention(agent.delegateMention ?? "");
+      setVisibility(agent.visibility);
       setError(null);
     }
   }, [open, agent]);
 
   const isHuman = agent.type === "human";
+  // Only the agent's manager or an admin can change visibility. The backend
+  // enforces this via assertCanManage; this mirrors that on the UI so the
+  // field is disabled when the caller can't persist the change anyway.
+  const canChangeVisibility = role === "admin" || agent.managerId === memberId;
   const assistantsQuery = useQuery({
     queryKey: ["agents-for-delegate"],
     queryFn: async () => {
@@ -128,10 +136,14 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
     setError(null);
     setSaving(true);
     try {
-      await onSave({
+      const patch: UpdateAgent = {
         displayName: displayName || null,
         delegateMention: delegateMention || null,
-      });
+      };
+      if (visibility !== agent.visibility) {
+        patch.visibility = visibility;
+      }
+      await onSave(patch);
       onOpenChange(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -161,6 +173,24 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
               placeholder="How teammates see this agent"
               maxLength={200}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="id-visibility">Visibility</Label>
+            <select
+              id="id-visibility"
+              value={visibility}
+              onChange={(e) => setVisibility(e.target.value as typeof visibility)}
+              disabled={!canChangeVisibility}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value={AGENT_VISIBILITY.PRIVATE}>Private — only the manager</option>
+              <option value={AGENT_VISIBILITY.ORGANIZATION}>Organization — all members</option>
+            </select>
+            <p className="text-xs text-muted-foreground">
+              {canChangeVisibility
+                ? "Private agents are only visible to their manager; organization agents appear in every member's list."
+                : "Only the manager or an admin can change this agent's visibility."}
+            </p>
           </div>
           {isHuman && (
             <div className="space-y-2">

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -73,6 +73,10 @@ export function IdentitySection({ agent, onSave }: IdentitySectionProps) {
           <span>
             type <Badge variant="secondary">{agent.type}</Badge>
           </span>
+          <span>
+            visibility{" "}
+            <Badge variant={agent.visibility === "organization" ? "default" : "outline"}>{agent.visibility}</Badge>
+          </span>
           {domains.length > 0 && (
             <span>
               domains{" "}

--- a/packages/web/src/pages/bindings.tsx
+++ b/packages/web/src/pages/bindings.tsx
@@ -33,12 +33,9 @@ export function BindingsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Platform Bindings</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Overview of all platform bindings. Manage bindings from each Agent's detail page.
-        </p>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        Overview of platform bindings for agents you can manage. Configure each binding from the Agent detail page.
+      </p>
 
       {/* Bot Bindings (non-human agents) */}
       <Card>

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -12,11 +12,13 @@ import {
   retireClient,
 } from "../api/activity.js";
 import { ApiError } from "../api/client.js";
+import { useAuth } from "../auth/auth-context.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import { StateChip } from "../components/ui/state-chip.js";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
+import { useUserNameMap } from "../lib/use-user-name-map.js";
 import { formatDate } from "../lib/utils.js";
 
 function ConnectCommandBanner() {
@@ -73,6 +75,9 @@ function ConnectCommandBanner() {
 export function ClientsPage() {
   const queryClient = useQueryClient();
   const agentName = useAgentNameMap();
+  const ownerName = useUserNameMap();
+  const { role } = useAuth();
+  const isAdmin = role === "admin";
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [confirmDisconnect, setConfirmDisconnect] = useState<HubClient | null>(null);
   const [confirmRetire, setConfirmRetire] = useState<HubClient | null>(null);
@@ -241,6 +246,7 @@ export function ClientsPage() {
               <TableRow>
                 <TableHead className="w-8" />
                 <TableHead>Hostname</TableHead>
+                {isAdmin && <TableHead>Owner</TableHead>}
                 <TableHead>OS</TableHead>
                 <TableHead>SDK</TableHead>
                 <TableHead>Agents</TableHead>
@@ -260,6 +266,8 @@ export function ClientsPage() {
                     boundAgents={boundAgents}
                     isExpanded={isExpanded}
                     agentName={agentName}
+                    showOwner={isAdmin}
+                    ownerName={ownerName}
                     onToggle={() => setExpandedId(isExpanded ? null : client.id)}
                     onDisconnect={() => setConfirmDisconnect(client)}
                     onRetire={() => {
@@ -282,6 +290,8 @@ function ClientRow({
   boundAgents,
   isExpanded,
   agentName,
+  showOwner,
+  ownerName,
   onToggle,
   onDisconnect,
   onRetire,
@@ -290,6 +300,8 @@ function ClientRow({
   boundAgents: RuntimeAgent[];
   isExpanded: boolean;
   agentName: (uuid: string | null | undefined) => string;
+  showOwner: boolean;
+  ownerName: (userId: string | null | undefined) => string;
   onToggle: () => void;
   onDisconnect: () => void;
   onRetire: () => void;
@@ -301,6 +313,7 @@ function ClientRow({
           {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
         </TableCell>
         <TableCell className="font-medium">{client.hostname ?? "\u2014"}</TableCell>
+        {showOwner && <TableCell className="text-sm">{ownerName(client.userId)}</TableCell>}
         <TableCell className="text-muted-foreground">{client.os ?? "\u2014"}</TableCell>
         <TableCell className="font-mono text-xs text-muted-foreground">{client.sdkVersion ?? "\u2014"}</TableCell>
         <TableCell>{client.agentCount}</TableCell>
@@ -339,7 +352,7 @@ function ClientRow({
       </TableRow>
       {isExpanded && (
         <TableRow>
-          <TableCell colSpan={8} className="bg-muted/30 px-8 py-3">
+          <TableCell colSpan={showOwner ? 9 : 8} className="bg-muted/30 px-8 py-3">
             <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
               Bound Agents ({boundAgents.length})
             </div>

--- a/packages/web/src/pages/members.tsx
+++ b/packages/web/src/pages/members.tsx
@@ -1,8 +1,8 @@
 import { MEMBER_ROLES } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Copy, Plus, Trash2 } from "lucide-react";
-import { type FormEvent, useState } from "react";
-import { createMember, deleteMember, listMembers } from "../api/members.js";
+import { Copy, Pencil, Plus, Trash2 } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+import { createMember, deleteMember, listMembers, updateMember } from "../api/members.js";
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
 import {
@@ -20,11 +20,19 @@ import { formatDate } from "../lib/utils.js";
 
 const roleValues = Object.values(MEMBER_ROLES);
 
+type MemberRow = {
+  id: string;
+  username: string;
+  displayName: string;
+  role: string;
+};
+
 export function MembersPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [form, setForm] = useState({ username: "", displayName: "", role: "member" });
   const [createdPassword, setCreatedPassword] = useState<string | null>(null);
+  const [editTarget, setEditTarget] = useState<MemberRow | null>(null);
 
   const {
     data: members,
@@ -155,6 +163,15 @@ export function MembersPage() {
         </Dialog>
       </div>
 
+      <EditMemberDialog
+        target={editTarget}
+        onClose={() => setEditTarget(null)}
+        onSaved={() => {
+          setEditTarget(null);
+          queryClient.invalidateQueries({ queryKey: ["members"] });
+        }}
+      />
+
       <div className="border rounded-lg">
         <Table>
           <TableHeader>
@@ -195,15 +212,32 @@ export function MembersPage() {
                   </TableCell>
                   <TableCell className="text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
                   <TableCell>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDelete(m.id)}
-                      disabled={deleteMut.isPending}
-                      title="Delete"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    <div className="flex items-center gap-1 justify-end">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() =>
+                          setEditTarget({
+                            id: m.id,
+                            username: m.username,
+                            displayName: m.displayName,
+                            role: m.role,
+                          })
+                        }
+                        title="Edit"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(m.id)}
+                        disabled={deleteMut.isPending}
+                        title="Delete"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))
@@ -212,5 +246,112 @@ export function MembersPage() {
         </Table>
       </div>
     </div>
+  );
+}
+
+function EditMemberDialog({
+  target,
+  onClose,
+  onSaved,
+}: {
+  target: MemberRow | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [displayName, setDisplayName] = useState("");
+  const [role, setRole] = useState<string>("member");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (target) {
+      setDisplayName(target.displayName);
+      setRole(target.role);
+      setError(null);
+    }
+  }, [target]);
+
+  const saveMut = useMutation({
+    mutationFn: async () => {
+      if (!target) throw new Error("No target");
+      const patch: { displayName?: string; role?: "admin" | "member" } = {};
+      if (displayName.trim() && displayName !== target.displayName) {
+        patch.displayName = displayName.trim();
+      }
+      if (role !== target.role) {
+        patch.role = role as "admin" | "member";
+      }
+      if (Object.keys(patch).length === 0) return target;
+      return updateMember(target.id, patch);
+    },
+    onSuccess: () => {
+      setError(null);
+      onSaved();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    saveMut.mutate();
+  }
+
+  const open = target !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Member</DialogTitle>
+        </DialogHeader>
+        {target && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label>Username</Label>
+              <Input value={target.username} disabled className="font-mono" />
+              <p className="text-xs text-muted-foreground">Username is permanent after creation.</p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-member-display">Display Name</Label>
+              <Input
+                id="edit-member-display"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                required
+                maxLength={200}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-member-role">Role</Label>
+              <select
+                id="edit-member-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {roleValues.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                Demoting the last admin is blocked — every org needs at least one admin to manage members.
+              </p>
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onClose} disabled={saveMut.isPending}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saveMut.isPending}>
+                {saveMut.isPending ? "Saving…" : "Save"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/web/src/pages/org-settings.tsx
+++ b/packages/web/src/pages/org-settings.tsx
@@ -1,0 +1,101 @@
+import { SYSTEM_CONFIG_DEFAULTS, SYSTEM_CONFIG_KEYS } from "@agent-team-foundation/first-tree-hub-shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type FormEvent, useEffect, useState } from "react";
+import { getConfigs, updateConfigs } from "../api/system-config.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
+
+const CONFIG_LABELS: Record<string, string> = {
+  [SYSTEM_CONFIG_KEYS.INBOX_TIMEOUT_SECONDS]: "Inbox Timeout (seconds)",
+  [SYSTEM_CONFIG_KEYS.MAX_RETRY_COUNT]: "Max Retry Count",
+  [SYSTEM_CONFIG_KEYS.POLLING_INTERVAL_SECONDS]: "Polling Interval (seconds)",
+  [SYSTEM_CONFIG_KEYS.PRESENCE_CLEANUP_SECONDS]: "Presence Cleanup (seconds)",
+};
+
+const configKeys = Object.values(SYSTEM_CONFIG_KEYS);
+
+export function OrgSettingsPage() {
+  const queryClient = useQueryClient();
+  const { data: configs, isLoading } = useQuery({
+    queryKey: ["system-config"],
+    queryFn: getConfigs,
+  });
+
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!configs) return;
+    const map: Record<string, string> = {};
+    for (const key of configKeys) {
+      const val = configs[key] ?? SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "";
+      map[key] = String(val);
+    }
+    setValues(map);
+  }, [configs]);
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const payload: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(values)) {
+        const trimmed = val.trim();
+        if (trimmed === "") {
+          // Restore default instead of sending 0
+          payload[key] = SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? 0;
+        } else {
+          const num = Number(trimmed);
+          payload[key] = Number.isNaN(num) ? trimmed : num;
+        }
+      }
+      return updateConfigs(payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["system-config"] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    mutation.mutate();
+  };
+
+  if (isLoading) {
+    return <div className="text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>System Configuration</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {configKeys.map((key) => (
+            <div key={key} className="space-y-2">
+              <Label htmlFor={key}>{CONFIG_LABELS[key] ?? key}</Label>
+              <Input
+                id={key}
+                value={values[key] ?? ""}
+                onChange={(e) => setValues({ ...values, [key]: e.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">
+                Default: {String(SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "—")}
+              </p>
+            </div>
+          ))}
+          {mutation.error instanceof Error && <div className="text-sm text-destructive">{mutation.error.message}</div>}
+          <div className="flex items-center gap-3">
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Saving..." : "Save Changes"}
+            </Button>
+            {saved && <span className="text-sm text-green-600">Saved!</span>}
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -1,106 +1,15 @@
-import { SYSTEM_CONFIG_DEFAULTS, SYSTEM_CONFIG_KEYS } from "@agent-team-foundation/first-tree-hub-shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type FormEvent, useEffect, useState } from "react";
-import { getConfigs, updateConfigs } from "../api/system-config.js";
-import { Button } from "../components/ui/button.js";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
-import { Input } from "../components/ui/input.js";
-import { Label } from "../components/ui/label.js";
+import { BindingsPage } from "./bindings.js";
 
-const CONFIG_LABELS: Record<string, string> = {
-  [SYSTEM_CONFIG_KEYS.INBOX_TIMEOUT_SECONDS]: "Inbox Timeout (seconds)",
-  [SYSTEM_CONFIG_KEYS.MAX_RETRY_COUNT]: "Max Retry Count",
-  [SYSTEM_CONFIG_KEYS.POLLING_INTERVAL_SECONDS]: "Polling Interval (seconds)",
-  [SYSTEM_CONFIG_KEYS.PRESENCE_CLEANUP_SECONDS]: "Presence Cleanup (seconds)",
-};
-
-const configKeys = Object.values(SYSTEM_CONFIG_KEYS);
-
+/**
+ * User-facing Settings page. Post hub-ui-polish split: every signed-in member
+ * sees `/settings` (Bindings is scoped per-role by the server). Admin-only
+ * organization controls (Members, org system config) moved to `/admin`.
+ */
 export function SettingsPage() {
-  const queryClient = useQueryClient();
-  const { data: configs, isLoading } = useQuery({
-    queryKey: ["system-config"],
-    queryFn: getConfigs,
-  });
-
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [saved, setSaved] = useState(false);
-
-  useEffect(() => {
-    if (!configs) return;
-    const map: Record<string, string> = {};
-    for (const key of configKeys) {
-      const val = configs[key] ?? SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "";
-      map[key] = String(val);
-    }
-    setValues(map);
-  }, [configs]);
-
-  const mutation = useMutation({
-    mutationFn: () => {
-      const payload: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(values)) {
-        const trimmed = val.trim();
-        if (trimmed === "") {
-          // Restore default instead of sending 0
-          payload[key] = SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? 0;
-        } else {
-          const num = Number(trimmed);
-          payload[key] = Number.isNaN(num) ? trimmed : num;
-        }
-      }
-      return updateConfigs(payload);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["system-config"] });
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    },
-  });
-
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    mutation.mutate();
-  };
-
-  if (isLoading) {
-    return <div className="text-muted-foreground">Loading...</div>;
-  }
-
   return (
     <div>
       <h1 className="text-2xl font-semibold mb-6">Settings</h1>
-      <Card>
-        <CardHeader>
-          <CardTitle>System Configuration</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {configKeys.map((key) => (
-              <div key={key} className="space-y-2">
-                <Label htmlFor={key}>{CONFIG_LABELS[key] ?? key}</Label>
-                <Input
-                  id={key}
-                  value={values[key] ?? ""}
-                  onChange={(e) => setValues({ ...values, [key]: e.target.value })}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Default: {String(SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "—")}
-                </p>
-              </div>
-            ))}
-            {mutation.error instanceof Error && (
-              <div className="text-sm text-destructive">{mutation.error.message}</div>
-            )}
-            <div className="flex items-center gap-3">
-              <Button type="submit" disabled={mutation.isPending}>
-                {mutation.isPending ? "Saving..." : "Save Changes"}
-              </Button>
-              {saved && <span className="text-sm text-green-600">Saved!</span>}
-            </div>
-          </form>
-        </CardContent>
-      </Card>
+      <BindingsPage />
     </div>
   );
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -21,11 +21,15 @@ import { resolveAgentState } from "../../../utils/agent-state.js";
 
 function formatClockTime(iso: string): string {
   const d = new Date(iso);
-  return new Intl.DateTimeFormat("en-GB", {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    month: "2-digit",
+    day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
-  }).format(d);
+  }).formatToParts(d);
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("month")}/${get("day")} ${get("hour")}:${get("minute")}`;
 }
 
 function formatRelative(iso: string | null): string {

--- a/packages/web/src/pages/workspace/context/agent-context.tsx
+++ b/packages/web/src/pages/workspace/context/agent-context.tsx
@@ -260,12 +260,8 @@ export function AgentContext({ agentId }: { agentId: string }) {
         <a href={`/agents/${agentId}`} style={{ fontSize: 11, color: "var(--accent)" }} className="hover:underline">
           Manage agent →
         </a>
-        <a
-          href="/admin#clients"
-          style={{ fontSize: 11, color: "var(--accent)", marginTop: 4 }}
-          className="hover:underline"
-        >
-          Admin · Computers →
+        <a href="/clients" style={{ fontSize: 11, color: "var(--accent)", marginTop: 4 }} className="hover:underline">
+          Computers →
         </a>
       </div>
 

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -17,6 +17,8 @@ import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 const STATIC_ROUTES = [
   { path: "/", label: "Workspace" },
   { path: "/agents", label: "Agents" },
+  { path: "/clients", label: "Computers" },
+  { path: "/settings", label: "Settings" },
   { path: "/admin", label: "Admin" },
 ];
 


### PR DESCRIPTION
## Summary

Hub UI polish batch (T1–T9): wraps up agent-visibility on the identity dialog, splits the admin surface into a shared `/settings` and an admin-only `/admin`, and pushes role enforcement down into the service layer so the UI split is backed by the API.

- **Route split** (T2): `/settings` (Bindings, every member) + `/admin` (Members / All Agents / Org Settings, admin only). Sidebar + command palette render the admin tab only for admin role; direct `/admin` access gates on role resolution to avoid a flash of admin UI.
- **Role-scoped access** (T3 / T6 / T8 / T9): Bindings, adapter status, and Computers lists scope by role in the handler, not via an admin-only hook. Computers also hides legacy unclaimed (`user_id IS NULL`) rows for every role because the `clients` table has no org column — they reappear only after the owning operator reclaims via `first-tree-hub connect`. Members edit (admin-only) adds `displayName` + `role`, syncing `users.displayName` and the member's human agent, with a last-admin demotion guard. New `GET /admin/agents/all` (admin-only) returns every agent in the caller's org ignoring the visibility filter for the new **All Agents** tab.
- **UX fixes** (T1 / T4 / T5 / T7): identity dialog gains a visibility select; chat timestamps render `MM/DD HH:mm`; notification mark-all invalidates the `["notifications"]` subtree so the badge refreshes in lockstep; new-agent dialog adds a Display Name input that tracks Name until edited, inline hub-ID format help, and a 409 conflict mapped to the name field.

## Test plan

- [x] `pnpm check` (Biome) — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @first-tree-hub/server test` — 367/367 pass (covers members, adapter scoping, agent visibility, client acl, etc.)
- [x] `pnpm --filter @first-tree-hub/web test` — 10/10 pass
- [ ] Manual: log in as a non-admin member — `/settings` shows only bindings for own agents, `/admin` redirects out, sidebar has no Admin tab
- [ ] Manual: log in as admin — Computers list shows Owner column; All Agents tab includes private agents owned by other members
- [ ] Manual: open Members edit dialog, change display name + role; confirm the member's human agent display name also updated; try to demote the last admin and verify it's blocked