### PR TITLE
fix(server): use selectDistinctOn for session summary query

### DIFF
--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -5,6 +5,7 @@ import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { chatParticipants, chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
 import { NotFoundError } from "../errors.js";
 
 const SUMMARY_MAX_LENGTH = 50;
@@ -93,19 +94,18 @@ export async function listAgentSessions(
   // Get first message content per chat for summary
   const firstMessages =
     chatIds.length > 0
-      ? await db.execute<{ chat_id: string; content: unknown }>(
-          sql`SELECT DISTINCT ON (chat_id) chat_id, content
-              FROM messages
-              WHERE chat_id = ANY(${chatIds})
-              ORDER BY chat_id, created_at ASC`,
-        )
-      : ([] as { chat_id: string; content: unknown }[]);
+      ? await db
+          .selectDistinctOn([messages.chatId], { chatId: messages.chatId, content: messages.content })
+          .from(messages)
+          .where(inArray(messages.chatId, chatIds))
+          .orderBy(messages.chatId, messages.createdAt)
+      : [];
 
   const summaryMap = new Map<string, string>();
   for (const row of firstMessages) {
     const summary = extractSummary(row.content);
     if (summary) {
-      summaryMap.set(row.chat_id, summary);
+      summaryMap.set(row.chatId, summary);
     }
   }
 


### PR DESCRIPTION
## Summary
- `GET /api/v1/admin/sessions/agents/:agentId` returned 500 whenever the agent had any sessions with messages.
- Root cause: `sql\`... WHERE chat_id = ANY(${chatIds})\`` — drizzle's `sql` template expands a JS array into a tuple `($1, $2, ...)`, which is invalid for Postgres `ANY()` (it requires a real array parameter).
- Switched to drizzle's `selectDistinctOn` + `inArray` so the array is passed with the correct parameter shape, and dropped the snake_case raw-SQL aliases in favor of schema-typed columns.
- Regression from #130.

## Test plan
- [ ] `pnpm --filter @first-tree-hub/server typecheck` passes (verified locally).
- [ ] Hit `GET /api/v1/admin/sessions/agents/:agentId` against an agent with multiple sessions and confirm 200 + `summary` populated from the first message of each chat.
- [ ] Verify the single-session path (`GET /api/v1/admin/sessions/agents/:agentId/chats/:chatId`) still returns summary — that path uses a different query and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)