### PR TITLE
feat!: rename client home ~/.first-tree-hub → ~/.first-tree/hub

### DIFF
--- a/packages/client/src/__tests__/claude-code-bootstrap.test.ts
+++ b/packages/client/src/__tests__/claude-code-bootstrap.test.ts
@@ -201,9 +201,9 @@ describe("CLAUDE.md generation", () => {
       metadata: {},
     };
 
-    const md = generateClaudeMd(workspace, identity, "/home/user/.first-tree-hub/data/context-tree");
+    const md = generateClaudeMd(workspace, identity, "/home/user/.first-tree/hub/data/context-tree");
     expect(md).toContain("Context Tree Location");
-    expect(md).toContain("/home/user/.first-tree-hub/data/context-tree");
+    expect(md).toContain("/home/user/.first-tree/hub/data/context-tree");
     expect(md).toContain("Read specific domain nodes as needed");
   });
 

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -7,7 +7,14 @@ import { registerConfigCommands } from "../commands/config.js";
 import { registerOnboardCommand } from "../commands/onboard.js";
 import { registerServerCommands } from "../commands/server.js";
 import { registerStatusCommand } from "../commands/status.js";
+import { runHomeMigration } from "../core/migrate-home.js";
 import { COMMAND_VERSION } from "../core/version.js";
+
+// Run once at startup, BEFORE any command touches config/credentials so the
+// very first CLI invocation on an upgraded install transparently picks up
+// the renamed `~/.first-tree/hub` home. Never throws — failures degrade to
+// a stderr warning and the CLI still runs.
+runHomeMigration();
 
 const program = new Command();
 

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -50,7 +50,7 @@ function decodeJwtPayload(token: string): JwtPayload | null {
  * and give the operator a chance to back out before we overwrite credentials.
  *
  * Why this gate exists: running `client connect` implicitly overwrites
- * `~/.first-tree-hub/config/credentials.json`. Without this prompt, someone
+ * `~/.first-tree/hub/config/credentials.json`. Without this prompt, someone
  * onboarding a second account on their own machine silently logs themselves
  * out of the first account — they'd only notice when their "main" agents
  * appeared offline later. We treat single-account-per-machine as the product
@@ -134,7 +134,7 @@ async function promptReplaceOrCancel(newMemberId: string, newServerUrl: string):
 function printIsolationGuide(newServerUrl: string): void {
   process.stderr.write("\n  Cancelled. The existing account on this computer is untouched.\n\n");
   process.stderr.write("  To run this new account alongside it (advanced — no background service):\n\n");
-  process.stderr.write('    export FIRST_TREE_HUB_HOME="$HOME/.first-tree-hub-<label>"\n');
+  process.stderr.write('    export FIRST_TREE_HUB_HOME="$HOME/.first-tree/hub-<label>"\n');
   process.stderr.write(`    first-tree-hub client connect ${newServerUrl} --token <token>\n`);
   process.stderr.write("    first-tree-hub client start\n\n");
   process.stderr.write("  Notes:\n");

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -36,6 +36,8 @@ export {
 export { bindFeishuBot, bindFeishuUser } from "./feishu.js";
 // Database
 export { runMigrations } from "./migrate.js";
+// Legacy home auto-migration (pre-v0.9 `~/.first-tree-hub` → `~/.first-tree/hub`)
+export { runHomeMigration } from "./migrate-home.js";
 // Onboard
 export {
   formatCheckReport,

--- a/packages/command/src/core/migrate-home.ts
+++ b/packages/command/src/core/migrate-home.ts
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_HOME_DIR,
+  type HomeMigrationResult,
+  migrateLegacyHome,
+} from "@agent-team-foundation/first-tree-hub-shared/config";
+import { getClientServiceStatus, installClientService } from "./service-install.js";
+
+/**
+ * Run the one-shot legacy home migration at CLI startup and, if it succeeds,
+ * re-register the background service so launchd/systemd pick up the new
+ * `StandardOutPath` / `StandardErrorPath` / `ExecStart` log paths (those are
+ * baked into the plist/unit file at install time — when we populate the new
+ * home, those paths would otherwise still point at the old location).
+ *
+ * Copy-only semantics: the legacy `~/.first-tree-hub/` tree is preserved
+ * as a safety net. The user can inspect/fall-back to it, and can delete it
+ * manually once they've confirmed the new layout is healthy.
+ *
+ * Contract:
+ *   - Synchronous and cheap when there's nothing to do (most runs — the
+ *     steady state is "new dir populated", which short-circuits the copy).
+ *   - Never throws — migration failures and service re-register failures
+ *     both fall through to a stderr warning so the CLI command still runs.
+ *   - Idempotent — safe to call on every CLI invocation.
+ *   - Skips service re-register when we are already running AS the service
+ *     (launchd/systemd invoke the CLI with `--no-interactive`), because the
+ *     re-register would bootout our own process mid-execution.
+ */
+export function runHomeMigration(): void {
+  const result: HomeMigrationResult = migrateLegacyHome({
+    newHome: DEFAULT_HOME_DIR,
+    envOverride: process.env.FIRST_TREE_HUB_HOME ?? null,
+  });
+
+  if (!result.migrated) {
+    // Only surface reasons that warrant user attention. `no-legacy-dir`,
+    // `custom-home`, and `new-dir-populated` are all steady states after
+    // first successful migration (or for fresh installs / custom homes) —
+    // staying silent avoids noise on every CLI call.
+    if (result.reason === "failed") {
+      process.stderr.write(
+        `[first-tree-hub] WARNING: failed to auto-migrate legacy home ${result.from} → ${result.to}: ${result.error ?? "unknown error"}\n` +
+          `  Resolve manually: cp -R "${result.from}" "${result.to}"\n`,
+      );
+    }
+    return;
+  }
+
+  process.stderr.write(
+    `[first-tree-hub] Copied client home to new layout: ${result.from} → ${result.to}\n` +
+      `  (Legacy directory preserved as a backup — delete it manually once you've verified the new location works.)\n`,
+  );
+
+  // Re-registering the service means launchctl bootout + bootstrap on macOS —
+  // that would kill our own process if we're the service. Detect via the
+  // flag passed by the installed unit (see `renderPlist` / `renderSystemdUnit`
+  // in service-install.ts).
+  const runningAsService = process.argv.includes("--no-interactive");
+  if (runningAsService) {
+    process.stderr.write(
+      `[first-tree-hub] Note: running as background service — skipped auto re-register to avoid self-termination.\n` +
+        `  Run \`first-tree-hub client service install\` from a terminal to refresh log paths.\n`,
+    );
+    return;
+  }
+
+  const status = getClientServiceStatus();
+  if (status.platform === "unsupported" || status.state === "not-installed") {
+    return;
+  }
+
+  try {
+    installClientService();
+    process.stderr.write(`[first-tree-hub] Re-registered background service with new home paths.\n`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[first-tree-hub] WARNING: home migration succeeded but re-registering the background service failed: ${msg}\n` +
+        `  Run \`first-tree-hub client service install\` to refresh log paths.\n`,
+    );
+  }
+}

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -38,6 +38,7 @@ export {
   resolveAccessToken,
   resolveCliInvocation,
   resolveServerUrl,
+  runHomeMigration,
   runMigrations,
   startServer,
   status,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub-shared",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "First Tree Hub shared schemas, types, and configuration",
   "license": "MIT",

--- a/packages/shared/src/config/__tests__/migrate-home.test.ts
+++ b/packages/shared/src/config/__tests__/migrate-home.test.ts
@@ -1,0 +1,157 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { migrateLegacyHome } from "../migrate-home.js";
+
+let sandbox: string;
+let legacy: string;
+let newHome: string;
+
+beforeEach(() => {
+  sandbox = join(tmpdir(), `ftt-migrate-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(sandbox, { recursive: true });
+  legacy = join(sandbox, "legacy", ".first-tree-hub");
+  newHome = join(sandbox, "new", ".first-tree", "hub");
+});
+
+afterEach(() => {
+  if (existsSync(sandbox)) rmSync(sandbox, { recursive: true, force: true });
+});
+
+function seedLegacy(): void {
+  mkdirSync(join(legacy, "config"), { recursive: true });
+  mkdirSync(join(legacy, "data", "workspaces"), { recursive: true });
+  writeFileSync(join(legacy, "config", "credentials.json"), '{"accessToken":"abc"}');
+  writeFileSync(join(legacy, "data", "workspaces", "marker"), "hello");
+}
+
+describe("migrateLegacyHome", () => {
+  it("skips when the legacy dir does not exist", () => {
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(false);
+    if (!res.migrated) expect(res.reason).toBe("no-legacy-dir");
+    expect(existsSync(newHome)).toBe(false);
+  });
+
+  it("skips when FIRST_TREE_HUB_HOME is set (user-controlled home)", () => {
+    seedLegacy();
+    const res = migrateLegacyHome({
+      newHome,
+      legacyHome: legacy,
+      envOverride: "/some/custom/path",
+    });
+    expect(res.migrated).toBe(false);
+    if (!res.migrated) expect(res.reason).toBe("custom-home");
+    // Legacy dir must be untouched so the custom-home user can inspect it.
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  it("copies the entire legacy home tree into the new location AND preserves the legacy as a backup", () => {
+    seedLegacy();
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+    if (res.migrated) {
+      expect(res.from).toBe(legacy);
+      expect(res.to).toBe(newHome);
+    }
+    // Copy semantics: BOTH locations exist after migration. Legacy is the
+    // safety-net backup the user can delete manually once verified.
+    expect(existsSync(legacy)).toBe(true);
+    expect(readFileSync(join(legacy, "config", "credentials.json"), "utf-8")).toBe('{"accessToken":"abc"}');
+    expect(readFileSync(join(newHome, "config", "credentials.json"), "utf-8")).toBe('{"accessToken":"abc"}');
+    expect(readFileSync(join(newHome, "data", "workspaces", "marker"), "utf-8")).toBe("hello");
+  });
+
+  it("creates the parent `.first-tree/` dir when missing", () => {
+    seedLegacy();
+    // Parent does not exist yet.
+    expect(existsSync(join(sandbox, "new", ".first-tree"))).toBe(false);
+
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+    expect(existsSync(join(sandbox, "new", ".first-tree"))).toBe(true);
+  });
+
+  it("copies into an existing empty new dir (e.g. sibling product already created `.first-tree/`)", () => {
+    seedLegacy();
+    mkdirSync(newHome, { recursive: true });
+    // New dir exists but empty — should still migrate.
+
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+    expect(existsSync(join(newHome, "config", "credentials.json"))).toBe(true);
+    // Legacy preserved.
+    expect(existsSync(join(legacy, "config", "credentials.json"))).toBe(true);
+  });
+
+  it("refuses to overwrite when the new dir already has content", () => {
+    seedLegacy();
+    mkdirSync(newHome, { recursive: true });
+    writeFileSync(join(newHome, "pre-existing.txt"), "already here");
+
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(false);
+    if (!res.migrated) expect(res.reason).toBe("new-dir-populated");
+    // Both dirs untouched so the user can inspect/resolve manually.
+    expect(existsSync(join(legacy, "config", "credentials.json"))).toBe(true);
+    expect(readFileSync(join(newHome, "pre-existing.txt"), "utf-8")).toBe("already here");
+  });
+
+  it("is idempotent — second call after a successful migration is a no-op (target populated)", () => {
+    seedLegacy();
+    const first = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(first.migrated).toBe(true);
+
+    // Legacy still exists after copy, so the "new-dir-populated" rule is
+    // what keeps us from re-copying and potentially clobbering live edits
+    // that happened against the new location between runs.
+    const second = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(second.migrated).toBe(false);
+    if (!second.migrated) expect(second.reason).toBe("new-dir-populated");
+  });
+
+  it("copies even an empty legacy dir (the user was on the old layout)", () => {
+    // An empty legacy dir still means the user had the pre-v0.9 layout;
+    // we create the target parent so subsequent writes land in the new path.
+    mkdirSync(legacy, { recursive: true });
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+    // Legacy preserved.
+    expect(existsSync(legacy)).toBe(true);
+    expect(existsSync(newHome)).toBe(true);
+  });
+
+  it("preserves directory modes (Node's cpSync regression — credentials/ must stay 0700)", () => {
+    // Seed a 0700 config dir with a 0600 secret inside. This mirrors the
+    // on-disk shape that `ensureDir(..., 0o700)` produces in resolver.ts.
+    mkdirSync(join(legacy, "config"), { recursive: true });
+    mkdirSync(join(legacy, "config", "agents"), { recursive: true });
+    writeFileSync(join(legacy, "config", "credentials.json"), '{"t":"x"}', { mode: 0o600 });
+    chmodSync(join(legacy, "config"), 0o700);
+    chmodSync(join(legacy, "config", "agents"), 0o700);
+    // Leave a 0755 sibling so we know the fix isn't just blanket-setting 0700.
+    mkdirSync(join(legacy, "data", "sessions"), { recursive: true });
+    chmodSync(join(legacy, "data"), 0o755);
+
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+
+    expect(statSync(join(newHome, "config")).mode & 0o7777).toBe(0o700);
+    expect(statSync(join(newHome, "config", "agents")).mode & 0o7777).toBe(0o700);
+    expect(statSync(join(newHome, "data")).mode & 0o7777).toBe(0o755);
+    // File modes were already handled by cpSync but re-assert to lock it in.
+    expect(statSync(join(newHome, "config", "credentials.json")).mode & 0o7777).toBe(0o600);
+  });
+
+  it("preserves file contents byte-for-byte (not a silent rewrite)", () => {
+    mkdirSync(legacy, { recursive: true });
+    const payload = Buffer.from([0x00, 0xff, 0x7f, 0x80, 0x10, 0x20]);
+    writeFileSync(join(legacy, "binary.dat"), payload);
+
+    const res = migrateLegacyHome({ newHome, legacyHome: legacy, envOverride: null });
+    expect(res.migrated).toBe(true);
+    const copied = readFileSync(join(newHome, "binary.dat"));
+    expect(copied.equals(payload)).toBe(true);
+  });
+});

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -3,7 +3,7 @@ import { defineConfig, field } from "./schema.js";
 import type { InferConfig } from "./types.js";
 
 /**
- * Agent config layout on disk: `~/.first-tree-hub/config/agents/<name>/agent.yaml`.
+ * Agent config layout on disk: `~/.first-tree/hub/config/agents/<name>/agent.yaml`.
  *
  * After the unified-user-token milestone the local config no longer stores an
  * agent bearer; authentication comes from the user's member JWT in

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -6,6 +6,9 @@ export type { ClientConfig } from "./client-config.js";
 export { clientConfigSchema, getClientConfig, updatePolicySchema } from "./client-config.js";
 // Agent loader
 export { loadAgents } from "./loader.js";
+// Legacy home auto-migration (pre-v0.9 `~/.first-tree-hub` → `~/.first-tree/hub`)
+export type { HomeMigrationResult } from "./migrate-home.js";
+export { LEGACY_HOME_DIR, migrateLegacyHome } from "./migrate-home.js";
 export type { UpdatePolicy } from "./phase.js";
 export { UPDATE_POLICY_DEFAULT } from "./phase.js";
 export type { ConfigMeta } from "./resolver.js";

--- a/packages/shared/src/config/migrate-home.ts
+++ b/packages/shared/src/config/migrate-home.ts
@@ -1,0 +1,156 @@
+import { chmodSync, cpSync, existsSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Pre-v0.9 path. The home directory was a flat `~/.first-tree-hub/` — this
+ * was renamed to `~/.first-tree/hub/` so the `.first-tree/` parent can be
+ * shared with sibling products (context-tree etc.) under the same brand.
+ */
+export const LEGACY_HOME_DIR = join(homedir(), ".first-tree-hub");
+
+export type HomeMigrationResult =
+  | {
+      migrated: false;
+      reason: "no-legacy-dir" | "custom-home" | "new-dir-populated" | "failed";
+      from?: string;
+      to?: string;
+      error?: string;
+    }
+  | { migrated: true; from: string; to: string };
+
+type MigrateOptions = {
+  /**
+   * Target home. In production this is `DEFAULT_HOME_DIR`; tests inject a
+   * temp path so they can exercise the migration without touching the real
+   * user home.
+   */
+  newHome: string;
+  /** Override the legacy source path (for tests). Defaults to `~/.first-tree-hub`. */
+  legacyHome?: string;
+  /**
+   * When set to a truthy value we treat the caller as "home path is
+   * user-overridden" and skip migration. Pass `process.env.FIRST_TREE_HUB_HOME`
+   * from the caller so the shared module stays free of direct env reads.
+   */
+  envOverride?: string | null | undefined;
+};
+
+/**
+ * Auto-migrate the legacy `~/.first-tree-hub/` home to the new
+ * `~/.first-tree/hub/` layout. Designed to be called once at CLI startup —
+ * idempotent, never throws, and skips any case that could merge state.
+ *
+ * **Copy-only semantics:** the legacy tree is preserved on disk as a safety
+ * net. Users can inspect or fall back to it, and can delete it manually
+ * once they've confirmed the new location is healthy. Idempotency is
+ * therefore keyed on whether the *target* already has content, not on
+ * whether the legacy path still exists.
+ *
+ * Skip rules (in order):
+ *   1. `FIRST_TREE_HUB_HOME` is set → user is driving the path explicitly.
+ *   2. Legacy path doesn't exist → nothing to migrate.
+ *   3. New path already has content → treat as already-migrated (or a
+ *      conflict the user must resolve). Either way, never merge.
+ *
+ * Otherwise we recursively copy legacy → new with `cpSync`, preserving
+ * mtimes so log rotation and mtime heuristics keep working.
+ */
+/**
+ * Walk `src` depth-first and mirror every directory's mode onto the matching
+ * path in `dest`. Skips symlinks (we don't want to chmod whatever they
+ * resolve to — that can reach outside the tree). Files are left alone
+ * because `cpSync` already preserves file modes.
+ */
+function syncDirectoryModes(src: string, dest: string): void {
+  // Top-level dir is created by cpSync itself; fix it first.
+  chmodSync(dest, statSync(src).mode & 0o7777);
+
+  const stack: string[] = [""];
+  while (stack.length > 0) {
+    const rel = stack.pop();
+    if (rel === undefined) break;
+    const srcDir = join(src, rel);
+    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+      // isDirectory() returns false for symlinks (even if they point at a
+      // directory), so this naturally skips them.
+      if (!entry.isDirectory()) continue;
+      const relChild = rel === "" ? entry.name : join(rel, entry.name);
+      const mode = statSync(join(src, relChild)).mode & 0o7777;
+      chmodSync(join(dest, relChild), mode);
+      stack.push(relChild);
+    }
+  }
+}
+
+export function migrateLegacyHome(opts: MigrateOptions): HomeMigrationResult {
+  const { newHome, envOverride } = opts;
+  const legacyHome = opts.legacyHome ?? LEGACY_HOME_DIR;
+
+  // Rule 1: respect explicit env override — the user is pointing at a
+  // non-default home (e.g. isolated test sandbox). Touching anything on
+  // their behalf would violate that intent.
+  if (envOverride) {
+    return { migrated: false, reason: "custom-home" };
+  }
+
+  // Rule 2: nothing to migrate.
+  if (!existsSync(legacyHome)) {
+    return { migrated: false, reason: "no-legacy-dir" };
+  }
+
+  // Rule 3: if the new path has content, we treat it as the authoritative
+  // state and leave it alone. This covers two cases with identical handling:
+  //   - Second+ CLI run after a successful migration (target populated by us).
+  //   - Independent fresh install that created the new layout, then the user
+  //     later restored a legacy backup alongside — copying on top would mix
+  //     two sessions' credentials.
+  // An empty target directory (e.g. a sibling product pre-created
+  // `~/.first-tree/hub/`) is allowed and we proceed to copy into it.
+  if (existsSync(newHome)) {
+    try {
+      const entries = readdirSync(newHome);
+      if (entries.length > 0) {
+        return { migrated: false, reason: "new-dir-populated", from: legacyHome, to: newHome };
+      }
+    } catch (err) {
+      return {
+        migrated: false,
+        reason: "failed",
+        from: legacyHome,
+        to: newHome,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  try {
+    // cpSync handles:
+    //   - Creating `newHome` and any missing parents (via `force: true` +
+    //     implicit parent creation in recursive mode).
+    //   - Cross-filesystem copies (no EXDEV dance needed).
+    //   - Symlink preservation (default behavior keeps them as symlinks).
+    //   - File mode preservation (credentials.json stays `0600`).
+    // Preserve timestamps so mtime-based heuristics (log rotation, "last
+    // used" displays) stay meaningful across the migration.
+    cpSync(legacyHome, newHome, { recursive: true, preserveTimestamps: true });
+
+    // Node's `fs.cpSync` does NOT preserve **directory** mode bits — it
+    // creates intermediate dirs with default mode (0o777 masked by umask,
+    // typically 0o755). That's a real security regression for the
+    // `config/` subtree, which is 0o700 on the source to hide the
+    // credentials listing. Walk the tree once post-copy and restore every
+    // directory's mode to match the source.
+    syncDirectoryModes(legacyHome, newHome);
+
+    return { migrated: true, from: legacyHome, to: newHome };
+  } catch (err) {
+    return {
+      migrated: false,
+      reason: "failed",
+      from: legacyHome,
+      to: newHome,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/shared/src/config/resolver.ts
+++ b/packages/shared/src/config/resolver.ts
@@ -14,7 +14,7 @@ import type {
   ResolvedFieldInfo,
 } from "./types.js";
 
-export const DEFAULT_HOME_DIR = process.env.FIRST_TREE_HUB_HOME ?? join(homedir(), ".first-tree-hub");
+export const DEFAULT_HOME_DIR = process.env.FIRST_TREE_HUB_HOME ?? join(homedir(), ".first-tree", "hub");
 export const DEFAULT_CONFIG_DIR = join(DEFAULT_HOME_DIR, "config");
 export const DEFAULT_DATA_DIR = join(DEFAULT_HOME_DIR, "data");
 


### PR DESCRIPTION
## Summary

Share the `~/.first-tree/` brand root with sibling products (context-tree etc.) by nesting first-tree-hub's home under a `hub/` subdirectory. Auto-migrates transparently on first CLI run after upgrade.

- **Shared (0.1.2 → 0.2.0):** `DEFAULT_HOME_DIR` → `~/.first-tree/hub`; new `migrateLegacyHome()` pure function.
- **Command (0.8.5 → 0.9.0):** `runHomeMigration()` orchestrator wired into CLI startup, before `commander.parse()`.

## Migration semantics — copy, not move

The legacy `~/.first-tree-hub/` tree is **preserved as a safety-net backup**. The user can verify the new location works, then delete the legacy dir manually. Idempotency is keyed on whether the *target* has content (not on whether the legacy path still exists).

Skip rules:
1. `FIRST_TREE_HUB_HOME` is set → custom-home, never touch anything.
2. Legacy path doesn't exist → fresh install, nothing to do.
3. New path has content → already migrated (or a conflict the user must resolve).

After a successful copy we re-register the launchd/systemd service (if installed) so `StandardOutPath` / `StandardErrorPath` point at the new home. Skipped when running AS the service (detected via `--no-interactive` in argv) to avoid self-termination.

## Bug found & fixed during real-FS verification

Node's `fs.cpSync({recursive: true})` preserves **file** modes but NOT **directory** modes — the intermediate dirs get created with default (0o755). This silently downgraded `config/` from `0700` → `0755`, leaking the credentials listing. Fix: a `syncDirectoryModes()` post-copy walk that mirrors source dir modes onto the target. Unit-tested.

## Validation

### Unit tests (10 new cases in \`migrate-home.test.ts\`)
- no-legacy-dir / custom-home / byte-for-byte copy / parent dir creation / empty-target-allowed / populated-target-refused / idempotency / empty-legacy / **dir mode preservation (0700 config, 0755 data, 0600 files)** / binary byte parity

### Real FS pure-function run (\`~/.first-tree-hub-test/\` → \`~/.first-tree-test/hub/\`)
- 7 files byte-identical (shasum) ✓
- Legacy tree byte-identical to pre-migration snapshot ✓
- All directory modes match source ✓
- mtimes preserved ✓

### Real CLI end-to-end (bundled \`dist/cli/index.mjs\` + fake \`\$HOME\` sandbox)
- **Migrate path:** stderr banner + copy + CLI exits cleanly ✓
- **Idempotent path:** 2nd run silent, zero re-copy ✓
- **Custom-home skip:** `FIRST_TREE_HUB_HOME` set → no banner, no `.first-tree/` created ✓
- Live `~/.first-tree-hub/` (production daemon) mtime unchanged throughout ✓

### Monorepo suite
- `pnpm check` ✓
- `pnpm typecheck` (9/9 packages) ✓
- `pnpm test` (9/9 tasks, including 384 server tests + 146 client + 64 shared + 17 command) ✓

## Test plan

- [ ] Real-machine dry run: pick a non-prod install, back up `~/.first-tree-hub/` to `~/.first-tree-hub-preupgrade-$(date +%F)/`, install from this PR's tarball, run any CLI command, observe the stderr migration banner and verify the service restarts cleanly with new log paths.
- [ ] Confirm `first-tree-hub client service status` reports the re-registered service as active.
- [ ] Verify `config/` in the new location retains `0700` perms (the security fix).
- [ ] Delete the legacy `~/.first-tree-hub/` directory and confirm subsequent CLI runs remain silent (no stray re-migration attempts).

## Follow-ups (not in this PR)

- Docs + skills updates: ~15 references to `~/.first-tree-hub` in `docs/` and `skills/` will need syncing to the new path.
- Consider a user-facing \`first-tree-hub config migrate-home --verify\` command to let users confirm new-location health before manually deleting the backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)