### PR TITLE
fix(chat): make uploaded image URLs publicly accessible

### DIFF
--- a/packages/server/src/__tests__/admin-uploads.test.ts
+++ b/packages/server/src/__tests__/admin-uploads.test.ts
@@ -36,18 +36,15 @@ describe("Admin Uploads API", () => {
 
     expect(uploadRes.statusCode).toBe(201);
     const result = uploadRes.json();
-    expect(result.url).toMatch(/^\/api\/v1\/admin\/uploads\//);
+    expect(result.url).toMatch(/^\/api\/v1\/uploads\//);
     expect(result.mimeType).toBe("image/png");
     expect(result.filename).toBe("test.png");
     expect(result.size).toBeGreaterThan(0);
 
-    // Retrieve the uploaded file
+    // Retrieve the uploaded file (public route, no auth needed)
     const getRes = await app.inject({
       method: "GET",
       url: result.url,
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-      },
     });
 
     expect(getRes.statusCode).toBe(200);
@@ -81,7 +78,7 @@ describe("Admin Uploads API", () => {
     expect(res.json().error).toContain("Unsupported file type");
   });
 
-  it("rejects unauthenticated requests", async () => {
+  it("rejects unauthenticated upload", async () => {
     const app = getApp();
 
     const res = await app.inject({
@@ -94,14 +91,10 @@ describe("Admin Uploads API", () => {
 
   it("returns 404 for non-existent file", async () => {
     const app = getApp();
-    const admin = await createTestAdmin(app);
 
     const res = await app.inject({
       method: "GET",
-      url: "/api/v1/admin/uploads/nonexistent.png",
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-      },
+      url: "/api/v1/uploads/nonexistent.png",
     });
 
     expect(res.statusCode).toBe(404);
@@ -109,14 +102,10 @@ describe("Admin Uploads API", () => {
 
   it("rejects path traversal in filename", async () => {
     const app = getApp();
-    const admin = await createTestAdmin(app);
 
     const res = await app.inject({
       method: "GET",
-      url: "/api/v1/admin/uploads/..%2F..%2Fetc%2Fpasswd",
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-      },
+      url: "/api/v1/uploads/..%2F..%2Fetc%2Fpasswd",
     });
 
     // Should be 400 or 404, not serve the file

--- a/packages/server/src/api/admin/uploads.ts
+++ b/packages/server/src/api/admin/uploads.ts
@@ -69,7 +69,7 @@ export async function adminUploadRoutes(app: FastifyInstance): Promise<void> {
       throw err;
     }
 
-    const url = `/api/v1/admin/uploads/${uniqueName}`;
+    const url = `/api/v1/uploads/${uniqueName}`;
 
     return reply.status(201).send({
       url,
@@ -79,11 +79,14 @@ export async function adminUploadRoutes(app: FastifyInstance): Promise<void> {
       size: totalSize,
     });
   });
+}
 
-  /** GET /admin/uploads/:filename — serve uploaded file */
+/** Public routes — GET uploaded files (URL contains random UUID, not guessable) */
+export async function publicUploadRoutes(app: FastifyInstance): Promise<void> {
+  ensureUploadsDir();
+
+  /** GET /uploads/:filename — serve uploaded file without auth */
   app.get<{ Params: { filename: string } }>("/:filename", async (request, reply) => {
-    requireMember(request);
-
     const { filename } = request.params;
     if (filename.includes("/") || filename.includes("..")) {
       return reply.status(400).send({ error: "Invalid filename" });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -25,7 +25,7 @@ import { adminSessionRoutes } from "./api/admin/sessions.js";
 import { adminStatsRoutes } from "./api/admin/stats.js";
 import { adminSystemConfigRoutes } from "./api/admin/system-config.js";
 import { adminTaskRoutes } from "./api/admin/tasks.js";
-import { adminUploadRoutes } from "./api/admin/uploads.js";
+import { adminUploadRoutes, publicUploadRoutes } from "./api/admin/uploads.js";
 import { adminWsRoutes } from "./api/admin/ws-admin.js";
 import { agentChatRoutes } from "./api/agent/chats.js";
 import { agentConfigRoutes } from "./api/agent/config.js";
@@ -160,6 +160,7 @@ export async function buildApp(config: Config) {
       await api.register(authRoutes, { prefix: "/auth" });
       await api.register(contextTreeInfoRoutes, { prefix: "/context-tree" });
       await api.register(bootstrapConfigRoutes, { prefix: "/bootstrap" });
+      await api.register(publicUploadRoutes, { prefix: "/uploads" });
 
       // Admin routes (JWT protected)
       await api.register(


### PR DESCRIPTION
## Summary
- Image `<img src="...">` tags failed to load because GET endpoint required auth (browser doesn't send Authorization header for image requests)
- Split into authenticated `POST /admin/uploads` and public `GET /uploads/:filename`
- Random UUID filenames keep URLs non-guessable

## Test plan
- [x] 5 integration tests pass (upload, retrieve, auth, MIME validation, path traversal)
- [ ] Verify uploaded images render correctly in chat after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)