### PR TITLE
feat(workspace): show session summary and participants in roster and chat header

### DIFF
--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -99,10 +99,10 @@ export async function listAgentSessions(
               WHERE chat_id = ANY(${chatIds})
               ORDER BY chat_id, created_at ASC`,
         )
-      : { rows: [] as { chat_id: string; content: unknown }[] };
+      : ([] as { chat_id: string; content: unknown }[]);
 
   const summaryMap = new Map<string, string>();
-  for (const row of firstMessages.rows) {
+  for (const row of firstMessages) {
     const summary = extractSummary(row.content);
     if (summary) {
       summaryMap.set(row.chat_id, summary);
@@ -159,7 +159,7 @@ export async function getSession(db: Database, agentId: string, chatId: string):
   const firstMsgRows = await db.execute<{ content: unknown }>(
     sql`SELECT content FROM messages WHERE chat_id = ${chatId} ORDER BY created_at ASC LIMIT 1`,
   );
-  const summary = firstMsgRows.rows.length > 0 ? extractSummary(firstMsgRows.rows[0].content) : null;
+  const summary = firstMsgRows.length > 0 ? extractSummary(firstMsgRows[0].content) : null;
 
   return {
     agentId: row.agentId,

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -7,6 +7,19 @@ import { chatParticipants, chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { NotFoundError } from "../errors.js";
 
+const SUMMARY_MAX_LENGTH = 50;
+
+/** Extract a plain-text summary from a message's JSONB content field. */
+function extractSummary(content: unknown, maxLen = SUMMARY_MAX_LENGTH): string | null {
+  let text = "";
+  if (typeof content === "object" && content !== null && "text" in content) {
+    text = String((content as { text: unknown }).text ?? "");
+  } else if (typeof content === "string") {
+    text = content;
+  }
+  return text ? text.slice(0, maxLen) : null;
+}
+
 export type SessionListItem = {
   agentId: string;
   chatId: string;
@@ -15,6 +28,7 @@ export type SessionListItem = {
   startedAt: string;
   lastActivityAt: string;
   messageCount: number;
+  summary: string | null;
 };
 
 /** List sessions for a specific agent, with optional state filters. */
@@ -76,6 +90,25 @@ export async function listAgentSessions(
 
   const countMap = new Map(messageCounts.map((r) => [r.chatId, r.count]));
 
+  // Get first message content per chat for summary
+  const firstMessages =
+    chatIds.length > 0
+      ? await db.execute<{ chat_id: string; content: unknown }>(
+          sql`SELECT DISTINCT ON (chat_id) chat_id, content
+              FROM messages
+              WHERE chat_id = ANY(${chatIds})
+              ORDER BY chat_id, created_at ASC`,
+        )
+      : { rows: [] as { chat_id: string; content: unknown }[] };
+
+  const summaryMap = new Map<string, string>();
+  for (const row of firstMessages.rows) {
+    const summary = extractSummary(row.content);
+    if (summary) {
+      summaryMap.set(row.chat_id, summary);
+    }
+  }
+
   return rows.map((r) => ({
     agentId: r.agentId,
     chatId: r.chatId,
@@ -84,6 +117,7 @@ export async function listAgentSessions(
     startedAt: r.chatCreatedAt.toISOString(),
     lastActivityAt: r.updatedAt.toISOString(),
     messageCount: countMap.get(r.chatId) ?? 0,
+    summary: summaryMap.get(r.chatId) ?? null,
   }));
 }
 
@@ -121,6 +155,12 @@ export async function getSession(db: Database, agentId: string, chatId: string):
       ),
     );
 
+  // Get first message for summary
+  const firstMsgRows = await db.execute<{ content: unknown }>(
+    sql`SELECT content FROM messages WHERE chat_id = ${chatId} ORDER BY created_at ASC LIMIT 1`,
+  );
+  const summary = firstMsgRows.rows.length > 0 ? extractSummary(firstMsgRows.rows[0].content) : null;
+
   return {
     agentId: row.agentId,
     chatId: row.chatId,
@@ -129,6 +169,7 @@ export async function getSession(db: Database, agentId: string, chatId: string):
     startedAt: row.chatCreatedAt.toISOString(),
     lastActivityAt: row.updatedAt.toISOString(),
     messageCount: countRow?.count ?? 0,
+    summary,
   };
 }
 
@@ -194,6 +235,7 @@ export async function listAllSessions(
       startedAt: r.chatCreatedAt.toISOString(),
       lastActivityAt: r.updatedAt.toISOString(),
       messageCount: 0, // Omit per-session message count in global list for performance
+      summary: null, // Omit summary in global list for performance
     })),
     nextCursor,
   };

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -159,7 +159,8 @@ export async function getSession(db: Database, agentId: string, chatId: string):
   const firstMsgRows = await db.execute<{ content: unknown }>(
     sql`SELECT content FROM messages WHERE chat_id = ${chatId} ORDER BY created_at ASC LIMIT 1`,
   );
-  const summary = firstMsgRows.length > 0 ? extractSummary(firstMsgRows[0].content) : null;
+  const firstMsg = firstMsgRows[0];
+  const summary = firstMsg ? extractSummary(firstMsg.content) : null;
 
   return {
     agentId: row.agentId,

--- a/packages/web/src/api/sessions.ts
+++ b/packages/web/src/api/sessions.ts
@@ -8,6 +8,7 @@ export type SessionListItem = {
   startedAt: string;
   lastActivityAt: string;
   messageCount: number;
+  summary: string | null;
 };
 
 export type SessionListResponse = {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Leaf, MessageSquare, Pause, Play, Send, Square } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { listChatMessages, type MessageWithDelivery, sendChatMessage } from "../../../api/chats.js";
+import { getChat, listChatMessages, type MessageWithDelivery, sendChatMessage } from "../../../api/chats.js";
 import {
   asAssistantTextPayload,
   asErrorPayload,
@@ -496,6 +496,11 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
     refetchInterval: 5_000,
   });
 
+  const { data: chatDetail } = useQuery({
+    queryKey: ["chat-detail", chatId],
+    queryFn: () => getChat(chatId),
+  });
+
   const sendMut = useMutation({
     mutationFn: (content: string) => sendChatMessage(chatId, content),
     onSuccess: () => {
@@ -535,6 +540,9 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
     }
   }, [itemCount]);
 
+  const participantsLabel = chatDetail?.participants
+    ? chatDetail.participants.map((p) => `@${agentName(p.agentId)}`).join(" ")
+    : `@${agentName(agentId)}`;
   const displayName = agentName(agentId);
   const runtimeLabel = session?.runtimeState ?? "idle";
   const runtimeState = resolveAgentState(session?.runtimeState ?? null, agentId ? "connected" : null);
@@ -555,7 +563,9 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
         <div className="min-w-0">
           <div className="flex items-center" style={{ gap: 8 }}>
             <StateDot state={runtimeState} size={8} />
-            <span style={{ fontSize: 13, fontWeight: 600, color: "var(--fg)" }}>Chat · {chatId.slice(0, 8)}</span>
+            <span className="truncate" style={{ fontSize: 13, fontWeight: 600, color: "var(--fg)" }}>
+              {session?.summary || `Chat · ${chatId.slice(0, 8)}`}
+            </span>
             <span
               className="mono"
               style={{
@@ -578,7 +588,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               gap: 10,
             }}
           >
-            <span className="mono">{displayName}</span>
+            <span className="mono">{participantsLabel}</span>
             <span>·</span>
             <span>started {formatRelative(session?.startedAt ?? null)}</span>
             <span>·</span>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -499,6 +499,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
   const { data: chatDetail } = useQuery({
     queryKey: ["chat-detail", chatId],
     queryFn: () => getChat(chatId),
+    enabled: !!chatId,
   });
 
   const sendMut = useMutation({
@@ -541,7 +542,12 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
   }, [itemCount]);
 
   const participantsLabel = chatDetail?.participants
-    ? chatDetail.participants.map((p) => `@${agentName(p.agentId)}`).join(" ")
+    ? chatDetail.participants
+        .map((p) => {
+          const name = agentName(p.agentId);
+          return `@${name.length > 20 ? `${name.slice(0, 17)}…` : name}`;
+        })
+        .join(" ")
     : `@${agentName(agentId)}`;
   const displayName = agentName(agentId);
   const runtimeLabel = session?.runtimeState ?? "idle";

--- a/packages/web/src/pages/workspace/roster/index.tsx
+++ b/packages/web/src/pages/workspace/roster/index.tsx
@@ -209,7 +209,7 @@ export function AgentRoster({
                 >
                   <StateDot state={runtime} size={6} />
                   <span className="truncate" style={{ fontSize: 11, color: s.summary ? "var(--fg-2)" : "var(--fg-4)" }}>
-                    {s.summary || `Chat ${s.chatId.slice(0, 6)}`}
+                    {s.summary || `Chat · ${s.chatId.slice(0, 8)}`}
                   </span>
                 </button>
               );

--- a/packages/web/src/pages/workspace/roster/index.tsx
+++ b/packages/web/src/pages/workspace/roster/index.tsx
@@ -194,7 +194,7 @@ export function AgentRoster({
                   onClick={() => onSelectChat(agent.agentId, s.chatId)}
                   className="w-full grid items-center text-left transition-colors"
                   style={{
-                    gridTemplateColumns: "14px 1fr auto",
+                    gridTemplateColumns: "14px 1fr",
                     columnGap: 6,
                     padding: "4px 10px 4px 28px",
                     background: selectedChatId === s.chatId ? "var(--bg-hover)" : "transparent",
@@ -208,11 +208,8 @@ export function AgentRoster({
                   }}
                 >
                   <StateDot state={runtime} size={6} />
-                  <span className="truncate" style={{ fontSize: 11 }}>
-                    {s.chatId.slice(0, 8)}
-                  </span>
-                  <span className="mono" style={{ fontSize: 9, color: "var(--fg-4)" }}>
-                    {s.state}
+                  <span className="truncate" style={{ fontSize: 11, color: s.summary ? "var(--fg-2)" : "var(--fg-4)" }}>
+                    {s.summary || `Chat ${s.chatId.slice(0, 6)}`}
                   </span>
                 </button>
               );


### PR DESCRIPTION
## Summary
- Replace raw `chatId` display with auto-generated summary (first message content, truncated to 50 chars) in both the sidebar roster and the chat header title
- Show all chat participants with `@name` format in the chat header bar
- Extract shared `extractSummary` helper and `SUMMARY_MAX_LENGTH` constant to avoid duplication

## Test plan
- [ ] Open workspace, verify sidebar session rows show first message summary instead of chatId
- [ ] Verify chat header title shows summary instead of `Chat · xxxxxxxx`
- [ ] Verify chat header shows all participants as `@name1 @name2`
- [ ] Verify new sessions with no messages fall back to `Chat {chatId.slice(0,6)}`
- [ ] Verify summary updates after first message is sent (within 10s polling interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)