### PR TITLE
feat(chat): image upload in workspace chat

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@agent-team-foundation/first-tree-hub-shared": "workspace:*",
     "@fastify/cors": "^11.2.0",
+    "@fastify/multipart": "^10.0.0",
     "@fastify/otel": "^0.9.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/packages/server/src/__tests__/admin-uploads.test.ts
+++ b/packages/server/src/__tests__/admin-uploads.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("Admin Uploads API", () => {
+  const getApp = useTestApp();
+
+  it("uploads an image and retrieves it", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    // Create a minimal 1x1 PNG
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "base64",
+    );
+
+    // Build multipart form data manually
+    const boundary = "----TestBoundary123";
+    const body = Buffer.concat([
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="test.png"\r\nContent-Type: image/png\r\n\r\n`,
+      ),
+      pngBytes,
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ]);
+
+    const uploadRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/uploads",
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(uploadRes.statusCode).toBe(201);
+    const result = uploadRes.json();
+    expect(result.url).toMatch(/^\/api\/v1\/admin\/uploads\//);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.filename).toBe("test.png");
+    expect(result.size).toBeGreaterThan(0);
+
+    // Retrieve the uploaded file
+    const getRes = await app.inject({
+      method: "GET",
+      url: result.url,
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+      },
+    });
+
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.headers["content-type"]).toContain("image/png");
+  });
+
+  it("rejects non-image file types", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const boundary = "----TestBoundary456";
+    const body = Buffer.concat([
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="hack.exe"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+      ),
+      Buffer.from("not an image"),
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/uploads",
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Unsupported file type");
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const app = getApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/admin/uploads",
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for non-existent file", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/uploads/nonexistent.png",
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects path traversal in filename", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/admin/uploads/..%2F..%2Fetc%2Fpasswd",
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+      },
+    });
+
+    // Should be 400 or 404, not serve the file
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/packages/server/src/api/admin/uploads.ts
+++ b/packages/server/src/api/admin/uploads.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import { createReadStream, createWriteStream, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { extname, join } from "node:path";
+import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+import type { FastifyInstance } from "fastify";
+import { requireMember } from "../../middleware/require-identity.js";
+
+const UPLOADS_DIR = join(DEFAULT_DATA_DIR, "uploads");
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"]);
+
+function ensureUploadsDir(): void {
+  if (!existsSync(UPLOADS_DIR)) {
+    mkdirSync(UPLOADS_DIR, { recursive: true });
+  }
+}
+
+export async function adminUploadRoutes(app: FastifyInstance): Promise<void> {
+  ensureUploadsDir();
+
+  /** POST /admin/uploads — upload a file, returns URL */
+  app.post("/", async (request, reply) => {
+    requireMember(request);
+
+    const data = await request.file();
+    if (!data) {
+      return reply.status(400).send({ error: "No file provided" });
+    }
+
+    const mimeType = data.mimetype;
+    if (!ALLOWED_MIME_TYPES.has(mimeType)) {
+      return reply.status(400).send({
+        error: `Unsupported file type: ${mimeType}. Allowed: ${[...ALLOWED_MIME_TYPES].join(", ")}`,
+      });
+    }
+
+    // Generate unique filename
+    const ext = extname(data.filename) || mimeExtension(mimeType);
+    const timestamp = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
+    const uniqueName = `${timestamp}_${randomUUID().slice(0, 8)}${ext}`;
+    const filePath = join(UPLOADS_DIR, uniqueName);
+
+    // Stream file to disk with size check
+    let totalSize = 0;
+    const writeStream = createWriteStream(filePath);
+
+    try {
+      const fileStream = data.file;
+      for await (const chunk of fileStream) {
+        totalSize += chunk.length;
+        if (totalSize > MAX_FILE_SIZE) {
+          writeStream.destroy();
+          try {
+            unlinkSync(filePath);
+          } catch {}
+          return reply.status(400).send({
+            error: `File too large. Maximum size: ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+          });
+        }
+        writeStream.write(chunk);
+      }
+      writeStream.end();
+      await new Promise<void>((resolve, reject) => {
+        writeStream.on("finish", resolve);
+        writeStream.on("error", reject);
+      });
+    } catch (err) {
+      writeStream.destroy();
+      throw err;
+    }
+
+    const url = `/api/v1/admin/uploads/${uniqueName}`;
+
+    return reply.status(201).send({
+      url,
+      filename: data.filename,
+      storedName: uniqueName,
+      mimeType,
+      size: totalSize,
+    });
+  });
+
+  /** GET /admin/uploads/:filename — serve uploaded file */
+  app.get<{ Params: { filename: string } }>("/:filename", async (request, reply) => {
+    requireMember(request);
+
+    const { filename } = request.params;
+    if (filename.includes("/") || filename.includes("..")) {
+      return reply.status(400).send({ error: "Invalid filename" });
+    }
+
+    const filePath = join(UPLOADS_DIR, filename);
+    if (!existsSync(filePath)) {
+      return reply.status(404).send({ error: "File not found" });
+    }
+
+    const ext = extname(filename).toLowerCase();
+    const contentType = extensionToMime(ext) ?? "application/octet-stream";
+
+    const stream = createReadStream(filePath);
+    return reply.type(contentType).send(stream);
+  });
+}
+
+function mimeExtension(mime: string): string {
+  switch (mime) {
+    case "image/png":
+      return ".png";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/svg+xml":
+      return ".svg";
+    default:
+      return "";
+  }
+}
+
+function extensionToMime(ext: string): string | null {
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".svg":
+      return "image/svg+xml";
+    default:
+      return null;
+  }
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import cors from "@fastify/cors";
+import multipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
@@ -24,6 +25,7 @@ import { adminSessionRoutes } from "./api/admin/sessions.js";
 import { adminStatsRoutes } from "./api/admin/stats.js";
 import { adminSystemConfigRoutes } from "./api/admin/system-config.js";
 import { adminTaskRoutes } from "./api/admin/tasks.js";
+import { adminUploadRoutes } from "./api/admin/uploads.js";
 import { adminWsRoutes } from "./api/admin/ws-admin.js";
 import { agentChatRoutes } from "./api/agent/chats.js";
 import { agentConfigRoutes } from "./api/agent/config.js";
@@ -108,6 +110,9 @@ export async function buildApp(config: Config) {
 
   // WebSocket plugin
   await app.register(websocket);
+
+  // Multipart support for file uploads
+  await app.register(multipart, { limits: { fileSize: 10 * 1024 * 1024 } });
 
   // CORS — explicit origins if configured; allow all in dev; same-origin in production
   const corsOrigin = config.cors?.origin;
@@ -252,6 +257,15 @@ export async function buildApp(config: Config) {
           await adminApp.register(adminChatRoutes);
         },
         { prefix: "/admin/chats" },
+      );
+
+      // File uploads (images etc.)
+      await api.register(
+        async (adminApp) => {
+          adminApp.addHook("onRequest", memberAuth);
+          await adminApp.register(adminUploadRoutes);
+        },
+        { prefix: "/admin/uploads" },
       );
 
       // M1: Client management routes

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -1,5 +1,5 @@
 import type { Chat, ChatDetail, Message } from "@agent-team-foundation/first-tree-hub-shared";
-import { api } from "./client.js";
+import { api, getStoredTokens } from "./client.js";
 
 type PaginatedChats = {
   items: (Chat & { participantCount: number })[];
@@ -34,6 +34,76 @@ export function renameChat(chatId: string, topic: string | null): Promise<Chat> 
 export function sendChatMessage(chatId: string, content: string): Promise<Message> {
   return api.post<Message>(`/admin/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "text",
+    content,
+  });
+}
+
+export type UploadResult = {
+  url: string;
+  filename: string;
+  storedName: string;
+  mimeType: string;
+  size: number;
+};
+
+export type FileMessageContent = {
+  url: string;
+  mimeType: string;
+  filename: string;
+  size: number;
+};
+
+export async function uploadFile(file: File): Promise<UploadResult> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const doFetch = (token?: string) => {
+    const headers: Record<string, string> = {};
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return fetch("/api/v1/admin/uploads", { method: "POST", headers, body: formData });
+  };
+
+  const tokens = getStoredTokens();
+  let res = await doFetch(tokens?.accessToken);
+
+  // Retry with refreshed token on 401
+  if (res.status === 401 && tokens?.refreshToken) {
+    const refreshRes = await fetch("/api/v1/auth/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: tokens.refreshToken }),
+    });
+    if (refreshRes.ok) {
+      const body = (await refreshRes.json()) as { accessToken: string; refreshToken?: string };
+      const updated = { accessToken: body.accessToken, refreshToken: body.refreshToken ?? tokens.refreshToken };
+      // Re-create FormData since the previous body was consumed
+      const retryData = new FormData();
+      retryData.append("file", file);
+      res = await fetch("/api/v1/admin/uploads", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${updated.accessToken}` },
+        body: retryData,
+      });
+    }
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    let msg: string;
+    try {
+      msg = (JSON.parse(text) as { error?: string }).error ?? text;
+    } catch {
+      msg = text;
+    }
+    throw new Error(msg);
+  }
+
+  return (await res.json()) as UploadResult;
+}
+
+export function sendFileMessage(chatId: string, content: FileMessageContent): Promise<Message> {
+  return api.post<Message>(`/admin/chats/${encodeURIComponent(chatId)}/messages`, {
+    format: "file",
     content,
   });
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,13 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Leaf, MessageSquare, Pause, Pencil, Send, Square, X } from "lucide-react";
-import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Leaf, MessageSquare, Paperclip, Pause, Pencil, Send, Square, X } from "lucide-react";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import {
+  type FileMessageContent,
   getChat,
   listChatMessages,
   type MessageWithDelivery,
   renameChat,
   sendChatMessage,
+  sendFileMessage,
+  uploadFile,
 } from "../../../api/chats.js";
 import {
   agentSessionsQueryKey,
@@ -604,7 +607,13 @@ function TextRow({
             lineHeight: 1.55,
           }}
         >
-          {msg.format === "text" ? (
+          {msg.format === "file" && isImageContent(msg.content) ? (
+            <img
+              src={(msg.content as FileMessageContent).url}
+              alt={(msg.content as FileMessageContent).filename ?? "image"}
+              style={{ maxWidth: 320, borderRadius: 6, marginTop: 4 }}
+            />
+          ) : msg.format === "text" ? (
             <Markdown>{typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}</Markdown>
           ) : (
             <pre
@@ -627,6 +636,18 @@ function TextRow({
   );
 }
 
+function isImageContent(content: unknown): content is FileMessageContent {
+  if (typeof content !== "object" || content === null) return false;
+  const c = content as Record<string, unknown>;
+  return typeof c.url === "string" && typeof c.mimeType === "string" && (c.mimeType as string).startsWith("image/");
+}
+
+type PendingImage = {
+  id: string;
+  file: File;
+  previewUrl: string;
+};
+
 type TimelineItem =
   | { kind: "message"; at: string; key: string; data: MessageWithDelivery }
   | { kind: "event"; at: string; key: string; data: SessionEventRow };
@@ -636,6 +657,10 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
   const agentName = useAgentNameMap();
   const { agentId: myAgentId } = useAuth();
   const [draft, setDraft] = useState("");
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const { data: messagesData } = useQuery({
@@ -674,9 +699,57 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
     },
   });
 
-  const handleSend = () => {
+  const addImages = useCallback((files: File[]) => {
+    const imageFiles = files.filter((f) => f.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
+    const newImages: PendingImage[] = imageFiles.map((file) => ({
+      id: crypto.randomUUID(),
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+    setPendingImages((prev) => [...prev, ...newImages]);
+  }, []);
+
+  const removeImage = useCallback((id: string) => {
+    setPendingImages((prev) => {
+      const img = prev.find((i) => i.id === id);
+      if (img) URL.revokeObjectURL(img.previewUrl);
+      return prev.filter((i) => i.id !== id);
+    });
+  }, []);
+
+  const handleSend = async () => {
     const text = draft.trim();
-    if (!text) return;
+    const images = pendingImages;
+    if (!text && images.length === 0) return;
+    if (uploading) return;
+
+    if (images.length > 0) {
+      setUploading(true);
+      setUploadError(null);
+      try {
+        for (const img of images) {
+          const result = await uploadFile(img.file);
+          await sendFileMessage(chatId, {
+            url: result.url,
+            mimeType: result.mimeType,
+            filename: result.filename,
+            size: result.size,
+          });
+          URL.revokeObjectURL(img.previewUrl);
+        }
+        setPendingImages([]);
+        if (text) await sendChatMessage(chatId, text);
+        setDraft("");
+        queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
+      } catch (err) {
+        setUploadError(err instanceof Error ? err.message : "Failed to upload image");
+      } finally {
+        setUploading(false);
+      }
+      return;
+    }
+
     sendMut.mutate(text);
   };
 
@@ -918,6 +991,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
           borderTop: "1px solid var(--border)",
         }}
       >
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
         <div
           style={{
             position: "relative",
@@ -925,10 +999,22 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
             borderRadius: 6,
             background: "var(--bg-sunken)",
           }}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            addImages(Array.from(e.dataTransfer.files));
+          }}
         >
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            onPaste={(e) => {
+              const files = Array.from(e.clipboardData.files);
+              if (files.length > 0) {
+                e.preventDefault();
+                addImages(files);
+              }
+            }}
             placeholder={`Message @${displayName}  ·  / for commands  ·  @ to mention`}
             rows={2}
             onKeyDown={(e) => {
@@ -937,7 +1023,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
                 handleSend();
               }
             }}
-            disabled={sendMut.isPending}
+            disabled={sendMut.isPending || uploading}
             className="w-full outline-none"
             style={{
               padding: "9px 12px 30px",
@@ -949,6 +1035,51 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               color: "var(--fg)",
             }}
           />
+          {/* Image preview area */}
+          {pendingImages.length > 0 && (
+            <div className="flex items-center" style={{ gap: 6, padding: "4px 10px", overflowX: "auto" }}>
+              {pendingImages.map((img) => (
+                <div
+                  key={img.id}
+                  style={{
+                    position: "relative",
+                    flexShrink: 0,
+                    borderRadius: 4,
+                    border: "1px solid var(--border)",
+                    overflow: "hidden",
+                  }}
+                >
+                  <img
+                    src={img.previewUrl}
+                    alt={img.file.name}
+                    style={{ height: 56, width: "auto", display: "block" }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(img.id)}
+                    style={{
+                      position: "absolute",
+                      top: 2,
+                      right: 2,
+                      width: 16,
+                      height: 16,
+                      borderRadius: "50%",
+                      background: "rgba(0,0,0,0.6)",
+                      border: "none",
+                      color: "#fff",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      cursor: "pointer",
+                      padding: 0,
+                    }}
+                  >
+                    <X className="h-2.5 w-2.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <div
             className="flex items-center justify-between"
             style={{
@@ -960,23 +1091,58 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               color: "var(--fg-4)",
             }}
           >
-            <span className="mono flex" style={{ gap: 8 }}>
+            <span className="mono flex items-center" style={{ gap: 8 }}>
               <span>/suspend</span>
               <span>/resume</span>
               <span>/branch</span>
               <span>/promote</span>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                title="Attach image"
+                style={{
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  color: "var(--fg-3)",
+                  padding: 0,
+                  display: "inline-flex",
+                  alignItems: "center",
+                }}
+              >
+                <Paperclip className="h-3.5 w-3.5" />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  if (e.target.files) {
+                    addImages(Array.from(e.target.files));
+                    e.target.value = "";
+                  }
+                }}
+              />
             </span>
             <span className="flex items-center" style={{ gap: 8 }}>
+              {uploading && (
+                <span className="mono" style={{ fontSize: 10, color: "var(--accent)" }}>
+                  uploading…
+                </span>
+              )}
               <span>
                 <span className="kbd">⏎</span> send <span className="kbd">⇧⏎</span> new line
               </span>
               <button
                 type="button"
                 onClick={handleSend}
-                disabled={sendMut.isPending || !draft.trim()}
+                disabled={sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0)}
                 className={cn(
                   "inline-flex items-center transition-colors",
-                  (sendMut.isPending || !draft.trim()) && "opacity-50 cursor-not-allowed",
+                  (sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0)) &&
+                    "opacity-50 cursor-not-allowed",
                 )}
                 style={{
                   gap: 6,
@@ -994,7 +1160,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
             </span>
           </div>
         </div>
-        {sendMut.isError && (
+        {(sendMut.isError || uploadError) && (
           <p
             className="mono"
             style={{
@@ -1003,7 +1169,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               padding: "6px 2px 0",
             }}
           >
-            {sendMut.error instanceof Error ? sendMut.error.message : "Failed to send"}
+            {uploadError ?? (sendMut.error instanceof Error ? sendMut.error.message : "Failed to send")}
           </p>
         )}
       </div>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1005,6 +1005,51 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
             addImages(Array.from(e.dataTransfer.files));
           }}
         >
+          {/* Image preview area — above textarea */}
+          {pendingImages.length > 0 && (
+            <div className="flex items-center" style={{ gap: 6, padding: "6px 10px 0", overflowX: "auto" }}>
+              {pendingImages.map((img) => (
+                <div
+                  key={img.id}
+                  style={{
+                    position: "relative",
+                    flexShrink: 0,
+                    borderRadius: 4,
+                    border: "1px solid var(--border)",
+                    overflow: "hidden",
+                  }}
+                >
+                  <img
+                    src={img.previewUrl}
+                    alt={img.file.name}
+                    style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(img.id)}
+                    style={{
+                      position: "absolute",
+                      top: 1,
+                      right: 1,
+                      width: 14,
+                      height: 14,
+                      borderRadius: "50%",
+                      background: "rgba(0,0,0,0.6)",
+                      border: "none",
+                      color: "#fff",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      cursor: "pointer",
+                      padding: 0,
+                    }}
+                  >
+                    <X className="h-2 w-2" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -1035,51 +1080,6 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               color: "var(--fg)",
             }}
           />
-          {/* Image preview area */}
-          {pendingImages.length > 0 && (
-            <div className="flex items-center" style={{ gap: 6, padding: "4px 10px", overflowX: "auto" }}>
-              {pendingImages.map((img) => (
-                <div
-                  key={img.id}
-                  style={{
-                    position: "relative",
-                    flexShrink: 0,
-                    borderRadius: 4,
-                    border: "1px solid var(--border)",
-                    overflow: "hidden",
-                  }}
-                >
-                  <img
-                    src={img.previewUrl}
-                    alt={img.file.name}
-                    style={{ height: 56, width: "auto", display: "block" }}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeImage(img.id)}
-                    style={{
-                      position: "absolute",
-                      top: 2,
-                      right: 2,
-                      width: 16,
-                      height: 16,
-                      borderRadius: "50%",
-                      background: "rgba(0,0,0,0.6)",
-                      border: "none",
-                      color: "#fff",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      cursor: "pointer",
-                      padding: 0,
-                    }}
-                  >
-                    <X className="h-2.5 w-2.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
           <div
             className="flex items-center justify-between"
             style={{
@@ -1092,10 +1092,6 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
             }}
           >
             <span className="mono flex items-center" style={{ gap: 8 }}>
-              <span>/suspend</span>
-              <span>/resume</span>
-              <span>/branch</span>
-              <span>/promote</span>
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
@@ -1125,6 +1121,10 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
                   }
                 }}
               />
+              <span>/suspend</span>
+              <span>/resume</span>
+              <span>/branch</span>
+              <span>/promote</span>
             </span>
             <span className="flex items-center" style={{ gap: 8 }}>
               {uploading && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/multipart':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@fastify/otel':
         specifier: ^0.9.0
         version: 0.9.4(@opentelemetry/api@1.9.1)
@@ -967,8 +970,14 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -981,6 +990,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.0.0':
+    resolution: {integrity: sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==}
 
   '@fastify/otel@0.9.4':
     resolution: {integrity: sha512-NboTg+WAJPQ/prwmXA9ey2araV2Dj5+5NoCP5dZ5sI49wGKuZZ3k0kGLiFD1CIPEh2bI2G2HXF7ozTbDauh9Yg==}
@@ -4522,10 +4534,14 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/busboy@3.2.0': {}
+
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
+
+  '@fastify/deepmerge@3.2.1': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -4538,6 +4554,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@10.0.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+      secure-json-parse: 4.1.0
 
   '@fastify/otel@0.9.4(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- Add image upload support to workspace chat input (paste, drag-and-drop, paperclip button)
- Backend: `POST/GET /admin/uploads` endpoints with multipart support, images stored locally under `data/uploads/`
- Frontend: image preview in input area (32px height, above textarea), `<img>` rendering for file-format messages
- Integration tests covering upload, retrieval, auth, MIME validation, and path traversal

## Test plan
- [ ] Start server + web dev, open a chat, test paste/drag/click image upload
- [ ] Verify image preview appears above textarea with ✕ to remove
- [ ] Verify sent image renders as `<img>` in chat timeline
- [ ] Verify non-image files are rejected (400)
- [ ] Run `vitest run src/__tests__/admin-uploads.test.ts` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)