### PR TITLE
fix(server): allow managers to edit agent behavior; keep prompt manager-only

### DIFF
--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -312,7 +312,7 @@ describe("Admin agent-config API (Step 2)", () => {
     const fresh = loginRes.json<{ accessToken: string }>();
     const auth = { authorization: `Bearer ${fresh.accessToken}` };
 
-    // GET — manager can read config (assertAgentVisible allows any visible viewer).
+    // GET — manager can read config (assertCanManage allows managerId = self).
     const get = await app.inject({
       method: "GET",
       url: `/api/v1/admin/agents/${agent.uuid}/config`,
@@ -330,5 +330,73 @@ describe("Admin agent-config API (Step 2)", () => {
     });
     expect(patch.statusCode).toBe(200);
     expect(patch.json().payload.model).toBe("claude-opus-4-6");
+  });
+
+  it("non-manager member cannot GET config even when agent is org-visible", async () => {
+    // Behavior (system prompt, tools, env) is manager-only — visibility only
+    // grants card-view access (GET /admin/agents/:uuid), not internal config.
+    // This mirrors ChatGPT Custom GPTs / Poe / Slack bots: "usable by org ≠
+    // prompt readable by org".
+    const app = getApp();
+    const { createAgent } = await import("../services/agent.js");
+    const { members } = await import("../db/schema/members.js");
+    const { users } = await import("../db/schema/users.js");
+    const { clients } = await import("../db/schema/clients.js");
+
+    // Manager admin creates an org-visible agent.
+    const manager = await createTestAdmin(app, {
+      username: `cfg-vis-mgr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    });
+    const [mgrMember] = await app.db.select().from(members).where(eq(members.id, manager.memberId)).limit(1);
+    if (!mgrMember) throw new Error("manager member missing");
+    const clientId = `cli-vis-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({ id: clientId, userId: mgrMember.userId, status: "connected" });
+    const agent = await createAgent(app.db, {
+      name: `cfg-vis-agent-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Shared Agent",
+      managerId: manager.memberId,
+      clientId,
+      visibility: "organization",
+    });
+
+    // A different member in the same org — has visibility but is not manager.
+    const viewer = await createTestAdmin(app, {
+      username: `cfg-vis-viewer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    });
+    await app.db
+      .update(members)
+      .set({ role: "member" })
+      .where(
+        eq(
+          members.userId,
+          (await app.db.select({ id: users.id }).from(users).where(eq(users.username, viewer.username)).limit(1))[0]
+            ?.id ?? "",
+        ),
+      );
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username: viewer.username, password: viewer.password },
+    });
+    const fresh = loginRes.json<{ accessToken: string }>();
+    const auth = { authorization: `Bearer ${fresh.accessToken}` };
+
+    // Card view works — agent IS visible to this member.
+    const card = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/agents/${agent.uuid}`,
+      headers: auth,
+    });
+    expect(card.statusCode).toBe(200);
+    expect(card.json().uuid).toBe(agent.uuid);
+
+    // But config (behavior) is not readable — manager-only.
+    const cfg = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/agents/${agent.uuid}/config`,
+      headers: auth,
+    });
+    expect(cfg.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -214,13 +214,17 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(events.some((e) => e === `agent:${agent.uuid}`)).toBe(true);
   });
 
-  it("non-admin member is rejected with 403", async () => {
+  it("non-manager member is rejected with 404 (agent they do not manage)", async () => {
+    // assertCanManage throws NotFoundError — 404 rather than 403, so the
+    // request cannot be used to enumerate agent UUIDs a member cannot see.
     const app = getApp();
     const admin = await createTestAdmin(app, {
-      username: `cfg-non-admin-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      username: `cfg-non-mgr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     });
+    // seedAgentFactory creates its own admin as the manager — so the agent
+    // below is NOT managed by `admin` above.
     const agent = await (await seedAgentFactory(app))({
-      name: `cfg-403-${crypto.randomUUID().slice(0, 8)}`,
+      name: `cfg-404-${crypto.randomUUID().slice(0, 8)}`,
       type: "autonomous_agent",
     });
 
@@ -256,6 +260,75 @@ describe("Admin agent-config API (Step 2)", () => {
       headers: { authorization: `Bearer ${fresh.accessToken}` },
       payload: { expectedVersion: 1, payload: { model: "claude-opus-4-6" } },
     });
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("manager (non-admin) can GET and PATCH config on an agent they manage", async () => {
+    // Regression guard: prior to removing the plugin-scoped adminOnly hook on
+    // /admin/agents/:uuid/config, a member editing their own personal_assistant
+    // got "Admin role required" — blocking the documented "manager retains
+    // CRUD" semantics from agents schema.
+    const app = getApp();
+    const { createAgent } = await import("../services/agent.js");
+    const { members } = await import("../db/schema/members.js");
+    const { users } = await import("../db/schema/users.js");
+    const { clients } = await import("../db/schema/clients.js");
+
+    // Create an admin, seed a client owned by them, create an agent managed
+    // by them, then demote the member to "member" role.
+    const admin = await createTestAdmin(app, {
+      username: `cfg-mgr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    });
+    const [member] = await app.db.select().from(members).where(eq(members.id, admin.memberId)).limit(1);
+    if (!member) throw new Error("admin member missing");
+    const clientId = `cli-mgr-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({ id: clientId, userId: member.userId, status: "connected" });
+    const agent = await createAgent(app.db, {
+      name: `cfg-mgr-agent-${crypto.randomUUID().slice(0, 8)}`,
+      type: "personal_assistant",
+      displayName: "My Assistant",
+      managerId: admin.memberId,
+      clientId,
+    });
+
+    // Demote the member who manages this agent.
+    await app.db
+      .update(members)
+      .set({ role: "member" })
+      .where(
+        eq(
+          members.userId,
+          (await app.db.select({ id: users.id }).from(users).where(eq(users.username, admin.username)).limit(1))[0]
+            ?.id ?? "",
+        ),
+      );
+
+    // Fresh JWT so role:"member" replaces the cached role:"admin".
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username: admin.username, password: admin.password },
+    });
+    const fresh = loginRes.json<{ accessToken: string }>();
+    const auth = { authorization: `Bearer ${fresh.accessToken}` };
+
+    // GET — manager can read config (assertAgentVisible allows any visible viewer).
+    const get = await app.inject({
+      method: "GET",
+      url: `/api/v1/admin/agents/${agent.uuid}/config`,
+      headers: auth,
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json().version).toBe(1);
+
+    // PATCH — manager can edit config (assertCanManage allows managerId = self).
+    const patch = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/admin/agents/${agent.uuid}/config`,
+      headers: auth,
+      payload: { expectedVersion: 1, payload: { model: "claude-opus-4-6" } },
+    });
+    expect(patch.statusCode).toBe(200);
+    expect(patch.json().payload.model).toBe("claude-opus-4-6");
   });
 });

--- a/packages/server/src/api/admin/agent-config.ts
+++ b/packages/server/src/api/admin/agent-config.ts
@@ -4,12 +4,18 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance } from "fastify";
 import { requireMember } from "../../middleware/require-identity.js";
-import { assertAgentVisible, assertCanManage, memberScope } from "../../services/access-control.js";
+import { assertCanManage, memberScope } from "../../services/access-control.js";
 
 export async function adminAgentConfigRoutes(app: FastifyInstance): Promise<void> {
+  // Runtime config is behavior-sensitive (system prompt, tools, env — the
+  // agent's "soul"). Visibility controls whether a member sees the agent
+  // exists; manageability controls whether they can inspect its behavior.
+  // This mirrors how public GPTs / bots across the industry expose a card
+  // view but keep the prompt private.
+  //   GET  /:uuid         → assertAgentVisible (card view in agents.ts)
+  //   GET  /:uuid/config  → assertCanManage    (this file, all three routes)
   app.get<{ Params: { uuid: string } }>("/:uuid/config", async (request) => {
-    const scope = memberScope(request);
-    await assertAgentVisible(app.db, scope, request.params.uuid);
+    await assertCanManage(app.db, memberScope(request), request.params.uuid);
     const cfg = await app.configService.get(request.params.uuid);
     return cfg;
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -191,11 +191,17 @@ export async function buildApp(config: Config) {
         { prefix: "/admin/agents" },
       );
 
-      // Step 2: per-agent runtime config (admin role required)
+      // Step 2: per-agent runtime config.
+      // Per-route guards in agent-config.ts enforce the real rule:
+      //   GET    /:uuid/config          → assertAgentVisible (any visible viewer may read)
+      //   PATCH  /:uuid/config          → assertCanManage   (manager or admin may edit)
+      //   POST   /:uuid/config/dry-run  → assertCanManage   (manager or admin may preview)
+      // This mirrors agents.managerId's documented "manager retains CRUD" semantics;
+      // the previous plugin-scoped adminOnly hook short-circuited that, blocking
+      // non-admin managers from editing behavior on agents they own.
       await api.register(
         async (adminApp) => {
           adminApp.addHook("onRequest", memberAuth);
-          adminApp.addHook("onRequest", adminOnly);
           await adminApp.register(adminAgentConfigRoutes);
         },
         { prefix: "/admin/agents" },


### PR DESCRIPTION
## Summary

Three sibling permission fixes on the per-agent runtime-config routes + the agent-detail page, found when a non-admin member (owner of a `personal_assistant`) hit **"Admin role required"** just trying to view the Behavior section on their own agent's detail page.

- **Commit 1 — unblock managers (backend):** remove the plugin-scoped `adminOnly` hook on `/admin/agents/:uuid/config`. The handler already has the right per-route guards (`assertAgentVisible` for read, `assertCanManage` for write); the hook was short-circuiting them, contradicting the `agents` schema's documented *"manager retains CRUD"* rule.
- **Commit 2 — tighten reads to manager-only (backend):** switch `GET /:uuid/config` from `assertAgentVisible` to `assertCanManage`. Behavior (system prompt, tools, env) is the manager's intellectual work; visibility should gate the *card view* (`GET /admin/agents/:uuid`), manageability should gate behavior. Aligns with ChatGPT Custom GPTs / Poe / Slack apps — usable by others, prompt private.
- **Commit 3 — gate UI on canManage (web):** without this, non-managers landing on an agent-detail page for an org-visible agent would see 404 errors in every behavior section. A single `canManage = role === "admin" || managerId === me` flag now hides BehaviorSection, Platform bindings, DangerZone, dry-run, SaveBar, and the Test button. Non-managers see a clean read-only profile card.

Final route guards:

| Route | Guard | Meaning |
|-------|-------|---------|
| `GET /admin/agents/:uuid` | `assertAgentVisible` | Card view (org-visible) |
| `GET /admin/agents/:uuid/config` | `assertCanManage` | Behavior read (manager/admin) |
| `PATCH /admin/agents/:uuid/config` | `assertCanManage` | Behavior edit (manager/admin) |
| `POST /admin/agents/:uuid/config/dry-run` | `assertCanManage` | Behavior preview (manager/admin) |

Non-manager callers get **404** (not 403), consistent with the enumeration-prevention convention in `access-control.ts`.

## Repro (before this PR)

1. Log in as a non-admin member.
2. Open the detail page of a `personal_assistant` where you are the manager.
3. Behavior section shows: `Failed to load configuration: ApiError: Admin role required`.

After this PR: Behavior loads and is editable for the manager.

For a non-manager viewer of an org-visible agent: page renders a clean profile card (name, type, visibility, "Managed by {name}") without broken sections.

## Test plan

- [x] `pnpm typecheck` (server + web)
- [x] `pnpm biome check` (web)
- [x] `pnpm vitest run admin-agent-config` — **10/10 pass**, including three new tests:
  - `non-manager member is rejected with 404 (agent they do not manage)` — 403→404 per NotFoundError convention
  - `manager (non-admin) can GET and PATCH config on an agent they manage` — positive regression guard
  - `non-manager member cannot GET config even when agent is org-visible` — proves card view ≠ behavior read
- [x] `pnpm vitest run agent-configs` — 10/10 pass (no regressions in sibling suite)
- [ ] Manual: non-admin manager edits own agent Behavior in web UI
- [ ] Manual: non-manager member opens org-visible agent detail, sees only identity card (no 404s, no edit buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)