### PR TITLE
feat(session-state): server-authoritative suspend/terminate + reconcile

### DIFF
--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -31,7 +31,7 @@ function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
 function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
-  session?: { idle_timeout: number; max_sessions: number };
+  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
   log?: (msg: string) => void;
 }) {
@@ -40,7 +40,7 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10 },
+    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -117,7 +117,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10 },
+      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -202,7 +202,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 2 },
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -245,7 +245,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 2 },
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -297,7 +297,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10 },
+      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
       concurrency: 2,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -46,7 +46,7 @@ function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
   handlerFactory?: HandlerFactory;
-  session?: { idle_timeout: number; max_sessions: number };
+  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
   log?: (msg: string) => void;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
@@ -56,7 +56,7 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10 },
+    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -228,7 +228,7 @@ describe("SessionManager: runtime state cleanup on eviction", () => {
       });
 
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2 },
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
       handlerFactory: factory,
       onRuntimeStateChange: (state) => runtimeChanges.push(state),
     });
@@ -320,39 +320,6 @@ describe("SessionManager: getAggregateRuntimeState()", () => {
 
     defined(capturedCtx, "ctx").setRuntimeState("idle");
     expect(sm.getAggregateRuntimeState()).toBe("idle");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: admin resume passes no message to handler", () => {
-  it("handleCommand('session:resume') does not push user content", async () => {
-    const resumeCalls: Array<{ message: unknown; sessionId: string }> = [];
-    const handler = createMockHandler({
-      async start() {
-        return "session-resume-test";
-      },
-      async resume(message, sessionId) {
-        resumeCalls.push({ message, sessionId });
-        return sessionId;
-      },
-    });
-
-    const sm = createSessionManager({ handler, concurrency: 1 });
-
-    // Start a session, then preempt it so it becomes suspended
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    // chat-a is now suspended
-
-    resumeCalls.length = 0;
-
-    // Admin resume — should pass undefined message
-    await sm.handleCommand("chat-a", "session:resume");
-
-    expect(resumeCalls).toHaveLength(1);
-    expect(resumeCalls[0]?.message).toBeUndefined();
-    expect(resumeCalls[0]?.sessionId).toBe("session-resume-test");
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -36,7 +36,7 @@ function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
   handlerFactory?: HandlerFactory;
-  session?: { idle_timeout: number; max_sessions: number };
+  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
   log?: (msg: string) => void;
   onStateChange?: (chatId: string, state: SessionState) => void;
@@ -46,7 +46,7 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10 },
+    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -101,11 +101,15 @@ describe("SessionManager: state notifications", () => {
     await sm.shutdown();
   });
 
-  it("fires onStateChange('evicted') when a session is evicted", async () => {
+  it("does NOT emit a state notification when a session is LRU-evicted", async () => {
+    // LRU eviction is local-only: emitting any wire state on eviction would
+    // either accumulate stale rows in agent_chat_sessions (for `suspended`)
+    // or conflict with the server-authoritative `evicted` terminal. The row
+    // stays as last reported; local `evictedMappings` handles resume.
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const handlers: AgentHandler[] = [];
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2 },
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
       handlerFactory: () => {
         const h = createMockHandler();
         handlers.push(h);
@@ -120,7 +124,8 @@ describe("SessionManager: state notifications", () => {
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
-    expect(chatAChanges).toContainEqual({ chatId: "chat-a", state: "evicted" });
+    // Only the initial `active` for chat-a should appear — no wire event on LRU.
+    expect(chatAChanges).toEqual([{ chatId: "chat-a", state: "active" }]);
 
     await sm.shutdown();
   });
@@ -257,5 +262,69 @@ describe("SessionManager: shutdown state reporting", () => {
 
     const chatBChanges = stateChanges.filter((c) => c.chatId === "chat-b");
     expect(chatBChanges).toEqual([{ chatId: "chat-b", state: "suspended" }]);
+  });
+});
+
+describe("SessionManager: terminate + reconcile", () => {
+  it("handleCommand('session:terminate') deletes local state and does NOT emit any state notification", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    stateChanges.length = 0;
+
+    await sm.handleCommand("chat-a", "session:terminate");
+
+    expect(stateChanges).toHaveLength(0); // server is authoritative
+    expect(sm.getSessionStates()).toEqual([]);
+    expect(sm.getHeldChatIds()).toEqual([]);
+
+    await sm.shutdown();
+  });
+
+  it("getHeldChatIds() unions active sessions and evicted mappings", async () => {
+    const sm = createSessionManager({
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    // LRU evicts chat-a into evictedMappings when chat-c enters
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
+
+    const held = new Set(sm.getHeldChatIds());
+    expect(held.has("chat-a")).toBe(true); // evictedMappings
+    expect(held.has("chat-b") || held.has("chat-c")).toBe(true); // live sessions
+
+    await sm.shutdown();
+  });
+
+  it("applyStaleChatIds() cleans up both live sessions and evicted mappings", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = createSessionManager({
+      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" })); // chat-a → evictedMappings
+
+    const held = sm.getHeldChatIds();
+    expect(held).toContain("chat-a");
+
+    stateChanges.length = 0;
+    sm.applyStaleChatIds(held);
+
+    // Wait a tick for the async handleCommand chain to drain
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(sm.getHeldChatIds()).toEqual([]);
+    // Terminate should not emit wire notifications; server is authoritative
+    expect(stateChanges).toHaveLength(0);
+
+    await sm.shutdown();
   });
 });

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -34,9 +34,14 @@ export type BoundAgent = {
 };
 
 export type SessionCommand = {
-  type: "session:suspend" | "session:resume" | "session:terminate";
+  type: "session:suspend" | "session:terminate";
   agentId: string;
   chatId: string;
+};
+
+export type SessionReconcileResult = {
+  agentId: string;
+  staleChatIds: string[];
 };
 
 type ClientConnectionEvents = {
@@ -57,6 +62,7 @@ type ClientConnectionEvents = {
    */
   "agent:pinned": [message: AgentPinnedMessage];
   "session:command": [command: SessionCommand];
+  "session:reconcile:result": [result: SessionReconcileResult];
   "auth:expired": [];
 };
 
@@ -202,6 +208,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   reportSessionCompletion(agentId: string, chatId: string): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "session:completion", agentId, chatId }));
+  }
+
+  /** Ask the server which of the supplied chatIds the client should drop. */
+  sendSessionReconcile(agentId: string, chatIds: string[]): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "session:reconcile", agentId, chatIds }));
   }
 
   async disconnect(): Promise<void> {
@@ -421,11 +433,20 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       return;
     }
 
-    if (type === "session:suspend" || type === "session:resume" || type === "session:terminate") {
+    if (type === "session:suspend" || type === "session:terminate") {
       const agentId = msg.agentId as string;
       const chatId = msg.chatId as string;
       if (agentId && chatId) {
         this.emit("session:command", { type: type as SessionCommand["type"], agentId, chatId });
+      }
+      return;
+    }
+
+    if (type === "session:reconcile:result") {
+      const agentId = msg.agentId as string;
+      const staleChatIds = Array.isArray(msg.staleChatIds) ? (msg.staleChatIds as string[]) : null;
+      if (agentId && staleChatIds) {
+        this.emit("session:reconcile:result", { agentId, staleChatIds });
       }
       return;
     }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -6,7 +6,7 @@ import type {
   SessionState,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
-import type { ClientConnection } from "../client-connection.js";
+import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import type { RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
 import type { SessionConfig } from "./config.js";
@@ -32,7 +32,8 @@ export type AgentSlotConfig = {
 type ConnectionListener =
   | { event: "agent:message"; fn: (agentId: string, data: unknown) => void }
   | { event: "agent:bound"; fn: (agent: { agentId: string }) => void }
-  | { event: "session:command"; fn: (cmd: { agentId: string; chatId: string; type: string }) => void };
+  | { event: "session:command"; fn: (cmd: { agentId: string; chatId: string; type: string }) => void }
+  | { event: "session:reconcile:result"; fn: (result: SessionReconcileResult) => void };
 
 export class AgentSlot {
   private sessionManager: SessionManager | null = null;
@@ -41,6 +42,7 @@ export class AgentSlot {
   private sdk: import("../sdk.js").FirstTreeHubSDK | null = null;
   private agentConfigCache: AgentConfigCache | null = null;
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
   private listeners: ConnectionListener[] = [];
 
   constructor(config: AgentSlotConfig) {
@@ -85,11 +87,26 @@ export class AgentSlot {
       if (agentId === this.config.agentId) this.pullAndDispatch();
     };
     const onBound = (boundAgent: { agentId: string }) => {
-      if (boundAgent.agentId === this.config.agentId) this.fullStateSync();
+      if (boundAgent.agentId === this.config.agentId) {
+        this.fullStateSync();
+        // One-shot post-bind reconcile catches operator-terminates that
+        // landed while this client was offline; a duplicate tick is harmless.
+        setTimeout(() => this.reconcileNow(), 5000);
+      }
+    };
+    const onReconcileResult = (result: SessionReconcileResult) => {
+      if (result.agentId === this.config.agentId && this.sessionManager) {
+        this.sessionManager.applyStaleChatIds(result.staleChatIds);
+      }
     };
     this.clientConnection.on("agent:message", onMessage);
     this.clientConnection.on("agent:bound", onBound);
-    this.listeners.push({ event: "agent:message", fn: onMessage }, { event: "agent:bound", fn: onBound });
+    this.clientConnection.on("session:reconcile:result", onReconcileResult);
+    this.listeners.push(
+      { event: "agent:message", fn: onMessage },
+      { event: "agent:bound", fn: onBound },
+      { event: "session:reconcile:result", fn: onReconcileResult },
+    );
 
     const registryPath = join(DEFAULT_DATA_DIR, "sessions", `${this.config.name}.json`);
 
@@ -129,15 +146,18 @@ export class AgentSlot {
 
     const onCommand = (cmd: { agentId: string; chatId: string; type: string }) => {
       if (cmd.agentId === this.config.agentId && this.sessionManager) {
-        this.sessionManager.handleCommand(cmd.chatId, cmd.type as "session:suspend").catch((err) => {
-          this.logFn(`Session command error: ${err instanceof Error ? err.message : String(err)}`);
-        });
+        this.sessionManager
+          .handleCommand(cmd.chatId, cmd.type as "session:suspend" | "session:terminate")
+          .catch((err) => {
+            this.logFn(`Session command error: ${err instanceof Error ? err.message : String(err)}`);
+          });
       }
     };
     this.clientConnection.on("session:command", onCommand);
     this.listeners.push({ event: "session:command", fn: onCommand });
 
     this.startPolling();
+    this.startReconcileLoop();
 
     return agent;
   }
@@ -147,9 +167,14 @@ export class AgentSlot {
       clearInterval(this.pollingTimer);
       this.pollingTimer = null;
     }
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
     for (const entry of this.listeners) {
       if (entry.event === "agent:message") this.clientConnection.off(entry.event, entry.fn);
       else if (entry.event === "agent:bound") this.clientConnection.off(entry.event, entry.fn);
+      else if (entry.event === "session:reconcile:result") this.clientConnection.off(entry.event, entry.fn);
       else this.clientConnection.off(entry.event, entry.fn);
     }
     this.listeners = [];
@@ -190,6 +215,18 @@ export class AgentSlot {
       this.pullAndDispatch();
     }, 5000);
     this.pullAndDispatch();
+  }
+
+  private startReconcileLoop(): void {
+    const intervalSec = this.config.session.reconcile_interval_seconds ?? 300;
+    this.reconcileTimer = setInterval(() => this.reconcileNow(), intervalSec * 1000);
+  }
+
+  private reconcileNow(): void {
+    if (!this.sessionManager) return;
+    const chatIds = this.sessionManager.getHeldChatIds();
+    if (chatIds.length === 0) return;
+    this.clientConnection.sendSessionReconcile(this.config.agentId, chatIds);
   }
 
   private async pullAndDispatch(): Promise<void> {

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -26,6 +26,8 @@ const sessionConfigSchema = z
       .positive()
       .default(IDLE_TIMEOUT_MS / 1000),
     max_sessions: z.number().int().positive().default(MAX_SESSIONS),
+    /** How often the client reconciles its local chatIds with the server. */
+    reconcile_interval_seconds: z.number().int().min(30).max(3600).default(300),
   })
   .passthrough();
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -132,43 +132,58 @@ export class SessionManager {
     await this.routeMessage(chatId, message, entry.id);
   }
 
-  /** Handle a session command from the server (suspend/resume/terminate). */
-  async handleCommand(
-    chatId: string,
-    command: "session:suspend" | "session:resume" | "session:terminate",
-  ): Promise<void> {
-    const session = this.sessions.get(chatId);
-
+  /** Handle a server-issued session command. Terminate drops all local state without reporting back. */
+  async handleCommand(chatId: string, command: "session:suspend" | "session:terminate"): Promise<void> {
     if (command === "session:suspend") {
+      const session = this.sessions.get(chatId);
       if (session?.status === "active") {
         this.config.log(`Session ${chatId}: suspend command received`);
         this.suspendSession(session);
       }
-    } else if (command === "session:resume") {
-      if (session?.status === "suspended") {
-        this.config.log(`Session ${chatId}: resume command received`);
-        // Resume with no new user message — pass null to signal admin-triggered resume
-        await this.resumeSession(session, null);
+      return;
+    }
+
+    if (command === "session:terminate") {
+      const session = this.sessions.get(chatId);
+      const hadMapping = this.evictedMappings.has(chatId);
+      if (!session && !hadMapping) return;
+
+      this.config.log(`Session ${chatId}: terminate command received`);
+      if (session?.status === "active") {
+        this._activeCount--;
+        await session.handler.shutdown().catch(() => {});
       }
-    } else if (command === "session:terminate") {
-      if (session) {
-        this.config.log(`Session ${chatId}: terminate command received`);
-        if (session.status === "active") {
-          this._activeCount--;
-          await session.handler.shutdown();
-        }
-        // Move to evicted
-        this.addEvictedMapping(chatId, {
-          claudeSessionId: session.claudeSessionId,
-          lastActivity: session.lastActivity,
-        });
-        this.sessions.delete(chatId);
-        this.sessionRuntimeStates.delete(chatId);
-        this.recomputeRuntimeState();
-        this.notifySessionState(chatId, "evicted");
-        this.persistRegistry();
-        this.drainPendingQueue();
+
+      this.sessions.delete(chatId);
+      this.evictedMappings.delete(chatId);
+      this.sessionRuntimeStates.delete(chatId);
+      this.lastReportedStates.delete(chatId);
+
+      for (let i = this.pendingQueue.length - 1; i >= 0; i--) {
+        if (this.pendingQueue[i]?.chatId === chatId) this.pendingQueue.splice(i, 1);
       }
+
+      this.recomputeRuntimeState();
+      this.persistRegistry();
+      this.drainPendingQueue();
+    }
+  }
+
+  /** Chat IDs this client still holds locally (sessions + evictedMappings). */
+  getHeldChatIds(): string[] {
+    const ids = new Set<string>();
+    for (const id of this.sessions.keys()) ids.add(id);
+    for (const id of this.evictedMappings.keys()) ids.add(id);
+    return [...ids];
+  }
+
+  /**
+   * Apply a server-declared stale list from `session:reconcile:result` — treat
+   * each chatId as if a `session:terminate` command had arrived.
+   */
+  applyStaleChatIds(staleChatIds: string[]): void {
+    for (const id of staleChatIds) {
+      void this.handleCommand(id, "session:terminate");
     }
   }
 
@@ -448,8 +463,11 @@ export class SessionManager {
         this._activeCount--;
         candidate.session.handler.shutdown().catch(() => {});
       }
-      candidate.session.status = "evicted";
-      this.notifySessionState(candidate.key, "evicted");
+      // LRU eviction is a local memory-management concern, not operator intent
+      // — do NOT emit a wire state. The server row stays as last reported;
+      // the local `evictedMappings` entry keeps resume-on-next-message working.
+      // (`suspended` here would accumulate rows in agent_chat_sessions forever
+      // since the cleanup cron is out of scope for this redesign.)
       this.sessions.delete(candidate.key);
       this.sessionRuntimeStates.delete(candidate.key);
       this.recomputeRuntimeState();

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -705,7 +705,6 @@ export function registerAgentCommands(program: Command): void {
 
   for (const [cmd, desc] of [
     ["suspend", "Suspend a session"],
-    ["resume", "Resume a suspended session"],
     ["terminate", "Terminate a session"],
   ] as const) {
     sessionCmd

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -81,6 +81,9 @@ export class ClientRuntime {
       session: {
         idle_timeout: config.session.idle_timeout,
         max_sessions: config.session.max_sessions,
+        // Admin-managed runtime config doesn't carry this field yet; local
+        // `agent.yaml` users can override via the client YAML schema.
+        reconcile_interval_seconds: 300,
       },
       concurrency: config.concurrency,
       clientConnection: this.connection,

--- a/packages/server/src/__tests__/admin-sessions-suspend-terminate.test.ts
+++ b/packages/server/src/__tests__/admin-sessions-suspend-terminate.test.ts
@@ -1,0 +1,259 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import * as activityService from "../services/activity.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import * as sessionEventService from "../services/session-event.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("Admin sessions — Suspend / Terminate (server-authoritative)", () => {
+  const getApp = useTestApp();
+
+  async function seedSession(app: FastifyInstance, agentId: string, chatId: string, state: string) {
+    await app.db
+      .insert(agentChatSessions)
+      .values({ agentId, chatId, state })
+      .onConflictDoUpdate({
+        target: [agentChatSessions.agentId, agentChatSessions.chatId],
+        set: { state, updatedAt: new Date() },
+      });
+  }
+
+  async function readState(app: FastifyInstance, agentId: string, chatId: string): Promise<string | null> {
+    const { and, eq } = await import("drizzle-orm");
+    const [row] = await app.db
+      .select({ state: agentChatSessions.state })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+      .limit(1);
+    return row?.state ?? null;
+  }
+
+  it("Suspend on an active row transitions to suspended and returns 200 { transitioned: true }", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `suspend-a-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `susp-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Susp target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "active");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/suspend`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ state: string; transitioned: boolean; agentId: string; chatId: string }>();
+    expect(body).toMatchObject({ agentId: agent.uuid, chatId: chat.id, state: "suspended", transitioned: true });
+
+    expect(await readState(app, agent.uuid, chat.id)).toBe("suspended");
+  });
+
+  it("Suspend on an already-suspended row is a no-op 200 { transitioned: false }", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `suspend-b-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `susp-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Susp target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "suspended");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/suspend`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ state: "suspended", transitioned: false });
+  });
+
+  it("Terminate on a suspended row transitions to evicted, clears events, returns 200", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `term-a-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `term-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Term target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "suspended");
+    await sessionEventService.appendEvent(app.db, agent.uuid, chat.id, {
+      kind: "error",
+      payload: { source: "sdk", message: "pre-terminate event" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/terminate`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ state: "evicted", transitioned: true });
+
+    expect(await readState(app, agent.uuid, chat.id)).toBe("evicted");
+
+    // clearEvents fires best-effort — poll briefly for eventual consistency.
+    const deadline = Date.now() + 2000;
+    let items: Awaited<ReturnType<typeof sessionEventService.listEvents>>["items"] = [];
+    while (Date.now() < deadline) {
+      items = (await sessionEventService.listEvents(app.db, agent.uuid, chat.id, { limit: 10 })).items;
+      if (items.length === 0) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(items).toEqual([]);
+  });
+
+  it("Terminate on an active row is a no-op 200 { transitioned: false } — UI gates behind Suspend", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `term-b-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `term-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Term target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "active");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/terminate`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ state: "active", transitioned: false });
+    expect(await readState(app, agent.uuid, chat.id)).toBe("active");
+  });
+
+  it("Terminate on an already-evicted row is idempotent 200 { transitioned: false }", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `term-c-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `term-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Term target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "evicted");
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/terminate`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ state: "evicted", transitioned: false });
+  });
+
+  it("Suspend on a missing chat returns 404", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `term-d-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `term-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Term target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/chat-does-not-exist/suspend`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("Resume route is removed — 404 on POST", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `resume-x-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `resume-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Resume target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}/${chat.id}/resume`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("revival defense — upsertSessionState on an evicted row is a no-op and keeps state='evicted'", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `revive-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `revive-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Revive target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    await seedSession(app, agent.uuid, chat.id, "evicted");
+
+    // Simulate a client reporting `active` (e.g. just resumed a session locally).
+    // organizationId is used only for NOTIFY payload; revival defense runs regardless.
+    await activityService.upsertSessionState(app.db, agent.uuid, chat.id, "active", "org-test");
+
+    expect(await readState(app, agent.uuid, chat.id)).toBe("evicted");
+  });
+
+  it("default listing hides evicted rows; explicit ?state=evicted still returns them", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `list-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `list-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "List target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chatActive = await createChat(app.db, admin.humanAgentUuid, { type: "direct", participantIds: [agent.uuid] });
+    const chatEvicted = await createChat(app.db, admin.humanAgentUuid, {
+      type: "direct",
+      participantIds: [agent.uuid],
+    });
+    await seedSession(app, agent.uuid, chatActive.id, "active");
+    await seedSession(app, agent.uuid, chatEvicted.id, "evicted");
+
+    const defaultRes = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(defaultRes.statusCode).toBe(200);
+    const defaultChats = defaultRes.json<Array<{ chatId: string; state: string }>>().map((r) => r.chatId);
+    expect(defaultChats).toContain(chatActive.id);
+    expect(defaultChats).not.toContain(chatEvicted.id);
+
+    const filteredRes = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/sessions/agents/${agent.uuid}?state=evicted`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(filteredRes.statusCode).toBe(200);
+    const filteredChats = filteredRes.json<Array<{ chatId: string; state: string }>>().map((r) => r.chatId);
+    expect(filteredChats).toContain(chatEvicted.id);
+  });
+});

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -222,25 +222,30 @@ describe("Agent WS — session event protocol (S10)", () => {
     }
   }, 15000);
 
-  it("clears events when a `session:state` transition to 'evicted' arrives", async () => {
+  it("rejects an `evicted` session:state frame from a stale client and preserves events", async () => {
     const seed = await seedBoundAgent("evict");
     const ws = await openBoundSocket(seed);
     const chatId = `chat-${crypto.randomUUID()}`;
 
     try {
-      // Pre-populate two events
       await sessionEventService.appendEvent(app.db, seed.agent.uuid, chatId, {
         kind: "error",
-        payload: { source: "sdk", message: "before eviction" },
+        payload: { source: "sdk", message: "before stale evicted frame" },
       });
       await sessionEventService.appendEvent(app.db, seed.agent.uuid, chatId, {
         kind: "tool_call",
         payload: { toolUseId: "t1", name: "Read", args: {}, status: "ok" },
       });
 
-      const beforeCount = (await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 10 })).items
-        .length;
-      expect(beforeCount).toBe(2);
+      const errorMessages: string[] = [];
+      ws.on("message", (raw) => {
+        try {
+          const parsed = JSON.parse(raw.toString()) as { type?: string; message?: string };
+          if (parsed.type === "error" && parsed.message) errorMessages.push(parsed.message);
+        } catch {
+          // ignore
+        }
+      });
 
       ws.send(
         JSON.stringify({
@@ -252,9 +257,12 @@ describe("Agent WS — session event protocol (S10)", () => {
       );
 
       await waitForCondition(async () => {
-        const { items } = await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 10 });
-        return items.length === 0 ? true : null;
+        return errorMessages.some((m) => m.includes("Unsupported session state")) ? true : null;
       });
+
+      // Events were NOT cleared — the stale frame produces an error, not a side effect.
+      const { items } = await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 10 });
+      expect(items).toHaveLength(2);
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));
@@ -291,15 +299,12 @@ describe("Agent WS — session event protocol (S10)", () => {
     }
   }, 15000);
 
-  it("eviction immediately following session:event leaves no resurrected row", async () => {
+  it("rejected `evicted` frame following session:event does not disturb persisted events", async () => {
     const seed = await seedBoundAgent("race");
     const ws = await openBoundSocket(seed);
     const chatId = `chat-${crypto.randomUUID()}`;
 
     try {
-      // Send N events back-to-back, then immediately send eviction. Without the
-      // per-(agent, chat) FIFO guard, the late appendEvent(s) can land AFTER
-      // clearEvents and resurrect rows for a session that was supposed to be wiped.
       const eventCount = 5;
       for (let i = 0; i < eventCount; i += 1) {
         ws.send(
@@ -323,11 +328,11 @@ describe("Agent WS — session event protocol (S10)", () => {
         }),
       );
 
-      // Give the server time to drain the queue and process the eviction.
+      // Give the server time to persist the events and reject the stale frame.
       await new Promise((r) => setTimeout(r, 800));
 
       const { items } = await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 50 });
-      expect(items).toEqual([]);
+      expect(items).toHaveLength(eventCount);
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));
@@ -358,6 +363,57 @@ describe("Agent WS — session event protocol (S10)", () => {
 
       expect(hit.type).toBe("session_completed");
       expect(hit.severity).toBe("low");
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("`session:reconcile` returns staleChatIds for evicted or missing rows", async () => {
+    const seed = await seedBoundAgent("recon");
+    const ws = await openBoundSocket(seed);
+
+    try {
+      const { agentChatSessions: table } = await import("../db/schema/agent-chat-sessions.js");
+      const { chats: chatsTable } = await import("../db/schema/chats.js");
+
+      const activeId = `chat-active-${crypto.randomUUID()}`;
+      const suspendedId = `chat-suspended-${crypto.randomUUID()}`;
+      const evictedId = `chat-evicted-${crypto.randomUUID()}`;
+      const missingId = `chat-missing-${crypto.randomUUID()}`;
+
+      await app.db
+        .insert(chatsTable)
+        .values([
+          { id: activeId, organizationId: seed.organizationId },
+          { id: suspendedId, organizationId: seed.organizationId },
+          { id: evictedId, organizationId: seed.organizationId },
+        ])
+        .onConflictDoNothing();
+      await app.db
+        .insert(table)
+        .values([
+          { agentId: seed.agent.uuid, chatId: activeId, state: "active" },
+          { agentId: seed.agent.uuid, chatId: suspendedId, state: "suspended" },
+          { agentId: seed.agent.uuid, chatId: evictedId, state: "evicted" },
+        ])
+        .onConflictDoNothing();
+
+      ws.send(
+        JSON.stringify({
+          type: "session:reconcile",
+          agentId: seed.agent.uuid,
+          chatIds: [activeId, suspendedId, evictedId, missingId],
+        }),
+      );
+
+      const result = (await waitForFrame(ws, (m) => (m as { type?: string }).type === "session:reconcile:result")) as {
+        staleChatIds: string[];
+        agentId: string;
+      };
+
+      expect(result.agentId).toBe(seed.agent.uuid);
+      expect(new Set(result.staleChatIds)).toEqual(new Set([evictedId, missingId]));
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));

--- a/packages/server/src/api/admin/sessions.ts
+++ b/packages/server/src/api/admin/sessions.ts
@@ -1,7 +1,6 @@
 import { paginationQuerySchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { ConflictError } from "../../errors.js";
 import { requireMember } from "../../middleware/require-identity.js";
 import { assertAgentVisible, assertCanManage, assertChatAccess, memberScope } from "../../services/access-control.js";
 import * as agentService from "../../services/agent.js";
@@ -79,45 +78,34 @@ export async function adminSessionRoutes(app: FastifyInstance): Promise<void> {
     });
   });
 
-  /** POST /admin/sessions/agents/:agentId/:chatId/suspend — suspend a session */
+  /** POST /admin/sessions/agents/:agentId/:chatId/suspend — commit first, WS-send best-effort. */
   app.post<{ Params: { agentId: string; chatId: string } }>(
     "/agents/:agentId/:chatId/suspend",
     async (request, reply) => {
       const { agentId, chatId } = request.params;
       await assertCanManage(app.db, memberScope(request), agentId);
-      const sent = sendToAgent(agentId, { type: "session:suspend", chatId });
-      if (!sent) {
-        throw new ConflictError("Agent is not connected — session command requires a live connection");
+      const member = requireMember(request);
+      const result = await sessionService.suspendSession(app.db, agentId, chatId, member.organizationId, app.notifier);
+      if (result.transitioned) {
+        sendToAgent(agentId, { type: "session:suspend", chatId });
       }
-      return reply.status(202).send({ status: "sent", command: "suspend", agentId, chatId });
+      return reply.status(200).send({ agentId, chatId, state: result.state, transitioned: result.transitioned });
     },
   );
 
-  /** POST /admin/sessions/agents/:agentId/:chatId/resume — resume a session */
-  app.post<{ Params: { agentId: string; chatId: string } }>(
-    "/agents/:agentId/:chatId/resume",
-    async (request, reply) => {
-      const { agentId, chatId } = request.params;
-      await assertCanManage(app.db, memberScope(request), agentId);
-      const sent = sendToAgent(agentId, { type: "session:resume", chatId });
-      if (!sent) {
-        throw new ConflictError("Agent is not connected — session command requires a live connection");
-      }
-      return reply.status(202).send({ status: "sent", command: "resume", agentId, chatId });
-    },
-  );
-
-  /** POST /admin/sessions/agents/:agentId/:chatId/terminate — terminate a session */
+  /** POST /admin/sessions/agents/:agentId/:chatId/terminate — archive; clear events + best-effort WS. */
   app.post<{ Params: { agentId: string; chatId: string } }>(
     "/agents/:agentId/:chatId/terminate",
     async (request, reply) => {
       const { agentId, chatId } = request.params;
       await assertCanManage(app.db, memberScope(request), agentId);
-      const sent = sendToAgent(agentId, { type: "session:terminate", chatId });
-      if (!sent) {
-        throw new ConflictError("Agent is not connected — session command requires a live connection");
+      const member = requireMember(request);
+      const result = await sessionService.archiveSession(app.db, agentId, chatId, member.organizationId, app.notifier);
+      if (result.transitioned) {
+        sessionEventService.clearEvents(app.db, agentId, chatId).catch(() => {});
+        sendToAgent(agentId, { type: "session:terminate", chatId });
       }
-      return reply.status(202).send({ status: "sent", command: "terminate", agentId, chatId });
+      return reply.status(200).send({ agentId, chatId, state: result.state, transitioned: result.transitioned });
     },
   );
 }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -7,15 +7,17 @@ import {
   runtimeStateMessageSchema,
   sessionCompletionMessageSchema,
   sessionEventMessageSchema,
+  sessionReconcileRequestSchema,
   sessionStateMessageSchema,
   WS_AUTH_FRAME_TIMEOUT_MS,
   wsAuthFrameSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { jwtVerify } from "jose";
 import type { WebSocket } from "ws";
 import { z } from "zod";
+import { agentChatSessions } from "../../db/schema/agent-chat-sessions.js";
 import { agents } from "../../db/schema/agents.js";
 import { clients } from "../../db/schema/clients.js";
 import { members } from "../../db/schema/members.js";
@@ -402,23 +404,66 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 return;
               }
 
-              const payload = sessionStateMessageSchema.parse(msg);
-
-              // Drop persisted events on eviction. Chained through the per-session FIFO so any
-              // in-flight appendEvent finishes BEFORE clearEvents (otherwise late inserts resurrect rows).
-              if (payload.state === "evicted") {
-                chainSessionOp(agentId, payload.chatId, () =>
-                  sessionEventService.clearEvents(app.db, agentId, payload.chatId).catch(() => {}),
+              const payloadResult = sessionStateMessageSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                // Strict wire contract: the client may only report active/suspended.
+                // A stale client sending `evicted` gets a hard reject; its local state
+                // has already moved, and the next inbound message will re-sync via the
+                // evictedMappings resume path. See proposal §Wire-Level Strictness.
+                socket.send(
+                  JSON.stringify({
+                    type: "error",
+                    message: "Unsupported session state from client; client upgrade required",
+                  }),
                 );
+                const rawState = (msg as { state?: unknown }).state;
+                app.log.warn({ clientId, agentId, rawState }, "session:state rejected — stale client wire");
+                return;
               }
 
               await activityService.upsertSessionState(
                 app.db,
                 agentId,
-                payload.chatId,
-                payload.state,
+                payloadResult.data.chatId,
+                payloadResult.data.state,
                 session.organizationId,
                 notifier,
+              );
+            } else if (type === "session:reconcile") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
+
+              const payloadResult = sessionReconcileRequestSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                socket.send(JSON.stringify({ type: "error", message: "Malformed session:reconcile frame" }));
+                return;
+              }
+
+              const { chatIds } = payloadResult.data;
+              const aliveRows = chatIds.length
+                ? await app.db
+                    .select({ chatId: agentChatSessions.chatId })
+                    .from(agentChatSessions)
+                    .where(
+                      and(
+                        eq(agentChatSessions.agentId, agentId),
+                        inArray(agentChatSessions.chatId, chatIds),
+                        ne(agentChatSessions.state, "evicted"),
+                      ),
+                    )
+                : [];
+              const alive = new Set(aliveRows.map((r) => r.chatId));
+              const staleChatIds = chatIds.filter((id) => !alive.has(id));
+
+              socket.send(
+                JSON.stringify({
+                  type: "session:reconcile:result",
+                  agentId,
+                  staleChatIds,
+                }),
               );
             } else if (type === "runtime:state") {
               const agentId = parsed.data.agentId;

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -8,7 +8,12 @@ import { clients } from "../db/schema/clients.js";
 import { agentVisibilityCondition, type MemberScope } from "./access-control.js";
 import type { Notifier } from "./notifier.js";
 
-/** Upsert a session state, refresh materialized aggregates on agent_presence, and emit org-scoped NOTIFY. */
+/**
+ * Upsert session state + refresh presence aggregates + NOTIFY.
+ *
+ * Revival defense: an admin-terminated (`evicted`) row is immutable; a client
+ * report for the same chatId is silently dropped after the FOR UPDATE check.
+ */
 export async function upsertSessionState(
   db: Database,
   agentId: string,
@@ -18,8 +23,16 @@ export async function upsertSessionState(
   notifier?: Notifier,
 ) {
   const now = new Date();
+  let wrote = false;
   await db.transaction(async (tx) => {
-    // 1. Upsert session row
+    const [existing] = await tx
+      .select({ state: agentChatSessions.state })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+      .for("update");
+
+    if (existing?.state === "evicted") return;
+
     await tx
       .insert(agentChatSessions)
       .values({ agentId, chatId, state, updatedAt: now })
@@ -28,9 +41,8 @@ export async function upsertSessionState(
         set: { state, updatedAt: now },
       });
 
-    // 2. Aggregate session counts and update presence (session counts only).
-    //    runtimeState is NOT written here — the client-reported runtime:state
-    //    message is the single authority for runtimeState to avoid dual-write conflicts.
+    // runtimeState is owned by the client's `runtime:state` frame — do not
+    // write it here to avoid dual-write conflicts.
     const [counts] = await tx
       .select({
         active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
@@ -50,10 +62,11 @@ export async function upsertSessionState(
         lastSeenAt: now,
       })
       .where(eq(agentPresence.agentId, agentId));
+
+    wrote = true;
   });
 
-  // Fire-and-forget PG NOTIFY for session state changes
-  if (notifier) {
+  if (wrote && notifier) {
     notifier.notifySessionStateChange(agentId, chatId, state, organizationId).catch(() => {});
   }
 }
@@ -133,22 +146,4 @@ export async function listAgentsWithRuntime(db: Database, scope?: MemberScope) {
     .from(agentPresence)
     .innerJoin(agents, eq(agentPresence.agentId, agents.uuid))
     .where(and(isNotNull(agentPresence.runtimeState), agentVisibilityCondition(scope)));
-}
-
-/**
- * Clean up stale session rows from agent_chat_sessions.
- * Removes evicted rows older than staleSeconds and suspended rows older than staleSeconds.
- * Returns the number of rows deleted.
- */
-export async function cleanupStaleSessions(db: Database, staleSeconds = 604_800): Promise<number> {
-  const result = await db.execute<{ cnt: number }>(sql`
-    WITH deleted AS (
-      DELETE FROM agent_chat_sessions
-      WHERE state IN ('evicted', 'suspended')
-      AND updated_at < NOW() - make_interval(secs => ${staleSeconds})
-      RETURNING 1
-    )
-    SELECT count(*)::int AS cnt FROM deleted
-  `);
-  return result[0]?.cnt ?? 0;
 }

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,6 +1,5 @@
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../observability/index.js";
-import * as activityService from "./activity.js";
 import type { AdapterManager } from "./adapter-manager.js";
 import * as clientService from "./client.js";
 import * as inboxService from "./inbox.js";
@@ -26,7 +25,6 @@ export function createBackgroundTasks(
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let adapterOutboundTimer: ReturnType<typeof setInterval> | null = null;
   let kaelOutboundTimer: ReturnType<typeof setInterval> | null = null;
-  let sessionCleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   return {
     start() {
@@ -86,18 +84,6 @@ export function createBackgroundTasks(
         }, 5_000);
       }
 
-      // Session cleanup — runs every hour, removes evicted/suspended sessions older than 7 days
-      sessionCleanupTimer = setInterval(async () => {
-        try {
-          const deleted = await activityService.cleanupStaleSessions(app.db);
-          if (deleted > 0) {
-            log.info({ count: deleted }, "cleaned up stale sessions");
-          }
-        } catch (err) {
-          log.error({ err }, "failed to clean up stale sessions");
-        }
-      }, 3_600_000);
-
       // Initial heartbeat
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
         log.error({ err }, "failed initial heartbeat");
@@ -120,10 +106,6 @@ export function createBackgroundTasks(
       if (kaelOutboundTimer) {
         clearInterval(kaelOutboundTimer);
         kaelOutboundTimer = null;
-      }
-      if (sessionCleanupTimer) {
-        clearInterval(sessionCleanupTimer);
-        sessionCleanupTimer = null;
       }
     },
   };

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -1,4 +1,5 @@
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
@@ -7,6 +8,7 @@ import { chatParticipants, chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { NotFoundError } from "../errors.js";
+import type { Notifier } from "./notifier.js";
 
 const SUMMARY_MAX_LENGTH = 50;
 
@@ -42,6 +44,9 @@ export async function listAgentSessions(
   const conditions = [eq(agentChatSessions.agentId, agentId)];
   if (filters?.state) {
     conditions.push(eq(agentChatSessions.state, filters.state));
+  } else {
+    // Default: hide archived (evicted) rows from listings.
+    conditions.push(ne(agentChatSessions.state, "evicted"));
   }
 
   const rows = await db
@@ -189,6 +194,9 @@ export async function listAllSessions(
   const conditions = [];
   if (filters?.state) {
     conditions.push(eq(agentChatSessions.state, filters.state));
+  } else {
+    // Default: hide archived (evicted) rows from listings.
+    conditions.push(ne(agentChatSessions.state, "evicted"));
   }
   if (filters?.agentId) {
     conditions.push(eq(agentChatSessions.agentId, filters.agentId));
@@ -246,6 +254,96 @@ export async function listAllSessions(
     })),
     nextCursor,
   };
+}
+
+export type StateTransitionResult = {
+  state: SessionState;
+  transitioned: boolean;
+};
+
+/** Commit `active → suspended`. No-op on suspended/evicted. Throws if row is missing. */
+export async function suspendSession(
+  db: Database,
+  agentId: string,
+  chatId: string,
+  organizationId: string,
+  notifier?: Notifier,
+): Promise<StateTransitionResult> {
+  return transitionSessionState(db, agentId, chatId, "suspended", ["active"], organizationId, notifier);
+}
+
+/** Commit `suspended → evicted` (terminal — listings hide it, revival defense blocks resurrection). */
+export async function archiveSession(
+  db: Database,
+  agentId: string,
+  chatId: string,
+  organizationId: string,
+  notifier?: Notifier,
+): Promise<StateTransitionResult> {
+  return transitionSessionState(db, agentId, chatId, "evicted", ["suspended"], organizationId, notifier);
+}
+
+async function transitionSessionState(
+  db: Database,
+  agentId: string,
+  chatId: string,
+  target: SessionState,
+  from: SessionState[],
+  organizationId: string,
+  notifier: Notifier | undefined,
+): Promise<StateTransitionResult> {
+  const now = new Date();
+  let finalState: SessionState | null = null;
+  let transitioned = false;
+
+  await db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select({ state: agentChatSessions.state })
+      .from(agentChatSessions)
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+      .for("update");
+
+    if (!existing) return;
+    const current = existing.state as SessionState;
+    finalState = current;
+
+    if (!from.includes(current)) return;
+
+    await tx
+      .update(agentChatSessions)
+      .set({ state: target, updatedAt: now })
+      .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
+
+    const [counts] = await tx
+      .select({
+        active: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} = 'active')::int`,
+        total: sql<number>`count(*) FILTER (WHERE ${agentChatSessions.state} != 'evicted')::int`,
+      })
+      .from(agentChatSessions)
+      .where(eq(agentChatSessions.agentId, agentId));
+
+    await tx
+      .update(agentPresence)
+      .set({
+        activeSessions: counts?.active ?? 0,
+        totalSessions: counts?.total ?? 0,
+        lastSeenAt: now,
+      })
+      .where(eq(agentPresence.agentId, agentId));
+
+    finalState = target;
+    transitioned = true;
+  });
+
+  if (finalState === null) {
+    throw new NotFoundError(`Session (${agentId}, ${chatId}) not found`);
+  }
+
+  if (transitioned && notifier) {
+    notifier.notifySessionStateChange(agentId, chatId, target, organizationId).catch(() => {});
+  }
+
+  return { state: finalState, transitioned };
 }
 
 /**

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub-shared",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "First Tree Hub shared schemas, types, and configuration",
   "license": "MIT",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -200,6 +200,8 @@ export {
   agentBindRejectReasonSchema,
   agentBindRequestSchema,
   agentPresenceSchema,
+  type ClientSessionState,
+  clientSessionStateSchema,
   PRESENCE_STATUSES,
   type PresenceStatus,
   presenceStatusSchema,
@@ -242,6 +244,12 @@ export {
   toolCallEventPayload,
   turnEndEventPayload,
 } from "./schemas/session-event.js";
+export {
+  type SessionReconcileRequest,
+  type SessionReconcileResult,
+  sessionReconcileRequestSchema,
+  sessionReconcileResultSchema,
+} from "./schemas/session-reconcile.js";
 export {
   type OrgStats,
   orgStatsSchema,

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -20,7 +20,7 @@ export const RUNTIME_STATES = {
 export const runtimeStateSchema = z.enum(["idle", "working", "blocked", "error"]);
 export type RuntimeState = z.infer<typeof runtimeStateSchema>;
 
-// -- Session State (client → server, per-session) --
+// -- Session State --
 
 export const SESSION_STATES = {
   ACTIVE: "active",
@@ -28,12 +28,17 @@ export const SESSION_STATES = {
   EVICTED: "evicted",
 } as const;
 
+/** DB + admin surface. `evicted` is server-only (admin Terminate); never carried on the wire. */
 export const sessionStateSchema = z.enum(["active", "suspended", "evicted"]);
 export type SessionState = z.infer<typeof sessionStateSchema>;
 
+/** Wire-level states a client may report. `evicted` from a stale client is rejected. */
+export const clientSessionStateSchema = z.enum(["active", "suspended"]);
+export type ClientSessionState = z.infer<typeof clientSessionStateSchema>;
+
 export const sessionStateMessageSchema = z.object({
   chatId: z.string().min(1),
-  state: sessionStateSchema,
+  state: clientSessionStateSchema,
 });
 export type SessionStateMessage = z.infer<typeof sessionStateMessageSchema>;
 

--- a/packages/shared/src/schemas/session-reconcile.ts
+++ b/packages/shared/src/schemas/session-reconcile.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/** Client → server: list locally-held chatIds; server replies with the subset to drop. */
+export const sessionReconcileRequestSchema = z.object({
+  type: z.literal("session:reconcile"),
+  agentId: z.string().min(1),
+  chatIds: z.array(z.string().min(1)).max(500),
+});
+export type SessionReconcileRequest = z.infer<typeof sessionReconcileRequestSchema>;
+
+export const sessionReconcileResultSchema = z.object({
+  type: z.literal("session:reconcile:result"),
+  agentId: z.string().min(1),
+  staleChatIds: z.array(z.string().min(1)),
+});
+export type SessionReconcileResult = z.infer<typeof sessionReconcileResultSchema>;

--- a/packages/web/src/api/sessions.ts
+++ b/packages/web/src/api/sessions.ts
@@ -1,3 +1,4 @@
+import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
 import { api } from "./client.js";
 
 export type SessionListItem = {
@@ -11,6 +12,9 @@ export type SessionListItem = {
   summary: string | null;
   topic: string | null;
 };
+
+export const sessionQueryKey = (agentId: string, chatId: string) => ["session", agentId, chatId] as const;
+export const agentSessionsQueryKey = (agentId: string) => ["agent-sessions", agentId] as const;
 
 export type SessionListResponse = {
   items: SessionListItem[];
@@ -138,14 +142,17 @@ export function listSessionEvents(
   );
 }
 
-export function suspendSession(agentId: string, chatId: string): Promise<unknown> {
-  return api.post(`/admin/sessions/agents/${agentId}/${chatId}/suspend`);
+export type SessionMutationResponse = {
+  agentId: string;
+  chatId: string;
+  state: SessionState;
+  transitioned: boolean;
+};
+
+export function suspendSession(agentId: string, chatId: string): Promise<SessionMutationResponse> {
+  return api.post<SessionMutationResponse>(`/admin/sessions/agents/${agentId}/${chatId}/suspend`);
 }
 
-export function resumeSession(agentId: string, chatId: string): Promise<unknown> {
-  return api.post(`/admin/sessions/agents/${agentId}/${chatId}/resume`);
-}
-
-export function terminateSession(agentId: string, chatId: string): Promise<unknown> {
-  return api.post(`/admin/sessions/agents/${agentId}/${chatId}/terminate`);
+export function terminateSession(agentId: string, chatId: string): Promise<SessionMutationResponse> {
+  return api.post<SessionMutationResponse>(`/admin/sessions/agents/${agentId}/${chatId}/terminate`);
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Leaf, MessageSquare, Pause, Pencil, Play, Send, Square, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Leaf, MessageSquare, Pause, Pencil, Send, Square, X } from "lucide-react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import {
   getChat,
   listChatMessages,
@@ -9,18 +10,22 @@ import {
   sendChatMessage,
 } from "../../../api/chats.js";
 import {
+  agentSessionsQueryKey,
   asAssistantTextPayload,
   asErrorPayload,
   asToolCallPayload,
   listAgentSessions,
   listSessionEvents,
-  resumeSession,
   type SessionEventRow,
   type SessionListItem,
+  type SessionMutationResponse,
+  sessionQueryKey,
   suspendSession,
   terminateSession,
 } from "../../../api/sessions.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import { Button } from "../../../components/ui/button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog.js";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { StateDot } from "../../../components/ui/state-dot.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
@@ -104,79 +109,131 @@ function SessionControls({
   session: SessionListItem | null;
 }) {
   const queryClient = useQueryClient();
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["session", agentId, chatId] });
+  const [, setSearchParams] = useSearchParams();
+  const [terminateOpen, setTerminateOpen] = useState(false);
+  const [terminateError, setTerminateError] = useState<string | null>(null);
 
-  const suspendMut = useMutation({ mutationFn: () => suspendSession(agentId, chatId), onSuccess: invalidate });
-  const resumeMut = useMutation({ mutationFn: () => resumeSession(agentId, chatId), onSuccess: invalidate });
-  const terminateMut = useMutation({ mutationFn: () => terminateSession(agentId, chatId), onSuccess: invalidate });
+  const sessionKey = sessionQueryKey(agentId, chatId);
+  const agentSessionsKey = agentSessionsQueryKey(agentId);
+
+  const setSessionStateInCaches = (state: SessionListItem["state"]): void => {
+    queryClient.setQueryData<SessionListItem>(sessionKey, (old) => (old ? { ...old, state } : old));
+    queryClient.setQueryData<SessionListItem[]>(agentSessionsKey, (old) =>
+      old ? old.map((s) => (s.chatId === chatId ? { ...s, state } : s)) : old,
+    );
+  };
+
+  const suspendMut = useMutation<
+    SessionMutationResponse,
+    Error,
+    void,
+    { previousSession: SessionListItem | undefined; previousList: SessionListItem[] | undefined }
+  >({
+    mutationFn: () => suspendSession(agentId, chatId),
+    onMutate: async () => {
+      // Cancel both caches — the roster's 10s poller would otherwise clobber
+      // the optimistic `suspended` flip mid-flight.
+      await queryClient.cancelQueries({ queryKey: sessionKey });
+      await queryClient.cancelQueries({ queryKey: agentSessionsKey });
+      const previousSession = queryClient.getQueryData<SessionListItem>(sessionKey);
+      const previousList = queryClient.getQueryData<SessionListItem[]>(agentSessionsKey);
+      setSessionStateInCaches("suspended");
+      return { previousSession, previousList };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previousSession) queryClient.setQueryData(sessionKey, ctx.previousSession);
+      if (ctx?.previousList) queryClient.setQueryData(agentSessionsKey, ctx.previousList);
+    },
+    onSuccess: (res) => {
+      setSessionStateInCaches(res.state);
+    },
+  });
+
+  const terminateMut = useMutation<
+    SessionMutationResponse,
+    Error,
+    void,
+    { previousSession: SessionListItem | undefined; previousList: SessionListItem[] | undefined }
+  >({
+    mutationFn: () => terminateSession(agentId, chatId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: sessionKey });
+      await queryClient.cancelQueries({ queryKey: agentSessionsKey });
+      const previousSession = queryClient.getQueryData<SessionListItem>(sessionKey);
+      const previousList = queryClient.getQueryData<SessionListItem[]>(agentSessionsKey);
+      queryClient.setQueryData<SessionListItem[]>(agentSessionsKey, (old) =>
+        old ? old.filter((s) => s.chatId !== chatId) : old,
+      );
+      return { previousSession, previousList };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previousSession) queryClient.setQueryData(sessionKey, ctx.previousSession);
+      if (ctx?.previousList) queryClient.setQueryData(agentSessionsKey, ctx.previousList);
+      setTerminateError(err instanceof Error ? err.message : "Terminate failed");
+    },
+    onSuccess: (res, _vars, ctx) => {
+      // The admin API is lenient: a no-op response (e.g. the session was
+      // reactivated between dialog-open and confirm) returns transitioned=false
+      // with the current authoritative state. Only hide + navigate when the
+      // row is actually gone.
+      if (res.state !== "evicted") {
+        if (ctx?.previousList) queryClient.setQueryData(agentSessionsKey, ctx.previousList);
+        setSessionStateInCaches(res.state);
+        setTerminateError(`Session is ${res.state}; terminate only applies to suspended sessions.`);
+        return;
+      }
+      setTerminateError(null);
+      setTerminateOpen(false);
+      setSearchParams({ a: agentId });
+    },
+  });
 
   const isActive = session?.state === "active";
   const isSuspended = session?.state === "suspended";
-  const isEvicted = session?.state === "evicted";
+
+  if (!isActive && !isSuspended) return null;
 
   return (
-    <div
-      className="inline-flex items-center"
-      style={{
-        gap: 4,
-        padding: 4,
-        border: "1px solid var(--border)",
-        borderRadius: 6,
-        background: "var(--bg-sunken)",
-      }}
-    >
-      {isActive && (
-        <button
-          type="button"
-          onClick={() => suspendMut.mutate()}
-          disabled={suspendMut.isPending}
-          className="inline-flex items-center transition-colors"
-          style={{
-            gap: 6,
-            padding: "4px 10px",
-            fontSize: 11,
-            fontWeight: 500,
-            color: "var(--fg-2)",
-            borderRadius: 4,
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
-          onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-        >
-          <Pause className="h-3 w-3" /> Suspend
-          <span className="kbd" style={{ marginLeft: 2 }}>
-            ⌘⇧P
-          </span>
-        </button>
-      )}
-      {isSuspended && (
-        <button
-          type="button"
-          onClick={() => resumeMut.mutate()}
-          disabled={resumeMut.isPending}
-          className="inline-flex items-center transition-colors"
-          style={{
-            gap: 6,
-            padding: "4px 10px",
-            fontSize: 11,
-            fontWeight: 500,
-            color: "var(--fg-2)",
-            borderRadius: 4,
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
-          onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-        >
-          <Play className="h-3 w-3" /> Resume
-        </button>
-      )}
-      {!isEvicted && (
-        <>
-          <span style={{ width: 1, height: 16, background: "var(--border)" }} />
+    <>
+      <div
+        className="inline-flex items-center"
+        style={{
+          gap: 4,
+          padding: 4,
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          background: "var(--bg-sunken)",
+        }}
+      >
+        {isActive && (
+          <button
+            type="button"
+            onClick={() => suspendMut.mutate()}
+            disabled={suspendMut.isPending}
+            className="inline-flex items-center transition-colors"
+            style={{
+              gap: 6,
+              padding: "4px 10px",
+              fontSize: 11,
+              fontWeight: 500,
+              color: "var(--fg-2)",
+              borderRadius: 4,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-hover)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            <Pause className="h-3 w-3" /> Suspend
+            <span className="kbd" style={{ marginLeft: 2 }}>
+              ⌘⇧P
+            </span>
+          </button>
+        )}
+        {isSuspended && (
           <button
             type="button"
             onClick={() => {
-              if (window.confirm("Terminate this session?")) {
-                terminateMut.mutate();
-              }
+              setTerminateError(null);
+              setTerminateOpen(true);
             }}
             disabled={terminateMut.isPending}
             className="inline-flex items-center transition-colors"
@@ -198,9 +255,86 @@ function SessionControls({
           >
             <Square className="h-3 w-3" /> Terminate
           </button>
-        </>
-      )}
-    </div>
+        )}
+      </div>
+
+      <TerminateSessionDialog
+        open={terminateOpen}
+        onOpenChange={(o) => {
+          if (!terminateMut.isPending) setTerminateOpen(o);
+          if (!o) setTerminateError(null);
+        }}
+        session={session}
+        chatId={chatId}
+        error={terminateError}
+        pending={terminateMut.isPending}
+        onConfirm={() => terminateMut.mutate()}
+      />
+    </>
+  );
+}
+
+function TerminateSessionDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  session: SessionListItem | null;
+  chatId: string;
+  pending: boolean;
+  error: string | null;
+  onConfirm: () => void;
+}) {
+  const { open, onOpenChange, session, chatId, pending, error, onConfirm } = props;
+  function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!pending) onConfirm();
+  }
+  const shortId = chatId.slice(0, 8);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Terminate session?</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Ending this session is permanent. It is removed from the workspace and cannot be resumed. Chat history is
+            preserved; a new message will start a fresh session.
+          </p>
+          <div
+            className="mono"
+            style={{
+              fontSize: 11,
+              padding: "8px 10px",
+              borderRadius: 4,
+              background: "var(--bg-sunken)",
+              border: "1px solid var(--border)",
+              color: "var(--fg-2)",
+              display: "grid",
+              gap: 4,
+            }}
+          >
+            <span>
+              chat: <span className="font-medium">{shortId}…</span>
+            </span>
+            {session?.lastActivityAt && <span>last activity: {formatRelative(session.lastActivityAt)}</span>}
+            {typeof session?.messageCount === "number" && <span>messages: {session.messageCount}</span>}
+          </div>
+          {error && (
+            <p className="mono" style={{ fontSize: 11, color: "var(--state-error)" }}>
+              {error}
+            </p>
+          )}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="destructive" disabled={pending}>
+              {pending ? "Terminating…" : "Terminate"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -521,7 +655,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
   });
 
   const { data: session } = useQuery({
-    queryKey: ["session", agentId, chatId],
+    queryKey: sessionQueryKey(agentId, chatId),
     queryFn: () => listAgentSessions(agentId).then((sessions) => sessions.find((s) => s.chatId === chatId) ?? null),
     refetchInterval: 5_000,
   });

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -38,11 +38,15 @@ export function WorkspacePage() {
     enabled: !!selectedAgentId && !selectedChatId,
   });
 
-  // Auto-redirect: when an agent is selected but no chat, jump to the most recent chat.
+  // Auto-redirect: when an agent is selected but no chat, jump to the most recent
+  // non-terminated chat. Server already hides `evicted` from this listing; the
+  // local filter is a belt-and-suspenders guard during optimistic-update windows.
   useEffect(() => {
     if (!selectedAgentId || selectedChatId) return;
     if (!agentSessions || agentSessions.length === 0) return;
-    const latest = [...agentSessions].sort((a, b) => (b.lastActivityAt ?? "").localeCompare(a.lastActivityAt ?? ""))[0];
+    const latest = [...agentSessions]
+      .filter((s) => s.state !== "evicted")
+      .sort((a, b) => (b.lastActivityAt ?? "").localeCompare(a.lastActivityAt ?? ""))[0];
     if (latest) {
       setSearchParams({ a: selectedAgentId, c: latest.chatId }, { replace: true });
     }

--- a/packages/web/src/pages/workspace/roster/index.tsx
+++ b/packages/web/src/pages/workspace/roster/index.tsx
@@ -3,7 +3,7 @@ import { Plus, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { getActivityOverview, type RuntimeAgent } from "../../../api/activity.js";
 import { createAgentChat } from "../../../api/chats.js";
-import { listAgentSessions } from "../../../api/sessions.js";
+import { agentSessionsQueryKey, listAgentSessions } from "../../../api/sessions.js";
 import { StateDot } from "../../../components/ui/state-dot.js";
 import { usePulse } from "../../../hooks/pulse-context.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
@@ -53,7 +53,7 @@ export function AgentRoster({
   });
 
   const { data: sessions } = useQuery({
-    queryKey: ["agent-sessions", selectedAgentId],
+    queryKey: selectedAgentId ? agentSessionsQueryKey(selectedAgentId) : ["agent-sessions", null],
     queryFn: () => (selectedAgentId ? listAgentSessions(selectedAgentId) : Promise.resolve([])),
     enabled: !!selectedAgentId,
     refetchInterval: 10_000,
@@ -62,7 +62,7 @@ export function AgentRoster({
   const newChatMut = useMutation({
     mutationFn: (agentId: string) => createAgentChat(agentId),
     onSuccess: (result, agentId) => {
-      queryClient.invalidateQueries({ queryKey: ["agent-sessions", agentId] });
+      queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
       onSelectChat(agentId, result.id);
     },
   });
@@ -185,38 +185,40 @@ export function AgentRoster({
                 No sessions yet
               </div>
             )}
-            {sessions?.map((s) => {
-              const runtime = s.state === "active" ? "working" : s.state === "suspended" ? "idle" : "offline";
-              return (
-                <button
-                  key={s.chatId}
-                  type="button"
-                  onClick={() => onSelectChat(agent.agentId, s.chatId)}
-                  className="w-full grid items-center text-left transition-colors"
-                  style={{
-                    gridTemplateColumns: "14px 1fr",
-                    columnGap: 6,
-                    padding: "4px 10px 4px 28px",
-                    background: selectedChatId === s.chatId ? "var(--bg-hover)" : "transparent",
-                    color: s.state === "active" ? "var(--fg-2)" : "var(--fg-3)",
-                  }}
-                  onMouseEnter={(e) => {
-                    if (selectedChatId !== s.chatId) e.currentTarget.style.background = "var(--bg-hover)";
-                  }}
-                  onMouseLeave={(e) => {
-                    if (selectedChatId !== s.chatId) e.currentTarget.style.background = "transparent";
-                  }}
-                >
-                  <StateDot state={runtime} size={6} />
-                  <span
-                    className="truncate"
-                    style={{ fontSize: 11, color: s.topic || s.summary ? "var(--fg-2)" : "var(--fg-4)" }}
+            {sessions
+              ?.filter((s) => s.state !== "evicted")
+              .map((s) => {
+                const runtime = s.state === "active" ? "working" : "idle";
+                return (
+                  <button
+                    key={s.chatId}
+                    type="button"
+                    onClick={() => onSelectChat(agent.agentId, s.chatId)}
+                    className="w-full grid items-center text-left transition-colors"
+                    style={{
+                      gridTemplateColumns: "14px 1fr",
+                      columnGap: 6,
+                      padding: "4px 10px 4px 28px",
+                      background: selectedChatId === s.chatId ? "var(--bg-hover)" : "transparent",
+                      color: s.state === "active" ? "var(--fg-2)" : "var(--fg-3)",
+                    }}
+                    onMouseEnter={(e) => {
+                      if (selectedChatId !== s.chatId) e.currentTarget.style.background = "var(--bg-hover)";
+                    }}
+                    onMouseLeave={(e) => {
+                      if (selectedChatId !== s.chatId) e.currentTarget.style.background = "transparent";
+                    }}
                   >
-                    {s.topic || s.summary || `Chat · ${s.chatId.slice(0, 8)}`}
-                  </span>
-                </button>
-              );
-            })}
+                    <StateDot state={runtime} size={6} />
+                    <span
+                      className="truncate"
+                      style={{ fontSize: 11, color: s.topic || s.summary ? "var(--fg-2)" : "var(--fg-4)" }}
+                    >
+                      {s.topic || s.summary || `Chat · ${s.chatId.slice(0, 8)}`}
+                    </span>
+                  </button>
+                );
+              })}
             <button
               type="button"
               onClick={() => newChatMut.mutate(agent.agentId)}


### PR DESCRIPTION
## Summary

Reshape per-chat session lifecycle so the workbench drives one state-changing button at a time (Suspend → Terminate), the server commits state changes immediately, and the client cleans up locally via periodic reconcile. See proposal: `first-tree-context/proposals/session-state-redesign.20260421.md`.

- **Admin API** — Suspend/Terminate commit first, always return 200 `{ state, transitioned }`; state-machine no-ops are silent. Resume route removed. `transitionSessionState` uses single-row `SELECT … FOR UPDATE` to make precondition + write atomic.
- **Revival defense** — `upsertSessionState` short-circuits when the locked row is already `evicted`, serializing concurrent client reports against admin terminate so an offline-then-reconnecting client cannot resurrect a terminated session.
- **Wire strictness** — `clientSessionStateSchema` is `active|suspended` only; stale clients reporting `evicted` get an error frame + warn log, no DB write.
- **Client reconcile** — new `session:reconcile` frame: client sends locally-held chatIds every 300s (+ one-shot 5s after bind), server replies with `staleChatIds` (evicted or missing), client applies them as terminates. Replaces the scrapped `cleanupStaleSessions` cron.
- **Client terminate** — drops sessions, evictedMappings, pendingQueue, and sessionRuntimeStates; no `session:state` echo (server is authoritative). LRU eviction no longer emits wire state.
- **Web** — single-button flow: Suspend when active, Terminate when suspended; new `TerminateSessionDialog` with chat context + destructive confirm; optimistic cache updates with rollback; evicted rows filtered from listings and routes.
- **Versions** — `@agent-team-foundation/first-tree-hub` 0.8.4 → 0.8.5; `@agent-team-foundation/first-tree-hub-shared` 0.1.1 → 0.1.2 (new exports: `sessionReconcileRequest/ResultSchema`, `clientSessionStateSchema`).

## Test plan

- [x] `pnpm check` (biome)
- [x] `pnpm typecheck` (all 9 tasks)
- [x] `pnpm --filter @first-tree-hub/server test` — 379/379 (incl. new `admin-sessions-suspend-terminate.test.ts`, extended `ws-session-event.test.ts` with reconcile)
- [x] `pnpm --filter @first-tree-hub/client test` — 146/146 (incl. updated `session-state-notifications.test.ts` covering terminate-no-wire and `applyStaleChatIds`)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` — 54/54
- [x] `pnpm --filter @first-tree-hub/web test` — 21/21
- [x] Local e2e against a real PG + running Fastify: every REST transition (suspend/terminate/idempotent no-ops, 404 on missing chat, 404 on removed resume), plus WS `session:reconcile` staleChatIds derivation, revival defense, and stale-client `evicted` rejection.

## Known trade-offs

- `session.reconcile_interval_seconds` is only exposed in the local client YAML schema (`packages/client/src/runtime/config.ts`); CLI users go through `AgentConfig` in `shared`, where the knob isn't wired yet — it stays at the 300s default. Follow-up if operators want to tune per-agent.
- LRU `evictIfNeeded()` emits no wire state (proposal said `suspended`) to avoid accumulating non-cleanable rows now that `cleanupStaleSessions` is gone. Justification captured in code comment + `session-state-notifications.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)