### PR TITLE
feat(web): redesign admin pages with denser layout primitives

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -169,7 +169,7 @@ export function Layout() {
         <Outlet />
       ) : (
         <main className="flex-1 overflow-auto">
-          <div className="p-6 max-w-5xl mx-auto">
+          <div className="p-6 mx-auto" style={{ maxWidth: 1280 }}>
             <Outlet />
           </div>
         </main>

--- a/packages/web/src/components/ui/breadcrumb.tsx
+++ b/packages/web/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,55 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+type BreadcrumbProps = HTMLAttributes<HTMLDivElement>;
+
+export function Breadcrumb({ className, style, ...rest }: BreadcrumbProps) {
+  return (
+    <div
+      className={cn("flex items-center", className)}
+      style={{
+        gap: 6,
+        fontSize: 12,
+        color: "var(--fg-3)",
+        ...style,
+      }}
+      {...rest}
+    />
+  );
+}
+
+type BreadcrumbLinkProps = {
+  onClick?: () => void;
+  children: ReactNode;
+};
+
+export function BreadcrumbLink({ onClick, children }: BreadcrumbLinkProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="bg-transparent border-0 p-0 cursor-pointer"
+      style={{ color: "var(--fg-3)", textDecoration: "none", font: "inherit" }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.color = "var(--fg)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = "var(--fg-3)";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function BreadcrumbSep() {
+  return <span style={{ color: "var(--fg-4)" }}>/</span>;
+}
+
+export function BreadcrumbCurrent({ children, mono }: { children: ReactNode; mono?: boolean }) {
+  return (
+    <span className={mono ? "mono" : undefined} style={{ color: "var(--fg)", fontWeight: 500 }}>
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -18,6 +18,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
+        xs: "h-7 rounded px-2.5 text-xs gap-1.5",
         lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",
       },

--- a/packages/web/src/components/ui/dense-badge.tsx
+++ b/packages/web/src/components/ui/dense-badge.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+import { cn } from "../../lib/utils.js";
+
+export type DenseBadgeTone = "neutral" | "accent" | "warn" | "error" | "outline";
+
+type DenseBadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  tone?: DenseBadgeTone;
+};
+
+// Mirrors the Badge atom in design-canvas/atoms.jsx:
+//   mono / 10px / uppercase / padding 1px 7px / radius 3 / 1px border.
+// shadcn Badge is 12px + rounded-md and reads as "chunky" in dense panels.
+export function DenseBadge({ tone = "neutral", className, style, ...rest }: DenseBadgeProps) {
+  const t = TONE_STYLES[tone];
+  const merged: CSSProperties = {
+    background: t.bg,
+    color: t.fg,
+    border: `1px solid ${t.bd}`,
+    ...style,
+  };
+  return (
+    <span
+      className={cn("mono inline-flex items-center uppercase", className)}
+      style={{
+        fontSize: 10,
+        padding: "1px 7px",
+        borderRadius: 3,
+        letterSpacing: "0.06em",
+        lineHeight: 1.6,
+        ...merged,
+      }}
+      {...rest}
+    />
+  );
+}
+
+const TONE_STYLES: Record<DenseBadgeTone, { bg: string; fg: string; bd: string }> = {
+  neutral: { bg: "var(--bg-sunken)", fg: "var(--fg-2)", bd: "var(--border)" },
+  accent: {
+    bg: "var(--accent-bg)",
+    fg: "var(--accent-dim)",
+    bd: "color-mix(in oklch, var(--accent) 30%, transparent)",
+  },
+  warn: {
+    bg: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+    fg: "color-mix(in oklch, var(--state-blocked) 50%, var(--fg))",
+    bd: "color-mix(in oklch, var(--state-blocked) 30%, transparent)",
+  },
+  error: {
+    bg: "color-mix(in oklch, var(--state-error) 14%, transparent)",
+    fg: "var(--state-error)",
+    bd: "color-mix(in oklch, var(--state-error) 30%, transparent)",
+  },
+  outline: { bg: "transparent", fg: "var(--fg-3)", bd: "var(--border)" },
+};

--- a/packages/web/src/components/ui/dense-table.tsx
+++ b/packages/web/src/components/ui/dense-table.tsx
@@ -1,0 +1,90 @@
+import { forwardRef, type HTMLAttributes, type TdHTMLAttributes, type ThHTMLAttributes } from "react";
+import { cn } from "../../lib/utils.js";
+
+// Dense table variant aligned with the workspace page redesigns:
+// - 9.5px uppercase mono column headers with letter-spacing
+// - 12px cell body text, 9px vertical padding
+// - Hairline row separators
+// - No outer border (meant to live inside a Panel).
+
+const DenseTable = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <table
+    ref={ref}
+    className={cn("w-full", className)}
+    style={{ borderCollapse: "separate", borderSpacing: 0 }}
+    {...props}
+  />
+));
+DenseTable.displayName = "DenseTable";
+
+const DenseTableHeader = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <thead ref={ref} className={className} {...props} />,
+);
+DenseTableHeader.displayName = "DenseTableHeader";
+
+const DenseTableBody = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <tbody ref={ref} className={className} {...props} />,
+);
+DenseTableBody.displayName = "DenseTableBody";
+
+type DenseRowProps = HTMLAttributes<HTMLTableRowElement> & {
+  interactive?: boolean;
+  selected?: boolean;
+};
+
+const DenseTableRow = forwardRef<HTMLTableRowElement, DenseRowProps>(
+  ({ className, interactive, selected, style, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn("transition-colors", className)}
+      data-interactive={interactive ? "" : undefined}
+      data-selected={selected ? "" : undefined}
+      style={{
+        background: selected ? "var(--bg-active)" : undefined,
+        cursor: interactive ? "pointer" : undefined,
+        ...style,
+      }}
+      {...props}
+    />
+  ),
+);
+DenseTableRow.displayName = "DenseTableRow";
+
+const DenseTableHead = forwardRef<HTMLTableCellElement, ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, style, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn("mono text-left uppercase font-medium whitespace-nowrap", className)}
+      style={{
+        padding: "8px 12px",
+        fontSize: 9.5,
+        letterSpacing: "0.09em",
+        color: "var(--fg-4)",
+        background: "var(--bg-sunken)",
+        borderBottom: "1px solid var(--border)",
+        ...style,
+      }}
+      {...props}
+    />
+  ),
+);
+DenseTableHead.displayName = "DenseTableHead";
+
+const DenseTableCell = forwardRef<HTMLTableCellElement, TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, style, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn("align-middle", className)}
+      style={{
+        padding: "9px 12px",
+        borderBottom: "1px solid var(--border-faint)",
+        fontSize: 12,
+        ...style,
+      }}
+      {...props}
+    />
+  ),
+);
+DenseTableCell.displayName = "DenseTableCell";
+
+export { DenseTable, DenseTableBody, DenseTableCell, DenseTableHead, DenseTableHeader, DenseTableRow };

--- a/packages/web/src/components/ui/filter-pill.tsx
+++ b/packages/web/src/components/ui/filter-pill.tsx
@@ -1,0 +1,41 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+type FilterPillProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean;
+  count?: ReactNode;
+  warn?: boolean;
+};
+
+export function FilterPill({ active, count, warn, className, children, style, ...rest }: FilterPillProps) {
+  return (
+    <button
+      type="button"
+      className={cn("mono inline-flex items-center gap-1", className)}
+      style={{
+        fontSize: 10,
+        lineHeight: 1.6,
+        padding: "2px 7px",
+        borderRadius: 3,
+        border: `1px solid ${active ? "var(--border-strong)" : "var(--border)"}`,
+        background: active ? "var(--bg-active)" : "transparent",
+        color: active ? "var(--fg)" : "var(--fg-3)",
+        cursor: "pointer",
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+      {count !== undefined && (
+        <span
+          className="mono"
+          style={{
+            color: warn && typeof count === "number" && count > 0 ? "var(--state-error)" : "var(--fg-4)",
+          }}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/web/src/components/ui/page-header.tsx
+++ b/packages/web/src/components/ui/page-header.tsx
@@ -1,0 +1,38 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+type PageHeaderProps = HTMLAttributes<HTMLDivElement> & {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  right?: ReactNode;
+};
+
+export function PageHeader({ title, subtitle, right, className, style, ...rest }: PageHeaderProps) {
+  return (
+    <div
+      className={cn("flex items-baseline gap-3 shrink-0", className)}
+      style={{
+        padding: "12px 20px 10px",
+        borderBottom: "1px solid var(--border-faint)",
+        background: "var(--bg-raised)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <h1
+        className="m-0"
+        style={{
+          fontSize: 16,
+          fontWeight: 600,
+          letterSpacing: -0.2,
+          color: "var(--fg)",
+        }}
+      >
+        {title}
+      </h1>
+      {subtitle && <span style={{ fontSize: 11.5, color: "var(--fg-3)" }}>{subtitle}</span>}
+      <div style={{ flex: 1 }} />
+      {right}
+    </div>
+  );
+}

--- a/packages/web/src/components/ui/panel.tsx
+++ b/packages/web/src/components/ui/panel.tsx
@@ -1,0 +1,46 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "../../lib/utils.js";
+
+const Panel = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("overflow-hidden", className)}
+    style={{
+      background: "var(--bg-raised)",
+      border: "1px solid var(--border)",
+      borderRadius: 6,
+    }}
+    {...props}
+  />
+));
+Panel.displayName = "Panel";
+
+const PanelHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center justify-between gap-3", className)}
+    style={{
+      padding: "10px 14px",
+      borderBottom: "1px solid var(--border-faint)",
+    }}
+    {...props}
+  />
+));
+PanelHeader.displayName = "PanelHeader";
+
+const PanelTitle = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("inline-flex items-center gap-2 font-semibold text-[12px]", className)}
+    style={{ color: "var(--fg)" }}
+    {...props}
+  />
+));
+PanelTitle.displayName = "PanelTitle";
+
+const PanelBody = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn(className)} style={{ padding: "12px 14px" }} {...props} />
+));
+PanelBody.displayName = "PanelBody";
+
+export { Panel, PanelBody, PanelHeader, PanelTitle };

--- a/packages/web/src/components/ui/section-header.tsx
+++ b/packages/web/src/components/ui/section-header.tsx
@@ -1,0 +1,43 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+type SectionHeaderProps = HTMLAttributes<HTMLDivElement> & {
+  children: ReactNode;
+  right?: ReactNode;
+};
+
+export function SectionHeader({ children, right, className, style, ...rest }: SectionHeaderProps) {
+  return (
+    <div
+      className={cn("mono flex items-center justify-between uppercase", className)}
+      style={{
+        padding: "7px 14px",
+        fontSize: 9,
+        letterSpacing: "0.12em",
+        color: "var(--fg-4)",
+        background: "var(--bg-raised)",
+        borderBottom: "1px solid var(--border-faint)",
+        ...style,
+      }}
+      {...rest}
+    >
+      <span>{children}</span>
+      {right}
+    </div>
+  );
+}
+
+export function UppercaseLabel({ className, style, ...rest }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn("mono uppercase", className)}
+      style={{
+        fontSize: 10,
+        letterSpacing: "0.08em",
+        color: "var(--fg-3)",
+        ...style,
+      }}
+      {...rest}
+    />
+  );
+}

--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -1,0 +1,71 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+// Workspace-style underline tab bar.
+//
+// Usage:
+//   <TabBar>
+//     <Tab active>Members<TabBadge>5</TabBadge></Tab>
+//     <Tab>All agents<TabBadge>12</TabBadge></Tab>
+//   </TabBar>
+
+type TabBarProps = HTMLAttributes<HTMLDivElement>;
+
+export function TabBar({ className, style, ...rest }: TabBarProps) {
+  return (
+    <div
+      className={cn("flex items-end", className)}
+      style={{
+        gap: 2,
+        height: 34,
+        padding: "0 20px",
+        borderBottom: "1px solid var(--border)",
+        background: "var(--bg-raised)",
+        ...style,
+      }}
+      {...rest}
+    />
+  );
+}
+
+type TabProps = {
+  active?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+};
+
+export function Tab({ active, onClick, children }: TabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 bg-transparent"
+      style={{
+        padding: "7px 12px",
+        marginBottom: -1,
+        borderBottom: `2px solid ${active ? "var(--accent)" : "transparent"}`,
+        fontSize: 12,
+        fontWeight: 500,
+        color: active ? "var(--fg)" : "var(--fg-3)",
+        cursor: "pointer",
+        transition: "color 0.12s",
+      }}
+      onMouseEnter={(e) => {
+        if (!active) e.currentTarget.style.color = "var(--fg)";
+      }}
+      onMouseLeave={(e) => {
+        if (!active) e.currentTarget.style.color = "var(--fg-3)";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="mono" style={{ fontSize: 10, color: "var(--fg-4)" }}>
+      {children}
+    </span>
+  );
+}

--- a/packages/web/src/components/ui/tile.tsx
+++ b/packages/web/src/components/ui/tile.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+type TileProps = {
+  label: ReactNode;
+  value: ReactNode;
+  accent?: string;
+};
+
+export function Tile({ label, value, accent }: TileProps) {
+  return (
+    <div
+      style={{
+        padding: "8px 10px",
+        background: "var(--bg-sunken)",
+        borderRadius: 4,
+      }}
+    >
+      <div
+        className="mono uppercase"
+        style={{
+          fontSize: 9,
+          letterSpacing: "0.08em",
+          color: "var(--fg-4)",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        className="mono"
+        style={{
+          fontSize: 15,
+          fontWeight: 600,
+          color: accent ?? "var(--fg)",
+          marginTop: 1,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -235,3 +235,8 @@
 .fade-in {
   animation: subtle-fade 180ms ease-out;
 }
+
+/* Dense table row hover — used by DenseTableRow[data-interactive] */
+tr[data-interactive]:hover {
+  background: var(--bg-hover);
+}

--- a/packages/web/src/pages/admin-all-agents.tsx
+++ b/packages/web/src/pages/admin-all-agents.tsx
@@ -1,94 +1,103 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { listAllAgentsForAdmin } from "../api/agents.js";
-import { Badge } from "../components/ui/badge.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "../components/ui/dense-table.js";
+import { Panel } from "../components/ui/panel.js";
+import { SectionHeader } from "../components/ui/section-header.js";
 import { useMemberNameMap } from "../lib/use-member-name-map.js";
 import { formatDate } from "../lib/utils.js";
 
 /**
  * Admin-only view of every agent in the organization, including private ones
- * owned by other members. The default `/agents` list still applies the
- * visibility filter (Rule: visibility != manageability); this page is the
- * manageability-oriented view used to troubleshoot or reassign.
+ * owned by other members.
  */
 export function AdminAllAgentsPage() {
   const navigate = useNavigate();
   const resolveMember = useMemberNameMap();
 
-  // `paginationQuerySchema` caps `limit` at 100 server-side. Stay at the max
-  // here — if the org grows past 100 agents we'll need cursor pagination
-  // (same story as the rest of the admin list views).
   const { data, isLoading, error } = useQuery({
     queryKey: ["admin-all-agents"],
     queryFn: () => listAllAgentsForAdmin({ limit: 100 }),
   });
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">
-        Every agent in the organization, including private agents owned by other members. Use this view to troubleshoot
-        or reassign — the regular Agents page still hides private agents you don't manage.
+    <div>
+      <p style={{ fontSize: 11.5, color: "var(--fg-3)", padding: "0 2px 10px" }}>
+        Every agent in the organization — including private agents owned by other members. Use this view to troubleshoot
+        or reassign.
       </p>
 
-      <div className="border rounded-lg">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Display Name</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Visibility</TableHead>
-              <TableHead>Owner</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Created</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  Loading...
-                </TableCell>
-              </TableRow>
-            ) : error ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-destructive">
-                  Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
-                </TableCell>
-              </TableRow>
-            ) : !data || data.items.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  No agents
-                </TableCell>
-              </TableRow>
-            ) : (
-              data.items.map((a) => (
-                <TableRow
+      <Panel>
+        <SectionHeader>All agents · {data?.items.length ?? 0}</SectionHeader>
+        {isLoading ? (
+          <div className="text-center py-8" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            Loading…
+          </div>
+        ) : error ? (
+          <div className="text-center py-8" style={{ color: "var(--state-error)", fontSize: 12 }}>
+            Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
+          </div>
+        ) : !data || data.items.length === 0 ? (
+          <div className="text-center py-8" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            No agents
+          </div>
+        ) : (
+          <DenseTable>
+            <DenseTableHeader>
+              <DenseTableRow>
+                <DenseTableHead>Name</DenseTableHead>
+                <DenseTableHead>Display</DenseTableHead>
+                <DenseTableHead>Type</DenseTableHead>
+                <DenseTableHead>Visibility</DenseTableHead>
+                <DenseTableHead>Owner</DenseTableHead>
+                <DenseTableHead>Status</DenseTableHead>
+                <DenseTableHead>Created</DenseTableHead>
+              </DenseTableRow>
+            </DenseTableHeader>
+            <DenseTableBody>
+              {data.items.map((a) => (
+                <DenseTableRow
                   key={a.uuid}
-                  className="cursor-pointer"
+                  interactive
                   onClick={() => navigate(`/agents/${encodeURIComponent(a.uuid)}`)}
                 >
-                  <TableCell className="font-mono text-sm">{a.name ?? a.uuid.slice(0, 8)}</TableCell>
-                  <TableCell>{a.displayName ?? "—"}</TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">{a.type}</Badge>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={a.visibility === "organization" ? "default" : "outline"}>{a.visibility}</Badge>
-                  </TableCell>
-                  <TableCell className="text-sm">{a.managerId ? resolveMember(a.managerId) : "—"}</TableCell>
-                  <TableCell>
-                    <Badge variant={a.status === "active" ? "default" : "secondary"}>{a.status}</Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">{formatDate(a.createdAt)}</TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+                  <DenseTableCell>
+                    <span className="mono" style={{ fontSize: 12, fontWeight: 500 }}>
+                      {a.name ?? a.uuid.slice(0, 8)}
+                    </span>
+                  </DenseTableCell>
+                  <DenseTableCell style={{ color: "var(--fg-2)" }}>{a.displayName ?? "—"}</DenseTableCell>
+                  <DenseTableCell>
+                    <DenseBadge tone={a.type === "autonomous_agent" ? "accent" : "neutral"}>{a.type}</DenseBadge>
+                  </DenseTableCell>
+                  <DenseTableCell>
+                    <DenseBadge tone={a.visibility === "organization" ? "accent" : "outline"}>
+                      {a.visibility}
+                    </DenseBadge>
+                  </DenseTableCell>
+                  <DenseTableCell style={{ fontSize: 11.5, color: "var(--fg-2)" }}>
+                    {a.managerId ? resolveMember(a.managerId) : "—"}
+                  </DenseTableCell>
+                  <DenseTableCell>
+                    <DenseBadge tone={a.status === "active" ? "accent" : "neutral"}>{a.status}</DenseBadge>
+                  </DenseTableCell>
+                  <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                    {formatDate(a.createdAt)}
+                  </DenseTableCell>
+                </DenseTableRow>
+              ))}
+            </DenseTableBody>
+          </DenseTable>
+        )}
+      </Panel>
     </div>
   );
 }

--- a/packages/web/src/pages/admin.tsx
+++ b/packages/web/src/pages/admin.tsx
@@ -1,14 +1,15 @@
 import { Navigate, useLocation, useNavigate } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
-import { cn } from "../lib/utils.js";
+import { PageHeader } from "../components/ui/page-header.js";
+import { Tab, TabBar } from "../components/ui/tab-bar.js";
 import { AdminAllAgentsPage } from "./admin-all-agents.js";
 import { MembersPage } from "./members.js";
 import { OrgSettingsPage } from "./org-settings.js";
 
 const tabs = [
   { key: "members", label: "Members" },
-  { key: "all-agents", label: "All Agents" },
-  { key: "settings", label: "Org Settings" },
+  { key: "all-agents", label: "All agents" },
+  { key: "settings", label: "Org settings" },
 ] as const;
 
 type TabKey = (typeof tabs)[number]["key"];
@@ -18,13 +19,8 @@ export function AdminPage() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // `role` is null until the first `/me` response lands. Rendering the
-  // admin shell while we wait would flash admin-only UI to a non-admin
-  // for a tick — gate on role being resolved. Server-side enforcement
-  // still lives on the individual admin routes; this is only here to
-  // keep the UI honest during the loading window.
   if (role === null) {
-    return <div className="text-sm text-muted-foreground">Loading…</div>;
+    return <div style={{ padding: 20, color: "var(--fg-3)", fontSize: 12 }}>Loading…</div>;
   }
   if (role !== "admin") {
     return <Navigate to="/settings" replace />;
@@ -38,28 +34,20 @@ export function AdminPage() {
   };
 
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-4">Admin</h1>
-      <div className="flex gap-1 border-b border-border mb-6">
+    <div className="-m-6">
+      <PageHeader title="Admin" subtitle="Organization-wide controls" />
+      <TabBar>
         {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            type="button"
-            onClick={() => switchTab(tab.key)}
-            className={cn(
-              "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-              active === tab.key
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
+          <Tab key={tab.key} active={active === tab.key} onClick={() => switchTab(tab.key)}>
             {tab.label}
-          </button>
+          </Tab>
         ))}
+      </TabBar>
+      <div style={{ padding: "16px 20px 28px" }}>
+        {active === "members" && <MembersPage />}
+        {active === "all-agents" && <AdminAllAgentsPage />}
+        {active === "settings" && <OrgSettingsPage />}
       </div>
-      {active === "members" && <MembersPage />}
-      {active === "all-agents" && <AdminAllAgentsPage />}
-      {active === "settings" && <OrgSettingsPage />}
     </div>
   );
 }

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1,7 +1,7 @@
 import { ADAPTER_PLATFORMS } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Cable, Link2, MoreHorizontal, Play, Plus, Trash2 } from "lucide-react";
-import { type FormEvent, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { Cable, Link2, Play, Plus, Trash2 } from "lucide-react";
+import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { type HubClient, listClients } from "./../api/activity.js";
 import { createAdapterMapping, deleteAdapterMapping, listAdapterMappings } from "./../api/adapter-mappings.js";
@@ -25,13 +25,25 @@ import {
 } from "./../api/agents.js";
 import { ApiError } from "./../api/client.js";
 import { listAgentSessions } from "./../api/sessions.js";
-import { Badge } from "./../components/ui/badge.js";
+import { FirstTreeLogo } from "./../components/first-tree-logo.js";
+import { Breadcrumb, BreadcrumbCurrent, BreadcrumbLink, BreadcrumbSep } from "./../components/ui/breadcrumb.js";
 import { Button } from "./../components/ui/button.js";
-import { Card, CardContent, CardHeader, CardTitle } from "./../components/ui/card.js";
+import { DenseBadge, type DenseBadgeTone } from "./../components/ui/dense-badge.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "./../components/ui/dense-table.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./../components/ui/dialog.js";
 import { Input } from "./../components/ui/input.js";
 import { Label } from "./../components/ui/label.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./../components/ui/table.js";
+import { Panel } from "./../components/ui/panel.js";
+import { UppercaseLabel } from "./../components/ui/section-header.js";
+import { StateChip } from "./../components/ui/state-chip.js";
+import { Tile } from "./../components/ui/tile.js";
 import { cn, formatDate } from "./../lib/utils.js";
 import { DangerZone } from "./agent-detail/danger-zone.js";
 import { EnvSection } from "./agent-detail/env-section.js";
@@ -41,10 +53,42 @@ import { McpSection } from "./agent-detail/mcp-section.js";
 import { ModelSection } from "./agent-detail/model-section.js";
 import { PromptSection } from "./agent-detail/prompt-section.js";
 import { SaveBar, sectionAnchorId } from "./agent-detail/save-bar.js";
-import { deriveSaveHint, StatusBar } from "./agent-detail/status-bar.js";
-import { type DraftSectionName, useConfigDraft } from "./agent-detail/use-config-draft.js";
+import { deriveSaveHint } from "./agent-detail/status-bar.js";
+import { useConfigDraft } from "./agent-detail/use-config-draft.js";
 
 const platformValues = Object.values(ADAPTER_PLATFORMS);
+
+type SidebarItem = {
+  key: string;
+  label: string;
+  anchor: string;
+};
+
+type SidebarGroup = {
+  label: string;
+  items: SidebarItem[];
+};
+
+function buildSidebar(isHuman: boolean): SidebarGroup[] {
+  const identity: SidebarItem[] = [
+    { key: "identity", label: "Profile", anchor: "ad-identity" },
+    { key: "bindings", label: "Bindings", anchor: "ad-bindings" },
+  ];
+  const runtime: SidebarItem[] = isHuman
+    ? []
+    : [
+        { key: "prompt", label: "Prompt", anchor: sectionAnchorId("prompt") },
+        { key: "model", label: "Model", anchor: sectionAnchorId("model") },
+        { key: "mcp", label: "MCP tools", anchor: sectionAnchorId("mcp") },
+        { key: "env", label: "Environment", anchor: sectionAnchorId("env") },
+        { key: "git", label: "Git", anchor: sectionAnchorId("git") },
+      ];
+  const danger: SidebarItem[] = [{ key: "danger", label: "Danger zone", anchor: "ad-danger" }];
+  const groups: SidebarGroup[] = [{ label: "Identity", items: identity }];
+  if (runtime.length > 0) groups.push({ label: "Runtime", items: runtime });
+  groups.push({ label: "Danger zone", items: danger });
+  return groups;
+}
 
 export function AgentDetailPage() {
   const params = useParams<{ uuid: string }>();
@@ -121,8 +165,8 @@ export function AgentDetailPage() {
     draft.resetAll();
   }, [queryClient, uuid, draft]);
 
-  const jumpTo = useCallback((section: DraftSectionName) => {
-    const el = document.getElementById(sectionAnchorId(section));
+  const jumpTo = useCallback((anchor: string) => {
+    const el = document.getElementById(anchor);
     if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
@@ -152,18 +196,6 @@ export function AgentDetailPage() {
   // Test connection
   const testMutation = useMutation({ mutationFn: () => testAgentConnection(uuid) });
 
-  // Header ⋯ menu + binding dialogs
-  const [moreOpen, setMoreOpen] = useState(false);
-  const moreRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (!moreOpen) return;
-    function onClickAway(e: MouseEvent) {
-      if (moreRef.current && !moreRef.current.contains(e.target as Node)) setMoreOpen(false);
-    }
-    window.addEventListener("mousedown", onClickAway);
-    return () => window.removeEventListener("mousedown", onClickAway);
-  }, [moreOpen]);
-
   // Bind-client (agent ↔ client first-time binding) dialog state
   const [bindClientOpen, setBindClientOpen] = useState(false);
   const [bindClientSelected, setBindClientSelected] = useState<string>("");
@@ -186,7 +218,6 @@ export function AgentDetailPage() {
     onError: (err) => setBindClientError(err instanceof Error ? err.message : String(err)),
   });
 
-  // Binding dialog state (unchanged from previous)
   const [bindingDialogOpen, setBindingDialogOpen] = useState(false);
   const [bindingEditId, setBindingEditId] = useState<number | null>(null);
   const [bindingForm, setBindingForm] = useState(EMPTY_BINDING_FORM);
@@ -243,7 +274,6 @@ export function AgentDetailPage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["adapter-mappings"] }),
   });
 
-  // Dry-run (surfaced via small helper button next to Save)
   const [dryRunText, setDryRunText] = useState<string | null>(null);
   const dryRunMutation = useMutation({
     mutationFn: () => dryRunAgentConfig(uuid, draft.buildPayloadPatch()),
@@ -265,16 +295,33 @@ export function AgentDetailPage() {
     return () => window.removeEventListener("beforeunload", handler);
   }, [draft.summary.anyDirty]);
 
-  if (agentQuery.isLoading) return <div className="text-muted-foreground">Loading...</div>;
+  const isHumanLocal = agentQuery.data?.type === "human";
+  const sidebarGroups = useMemo(() => buildSidebar(isHumanLocal), [isHumanLocal]);
+
+  if (agentQuery.isLoading) {
+    return (
+      <div className="-m-6 flex" style={{ minHeight: "100%" }}>
+        <div className="p-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+          Loading…
+        </div>
+      </div>
+    );
+  }
   if (agentQuery.error) {
     return (
-      <div className="text-destructive">
+      <div className="-m-6 p-6" style={{ color: "var(--state-error)", fontSize: 12 }}>
         Failed to load agent: {agentQuery.error instanceof Error ? agentQuery.error.message : "Unknown error"}
       </div>
     );
   }
   const agent = agentQuery.data;
-  if (!agent) return <div className="text-muted-foreground">Agent not found</div>;
+  if (!agent) {
+    return (
+      <div className="-m-6 p-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+        Agent not found
+      </div>
+    );
+  }
 
   const isHuman = agent.type === "human";
 
@@ -286,8 +333,10 @@ export function AgentDetailPage() {
   const runtimeExt = agent as Record<string, unknown>;
   const runtimeState = (runtimeExt.runtimeState as string | null) ?? null;
   const runtimeType = (runtimeExt.runtimeType as string | null) ?? null;
+  const totalSessions = (runtimeExt.totalSessions as number | null) ?? null;
 
-  // -- helpers local to this component
+  const shortId = agent.uuid.slice(0, 8);
+
   function closeBindingDialog() {
     setBindingDialogOpen(false);
     setBindingEditId(null);
@@ -369,372 +418,440 @@ export function AgentDetailPage() {
         .filter(Boolean),
     );
 
+  const tileValues = {
+    sessions: totalSessions ?? "—",
+    active: activeSessions,
+    runtime: runtimeType ?? (isHuman ? "human" : "—"),
+    model: cfgQuery.data?.payload.model?.trim() || "—",
+  };
+
   return (
-    <div className="space-y-5 pb-24">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Button variant="ghost" size="icon" onClick={() => navigate("/agents")}>
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
-        <div className="flex-1 min-w-0">
-          <h1 className="text-2xl font-semibold truncate">{agent.displayName ?? agent.name}</h1>
-          <p className="text-xs text-muted-foreground font-mono truncate">
-            @{agent.name ?? agent.uuid} · {agent.type}
-          </p>
+    <div className="-m-6 flex" style={{ minHeight: "calc(100vh - 40px)" }}>
+      <aside
+        className="shrink-0 overflow-auto"
+        style={{
+          width: 220,
+          borderRight: "1px solid var(--border)",
+          background: "var(--bg-raised)",
+          padding: "12px 0",
+        }}
+      >
+        {sidebarGroups.map((group) => (
+          <div key={group.label} style={{ marginBottom: 12 }}>
+            <UppercaseLabel style={{ display: "block", padding: "4px 16px" }}>{group.label}</UppercaseLabel>
+            {group.items.map((it) => (
+              <button
+                key={it.key}
+                type="button"
+                onClick={() => jumpTo(it.anchor)}
+                className="block w-full text-left bg-transparent"
+                style={{
+                  padding: "5px 16px 5px 14px",
+                  fontSize: 12,
+                  color: "var(--fg-3)",
+                  border: "none",
+                  borderLeft: "2px solid transparent",
+                  cursor: "pointer",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.color = "var(--fg)";
+                  e.currentTarget.style.background = "var(--bg-hover)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.color = "var(--fg-3)";
+                  e.currentTarget.style.background = "transparent";
+                }}
+              >
+                {it.label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </aside>
+
+      <div className="flex-1 min-w-0 overflow-auto" style={{ background: "var(--bg)" }}>
+        <div
+          style={{
+            padding: "14px 20px",
+            borderBottom: "1px solid var(--border-faint)",
+            background: "var(--bg-raised)",
+          }}
+        >
+          <Breadcrumb style={{ marginBottom: 8 }}>
+            <BreadcrumbLink onClick={() => navigate("/agents")}>Agents</BreadcrumbLink>
+            <BreadcrumbSep />
+            <BreadcrumbCurrent mono>{agent.name ?? shortId}</BreadcrumbCurrent>
+          </Breadcrumb>
+          <div className="flex items-center gap-3">
+            <div
+              className="inline-flex items-center justify-center"
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 6,
+                background: "var(--bg-active)",
+                border: "1px solid var(--border-strong)",
+              }}
+            >
+              <FirstTreeLogo width={18} height={20} style={{ color: "var(--accent)" }} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-baseline gap-2">
+                <span style={{ fontSize: 16, fontWeight: 600, letterSpacing: -0.2 }}>
+                  {agent.displayName ?? agent.name ?? shortId}
+                </span>
+                <span className="mono" style={{ fontSize: 11, color: "var(--fg-4)" }}>
+                  @{agent.name ?? shortId}
+                </span>
+              </div>
+              <div className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                agt_{shortId} · {agent.type}
+                {agent.visibility ? ` · ${agent.visibility}` : ""}
+              </div>
+            </div>
+            <StateChip state={runtimeState} />
+            <div className="flex gap-1.5">
+              <Button variant="ghost" size="xs" onClick={() => navigate(`/?a=${agent.uuid}`)}>
+                Open chat →
+              </Button>
+              {!isHuman && agent.status === "active" && (
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => {
+                    testMutation.reset();
+                    testMutation.mutate();
+                  }}
+                  disabled={testMutation.isPending}
+                >
+                  <Play className="h-3 w-3" />
+                  {testMutation.isPending ? "Testing…" : "Test"}
+                </Button>
+              )}
+            </div>
+          </div>
+          <div className="grid gap-1.5 mt-3" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
+            <Tile label="sessions" value={tileValues.sessions} />
+            <Tile
+              label="active"
+              value={tileValues.active}
+              accent={typeof tileValues.active === "number" && tileValues.active > 0 ? "var(--accent)" : undefined}
+            />
+            <Tile label="runtime" value={tileValues.runtime} />
+            <Tile label="model" value={tileValues.model} />
+          </div>
         </div>
-        <div className="relative" ref={moreRef}>
-          <Button variant="outline" size="icon" onClick={() => setMoreOpen((v) => !v)} title="More actions">
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-          {moreOpen && (
-            <div className="absolute right-0 mt-1 z-40 min-w-48 rounded-md border bg-white shadow-lg text-sm">
-              <ul className="py-1">
-                {!isHuman && agent.status === "active" && (
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMoreOpen(false);
-                        testMutation.reset();
-                        testMutation.mutate();
-                      }}
-                      className="w-full text-left px-3 py-1.5 hover:bg-gray-50 flex items-center gap-2"
-                      disabled={testMutation.isPending}
-                    >
-                      <Play className="h-3.5 w-3.5" />
-                      {testMutation.isPending ? "Testing…" : "Test connection"}
-                    </button>
-                  </li>
-                )}
-                {agent.status === "active" ? (
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMoreOpen(false);
-                        if (confirm("Suspend this agent? All tokens will be revoked.")) {
-                          suspendMutation.mutate();
-                        }
-                      }}
-                      className="w-full text-left px-3 py-1.5 hover:bg-gray-50"
-                    >
-                      Suspend
-                    </button>
-                  </li>
-                ) : (
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMoreOpen(false);
-                        reactivateMutation.mutate();
-                      }}
-                      className="w-full text-left px-3 py-1.5 hover:bg-gray-50"
-                    >
-                      Reactivate
-                    </button>
-                  </li>
-                )}
-                <li className="border-t">
-                  <a
-                    href={`#${sectionAnchorId("prompt")}`}
-                    onClick={() => setMoreOpen(false)}
-                    className="block px-3 py-1.5 text-xs text-muted-foreground hover:bg-gray-50"
-                  >
-                    Jump to Behavior
-                  </a>
-                </li>
-              </ul>
+
+        <div
+          className="mx-auto"
+          style={{ padding: "14px 20px 28px", maxWidth: 960, display: "flex", flexDirection: "column", gap: 16 }}
+        >
+          {(testMutation.data || testMutation.error) && (
+            <TestResultCard
+              result={testMutation.data ?? { status: "error", message: "Failed to reach server" }}
+              onDismiss={() => testMutation.reset()}
+            />
+          )}
+
+          {isUnclaimed && agent.status === "active" && (
+            <div
+              className="flex items-center justify-between gap-3"
+              style={{
+                borderRadius: 6,
+                padding: "10px 14px",
+                background: "color-mix(in oklch, var(--state-blocked) 10%, transparent)",
+                border: "1px solid color-mix(in oklch, var(--state-blocked) 28%, transparent)",
+              }}
+            >
+              <div style={{ fontSize: 12 }}>
+                <div style={{ fontWeight: 500 }}>No computer bound</div>
+                <div style={{ color: "var(--fg-3)", fontSize: 11 }}>
+                  Bind this agent to a computer so it can run. A computer will also claim it on first WebSocket connect.
+                </div>
+              </div>
+              <Button size="xs" variant="outline" onClick={() => setBindClientOpen(true)}>
+                <Link2 className="h-3 w-3" />
+                Bind computer
+              </Button>
             </div>
           )}
-        </div>
-      </div>
 
-      {(testMutation.data || testMutation.error) && (
-        <TestResultCard
-          result={testMutation.data ?? { status: "error", message: "Failed to reach server" }}
-          onDismiss={() => testMutation.reset()}
-        />
-      )}
-
-      {/* Status Bar */}
-      <StatusBar
-        agent={agent}
-        cfg={cfgQuery.data}
-        clientStatus={clientStatus}
-        runtimeState={runtimeState}
-        runtimeType={runtimeType}
-        activeSessions={activeSessions}
-        isHuman={isHuman}
-      />
-
-      {isUnclaimed && agent.status === "active" && (
-        <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 flex items-center justify-between gap-3">
-          <div className="text-sm text-amber-900">
-            <div className="font-medium">No computer bound</div>
-            <div className="text-xs text-amber-800/80">
-              Bind this agent to a computer so it can run. A computer will also claim it on first WebSocket connect.
-            </div>
-          </div>
-          <Button size="sm" variant="outline" onClick={() => setBindClientOpen(true)}>
-            <Link2 className="h-4 w-4 mr-2" />
-            Bind Computer
-          </Button>
-        </div>
-      )}
-
-      {/* Identity */}
-      <IdentitySection
-        agent={agent}
-        onSave={async (patch) => {
-          await identityUpdateMutation.mutateAsync(patch);
-        }}
-      />
-
-      {/* Behavior */}
-      {!isHuman && (
-        <BehaviorSection
-          loaded={!!cfgQuery.data}
-          loading={cfgQuery.isLoading}
-          error={cfgQuery.error ? String(cfgQuery.error) : null}
-          version={cfgQuery.data?.version ?? null}
-          dirty={draft.summary.anyDirty}
-        >
-          <div id={sectionAnchorId("prompt")}>
-            <PromptSection
-              value={draft.draft.promptAppend}
-              baseline={cfgQuery.data?.payload.prompt.append ?? ""}
-              onChange={draft.setPromptAppend}
-              onRevert={draft.revertPrompt}
-              disabled={agent.status !== "active"}
+          <div id="ad-identity">
+            <IdentitySection
+              agent={agent}
+              onSave={async (patch) => {
+                await identityUpdateMutation.mutateAsync(patch);
+              }}
             />
           </div>
-          <div id={sectionAnchorId("model")}>
-            <ModelSection
-              value={draft.draft.model}
-              baseline={cfgQuery.data?.payload.model ?? ""}
-              onChange={draft.setModel}
-              onRevert={draft.revertModel}
-              disabled={agent.status !== "active"}
-            />
-          </div>
-          <div id={sectionAnchorId("mcp")}>
-            <McpSection
-              items={draft.draft.mcp}
-              otherNames={mcpOtherNames}
-              onAdd={draft.addMcp}
-              onUpdate={draft.updateMcp}
-              onDelete={draft.deleteMcp}
-              onUndoDelete={draft.undoDeleteMcp}
-              disabled={agent.status !== "active"}
-            />
-          </div>
-          <div id={sectionAnchorId("env")}>
-            <EnvSection
-              items={draft.draft.env}
-              otherKeys={envOtherKeys}
-              onAdd={draft.addEnv}
-              onUpdate={draft.updateEnv}
-              onDelete={draft.deleteEnv}
-              onUndoDelete={draft.undoDeleteEnv}
-              disabled={agent.status !== "active"}
-            />
-          </div>
-          <div id={sectionAnchorId("git")}>
-            <GitSection
-              items={draft.draft.git}
-              otherPaths={gitOtherPaths}
-              onAdd={draft.addGit}
-              onUpdate={draft.updateGit}
-              onDelete={draft.deleteGit}
-              onUndoDelete={draft.undoDeleteGit}
-              disabled={agent.status !== "active"}
-            />
-          </div>
-          {dryRunText && <pre className="whitespace-pre-wrap rounded border bg-gray-50 p-2 text-xs">{dryRunText}</pre>}
-        </BehaviorSection>
-      )}
 
-      {/* Platform Bindings (secondary) */}
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-base">
-            {isHuman ? <Link2 className="h-4 w-4" /> : <Cable className="h-4 w-4" />}
-            Platform Bindings
-          </CardTitle>
-          <Button size="sm" variant="outline" onClick={() => setBindingDialogOpen(true)}>
-            <Plus className="h-4 w-4 mr-2" />
-            {isHuman ? "Bind User" : "Bind Bot"}
-          </Button>
-        </CardHeader>
-        <CardContent>
-          {isHuman ? (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Platform</TableHead>
-                  <TableHead>External User ID</TableHead>
-                  <TableHead>Display Name</TableHead>
-                  <TableHead>Bound Via</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead className="w-16" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {agentMappings.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={6} className="text-center py-4 text-muted-foreground">
-                      No platform bindings
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  agentMappings.map((m) => (
-                    <TableRow key={m.id}>
-                      <TableCell>
-                        <Badge variant="secondary">{m.platform}</Badge>
-                      </TableCell>
-                      <TableCell className="font-mono text-sm">{m.externalUserId}</TableCell>
-                      <TableCell>{m.displayName ?? "—"}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{m.boundVia ?? "—"}</Badge>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
-                      <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => {
-                            if (confirm("Remove this binding?")) deleteMappingMutation.mutate(m.id);
-                          }}
-                          disabled={deleteMappingMutation.isPending}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Platform</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Connection</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead className="w-24" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {agentAdapters.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center py-4 text-muted-foreground">
-                      No platform bindings
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  agentAdapters.map((a) => {
-                    const status = botStatuses?.find((s) => s.configId === a.id);
-                    const isConnected = a.platform === "kael" ? a.status === "active" : !!status?.connected;
-                    return (
-                      <TableRow key={a.id}>
-                        <TableCell>
-                          <Badge variant="secondary">{a.platform}</Badge>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={a.status === "active" ? "default" : "destructive"}>{a.status}</Badge>
-                        </TableCell>
-                        <TableCell>
-                          <span className="flex items-center gap-1.5">
-                            <span
-                              className={cn(
-                                "inline-block h-2 w-2 rounded-full",
-                                isConnected ? "bg-green-500" : "bg-gray-300",
-                              )}
-                            />
-                            <span className="text-xs text-muted-foreground">{isConnected ? "Online" : "Offline"}</span>
-                          </span>
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">{formatDate(a.createdAt)}</TableCell>
-                        <TableCell>
-                          <div className="flex gap-1">
-                            <Button variant="ghost" size="icon" onClick={() => openEditAdapter(a)} title="Edit">
-                              …
-                            </Button>
+          {!isHuman && (
+            <BehaviorSection
+              loaded={!!cfgQuery.data}
+              loading={cfgQuery.isLoading}
+              error={cfgQuery.error ? String(cfgQuery.error) : null}
+              version={cfgQuery.data?.version ?? null}
+              dirty={draft.summary.anyDirty}
+            >
+              <div id={sectionAnchorId("prompt")}>
+                <PromptSection
+                  value={draft.draft.promptAppend}
+                  baseline={cfgQuery.data?.payload.prompt.append ?? ""}
+                  onChange={draft.setPromptAppend}
+                  onRevert={draft.revertPrompt}
+                  disabled={agent.status !== "active"}
+                />
+              </div>
+              <div id={sectionAnchorId("model")}>
+                <ModelSection
+                  value={draft.draft.model}
+                  baseline={cfgQuery.data?.payload.model ?? ""}
+                  onChange={draft.setModel}
+                  onRevert={draft.revertModel}
+                  disabled={agent.status !== "active"}
+                />
+              </div>
+              <div id={sectionAnchorId("mcp")}>
+                <McpSection
+                  items={draft.draft.mcp}
+                  otherNames={mcpOtherNames}
+                  onAdd={draft.addMcp}
+                  onUpdate={draft.updateMcp}
+                  onDelete={draft.deleteMcp}
+                  onUndoDelete={draft.undoDeleteMcp}
+                  disabled={agent.status !== "active"}
+                />
+              </div>
+              <div id={sectionAnchorId("env")}>
+                <EnvSection
+                  items={draft.draft.env}
+                  otherKeys={envOtherKeys}
+                  onAdd={draft.addEnv}
+                  onUpdate={draft.updateEnv}
+                  onDelete={draft.deleteEnv}
+                  onUndoDelete={draft.undoDeleteEnv}
+                  disabled={agent.status !== "active"}
+                />
+              </div>
+              <div id={sectionAnchorId("git")}>
+                <GitSection
+                  items={draft.draft.git}
+                  otherPaths={gitOtherPaths}
+                  onAdd={draft.addGit}
+                  onUpdate={draft.updateGit}
+                  onDelete={draft.deleteGit}
+                  onUndoDelete={draft.undoDeleteGit}
+                  disabled={agent.status !== "active"}
+                />
+              </div>
+              {dryRunText && (
+                <pre
+                  className="whitespace-pre-wrap mono"
+                  style={{
+                    padding: 8,
+                    borderRadius: 4,
+                    background: "var(--bg-sunken)",
+                    border: "1px solid var(--border-faint)",
+                    fontSize: 11,
+                    color: "var(--fg-2)",
+                  }}
+                >
+                  {dryRunText}
+                </pre>
+              )}
+            </BehaviorSection>
+          )}
+
+          <div id="ad-bindings">
+            <Panel>
+              <div
+                className="flex items-center justify-between"
+                style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+              >
+                <div className="inline-flex items-center gap-2" style={{ fontSize: 12, fontWeight: 600 }}>
+                  {isHuman ? <Link2 className="h-3.5 w-3.5" /> : <Cable className="h-3.5 w-3.5" />}
+                  Platform bindings
+                </div>
+                <Button size="xs" variant="outline" onClick={() => setBindingDialogOpen(true)}>
+                  <Plus className="h-3 w-3" />
+                  {isHuman ? "Bind user" : "Bind bot"}
+                </Button>
+              </div>
+              {isHuman ? (
+                <DenseTable>
+                  <DenseTableHeader>
+                    <DenseTableRow>
+                      <DenseTableHead>Platform</DenseTableHead>
+                      <DenseTableHead>External user ID</DenseTableHead>
+                      <DenseTableHead>Display name</DenseTableHead>
+                      <DenseTableHead>Bound via</DenseTableHead>
+                      <DenseTableHead>Created</DenseTableHead>
+                      <DenseTableHead style={{ width: 32 }} />
+                    </DenseTableRow>
+                  </DenseTableHeader>
+                  <DenseTableBody>
+                    {agentMappings.length === 0 ? (
+                      <DenseTableRow>
+                        <DenseTableCell colSpan={6} style={{ textAlign: "center", color: "var(--fg-3)", padding: 16 }}>
+                          No platform bindings
+                        </DenseTableCell>
+                      </DenseTableRow>
+                    ) : (
+                      agentMappings.map((m) => (
+                        <DenseTableRow key={m.id}>
+                          <DenseTableCell>
+                            <DenseBadge>{m.platform}</DenseBadge>
+                          </DenseTableCell>
+                          <DenseTableCell className="mono" style={{ fontSize: 11 }}>
+                            {m.externalUserId}
+                          </DenseTableCell>
+                          <DenseTableCell>{m.displayName ?? "—"}</DenseTableCell>
+                          <DenseTableCell>
+                            <DenseBadge tone="outline">{m.boundVia ?? "—"}</DenseBadge>
+                          </DenseTableCell>
+                          <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                            {formatDate(m.createdAt)}
+                          </DenseTableCell>
+                          <DenseTableCell>
                             <Button
                               variant="ghost"
                               size="icon"
+                              className="h-7 w-7"
                               onClick={() => {
-                                if (confirm("Remove this bot binding?")) deleteAdapterMutation.mutate(a.id);
+                                if (confirm("Remove this binding?")) deleteMappingMutation.mutate(m.id);
                               }}
-                              disabled={deleteAdapterMutation.isPending}
-                              title="Delete"
+                              disabled={deleteMappingMutation.isPending}
                             >
-                              <Trash2 className="h-4 w-4" />
+                              <Trash2 className="h-3.5 w-3.5" />
                             </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })
-                )}
-              </TableBody>
-            </Table>
+                          </DenseTableCell>
+                        </DenseTableRow>
+                      ))
+                    )}
+                  </DenseTableBody>
+                </DenseTable>
+              ) : (
+                <DenseTable>
+                  <DenseTableHeader>
+                    <DenseTableRow>
+                      <DenseTableHead>Platform</DenseTableHead>
+                      <DenseTableHead>Status</DenseTableHead>
+                      <DenseTableHead>Connection</DenseTableHead>
+                      <DenseTableHead>Created</DenseTableHead>
+                      <DenseTableHead style={{ width: 64 }} />
+                    </DenseTableRow>
+                  </DenseTableHeader>
+                  <DenseTableBody>
+                    {agentAdapters.length === 0 ? (
+                      <DenseTableRow>
+                        <DenseTableCell colSpan={5} style={{ textAlign: "center", color: "var(--fg-3)", padding: 16 }}>
+                          No platform bindings
+                        </DenseTableCell>
+                      </DenseTableRow>
+                    ) : (
+                      agentAdapters.map((a) => {
+                        const status = botStatuses?.find((s) => s.configId === a.id);
+                        const isConnected = a.platform === "kael" ? a.status === "active" : !!status?.connected;
+                        return (
+                          <DenseTableRow key={a.id}>
+                            <DenseTableCell>
+                              <DenseBadge>{a.platform}</DenseBadge>
+                            </DenseTableCell>
+                            <DenseTableCell>
+                              <DenseBadge tone={a.status === "active" ? "accent" : "outline"}>{a.status}</DenseBadge>
+                            </DenseTableCell>
+                            <DenseTableCell>
+                              <StateChip state={isConnected ? "idle" : "offline"} />
+                            </DenseTableCell>
+                            <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                              {formatDate(a.createdAt)}
+                            </DenseTableCell>
+                            <DenseTableCell>
+                              <div className="flex gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  onClick={() => openEditAdapter(a)}
+                                  title="Edit"
+                                >
+                                  …
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  onClick={() => {
+                                    if (confirm("Remove this bot binding?")) deleteAdapterMutation.mutate(a.id);
+                                  }}
+                                  disabled={deleteAdapterMutation.isPending}
+                                  title="Delete"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </div>
+                            </DenseTableCell>
+                          </DenseTableRow>
+                        );
+                      })
+                    )}
+                  </DenseTableBody>
+                </DenseTable>
+              )}
+            </Panel>
+          </div>
+
+          <div id="ad-danger">
+            <DangerZone
+              agent={agent}
+              suspendPending={suspendMutation.isPending}
+              reactivatePending={reactivateMutation.isPending}
+              deletePending={deleteMutation.isPending}
+              onSuspend={() => {
+                if (confirm("Suspend this agent? Runtime binds and HTTP calls will be refused."))
+                  suspendMutation.mutate();
+              }}
+              onReactivate={() => reactivateMutation.mutate()}
+              onDelete={() => deleteMutation.mutate()}
+            />
+          </div>
+
+          {!isHuman && draft.summary.anyDirty && (
+            <div style={{ fontSize: 11, color: "var(--fg-3)" }}>
+              <button
+                type="button"
+                onClick={() => dryRunMutation.mutate()}
+                className="underline bg-transparent border-0 cursor-pointer"
+                style={{ color: "var(--fg-3)" }}
+                disabled={dryRunMutation.isPending}
+              >
+                {dryRunMutation.isPending ? "Computing dry-run…" : "Preview server-side diff"}
+              </button>
+            </div>
           )}
-        </CardContent>
-      </Card>
-
-      {/* Danger Zone */}
-      <DangerZone
-        agent={agent}
-        suspendPending={suspendMutation.isPending}
-        reactivatePending={reactivateMutation.isPending}
-        deletePending={deleteMutation.isPending}
-        onSuspend={() => {
-          if (confirm("Suspend this agent? Runtime binds and HTTP calls will be refused.")) suspendMutation.mutate();
-        }}
-        onReactivate={() => reactivateMutation.mutate()}
-        onDelete={() => deleteMutation.mutate()}
-      />
-
-      {/* Save Bar */}
-      {!isHuman && (
-        <SaveBar
-          summary={draft.summary}
-          saveHint={saveHint}
-          conflictMessage={conflictMsg}
-          errorMessage={saveError}
-          saving={saveMutation.isPending}
-          onSave={() => saveMutation.mutate()}
-          onDiscard={() => {
-            if (!draft.summary.anyDirty || confirm("Discard all unsaved changes?")) {
-              draft.resetAll();
-              setSaveError(null);
-              setConflictMsg(null);
-            }
-          }}
-          onReloadRemote={reloadRemote}
-          onJumpTo={jumpTo}
-        />
-      )}
-
-      {/* Dry-run helper (below Save Bar to avoid clutter) */}
-      {!isHuman && draft.summary.anyDirty && (
-        <div className="text-xs text-muted-foreground">
-          <button
-            type="button"
-            onClick={() => dryRunMutation.mutate()}
-            className="underline hover:text-gray-900"
-            disabled={dryRunMutation.isPending}
-          >
-            {dryRunMutation.isPending ? "Computing dry-run…" : "Preview server-side diff"}
-          </button>
         </div>
-      )}
 
-      {/* Bind Computer Dialog — first-time NULL → ID bind only */}
+        {!isHuman && (
+          <SaveBar
+            summary={draft.summary}
+            saveHint={saveHint}
+            conflictMessage={conflictMsg}
+            errorMessage={saveError}
+            saving={saveMutation.isPending}
+            onSave={() => saveMutation.mutate()}
+            onDiscard={() => {
+              if (!draft.summary.anyDirty || confirm("Discard all unsaved changes?")) {
+                draft.resetAll();
+                setSaveError(null);
+                setConflictMsg(null);
+              }
+            }}
+            onReloadRemote={reloadRemote}
+            onJumpTo={(section) => jumpTo(sectionAnchorId(section))}
+          />
+        )}
+      </div>
+
       <Dialog
         open={bindClientOpen}
         onOpenChange={(open) => {
@@ -751,14 +868,16 @@ export function AgentDetailPage() {
             <DialogTitle>Bind computer</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm" style={{ color: "var(--fg-3)" }}>
               Pick a computer you own to pin this agent to. The bind is one-shot — once set, moving the agent requires
               deleting and re-creating it on the target computer.
             </p>
             {clientsQuery.isLoading ? (
-              <div className="text-sm text-muted-foreground">Loading computers…</div>
+              <div className="text-sm" style={{ color: "var(--fg-3)" }}>
+                Loading computers…
+              </div>
             ) : clientsQuery.error ? (
-              <div className="text-sm text-destructive">
+              <div className="text-sm" style={{ color: "var(--state-error)" }}>
                 Failed to load computers: {clientsQuery.error instanceof Error ? clientsQuery.error.message : "Unknown"}
               </div>
             ) : (
@@ -768,7 +887,11 @@ export function AgentDetailPage() {
                 onSelect={setBindClientSelected}
               />
             )}
-            {bindClientError && <div className="text-sm text-destructive">{bindClientError}</div>}
+            {bindClientError && (
+              <div className="text-sm" style={{ color: "var(--state-error)" }}>
+                {bindClientError}
+              </div>
+            )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setBindClientOpen(false)}>
@@ -787,7 +910,6 @@ export function AgentDetailPage() {
         </DialogContent>
       </Dialog>
 
-      {/* Binding Dialog */}
       <Dialog
         open={bindingDialogOpen}
         onOpenChange={(open) => (open ? setBindingDialogOpen(true) : closeBindingDialog())}
@@ -898,7 +1020,7 @@ export function AgentDetailPage() {
                       />
                     </div>
                     {!bindingEditId && (
-                      <p className="text-sm text-muted-foreground">
+                      <p className="text-sm" style={{ color: "var(--fg-3)" }}>
                         Agent Token will be created automatically when you save.
                       </p>
                     )}
@@ -918,7 +1040,11 @@ export function AgentDetailPage() {
                     />
                   </div>
                 )}
-                {bindingCredError && <p className="text-sm text-destructive">{bindingCredError}</p>}
+                {bindingCredError && (
+                  <p className="text-sm" style={{ color: "var(--state-error)" }}>
+                    {bindingCredError}
+                  </p>
+                )}
                 <div className="space-y-2">
                   <Label htmlFor="binding-status">Status</Label>
                   <select
@@ -935,7 +1061,9 @@ export function AgentDetailPage() {
             )}
 
             {bindingMutationError instanceof Error && (
-              <div className="text-sm text-destructive">{bindingMutationError.message}</div>
+              <div className="text-sm" style={{ color: "var(--state-error)" }}>
+                {bindingMutationError.message}
+              </div>
             )}
             <DialogFooter>
               <Button type="submit" disabled={bindingIsPending}>
@@ -960,14 +1088,20 @@ function BehaviorSection(props: {
   return (
     <section className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold">Behavior</h2>
-        <div className="text-xs text-muted-foreground">
-          {props.version != null && <span>v{props.version}</span>}
-          {props.dirty && <span className="ml-2 text-amber-700">· draft</span>}
+        <div className="inline-flex items-baseline gap-2">
+          <h2 style={{ fontSize: 13, fontWeight: 600 }}>Behavior</h2>
+          {props.version != null && (
+            <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+              v{props.version}
+            </span>
+          )}
+          {props.dirty && <UppercaseLabel style={{ color: "var(--state-blocked)" }}>draft</UppercaseLabel>}
         </div>
       </div>
-      {props.loading && <div className="text-sm text-muted-foreground">Loading configuration…</div>}
-      {props.error && <div className="text-sm text-destructive">Failed to load configuration: {props.error}</div>}
+      {props.loading && <div style={{ fontSize: 12, color: "var(--fg-3)" }}>Loading configuration…</div>}
+      {props.error && (
+        <div style={{ fontSize: 12, color: "var(--state-error)" }}>Failed to load configuration: {props.error}</div>
+      )}
       {props.loaded && <div className="space-y-3">{props.children}</div>}
     </section>
   );
@@ -1030,41 +1164,59 @@ function BindClientList({
   const bindable = clients.filter((c) => c.status === "connected");
   if (bindable.length === 0) {
     return (
-      <div className="rounded border bg-muted/40 px-3 py-4 text-sm text-muted-foreground">
+      <div
+        className="text-sm"
+        style={{
+          background: "var(--bg-sunken)",
+          border: "1px solid var(--border-faint)",
+          borderRadius: 4,
+          padding: "10px 12px",
+          color: "var(--fg-3)",
+        }}
+      >
         No connected computers available. Run{" "}
-        <code className="font-mono text-xs">first-tree-hub client connect &lt;url&gt;</code> on the computer that should
-        run this agent, then reopen this dialog.
+        <code className="mono" style={{ fontSize: 11 }}>
+          first-tree-hub client connect &lt;url&gt;
+        </code>{" "}
+        on the computer that should run this agent, then reopen this dialog.
       </div>
     );
   }
   return (
-    <ul className="divide-y rounded border max-h-64 overflow-y-auto">
+    <ul
+      className="max-h-64 overflow-y-auto"
+      style={{ border: "1px solid var(--border)", borderRadius: 4, margin: 0, padding: 0, listStyle: "none" }}
+    >
       {bindable.map((c) => {
         const picked = c.id === selected;
         const online = c.status === "online" || c.status === "active";
         return (
-          <li key={c.id}>
+          <li key={c.id} style={{ borderTop: "1px solid var(--border-faint)" }}>
             <button
               type="button"
               onClick={() => onSelect(c.id)}
-              className={cn(
-                "w-full text-left px-3 py-2 flex items-center gap-3 hover:bg-gray-50",
-                picked && "bg-blue-50",
-              )}
+              className={cn("w-full text-left flex items-center gap-3")}
+              style={{
+                padding: "8px 12px",
+                background: picked ? "var(--accent-bg)" : "transparent",
+                border: "none",
+                cursor: "pointer",
+              }}
             >
               <span
-                className={cn("inline-block h-2 w-2 rounded-full", online ? "bg-green-500" : "bg-gray-400")}
+                className={cn("inline-block h-2 w-2 rounded-full shrink-0")}
+                style={{ background: online ? "var(--state-idle)" : "var(--fg-4)" }}
                 aria-hidden
               />
               <span className="flex-1 min-w-0">
                 <span className="block text-sm font-medium truncate">{c.hostname ?? c.id}</span>
-                <span className="block text-xs text-muted-foreground font-mono truncate">
+                <span className="block mono truncate" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
                   {c.id}
                   {c.os ? ` · ${c.os}` : ""}
                   {c.sdkVersion ? ` · SDK ${c.sdkVersion}` : ""}
                 </span>
               </span>
-              <span className="text-xs text-muted-foreground">{c.status}</span>
+              <span style={{ fontSize: 11, color: "var(--fg-3)" }}>{c.status}</span>
             </button>
           </li>
         );
@@ -1083,78 +1235,93 @@ const STATUS_LABELS: Record<TestResult["status"], string> = {
   error: "Error",
 };
 
-const HEALTH_INDICATOR: Record<string, { icon: string; color: string; label: string }> = {
-  connected: { icon: "●", color: "text-green-500", label: "Connected" },
-  stale: { icon: "◐", color: "text-yellow-500", label: "Stale" },
-  disconnected: { icon: "○", color: "text-gray-400", label: "Disconnected" },
+const TEST_RESULT_BORDER: Record<TestResult["status"], string> = {
+  success: "var(--state-idle)",
+  timeout: "var(--state-blocked)",
+  offline: "var(--state-offline)",
+  stale: "var(--state-blocked)",
+  error: "var(--state-error)",
+};
+
+const TEST_RESULT_TONE: Record<TestResult["status"], DenseBadgeTone> = {
+  success: "accent",
+  timeout: "warn",
+  stale: "warn",
+  error: "error",
+  offline: "neutral",
 };
 
 function TestResultCard({ result, onDismiss }: { result: TestResult; onDismiss: () => void }) {
-  const borderColor = {
-    success: "border-l-green-500",
-    timeout: "border-l-yellow-500",
-    offline: "border-l-gray-400",
-    stale: "border-l-yellow-500",
-    error: "border-l-red-500",
-  }[result.status];
-
-  const badgeVariant =
-    result.status === "success"
-      ? "default"
-      : result.status === "timeout" || result.status === "stale"
-        ? "secondary"
-        : "destructive";
+  const borderColor = TEST_RESULT_BORDER[result.status];
+  const badgeTone = TEST_RESULT_TONE[result.status];
 
   const conn = result.connection;
-  const healthInfo = conn ? HEALTH_INDICATOR[conn.health] : null;
 
   return (
-    <Card className={cn("border-l-4", borderColor)}>
-      <CardContent className="pt-4">
-        <div className="flex items-start justify-between">
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <Badge variant={badgeVariant}>{STATUS_LABELS[result.status]}</Badge>
-              {result.responseTime != null && (
-                <span className="text-xs text-muted-foreground">{(result.responseTime / 1000).toFixed(1)}s</span>
-              )}
-            </div>
-            {result.message && <p className="text-sm text-muted-foreground">{result.message}</p>}
-            {conn && (
-              <div className="text-xs space-y-1 border-t pt-2 mt-1">
-                <div className="flex items-center gap-2">
-                  {healthInfo && (
-                    <span className={healthInfo.color}>
-                      {healthInfo.icon} {healthInfo.label}
-                    </span>
-                  )}
-                  {conn.runtimeState && <span className="text-muted-foreground">runtime: {conn.runtimeState}</span>}
-                </div>
-                {conn.client ? (
-                  <div className="text-muted-foreground">
-                    Computer: {conn.client.hostname ?? conn.client.id}
-                    {conn.client.os && ` (${conn.client.os})`}
-                    {conn.client.sdkVersion && ` · SDK ${conn.client.sdkVersion}`}
-                  </div>
-                ) : (
-                  <div className="text-muted-foreground">No computer bound</div>
-                )}
-                {conn.lastSeenAt && (
-                  <div className="text-muted-foreground">Last seen: {new Date(conn.lastSeenAt).toLocaleString()}</div>
-                )}
-              </div>
-            )}
-            {result.responseContent && (
-              <p className="text-sm mt-2 whitespace-pre-wrap bg-muted rounded p-2 max-h-40 overflow-auto">
-                {result.responseContent}
-              </p>
+    <div
+      style={{
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderLeft: `3px solid ${borderColor}`,
+        borderRadius: 6,
+        padding: "12px 14px",
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <DenseBadge tone={badgeTone}>{STATUS_LABELS[result.status]}</DenseBadge>
+            {result.responseTime != null && (
+              <span className="mono" style={{ fontSize: 11, color: "var(--fg-4)" }}>
+                {(result.responseTime / 1000).toFixed(1)}s
+              </span>
             )}
           </div>
-          <Button variant="ghost" size="sm" onClick={onDismiss}>
-            Dismiss
-          </Button>
+          {result.message && <p style={{ fontSize: 12, color: "var(--fg-3)" }}>{result.message}</p>}
+          {conn && (
+            <div
+              style={{
+                fontSize: 11,
+                color: "var(--fg-3)",
+                borderTop: "1px solid var(--border-faint)",
+                paddingTop: 6,
+                marginTop: 2,
+              }}
+            >
+              <div>{conn.runtimeState && <span className="mono">runtime: {conn.runtimeState}</span>}</div>
+              {conn.client ? (
+                <div>
+                  Computer: {conn.client.hostname ?? conn.client.id}
+                  {conn.client.os && ` (${conn.client.os})`}
+                  {conn.client.sdkVersion && ` · SDK ${conn.client.sdkVersion}`}
+                </div>
+              ) : (
+                <div>No computer bound</div>
+              )}
+              {conn.lastSeenAt && <div>Last seen: {new Date(conn.lastSeenAt).toLocaleString()}</div>}
+            </div>
+          )}
+          {result.responseContent && (
+            <p
+              className="mono whitespace-pre-wrap"
+              style={{
+                background: "var(--bg-sunken)",
+                border: "1px solid var(--border-faint)",
+                borderRadius: 4,
+                padding: 8,
+                fontSize: 11,
+                maxHeight: 160,
+                overflow: "auto",
+              }}
+            >
+              {result.responseContent}
+            </p>
+          )}
         </div>
-      </CardContent>
-    </Card>
+        <Button variant="ghost" size="sm" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/danger-zone.tsx
+++ b/packages/web/src/pages/agent-detail/danger-zone.tsx
@@ -26,18 +26,24 @@ export function DangerZone(props: DangerZoneProps) {
   const displayLabel = agent.displayName || agent.name || agent.uuid;
 
   return (
-    <section className="rounded-md border border-red-200 bg-red-50/40">
-      <header className="flex items-center gap-2 border-b border-red-200 px-4 py-2">
-        <AlertTriangle className="h-4 w-4 text-red-700" />
-        <h3 className="text-sm font-medium text-red-800">Danger Zone</h3>
+    <section
+      style={{
+        background: "color-mix(in oklch, var(--state-error) 6%, var(--bg-raised))",
+        border: "1px solid color-mix(in oklch, var(--state-error) 28%, transparent)",
+        borderRadius: 6,
+      }}
+    >
+      <header className="flex items-center gap-2" style={{ padding: "10px 14px" }}>
+        <AlertTriangle className="h-3.5 w-3.5" style={{ color: "var(--state-error)" }} />
+        <h3 style={{ fontSize: 12, fontWeight: 600, color: "var(--state-error)" }}>Danger zone</h3>
       </header>
-      <div className="divide-y divide-red-200">
+      <div>
         {agent.status === "active" ? (
           <DangerRow
             title="Suspend agent"
             body="Pause all active sessions. You can reactivate later; tokens stay revoked until then."
             action={
-              <Button variant="outline" size="sm" onClick={props.onSuspend} disabled={props.suspendPending}>
+              <Button variant="outline" size="xs" onClick={props.onSuspend} disabled={props.suspendPending}>
                 {props.suspendPending ? "Suspending…" : "Suspend"}
               </Button>
             }
@@ -47,7 +53,7 @@ export function DangerZone(props: DangerZoneProps) {
             title="Reactivate agent"
             body="Resume sessions. Tokens must be recreated — they are not restored."
             action={
-              <Button variant="outline" size="sm" onClick={props.onReactivate} disabled={props.reactivatePending}>
+              <Button variant="outline" size="xs" onClick={props.onReactivate} disabled={props.reactivatePending}>
                 {props.reactivatePending ? "Reactivating…" : "Reactivate"}
               </Button>
             }
@@ -57,8 +63,8 @@ export function DangerZone(props: DangerZoneProps) {
           title="Delete agent"
           body="Permanent. Configuration, bindings, tokens, and session history are all dropped."
           action={
-            <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)} disabled={props.deletePending}>
-              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+            <Button variant="destructive" size="xs" onClick={() => setDeleteOpen(true)} disabled={props.deletePending}>
+              <Trash2 className="h-3 w-3" />
               Delete
             </Button>
           }
@@ -81,10 +87,17 @@ export function DangerZone(props: DangerZoneProps) {
 
 function DangerRow(props: { title: string; body: string; action: React.ReactNode }) {
   return (
-    <div className="flex items-start justify-between gap-4 px-4 py-3 text-sm">
+    <div
+      className="flex items-start justify-between gap-4"
+      style={{
+        padding: "10px 14px",
+        borderTop: "1px solid color-mix(in oklch, var(--state-error) 14%, transparent)",
+        fontSize: 12,
+      }}
+    >
       <div>
-        <p className="font-medium text-red-900">{props.title}</p>
-        <p className="text-xs text-red-800/80">{props.body}</p>
+        <p style={{ fontWeight: 500, color: "var(--fg)" }}>{props.title}</p>
+        <p style={{ fontSize: 11, color: "var(--fg-3)" }}>{props.body}</p>
       </div>
       <div>{props.action}</div>
     </div>

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -29,12 +29,21 @@ export function EnvSection(props: EnvSectionProps) {
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
   return (
-    <section className="rounded-md border bg-white">
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h3 className="text-sm font-medium">Environment Variables ({activeCount})</h3>
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+      >
+        <h3 style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>Environment Variables ({activeCount})</h3>
         {!props.disabled && (
-          <Button size="sm" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3.5 w-3.5 mr-1.5" /> Add
+          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+            <Plus className="h-3 w-3" /> Add
           </Button>
         )}
       </header>

--- a/packages/web/src/pages/agent-detail/git-section.tsx
+++ b/packages/web/src/pages/agent-detail/git-section.tsx
@@ -28,12 +28,21 @@ export function GitSection(props: GitSectionProps) {
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
   return (
-    <section className="rounded-md border bg-white">
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h3 className="text-sm font-medium">Git Repositories ({activeCount})</h3>
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+      >
+        <h3 style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>Git Repositories ({activeCount})</h3>
         {!props.disabled && (
-          <Button size="sm" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3.5 w-3.5 mr-1.5" /> Add
+          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+            <Plus className="h-3 w-3" /> Add
           </Button>
         )}
       </header>

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -4,8 +4,8 @@ import { Pencil } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 import { listAgents } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
-import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
+import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
@@ -38,12 +38,24 @@ export function IdentitySection({ agent, onSave }: IdentitySectionProps) {
   const delegateLabel = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
 
   return (
-    <section className="rounded-md border bg-white">
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h2 className="text-sm font-medium">Identity</h2>
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{
+          padding: "10px 14px",
+          borderBottom: "1px solid var(--border-faint)",
+        }}
+      >
+        <h2 style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>Profile</h2>
         {agent.status === "active" && (
-          <Button size="sm" variant="outline" onClick={() => setOpen(true)}>
-            <Pencil className="h-3.5 w-3.5 mr-1.5" /> Edit
+          <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+            <Pencil className="h-3 w-3" /> Edit
           </Button>
         )}
       </header>
@@ -71,20 +83,22 @@ export function IdentitySection({ agent, onSave }: IdentitySectionProps) {
             </span>
           )}
           <span>
-            type <Badge variant="secondary">{agent.type}</Badge>
+            type <DenseBadge tone={agent.type === "autonomous_agent" ? "accent" : "neutral"}>{agent.type}</DenseBadge>
           </span>
           <span>
             visibility{" "}
-            <Badge variant={agent.visibility === "organization" ? "default" : "outline"}>{agent.visibility}</Badge>
+            <DenseBadge tone={agent.visibility === "organization" ? "accent" : "outline"}>
+              {agent.visibility}
+            </DenseBadge>
           </span>
           {domains.length > 0 && (
             <span>
               domains{" "}
               <span className="inline-flex flex-wrap gap-1 align-middle">
                 {domains.map((d) => (
-                  <Badge key={d} variant="outline">
+                  <DenseBadge key={d} tone="outline">
                     {d}
-                  </Badge>
+                  </DenseBadge>
                 ))}
               </span>
             </span>

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -30,12 +30,21 @@ export function McpSection(props: McpSectionProps) {
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
   return (
-    <section className="rounded-md border bg-white">
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h3 className="text-sm font-medium">MCP Servers ({activeCount})</h3>
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+      >
+        <h3 style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>MCP Servers ({activeCount})</h3>
         {!props.disabled && (
-          <Button size="sm" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3.5 w-3.5 mr-1.5" /> Add
+          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+            <Plus className="h-3 w-3" /> Add
           </Button>
         )}
       </header>

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -26,14 +26,37 @@ export function ModelSection({ value, baseline, onChange, onRevert, disabled }: 
   const hasExtra = !CLAUDE_MODEL_OPTIONS.some((o) => o.value === value) && value !== "";
 
   return (
-    <section className={`rounded-md border bg-white ${dirty ? "border-amber-300" : "border-gray-200"}`}>
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h3 className="text-sm font-medium flex items-center gap-2">
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: `1px solid ${dirty ? "color-mix(in oklch, var(--state-blocked) 40%, transparent)" : "var(--border)"}`,
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+      >
+        <h3 className="inline-flex items-center gap-2" style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>
           Model
-          {dirty && <span className="text-xs rounded bg-amber-100 px-1.5 py-0.5 text-amber-900">changed</span>}
+          {dirty && (
+            <span
+              className="mono uppercase"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.06em",
+                padding: "1px 6px",
+                borderRadius: 3,
+                background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+                color: "color-mix(in oklch, var(--state-blocked) 50%, var(--fg))",
+              }}
+            >
+              changed
+            </span>
+          )}
         </h3>
         {dirty && (
-          <Button size="sm" variant="ghost" onClick={onRevert} disabled={disabled}>
+          <Button size="xs" variant="ghost" onClick={onRevert} disabled={disabled}>
             Revert
           </Button>
         )}

--- a/packages/web/src/pages/agent-detail/prompt-section.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-section.tsx
@@ -27,16 +27,39 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
   }, [editing]);
 
   return (
-    <section className={`rounded-md border bg-white ${dirty ? "border-amber-300" : "border-gray-200"}`}>
-      <header className="flex items-center justify-between border-b px-4 py-2">
-        <h3 className="text-sm font-medium flex items-center gap-2">
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: `1px solid ${dirty ? "color-mix(in oklch, var(--state-blocked) 40%, transparent)" : "var(--border)"}`,
+        borderRadius: 6,
+      }}
+    >
+      <header
+        className="flex items-center justify-between"
+        style={{ padding: "10px 14px", borderBottom: "1px solid var(--border-faint)" }}
+      >
+        <h3 className="inline-flex items-center gap-2" style={{ fontSize: 12, fontWeight: 600, color: "var(--fg)" }}>
           System Prompt Append
-          {dirty && <span className="text-xs rounded bg-amber-100 px-1.5 py-0.5 text-amber-900">changed</span>}
+          {dirty && (
+            <span
+              className="mono uppercase"
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.06em",
+                padding: "1px 6px",
+                borderRadius: 3,
+                background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+                color: "color-mix(in oklch, var(--state-blocked) 50%, var(--fg))",
+              }}
+            >
+              changed
+            </span>
+          )}
         </h3>
         <div className="flex gap-2">
           {!editing && !disabled && (
-            <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
-              <Pencil className="h-3.5 w-3.5 mr-1.5" /> Edit
+            <Button size="xs" variant="outline" onClick={() => setEditing(true)}>
+              <Pencil className="h-3 w-3" /> Edit
             </Button>
           )}
         </div>
@@ -63,7 +86,7 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
             />
             <div className="flex justify-end gap-2">
               <Button
-                size="sm"
+                size="xs"
                 variant="ghost"
                 onClick={() => {
                   onRevert();
@@ -73,7 +96,7 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
               >
                 Revert
               </Button>
-              <Button size="sm" onClick={() => setEditing(false)}>
+              <Button size="xs" onClick={() => setEditing(false)}>
                 Done
               </Button>
             </div>

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -1,21 +1,40 @@
 import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
 import { AGENT_TYPES } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
-import { Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Filter, Plus, Search } from "lucide-react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
+import { getActivityOverview, type RuntimeAgent } from "../api/activity.js";
 import { listAgents } from "../api/agents.js";
 import { useAuth } from "../auth/auth-context.js";
 import { LastStepModal } from "../components/last-step-modal.js";
 import { NewAgentDialog } from "../components/new-agent-dialog.js";
-import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "../components/ui/dense-table.js";
+import { FilterPill } from "../components/ui/filter-pill.js";
+import { PageHeader } from "../components/ui/page-header.js";
+import { Panel } from "../components/ui/panel.js";
+import { SectionHeader } from "../components/ui/section-header.js";
+import { StateDot } from "../components/ui/state-dot.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { useMemberNameMap } from "../lib/use-member-name-map.js";
-import { cn, formatDate } from "../lib/utils.js";
+import { formatDate } from "../lib/utils.js";
 
 const agentTypeValues = Object.values(AGENT_TYPES);
+
+type RuntimeInfo = {
+  runtimeState: string | null;
+  activeSessions: number | null;
+  totalSessions: number | null;
+};
 
 function sortByName(agents: Agent[]): Agent[] {
   return [...agents].sort((a, b) => {
@@ -25,15 +44,34 @@ function sortByName(agents: Agent[]): Agent[] {
   });
 }
 
+function pickRuntime(agent: Agent, map: Map<string, RuntimeAgent>): RuntimeInfo {
+  const r = map.get(agent.uuid);
+  return {
+    runtimeState: r?.runtimeState ?? null,
+    activeSessions: r?.activeSessions ?? null,
+    totalSessions: r?.totalSessions ?? null,
+  };
+}
+
+function countByRuntime(agents: Agent[], map: Map<string, RuntimeAgent>, state: string): number {
+  let n = 0;
+  for (const a of agents) {
+    if (map.get(a.uuid)?.runtimeState === state) n++;
+  }
+  return n;
+}
+
+type PillKey = "all" | "mine" | "running" | "attn";
+
 export function AgentsPage() {
   const navigate = useNavigate();
   const { memberId } = useAuth();
   const [cursor, setCursor] = useState<string | undefined>();
   const [typeFilter, setTypeFilter] = useState<string>("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  // After create: Claude Code → show Last-step modal; Kael → skip straight
-  // to the Workspace. `lastStepAgent` non-null means the modal is visible.
   const [lastStepAgent, setLastStepAgent] = useState<Agent | null>(null);
+  const [pill, setPill] = useState<PillKey>("all");
+  const [search, setSearch] = useState("");
   const resolveAgentName = useAgentNameMap();
   const resolveMemberName = useMemberNameMap();
 
@@ -42,37 +80,75 @@ export function AgentsPage() {
     queryFn: () => listAgents({ limit: 100, cursor, type: typeFilter || undefined }),
   });
 
+  const { data: activity } = useQuery({
+    queryKey: ["activity"],
+    queryFn: getActivityOverview,
+    refetchInterval: 10_000,
+  });
+
+  const runtimeMap = useMemo(() => {
+    const map = new Map<string, RuntimeAgent>();
+    for (const r of activity?.agents ?? []) map.set(r.agentId, r);
+    return map;
+  }, [activity?.agents]);
+
   const { myAgents, teamAgents } = useMemo(() => {
     if (!data?.items) return { myAgents: [], teamAgents: [] };
     const my: Agent[] = [];
     const team: Agent[] = [];
     for (const agent of data.items) {
-      if (memberId && agent.managerId === memberId) {
-        my.push(agent);
-      } else {
-        team.push(agent);
-      }
+      if (memberId && agent.managerId === memberId) my.push(agent);
+      else team.push(agent);
     }
     return { myAgents: sortByName(my), teamAgents: sortByName(team) };
   }, [data, memberId]);
 
+  const totalCount = data?.items.length ?? 0;
+  const mineCount = myAgents.length;
+  const teamCount = teamAgents.length;
+  const runningCount = useMemo(
+    () => (data?.items ?? []).filter((a) => runtimeMap.get(a.uuid)?.runtimeState === "working").length,
+    [data?.items, runtimeMap],
+  );
+  const attnCount = useMemo(
+    () =>
+      (data?.items ?? []).filter((a) => {
+        const s = runtimeMap.get(a.uuid)?.runtimeState;
+        return s === "blocked" || s === "error";
+      }).length,
+    [data?.items, runtimeMap],
+  );
+
+  function matchesPill(agent: Agent): boolean {
+    const s = runtimeMap.get(agent.uuid)?.runtimeState;
+    if (pill === "mine") return memberId != null && agent.managerId === memberId;
+    if (pill === "running") return s === "working";
+    if (pill === "attn") return s === "blocked" || s === "error";
+    return true;
+  }
+
+  function matchesSearch(agent: Agent): boolean {
+    if (!search.trim()) return true;
+    const q = search.toLowerCase();
+    const delegate = agent.delegateMention ? resolveAgentName(agent.delegateMention) : "";
+    const owner = resolveMemberName(agent.managerId);
+    return (
+      (agent.name ?? "").toLowerCase().includes(q) ||
+      (agent.displayName ?? "").toLowerCase().includes(q) ||
+      delegate.toLowerCase().includes(q) ||
+      owner.toLowerCase().includes(q)
+    );
+  }
+
+  const filteredMy = myAgents.filter((a) => matchesPill(a) && matchesSearch(a));
+  const filteredTeam = teamAgents.filter((a) => matchesPill(a) && matchesSearch(a));
+
   function handleCreated(agent: Agent, runtime: "claude-code" | "kael") {
     setCreateDialogOpen(false);
-
-    // Scenario B (server already pinned the agent to one of the caller's
-    // connected computers). The server has emitted an `agent:pinned` frame
-    // to that client; its runtime auto-registers the local alias and opens
-    // the agent WS within ~1-2s. Skip the Last-step terminal flow entirely
-    // and jump to the Workspace — the agent will light up green shortly.
     if (agent.clientId) {
       navigate(`/?a=${agent.uuid}`);
       return;
     }
-
-    // Scenario A (no connected computer yet, or the caller explicitly
-    // chose not to pin). Claude Code needs a computer — hand off to the
-    // Last-step modal so the user can paste the install/add/connect
-    // command. Kael is cloud-hosted — just jump straight to the chat.
     if (runtime === "claude-code") {
       setLastStepAgent(agent);
       return;
@@ -80,142 +156,160 @@ export function AgentsPage() {
     navigate(`/?a=${agent.uuid}`);
   }
 
-  function renderAgentRow(agent: Agent) {
-    const ext = agent as Record<string, unknown>;
-    const runtimeState = ext.runtimeState as string | null;
-    const runtimeColors: Record<string, string> = {
-      idle: "bg-green-500",
-      working: "bg-blue-500",
-      error: "bg-red-500",
-    };
-
-    return (
-      <TableRow key={agent.uuid} className="cursor-pointer" onClick={() => navigate(`/agents/${agent.uuid}`)}>
-        <TableCell className="font-mono text-sm">{agent.name}</TableCell>
-        <TableCell>{agent.displayName ?? "\u2014"}</TableCell>
-        <TableCell>
-          <Badge variant="secondary">{agent.type}</Badge>
-        </TableCell>
-        <TableCell className="font-mono text-sm text-muted-foreground">
-          {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "\u2014"}
-        </TableCell>
-        <TableCell className="text-sm text-muted-foreground">{resolveMemberName(agent.managerId)}</TableCell>
-        <TableCell>
-          {runtimeState ? (
-            <span className="flex items-center gap-1.5">
-              <span className={cn("inline-block h-2 w-2 rounded-full", runtimeColors[runtimeState] ?? "bg-gray-300")} />
-              <span className="text-xs text-muted-foreground">{runtimeState}</span>
-            </span>
-          ) : (
-            <span className="inline-block h-2 w-2 rounded-full bg-gray-300" title="not running" />
-          )}
-        </TableCell>
-        <TableCell>
-          <Badge variant={agent.status === "active" ? "default" : "destructive"}>{agent.status}</Badge>
-        </TableCell>
-        <TableCell className="text-muted-foreground">{formatDate(agent.createdAt)}</TableCell>
-      </TableRow>
-    );
-  }
-
   return (
-    <div className="space-y-8">
-      <div className="flex items-center gap-4">
-        <h1 className="text-2xl font-semibold">Agents</h1>
-        <select
-          value={typeFilter}
-          onChange={(e) => {
-            setTypeFilter(e.target.value);
-            setCursor(undefined);
+    <div className="-m-6">
+      <PageHeader
+        title="Agents"
+        subtitle={
+          totalCount > 0 ? (
+            <>
+              {totalCount} total · {mineCount} mine · {teamCount} team
+            </>
+          ) : null
+        }
+        right={
+          <div className="flex items-center gap-1.5">
+            <Button variant="outline" size="xs">
+              Import
+            </Button>
+            <Button size="xs" onClick={() => setCreateDialogOpen(true)}>
+              <Plus className="h-3 w-3" />
+              New agent
+            </Button>
+          </div>
+        }
+      />
+
+      <div style={{ padding: "14px 20px 28px" }}>
+        <div
+          className="flex items-center gap-2.5 mb-3.5"
+          style={{
+            padding: "8px 10px",
+            background: "var(--bg-raised)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
           }}
-          className="h-8 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
-          <option value="">All types</option>
-          {agentTypeValues.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {isLoading ? (
-        <div className="text-center py-8 text-muted-foreground">Loading...</div>
-      ) : error ? (
-        <div className="text-center py-8 text-destructive">
-          Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
-        </div>
-      ) : (
-        <>
-          <section>
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="text-lg font-medium">My Agents</h2>
-              <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                New Agent
-              </Button>
-            </div>
-            <div className="border rounded-lg">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead>Display Name</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Delegate</TableHead>
-                    <TableHead>Owner</TableHead>
-                    <TableHead>Runtime</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Created</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {myAgents.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
-                        No agents yet — create one to get started
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    myAgents.map((agent) => renderAgentRow(agent))
-                  )}
-                </TableBody>
-              </Table>
-            </div>
-          </section>
-
-          {teamAgents.length > 0 && (
-            <section>
-              <h2 className="text-lg font-medium mb-3">Team Agents</h2>
-              <div className="border rounded-lg">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Name</TableHead>
-                      <TableHead>Display Name</TableHead>
-                      <TableHead>Type</TableHead>
-                      <TableHead>Delegate</TableHead>
-                      <TableHead>Owner</TableHead>
-                      <TableHead>Runtime</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Created</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>{teamAgents.map((agent) => renderAgentRow(agent))}</TableBody>
-                </Table>
-              </div>
-            </section>
-          )}
-        </>
-      )}
-
-      {data?.nextCursor && (
-        <div className="flex justify-end">
-          <Button variant="outline" onClick={() => setCursor(data.nextCursor ?? undefined)}>
-            Next Page
+          <div className="relative" style={{ width: 240 }}>
+            <Search
+              className="absolute pointer-events-none"
+              style={{ left: 8, top: "50%", transform: "translateY(-50%)", color: "var(--fg-4)" }}
+              size={13}
+            />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Filter by name, delegate, owner…"
+              className="w-full outline-none"
+              style={{
+                padding: "5px 10px 5px 28px",
+                fontSize: 12,
+                background: "var(--bg-sunken)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                color: "var(--fg)",
+              }}
+            />
+          </div>
+          <div className="flex gap-1">
+            <FilterPill active={pill === "all"} count={totalCount} onClick={() => setPill("all")}>
+              all
+            </FilterPill>
+            <FilterPill active={pill === "mine"} count={mineCount} onClick={() => setPill("mine")}>
+              mine
+            </FilterPill>
+            <FilterPill active={pill === "running"} count={runningCount} onClick={() => setPill("running")}>
+              running
+            </FilterPill>
+            <FilterPill active={pill === "attn"} count={attnCount} warn onClick={() => setPill("attn")}>
+              attn
+            </FilterPill>
+          </div>
+          <div style={{ flex: 1 }} />
+          <select
+            value={typeFilter}
+            onChange={(e) => {
+              setTypeFilter(e.target.value);
+              setCursor(undefined);
+            }}
+            className="outline-none"
+            style={{
+              padding: "5px 10px",
+              fontSize: 11,
+              background: "var(--bg-sunken)",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              color: "var(--fg)",
+            }}
+          >
+            <option value="">all types</option>
+            {agentTypeValues.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <Button variant="ghost" size="xs" className="text-[11px]">
+            <Filter className="h-3 w-3" /> Columns
           </Button>
         </div>
-      )}
+
+        {isLoading ? (
+          <div className="text-center py-8" style={{ color: "var(--fg-3)" }}>
+            Loading…
+          </div>
+        ) : error ? (
+          <div className="text-center py-8" style={{ color: "var(--state-error)" }}>
+            Failed to load agents: {error instanceof Error ? error.message : "Unknown error"}
+          </div>
+        ) : (
+          <>
+            <AgentsPanel
+              title={`My agents · ${filteredMy.length}`}
+              agents={filteredMy}
+              runtimeMap={runtimeMap}
+              resolveAgentName={resolveAgentName}
+              resolveMemberName={resolveMemberName}
+              navigate={navigate}
+              emptyLabel={
+                myAgents.length === 0
+                  ? "No agents yet — create one to get started"
+                  : "No agents match the current filter"
+              }
+              breakdown={
+                <StateBreakdown
+                  items={[
+                    { state: "working", count: countByRuntime(myAgents, runtimeMap, "working") },
+                    { state: "blocked", count: countByRuntime(myAgents, runtimeMap, "blocked") },
+                    { state: "error", count: countByRuntime(myAgents, runtimeMap, "error") },
+                  ]}
+                />
+              }
+              className="mb-4"
+            />
+
+            {teamAgents.length > 0 && (
+              <AgentsPanel
+                title={`Team agents · ${filteredTeam.length}`}
+                agents={filteredTeam}
+                runtimeMap={runtimeMap}
+                resolveAgentName={resolveAgentName}
+                resolveMemberName={resolveMemberName}
+                navigate={navigate}
+                emptyLabel="No agents match the current filter"
+              />
+            )}
+          </>
+        )}
+
+        {data?.nextCursor && (
+          <div className="flex justify-end mt-4">
+            <Button variant="outline" size="xs" onClick={() => setCursor(data.nextCursor ?? undefined)}>
+              Next page
+            </Button>
+          </div>
+        )}
+      </div>
 
       <NewAgentDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} onCreated={handleCreated} />
 
@@ -224,18 +318,180 @@ export function AgentsPage() {
           agent={lastStepAgent}
           open={lastStepAgent !== null}
           onClose={() => {
-            // "Skip for now" — user can still chat; Workspace shows Offline.
             const uuid = lastStepAgent.uuid;
             setLastStepAgent(null);
             navigate(`/?a=${uuid}`);
           }}
           onBound={(bound) => {
-            // Computer claimed the agent — land in Workspace with it selected.
             setLastStepAgent(null);
             navigate(`/?a=${bound.uuid}`);
           }}
         />
       )}
     </div>
+  );
+}
+
+type NavigateFn = ReturnType<typeof useNavigate>;
+
+function AgentsPanel({
+  title,
+  agents,
+  runtimeMap,
+  resolveAgentName,
+  resolveMemberName,
+  navigate,
+  emptyLabel,
+  breakdown,
+  className,
+}: {
+  title: string;
+  agents: Agent[];
+  runtimeMap: Map<string, RuntimeAgent>;
+  resolveAgentName: (mention: string | null | undefined) => string;
+  resolveMemberName: (id: string | null | undefined) => string;
+  navigate: NavigateFn;
+  emptyLabel: string;
+  breakdown?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Panel className={className}>
+      <SectionHeader right={breakdown}>{title}</SectionHeader>
+      {agents.length === 0 ? (
+        <div className="text-center py-8" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+          {emptyLabel}
+        </div>
+      ) : (
+        <DenseTable>
+          <DenseTableHeader>
+            <DenseTableRow>
+              <DenseTableHead>Name</DenseTableHead>
+              <DenseTableHead>Display</DenseTableHead>
+              <DenseTableHead>Type</DenseTableHead>
+              <DenseTableHead>Delegate</DenseTableHead>
+              <DenseTableHead>Owner</DenseTableHead>
+              <DenseTableHead>Runtime</DenseTableHead>
+              <DenseTableHead>Sessions</DenseTableHead>
+              <DenseTableHead>Status</DenseTableHead>
+              <DenseTableHead>Created</DenseTableHead>
+            </DenseTableRow>
+          </DenseTableHeader>
+          <DenseTableBody>
+            {agents.map((agent) => (
+              <AgentRow
+                key={agent.uuid}
+                agent={agent}
+                runtime={pickRuntime(agent, runtimeMap)}
+                resolveAgentName={resolveAgentName}
+                resolveMemberName={resolveMemberName}
+                navigate={navigate}
+              />
+            ))}
+          </DenseTableBody>
+        </DenseTable>
+      )}
+    </Panel>
+  );
+}
+
+function StateBreakdown({ items }: { items: Array<{ state: string; count: number; label?: string }> }) {
+  const nonZero = items.filter((i) => i.count > 0);
+  if (nonZero.length === 0) return null;
+  return (
+    <span className="inline-flex items-center">
+      {nonZero.map((item, idx) => (
+        <span key={item.state} className="inline-flex items-center">
+          {idx > 0 && (
+            <span style={{ color: "var(--fg-4)", margin: "0 6px" }} aria-hidden>
+              ·
+            </span>
+          )}
+          <span
+            className="mono inline-flex items-center gap-1"
+            style={{ fontSize: 10.5, color: `var(--state-${item.state})` }}
+          >
+            <span aria-hidden>●</span>
+            {item.count} {item.label ?? item.state}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function AgentRow({
+  agent,
+  runtime,
+  resolveAgentName,
+  resolveMemberName,
+  navigate,
+}: {
+  agent: Agent;
+  runtime: RuntimeInfo;
+  resolveAgentName: (mention: string | null | undefined) => string;
+  resolveMemberName: (id: string | null | undefined) => string;
+  navigate: NavigateFn;
+}) {
+  const { runtimeState, activeSessions, totalSessions } = runtime;
+  const isKnownState =
+    runtimeState === "idle" ||
+    runtimeState === "working" ||
+    runtimeState === "blocked" ||
+    runtimeState === "error" ||
+    runtimeState === "offline";
+  return (
+    <DenseTableRow interactive onClick={() => navigate(`/agents/${agent.uuid}`)}>
+      <DenseTableCell>
+        <span className="mono" style={{ fontSize: 12, fontWeight: 500 }}>
+          {agent.name}
+        </span>
+      </DenseTableCell>
+      <DenseTableCell style={{ color: "var(--fg-2)" }}>{agent.displayName ?? "—"}</DenseTableCell>
+      <DenseTableCell>
+        <DenseBadge tone={agent.type === "autonomous_agent" ? "accent" : "neutral"}>{agent.type}</DenseBadge>
+      </DenseTableCell>
+      <DenseTableCell
+        className="mono"
+        style={{ fontSize: 11, color: agent.delegateMention ? "var(--accent-dim)" : "var(--fg-4)" }}
+      >
+        {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "—"}
+      </DenseTableCell>
+      <DenseTableCell style={{ fontSize: 11.5, color: "var(--fg-2)" }}>
+        {resolveMemberName(agent.managerId)}
+      </DenseTableCell>
+      <DenseTableCell>
+        {runtimeState && isKnownState ? (
+          <span className="inline-flex items-center gap-1.5">
+            <StateDot state={runtimeState} size={7} />
+            <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-3)" }}>
+              {runtimeState}
+            </span>
+          </span>
+        ) : (
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+            —
+          </span>
+        )}
+      </DenseTableCell>
+      <DenseTableCell>
+        {activeSessions === null && totalSessions === null ? (
+          <span className="mono" style={{ fontSize: 11, color: "var(--fg-4)" }}>
+            —
+          </span>
+        ) : (
+          <span className="mono tnum" style={{ fontSize: 11 }}>
+            <span style={{ color: "var(--fg-2)" }}>{activeSessions ?? 0}</span>
+            <span style={{ color: "var(--fg-4)" }}> / {totalSessions ?? 0}</span>
+          </span>
+        )}
+      </DenseTableCell>
+      <DenseTableCell>
+        <DenseBadge tone={agent.status === "active" ? "accent" : "outline"}>{agent.status}</DenseBadge>
+      </DenseTableCell>
+      <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+        {formatDate(agent.createdAt)}
+      </DenseTableCell>
+    </DenseTableRow>
   );
 }

--- a/packages/web/src/pages/bindings.tsx
+++ b/packages/web/src/pages/bindings.tsx
@@ -1,13 +1,26 @@
+import type { AdapterBotStatus } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
+import { Link2 } from "lucide-react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router";
 import { listAdapterMappings } from "../api/adapter-mappings.js";
 import { getAdapterStatuses } from "../api/adapter-status.js";
 import { listAdapters } from "../api/adapters.js";
-import { Badge } from "../components/ui/badge.js";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { Button } from "../components/ui/button.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "../components/ui/dense-table.js";
+import { Panel } from "../components/ui/panel.js";
+import { SectionHeader } from "../components/ui/section-header.js";
+import { StateDot } from "../components/ui/state-dot.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
-import { cn, formatDate } from "../lib/utils.js";
+import { formatDate } from "../lib/utils.js";
 
 export function BindingsPage() {
   const navigate = useNavigate();
@@ -31,126 +44,166 @@ export function BindingsPage() {
 
   const isLoading = loadingAdapters || loadingMappings;
 
+  const statusByConfigId = useMemo(() => {
+    const map = new Map<number, AdapterBotStatus>();
+    for (const s of botStatuses ?? []) map.set(s.configId, s);
+    return map;
+  }, [botStatuses]);
+
+  const { onlineBots, offlineBots } = useMemo(() => {
+    let on = 0;
+    let off = 0;
+    for (const a of adapters ?? []) {
+      if (statusByConfigId.get(a.id)?.connected) on++;
+      else off++;
+    }
+    return { onlineBots: on, offlineBots: off };
+  }, [adapters, statusByConfigId]);
+
   return (
-    <div className="space-y-6">
-      <p className="text-sm text-muted-foreground">
+    <>
+      <p style={{ fontSize: 11.5, color: "var(--fg-3)", padding: "0 2px 12px" }}>
         Overview of platform bindings for agents you can manage. Configure each binding from the Agent detail page.
       </p>
 
-      {/* Bot Bindings (non-human agents) */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Bot Bindings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Agent</TableHead>
-                <TableHead>Platform</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Connection</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={5} className="text-center py-4 text-muted-foreground">
-                    Loading...
-                  </TableCell>
-                </TableRow>
-              ) : !adapters?.length ? (
-                <TableRow>
-                  <TableCell colSpan={5} className="text-center py-4 text-muted-foreground">
-                    No bot bindings
-                  </TableCell>
-                </TableRow>
-              ) : (
-                adapters.map((a) => {
-                  const status = botStatuses?.find((s) => s.configId === a.id);
-                  return (
-                    <TableRow key={a.id} className="cursor-pointer" onClick={() => navigate(`/agents/${a.agentId}`)}>
-                      <TableCell className="font-mono text-sm">{resolveAgentName(a.agentId)}</TableCell>
-                      <TableCell>
-                        <Badge variant="secondary">{a.platform}</Badge>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={a.status === "active" ? "default" : "destructive"}>{a.status}</Badge>
-                      </TableCell>
-                      <TableCell>
-                        <span className="flex items-center gap-1.5">
-                          <span
-                            className={cn(
-                              "inline-block h-2 w-2 rounded-full",
-                              status?.connected ? "bg-green-500" : "bg-gray-300",
-                            )}
-                          />
-                          <span className="text-xs text-muted-foreground">
-                            {status?.connected ? "Online" : "Offline"}
-                          </span>
-                        </span>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">{formatDate(a.createdAt)}</TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
+      <Panel className="mb-3.5">
+        <SectionHeader
+          right={
+            <span className="inline-flex items-center">
+              <span className="mono inline-flex items-center gap-1" style={{ color: "var(--state-idle)" }}>
+                <span aria-hidden>●</span>
+                {onlineBots} online
+              </span>
+              <span style={{ color: "var(--fg-4)", margin: "0 6px" }} aria-hidden>
+                ·
+              </span>
+              <span className="mono inline-flex items-center gap-1" style={{ color: "var(--fg-4)" }}>
+                <span aria-hidden>○</span>
+                {offlineBots} offline
+              </span>
+            </span>
+          }
+        >
+          Bot bindings · {adapters?.length ?? 0}
+        </SectionHeader>
+        {isLoading ? (
+          <div className="text-center py-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            Loading…
+          </div>
+        ) : !adapters?.length ? (
+          <div className="text-center py-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            No bot bindings
+          </div>
+        ) : (
+          <DenseTable>
+            <DenseTableHeader>
+              <DenseTableRow>
+                <DenseTableHead>Agent</DenseTableHead>
+                <DenseTableHead>Platform</DenseTableHead>
+                <DenseTableHead>Status</DenseTableHead>
+                <DenseTableHead>Connection</DenseTableHead>
+                <DenseTableHead>Created</DenseTableHead>
+                <DenseTableHead />
+              </DenseTableRow>
+            </DenseTableHeader>
+            <DenseTableBody>
+              {adapters.map((a) => {
+                const connected = statusByConfigId.get(a.id)?.connected ?? false;
+                return (
+                  <DenseTableRow key={a.id} interactive onClick={() => navigate(`/agents/${a.agentId}`)}>
+                    <DenseTableCell>
+                      <span className="mono" style={{ fontSize: 12, fontWeight: 500 }}>
+                        {resolveAgentName(a.agentId)}
+                      </span>
+                    </DenseTableCell>
+                    <DenseTableCell>
+                      <DenseBadge>{a.platform}</DenseBadge>
+                    </DenseTableCell>
+                    <DenseTableCell>
+                      <DenseBadge tone={a.status === "active" ? "accent" : "outline"}>{a.status}</DenseBadge>
+                    </DenseTableCell>
+                    <DenseTableCell>
+                      <span className="inline-flex items-center gap-1.5" style={{ fontSize: 11 }}>
+                        <StateDot state={connected ? "idle" : "offline"} size={7} />
+                        <span style={{ color: "var(--fg-3)" }}>{connected ? "Online" : "Offline"}</span>
+                      </span>
+                    </DenseTableCell>
+                    <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                      {formatDate(a.createdAt)}
+                    </DenseTableCell>
+                    <DenseTableCell style={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="text-[11px]"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          navigate(`/agents/${a.agentId}`);
+                        }}
+                      >
+                        <Link2 className="h-3 w-3" />
+                        Manage
+                      </Button>
+                    </DenseTableCell>
+                  </DenseTableRow>
+                );
+              })}
+            </DenseTableBody>
+          </DenseTable>
+        )}
+      </Panel>
 
-      {/* User Bindings (human agents) */}
-      <Card>
-        <CardHeader>
-          <CardTitle>User Bindings</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Agent</TableHead>
-                <TableHead>Platform</TableHead>
-                <TableHead>External User ID</TableHead>
-                <TableHead>Display Name</TableHead>
-                <TableHead>Bound Via</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading ? (
-                <TableRow>
-                  <TableCell colSpan={6} className="text-center py-4 text-muted-foreground">
-                    Loading...
-                  </TableCell>
-                </TableRow>
-              ) : !mappings?.length ? (
-                <TableRow>
-                  <TableCell colSpan={6} className="text-center py-4 text-muted-foreground">
-                    No user bindings
-                  </TableCell>
-                </TableRow>
-              ) : (
-                mappings.map((m) => (
-                  <TableRow key={m.id} className="cursor-pointer" onClick={() => navigate(`/agents/${m.agentId}`)}>
-                    <TableCell className="font-mono text-sm">{resolveAgentName(m.agentId)}</TableCell>
-                    <TableCell>
-                      <Badge variant="secondary">{m.platform}</Badge>
-                    </TableCell>
-                    <TableCell className="font-mono text-sm">{m.externalUserId}</TableCell>
-                    <TableCell>{m.displayName ?? "—"}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline">{m.boundVia ?? "—"}</Badge>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-    </div>
+      <Panel>
+        <SectionHeader>User bindings · {mappings?.length ?? 0}</SectionHeader>
+        {isLoading ? (
+          <div className="text-center py-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            Loading…
+          </div>
+        ) : !mappings?.length ? (
+          <div className="text-center py-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            No user bindings
+          </div>
+        ) : (
+          <DenseTable>
+            <DenseTableHeader>
+              <DenseTableRow>
+                <DenseTableHead>Agent</DenseTableHead>
+                <DenseTableHead>Platform</DenseTableHead>
+                <DenseTableHead>External user ID</DenseTableHead>
+                <DenseTableHead>Display name</DenseTableHead>
+                <DenseTableHead>Bound via</DenseTableHead>
+                <DenseTableHead>Created</DenseTableHead>
+              </DenseTableRow>
+            </DenseTableHeader>
+            <DenseTableBody>
+              {mappings.map((m) => (
+                <DenseTableRow key={m.id} interactive onClick={() => navigate(`/agents/${m.agentId}`)}>
+                  <DenseTableCell>
+                    <span className="mono" style={{ fontSize: 12, fontWeight: 500, color: "var(--accent-dim)" }}>
+                      {resolveAgentName(m.agentId)}
+                    </span>
+                  </DenseTableCell>
+                  <DenseTableCell>
+                    <DenseBadge>{m.platform}</DenseBadge>
+                  </DenseTableCell>
+                  <DenseTableCell>
+                    <span className="mono" style={{ fontSize: 11, color: "var(--fg-2)" }}>
+                      {m.externalUserId}
+                    </span>
+                  </DenseTableCell>
+                  <DenseTableCell style={{ color: "var(--fg-2)" }}>{m.displayName ?? "—"}</DenseTableCell>
+                  <DenseTableCell>
+                    <DenseBadge tone="outline">{m.boundVia ?? "—"}</DenseBadge>
+                  </DenseTableCell>
+                  <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                    {formatDate(m.createdAt)}
+                  </DenseTableCell>
+                </DenseTableRow>
+              ))}
+            </DenseTableBody>
+          </DenseTable>
+        )}
+      </Panel>
+    </>
   );
 }

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -13,15 +13,24 @@ import {
 } from "../api/activity.js";
 import { ApiError } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
-import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "../components/ui/dense-table.js";
+import { PageHeader } from "../components/ui/page-header.js";
+import { Panel } from "../components/ui/panel.js";
+import { SectionHeader, UppercaseLabel } from "../components/ui/section-header.js";
 import { StateChip } from "../components/ui/state-chip.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { useUserNameMap } from "../lib/use-user-name-map.js";
 import { formatDate } from "../lib/utils.js";
 
-function ConnectCommandBanner() {
+function ConnectStrip() {
   const [connectData, setConnectData] = useState<ConnectTokenResponse | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -40,34 +49,49 @@ function ConnectCommandBanner() {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  if (!connectData) {
-    return (
-      <div className="flex items-center gap-3 mb-4 p-3 border border-border rounded-lg bg-muted/30">
-        <Terminal className="h-4 w-4 text-muted-foreground shrink-0" />
-        <span className="text-sm text-muted-foreground">Connect a new computer to this Hub</span>
-        <Button variant="outline" size="sm" onClick={() => generateMut.mutate()} disabled={generateMut.isPending}>
-          {generateMut.isPending ? "Generating..." : "Generate Connect Command"}
-        </Button>
-      </div>
-    );
-  }
-
   return (
-    <div className="mb-4 p-3 border border-border rounded-lg bg-muted/30 space-y-2">
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Terminal className="h-4 w-4 shrink-0" />
-        <span>Run this command in your terminal (expires in {connectData.expiresIn / 60} min):</span>
-      </div>
-      <div className="flex items-center gap-2">
-        <code className="flex-1 text-xs bg-background border border-border rounded px-3 py-2 font-mono break-all select-all">
-          {connectData.command}
+    <div
+      className="grid items-center gap-2.5 mb-3.5"
+      style={{
+        gridTemplateColumns: "auto 1fr auto auto",
+        padding: "8px 12px",
+        background: "var(--bg-raised)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <span className="inline-flex items-center gap-2" style={{ color: "var(--fg-2)", fontSize: 12 }}>
+        <Terminal className="h-3.5 w-3.5" />
+        Connect a computer
+      </span>
+      {connectData ? (
+        <code
+          className="mono whitespace-nowrap overflow-hidden text-ellipsis"
+          style={{
+            fontSize: 11,
+            padding: "5px 10px",
+            background: "var(--bg-sunken)",
+            border: "1px solid var(--border-faint)",
+            borderRadius: 4,
+            color: "var(--fg-2)",
+          }}
+          title={connectData.command}
+        >
+          {connectData.command}{" "}
+          <span style={{ color: "var(--fg-4)" }}># expires in {Math.round(connectData.expiresIn / 60)}m</span>
         </code>
-        <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0">
-          {copied ? <Check className="h-3 w-3 mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
-          {copied ? "Copied" : "Copy"}
-        </Button>
-      </div>
-      <p className="text-xs text-muted-foreground">This token is single-use. Generate a new one if it expires.</p>
+      ) : (
+        <span className="mono" style={{ fontSize: 11, color: "var(--fg-4)" }}>
+          Generate a single-use command to pair a new machine with this Hub.
+        </span>
+      )}
+      <Button variant="outline" size="xs" onClick={handleCopy} disabled={!connectData}>
+        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+      <Button variant="outline" size="xs" onClick={() => generateMut.mutate()} disabled={generateMut.isPending}>
+        {generateMut.isPending ? "Generating…" : connectData ? "Regenerate" : "Generate"}
+      </Button>
     </div>
   );
 }
@@ -113,8 +137,6 @@ export function ClientsPage() {
       queryClient.invalidateQueries({ queryKey: ["activity"] });
     },
     onError: (err: unknown) => {
-      // WB7: 409 conflict carries the pinned-agent list in the error message.
-      // Surface it verbatim so the operator knows which agents block retire.
       if (err instanceof ApiError) setRetireError(err.message);
       else setRetireError(err instanceof Error ? err.message : String(err));
     },
@@ -133,154 +155,211 @@ export function ClientsPage() {
 
   const getClientAgents = (clientId: string): RuntimeAgent[] => agentsByClient.get(clientId) ?? [];
 
+  const connectedCount = (clients ?? []).filter((c) => c.status === "connected").length;
+  const totalAgentsBound = (clients ?? []).reduce((n, c) => n + c.agentCount, 0);
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-4">Computers</h1>
-      <ConnectCommandBanner />
+    <div className="-m-6">
+      <PageHeader
+        title="Computers"
+        subtitle={
+          clients && clients.length > 0 ? (
+            <>
+              {clients.length} total · {connectedCount} connected · {totalAgentsBound} agents bound
+            </>
+          ) : null
+        }
+      />
 
-      {/* Confirm retire dialog */}
-      {confirmRetire && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card border border-border rounded-lg p-6 max-w-md w-full shadow-lg">
-            <h3 className="text-lg font-semibold mb-2">Retire Computer</h3>
-            <p className="text-sm text-muted-foreground mb-3">
-              Permanently remove{" "}
-              <span className="font-medium text-foreground">
-                {confirmRetire.hostname ?? confirmRetire.id.slice(0, 8)}
-              </span>
-              . Retire refuses if any agent is still pinned to this computer — you must delete those agents first
-              (reassign is not available in this milestone).
-            </p>
-            {getClientAgents(confirmRetire.id).length > 0 && (
-              <div className="mb-3 p-2 rounded bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-900">
-                <div className="text-xs font-medium text-yellow-900 dark:text-yellow-200 mb-1">
-                  Agents currently bound to this computer (delete them first):
+      <div style={{ padding: "14px 20px 28px" }}>
+        <ConnectStrip />
+
+        {confirmRetire && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+            <div
+              className="max-w-md w-full"
+              style={{
+                background: "var(--bg-raised)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                padding: 24,
+                boxShadow: "var(--shadow-md)",
+              }}
+            >
+              <h3 className="text-base font-semibold mb-2">Retire Computer</h3>
+              <p className="text-sm mb-3" style={{ color: "var(--fg-3)" }}>
+                Permanently remove{" "}
+                <span style={{ color: "var(--fg)", fontWeight: 500 }}>
+                  {confirmRetire.hostname ?? confirmRetire.id.slice(0, 8)}
+                </span>
+                . Retire refuses if any agent is still pinned to this computer — you must delete those agents first
+                (reassign is not available in this milestone).
+              </p>
+              {getClientAgents(confirmRetire.id).length > 0 && (
+                <div
+                  className="mb-3 p-2 rounded"
+                  style={{
+                    background: "color-mix(in oklch, var(--state-blocked) 12%, transparent)",
+                    border: "1px solid color-mix(in oklch, var(--state-blocked) 28%, transparent)",
+                  }}
+                >
+                  <div className="text-xs font-medium mb-1">
+                    Agents currently bound to this computer (delete them first):
+                  </div>
+                  <ul className="text-sm space-y-0.5">
+                    {getClientAgents(confirmRetire.id).map((a) => (
+                      <li key={a.agentId} className="font-medium">
+                        {agentName(a.agentId)}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
-                <ul className="text-sm space-y-0.5">
-                  {getClientAgents(confirmRetire.id).map((a) => (
-                    <li key={a.agentId} className="font-medium">
-                      {agentName(a.agentId)}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {retireError && (
-              <div className="mb-3 p-2 rounded bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 text-sm text-red-900 dark:text-red-200">
-                {retireError}
-              </div>
-            )}
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setConfirmRetire(null);
-                  setRetireError(null);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => retireMut.mutate(confirmRetire.id)}
-                disabled={retireMut.isPending}
-              >
-                {retireMut.isPending ? "Retiring..." : "Retire"}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Confirm disconnect dialog */}
-      {confirmDisconnect && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card border border-border rounded-lg p-6 max-w-md w-full shadow-lg">
-            <h3 className="text-lg font-semibold mb-2">Disconnect Computer</h3>
-            <p className="text-sm text-muted-foreground mb-3">
-              This will disconnect{" "}
-              <span className="font-medium text-foreground">
-                {confirmDisconnect.hostname ?? confirmDisconnect.id.slice(0, 8)}
-              </span>{" "}
-              and affect all bound agents:
-            </p>
-            <ul className="mb-4 space-y-1">
-              {getClientAgents(confirmDisconnect.id).length === 0 ? (
-                <li className="text-sm text-muted-foreground">No bound agents</li>
-              ) : (
-                getClientAgents(confirmDisconnect.id).map((a) => (
-                  <li key={a.agentId} className="text-sm flex items-center gap-2">
-                    <span className="font-medium">{agentName(a.agentId)}</span>
-                    <StateChip state={a.runtimeState} />
-                  </li>
-                ))
               )}
-            </ul>
-            <div className="flex justify-end gap-2">
-              <Button variant="outline" size="sm" onClick={() => setConfirmDisconnect(null)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => disconnectMut.mutate(confirmDisconnect.id)}
-                disabled={disconnectMut.isPending}
-              >
-                {disconnectMut.isPending ? "Disconnecting..." : "Disconnect"}
-              </Button>
+              {retireError && (
+                <div
+                  className="mb-3 p-2 rounded text-sm"
+                  style={{
+                    background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+                    border: "1px solid color-mix(in oklch, var(--state-error) 28%, transparent)",
+                    color: "var(--state-error)",
+                  }}
+                >
+                  {retireError}
+                </div>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setConfirmRetire(null);
+                    setRetireError(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => retireMut.mutate(confirmRetire.id)}
+                  disabled={retireMut.isPending}
+                >
+                  {retireMut.isPending ? "Retiring…" : "Retire"}
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {!clients || clients.length === 0 ? (
-        <div className="text-center text-muted-foreground py-12">
-          No computers. Use the button above to generate a connect command.
-        </div>
-      ) : (
-        <div className="border rounded-lg overflow-hidden">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-8" />
-                <TableHead>Hostname</TableHead>
-                {isAdmin && <TableHead>Owner</TableHead>}
-                <TableHead>OS</TableHead>
-                <TableHead>SDK</TableHead>
-                <TableHead>Agents</TableHead>
-                <TableHead>Connected</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {clients.map((client) => {
-                const isExpanded = expandedId === client.id;
-                const boundAgents = getClientAgents(client.id);
-                return (
-                  <ClientRow
-                    key={client.id}
-                    client={client}
-                    boundAgents={boundAgents}
-                    isExpanded={isExpanded}
-                    agentName={agentName}
-                    showOwner={isAdmin}
-                    ownerName={ownerName}
-                    onToggle={() => setExpandedId(isExpanded ? null : client.id)}
-                    onDisconnect={() => setConfirmDisconnect(client)}
-                    onRetire={() => {
-                      setRetireError(null);
-                      setConfirmRetire(client);
-                    }}
-                  />
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+        {confirmDisconnect && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+            <div
+              className="max-w-md w-full"
+              style={{
+                background: "var(--bg-raised)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                padding: 24,
+                boxShadow: "var(--shadow-md)",
+              }}
+            >
+              <h3 className="text-base font-semibold mb-2">Disconnect Computer</h3>
+              <p className="text-sm mb-3" style={{ color: "var(--fg-3)" }}>
+                This will disconnect{" "}
+                <span style={{ color: "var(--fg)", fontWeight: 500 }}>
+                  {confirmDisconnect.hostname ?? confirmDisconnect.id.slice(0, 8)}
+                </span>{" "}
+                and affect all bound agents:
+              </p>
+              <ul className="mb-4 space-y-1">
+                {getClientAgents(confirmDisconnect.id).length === 0 ? (
+                  <li className="text-sm" style={{ color: "var(--fg-3)" }}>
+                    No bound agents
+                  </li>
+                ) : (
+                  getClientAgents(confirmDisconnect.id).map((a) => (
+                    <li key={a.agentId} className="text-sm flex items-center gap-2">
+                      <span className="font-medium">{agentName(a.agentId)}</span>
+                      <StateChip state={a.runtimeState} />
+                    </li>
+                  ))
+                )}
+              </ul>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={() => setConfirmDisconnect(null)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => disconnectMut.mutate(confirmDisconnect.id)}
+                  disabled={disconnectMut.isPending}
+                >
+                  {disconnectMut.isPending ? "Disconnecting…" : "Disconnect"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!clients || clients.length === 0 ? (
+          <Panel>
+            <div className="text-center py-10" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+              No computers. Use the button above to generate a connect command.
+            </div>
+          </Panel>
+        ) : (
+          <Panel>
+            <SectionHeader
+              right={
+                <span className="mono" style={{ color: "var(--fg-3)", textTransform: "none", letterSpacing: 0 }}>
+                  click a row to expand
+                </span>
+              }
+            >
+              Registered · {clients.length}
+            </SectionHeader>
+            <DenseTable>
+              <DenseTableHeader>
+                <DenseTableRow>
+                  <DenseTableHead style={{ width: 16 }} />
+                  <DenseTableHead>Hostname</DenseTableHead>
+                  {isAdmin && <DenseTableHead>Owner</DenseTableHead>}
+                  <DenseTableHead>OS</DenseTableHead>
+                  <DenseTableHead>SDK</DenseTableHead>
+                  <DenseTableHead>Agents</DenseTableHead>
+                  <DenseTableHead>Connected</DenseTableHead>
+                  <DenseTableHead>Status</DenseTableHead>
+                  <DenseTableHead />
+                </DenseTableRow>
+              </DenseTableHeader>
+              <DenseTableBody>
+                {clients.map((client) => {
+                  const isExpanded = expandedId === client.id;
+                  const boundAgents = getClientAgents(client.id);
+                  return (
+                    <ClientRow
+                      key={client.id}
+                      client={client}
+                      boundAgents={boundAgents}
+                      isExpanded={isExpanded}
+                      agentName={agentName}
+                      showOwner={isAdmin}
+                      ownerName={ownerName}
+                      onToggle={() => setExpandedId(isExpanded ? null : client.id)}
+                      onDisconnect={() => setConfirmDisconnect(client)}
+                      onRetire={() => {
+                        setRetireError(null);
+                        setConfirmRetire(client);
+                      }}
+                    />
+                  );
+                })}
+              </DenseTableBody>
+            </DenseTable>
+          </Panel>
+        )}
+      </div>
     </div>
   );
 }
@@ -306,73 +385,91 @@ function ClientRow({
   onDisconnect: () => void;
   onRetire: () => void;
 }) {
+  const colSpan = showOwner ? 9 : 8;
+  const statusState = client.status === "connected" ? "idle" : "offline";
   return (
     <>
-      <TableRow className="cursor-pointer hover:bg-accent/50" onClick={onToggle}>
-        <TableCell className="px-2">
-          {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-        </TableCell>
-        <TableCell className="font-medium">{client.hostname ?? "\u2014"}</TableCell>
-        {showOwner && <TableCell className="text-sm">{ownerName(client.userId)}</TableCell>}
-        <TableCell className="text-muted-foreground">{client.os ?? "\u2014"}</TableCell>
-        <TableCell className="font-mono text-xs text-muted-foreground">{client.sdkVersion ?? "\u2014"}</TableCell>
-        <TableCell>{client.agentCount}</TableCell>
-        <TableCell className="text-muted-foreground text-sm">
-          {client.connectedAt ? formatDate(client.connectedAt) : "\u2014"}
-        </TableCell>
-        <TableCell>
-          <Badge variant={client.status === "connected" ? "default" : "secondary"}>{client.status}</Badge>
-        </TableCell>
-        <TableCell>
-          <div className="flex gap-2 justify-end">
+      <DenseTableRow interactive selected={isExpanded} onClick={onToggle}>
+        <DenseTableCell style={{ width: 16 }}>
+          <span style={{ color: "var(--fg-4)", display: "inline-flex" }}>
+            {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </span>
+        </DenseTableCell>
+        <DenseTableCell style={{ fontWeight: 500 }}>{client.hostname ?? "—"}</DenseTableCell>
+        {showOwner && <DenseTableCell style={{ color: "var(--fg-2)" }}>{ownerName(client.userId)}</DenseTableCell>}
+        <DenseTableCell style={{ color: "var(--fg-3)" }}>{client.os ?? "—"}</DenseTableCell>
+        <DenseTableCell className="mono" style={{ fontSize: 11, color: "var(--fg-3)" }}>
+          {client.sdkVersion ?? "—"}
+        </DenseTableCell>
+        <DenseTableCell>
+          <span className="mono tnum" style={{ fontSize: 11.5 }}>
+            {client.agentCount}
+          </span>
+        </DenseTableCell>
+        <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+          {client.connectedAt ? formatDate(client.connectedAt) : "—"}
+        </DenseTableCell>
+        <DenseTableCell>
+          <StateChip state={statusState} />
+        </DenseTableCell>
+        <DenseTableCell style={{ width: 1, whiteSpace: "nowrap" }}>
+          <div className="flex gap-1 justify-end">
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="xs"
+              className="text-[11px]"
               onClick={(e) => {
                 e.stopPropagation();
                 onDisconnect();
               }}
             >
-              <Unplug className="h-3 w-3 mr-1" />
-              Disconnect
+              <Unplug className="h-3 w-3" /> Disconnect
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="xs"
+              className="text-[11px]"
+              style={{ color: "var(--fg-4)" }}
               onClick={(e) => {
                 e.stopPropagation();
                 onRetire();
               }}
             >
-              <Trash2 className="h-3 w-3 mr-1" />
-              Retire
+              <Trash2 className="h-3 w-3" /> Retire
             </Button>
           </div>
-        </TableCell>
-      </TableRow>
+        </DenseTableCell>
+      </DenseTableRow>
       {isExpanded && (
-        <TableRow>
-          <TableCell colSpan={showOwner ? 9 : 8} className="bg-muted/30 px-8 py-3">
-            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
-              Bound Agents ({boundAgents.length})
-            </div>
+        <tr style={{ background: "var(--bg-sunken)" }}>
+          <DenseTableCell />
+          <DenseTableCell colSpan={colSpan - 1} style={{ padding: "10px 12px 14px" }}>
+            <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>
+              Bound agents · {boundAgents.length}
+            </UppercaseLabel>
             {boundAgents.length === 0 ? (
-              <div className="text-sm text-muted-foreground">No agents bound to this computer</div>
+              <div className="text-sm" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+                No agents bound to this computer
+              </div>
             ) : (
-              <div className="space-y-1">
+              <div className="flex flex-col gap-1">
                 {boundAgents.map((a) => (
-                  <div key={a.agentId} className="flex items-center gap-3 text-sm">
-                    <span className="font-medium">{agentName(a.agentId)}</span>
-                    <StateChip state={a.runtimeState} />
-                    <span className="text-xs text-muted-foreground">
-                      {a.activeSessions !== null ? `${a.activeSessions}/${a.totalSessions ?? 0} sessions` : ""}
+                  <div key={a.agentId} className="flex items-center gap-2.5" style={{ fontSize: 12 }}>
+                    <span className="mono" style={{ fontWeight: 500, minWidth: 180 }}>
+                      {agentName(a.agentId)}
                     </span>
+                    <StateChip state={a.runtimeState} />
+                    {a.activeSessions !== null && (
+                      <span className="mono tnum" style={{ fontSize: 10.5, color: "var(--fg-3)" }}>
+                        {a.activeSessions} / {a.totalSessions ?? 0} sessions
+                      </span>
+                    )}
                   </div>
                 ))}
               </div>
             )}
-          </TableCell>
-        </TableRow>
+          </DenseTableCell>
+        </tr>
       )}
     </>
   );

--- a/packages/web/src/pages/members.tsx
+++ b/packages/web/src/pages/members.tsx
@@ -3,8 +3,17 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Copy, Pencil, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 import { createMember, deleteMember, listMembers, updateMember } from "../api/members.js";
-import { Badge } from "../components/ui/badge.js";
+import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
+import {
+  DenseTable,
+  DenseTableBody,
+  DenseTableCell,
+  DenseTableHead,
+  DenseTableHeader,
+  DenseTableRow,
+} from "../components/ui/dense-table.js";
 import {
   Dialog,
   DialogContent,
@@ -15,7 +24,8 @@ import {
 } from "../components/ui/dialog.js";
 import { Input } from "../components/ui/input.js";
 import { Label } from "../components/ui/label.js";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { Panel } from "../components/ui/panel.js";
+import { SectionHeader, UppercaseLabel } from "../components/ui/section-header.js";
 import { formatDate } from "../lib/utils.js";
 
 const roleValues = Object.values(MEMBER_ROLES);
@@ -27,8 +37,20 @@ type MemberRow = {
   role: string;
 };
 
+function initials(displayName: string, username: string): string {
+  const source = displayName?.trim() || username;
+  const parts = source.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    const first = parts[0] ?? "";
+    const second = parts[1] ?? "";
+    return `${first[0] ?? ""}${second[0] ?? ""}`.toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+}
+
 export function MembersPage() {
   const queryClient = useQueryClient();
+  const { memberId: selfId } = useAuth();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [form, setForm] = useState({ username: "", displayName: "", role: "member" });
   const [createdPassword, setCreatedPassword] = useState<string | null>(null);
@@ -79,89 +101,196 @@ export function MembersPage() {
   }
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold">Members</h1>
-        <Dialog open={dialogOpen} onOpenChange={(open) => (open ? setDialogOpen(true) : closeDialog())}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Member
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>{createdPassword ? "Member Created" : "Create Member"}</DialogTitle>
-            </DialogHeader>
-            {createdPassword ? (
-              <div className="space-y-4">
-                <p className="text-sm text-muted-foreground">
-                  Member created. Share the password below — it will only be shown once.
-                </p>
-                <div className="flex items-center gap-2 rounded-md border p-3 bg-muted">
-                  <code className="flex-1 text-sm font-mono">{createdPassword}</code>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => navigator.clipboard.writeText(createdPassword)}
-                    title="Copy password"
-                  >
-                    <Copy className="h-4 w-4" />
-                  </Button>
-                </div>
-                <DialogFooter>
-                  <Button onClick={closeDialog}>Done</Button>
-                </DialogFooter>
-              </div>
-            ) : (
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="member-username">Username</Label>
-                  <Input
-                    id="member-username"
-                    type="text"
-                    value={form.username}
-                    onChange={(e) => setForm({ ...form, username: e.target.value })}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="member-name">Display Name</Label>
-                  <Input
-                    id="member-name"
-                    value={form.displayName}
-                    onChange={(e) => setForm({ ...form, displayName: e.target.value })}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="member-role">Role</Label>
-                  <select
-                    id="member-role"
-                    value={form.role}
-                    onChange={(e) => setForm({ ...form, role: e.target.value })}
-                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  >
-                    {roleValues.map((r) => (
-                      <option key={r} value={r}>
-                        {r}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                {createMut.error instanceof Error && (
-                  <div className="text-sm text-destructive">{createMut.error.message}</div>
+    <>
+      <Panel>
+        <SectionHeader
+          right={
+            <Dialog open={dialogOpen} onOpenChange={(open) => (open ? setDialogOpen(true) : closeDialog())}>
+              <DialogTrigger asChild>
+                <Button size="xs" className="normal-case tracking-normal">
+                  <Plus className="h-3 w-3" />
+                  Add member
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>{createdPassword ? "Member Created" : "Create Member"}</DialogTitle>
+                </DialogHeader>
+                {createdPassword ? (
+                  <div className="space-y-4">
+                    <p className="text-sm" style={{ color: "var(--fg-3)" }}>
+                      Member created. Share the password below — it will only be shown once.
+                    </p>
+                    <div
+                      className="flex items-center gap-2 rounded-md p-3"
+                      style={{ background: "var(--bg-sunken)", border: "1px solid var(--border-faint)" }}
+                    >
+                      <code className="flex-1 text-sm mono">{createdPassword}</code>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => navigator.clipboard.writeText(createdPassword)}
+                        title="Copy password"
+                      >
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <DialogFooter>
+                      <Button onClick={closeDialog}>Done</Button>
+                    </DialogFooter>
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="member-username">Username</Label>
+                      <Input
+                        id="member-username"
+                        type="text"
+                        value={form.username}
+                        onChange={(e) => setForm({ ...form, username: e.target.value })}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="member-name">Display Name</Label>
+                      <Input
+                        id="member-name"
+                        value={form.displayName}
+                        onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="member-role">Role</Label>
+                      <select
+                        id="member-role"
+                        value={form.role}
+                        onChange={(e) => setForm({ ...form, role: e.target.value })}
+                        className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      >
+                        {roleValues.map((r) => (
+                          <option key={r} value={r}>
+                            {r}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    {createMut.error instanceof Error && (
+                      <div className="text-sm" style={{ color: "var(--state-error)" }}>
+                        {createMut.error.message}
+                      </div>
+                    )}
+                    <DialogFooter>
+                      <Button type="submit" disabled={createMut.isPending}>
+                        {createMut.isPending ? "Creating..." : "Create"}
+                      </Button>
+                    </DialogFooter>
+                  </form>
                 )}
-                <DialogFooter>
-                  <Button type="submit" disabled={createMut.isPending}>
-                    {createMut.isPending ? "Creating..." : "Create"}
-                  </Button>
-                </DialogFooter>
-              </form>
-            )}
-          </DialogContent>
-        </Dialog>
-      </div>
+              </DialogContent>
+            </Dialog>
+          }
+        >
+          Members · {members?.length ?? 0}
+        </SectionHeader>
+
+        {isLoading ? (
+          <div className="text-center py-8" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            Loading…
+          </div>
+        ) : error ? (
+          <div className="text-center py-8" style={{ color: "var(--state-error)", fontSize: 12 }}>
+            Failed to load members: {error instanceof Error ? error.message : "Unknown error"}
+          </div>
+        ) : members?.length === 0 ? (
+          <div className="text-center py-8" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            No members
+          </div>
+        ) : (
+          <DenseTable>
+            <DenseTableHeader>
+              <DenseTableRow>
+                <DenseTableHead style={{ width: 30 }} />
+                <DenseTableHead>Username</DenseTableHead>
+                <DenseTableHead>Name</DenseTableHead>
+                <DenseTableHead>Role</DenseTableHead>
+                <DenseTableHead>Created</DenseTableHead>
+                <DenseTableHead style={{ width: 1 }} />
+              </DenseTableRow>
+            </DenseTableHeader>
+            <DenseTableBody>
+              {members?.map((m) => {
+                const isSelf = selfId === m.id;
+                return (
+                  <DenseTableRow key={m.id}>
+                    <DenseTableCell>
+                      <span
+                        className="mono inline-flex items-center justify-center"
+                        style={{
+                          width: 22,
+                          height: 22,
+                          borderRadius: 4,
+                          background: isSelf ? "var(--accent-bg)" : "var(--bg-active)",
+                          border: "1px solid var(--border-strong)",
+                          fontSize: 9.5,
+                          fontWeight: 600,
+                          color: isSelf ? "var(--accent-dim)" : "var(--fg-2)",
+                        }}
+                      >
+                        {initials(m.displayName, m.username)}
+                      </span>
+                    </DenseTableCell>
+                    <DenseTableCell>
+                      <span className="mono" style={{ fontSize: 12, fontWeight: 500 }}>
+                        {m.username}
+                      </span>
+                      {isSelf && <UppercaseLabel style={{ marginLeft: 6 }}>you</UppercaseLabel>}
+                    </DenseTableCell>
+                    <DenseTableCell style={{ color: "var(--fg-2)" }}>{m.displayName}</DenseTableCell>
+                    <DenseTableCell>
+                      <DenseBadge tone={m.role === "admin" ? "accent" : "neutral"}>{m.role}</DenseBadge>
+                    </DenseTableCell>
+                    <DenseTableCell className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+                      {formatDate(m.createdAt)}
+                    </DenseTableCell>
+                    <DenseTableCell style={{ whiteSpace: "nowrap" }}>
+                      <div className="flex gap-0.5 justify-end">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() =>
+                            setEditTarget({
+                              id: m.id,
+                              username: m.username,
+                              displayName: m.displayName,
+                              role: m.role,
+                            })
+                          }
+                          title="Edit"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => handleDelete(m.id)}
+                          disabled={deleteMut.isPending}
+                          title="Delete"
+                          style={{ color: "var(--fg-4)" }}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </DenseTableCell>
+                  </DenseTableRow>
+                );
+              })}
+            </DenseTableBody>
+          </DenseTable>
+        )}
+      </Panel>
 
       <EditMemberDialog
         target={editTarget}
@@ -171,81 +300,7 @@ export function MembersPage() {
           queryClient.invalidateQueries({ queryKey: ["members"] });
         }}
       />
-
-      <div className="border rounded-lg">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Username</TableHead>
-              <TableHead>Name</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead className="w-16" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                  Loading...
-                </TableCell>
-              </TableRow>
-            ) : error ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-destructive">
-                  Failed to load members: {error instanceof Error ? error.message : "Unknown error"}
-                </TableCell>
-              </TableRow>
-            ) : members?.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                  No members
-                </TableCell>
-              </TableRow>
-            ) : (
-              members?.map((m) => (
-                <TableRow key={m.id}>
-                  <TableCell className="font-medium">{m.username}</TableCell>
-                  <TableCell>{m.displayName}</TableCell>
-                  <TableCell>
-                    <Badge variant={m.role === "admin" ? "default" : "secondary"}>{m.role}</Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-1 justify-end">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() =>
-                          setEditTarget({
-                            id: m.id,
-                            username: m.username,
-                            displayName: m.displayName,
-                            role: m.role,
-                          })
-                        }
-                        title="Edit"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(m.id)}
-                        disabled={deleteMut.isPending}
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
-    </div>
+    </>
   );
 }
 
@@ -310,7 +365,9 @@ function EditMemberDialog({
             <div className="space-y-2">
               <Label>Username</Label>
               <Input value={target.username} disabled className="font-mono" />
-              <p className="text-xs text-muted-foreground">Username is permanent after creation.</p>
+              <p className="text-xs" style={{ color: "var(--fg-3)" }}>
+                Username is permanent after creation.
+              </p>
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-member-display">Display Name</Label>
@@ -336,11 +393,15 @@ function EditMemberDialog({
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs" style={{ color: "var(--fg-3)" }}>
                 Demoting the last admin is blocked — every org needs at least one admin to manage members.
               </p>
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && (
+              <p className="text-sm" style={{ color: "var(--state-error)" }}>
+                {error}
+              </p>
+            )}
             <DialogFooter>
               <Button type="button" variant="ghost" onClick={onClose} disabled={saveMut.isPending}>
                 Cancel

--- a/packages/web/src/pages/org-settings.tsx
+++ b/packages/web/src/pages/org-settings.tsx
@@ -1,20 +1,47 @@
 import { SYSTEM_CONFIG_DEFAULTS, SYSTEM_CONFIG_KEYS } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 import { getConfigs, updateConfigs } from "../api/system-config.js";
 import { Button } from "../components/ui/button.js";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
-import { Input } from "../components/ui/input.js";
-import { Label } from "../components/ui/label.js";
+import { Panel, PanelHeader, PanelTitle } from "../components/ui/panel.js";
+import { UppercaseLabel } from "../components/ui/section-header.js";
 
-const CONFIG_LABELS: Record<string, string> = {
-  [SYSTEM_CONFIG_KEYS.INBOX_TIMEOUT_SECONDS]: "Inbox Timeout (seconds)",
-  [SYSTEM_CONFIG_KEYS.MAX_RETRY_COUNT]: "Max Retry Count",
-  [SYSTEM_CONFIG_KEYS.POLLING_INTERVAL_SECONDS]: "Polling Interval (seconds)",
-  [SYSTEM_CONFIG_KEYS.PRESENCE_CLEANUP_SECONDS]: "Presence Cleanup (seconds)",
+type ConfigMeta = {
+  key: string;
+  label: string;
+  description: string;
+  unit: string | null;
 };
 
-const configKeys = Object.values(SYSTEM_CONFIG_KEYS);
+const CONFIG_FIELDS: ConfigMeta[] = [
+  {
+    key: SYSTEM_CONFIG_KEYS.INBOX_TIMEOUT_SECONDS,
+    label: "Inbox timeout",
+    description: "How long an agent waits for inbound messages before sleeping.",
+    unit: "seconds",
+  },
+  {
+    key: SYSTEM_CONFIG_KEYS.MAX_RETRY_COUNT,
+    label: "Max retry count",
+    description: "Delivery attempts before a message is marked failed.",
+    unit: null,
+  },
+  {
+    key: SYSTEM_CONFIG_KEYS.POLLING_INTERVAL_SECONDS,
+    label: "Polling interval",
+    description: "Runtime heartbeat cadence for offline detection.",
+    unit: "seconds",
+  },
+  {
+    key: SYSTEM_CONFIG_KEYS.PRESENCE_CLEANUP_SECONDS,
+    label: "Presence cleanup",
+    description: "When presence rows expire after disconnect.",
+    unit: "seconds",
+  },
+];
+
+const configKeys = CONFIG_FIELDS.map((c) => c.key);
 
 export function OrgSettingsPage() {
   const queryClient = useQueryClient();
@@ -42,7 +69,6 @@ export function OrgSettingsPage() {
       for (const [key, val] of Object.entries(values)) {
         const trimmed = val.trim();
         if (trimmed === "") {
-          // Restore default instead of sending 0
           payload[key] = SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? 0;
         } else {
           const num = Number(trimmed);
@@ -58,44 +84,122 @@ export function OrgSettingsPage() {
     },
   });
 
-  const handleSubmit = (e: FormEvent) => {
+  function handleReset() {
+    const map: Record<string, string> = {};
+    for (const key of configKeys) {
+      map[key] = String(SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "");
+    }
+    setValues(map);
+  }
+
+  function handleSubmit(e: FormEvent) {
     e.preventDefault();
     mutation.mutate();
-  };
-
-  if (isLoading) {
-    return <div className="text-muted-foreground">Loading...</div>;
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>System Configuration</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {configKeys.map((key) => (
-            <div key={key} className="space-y-2">
-              <Label htmlFor={key}>{CONFIG_LABELS[key] ?? key}</Label>
-              <Input
-                id={key}
-                value={values[key] ?? ""}
-                onChange={(e) => setValues({ ...values, [key]: e.target.value })}
-              />
-              <p className="text-xs text-muted-foreground">
-                Default: {String(SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "—")}
-              </p>
-            </div>
-          ))}
-          {mutation.error instanceof Error && <div className="text-sm text-destructive">{mutation.error.message}</div>}
-          <div className="flex items-center gap-3">
-            <Button type="submit" disabled={mutation.isPending}>
-              {mutation.isPending ? "Saving..." : "Save Changes"}
+    <form onSubmit={handleSubmit}>
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>System configuration</PanelTitle>
+          <div className="flex items-center gap-1.5">
+            {saved && (
+              <span className="mono" style={{ fontSize: 10.5, color: "var(--accent-dim)" }}>
+                saved
+              </span>
+            )}
+            <Button type="button" variant="ghost" size="xs" onClick={handleReset} disabled={mutation.isPending}>
+              Reset defaults
             </Button>
-            {saved && <span className="text-sm text-green-600">Saved!</span>}
+            <Button type="submit" size="xs" disabled={mutation.isPending}>
+              <Check className="h-3 w-3" />
+              {mutation.isPending ? "Saving…" : "Save changes"}
+            </Button>
           </div>
-        </form>
-      </CardContent>
-    </Card>
+        </PanelHeader>
+        <div style={{ padding: "4px 16px 14px" }}>
+          {isLoading ? (
+            <div className="py-6" style={{ color: "var(--fg-3)", fontSize: 12 }}>
+              Loading…
+            </div>
+          ) : (
+            CONFIG_FIELDS.map((field) => (
+              <ConfigRow
+                key={field.key}
+                field={field}
+                value={values[field.key] ?? ""}
+                onChange={(v) => setValues({ ...values, [field.key]: v })}
+              />
+            ))
+          )}
+          {mutation.error instanceof Error && (
+            <div className="text-sm pt-2" style={{ color: "var(--state-error)" }}>
+              {mutation.error.message}
+            </div>
+          )}
+        </div>
+      </Panel>
+    </form>
+  );
+}
+
+function ConfigRow({ field, value, onChange }: { field: ConfigMeta; value: string; onChange: (next: string) => void }) {
+  const def = String(SYSTEM_CONFIG_DEFAULTS[field.key as keyof typeof SYSTEM_CONFIG_DEFAULTS] ?? "—");
+  return (
+    <div
+      className="grid items-start gap-5"
+      style={{
+        gridTemplateColumns: "1fr 180px",
+        padding: "14px 0",
+        borderTop: "1px solid var(--border-faint)",
+      }}
+    >
+      <div>
+        <div className="flex items-baseline gap-2">
+          <span style={{ fontSize: 12.5, fontWeight: 500, color: "var(--fg)" }}>{field.label}</span>
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-4)" }}>
+            {field.key}
+          </span>
+        </div>
+        <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 2 }}>{field.description}</div>
+        <UppercaseLabel style={{ marginTop: 4, display: "block" }}>
+          default{" "}
+          <span className="mono" style={{ color: "var(--fg-3)", textTransform: "none", letterSpacing: 0 }}>
+            {def}
+          </span>
+        </UppercaseLabel>
+      </div>
+      <div style={{ position: "relative" }}>
+        <input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full outline-none mono"
+          style={{
+            padding: `5px ${field.unit ? 56 : 10}px 5px 10px`,
+            fontSize: 12,
+            background: "var(--bg-sunken)",
+            border: "1px solid var(--border)",
+            borderRadius: 4,
+            color: "var(--fg)",
+          }}
+        />
+        {field.unit && (
+          <span
+            className="mono"
+            style={{
+              position: "absolute",
+              right: 8,
+              top: "50%",
+              transform: "translateY(-50%)",
+              fontSize: 10,
+              color: "var(--fg-4)",
+              pointerEvents: "none",
+            }}
+          >
+            {field.unit}
+          </span>
+        )}
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -1,3 +1,5 @@
+import { PageHeader } from "../components/ui/page-header.js";
+import { Tab, TabBar } from "../components/ui/tab-bar.js";
 import { BindingsPage } from "./bindings.js";
 
 /**
@@ -7,9 +9,14 @@ import { BindingsPage } from "./bindings.js";
  */
 export function SettingsPage() {
   return (
-    <div>
-      <h1 className="text-2xl font-semibold mb-6">Settings</h1>
-      <BindingsPage />
+    <div className="-m-6">
+      <PageHeader title="Settings" subtitle="Per-member controls" />
+      <TabBar>
+        <Tab active>Bindings</Tab>
+      </TabBar>
+      <div style={{ padding: "16px 20px 28px" }}>
+        <BindingsPage />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Introduce shared dense layout primitives in `packages/web/src/components/ui/`: `Panel`, `SectionHeader`, `PageHeader`, `Breadcrumb`, `TabBar`, `Tile`, `DenseTable`, `DenseBadge`, `FilterPill`.
- Adopt them across Agents, Agent Detail, Computers (Clients), Bindings, Members, Admin, Org Settings, and Settings pages for a denser, more consistent admin surface.
- Add `xs` size variant to the `Button` component.
- Bump `@agent-team-foundation/first-tree-hub` to `0.9.3`.

## Test plan

- [ ] `pnpm check && pnpm typecheck` pass
- [ ] `pnpm --filter @first-tree-hub/web test` passes
- [ ] Agents list — filter pills, search, team/my scopes, state breakdown render correctly
- [ ] Agent detail — sidebar jump-to, identity/runtime/bindings/danger sections, save bar, binding dialog
- [ ] Computers (Clients) — list, retire/disconnect dialogs
- [ ] Bindings — bot + user tables, online/offline counts
- [ ] Members — list, create/edit dialogs
- [ ] Admin — all-agents, dashboard tiles
- [ ] Org Settings and user Settings pages
- [ ] Dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)