### PR TITLE
fix(command): resolve own version via walk-up to survive tsdown bundle

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/resolve-command-version.test.ts
+++ b/packages/command/src/__tests__/resolve-command-version.test.ts
@@ -1,0 +1,137 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCommandVersion } from "../core/version.js";
+
+const PACKAGE_NAME = "@agent-team-foundation/first-tree-hub";
+
+describe("resolveCommandVersion", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "ftHub-version-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Dev layout: `tsx src/cli/index.ts` runs source files, so this module
+  // resolves from `packages/command/src/core/version.ts` and must walk up
+  // two levels to `packages/command/package.json`.
+  it("reads the version from the dev-source layout (two levels up)", () => {
+    const pkgDir = join(root, "packages", "command");
+    const moduleDir = join(pkgDir, "src", "core");
+    mkdirSync(moduleDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "9.9.9" }));
+    const moduleUrl = pathToFileURL(join(moduleDir, "version.ts")).href;
+    expect(resolveCommandVersion(moduleUrl)).toBe("9.9.9");
+  });
+
+  // Bundled layout that v0.9.1 shipped: tsdown flattens `src/core/version.ts`
+  // into `dist/core-*.mjs`, so the module resolves only one level up from
+  // its `package.json`. The old `require("../../package.json")` looked two
+  // levels up and crashed — this test pins the fix.
+  it("reads the version from the bundled dist layout (one level up)", () => {
+    const pkgDir = join(root, "node_modules", PACKAGE_NAME);
+    const distDir = join(pkgDir, "dist");
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "0.9.2" }));
+    const moduleUrl = pathToFileURL(join(distDir, "core-abc123.mjs")).href;
+    expect(resolveCommandVersion(moduleUrl)).toBe("0.9.2");
+  });
+
+  // Bundled CLI entry lives one directory deeper than the `core-*.mjs`
+  // chunk, so double-check the walk doesn't stop at the wrong level.
+  it("reads the version from dist/cli/index.mjs (two levels up)", () => {
+    const pkgDir = join(root, "node_modules", PACKAGE_NAME);
+    const cliDir = join(pkgDir, "dist", "cli");
+    mkdirSync(cliDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "1.2.3" }));
+    const moduleUrl = pathToFileURL(join(cliDir, "index.mjs")).href;
+    expect(resolveCommandVersion(moduleUrl)).toBe("1.2.3");
+  });
+
+  // A sibling `package.json` belonging to a different workspace package (or
+  // a parent-monorepo root) must be skipped so the walker keeps going up.
+  it("skips package.json entries whose name does not match", () => {
+    const monoRoot = join(root, "mono");
+    const pkgDir = join(monoRoot, "packages", "command");
+    const moduleDir = join(pkgDir, "dist");
+    mkdirSync(moduleDir, { recursive: true });
+    writeFileSync(join(monoRoot, "package.json"), JSON.stringify({ name: "mono-root", version: "0.0.1" }));
+    writeFileSync(
+      join(monoRoot, "packages", "package.json"),
+      JSON.stringify({ name: "packages-shim", version: "0.0.1" }),
+    );
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "5.5.5" }));
+    const moduleUrl = pathToFileURL(join(moduleDir, "core.mjs")).href;
+    expect(resolveCommandVersion(moduleUrl)).toBe("5.5.5");
+  });
+
+  // Fallback when nothing matches — must return "unknown" (deliberately not
+  // valid SemVer so the client UpdateManager's `semver.valid(current)` check
+  // routes to warn-and-skip instead of `semver.lt("0.0.0", target) === true`
+  // triggering a spurious auto-update loop).
+  it("falls back to 'unknown' when no matching package.json is found", () => {
+    const stray = join(root, "stray");
+    mkdirSync(stray, { recursive: true });
+    const moduleUrl = pathToFileURL(join(stray, "module.mjs")).href;
+    expect(resolveCommandVersion(moduleUrl)).toBe("unknown");
+  });
+
+  // Skips malformed JSON without crashing, and surfaces a stderr warning so
+  // an operator can tell the walker found something unusual (rather than
+  // silently degrading to the fallback).
+  it("warns on malformed JSON but keeps walking", () => {
+    const pkgDir = join(root, "packages", "command");
+    const moduleDir = join(pkgDir, "dist");
+    const parentDir = root;
+    mkdirSync(moduleDir, { recursive: true });
+    // Closer (wrong) manifest is malformed; correct manifest sits higher up.
+    writeFileSync(join(pkgDir, "package.json"), "{not valid json");
+    writeFileSync(join(parentDir, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "7.7.7" }));
+
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const moduleUrl = pathToFileURL(join(moduleDir, "core.mjs")).href;
+      expect(resolveCommandVersion(moduleUrl)).toBe("7.7.7");
+      expect(warn).toHaveBeenCalled();
+      const firstCall = warn.mock.calls[0]?.[0];
+      expect(typeof firstCall === "string" ? firstCall : "").toMatch(/could not read/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // Permission-denied (EACCES) on an intermediate manifest must warn but not
+  // abort the walk: the v0.9.1 startup-crash regression this module avoids
+  // hinges on NEVER throwing from module load. Skip on platforms that don't
+  // honour chmod 000 (Windows).
+  it.skipIf(process.platform === "win32")("warns on EACCES but keeps walking", () => {
+    const pkgDir = join(root, "packages", "command");
+    const moduleDir = join(pkgDir, "dist");
+    mkdirSync(moduleDir, { recursive: true });
+    const lockedPkg = join(pkgDir, "package.json");
+    writeFileSync(lockedPkg, JSON.stringify({ name: PACKAGE_NAME, version: "8.8.8" }));
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: "6.6.6" }));
+    chmodSync(lockedPkg, 0o000);
+
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const moduleUrl = pathToFileURL(join(moduleDir, "core.mjs")).href;
+      // Locked manifest is unreadable, so the walker falls through to the
+      // grand-parent manifest. Either outcome is acceptable; what matters is
+      // that the function does not throw and that it surfaces a warning.
+      const result = resolveCommandVersion(moduleUrl);
+      expect(["6.6.6", "unknown"]).toContain(result);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      // Restore perms so afterEach's rmSync can clean up.
+      chmodSync(lockedPkg, 0o644);
+    }
+  });
+});

--- a/packages/command/src/core/version.ts
+++ b/packages/command/src/core/version.ts
@@ -1,12 +1,68 @@
-import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Version of the consumer-facing `@agent-team-foundation/first-tree-hub`
- * package. Read once at module load from the bundled `package.json` so the
- * CLI, client runtime, and server bootstrap all quote the same string.
+ * package. Read once at module load so the CLI, client runtime, and server
+ * bootstrap all quote the same string.
+ *
+ * Path-based lookups (`require("../../package.json")`) do not survive the
+ * tsdown bundle: the source lives at `src/core/version.ts` but every
+ * emitted chunk lands in `dist/` — shifting the relative depth by one and
+ * pointing at `packages/package.json` instead of our own manifest (the
+ * v0.9.1 "Cannot find module ../../package.json" crash). Walk up from this
+ * module's URL and accept the first `package.json` whose `name` matches, so
+ * dev runs (`tsx src/cli/index.ts`) and the published bundle
+ * (`dist/cli/index.mjs`) both resolve the same file.
  */
-const require = createRequire(import.meta.url);
-const pkg = require("../../package.json") as { version?: string };
+const PACKAGE_NAME = "@agent-team-foundation/first-tree-hub";
 
-export const COMMAND_VERSION: string =
-  typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : "0.0.0";
+/**
+ * Sentinel returned when the walker exhausts every parent directory without
+ * finding our manifest. Deliberately NOT valid SemVer so the client-side
+ * `UpdateManager` drops into its `semver.valid(current) === false` warn-and-
+ * skip branch instead of treating it as `< target` and triggering a spurious
+ * self-update loop (the scenario where the startup crash this module fixes
+ * would otherwise quietly reincarnate as repeated `npm install -g @latest`).
+ */
+const UNRESOLVED_VERSION = "unknown";
+
+type PartialPackageJson = { name?: string; version?: string };
+
+/**
+ * Exported for tests. Walks up from `moduleUrl`'s directory looking for a
+ * `package.json` whose `name` field equals {@link PACKAGE_NAME}. Returns
+ * {@link UNRESOLVED_VERSION} as a last-resort fallback so the CLI never
+ * crashes on a missing manifest.
+ */
+export function resolveCommandVersion(moduleUrl: string = import.meta.url): string {
+  let dir = dirname(fileURLToPath(moduleUrl));
+  for (let i = 0; i < 10; i++) {
+    try {
+      const pkg = JSON.parse(readFileSync(resolve(dir, "package.json"), "utf8")) as PartialPackageJson;
+      if (pkg.name === PACKAGE_NAME && typeof pkg.version === "string" && pkg.version.length > 0) {
+        return pkg.version;
+      }
+    } catch (err) {
+      // Expected at levels without a manifest — silent.
+      // Any other code (EACCES on a locked-down manifest, EISDIR if the
+      // path has been replaced with a directory, SyntaxError on a truncated
+      // install) is unusual and would otherwise hide a real install
+      // problem behind the fallback value. Warn to stderr but keep
+      // walking: throwing here would reinstate the v0.9.1 startup crash
+      // this module exists to prevent.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[first-tree-hub] warning: could not read ${dir}/package.json: ${message}\n`);
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return UNRESOLVED_VERSION;
+}
+
+export const COMMAND_VERSION: string = resolveCommandVersion();


### PR DESCRIPTION
## Summary

- **v0.9.1 crashed on startup.** `packages/command/src/core/version.ts` used `require("../../package.json")`, but tsdown flattens every chunk into `dist/`, so the bundled path resolved to `packages/package.json` (or `node_modules/@agent-team-foundation/package.json` under a global install) — neither exists. The CLI threw `Cannot find module '../../package.json'` before it could run any command.
- **Fix**: walk up from `dirname(fileURLToPath(import.meta.url))` until we find a `package.json` whose `name` matches this package. Works identically in dev (`tsx src/cli/index.ts` → `src/core/` finds `packages/command/package.json` two levels up) and in the published tarball (`dist/cli/index.mjs` → one level up in a global install, two from the CLI entry).
- **Hardened fallback path** during code review — see Risks below.
- Bumps `packages/command` to `0.9.2` per the consumer-tarball versioning policy.

## Why the bundled path diverged

Source layout: `packages/command/src/core/version.ts` — `../../` = `packages/command/` ✅

Bundled layout: `packages/command/dist/core-*.mjs` — `../../` = `packages/` ❌ (nothing there). In a global install: `node_modules/@agent-team-foundation/first-tree-hub/dist/core-*.mjs` → `../../` = `node_modules/@agent-team-foundation/` ❌. tsdown doesn't rewrite string literals passed to `require()`, so the depth assumption baked into the source doesn't survive the bundler.

## Risks surfaced during review (fixed in-PR)

Two issues turned up when reviewing the initial fix. Both are now addressed:

1. **Silent `"0.0.0"` fallback would trigger a self-update loop.** `"0.0.0"` is valid SemVer and less than any real version. If the walker ever bottoms out (EACCES-locked manifest, exotic install layout, >10 parent dirs), `ClientRuntime.currentVersion` becomes `"0.0.0"`, `UpdateManager.decide` treats it as "way behind," and in `policy=auto` on a non-TTY service unit the client would `npm install -g @latest` on every reconnect. The v0.9.1 startup-crash would have quietly reincarnated as an install storm. **Fix**: fallback is now the string `"unknown"` (not valid SemVer). `packages/client/src/runtime/update-manager.ts:151` already has a `semver.valid(current) === false` → warn-and-skip branch, and the welcome-frame schema at `packages/shared/src/schemas/ws-auth.ts:27` is `z.string().min(1)` so it accepts the sentinel.
2. **`catch {}` hid non-ENOENT errors.** EACCES on a locked manifest, EISDIR on a weird layout, `SyntaxError` on a truncated install — all were swallowed identically to "no file here." **Fix**: inspect `err.code`, silent on `ENOENT` / `ENOTDIR`, stderr warning on anything else. Still never throws — throwing from module load would reinstate exactly the v0.9.1 crash this PR exists to prevent.

## Follow-ups (not in this PR)

- Add a build-then-load integration test that catches dev-vs-bundle divergence. The unit tests here exercise `resolveCommandVersion(mockUrl)` directly; a regression that reverts to `createRequire(...).require("../../package.json")` would still pass them because the old pattern works fine under `tsx`. Only a test that loads the actual `dist/core-*.mjs` catches the ship-blocking shape.
- `packages/server/src/app.ts:88-98` has its own `resolveCommandVersion` with the same `"0.0.0"` fallback pattern. Same class of bug, different file. Deserves a matching fix.

## Test plan

- [x] `pnpm check` (biome)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub typecheck`
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test src/__tests__/resolve-command-version.test.ts` — 7/7 pass:
  - dev-source layout (walk up two)
  - bundled dist layout (walk up one)
  - deeper dist/cli layout (walk up two)
  - sibling non-matching package.json (skip and keep walking)
  - `"unknown"` fallback when nothing matches
  - malformed JSON surfaces a stderr warning but keeps walking
  - EACCES on an intermediate manifest (Unix only) surfaces a warning but does not throw
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub build` succeeds
- [x] `node packages/command/dist/cli/index.mjs --version` → `0.9.2` (was `Cannot find module '../../package.json'` on v0.9.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)