### PR TITLE
feat(client): server-welcome version broadcast + self-update

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
     "pino": "^9.5.0",
+    "semver": "^7.6.3",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@agent-team-foundation/first-tree-hub-shared": "workspace:*",
     "@types/node": "^22.16.0",
+    "@types/semver": "^7.5.8",
     "@types/ws": "^8.18.1",
     "tsdown": "^0.21.4",
     "vitest": "^3.2.0"

--- a/packages/client/src/__tests__/client-connection-server-welcome.test.ts
+++ b/packages/client/src/__tests__/client-connection-server-welcome.test.ts
@@ -1,0 +1,98 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { ClientConnection, type ServerWelcome } from "../client-connection.js";
+
+describe("ClientConnection — server:welcome dispatch", () => {
+  let httpServer: HttpServer;
+  let wss: WebSocketServer;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    httpServer = createServer();
+    wss = new WebSocketServer({ server: httpServer, path: "/api/v1/agent/ws/client" });
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") throw new Error("no server address");
+    serverUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("emits 'server:welcome' with isReconnect=false on first connect", async () => {
+    wss.on("connection", (ws: WebSocket) => {
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          ws.send(
+            JSON.stringify({
+              type: "server:welcome",
+              serverCommandVersion: "0.9.2",
+              serverTimeMs: 1_700_000_000_000,
+            }),
+          );
+          return;
+        }
+        if (msg.type === "client:register") {
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_test0001",
+      getAccessToken: async () => "test-token",
+    });
+
+    const received: ServerWelcome[] = [];
+    connection.on("server:welcome", (w) => received.push(w));
+
+    // Register listener BEFORE connect to avoid missing the first welcome frame.
+    const connectPromise = connection.connect();
+    await connectPromise;
+    // Welcome frame arrives between auth:ok and client:registered — but the
+    // connect promise resolves on client:registered, so the welcome has
+    // already been dispatched synchronously by then.
+    await connection.disconnect();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.frame.serverCommandVersion).toBe("0.9.2");
+    expect(received[0]?.isReconnect).toBe(false);
+  });
+
+  it("ignores malformed welcome frames without crashing", async () => {
+    wss.on("connection", (ws: WebSocket) => {
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          ws.send(JSON.stringify({ type: "server:welcome", serverCommandVersion: "", serverTimeMs: -5 }));
+          return;
+        }
+        if (msg.type === "client:register") {
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_test0002",
+      getAccessToken: async () => "test-token",
+    });
+
+    const received: ServerWelcome[] = [];
+    connection.on("server:welcome", (w) => received.push(w));
+
+    await connection.connect();
+    await new Promise((r) => setTimeout(r, 20));
+    await connection.disconnect();
+
+    expect(received).toHaveLength(0);
+  });
+});

--- a/packages/client/src/__tests__/update-manager.test.ts
+++ b/packages/client/src/__tests__/update-manager.test.ts
@@ -1,0 +1,294 @@
+import { EventEmitter } from "node:events";
+import type { ClientConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { describe, expect, it, vi } from "vitest";
+import type { ServerWelcome } from "../client-connection.js";
+import { UpdateManager } from "../runtime/update-manager.js";
+
+/**
+ * Minimal stand-in for ClientConnection. UpdateManager only touches
+ * `.on("server:welcome")` and `.off(...)`, so a plain EventEmitter keeps the
+ * test harness free of sockets.
+ */
+type FakeConnection = EventEmitter & {
+  emitWelcome(frame: ServerWelcome): void;
+};
+
+function makeFakeConnection(): FakeConnection {
+  const emitter = new EventEmitter() as FakeConnection;
+  emitter.emitWelcome = (welcome) => {
+    emitter.emit("server:welcome", welcome);
+  };
+  return emitter;
+}
+
+function makeUpdateConfig(overrides: Partial<ClientConfig["update"]> = {}): ClientConfig["update"] {
+  return {
+    policy: "auto",
+    restart_quiet_seconds: 30,
+    restart_check_interval_seconds: 10,
+    prompt_timeout_seconds: 60,
+    ...overrides,
+  };
+}
+
+function makeWelcome(serverCommandVersion: string, isReconnect = false): ServerWelcome {
+  return {
+    frame: {
+      type: "server:welcome",
+      serverCommandVersion,
+      serverTimeMs: 1_700_000_000_000,
+    },
+    isReconnect,
+  };
+}
+
+async function waitForMicrotasks(): Promise<void> {
+  // UpdateManager's welcome handler is async; allow one macro-tick so
+  // `executeUpdate` resolves and test assertions see the final state.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("UpdateManager decision flow", () => {
+  it("does nothing when server version matches", async () => {
+    const conn = makeFakeConnection();
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    const prompt = vi.fn(async () => true);
+    UpdateManager.attach(conn, {
+      currentVersion: "0.9.2",
+      updateConfig: makeUpdateConfig({ policy: "auto" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(executeUpdate).not.toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when client is ahead of server (lt)", async () => {
+    const conn = makeFakeConnection();
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    UpdateManager.attach(conn, {
+      currentVersion: "0.9.3",
+      updateConfig: makeUpdateConfig({ policy: "auto" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt: async () => true,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when policy=off even on drift", async () => {
+    const conn = makeFakeConnection();
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "off" }),
+      isTTY: true,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt: async () => true,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("policy=prompt, daemon (no TTY) → log only, no prompt or update", async () => {
+    const conn = makeFakeConnection();
+    const prompt = vi.fn(async () => true);
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "prompt" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("policy=prompt, TTY, user says Y → executeUpdate, no quiet-gate wait", async () => {
+    const conn = makeFakeConnection();
+    const prompt = vi.fn(async () => true);
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    const getQuietGateSnapshot = vi.fn(() => ({
+      activeCount: 5,
+      lastActivityMs: Date.now(), // busy now — would block quiet gate
+    }));
+
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "prompt" }),
+      isTTY: true,
+      log: () => {},
+      getQuietGateSnapshot,
+      prompt,
+      executeUpdate,
+    });
+
+    // Reconnect welcome — quiet gate would normally apply, but explicit Y waives it.
+    conn.emitWelcome(makeWelcome("0.9.2", true));
+    await waitForMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(executeUpdate).toHaveBeenCalledOnce();
+    expect(getQuietGateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("policy=prompt, TTY, user declines → no update", async () => {
+    const conn = makeFakeConnection();
+    const prompt = vi.fn(async () => false);
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "prompt" }),
+      isTTY: true,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("policy=auto, daemon, first welcome → update immediately (no quiet gate)", async () => {
+    const conn = makeFakeConnection();
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    const getQuietGateSnapshot = vi.fn(() => ({
+      activeCount: 3,
+      lastActivityMs: Date.now(),
+    }));
+
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "auto" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot,
+      prompt: async () => false,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2", false));
+    await waitForMicrotasks();
+
+    expect(executeUpdate).toHaveBeenCalledOnce();
+    expect(getQuietGateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("policy=auto, daemon, reconnect welcome → waits on quiet gate until idle", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = makeFakeConnection();
+      const executeUpdate = vi.fn(async () => ({ installed: false }));
+      // First call returns busy, second call returns idle.
+      const snapshots = [
+        { activeCount: 1, lastActivityMs: Date.now() },
+        { activeCount: 0, lastActivityMs: 0 },
+      ];
+      const getQuietGateSnapshot = vi.fn(() => snapshots.shift() ?? { activeCount: 0, lastActivityMs: 0 });
+
+      UpdateManager.attach(conn, {
+        currentVersion: "0.8.4",
+        updateConfig: makeUpdateConfig({
+          policy: "auto",
+          restart_quiet_seconds: 30,
+          restart_check_interval_seconds: 10,
+        }),
+        isTTY: false,
+        log: () => {},
+        getQuietGateSnapshot,
+        prompt: async () => false,
+        executeUpdate,
+      });
+
+      conn.emitWelcome(makeWelcome("0.9.2", true));
+      // Allow the async handler to run up to the first quiet-gate check
+      await vi.advanceTimersByTimeAsync(1);
+      expect(getQuietGateSnapshot).toHaveBeenCalledTimes(1);
+      expect(executeUpdate).not.toHaveBeenCalled();
+
+      // Advance past one re-check interval (10s) — second snapshot is idle, update fires.
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(getQuietGateSnapshot).toHaveBeenCalledTimes(2);
+      expect(executeUpdate).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose() stops listening — later welcome frames are ignored", async () => {
+    const conn = makeFakeConnection();
+    const executeUpdate = vi.fn(async () => ({ installed: false }));
+    const mgr = UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "auto" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt: async () => false,
+      executeUpdate,
+    });
+
+    mgr.dispose();
+    conn.emitWelcome(makeWelcome("0.9.2"));
+    await waitForMicrotasks();
+
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("standalone install (installed=true) stops further retry attempts", async () => {
+    const conn = makeFakeConnection();
+    // Standalone mode: executeUpdate installs npm bits but stays alive.
+    // Later welcome frames must not re-fire npm — only a process restart
+    // can pick up the new version.
+    const executeUpdate = vi.fn(async () => ({ installed: true }));
+    UpdateManager.attach(conn, {
+      currentVersion: "0.8.4",
+      updateConfig: makeUpdateConfig({ policy: "auto" }),
+      isTTY: false,
+      log: () => {},
+      getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+      prompt: async () => false,
+      executeUpdate,
+    });
+
+    conn.emitWelcome(makeWelcome("0.9.2", false));
+    await waitForMicrotasks();
+    expect(executeUpdate).toHaveBeenCalledOnce();
+
+    conn.emitWelcome(makeWelcome("0.9.2", true));
+    await waitForMicrotasks();
+    expect(executeUpdate).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -6,8 +6,10 @@ import {
   type AgentPinnedMessage,
   agentPinnedMessageSchema,
   type RuntimeState,
+  type ServerWelcomeFrame,
   type SessionEvent,
   type SessionState,
+  serverWelcomeFrameSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import WebSocket from "ws";
 import { type AccessTokenProvider, FirstTreeHubSDK } from "./sdk.js";
@@ -44,6 +46,17 @@ export type SessionReconcileResult = {
   staleChatIds: string[];
 };
 
+/**
+ * Welcome frame received after `auth:ok`. `isReconnect` is true for every
+ * occurrence after the first welcome in the lifetime of this `ClientConnection`
+ * — lets consumers (UpdateManager) distinguish a cold-start install from a
+ * reconnect into a newer Server.
+ */
+export type ServerWelcome = {
+  frame: ServerWelcomeFrame;
+  isReconnect: boolean;
+};
+
 type ClientConnectionEvents = {
   connected: [];
   disconnected: [];
@@ -64,6 +77,7 @@ type ClientConnectionEvents = {
   "session:command": [command: SessionCommand];
   "session:reconcile:result": [result: SessionReconcileResult];
   "auth:expired": [];
+  "server:welcome": [welcome: ServerWelcome];
 };
 
 const RECONNECT_BASE_MS = 1000;
@@ -122,6 +136,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private reconnectAttempt = 0;
   private closing = false;
   private registered = false;
+  /** Count of `server:welcome` frames received; drives `isReconnect` flag. */
+  private welcomeFramesReceived = 0;
 
   private readonly boundAgents = new Map<string, BoundAgent>();
 
@@ -341,6 +357,25 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           sdkVersion: this.sdkVersion,
         }),
       );
+      return;
+    }
+
+    if (type === "server:welcome") {
+      const parsed = serverWelcomeFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        // Malformed welcome frame from a buggy server build — log and drop.
+        // Old clients that never knew about this frame simply fall through,
+        // so treating a parse failure the same way keeps behaviour aligned.
+        process.stderr.write(
+          `[ClientConnection] Ignoring malformed server:welcome frame: ${parsed.error.issues
+            .map((i) => i.message)
+            .join(", ")}\n`,
+        );
+        return;
+      }
+      const isReconnect = this.welcomeFramesReceived > 0;
+      this.welcomeFramesReceived++;
+      this.emit("server:welcome", { frame: parsed.data, isReconnect });
       return;
     }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,9 @@
-export type { BoundAgent, ClientConnectionConfig, SessionCommand } from "./client-connection.js";
+export type {
+  BoundAgent,
+  ClientConnectionConfig,
+  ServerWelcome,
+  SessionCommand,
+} from "./client-connection.js";
 export { ClientConnection } from "./client-connection.js";
 // Handlers
 export { registerBuiltinHandlers } from "./handlers/index.js";
@@ -23,6 +28,17 @@ export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 export { SessionManager } from "./runtime/session-manager.js";
 export { SessionRegistry } from "./runtime/session-registry.js";
+export type {
+  ExecuteUpdateFn,
+  ExecuteUpdateResult,
+  QuietGateSnapshot,
+  UpdateHooks,
+  UpdateLogger,
+  UpdateLogLevel,
+  UpdateManagerOptions,
+  UpdatePromptFn,
+} from "./runtime/update-manager.js";
+export { UpdateManager } from "./runtime/update-manager.js";
 export { acquireWorkspace, cleanWorkspaces, DEFAULT_WORKSPACE_TTL_MS } from "./runtime/workspace.js";
 export type { AccessTokenProvider, PaginatedResult, PullResult, RegisterResult, SdkConfig } from "./sdk.js";
 export { FirstTreeHubSDK, SdkError } from "./sdk.js";

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -56,6 +56,15 @@ export class AgentSlot {
     return this.config.clientConnection;
   }
 
+  /**
+   * Snapshot of this slot's busy/idle state used by the UpdateManager's
+   * quiet gate. Returns zeros before `start()` has built the session manager,
+   * which is the same semantics: idle.
+   */
+  getQuietGateSnapshot(): { activeCount: number; lastActivityMs: number } {
+    return this.sessionManager?.getQuietGateSnapshot() ?? { activeCount: 0, lastActivityMs: 0 };
+  }
+
   async start(contextTreePath?: string | null): Promise<RegisterResult> {
     const bound = await this.clientConnection.bindAgent(
       this.config.agentId,

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -4,6 +4,7 @@ import { AgentSlot } from "./agent-slot.js";
 import { syncContextTree } from "./bootstrap.js";
 import type { RuntimeConfig } from "./config.js";
 import { getHandlerFactory } from "./handler.js";
+import { type UpdateHooks, UpdateManager } from "./update-manager.js";
 
 export type AgentRuntimeOptions = {
   config: RuntimeConfig;
@@ -16,6 +17,19 @@ export type AgentRuntimeOptions = {
   /** Stable per-machine client identifier. Generated if omitted. */
   clientId?: string;
   shutdownTimeout?: number;
+  /**
+   * Version of the consumer-facing Command package this runtime was bundled
+   * with. Advertised to the server as `sdkVersion` at `client:register`, and
+   * compared by the UpdateManager against the server-advertised version.
+   * The UpdateManager only engages when both this and `update` are set.
+   */
+  currentVersion?: string;
+  /**
+   * Self-update config + command-layer callbacks. Grouped so half-wired
+   * configurations (e.g. config without prompt) can't silently disable the
+   * manager.
+   */
+  update?: UpdateHooks;
 };
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 30_000;
@@ -26,16 +40,22 @@ export class AgentRuntime {
   private readonly shutdownTimeout: number;
   private readonly clientConnection: ClientConnection;
   private readonly getAccessToken: AccessTokenProvider;
+  private readonly currentVersion: string | undefined;
+  private readonly updateHooks: UpdateHooks | undefined;
+  private updateManager: UpdateManager | null = null;
   private stopping = false;
 
   constructor(options: AgentRuntimeOptions) {
     this.config = options.config;
     this.shutdownTimeout = options.shutdownTimeout ?? DEFAULT_SHUTDOWN_TIMEOUT;
     this.getAccessToken = options.getAccessToken;
+    this.currentVersion = options.currentVersion;
+    this.updateHooks = options.update;
 
     this.clientConnection = new ClientConnection({
       serverUrl: this.config.server,
       clientId: options.clientId,
+      sdkVersion: options.currentVersion,
       getAccessToken: this.getAccessToken,
     });
 
@@ -66,12 +86,36 @@ export class AgentRuntime {
     process.stderr.write(`[runtime] ${msg}\n`);
   }
 
+  private aggregateQuietGate(): { activeCount: number; lastActivityMs: number } {
+    let activeCount = 0;
+    let lastActivityMs = 0;
+    for (const slot of this.slots) {
+      const snap = slot.getQuietGateSnapshot();
+      activeCount += snap.activeCount;
+      if (snap.lastActivityMs > lastActivityMs) lastActivityMs = snap.lastActivityMs;
+    }
+    return { activeCount, lastActivityMs };
+  }
+
   async start(): Promise<void> {
     const log = (msg: string) => this.log(msg);
 
     const contextTreePath = await syncContextTree(this.config.server, this.getAccessToken, log);
     if (!contextTreePath) {
       log("Context Tree not configured or sync skipped — agents will start without organizational context");
+    }
+
+    // Attach before connecting so the first welcome frame on a stale Client
+    // is acted on rather than missed until the next reconnect.
+    if (this.currentVersion && this.updateHooks) {
+      this.updateManager = UpdateManager.attach(this.clientConnection, {
+        currentVersion: this.currentVersion,
+        ...this.updateHooks,
+        isTTY: Boolean(process.stdout.isTTY),
+        log: (level, msg) => this.log(`[update/${level}] ${msg}`),
+        getQuietGateSnapshot: () => this.aggregateQuietGate(),
+      });
+      log(`Update manager attached (policy=${this.updateHooks.updateConfig.policy}, version=${this.currentVersion})`);
     }
 
     log(`Connecting client (${this.clientConnection.clientId})...`);
@@ -119,6 +163,8 @@ export class AgentRuntime {
   }
 
   async stop(): Promise<void> {
+    this.updateManager?.dispose();
+    this.updateManager = null;
     await Promise.allSettled(this.slots.map((slot) => slot.stop()));
     await this.clientConnection.disconnect();
   }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -226,6 +226,20 @@ export class SessionManager {
     return this.sessions.size;
   }
 
+  /**
+   * Snapshot used by the UpdateManager's quiet gate to decide whether it is
+   * safe to exit the process for a self-update. `activeCount` is the number of
+   * sessions currently handling a message; `lastActivityMs` is the most recent
+   * activity timestamp across all tracked sessions (0 when there are none).
+   */
+  getQuietGateSnapshot(): { activeCount: number; lastActivityMs: number } {
+    let lastActivityMs = 0;
+    for (const entry of this.sessions.values()) {
+      if (entry.lastActivity > lastActivityMs) lastActivityMs = entry.lastActivity;
+    }
+    return { activeCount: this._activeCount, lastActivityMs };
+  }
+
   /** Return the current aggregate runtime state, or null if no sessions have reported. */
   getAggregateRuntimeState(): RuntimeState | null {
     return this.lastReportedRuntimeState;

--- a/packages/client/src/runtime/update-manager.ts
+++ b/packages/client/src/runtime/update-manager.ts
@@ -1,0 +1,260 @@
+import type { ClientConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import * as semver from "semver";
+import type { ServerWelcome } from "../client-connection.js";
+
+/**
+ * Narrow subset of `ClientConnection` the manager uses. Declared structurally
+ * so tests can hand in a plain `EventEmitter` without dragging the full
+ * connection surface into unit tests.
+ */
+export type UpdateManagerConnection = {
+  on(event: "server:welcome", listener: (welcome: ServerWelcome) => void): unknown;
+  off(event: "server:welcome", listener: (welcome: ServerWelcome) => void): unknown;
+};
+
+export type QuietGateSnapshot = {
+  /** Number of sessions actively handling a message. */
+  activeCount: number;
+  /** Most-recent per-session `lastActivity` timestamp (0 when no sessions). */
+  lastActivityMs: number;
+};
+
+export type UpdateLogLevel = "debug" | "info" | "warn";
+
+export type UpdateLogger = (level: UpdateLogLevel, msg: string) => void;
+
+/**
+ * Command-layer TTY prompt. Returns `true` when the operator explicitly
+ * consents to the update (pressing `y`); returns `false` on `N`, timeout, or
+ * non-TTY decline. The UpdateManager uses the result as an explicit-consent
+ * waiver of the quiet gate — a `true` here means "restart now" even if
+ * sessions are active.
+ */
+export type UpdatePromptFn = (opts: {
+  currentVersion: string;
+  targetVersion: string;
+  timeoutSeconds: number;
+}) => Promise<boolean>;
+
+export type ExecuteUpdateResult = {
+  /**
+   * Whether the new version was successfully installed. `true` means the host
+   * should stop retrying on subsequent welcome frames (the bits are on disk;
+   * a restart is required to pick them up). `false` means install did not
+   * complete and a retry on the next welcome is appropriate.
+   */
+  installed: boolean;
+};
+
+/**
+ * Command-layer install + (optional) restart. A managed run (service-unit,
+ * Docker, etc.) is expected to `process.exit(SELF_RESTART_EXIT_CODE)` on
+ * success so the supervisor relaunches on the new binary — in that case this
+ * function never resolves. A standalone run has no supervisor, so it must
+ * leave the process alive and return `{ installed: true }`; the UpdateManager
+ * then stops attempting further updates until the operator restarts the
+ * process.
+ */
+export type ExecuteUpdateFn = (opts: { currentVersion: string; targetVersion: string }) => Promise<ExecuteUpdateResult>;
+
+export type UpdateManagerOptions = {
+  currentVersion: string;
+  updateConfig: ClientConfig["update"];
+  /** Whether stdin/stdout is attached to a TTY. Drives prompt vs log-only. */
+  isTTY: boolean;
+  log: UpdateLogger;
+  getQuietGateSnapshot: () => QuietGateSnapshot;
+  prompt: UpdatePromptFn;
+  executeUpdate: ExecuteUpdateFn;
+};
+
+/**
+ * Grouped update dependencies the host runtime forwards to the UpdateManager.
+ * All-or-nothing — runtimes only attach the manager when every field is
+ * present, so there's no "3 of 4" ambiguity at the construction site.
+ */
+export type UpdateHooks = {
+  updateConfig: ClientConfig["update"];
+  prompt: UpdatePromptFn;
+  executeUpdate: ExecuteUpdateFn;
+};
+
+/**
+ * Version-drift decision flow. Install, prompt, and exit are delegated to
+ * command-layer callbacks so the Client package stays free of CLI /
+ * filesystem knowledge.
+ */
+export class UpdateManager {
+  private readonly options: UpdateManagerOptions;
+  private readonly connection: UpdateManagerConnection;
+  private readonly welcomeListener: (welcome: ServerWelcome) => void;
+  private updateInFlight = false;
+  private quietGateTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  /**
+   * Set when a standalone (unmanaged) executeUpdate reports `installed: true`
+   * without exiting. The new bits are on disk; subsequent welcome frames must
+   * not re-invoke npm since a restart is the only way to pick them up.
+   */
+  private pendingRestart = false;
+
+  private constructor(connection: UpdateManagerConnection, options: UpdateManagerOptions) {
+    this.connection = connection;
+    this.options = options;
+    this.welcomeListener = (welcome) => {
+      this.onWelcome(welcome).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.options.log("warn", `update decision failed: ${msg}`);
+      });
+    };
+  }
+
+  /** Attach a manager to a connection. Returns the instance so callers can dispose. */
+  static attach(connection: UpdateManagerConnection, options: UpdateManagerOptions): UpdateManager {
+    const mgr = new UpdateManager(connection, options);
+    connection.on("server:welcome", mgr.welcomeListener);
+    return mgr;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.connection.off("server:welcome", this.welcomeListener);
+    if (this.quietGateTimer) {
+      clearTimeout(this.quietGateTimer);
+      this.quietGateTimer = null;
+    }
+  }
+
+  private async onWelcome(welcome: ServerWelcome): Promise<void> {
+    if (this.disposed || this.updateInFlight || this.pendingRestart) return;
+    // Claim the slot for the entire decision flow (not just runUpdate): a
+    // `policy=auto` TTY path awaits a 5s sleep + the quiet gate, and a
+    // reconnect storm inside that window would otherwise fan out parallel
+    // decisions.
+    this.updateInFlight = true;
+    try {
+      await this.decide(welcome);
+    } finally {
+      this.updateInFlight = false;
+    }
+  }
+
+  private async decide(welcome: ServerWelcome): Promise<void> {
+    const { serverCommandVersion: target } = welcome.frame;
+    const current = this.options.currentVersion;
+
+    if (!semver.valid(target)) {
+      this.options.log("warn", `Server advertised invalid version "${target}"; skipping drift check`);
+      return;
+    }
+    if (!semver.valid(current)) {
+      this.options.log("warn", `Own version "${current}" is not valid SemVer; skipping drift check`);
+      return;
+    }
+
+    if (semver.eq(target, current)) {
+      this.options.log("debug", `Server advertises ${target}, matching running version`);
+      return;
+    }
+    if (semver.lt(target, current)) {
+      this.options.log("info", `Server advertises ${target}, running ${current} (ahead)`);
+      return;
+    }
+
+    const policy = this.options.updateConfig.policy;
+
+    if (policy === "off") {
+      this.options.log("info", `Server advertises ${target}, running ${current}; self-update disabled (policy=off)`);
+      return;
+    }
+
+    if (policy === "prompt") {
+      if (!this.options.isTTY) {
+        this.options.log(
+          "warn",
+          `Update available (${current} → ${target}) but policy=prompt requires a terminal; operator action required`,
+        );
+        return;
+      }
+      const accepted = await this.options.prompt({
+        currentVersion: current,
+        targetVersion: target,
+        timeoutSeconds: this.options.updateConfig.prompt_timeout_seconds,
+      });
+      if (!accepted) {
+        this.options.log("info", `Update declined by operator (still running ${current})`);
+        return;
+      }
+      // Explicit consent waives the quiet gate — restart immediately.
+      await this.runUpdate(current, target);
+      return;
+    }
+
+    // policy === "auto"
+    this.options.log("info", `Server advertises ${target}, running ${current}; policy=auto`);
+
+    if (this.options.isTTY) {
+      // Brief notice delay so an attended operator can Ctrl+C. The
+      // process-level SIGINT handler installed by the runtime kills us
+      // cleanly without applying the update.
+      this.options.log("info", "Auto-update starting in 5s");
+      await sleep(5000);
+      if (this.disposed) return;
+    }
+
+    // First welcome: no quiet gate (no sessions could possibly be busy).
+    // Reconnect welcome: defer until the quiet gate passes.
+    if (welcome.isReconnect) {
+      await this.waitForQuietGate();
+      if (this.disposed) return;
+    }
+    await this.runUpdate(current, target);
+  }
+
+  private async waitForQuietGate(): Promise<void> {
+    const quietMs = this.options.updateConfig.restart_quiet_seconds * 1000;
+    const intervalMs = this.options.updateConfig.restart_check_interval_seconds * 1000;
+    while (!this.disposed) {
+      const snapshot = this.options.getQuietGateSnapshot();
+      const now = Date.now();
+      const idleFor = snapshot.lastActivityMs === 0 ? Number.POSITIVE_INFINITY : now - snapshot.lastActivityMs;
+      if (snapshot.activeCount === 0 && idleFor >= quietMs) return;
+      this.options.log(
+        "debug",
+        `Quiet gate: activeCount=${snapshot.activeCount}, idleFor=${Math.round(idleFor)}ms; re-checking in ${intervalMs}ms`,
+      );
+      await new Promise<void>((resolve) => {
+        this.quietGateTimer = setTimeout(() => {
+          this.quietGateTimer = null;
+          resolve();
+        }, intervalMs);
+      });
+    }
+  }
+
+  private async runUpdate(current: string, target: string): Promise<void> {
+    try {
+      const result = await this.options.executeUpdate({ currentVersion: current, targetVersion: target });
+      if (result.installed) {
+        // Standalone mode: install succeeded but the host left the process
+        // alive. Further welcome frames must not fire npm again — only a
+        // restart can pick up the new bits.
+        this.pendingRestart = true;
+        this.options.log(
+          "info",
+          `Update ${target} installed; restart required to pick it up (no further self-update attempts until restart)`,
+        );
+        return;
+      }
+      this.options.log("warn", "Self-update did not complete; will retry on next welcome frame");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.options.log("warn", `Self-update threw: ${msg}`);
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -48,6 +48,7 @@
     "gray-matter": "^4.0.3",
     "jose": "^6.0.0",
     "postgres": "^3.4.0",
+    "semver": "^7.6.3",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
@@ -59,6 +60,7 @@
     "@first-tree-hub/web": "workspace:*",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "^22.16.0",
+    "@types/semver": "^7.5.8",
     "tsdown": "^0.21.4",
     "tsx": "^4.21.0",
     "vitest": "^3.2.0"

--- a/packages/command/src/__tests__/update-detect-install-mode.test.ts
+++ b/packages/command/src/__tests__/update-detect-install-mode.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { detectInstallMode } from "../core/update.js";
+
+describe("detectInstallMode", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ftHub-install-mode-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns 'source' when a .git sibling is found", () => {
+    const binDir = join(root, "repo", "packages", "command", "dist", "cli");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(join(root, "repo", ".git"), { recursive: true });
+    const argv1 = join(binDir, "index.mjs");
+    writeFileSync(argv1, "// stub");
+    expect(detectInstallMode(argv1)).toBe("source");
+  });
+
+  it("returns 'global' when parent package.json matches the published name", () => {
+    const pkgDir = join(root, ".nvm/versions/node/v22/lib/node_modules/@agent-team-foundation/first-tree-hub");
+    mkdirSync(join(pkgDir, "dist/cli"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@agent-team-foundation/first-tree-hub", version: "0.9.2" }),
+    );
+    const argv1 = join(pkgDir, "dist/cli/index.mjs");
+    writeFileSync(argv1, "// stub");
+    expect(detectInstallMode(argv1)).toBe("global");
+  });
+
+  it("returns 'npx' when the package dir lives under an _npx cache root", () => {
+    const pkgDir = join(root, ".npm/_npx/abc123/node_modules/@agent-team-foundation/first-tree-hub");
+    mkdirSync(join(pkgDir, "dist/cli"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@agent-team-foundation/first-tree-hub", version: "0.9.2" }),
+    );
+    const argv1 = join(pkgDir, "dist/cli/index.mjs");
+    writeFileSync(argv1, "// stub");
+    expect(detectInstallMode(argv1)).toBe("npx");
+  });
+
+  it("returns 'npx' when no matching package.json or .git is found", () => {
+    const argv1 = join(root, "stray/dir/no-package.mjs");
+    mkdirSync(join(root, "stray/dir"), { recursive: true });
+    writeFileSync(argv1, "// stub");
+    expect(detectInstallMode(argv1)).toBe("npx");
+  });
+});

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent.js";
 import { registerClientCommands } from "../commands/client.js";
@@ -8,16 +7,14 @@ import { registerConfigCommands } from "../commands/config.js";
 import { registerOnboardCommand } from "../commands/onboard.js";
 import { registerServerCommands } from "../commands/server.js";
 import { registerStatusCommand } from "../commands/status.js";
-
-const require = createRequire(import.meta.url);
-const { version } = require("../../package.json") as { version: string };
+import { COMMAND_VERSION } from "../core/version.js";
 
 const program = new Command();
 
 program
   .name("first-tree-hub")
   .description("First Tree Hub — centralized collaboration platform for agent teams")
-  .version(version);
+  .version(COMMAND_VERSION);
 
 // Core subsystems — `client` group mounts `connect` too.
 registerServerCommands(program);

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -13,17 +13,21 @@ import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import {
   ClientRuntime,
+  COMMAND_VERSION,
   checkAgentConfigs,
   checkClientConfig,
   checkNodeVersion,
   checkServerReachable,
   checkWebSocket,
+  createExecuteUpdate,
+  declineUpdate,
   ensureFreshAccessToken,
   getClientServiceStatus,
   installClientService,
   isServiceSupported,
   printResults,
   promptMissingFields,
+  promptUpdate,
   resolveServerUrl,
   uninstallClientService,
 } from "../core/index.js";
@@ -65,7 +69,20 @@ export function registerClientCommands(program: Command): void {
 
         process.stderr.write(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
 
-        const runtime = new ClientRuntime(config.server.url, config.client.id);
+        // `--no-interactive` is the signal the service units (launchd /
+        // systemd) set — we piggy-back on it for two things: (1) suppress
+        // the update-confirm prompt so policy=prompt doesn't block a
+        // supervised run, (2) enable exit-for-restart since the supervisor
+        // will relaunch us on the new binary.
+        const managed = options.interactive === false;
+        const runtime = new ClientRuntime(config.server.url, config.client.id, {
+          currentVersion: COMMAND_VERSION,
+          update: {
+            updateConfig: config.update,
+            prompt: managed ? declineUpdate : promptUpdate,
+            executeUpdate: createExecuteUpdate({ managed }),
+          },
+        });
         for (const [name, agentConfig] of agents) {
           runtime.addAgent(name, agentConfig);
         }

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -14,10 +14,13 @@ import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import {
   ClientRuntime,
+  COMMAND_VERSION,
+  createExecuteUpdate,
   getClientServiceStatus,
   installClientService,
   isServiceSupported,
   loadCredentials,
+  promptUpdate,
   saveCredentials,
 } from "../core/index.js";
 
@@ -279,7 +282,17 @@ export function registerConnectCommand(parent: Command): void {
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
-        const runtime = new ClientRuntime(config.server.url, config.client.id);
+        // `connect --no-service` runs inline until Ctrl+C — no supervisor,
+        // so managed=false: self-update stays alive and prints a restart
+        // hint instead of exiting.
+        const runtime = new ClientRuntime(config.server.url, config.client.id, {
+          currentVersion: COMMAND_VERSION,
+          update: {
+            updateConfig: config.update,
+            prompt: promptUpdate,
+            executeUpdate: createExecuteUpdate({ managed: false }),
+          },
+        });
         for (const [name, agentConfig] of agents) {
           runtime.addAgent(name, agentConfig);
         }

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -4,13 +4,35 @@ import { join } from "node:path";
 import type { AgentPinnedMessage } from "@agent-team-foundation/first-tree-hub-shared";
 import type { AgentConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { agentConfigSchema, loadAgents } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { AgentSlot, ClientConnection, getHandlerFactory, registerBuiltinHandlers } from "@first-tree-hub/client";
+import {
+  AgentSlot,
+  ClientConnection,
+  getHandlerFactory,
+  registerBuiltinHandlers,
+  type UpdateHooks,
+  UpdateManager,
+} from "@first-tree-hub/client";
 import { stringify as stringifyYaml } from "yaml";
 import { ensureFreshAccessToken } from "./bootstrap.js";
 
 type AgentEntry = {
   name: string;
   slot: AgentSlot;
+};
+
+export type ClientRuntimeOptions = {
+  /**
+   * Version of the Command package this process was launched from. Passed to
+   * the server as `sdkVersion` on `client:register` and compared against the
+   * version the server advertises in `server:welcome`. Required to engage
+   * self-update.
+   */
+  currentVersion?: string;
+  /**
+   * Self-update config + command-layer callbacks. All-or-nothing: the
+   * UpdateManager attaches only when this and `currentVersion` are both set.
+   */
+  update?: UpdateHooks;
 };
 
 /**
@@ -31,6 +53,8 @@ export class ClientRuntime {
   private readonly agents: AgentEntry[] = [];
   private readonly agentNames = new Set<string>();
   private readonly agentIds = new Set<string>();
+  private readonly options: ClientRuntimeOptions;
+  private updateManager: UpdateManager | null = null;
   private watcher: FSWatcher | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   /**
@@ -40,11 +64,13 @@ export class ClientRuntime {
    */
   private agentsDir: string | null = null;
 
-  constructor(serverUrl: string, clientId: string) {
+  constructor(serverUrl: string, clientId: string, options: ClientRuntimeOptions = {}) {
     this.serverUrl = serverUrl;
+    this.options = options;
     this.connection = new ClientConnection({
       serverUrl,
       clientId,
+      sdkVersion: options.currentVersion,
       getAccessToken: () => ensureFreshAccessToken(),
     });
     registerBuiltinHandlers();
@@ -94,6 +120,18 @@ export class ClientRuntime {
   }
 
   async start(): Promise<void> {
+    // Attach before connecting so the first welcome frame on a stale client
+    // is acted on rather than missed until the next reconnect.
+    if (this.options.currentVersion && this.options.update) {
+      this.updateManager = UpdateManager.attach(this.connection, {
+        currentVersion: this.options.currentVersion,
+        ...this.options.update,
+        isTTY: Boolean(process.stdout.isTTY),
+        log: (level, msg) => process.stderr.write(`  [update/${level}] ${msg}\n`),
+        getQuietGateSnapshot: () => this.aggregateQuietGate(),
+      });
+    }
+
     await this.connection.connect();
     process.stderr.write(`  \u2713 Client registered: ${this.connection.clientId}\n`);
 
@@ -152,8 +190,21 @@ export class ClientRuntime {
 
   async stop(): Promise<void> {
     this.unwatchAgentsDir();
+    this.updateManager?.dispose();
+    this.updateManager = null;
     await Promise.allSettled(this.agents.map((a) => a.slot.stop()));
     await this.connection.disconnect();
+  }
+
+  private aggregateQuietGate(): { activeCount: number; lastActivityMs: number } {
+    let activeCount = 0;
+    let lastActivityMs = 0;
+    for (const entry of this.agents) {
+      const snap = entry.slot.getQuietGateSnapshot();
+      activeCount += snap.activeCount;
+      if (snap.lastActivityMs > lastActivityMs) lastActivityMs = snap.lastActivityMs;
+    }
+    return { activeCount, lastActivityMs };
   }
 
   private scanForNewAgents(agentsDir: string): void {

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -13,6 +13,7 @@ export {
   saveAgentConfig,
   saveCredentials,
 } from "./bootstrap.js";
+export type { ClientRuntimeOptions } from "./client-runtime.js";
 // Client runtime
 export { ClientRuntime } from "./client-runtime.js";
 // Docker PostgreSQL
@@ -58,3 +59,10 @@ export {
   resolveCliInvocation,
   uninstallClientService,
 } from "./service-install.js";
+export type { ExecuteUpdateResult, InstallMode } from "./update.js";
+// Self-update glue — exported so both `client start` and `client connect`
+// can pass identical prompt / install callbacks to the ClientRuntime.
+export { detectInstallMode, installGlobalLatest } from "./update.js";
+export { createExecuteUpdate, declineUpdate, promptUpdate, SELF_RESTART_EXIT_CODE } from "./update-glue.js";
+// Command package version (bundle self-identification)
+export { COMMAND_VERSION } from "./version.js";

--- a/packages/command/src/core/server.ts
+++ b/packages/command/src/core/server.ts
@@ -10,6 +10,7 @@ import { ensurePostgres, isDockerAvailable } from "./docker-postgres.js";
 import { runMigrations } from "./migrate.js";
 import { blank, status } from "./output.js";
 import { promptMissingFields } from "./prompt.js";
+import { COMMAND_VERSION } from "./version.js";
 
 export type StartOptions = {
   port?: number;
@@ -29,7 +30,7 @@ export type StartOptions = {
  * 7. Start Fastify server
  */
 export async function startServer(options: StartOptions): Promise<void> {
-  process.stderr.write("\n  First Tree Hub v0.1.0\n\n");
+  process.stderr.write(`\n  First Tree Hub v${COMMAND_VERSION}\n\n`);
 
   // 1. Build CLI args
   const cliArgs: Record<string, unknown> = {};
@@ -100,6 +101,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     ...serverConfig,
     webDistPath: webDistPath ?? undefined,
     instanceId: `srv_${randomUUID().slice(0, 8)}`,
+    commandVersion: COMMAND_VERSION,
   };
 
   // Initialize telemetry from resolved config before server bootstrap, so that

--- a/packages/command/src/core/update-glue.ts
+++ b/packages/command/src/core/update-glue.ts
@@ -1,0 +1,78 @@
+import type { ExecuteUpdateFn, UpdatePromptFn } from "@first-tree-hub/client";
+import { confirm } from "@inquirer/prompts";
+import { detectInstallMode, installGlobalLatest } from "./update.js";
+
+/** Reserved exit code that means "clean self-restart, service manager please bring me back". */
+export const SELF_RESTART_EXIT_CODE = 75;
+
+/** Interactive update prompt. Defaults to N on timeout. */
+export const promptUpdate: UpdatePromptFn = async ({ currentVersion, targetVersion, timeoutSeconds }) => {
+  const message = `A newer First Tree Hub client is available.\n  You: ${currentVersion}\n  Server bundled with: ${targetVersion}\n  Will install: latest on npm (>= ${targetVersion})\n  Updating will restart the client and briefly interrupt any active sessions.\n  Update now?`;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
+    try {
+      return await confirm({ message, default: false }, { signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // AbortError on timeout, or stdin-not-a-TTY
+    return false;
+  }
+};
+
+/**
+ * Update prompt that always declines. Wired in when the operator passes
+ * `--no-interactive` — the UpdateManager will log the drift and move on
+ * instead of blocking on a TTY confirm.
+ */
+export const declineUpdate: UpdatePromptFn = async () => false;
+
+/**
+ * Build the command-layer `executeUpdate` callback.
+ *
+ * `managed=true` means a process supervisor (launchd / systemd / Docker
+ * `restart`) is expected to relaunch us after `process.exit` — the callback
+ * installs the new bits and exits with `SELF_RESTART_EXIT_CODE` so the
+ * relaunch picks up the new binary.
+ *
+ * `managed=false` means the process is running standalone (e.g. manual
+ * `client start`, `client connect --no-service`, CI without a supervisor).
+ * Exiting in that mode would leave the client offline until an operator
+ * noticed — so the callback instead prints a restart hint, returns
+ * `{ installed: true }`, and the UpdateManager stops retrying until the
+ * operator restarts manually.
+ */
+export function createExecuteUpdate({ managed }: { managed: boolean }): ExecuteUpdateFn {
+  return async () => {
+    const mode = detectInstallMode();
+    if (mode === "source") {
+      process.stderr.write("  [update] Running from source checkout — self-update skipped. Use `git pull` instead.\n");
+      return { installed: false };
+    }
+    if (mode === "npx") {
+      process.stderr.write(
+        "  [update] Cannot self-update — not launched from a global npm install.\n  Run `npm i -g @agent-team-foundation/first-tree-hub` manually.\n",
+      );
+      return { installed: false };
+    }
+
+    process.stderr.write("  [update] Running `npm install -g @agent-team-foundation/first-tree-hub@latest`...\n");
+    const result = await installGlobalLatest();
+    if (!result.ok) {
+      process.stderr.write(`  [update] Install failed: ${result.reason}\n`);
+      return { installed: false };
+    }
+
+    const installed = result.installedVersion ?? "latest";
+    if (managed) {
+      process.stderr.write(`  [update] Installed ${installed}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).\n`);
+      process.exit(SELF_RESTART_EXIT_CODE);
+    }
+    process.stderr.write(
+      `  [update] Installed ${installed}. Restart the client manually (Ctrl+C then \`first-tree-hub client start\`) to pick up the new version.\n`,
+    );
+    return { installed: true };
+  };
+}

--- a/packages/command/src/core/update.ts
+++ b/packages/command/src/core/update.ts
@@ -1,0 +1,127 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import * as semver from "semver";
+
+export type InstallMode = "global" | "npx" | "source";
+
+const PACKAGE_NAME = "@agent-team-foundation/first-tree-hub";
+
+/**
+ * Pick the `npm` binary to invoke for self-update. Background service units
+ * hard-code a minimal PATH (/usr/local/bin, /opt/homebrew/bin, /usr/bin,
+ * /bin) that misses nvm / asdf / Volta toolchain directories — the client
+ * launches fine from an absolute path resolved at install time, but a plain
+ * `spawn("npm")` then ENOENTs. Node and npm always ship side-by-side, so
+ * `dirname(execPath)/npm` is the most reliable fallback across those
+ * managers; if the sibling is missing (e.g. corporate custom layout) we
+ * fall back to PATH lookup.
+ */
+function resolveNpmCommand(): string {
+  const binName = process.platform === "win32" ? "npm.cmd" : "npm";
+  const sibling = join(dirname(process.execPath), binName);
+  if (existsSync(sibling)) return sibling;
+  return "npm";
+}
+
+/**
+ * Detect how the CLI was launched. Used by the update path to decide whether
+ * `npm install -g <pkg>@latest` makes sense.
+ *
+ *  - `"global"`: launched from an `npm install -g` install. The self-update
+ *    reinstalls the same package at `@latest`.
+ *  - `"source"`: launched from inside a git checkout (dev / monorepo). Update
+ *    is a no-op; operator should `git pull`.
+ *  - `"npx"` (fallback): any other path (e.g. one-shot `npx`, pnpm dlx). Auto
+ *    update is not safe; log a hint and skip.
+ */
+export function detectInstallMode(argv1: string = process.argv[1] ?? ""): InstallMode {
+  if (!argv1) return "npx";
+  // Walk up from argv[1] looking for either a `.git` dir (source) or a
+  // `package.json` whose `name` matches ours (installed). Cap at 10 levels to
+  // avoid runaway walks on exotic symlink layouts.
+  let dir = dirname(resolve(argv1));
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(resolve(dir, ".git"))) return "source";
+    const pkgPath = resolve(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { name?: string };
+        if (pkg.name === PACKAGE_NAME) {
+          // Installed package — treat as global. `npx` also lays the tree out
+          // this way, but npx caches under a path whose basename starts with
+          // an underscore and lives under `_npx`. Probe for that.
+          if (/\/(?:_npx|\.npm\/_npx)\//.test(dir)) return "npx";
+          return "global";
+        }
+      } catch {
+        // malformed package.json — keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "npx";
+}
+
+export type ExecuteUpdateResult =
+  | { ok: true; mode: InstallMode; installedVersion: string | null }
+  | { ok: false; mode: InstallMode; reason: string };
+
+/**
+ * Install `<pkg>@latest` globally. Returns after the child exits. Does not
+ * exit the parent process — callers are expected to handle that (so the
+ * UpdateManager can attempt the restart itself while this function remains
+ * side-effect-scoped).
+ */
+export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
+  return new Promise((resolvePromise) => {
+    const npmCmd = resolveNpmCommand();
+    const npmArgs = ["install", "-g", `${PACKAGE_NAME}@latest`];
+    const child = spawn(npmCmd, npmArgs, { stdio: ["ignore", "pipe", "pipe"] });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      process.stderr.write(chunk);
+    });
+
+    child.on("error", (err) => {
+      resolvePromise({ ok: false, mode: "global", reason: err instanceof Error ? err.message : String(err) });
+    });
+
+    child.on("exit", (code) => {
+      if (code === 0) {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        resolvePromise({ ok: true, mode: "global", installedVersion: parseInstalledVersion(stdout) });
+      } else {
+        const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+        resolvePromise({
+          ok: false,
+          mode: "global",
+          reason: `npm install -g exited with code ${code}${stderr ? `: ${stderr.split("\n").slice(-3).join(" | ")}` : ""}`,
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Best-effort extraction of the version npm reported as installed. npm's
+ * stdout lines look like `+ @agent-team-foundation/first-tree-hub@0.9.2`.
+ * Returns null if nothing matches — callers treat null as "install succeeded
+ * but version unknown".
+ */
+function parseInstalledVersion(stdout: string): string | null {
+  const match = new RegExp(`${escapeForRegex(PACKAGE_NAME)}@(\\S+)`).exec(stdout);
+  if (!match?.[1]) return null;
+  const cleaned = match[1].replace(/[,\s)]+$/, "");
+  return semver.valid(cleaned) ?? cleaned;
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/command/src/core/version.ts
+++ b/packages/command/src/core/version.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+/**
+ * Version of the consumer-facing `@agent-team-foundation/first-tree-hub`
+ * package. Read once at module load from the bundled `package.json` so the
+ * CLI, client runtime, and server bootstrap all quote the same string.
+ */
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version?: string };
+
+export const COMMAND_VERSION: string =
+  typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";

--- a/packages/server/src/__tests__/ws-server-welcome.test.ts
+++ b/packages/server/src/__tests__/ws-server-welcome.test.ts
@@ -1,0 +1,92 @@
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+/**
+ * End-to-end wire check: the server must send `server:welcome` right after
+ * `auth:ok` so clients can detect version drift on connect / reconnect.
+ */
+describe("WS server:welcome — wire-additive frame after auth:ok", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+  let adminUserId: string;
+  let adminMemberId: string;
+  let adminOrgId: string;
+  let adminRole: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signJwt(): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({
+      sub: adminUserId,
+      memberId: adminMemberId,
+      organizationId: adminOrgId,
+      role: adminRole,
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(secret);
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+  });
+
+  beforeEach(async () => {
+    const admin = await createTestAdmin(app, { username: `welcome-${crypto.randomUUID().slice(0, 8)}` });
+    adminUserId = admin.userId;
+    adminMemberId = admin.memberId;
+    const { members } = await import("../db/schema/members.js");
+    const { eq } = await import("drizzle-orm");
+    const [member] = await app.db.select().from(members).where(eq(members.id, adminMemberId)).limit(1);
+    if (!member) throw new Error("member row missing after setup");
+    adminOrgId = member.organizationId;
+    adminRole = member.role;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("sends server:welcome immediately after auth:ok", async () => {
+    const token = await signJwt();
+    const ws = new WebSocket(wsUrl);
+    const frames: unknown[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("test timeout")), 5000);
+      ws.on("open", () => ws.send(JSON.stringify({ type: "auth", token })));
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(raw.toString());
+        frames.push(msg);
+        // Stop once we have at least auth:ok + server:welcome.
+        if (frames.length >= 2) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+      ws.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+    ws.close();
+
+    expect(frames[0]).toEqual({ type: "auth:ok" });
+    const welcome = frames[1] as { type: string; serverCommandVersion: string; serverTimeMs: number };
+    expect(welcome.type).toBe("server:welcome");
+    expect(typeof welcome.serverCommandVersion).toBe("string");
+    expect(welcome.serverCommandVersion.length).toBeGreaterThan(0);
+    expect(typeof welcome.serverTimeMs).toBe("number");
+    expect(welcome.serverTimeMs).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -224,6 +224,15 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             clearTimeout(authTimeout);
             scheduleAuthExpiry(claims.exp);
             socket.send(JSON.stringify({ type: "auth:ok" }));
+            // Wire-additive: older clients drop the unknown type; newer ones
+            // use it to detect version drift.
+            socket.send(
+              JSON.stringify({
+                type: "server:welcome",
+                serverCommandVersion: app.commandVersion,
+                serverTimeMs: Date.now(),
+              }),
+            );
           } catch (err) {
             const message = err instanceof Error ? err.message : "auth failure";
             socket.send(JSON.stringify({ type: "auth:rejected", reason: message }));

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import cors from "@fastify/cors";
@@ -77,6 +78,25 @@ export type AppContext = {
   kaelRuntime: KaelRuntime | undefined;
 };
 
+/**
+ * Resolve the Command-package version advertised to clients. Prefers the
+ * value the Command CLI explicitly injected; otherwise falls back to the
+ * server workspace's own package.json (dev mode, `pnpm --filter … dev`).
+ * Returning a string (rather than undefined) keeps the welcome frame well-
+ * formed — the client treats the value advisorily.
+ */
+function resolveCommandVersion(injected: string | undefined): string {
+  if (injected && injected.trim().length > 0) return injected;
+  try {
+    const req = createRequire(import.meta.url);
+    const pkg = req("../package.json") as { version?: string };
+    if (typeof pkg.version === "string" && pkg.version.length > 0) return pkg.version;
+  } catch {
+    // fall through
+  }
+  return "0.0.0";
+}
+
 export async function buildApp(config: Config) {
   applyLoggerConfig({
     level: config.observability.logging.level,
@@ -103,6 +123,12 @@ export async function buildApp(config: Config) {
   const db = connectDatabase(config.database.url);
   app.decorate("db", db);
   app.decorate("config", config);
+
+  // Advisory Command-package version broadcast to every Client via the
+  // `server:welcome` WS frame — lets clients detect version drift.
+  const commandVersion = resolveCommandVersion(config.commandVersion);
+  app.decorate("commandVersion", commandVersion);
+  app.log.info({ commandVersion }, "Hub server advertising command version");
 
   // Notifier: dedicated PG connection for LISTEN/NOTIFY
   const listenClient = postgres(config.database.url, { max: 1 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -9,4 +9,13 @@ export type Config = ServerConfig & {
   instanceId: string;
   /** Web static files dist path — resolved by CLI startup */
   webDistPath?: string;
+  /**
+   * Command package version this server was bundled with. Injected by the
+   * Command CLI at startup (which reads its own `package.json`). Advertised
+   * to every connecting client via the `server:welcome` WS frame so clients
+   * can detect version drift and self-update. Optional because the server
+   * can also be launched standalone via `pnpm --filter … dev`, in which case
+   * the bootstrap falls back to the server workspace's own package.json.
+   */
+  commandVersion?: string;
 };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -25,6 +25,8 @@ declare module "fastify" {
     adapterManager: AdapterManager;
     notifier: Notifier;
     configService: ConfigService;
+    /** Command-package version advertised via the `server:welcome` WS frame. */
+    commandVersion: string;
   }
   interface FastifyRequest {
     agent?: AgentIdentity;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub-shared",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "First Tree Hub shared schemas, types, and configuration",
   "license": "MIT",

--- a/packages/shared/src/__tests__/client-config-update.test.ts
+++ b/packages/shared/src/__tests__/client-config-update.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clientConfigSchema } from "../config/client-config.js";
+import { UPDATE_POLICY_DEFAULT } from "../config/phase.js";
+import { initConfig } from "../config/resolver.js";
+import { resetConfig } from "../config/singleton.js";
+
+describe("client config update block", () => {
+  let dir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = [
+    "FIRST_TREE_HUB_SERVER_URL",
+    "FIRST_TREE_HUB_CLIENT_ID",
+    "FIRST_TREE_HUB_UPDATE_POLICY",
+    "FIRST_TREE_HUB_UPDATE_RESTART_QUIET_SECONDS",
+    "FIRST_TREE_HUB_UPDATE_RESTART_CHECK_INTERVAL_SECONDS",
+    "FIRST_TREE_HUB_UPDATE_PROMPT_TIMEOUT_SECONDS",
+  ];
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ftHub-cfg-"));
+    for (const k of envKeys) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.FIRST_TREE_HUB_SERVER_URL = "http://localhost:8000";
+    process.env.FIRST_TREE_HUB_CLIENT_ID = "client_0a1b2c3d";
+    resetConfig();
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    rmSync(dir, { recursive: true, force: true });
+    resetConfig();
+  });
+
+  it("resolves defaults from UPDATE_POLICY_DEFAULT + schema defaults", async () => {
+    const cfg = await initConfig({
+      schema: clientConfigSchema,
+      role: "client",
+      configDir: dir,
+    });
+    expect(cfg.update.policy).toBe(UPDATE_POLICY_DEFAULT);
+    expect(cfg.update.restart_quiet_seconds).toBe(30);
+    expect(cfg.update.restart_check_interval_seconds).toBe(10);
+    expect(cfg.update.prompt_timeout_seconds).toBe(60);
+  });
+
+  it("honours env-var overrides", async () => {
+    process.env.FIRST_TREE_HUB_UPDATE_POLICY = "off";
+    process.env.FIRST_TREE_HUB_UPDATE_RESTART_QUIET_SECONDS = "120";
+    process.env.FIRST_TREE_HUB_UPDATE_PROMPT_TIMEOUT_SECONDS = "90";
+    const cfg = await initConfig({
+      schema: clientConfigSchema,
+      role: "client",
+      configDir: dir,
+    });
+    expect(cfg.update.policy).toBe("off");
+    expect(cfg.update.restart_quiet_seconds).toBe(120);
+    expect(cfg.update.prompt_timeout_seconds).toBe(90);
+  });
+
+  it("rejects an invalid policy literal", async () => {
+    process.env.FIRST_TREE_HUB_UPDATE_POLICY = "aggressive";
+    await expect(
+      initConfig({
+        schema: clientConfigSchema,
+        role: "client",
+        configDir: dir,
+      }),
+    ).rejects.toThrow(/Configuration validation failed/);
+  });
+});

--- a/packages/shared/src/__tests__/ws-auth-schema.test.ts
+++ b/packages/shared/src/__tests__/ws-auth-schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { serverWelcomeFrameSchema } from "../schemas/ws-auth.js";
+
+describe("serverWelcomeFrameSchema", () => {
+  it("accepts a well-formed frame", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "0.9.2",
+      serverTimeMs: 1_713_000_000_000,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("passes unknown fields through so future server versions can extend the frame", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "1.0.0",
+      serverTimeMs: 0,
+      channel: "beta",
+      featureHints: { sessionPersistence: true },
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      // unknown field survives — critical for forward-compat
+      expect((res.data as { channel?: string }).channel).toBe("beta");
+    }
+  });
+
+  it("rejects wrong discriminator", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "auth:ok",
+      serverCommandVersion: "0.9.2",
+      serverTimeMs: 0,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects empty serverCommandVersion", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "",
+      serverTimeMs: 0,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects negative serverTimeMs", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "0.9.2",
+      serverTimeMs: -1,
+    });
+    expect(res.success).toBe(false);
+  });
+});

--- a/packages/shared/src/config/client-config.ts
+++ b/packages/shared/src/config/client-config.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 import { logLevelSchema } from "../observability/logger-core.js";
+import { UPDATE_POLICIES, UPDATE_POLICY_DEFAULT } from "./phase.js";
 import { defineConfig, field } from "./schema.js";
 import { getConfig } from "./singleton.js";
 import type { InferConfig } from "./types.js";
+
+export const updatePolicySchema = z.enum(UPDATE_POLICIES);
 
 export const clientConfigSchema = defineConfig({
   server: {
@@ -19,6 +22,20 @@ export const clientConfigSchema = defineConfig({
     id: field(z.string().regex(/^client_[a-f0-9]{8}$/), {
       auto: "client-id",
       env: "FIRST_TREE_HUB_CLIENT_ID",
+    }),
+  },
+  update: {
+    policy: field(updatePolicySchema.default(UPDATE_POLICY_DEFAULT), {
+      env: "FIRST_TREE_HUB_UPDATE_POLICY",
+    }),
+    restart_quiet_seconds: field(z.number().int().min(1).max(3600).default(30), {
+      env: "FIRST_TREE_HUB_UPDATE_RESTART_QUIET_SECONDS",
+    }),
+    restart_check_interval_seconds: field(z.number().int().min(5).max(300).default(10), {
+      env: "FIRST_TREE_HUB_UPDATE_RESTART_CHECK_INTERVAL_SECONDS",
+    }),
+    prompt_timeout_seconds: field(z.number().int().min(10).max(600).default(60), {
+      env: "FIRST_TREE_HUB_UPDATE_PROMPT_TIMEOUT_SECONDS",
     }),
   },
   logLevel: field(logLevelSchema.default("info"), { env: "FIRST_TREE_HUB_LOG_LEVEL" }),

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -3,10 +3,11 @@
 export type { AgentConfig } from "./agent-config.js";
 export { agentConfigSchema } from "./agent-config.js";
 export type { ClientConfig } from "./client-config.js";
-export { clientConfigSchema, getClientConfig } from "./client-config.js";
-
+export { clientConfigSchema, getClientConfig, updatePolicySchema } from "./client-config.js";
 // Agent loader
 export { loadAgents } from "./loader.js";
+export type { UpdatePolicy } from "./phase.js";
+export { UPDATE_POLICY_DEFAULT } from "./phase.js";
 export type { ConfigMeta } from "./resolver.js";
 // Config initialization and access
 export {

--- a/packages/shared/src/config/phase.ts
+++ b/packages/shared/src/config/phase.ts
@@ -1,0 +1,16 @@
+/**
+ * Phase-dependent defaults that flip with release milestones. Kept as a plain
+ * module-level constant so reviews of the beta→GA transition are a one-line
+ * diff, and so tests can mock this module to exercise both branches.
+ */
+
+export const UPDATE_POLICIES = ["auto", "prompt", "off"] as const;
+export type UpdatePolicy = (typeof UPDATE_POLICIES)[number];
+
+/**
+ * Default value of `update.policy` on the Client config. During the beta this
+ * is `"auto"` — operators rarely know to `npm i -g` weekly and we chase the
+ * latest published Command by default. The GA PR flips it to `"prompt"` and
+ * bumps Command to `1.0.0`.
+ */
+export const UPDATE_POLICY_DEFAULT: UpdatePolicy = "auto";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -312,6 +312,6 @@ export {
   userSchema,
   userStatusSchema,
 } from "./schemas/user.js";
-export type { WsAuthFrame } from "./schemas/ws-auth.js";
-// -- WebSocket auth frame (client → server on connect) --
-export { WS_AUTH_FRAME_TIMEOUT_MS, wsAuthFrameSchema } from "./schemas/ws-auth.js";
+export type { ServerWelcomeFrame, WsAuthFrame } from "./schemas/ws-auth.js";
+// -- WebSocket handshake frames --
+export { serverWelcomeFrameSchema, WS_AUTH_FRAME_TIMEOUT_MS, wsAuthFrameSchema } from "./schemas/ws-auth.js";

--- a/packages/shared/src/schemas/ws-auth.ts
+++ b/packages/shared/src/schemas/ws-auth.ts
@@ -13,3 +13,19 @@ export type WsAuthFrame = z.infer<typeof wsAuthFrameSchema>;
 
 /** How long the server waits for the first `auth` frame before closing the WS. */
 export const WS_AUTH_FRAME_TIMEOUT_MS = 5_000;
+
+/**
+ * Advisory frame sent server → client immediately after `auth:ok`. It carries
+ * the Command-package version the server was bundled with, so the client can
+ * detect version drift on startup and on each reconnect. `.passthrough()` so
+ * future server versions may add fields without breaking older clients that
+ * validate this frame.
+ */
+export const serverWelcomeFrameSchema = z
+  .object({
+    type: z.literal("server:welcome"),
+    serverCommandVersion: z.string().min(1),
+    serverTimeMs: z.number().int().nonnegative(),
+  })
+  .passthrough();
+export type ServerWelcomeFrame = z.infer<typeof serverWelcomeFrameSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       pino:
         specifier: ^9.5.0
         version: 9.14.0
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.4
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -96,6 +102,9 @@ importers:
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.4
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -124,6 +133,9 @@ importers:
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
       tsdown:
         specifier: ^0.21.4
         version: 0.21.4(typescript@5.9.3)
@@ -2050,6 +2062,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -5495,6 +5510,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
 
   '@types/ssh2-streams@0.1.13':
     dependencies:


### PR DESCRIPTION
## Summary

- **Wire-additive `server:welcome` frame** — server sends its Command-package version (`serverCommandVersion`, `serverTimeMs`) immediately after `auth:ok`. Old clients silently drop the unknown type; newer ones compare it against their bundled version.
- **UpdateManager** (`packages/client/src/runtime/update-manager.ts`) — decision flow driven by a new `update` block in client config: `policy=auto|prompt|off`, `restart_quiet_seconds`, `restart_check_interval_seconds`, `prompt_timeout_seconds`. Auto updates wait on a quiet-gate (no active sessions + configurable idle window) before restarting; prompt path defaults to N on timeout.
- **managed vs standalone self-update**
  - launchd / systemd / Docker (`client start --no-interactive`) → install then `process.exit(75)` so the supervisor relaunches on the new binary.
  - `first-tree-hub client start`, `client connect --no-service`, any host without a supervisor → install, print a restart hint, stay alive; manager then locks out further npm invocations until the operator restarts.
- **Toolchain-aware `npm` resolution** — prefers `dirname(process.execPath)/npm` so nvm / asdf / Volta users don't ENOENT against the service unit's minimal PATH. Falls back to PATH lookup.
- **`--no-interactive` threaded through** — the flag now also suppresses the TTY update prompt, so a terminal run of `client start --no-interactive` with `policy=prompt` no longer blocks on confirm.

## Version bumps

- `@agent-team-foundation/first-tree-hub` — 0.8.5 → 0.8.6 (consumer tarball)
- `@agent-team-foundation/first-tree-hub-shared` — 0.1.2 → 0.1.3 (new exported schemas / types)

## Test plan

- [x] `pnpm check` (biome) clean
- [x] `pnpm typecheck` clean across all 9 packages
- [x] `pnpm test` — 385 server + 158 client + 62 shared + 21 command + 21 web + 3 web-harness, including:
  - `packages/server/src/__tests__/ws-server-welcome.test.ts` — server emits well-formed welcome after `auth:ok`
  - `packages/client/src/__tests__/client-connection-server-welcome.test.ts` — client dispatches event, ignores malformed frames, flags reconnect
  - `packages/client/src/__tests__/update-manager.test.ts` — full policy matrix + quiet-gate timing + standalone `installed:true` lock-out
  - `packages/command/src/__tests__/update-detect-install-mode.test.ts` — global / npx / source detection
  - `packages/shared/src/__tests__/client-config-update.test.ts` + `ws-auth-schema.test.ts` — defaults, env overrides, invalid-policy rejection, frame forward-compat
- [ ] Manual: `pnpm --filter @agent-team-foundation/first-tree-hub dev -- server start` against a `client start` with older version → verify prompt / auto path end-to-end
- [ ] Manual: `client start --no-interactive` under a service unit → verify exit 75 + supervisor relaunch on updated binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)