### PR TITLE
feat(client): tagged pino logging, print layer, rotating service logs

### DIFF
--- a/packages/client/src/__tests__/_logger-helpers.ts
+++ b/packages/client/src/__tests__/_logger-helpers.ts
@@ -1,0 +1,17 @@
+import { recordingDestination, silentDestination } from "@agent-team-foundation/first-tree-hub-shared/observability";
+import pino from "pino";
+
+/** Silent logger for tests that don't care about log output. */
+export function silentLogger(): pino.Logger {
+  return pino({ level: "silent" }, silentDestination());
+}
+
+/**
+ * Logger that captures every emitted record as a parsed JSON object. Useful
+ * when a test needs to assert on log content without scraping stderr.
+ */
+export function recordingLogger(): { logger: pino.Logger; records: Array<Record<string, unknown>> } {
+  const { dest, records } = recordingDestination();
+  const logger = pino({ level: "trace" }, dest);
+  return { logger, records };
+}

--- a/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
@@ -63,7 +63,7 @@ function buildCache() {
       updatedBy: "test",
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
-  return createAgentConfigCache({ sdk: stubSdk, log: () => {} });
+  return createAgentConfigCache({ sdk: stubSdk });
 }
 
 describe("claude-code handler — sendMessage failure surfaces lost result", () => {

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -67,7 +67,7 @@ function buildCache() {
       updatedBy: "test",
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
-  return createAgentConfigCache({ sdk: stubSdk, log: () => {} });
+  return createAgentConfigCache({ sdk: stubSdk });
 }
 
 describe("claude-code handler — turn_end on SDK-reported subtype error", () => {

--- a/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
@@ -89,7 +89,7 @@ function buildCache() {
       updatedBy: "test",
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
-  return createAgentConfigCache({ sdk: stubSdk, log: () => {} });
+  return createAgentConfigCache({ sdk: stubSdk });
 }
 
 describe("claude-code handler — turn_end serialization (race guard)", () => {

--- a/packages/client/src/__tests__/claude-code-turn-end.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end.test.ts
@@ -63,7 +63,7 @@ function buildCache() {
       updatedBy: "test",
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
-  return createAgentConfigCache({ sdk: stubSdk, log: () => {} });
+  return createAgentConfigCache({ sdk: stubSdk });
 }
 
 describe("claude-code handler — turn_end emission", () => {

--- a/packages/client/src/__tests__/gitrepos-session-integration.test.ts
+++ b/packages/client/src/__tests__/gitrepos-session-integration.test.ts
@@ -77,7 +77,7 @@ function buildCache(gitRepos: AgentRuntimeConfig["payload"]["gitRepos"]) {
         updatedBy: "test",
       }) as unknown as AgentRuntimeConfig,
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
-  return createAgentConfigCache({ sdk: stubSdk, log: () => {} });
+  return createAgentConfigCache({ sdk: stubSdk });
 }
 
 function buildSessionCtx(chatId: string, log: (msg: string) => void): SessionContext {

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,7 +1,9 @@
+import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
+import { recordingLogger, silentLogger } from "./_logger-helpers.js";
 import { mockEntry } from "./test-helpers.js";
 
 /** Create a mock SDK that satisfies FirstTreeHubSDK shape. */
@@ -33,7 +35,7 @@ function createSessionManager(opts: {
   handler?: AgentHandler;
   session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
-  log?: (msg: string) => void;
+  log?: pino.Logger;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = () => handler;
@@ -52,7 +54,7 @@ function createSessionManager(opts: {
       metadata: {},
     },
     sdk,
-    log: opts.log ?? (() => {}),
+    log: opts.log ?? silentLogger(),
   });
 }
 
@@ -129,7 +131,7 @@ describe("SessionManager", () => {
         metadata: {},
       },
       sdk,
-      log: () => {},
+      log: silentLogger(),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -177,17 +179,17 @@ describe("SessionManager", () => {
   });
 
   it("catches handler start errors without crashing", async () => {
-    const logs: string[] = [];
+    const { logger, records } = recordingLogger();
     const handler = createMockHandler({
       async start() {
         throw new Error("start boom");
       },
     });
 
-    const sm = createSessionManager({ handler, log: (msg) => logs.push(msg) });
+    const sm = createSessionManager({ handler, log: logger });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
-    expect(logs.some((l) => l.includes("start failed"))).toBe(true);
+    expect(records.some((r) => typeof r.msg === "string" && r.msg.includes("start/resume failed"))).toBe(true);
 
     await sm.shutdown();
   });
@@ -214,7 +216,7 @@ describe("SessionManager", () => {
         metadata: {},
       },
       sdk,
-      log: () => {},
+      log: silentLogger(),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
@@ -257,7 +259,7 @@ describe("SessionManager", () => {
         metadata: {},
       },
       sdk,
-      log: () => {},
+      log: silentLogger(),
     });
 
     // Fill up max_sessions
@@ -309,7 +311,7 @@ describe("SessionManager", () => {
         metadata: {},
       },
       sdk,
-      log: () => {},
+      log: silentLogger(),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -1,7 +1,9 @@
+import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
 import { mockEntry } from "./test-helpers.js";
 
 /** Assert value is defined and return it (avoids non-null assertions). */
@@ -48,7 +50,7 @@ function createSessionManager(opts: {
   handlerFactory?: HandlerFactory;
   session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
-  log?: (msg: string) => void;
+  log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
@@ -68,7 +70,7 @@ function createSessionManager(opts: {
       metadata: {},
     },
     sdk,
-    log: opts.log ?? (() => {}),
+    log: opts.log ?? silentLogger(),
     onRuntimeStateChange: opts.onRuntimeStateChange,
   });
 }
@@ -272,7 +274,7 @@ describe("SessionManager: runtime state cleanup on start failure", () => {
     const sm = createSessionManager({
       handlerFactory: factory,
       onRuntimeStateChange: (state) => runtimeChanges.push(state),
-      log: () => {},
+      log: silentLogger(),
     });
 
     // First session starts fine

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -1,8 +1,10 @@
 import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
+import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
 import { mockEntry } from "./test-helpers.js";
 
 /**
@@ -38,7 +40,7 @@ function createSessionManager(opts: {
   handlerFactory?: HandlerFactory;
   session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
   concurrency?: number;
-  log?: (msg: string) => void;
+  log?: pino.Logger;
   onStateChange?: (chatId: string, state: SessionState) => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
@@ -58,7 +60,7 @@ function createSessionManager(opts: {
       metadata: {},
     },
     sdk,
-    log: opts.log ?? (() => {}),
+    log: opts.log ?? silentLogger(),
     onStateChange: opts.onStateChange,
   });
 }

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -12,6 +12,7 @@ import {
   serverWelcomeFrameSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import WebSocket from "ws";
+import { createLogger, type pino } from "./observability/logger.js";
 import { type AccessTokenProvider, FirstTreeHubSDK } from "./sdk.js";
 
 export type ClientConnectionConfig = {
@@ -139,6 +140,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   /** Count of `server:welcome` frames received; drives `isReconnect` flag. */
   private welcomeFramesReceived = 0;
 
+  private readonly wsLogger: pino.Logger;
+  private readonly authLogger: pino.Logger;
+
   private readonly boundAgents = new Map<string, BoundAgent>();
 
   /** Agents scheduled to rebind automatically on every reconnect. */
@@ -164,6 +168,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.serverUrl = config.serverUrl.replace(/\/+$/, "");
     this.sdkVersion = config.sdkVersion;
     this.getAccessToken = config.getAccessToken;
+    this.wsLogger = createLogger("ws").child({ clientId: this.clientId });
+    this.authLogger = createLogger("auth").child({ clientId: this.clientId });
 
     // Tombstone listener: Node's EventEmitter re-throws `error` events that
     // have no listener, so a stray ECONNRESET would crash the host. Consumers
@@ -271,6 +277,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private openWebSocket(): Promise<void> {
     return new Promise((resolve, reject) => {
       const wsUrl = `${this.serverUrl.replace(/^http/, "ws")}/api/v1/agent/ws/client`;
+      this.wsLogger.info({ url: wsUrl }, "connecting");
       const ws = new WebSocket(wsUrl);
       let settled = false;
 
@@ -297,6 +304,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       ws.on("open", async () => {
         this.ws = ws;
         this.reconnectAttempt = 0;
+        this.wsLogger.debug("socket opened, sending auth");
 
         try {
           const token = await this.getAccessToken();
@@ -306,6 +314,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // exp itself is already fixed on the token payload.
           this.scheduleProactiveAuthRefresh(token);
         } catch (err) {
+          this.authLogger.error({ err }, "failed to obtain access token");
           settle(reject, err instanceof Error ? err : new Error(String(err)));
           ws.close();
         }
@@ -328,10 +337,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.rejectAllPendingBinds("WebSocket closed");
 
         if (!settled) {
+          this.wsLogger.warn({ code }, "closed before ready");
           settle(reject, new Error(`WebSocket closed before ready (code ${code})`));
           return;
         }
 
+        this.wsLogger.warn({ code, wasRegistered }, "disconnected");
         if (!this.closing) {
           this.emit("disconnected");
           if (wasRegistered) this.scheduleReconnect();
@@ -348,6 +359,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     const type = msg.type as string;
 
     if (type === "auth:ok") {
+      this.authLogger.info("auth accepted, registering client");
       this.ws?.send(
         JSON.stringify({
           type: "client:register",
@@ -366,10 +378,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         // Malformed welcome frame from a buggy server build — log and drop.
         // Old clients that never knew about this frame simply fall through,
         // so treating a parse failure the same way keeps behaviour aligned.
-        process.stderr.write(
-          `[ClientConnection] Ignoring malformed server:welcome frame: ${parsed.error.issues
-            .map((i) => i.message)
-            .join(", ")}\n`,
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed server:welcome frame",
         );
         return;
       }
@@ -383,13 +394,19 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       // The close handler reads `this.registered` to decide whether to
       // reconnect; clearing it here would make that decision see post-close
       // state and skip the reconnect after a mid-session auth:expired push.
-      if (type === "auth:expired") this.emit("auth:expired");
+      if (type === "auth:expired") {
+        this.authLogger.info("token expired, reconnecting with fresh token");
+        this.emit("auth:expired");
+      } else {
+        this.authLogger.warn("auth rejected by server");
+      }
       this.ws?.close(4401, type);
       return;
     }
 
     if (type === "client:register:rejected") {
       const err = new Error(`client:register rejected: ${msg.message ?? "unknown"}`);
+      this.wsLogger.error({ message: msg.message }, "client register rejected");
       this.emit("error", err);
       this.ws?.close(4403, "register rejected");
       return;
@@ -399,6 +416,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       const isReconnect = this.boundAgents.size > 0 || this.desiredBindings.size > 0;
       this.registered = true;
       this.startHeartbeat();
+      this.wsLogger.info({ isReconnect }, "registered");
       this.emit("connected");
       connectResolve?.();
 
@@ -528,6 +546,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.emit("reconnecting", this.reconnectAttempt);
 
     const delay = Math.min(RECONNECT_BASE_MS * 2 ** (this.reconnectAttempt - 1), RECONNECT_MAX_MS);
+    this.wsLogger.debug({ attempt: this.reconnectAttempt, delayMs: delay }, "scheduling reconnect");
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       if (!this.closing) {
@@ -595,9 +614,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     if (!exp) return;
     const delay = exp * 1000 - Date.now() - AUTH_REFRESH_LEAD_MS;
     if (delay <= 0) return;
+    this.authLogger.debug({ delayMs: delay }, "scheduled proactive auth refresh");
     this.authRefreshTimer = setTimeout(() => {
       this.authRefreshTimer = null;
       if (this.closing) return;
+      this.authLogger.info("triggering proactive auth refresh");
       // Silent reconnect: close gracefully, the close handler reconnects and
       // the new connection asks getAccessToken() for a fresh JWT.
       this.ws?.close(1000, "proactive auth refresh");

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,7 +7,12 @@ export type {
 export { ClientConnection } from "./client-connection.js";
 // Handlers
 export { registerBuiltinHandlers } from "./handlers/index.js";
-export { applyClientLoggerConfig, createLogger, rootLogger } from "./observability/index.js";
+export {
+  applyClientLoggerConfig,
+  configureClientLoggerForService,
+  createLogger,
+  rootLogger,
+} from "./observability/index.js";
 // Runtime
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
 export { AgentSlot } from "./runtime/agent-slot.js";

--- a/packages/client/src/observability/__tests__/logger.test.ts
+++ b/packages/client/src/observability/__tests__/logger.test.ts
@@ -1,0 +1,85 @@
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyClientLoggerConfig, createLogger } from "../logger.js";
+
+function collect(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
+
+describe("client logger", () => {
+  afterEach(() => {
+    // `explicit: false` un-pins any sticky level set by the previous test so
+    // state doesn't leak across cases.
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
+  });
+
+  it("redacts common sensitive fields in JSON output", () => {
+    const { dest, read } = collect();
+    applyClientLoggerConfig({ level: "trace", format: "json", destination: dest });
+    createLogger("test").info(
+      {
+        token: "abc123",
+        accessToken: "xyz",
+        jwt: "eyJ",
+        password: "p",
+        secret: "s",
+        authorization: "Bearer t",
+        nested: { token: "n", ok: "visible" },
+        ok: "visible",
+      },
+      "hi",
+    );
+    const line = read();
+    expect(line).toContain('"token":"[REDACTED]"');
+    expect(line).toContain('"accessToken":"[REDACTED]"');
+    expect(line).toContain('"jwt":"[REDACTED]"');
+    expect(line).toContain('"password":"[REDACTED]"');
+    expect(line).toContain('"secret":"[REDACTED]"');
+    expect(line).toContain('"authorization":"[REDACTED]"');
+    expect(line).toContain('"ok":"visible"');
+    // Nested path: pino v9 `*.token` matches one nesting level.
+    expect(line).toContain('"nested":');
+    expect(line).not.toMatch(/"token":"n"/);
+  });
+
+  it("explicit level sticks across subsequent non-explicit applies", () => {
+    const { dest } = collect();
+    applyClientLoggerConfig({ level: "debug", destination: dest, explicit: true });
+    // Simulate `client start` applying its config-sourced level; the CLI
+    // override must win.
+    applyClientLoggerConfig({ level: "info" });
+    const logger = createLogger("test");
+    expect(logger.level).toBe("debug");
+  });
+
+  it("non-explicit level gives way to later non-explicit applies", () => {
+    const { dest } = collect();
+    applyClientLoggerConfig({ level: "debug", destination: dest });
+    applyClientLoggerConfig({ level: "info" });
+    const logger = createLogger("test");
+    expect(logger.level).toBe("info");
+  });
+
+  it("does not write to process.stdout at any log level", () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    const { dest } = collect();
+    try {
+      applyClientLoggerConfig({ level: "trace", format: "pretty", destination: dest });
+      createLogger("test").trace("t");
+      createLogger("test").debug("d");
+      createLogger("test").info("i");
+      createLogger("test").warn("w");
+      createLogger("test").error("e");
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+});

--- a/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
+++ b/packages/client/src/observability/__tests__/rotating-file-stream.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RotatingFileStream } from "../rotating-file-stream.js";
+
+describe("RotatingFileStream", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rot-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes to the primary path until maxBytes is reached", () => {
+    const path = join(dir, "app.log");
+    const s = new RotatingFileStream({ path, maxBytes: 100, maxFiles: 3 });
+    s.write("line 1\n");
+    s.write("line 2\n");
+    s.end();
+    expect(readFileSync(path, "utf8")).toBe("line 1\nline 2\n");
+  });
+
+  it("rotates once maxBytes is reached, preserving historical files", () => {
+    const path = join(dir, "app.log");
+    const s = new RotatingFileStream({ path, maxBytes: 20, maxFiles: 3 });
+    s.write("aaaaaaaaaaaaaaaaaaaa\n"); // 21 bytes, triggers rotation
+    s.write("bbb\n");
+    s.end();
+    // Active file holds post-rotation writes.
+    expect(readFileSync(path, "utf8")).toBe("bbb\n");
+    // .1 is the most recently rotated file.
+    expect(readFileSync(`${path}.1`, "utf8")).toBe("aaaaaaaaaaaaaaaaaaaa\n");
+  });
+
+  it("shifts older rotated files up the numbered sequence and drops beyond maxFiles", () => {
+    const path = join(dir, "app.log");
+    // maxFiles=2 means we keep .1 and .2; a third rotation must evict the oldest.
+    const s = new RotatingFileStream({ path, maxBytes: 10, maxFiles: 2 });
+    s.write("AAAAAAAAAA\n"); // triggers rotation 1 → .1
+    s.write("BBBBBBBBBB\n"); // triggers rotation 2: .1 → .2, new → .1
+    s.write("CCCCCCCCCC\n"); // triggers rotation 3: .2 dropped, .1 → .2, new → .1
+    s.end();
+    expect(existsSync(`${path}.3`)).toBe(false);
+    expect(readFileSync(`${path}.2`, "utf8")).toBe("BBBBBBBBBB\n");
+    expect(readFileSync(`${path}.1`, "utf8")).toBe("CCCCCCCCCC\n");
+  });
+
+  it("continues from existing file size on reopen (append mode)", () => {
+    const path = join(dir, "app.log");
+    const a = new RotatingFileStream({ path, maxBytes: 100, maxFiles: 3 });
+    a.write("first\n");
+    a.end();
+    const b = new RotatingFileStream({ path, maxBytes: 100, maxFiles: 3 });
+    b.write("second\n");
+    b.end();
+    expect(readFileSync(path, "utf8")).toBe("first\nsecond\n");
+    // Size is the appended total, not just the newest chunk.
+    expect(statSync(path).size).toBe("first\nsecond\n".length);
+  });
+});

--- a/packages/client/src/observability/index.ts
+++ b/packages/client/src/observability/index.ts
@@ -1,1 +1,1 @@
-export { applyClientLoggerConfig, createLogger, rootLogger } from "./logger.js";
+export { applyClientLoggerConfig, configureClientLoggerForService, createLogger, rootLogger } from "./logger.js";

--- a/packages/client/src/observability/logger.ts
+++ b/packages/client/src/observability/logger.ts
@@ -1,11 +1,20 @@
+import { join } from "node:path";
+import type { Writable } from "node:stream";
 import {
   createLoggerOutputStream,
   formatLocalTime,
+  LOG_REDACT_CENSOR,
+  LOG_REDACT_PATHS,
   type LogFormat,
   type LogLevel,
   parseLogLevel,
 } from "@agent-team-foundation/first-tree-hub-shared/observability";
 import pino from "pino";
+import { RotatingFileStream } from "./rotating-file-stream.js";
+
+/** Rotation defaults for the background service log file. */
+const SERVICE_LOG_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const SERVICE_LOG_MAX_FILES = 7;
 
 /**
  * Client-side logger. Same pretty / NDJSON formats as the server logger, but
@@ -14,23 +23,43 @@ import pino from "pino";
  */
 
 const initialLevel = parseLogLevel(process.env.FIRST_TREE_HUB_LOG_LEVEL);
+// Tests get a silent logger unless FIRST_TREE_HUB_LOG_LEVEL is explicitly set,
+// otherwise vitest output would be flooded by runtime logs that happen to run
+// during setup.
+const initialPinoLevel: LogLevel | "silent" =
+  process.env.NODE_ENV === "test" && !process.env.FIRST_TREE_HUB_LOG_LEVEL ? "silent" : initialLevel.level;
 let _format: LogFormat = process.env.NODE_ENV === "production" ? "json" : "pretty";
-let _level: LogLevel = initialLevel.level;
+let _destination: Writable = process.stderr;
+// Tracks whether the level was pinned by an explicit operator decision (CLI
+// `--verbose` / `--json`, or a test harness). Once pinned, later config-driven
+// applies (e.g. `client start` reading `logLevel` from client.yaml) must not
+// overwrite it.
+let _levelExplicit = false;
 
-export function applyClientLoggerConfig(options: { level?: LogLevel; format?: LogFormat } = {}): void {
-  if (options.level) {
-    _level = options.level;
+export function applyClientLoggerConfig(
+  options: { level?: LogLevel | "silent"; format?: LogFormat; destination?: Writable; explicit?: boolean } = {},
+): void {
+  // Tri-state: `explicit: true` pins, `explicit: false` un-pins, undefined
+  // leaves the pin state alone.
+  if (options.explicit === false) _levelExplicit = false;
+  if (options.level !== undefined && (options.explicit === true || !_levelExplicit)) {
     rootLogger.level = options.level;
   }
+  if (options.explicit === true) _levelExplicit = true;
   if (options.format) _format = options.format;
+  if (options.destination) _destination = options.destination;
 }
 
-const outputStream = createLoggerOutputStream({ getFormat: () => _format });
+const outputStream = createLoggerOutputStream({
+  getFormat: () => _format,
+  getDestination: () => _destination,
+});
 
 export const rootLogger = pino(
   {
-    level: _level,
+    level: initialPinoLevel,
     timestamp: () => `,"time":"${formatLocalTime()}"`,
+    redact: { paths: [...LOG_REDACT_PATHS], censor: LOG_REDACT_CENSOR },
   },
   outputStream,
 );
@@ -45,3 +74,25 @@ if (initialLevel.fellBack) {
 export function createLogger(module: string): pino.Logger {
   return rootLogger.child({ module });
 }
+
+/**
+ * Switch the client logger over to the background-service file sink.
+ *
+ * The launchd / systemd unit files already set `StandardOutPath` /
+ * `StandardError` as a fallback for crash-time stderr; this routes normal
+ * operational logs into a size-rotated NDJSON file at
+ * `<logDir>/client.log` so it doesn't grow unbounded. Must be called once
+ * at `client start` when running under `FIRST_TREE_HUB_SERVICE_MODE=1`.
+ */
+export function configureClientLoggerForService(logDir: string): void {
+  const stream = new RotatingFileStream({
+    path: join(logDir, "client.log"),
+    maxBytes: SERVICE_LOG_MAX_BYTES,
+    maxFiles: SERVICE_LOG_MAX_FILES,
+  });
+  // Pretty ANSI codes in a log file are noise; lock format to NDJSON and let
+  // `client service logs` pretty-print on read.
+  applyClientLoggerConfig({ format: "json", destination: stream });
+}
+
+export type { pino };

--- a/packages/client/src/observability/rotating-file-stream.ts
+++ b/packages/client/src/observability/rotating-file-stream.ts
@@ -1,0 +1,105 @@
+import { closeSync, mkdirSync, openSync, renameSync, statSync, unlinkSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+import { Writable } from "node:stream";
+
+/**
+ * Thin size-triggered log rotator used by the background-service logger.
+ *
+ * Keeps the active file at `path`; on write-after-overflow it renames
+ * `path` → `path.1`, shifting older rotated files up to `path.<maxFiles>`
+ * and unlinking the oldest. Deliberately synchronous — logger writes arrive
+ * one line at a time, and the alternative (a queue + fs.promises) would add
+ * a buffering surface that is never observed by the consumer.
+ *
+ * Not a general-purpose replacement for logrotate — no time-based triggers,
+ * no compression. The trade-off is zero extra dependencies and a few dozen
+ * lines of code that live in the same tree as the logger that consumes it.
+ */
+export type RotatingFileStreamOptions = {
+  /** Target path of the active log file. */
+  path: string;
+  /** Rotate after the file reaches or exceeds this size in bytes. */
+  maxBytes: number;
+  /** Keep this many rotated files (`.1` … `.N`). Oldest is dropped on rotate. */
+  maxFiles: number;
+};
+
+export class RotatingFileStream extends Writable {
+  private size: number;
+  private fd: number;
+  private readonly path: string;
+  private readonly maxBytes: number;
+  private readonly maxFiles: number;
+
+  constructor(options: RotatingFileStreamOptions) {
+    super();
+    this.path = options.path;
+    this.maxBytes = options.maxBytes;
+    this.maxFiles = Math.max(1, options.maxFiles);
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+    try {
+      this.size = statSync(this.path).size;
+    } catch {
+      this.size = 0;
+    }
+    this.fd = openSync(this.path, "a", 0o600);
+  }
+
+  _write(chunk: Buffer | string, _enc: BufferEncoding, callback: (err?: Error | null) => void): void {
+    try {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      writeSync(this.fd, buf);
+      this.size += buf.length;
+      if (this.size >= this.maxBytes) {
+        this.rotate();
+      }
+      callback();
+    } catch (err) {
+      callback(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  _final(callback: (err?: Error | null) => void): void {
+    try {
+      closeSync(this.fd);
+      callback();
+    } catch (err) {
+      callback(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private rotate(): void {
+    closeSync(this.fd);
+    // Walk high → low so we never overwrite a file before moving its current
+    // occupant out of the way. Missing files are expected on a fresh service
+    // (rotation count still below maxFiles), so swallow ENOENT.
+    for (let i = this.maxFiles - 1; i >= 1; i--) {
+      renameIfExists(`${this.path}.${i}`, `${this.path}.${i + 1}`);
+    }
+    unlinkIfExists(`${this.path}.1`);
+    renameSync(this.path, `${this.path}.1`);
+    this.fd = openSync(this.path, "a", 0o600);
+    this.size = 0;
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && "code" in err && err.code === "ENOENT";
+}
+
+function renameIfExists(from: string, to: string): void {
+  try {
+    unlinkIfExists(to);
+    renameSync(from, to);
+  } catch (err) {
+    if (!isNotFound(err)) throw err;
+  }
+}
+
+function unlinkIfExists(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    if (!isNotFound(err)) throw err;
+  }
+}

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -1,4 +1,5 @@
 import type { AgentRuntimeConfig } from "@agent-team-foundation/first-tree-hub-shared";
+import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
 /**
@@ -11,7 +12,7 @@ import type { FirstTreeHubSDK } from "../sdk.js";
  * The prefix `agent-` distinguishes this from `runtime/config.ts` (the local
  * `agent.yaml` parser) — they are unrelated concepts.
  */
-export type AgentConfigCacheLogger = (msg: string) => void;
+export type AgentConfigCacheLogger = pino.Logger;
 
 export interface AgentConfigCache {
   /** Snapshot of the currently cached config, if any. */
@@ -45,7 +46,7 @@ export type AgentConfigCacheOptions = {
 
 export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConfigCache {
   const { sdk } = opts;
-  const log: AgentConfigCacheLogger = opts.log ?? (() => {});
+  const log = opts.log;
   const entries = new Map<string, CachedEntry>();
 
   function urlsFromConfig(cfg: AgentRuntimeConfig): Set<string> {
@@ -88,7 +89,7 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
       };
       slot.inflight = doFetch(agentId).catch((err) => {
         slot.inflight = null;
-        log(`[agent-config-cache] fetch failed for ${agentId}: ${err instanceof Error ? err.message : String(err)}`);
+        log?.warn({ agentId, err }, "agent config fetch failed");
         throw err;
       });
       entries.set(agentId, slot);

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -7,6 +7,7 @@ import type {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
+import { createLogger, type pino } from "../observability/logger.js";
 import type { RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
 import type { SessionConfig } from "./config.js";
@@ -38,7 +39,7 @@ type ConnectionListener =
 export class AgentSlot {
   private sessionManager: SessionManager | null = null;
   private readonly config: AgentSlotConfig;
-  private readonly logFn: (msg: string) => void;
+  private logger: pino.Logger;
   private sdk: import("../sdk.js").FirstTreeHubSDK | null = null;
   private agentConfigCache: AgentConfigCache | null = null;
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
@@ -47,9 +48,7 @@ export class AgentSlot {
 
   constructor(config: AgentSlotConfig) {
     this.config = config;
-    this.logFn = (msg: string) => {
-      process.stderr.write(`[${config.name}] ${msg}\n`);
-    };
+    this.logger = createLogger("slot").child({ agentName: config.name, agentId: config.agentId });
   }
 
   private get clientConnection(): ClientConnection {
@@ -75,20 +74,20 @@ export class AgentSlot {
     this.sdk = sdk;
     const agent = await sdk.register();
 
-    this.logFn(`Bound as ${agent.displayName ?? agent.agentId} (${agent.agentId})`);
+    this.logger.info({ displayName: agent.displayName ?? agent.agentId }, "agent bound");
 
     if (agent.type === "human") {
-      this.logFn("Server reports type=human — message processing disabled");
+      this.logger.info("server reports type=human — message processing disabled");
       return agent;
     }
 
-    this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logFn });
+    this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logger });
     try {
       const cfg = await this.agentConfigCache.refresh(agent.agentId);
-      this.logFn(`Loaded runtime config v${cfg.version}`);
+      this.logger.info({ version: cfg.version }, "runtime config loaded");
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.logFn(`Failed to fetch agent config — bind aborted: ${msg}`);
+      this.logger.error({ err }, "failed to fetch agent config — bind aborted");
       throw new Error(`Hub unreachable while loading agent config: ${msg}`);
     }
 
@@ -124,7 +123,7 @@ export class AgentSlot {
     // reuse the same mirror (PRD §5.1.5).
     const gitMirrorManager = createGitMirrorManager({
       dataDir: DEFAULT_DATA_DIR,
-      log: (event, fields) => this.logFn(`git[${event}] ${JSON.stringify(fields)}`),
+      log: createLogger("git-mirror").child({ agentName: this.config.name, agentId: this.config.agentId }),
     });
 
     this.sessionManager = new SessionManager({
@@ -144,7 +143,7 @@ export class AgentSlot {
         metadata: agent.metadata,
       },
       sdk,
-      log: this.logFn,
+      log: this.logger,
       registryPath,
       agentConfigCache: this.agentConfigCache,
       onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
@@ -158,7 +157,7 @@ export class AgentSlot {
         this.sessionManager
           .handleCommand(cmd.chatId, cmd.type as "session:suspend" | "session:terminate")
           .catch((err) => {
-            this.logFn(`Session command error: ${err instanceof Error ? err.message : String(err)}`);
+            this.logger.error({ err, chatId: cmd.chatId, type: cmd.type }, "session command error");
           });
       }
     };
@@ -189,7 +188,7 @@ export class AgentSlot {
     this.listeners = [];
     await this.clientConnection.unbindAgent(this.config.agentId);
     await this.sessionManager?.shutdown();
-    this.logFn("Stopped");
+    this.logger.info("stopped");
   }
 
   private reportSessionState(chatId: string, state: SessionState): void {
@@ -246,7 +245,7 @@ export class AgentSlot {
         await this.sessionManager.dispatch(entry);
       }
     } catch (err) {
-      this.logFn(`Poll error: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.warn({ err }, "poll error");
     }
   }
 }

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import type { pino } from "../observability/logger.js";
 
 const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -29,7 +30,7 @@ const SESSION_BRANCH_PREFIX = "hub-session";
 export type GitMirrorManagerOptions = {
   dataDir: string;
   cloneTimeoutMs?: number;
-  log?: (event: string, fields: Record<string, unknown>) => void;
+  log?: pino.Logger;
 };
 
 export interface GitMirrorManager {
@@ -71,7 +72,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   const mirrorsRoot = join(opts.dataDir, "git-mirrors");
   const cloneTimeoutMs =
     opts.cloneTimeoutMs ?? Number(process.env.FIRST_TREE_HUB_GIT_CLONE_TIMEOUT_MS ?? DEFAULT_CLONE_TIMEOUT_MS);
-  const log = opts.log ?? (() => {});
+  const log = opts.log;
 
   // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /
   // gcMirrors for the same URL from racing on the same directory.
@@ -199,7 +200,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
       // Failing `set-head --auto` is non-fatal — callers that pass an explicit
       // `ref` don't need origin/HEAD, and fallbacks below handle its absence.
       await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000);
-      log("mirrorConfigMigrated", { gitUrl: url });
+      log?.info({ gitUrl: url }, "mirror config migrated");
     }
 
     return { migrated };
@@ -274,11 +275,11 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         try {
           await bootstrapMirror(path, url);
           const elapsedMs = Date.now() - start;
-          log("ensureMirror", { gitUrl: url, elapsedMs, cloned: true });
+          log?.debug({ gitUrl: url, elapsedMs, cloned: true }, "mirror ensured");
           return { mirrorPath: path, elapsedMs, cloned: true };
         } catch (err) {
           if (err instanceof GitMirrorTimeoutError) {
-            log("mirrorCloneTimeout", { gitUrl: url, timeoutMs: cloneTimeoutMs, elapsedMs: cloneTimeoutMs });
+            log?.warn({ gitUrl: url, timeoutMs: cloneTimeoutMs, elapsedMs: cloneTimeoutMs }, "mirror clone timeout");
           }
           if (existsSync(path)) rmSync(path, { recursive: true, force: true });
           throw err;
@@ -296,11 +297,14 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           const { elapsedMs } = await git(["fetch", "--prune", "origin"], path, cloneTimeoutMs);
           return { elapsedMs };
         } catch (err) {
-          log("mirrorFetchFailed", {
-            gitUrl: url,
-            errorCode: err instanceof GitMirrorError ? "git-failed" : "unknown",
-            stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
-          });
+          log?.warn(
+            {
+              gitUrl: url,
+              errorCode: err instanceof GitMirrorError ? "git-failed" : "unknown",
+              stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
+            },
+            "mirror fetch failed",
+          );
           throw err;
         }
       });
@@ -317,11 +321,14 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
 
         // D13: target path must be free OR a Hub-managed worktree we can reuse.
         if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {
-          log("worktreeCreateConflict", {
-            gitUrl: url,
-            targetPath: absTarget,
-            occupantKind: classifyOccupant(absTarget),
-          });
+          log?.warn(
+            {
+              gitUrl: url,
+              targetPath: absTarget,
+              occupantKind: classifyOccupant(absTarget),
+            },
+            "worktree create conflict",
+          );
           throw new GitMirrorWorktreeConflictError(
             `Worktree target "${absTarget}" is already occupied by ${classifyOccupant(absTarget)} — aborting (D13)`,
           );

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -1,4 +1,5 @@
 import { ClientConnection } from "../client-connection.js";
+import { createLogger, type pino } from "../observability/logger.js";
 import type { AccessTokenProvider } from "../sdk.js";
 import { AgentSlot } from "./agent-slot.js";
 import { syncContextTree } from "./bootstrap.js";
@@ -44,6 +45,7 @@ export class AgentRuntime {
   private readonly updateHooks: UpdateHooks | undefined;
   private updateManager: UpdateManager | null = null;
   private stopping = false;
+  private logger: pino.Logger;
 
   constructor(options: AgentRuntimeOptions) {
     this.config = options.config;
@@ -51,6 +53,7 @@ export class AgentRuntime {
     this.getAccessToken = options.getAccessToken;
     this.currentVersion = options.currentVersion;
     this.updateHooks = options.update;
+    this.logger = createLogger("runtime");
 
     this.clientConnection = new ClientConnection({
       serverUrl: this.config.server,
@@ -62,7 +65,7 @@ export class AgentRuntime {
     // Surface transport-level errors (TLS resets, DNS hiccups, WS handshake
     // failures) to operators. ClientConnection's own reconnect loop handles
     // recovery; a process-wide crash guard lives in ClientConnection itself.
-    this.clientConnection.on("error", (err) => this.log(`client connection error: ${err.message}`));
+    this.clientConnection.on("error", (err) => this.logger.error({ err }, "client connection error"));
 
     for (const [name, agentConfig] of Object.entries(this.config.agents)) {
       const handlerFactory = getHandlerFactory(agentConfig.type);
@@ -82,10 +85,6 @@ export class AgentRuntime {
     }
   }
 
-  private log(msg: string): void {
-    process.stderr.write(`[runtime] ${msg}\n`);
-  }
-
   private aggregateQuietGate(): { activeCount: number; lastActivityMs: number } {
     let activeCount = 0;
     let lastActivityMs = 0;
@@ -98,38 +97,47 @@ export class AgentRuntime {
   }
 
   async start(): Promise<void> {
-    const log = (msg: string) => this.log(msg);
-
-    const contextTreePath = await syncContextTree(this.config.server, this.getAccessToken, log);
+    const contextTreeLogger = createLogger("context-tree");
+    const contextTreePath = await syncContextTree(this.config.server, this.getAccessToken, (msg) =>
+      contextTreeLogger.info(msg),
+    );
     if (!contextTreePath) {
-      log("Context Tree not configured or sync skipped — agents will start without organizational context");
+      this.logger.info(
+        "context tree not configured or sync skipped — agents will start without organizational context",
+      );
     }
 
     // Attach before connecting so the first welcome frame on a stale Client
     // is acted on rather than missed until the next reconnect.
     if (this.currentVersion && this.updateHooks) {
+      const updateLogger = createLogger("update");
       this.updateManager = UpdateManager.attach(this.clientConnection, {
         currentVersion: this.currentVersion,
         ...this.updateHooks,
         isTTY: Boolean(process.stdout.isTTY),
-        log: (level, msg) => this.log(`[update/${level}] ${msg}`),
+        log: (level, msg) => updateLogger[level](msg),
         getQuietGateSnapshot: () => this.aggregateQuietGate(),
       });
-      log(`Update manager attached (policy=${this.updateHooks.updateConfig.policy}, version=${this.currentVersion})`);
+      this.logger.info(
+        { policy: this.updateHooks.updateConfig.policy, version: this.currentVersion },
+        "update manager attached",
+      );
     }
 
-    log(`Connecting client (${this.clientConnection.clientId})...`);
+    this.logger.info({ clientId: this.clientConnection.clientId }, "connecting client");
     await this.clientConnection.connect();
-    log(`Client connected (${this.clientConnection.clientId})`);
+    // Rebind so downstream lines carry clientId automatically.
+    this.logger = this.logger.child({ clientId: this.clientConnection.clientId });
+    this.logger.info("client connected");
 
-    log(`Starting ${this.slots.length} agent(s)...`);
+    this.logger.info({ count: this.slots.length }, "starting agents");
 
     const results = await Promise.allSettled(this.slots.map((slot) => slot.start(contextTreePath)));
 
     let failed = 0;
     for (const result of results) {
       if (result.status === "rejected") {
-        log(`Failed to start agent: ${result.reason instanceof Error ? result.reason.message : result.reason}`);
+        this.logger.error({ err: result.reason }, "failed to start agent");
         failed++;
       }
     }
@@ -138,22 +146,22 @@ export class AgentRuntime {
       throw new Error("All agents failed to start");
     }
 
-    log("Ready. Press Ctrl+C to stop.");
+    this.logger.info("ready — press Ctrl+C to stop");
 
     await new Promise<void>((resolve) => {
       const shutdown = async () => {
         if (this.stopping) return;
         this.stopping = true;
-        log("Shutting down...");
+        this.logger.info("shutting down");
 
         const timer = setTimeout(() => {
-          log("Shutdown timeout reached, forcing exit");
+          this.logger.warn("shutdown timeout reached, forcing exit");
           process.exit(1);
         }, this.shutdownTimeout);
 
         await this.stop();
         clearTimeout(timer);
-        log("Stopped");
+        this.logger.info("stopped");
         resolve();
       };
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -4,6 +4,7 @@ import type {
   SessionEvent,
   SessionState,
 } from "@agent-team-foundation/first-tree-hub-shared";
+import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
 import type { SessionConfig } from "./config.js";
@@ -41,7 +42,7 @@ type SessionManagerConfig = {
   handlerConfig: HandlerConfig;
   agentIdentity: AgentIdentity;
   sdk: FirstTreeHubSDK;
-  log: (msg: string) => void;
+  log: pino.Logger;
   registryPath?: string;
   /** Step 4: optional config cache for refresh-before-dispatch on configVersion bump. */
   agentConfigCache?: AgentConfigCache;
@@ -103,7 +104,7 @@ export class SessionManager {
 
     // 1. Deduplication
     if (this.deduplicator.isDuplicate(messageId)) {
-      this.config.log(`Session ${chatId}: duplicate message ${messageId}, skipping`);
+      this.config.log.debug({ chatId, messageId }, "duplicate message, skipping");
       return;
     }
 
@@ -119,8 +120,14 @@ export class SessionManager {
           entry.message.configVersion,
         );
       } catch (err) {
-        this.config.log(
-          `[configVersionMismatch] agentId=${this.config.agentIdentity.agentId} chatId=${chatId} incomingVersion=${entry.message.configVersion} action=skip — ${err instanceof Error ? err.message : String(err)}`,
+        this.config.log.warn(
+          {
+            chatId,
+            agentId: this.config.agentIdentity.agentId,
+            incomingVersion: entry.message.configVersion,
+            err,
+          },
+          "config version mismatch — skipping refresh",
         );
       }
     }
@@ -137,7 +144,7 @@ export class SessionManager {
     if (command === "session:suspend") {
       const session = this.sessions.get(chatId);
       if (session?.status === "active") {
-        this.config.log(`Session ${chatId}: suspend command received`);
+        this.config.log.info({ chatId }, "suspend command received");
         this.suspendSession(session);
       }
       return;
@@ -148,7 +155,7 @@ export class SessionManager {
       const hadMapping = this.evictedMappings.has(chatId);
       if (!session && !hadMapping) return;
 
-      this.config.log(`Session ${chatId}: terminate command received`);
+      this.config.log.info({ chatId }, "terminate command received");
       if (session?.status === "active") {
         this._activeCount--;
         await session.handler.shutdown().catch(() => {});
@@ -265,7 +272,7 @@ export class SessionManager {
           await this.ackEntry(entryId, chatId);
           existing.handler.inject(message);
           existing.lastActivity = Date.now();
-          this.config.log(`Session ${chatId}: message injected`);
+          this.config.log.debug({ chatId }, "message injected");
           return;
 
         case "suspended":
@@ -318,18 +325,16 @@ export class SessionManager {
       if (evicted) {
         const sessionId = await handler.resume(message, evicted.claudeSessionId, ctx);
         entry.claudeSessionId = sessionId;
-        this.config.log(`Session ${chatId}: resumed from eviction (${sessionId})`);
+        this.config.log.info({ chatId, sessionId }, "session resumed from eviction");
       } else {
         const sessionId = await handler.start(message, ctx);
         entry.claudeSessionId = sessionId;
-        this.config.log(`Session ${chatId}: created (${sessionId})`);
+        this.config.log.info({ chatId, sessionId }, "session created");
       }
       this.persistRegistry();
       this.notifySessionState(chatId, "active");
     } catch (err) {
-      this.config.log(
-        `Session ${chatId}: ${evicted ? "resume" : "start"} failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      this.config.log.error({ chatId, err, phase: evicted ? "resume" : "start" }, "session start/resume failed");
       this.sessions.delete(chatId);
       this.sessionRuntimeStates.delete(chatId);
       this.recomputeRuntimeState();
@@ -370,11 +375,11 @@ export class SessionManager {
 
     try {
       await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx);
-      this.config.log(`Session ${entry.chatId}: resumed (${entry.claudeSessionId})`);
+      this.config.log.info({ chatId: entry.chatId, sessionId: entry.claudeSessionId }, "session resumed");
       this.persistRegistry();
       this.notifySessionState(entry.chatId, "active");
     } catch (err) {
-      this.config.log(`Session ${entry.chatId}: resume failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.config.log.warn({ chatId: entry.chatId, err }, "resume failed");
       entry.status = "suspended";
       this._activeCount--;
     }
@@ -401,13 +406,13 @@ export class SessionManager {
     }
 
     if (oldestActive) {
-      this.config.log(`Session ${oldestActive.chatId}: preempted for concurrency`);
+      this.config.log.info({ chatId: oldestActive.chatId }, "session preempted for concurrency");
       this.suspendSession(oldestActive);
       return true;
     }
 
     // All active sessions are busy — queue (no ACK yet — message stays as delivered)
-    this.config.log(`Session ${chatId}: concurrency limit reached, queuing`);
+    this.config.log.info({ chatId }, "concurrency limit reached, queuing");
     this.pendingQueue.push({ message, chatId, entryId: entryId ?? -1 });
     return false;
   }
@@ -421,7 +426,7 @@ export class SessionManager {
     entry.suspending = entry.handler
       .suspend()
       .catch((err) => {
-        this.config.log(`Session ${entry.chatId}: suspend error: ${err instanceof Error ? err.message : String(err)}`);
+        this.config.log.warn({ chatId: entry.chatId, err }, "suspend error");
       })
       .finally(() => {
         entry.suspending = null;
@@ -441,9 +446,7 @@ export class SessionManager {
     if (!next) return;
     // Route asynchronously — entryId is passed for delayed ACK
     this.routeMessage(next.chatId, next.message, next.entryId > 0 ? next.entryId : undefined).catch((err) => {
-      this.config.log(
-        `Session ${next.chatId}: pending drain error: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      this.config.log.warn({ chatId: next.chatId, err }, "pending drain error");
     });
   }
 
@@ -472,7 +475,7 @@ export class SessionManager {
         lastActivity: candidate.session.lastActivity,
       });
 
-      this.config.log(`Session ${candidate.key}: evicted (max_sessions reached)`);
+      this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
       if (candidate.session.status === "active") {
         this._activeCount--;
         candidate.session.handler.shutdown().catch(() => {});
@@ -500,14 +503,18 @@ export class SessionManager {
       const inactiveMs = now - session.lastActivity;
 
       if (inactiveMs > timeoutMs) {
-        this.config.log(`Session ${session.chatId}: idle ${this.config.session.idle_timeout}s, suspending`);
+        this.config.log.info(
+          { chatId: session.chatId, idleTimeoutSec: this.config.session.idle_timeout },
+          "session idle, suspending",
+        );
         this.suspendSession(session);
       } else if (inactiveMs > blockedThresholdMs) {
         // Only mark blocked if handler was actively working — don't override idle
         const currentState = this.sessionRuntimeStates.get(session.chatId);
         if (currentState === "working") {
-          this.config.log(
-            `Session ${session.chatId}: working but no output for ${Math.round(inactiveMs / 1000)}s, marking blocked`,
+          this.config.log.warn(
+            { chatId: session.chatId, inactiveSec: Math.round(inactiveMs / 1000) },
+            "session working but no output, marking blocked",
           );
           this.setSessionRuntimeState(session.chatId, "blocked");
         }
@@ -539,15 +546,16 @@ export class SessionManager {
     try {
       await this.config.sdk.ack(entryId);
     } catch {
-      this.config.log(`Session ${chatId}: ACK failed for entry ${entryId}, continuing`);
+      this.config.log.warn({ chatId, entryId }, "ACK failed, continuing");
     }
   }
 
   private buildSessionContext(chatId: string): SessionContext {
+    const sessionLog = this.config.log.child({ chatId });
     return {
       agent: this.config.agentIdentity,
       sdk: this.config.sdk,
-      log: (msg) => this.config.log(`Session ${chatId}: ${msg}`),
+      log: (msg) => sessionLog.info(msg),
       chatId,
       touch: () => {
         const entry = this.sessions.get(chatId);
@@ -625,7 +633,7 @@ export class SessionManager {
     }
 
     if (persisted.size > 0) {
-      this.config.log(`Loaded ${persisted.size} persisted session mapping(s)`);
+      this.config.log.info({ count: persisted.size }, "loaded persisted session mappings");
     }
   }
 

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/service-logs.test.ts
+++ b/packages/command/src/__tests__/service-logs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseDuration, validateLevel } from "../core/service-logs.js";
+
+describe("parseDuration", () => {
+  it("parses seconds", () => {
+    expect(parseDuration("10s")).toBe(10_000);
+  });
+  it("parses minutes", () => {
+    expect(parseDuration("5m")).toBe(300_000);
+  });
+  it("parses hours", () => {
+    expect(parseDuration("2h")).toBe(7_200_000);
+  });
+  it("parses days", () => {
+    expect(parseDuration("1d")).toBe(86_400_000);
+  });
+  it("tolerates inner whitespace", () => {
+    expect(parseDuration("  30  s  ")).toBe(30_000);
+  });
+  it("rejects malformed input", () => {
+    expect(() => parseDuration("10")).toThrow(/invalid duration/);
+    expect(() => parseDuration("1w")).toThrow(/invalid duration/);
+    expect(() => parseDuration("")).toThrow(/invalid duration/);
+  });
+});
+
+describe("validateLevel", () => {
+  it("returns the level when valid", () => {
+    expect(validateLevel("warn")).toBe("warn");
+    expect(validateLevel("trace")).toBe("trace");
+  });
+  it("returns undefined for unset", () => {
+    expect(validateLevel(undefined)).toBeUndefined();
+  });
+  it("throws on invalid level", () => {
+    expect(() => validateLevel("loud")).toThrow(/invalid --level/);
+  });
+});

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { applyClientLoggerConfig } from "@first-tree-hub/client";
 import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent.js";
 import { registerClientCommands } from "../commands/client.js";
@@ -8,6 +9,7 @@ import { registerOnboardCommand } from "../commands/onboard.js";
 import { registerServerCommands } from "../commands/server.js";
 import { registerStatusCommand } from "../commands/status.js";
 import { runHomeMigration } from "../core/migrate-home.js";
+import { setJsonMode } from "../core/output.js";
 import { COMMAND_VERSION } from "../core/version.js";
 
 // Run once at startup, BEFORE any command touches config/credentials so the
@@ -21,7 +23,33 @@ const program = new Command();
 program
   .name("first-tree-hub")
   .description("First Tree Hub — centralized collaboration platform for agent teams")
-  .version(COMMAND_VERSION);
+  .version(COMMAND_VERSION)
+  .option("--json", "emit only machine-readable JSON on stdout; silence human status lines on stderr")
+  .option("--verbose", "raise log level to debug (overrides FIRST_TREE_HUB_LOG_LEVEL)")
+  .hook("preAction", (thisCommand) => {
+    const opts = thisCommand.optsWithGlobals<{ json?: boolean; verbose?: boolean }>();
+    const json = opts.json === true || process.env.FIRST_TREE_HUB_JSON === "1";
+    setJsonMode(json);
+
+    // Log-level precedence: --verbose > FIRST_TREE_HUB_LOG_LEVEL > mode default.
+    // One-shot commands are noisy by default, so human mode defaults to `warn`,
+    // json mode to `error` — script consumers should get nothing on stderr
+    // unless something actually broke.
+    if (opts.verbose) {
+      applyClientLoggerConfig({ level: "debug", explicit: true });
+    } else if (process.env.FIRST_TREE_HUB_LOG_LEVEL) {
+      // Env var already applied at logger init; re-pin as explicit so later
+      // config-driven applies (client start reading client.yaml) can't
+      // override what the operator explicitly asked for.
+      applyClientLoggerConfig({ explicit: true });
+    } else if (json) {
+      // --json is an operator choice; pin the level so downstream commands
+      // can't re-introduce info/debug noise on stderr from their saved config.
+      applyClientLoggerConfig({ level: "error", explicit: true });
+    } else {
+      applyClientLoggerConfig({ level: "warn" });
+    }
+  });
 
 // Core subsystems — `client` group mounts `connect` too.
 registerServerCommands(program);

--- a/packages/command/src/cli/output.ts
+++ b/packages/command/src/cli/output.ts
@@ -1,10 +1,14 @@
-/** Write a success JSON envelope to stdout. */
+/**
+ * CLI output re-exports. The underlying implementation lives in
+ * `core/output.ts` (the Print layer). Keep these thin wrappers so callers that
+ * only depend on `cli/output.ts` keep working during the migration.
+ */
+import { print } from "../core/output.js";
+
 export function success(data: unknown): void {
-  process.stdout.write(`${JSON.stringify({ ok: true, data })}\n`);
+  print.result(data);
 }
 
-/** Write an error JSON envelope to stderr and exit with the given code. */
 export function fail(code: string, message: string, exitCode = 1): never {
-  process.stderr.write(`${JSON.stringify({ ok: false, error: { code, message } })}\n`);
-  process.exit(exitCode);
+  return print.fail(code, message, exitCode);
 }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -14,6 +14,7 @@ import { fail, success } from "../cli/output.js";
 import { ensureFreshAccessToken, resolveServerUrl, saveAgentConfig } from "../core/bootstrap.js";
 import { bindFeishuBot, bindFeishuUser } from "../core/feishu.js";
 import { promptAddAgent } from "../core/index.js";
+import { print } from "../core/output.js";
 import { registerAgentConfigCommands } from "./agent-config.js";
 
 const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -169,15 +170,15 @@ export function registerAgentCommands(program: Command): void {
         mkdirSync(agentDir, { recursive: true, mode: 0o700 });
         setConfigValue(join(agentDir, "agent.yaml"), "agentId", agentId);
 
-        process.stderr.write(`  Agent "${agentName}" added.\n`);
-        process.stderr.write(`  Config: ${join(agentDir, "agent.yaml")}\n`);
+        print.line(`  Agent "${agentName}" added.\n`);
+        print.line(`  Config: ${join(agentDir, "agent.yaml")}\n`);
       } catch (error) {
         if ((error as { name?: string }).name === "ExitPromptError") {
-          process.stderr.write("\n  Cancelled.\n");
+          print.line("\n  Cancelled.\n");
           return;
         }
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error: ${msg}\n`);
+        print.line(`  Error: ${msg}\n`);
         process.exit(1);
       }
     });
@@ -188,14 +189,14 @@ export function registerAgentCommands(program: Command): void {
     .action((name: string) => {
       const agentDir = join(DEFAULT_CONFIG_DIR, "agents", name);
       if (!existsSync(agentDir)) {
-        process.stderr.write(`  Agent "${name}" not found.\n`);
+        print.line(`  Agent "${name}" not found.\n`);
         process.exit(1);
       }
       rmSync(agentDir, { recursive: true, force: true });
       rmSync(join(DEFAULT_DATA_DIR, "workspaces", name), { recursive: true, force: true });
       rmSync(join(DEFAULT_DATA_DIR, "sessions", `${name}.json`), { force: true });
 
-      process.stderr.write(`  Agent "${name}" removed.\n`);
+      print.line(`  Agent "${name}" removed.\n`);
     });
 
   agent
@@ -206,16 +207,14 @@ export function registerAgentCommands(program: Command): void {
       try {
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
         if (agents.size === 0) {
-          process.stderr.write("  No agents configured.\n");
+          print.line("  No agents configured.\n");
           return;
         }
         for (const [name, config] of agents) {
-          process.stderr.write(
-            `  ${name.padEnd(20)} runtime: ${config.runtime.padEnd(14)} agentId: ${config.agentId}\n`,
-          );
+          print.line(`  ${name.padEnd(20)} runtime: ${config.runtime.padEnd(14)} agentId: ${config.agentId}\n`);
         }
       } catch {
-        process.stderr.write("  No agents configured.\n");
+        print.line("  No agents configured.\n");
       }
     });
 
@@ -263,11 +262,11 @@ export function registerAgentCommands(program: Command): void {
             fail("CREATE_ERROR", body.error ?? `Failed to create agent (HTTP ${createRes.status})`, 1);
           }
           const created = (await createRes.json()) as { uuid: string; name: string | null };
-          process.stderr.write(`  \u2713 Agent created: ${created.name ?? created.uuid}\n`);
+          print.line(`  \u2713 Agent created: ${created.name ?? created.uuid}\n`);
 
           const agentDir = saveAgentConfig(name, created.uuid, options.runtime);
-          process.stderr.write(`  \u2713 Config saved: ${agentDir}/agent.yaml\n`);
-          process.stderr.write("  \u2713 Agent ready — start the client on that machine to bind\n");
+          print.line(`  \u2713 Config saved: ${agentDir}/agent.yaml\n`);
+          print.line("  \u2713 Agent ready — start the client on that machine to bind\n");
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           fail("CREATE_ERROR", msg);
@@ -309,7 +308,7 @@ export function registerAgentCommands(program: Command): void {
           const body = (await patchRes.json().catch(() => ({}))) as { error?: string };
           fail("CLAIM_ERROR", body.error ?? `Claim failed (HTTP ${patchRes.status})`, 1);
         }
-        process.stderr.write(`  Claimed "${target.name ?? target.uuid}" — now managed by you.\n`);
+        print.line(`  Claimed "${target.name ?? target.uuid}" — now managed by you.\n`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("CLAIM_ERROR", msg);
@@ -330,7 +329,7 @@ export function registerAgentCommands(program: Command): void {
       const workspacesDir = join(DEFAULT_DATA_DIR, "workspaces");
 
       if (!existsSync(workspacesDir)) {
-        process.stderr.write("  No workspaces found.\n");
+        print.line("  No workspaces found.\n");
         return;
       }
 
@@ -354,11 +353,11 @@ export function registerAgentCommands(program: Command): void {
         const removed = cleanWorkspaces(agentWorkspaceRoot, activeChatIds, ttlMs);
         totalRemoved += removed.length;
         for (const chatId of removed) {
-          process.stderr.write(`  Removed: ${name}/${chatId}\n`);
+          print.line(`  Removed: ${name}/${chatId}\n`);
         }
       }
 
-      process.stderr.write(`  ${totalRemoved} workspace(s) cleaned.\n`);
+      print.line(`  ${totalRemoved} workspace(s) cleaned.\n`);
     });
 
   // ── Bind (client machine / Feishu bot / user) ───────────────────────
@@ -392,7 +391,7 @@ export function registerAgentCommands(program: Command): void {
           const body = (await patchRes.json().catch(() => ({}))) as { error?: string };
           fail("BIND_CLIENT_ERROR", body.error ?? `Bind failed (HTTP ${patchRes.status})`, 1);
         }
-        process.stderr.write(`  \u2713 Bound "${target.name ?? target.uuid}" to client ${options.clientId}.\n`);
+        print.line(`  \u2713 Bound "${target.name ?? target.uuid}" to client ${options.clientId}.\n`);
         success({ agentId: target.uuid, clientId: options.clientId });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -419,7 +418,7 @@ export function registerAgentCommands(program: Command): void {
           const { agentId } = resolveLocalAgent(options.agent);
           const accessToken = await ensureFreshAccessToken();
           await bindFeishuBot(serverUrl, accessToken, agentId, options.appId, options.appSecret);
-          process.stderr.write("Feishu bot bound successfully.\n");
+          print.line("Feishu bot bound successfully.\n");
           success({ platform: "feishu", bound: true });
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
@@ -449,7 +448,7 @@ export function registerAgentCommands(program: Command): void {
           const { agentId } = resolveLocalAgent(options.agent);
           const accessToken = await ensureFreshAccessToken();
           await bindFeishuUser(serverUrl, accessToken, agentId, humanAgentId, options.feishuId);
-          process.stderr.write(`Feishu user ${options.feishuId} bound to ${humanAgentId}.\n`);
+          print.line(`Feishu user ${options.feishuId} bound to ${humanAgentId}.\n`);
           success({ platform: "feishu", humanAgentId, feishuUserId: options.feishuId });
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
@@ -591,40 +590,40 @@ export function registerAgentCommands(program: Command): void {
         if (name) {
           const ag = data.agents.find((a) => a.agentId === name);
           if (!ag) {
-            process.stderr.write(`\n  Agent "${name}" is not running.\n\n`);
+            print.line(`\n  Agent "${name}" is not running.\n\n`);
             return;
           }
-          process.stderr.write(`\n  Agent: ${ag.agentId}\n`);
-          process.stderr.write(`  Runtime: ${ag.runtimeType ?? "—"}\n`);
-          process.stderr.write(`  State: ${ag.runtimeState ?? "—"}\n`);
+          print.line(`\n  Agent: ${ag.agentId}\n`);
+          print.line(`  Runtime: ${ag.runtimeType ?? "—"}\n`);
+          print.line(`  State: ${ag.runtimeState ?? "—"}\n`);
           if (ag.activeSessions !== null) {
-            process.stderr.write(`  Sessions: ${ag.activeSessions} active / ${ag.totalSessions ?? 0} total\n`);
+            print.line(`  Sessions: ${ag.activeSessions} active / ${ag.totalSessions ?? 0} total\n`);
           }
           if (ag.clientId) {
-            process.stderr.write(`  Client: ${ag.clientId}\n`);
+            print.line(`  Client: ${ag.clientId}\n`);
           }
-          process.stderr.write("\n");
+          print.line("\n");
           return;
         }
 
-        process.stderr.write(`\n  Hub: ${serverUrl}\n\n`);
-        process.stderr.write(`  Clients: ${data.clients} connected\n`);
-        process.stderr.write(`  Agents: ${data.running} running / ${data.total} total\n`);
-        process.stderr.write(
+        print.line(`\n  Hub: ${serverUrl}\n\n`);
+        print.line(`  Clients: ${data.clients} connected\n`);
+        print.line(`  Agents: ${data.running} running / ${data.total} total\n`);
+        print.line(
           `  Errors: ${data.byState.error} | Blocked: ${data.byState.blocked} | Working: ${data.byState.working} | Idle: ${data.byState.idle}\n\n`,
         );
 
         if (data.agents.length > 0) {
           const header = `  ${"AGENT".padEnd(18)} ${"RUNTIME".padEnd(14)} ${"STATE".padEnd(10)} SESSIONS`;
-          process.stderr.write(`${header}\n`);
-          process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
+          print.line(`${header}\n`);
+          print.line(`  ${"─".repeat(header.length - 2)}\n`);
           for (const a of data.agents) {
             const sessions = a.activeSessions !== null ? `${a.activeSessions}/${a.totalSessions ?? 0}` : "—";
-            process.stderr.write(
+            print.line(
               `  ${(a.agentId ?? "").padEnd(18)} ${(a.runtimeType ?? "—").padEnd(14)} ${(a.runtimeState ?? "—").padEnd(10)} ${sessions}\n`,
             );
           }
-          process.stderr.write("\n");
+          print.line("\n");
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -647,7 +646,7 @@ export function registerAgentCommands(program: Command): void {
         if (!response.ok) {
           fail("RESET_ERROR", `Server returned ${response.status}`, 1);
         }
-        process.stderr.write(`  Agent "${name}" reset to idle.\n`);
+        print.line(`  Agent "${name}" reset to idle.\n`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("RESET_ERROR", msg);
@@ -681,20 +680,20 @@ export function registerAgentCommands(program: Command): void {
           lastActivityAt: string;
         }>;
         if (sessions.length === 0) {
-          process.stderr.write(`\n  No sessions for "${agentName}".\n\n`);
+          print.line(`\n  No sessions for "${agentName}".\n\n`);
           return;
         }
-        process.stderr.write(`\n  Sessions for "${agentName}":\n\n`);
+        print.line(`\n  Sessions for "${agentName}":\n\n`);
         const header = `  ${"CHAT".padEnd(40)} ${"STATE".padEnd(12)} ${"RUNTIME".padEnd(10)} LAST ACTIVITY`;
-        process.stderr.write(`${header}\n`);
-        process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
+        print.line(`${header}\n`);
+        print.line(`  ${"─".repeat(header.length - 2)}\n`);
         for (const s of sessions) {
           const chatShort = s.chatId.length > 38 ? `${s.chatId.slice(0, 35)}...` : s.chatId;
-          process.stderr.write(
+          print.line(
             `  ${chatShort.padEnd(40)} ${s.state.padEnd(12)} ${(s.runtimeState ?? "—").padEnd(10)} ${s.lastActivityAt}\n`,
           );
         }
-        process.stderr.write("\n");
+        print.line("\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("SESSIONS_ERROR", msg);
@@ -725,7 +724,7 @@ export function registerAgentCommands(program: Command): void {
             const body = await response.text();
             fail("SESSION_CMD_ERROR", `Server returned ${response.status}: ${body}`, 1);
           }
-          process.stderr.write(`  Session ${cmd}: ${chatId} → sent\n`);
+          print.line(`  Session ${cmd}: ${chatId} → sent\n`);
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
           fail("SESSION_CMD_ERROR", msg);
@@ -761,9 +760,9 @@ export function registerAgentCommands(program: Command): void {
         }
         const dm = (await dmRes.json()) as { id: string };
 
-        process.stderr.write(`\n  Chat with ${targetAgent.displayName ?? targetAgent.name ?? targetAgent.uuid}\n`);
-        process.stderr.write(`  Chat ID: ${dm.id}\n`);
-        process.stderr.write(`  Type a message and press Enter. Ctrl+C to exit.\n\n`);
+        print.line(`\n  Chat with ${targetAgent.displayName ?? targetAgent.name ?? targetAgent.uuid}\n`);
+        print.line(`  Chat ID: ${dm.id}\n`);
+        print.line(`  Type a message and press Enter. Ctrl+C to exit.\n\n`);
 
         const readline = await import("node:readline");
         const rl = readline.createInterface({ input: process.stdin, output: process.stderr, prompt: "  > " });
@@ -795,7 +794,7 @@ export function registerAgentCommands(program: Command): void {
             for (const msg of newMessages) {
               const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
               const preview = content.length > 500 ? `${content.slice(0, 500)}...` : content;
-              process.stderr.write(`\r  [${targetAgent.displayName ?? targetAgent.name ?? "agent"}] ${preview}\n`);
+              print.line(`\r  [${targetAgent.displayName ?? targetAgent.name ?? "agent"}] ${preview}\n`);
             }
 
             if (msgData.items.length > 0 && msgData.items[0]) {
@@ -833,20 +832,20 @@ export function registerAgentCommands(program: Command): void {
             });
             if (!sendRes.ok) {
               const body = await sendRes.text();
-              process.stderr.write(`  [error] Failed to send: ${sendRes.status} — ${body}\n`);
+              print.line(`  [error] Failed to send: ${sendRes.status} — ${body}\n`);
             } else {
               const sent = (await sendRes.json()) as { createdAt: string };
               lastSeenAt = sent.createdAt;
             }
           } catch (err) {
-            process.stderr.write(`  [error] ${err instanceof Error ? err.message : String(err)}\n`);
+            print.line(`  [error] ${err instanceof Error ? err.message : String(err)}\n`);
           }
           rl.prompt();
         });
 
         rl.on("close", () => {
           clearInterval(pollTimer);
-          process.stderr.write("\n  Chat ended.\n");
+          print.line("\n  Chat ended.\n");
           process.exit(0);
         });
       } catch (error) {

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -3,12 +3,13 @@ import {
   agentConfigSchema,
   clientConfigSchema,
   DEFAULT_CONFIG_DIR,
+  DEFAULT_HOME_DIR,
   initConfig,
   loadAgents,
   resetConfig,
   resetConfigMeta,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { applyClientLoggerConfig } from "@first-tree-hub/client";
+import { applyClientLoggerConfig, configureClientLoggerForService } from "@first-tree-hub/client";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import {
@@ -25,12 +26,16 @@ import {
   getClientServiceStatus,
   installClientService,
   isServiceSupported,
+  parseDuration,
   printResults,
   promptMissingFields,
   promptUpdate,
   resolveServerUrl,
+  showServiceLogs,
   uninstallClientService,
+  validateLevel,
 } from "../core/index.js";
+import { print } from "../core/output.js";
 import { registerConnectCommand } from "./connect.js";
 
 export function registerClientCommands(program: Command): void {
@@ -63,11 +68,18 @@ export function registerClientCommands(program: Command): void {
         // `logLevel: debug` in client.yaml is parsed but never reaches pino.
         applyClientLoggerConfig({ level: config.logLevel });
 
+        // Service mode (launchd / systemd): route pino through a rotating
+        // NDJSON file instead of stderr, so the supervisor's stdout/stderr
+        // capture stays empty under normal operation.
+        if (process.env.FIRST_TREE_HUB_SERVICE_MODE === "1") {
+          configureClientLoggerForService(join(DEFAULT_HOME_DIR, "logs"));
+        }
+
         // Load agents (may be empty — client can start without agents)
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
-        process.stderr.write(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
+        print.line(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
 
         // `--no-interactive` is the signal the service units (launchd /
         // systemd) set — we piggy-back on it for two things: (1) suppress
@@ -94,7 +106,7 @@ export function registerClientCommands(program: Command): void {
 
         // Graceful shutdown
         const shutdown = async () => {
-          process.stderr.write("\n  Shutting down...\n");
+          print.line("\n  Shutting down...\n");
           runtime.unwatchAgentsDir();
           await runtime.stop();
           process.exit(0);
@@ -106,7 +118,7 @@ export function registerClientCommands(program: Command): void {
         await new Promise(() => {});
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error: ${msg}\n`);
+        print.line(`  Error: ${msg}\n`);
         process.exit(1);
       } finally {
         // Reset singleton so other commands can reinit
@@ -119,7 +131,7 @@ export function registerClientCommands(program: Command): void {
     .command("doctor")
     .description("Check client environment readiness")
     .action(async () => {
-      process.stderr.write("\n  First Tree Hub Client Doctor\n\n");
+      print.line("\n  First Tree Hub Client Doctor\n\n");
       const results = [
         checkNodeVersion(),
         checkClientConfig(),
@@ -134,8 +146,8 @@ export function registerClientCommands(program: Command): void {
     .command("stop")
     .description("Stop the client (sends SIGTERM to running process)")
     .action(() => {
-      process.stderr.write("  Client stop: use Ctrl+C or `kill` the running process.\n");
-      process.stderr.write("  Daemon mode with PID file is planned for a future release.\n");
+      print.line("  Client stop: use Ctrl+C or `kill` the running process.\n");
+      print.line("  Daemon mode with PID file is planned for a future release.\n");
     });
 
   client
@@ -146,18 +158,16 @@ export function registerClientCommands(program: Command): void {
       try {
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
         if (agents.size === 0) {
-          process.stderr.write("  No agents configured.\n");
+          print.line("  No agents configured.\n");
           return;
         }
-        process.stderr.write("\n  Configured agents:\n\n");
+        print.line("\n  Configured agents:\n\n");
         for (const [name, config] of agents) {
-          process.stderr.write(
-            `  ${name.padEnd(20)} runtime: ${config.runtime.padEnd(14)} agentId: ${config.agentId}\n`,
-          );
+          print.line(`  ${name.padEnd(20)} runtime: ${config.runtime.padEnd(14)} agentId: ${config.agentId}\n`);
         }
-        process.stderr.write("\n");
+        print.line("\n");
       } catch {
-        process.stderr.write("  No agents directory found.\n");
+        print.line("  No agents directory found.\n");
       }
     });
 
@@ -172,7 +182,7 @@ export function registerClientCommands(program: Command): void {
     .description("Install as a background service — auto-starts on login/boot")
     .action(() => {
       if (!isServiceSupported()) {
-        process.stderr.write(
+        print.line(
           `  Background service is not supported on ${process.platform}.\n` +
             "  Run `first-tree-hub client start` manually to keep the computer online.\n",
         );
@@ -180,15 +190,15 @@ export function registerClientCommands(program: Command): void {
       }
       try {
         const info = installClientService();
-        process.stderr.write(`\n  \u2713 Installed as a background service (${info.platform}).\n`);
-        process.stderr.write(`    Unit:  ${info.unitPath}\n`);
-        process.stderr.write(`    Logs:  ${info.logDir}\n`);
+        print.line(`\n  \u2713 Installed as a background service (${info.platform}).\n`);
+        print.line(`    Unit:  ${info.unitPath}\n`);
+        print.line(`    Logs:  ${info.logDir}\n`);
         if (info.state === "active") {
-          process.stderr.write(`    State: running${info.detail ? ` (${info.detail})` : ""}\n`);
+          print.line(`    State: running${info.detail ? ` (${info.detail})` : ""}\n`);
         } else {
-          process.stderr.write(`    State: ${info.state}${info.detail ? ` (${info.detail})` : ""}\n`);
+          print.line(`    State: ${info.state}${info.detail ? ` (${info.detail})` : ""}\n`);
         }
-        process.stderr.write("\n  You can close this terminal — the computer stays online.\n");
+        print.line("\n  You can close this terminal — the computer stays online.\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("SERVICE_INSTALL_ERROR", msg);
@@ -201,13 +211,13 @@ export function registerClientCommands(program: Command): void {
     .action(() => {
       const info = getClientServiceStatus();
       if (info.platform === "unsupported") {
-        process.stderr.write(`  Not supported on ${process.platform}.\n`);
+        print.line(`  Not supported on ${process.platform}.\n`);
         return;
       }
-      process.stderr.write(`\n  ${info.platform}: ${info.label}\n`);
-      process.stderr.write(`  Unit:  ${info.unitPath}\n`);
-      process.stderr.write(`  Logs:  ${info.logDir}\n`);
-      process.stderr.write(`  State: ${info.state}${info.detail ? ` (${info.detail})` : ""}\n\n`);
+      print.line(`\n  ${info.platform}: ${info.label}\n`);
+      print.line(`  Unit:  ${info.unitPath}\n`);
+      print.line(`  Logs:  ${info.logDir}\n`);
+      print.line(`  State: ${info.state}${info.detail ? ` (${info.detail})` : ""}\n\n`);
     });
 
   service
@@ -215,15 +225,38 @@ export function registerClientCommands(program: Command): void {
     .description("Stop and remove the background service")
     .action(() => {
       if (!isServiceSupported()) {
-        process.stderr.write(`  Not supported on ${process.platform}.\n`);
+        print.line(`  Not supported on ${process.platform}.\n`);
         return;
       }
       try {
         const info = uninstallClientService();
-        process.stderr.write(`\n  \u2713 Uninstalled background service (${info.platform}).\n\n`);
+        print.line(`\n  \u2713 Uninstalled background service (${info.platform}).\n\n`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("SERVICE_UNINSTALL_ERROR", msg);
+      }
+    });
+
+  service
+    .command("logs")
+    .description("Read background-service logs (pretty by default)")
+    .option("-f, --tail", "follow new lines as they arrive (Ctrl+C to stop)", false)
+    .option("--since <duration>", "only show records newer than duration (e.g. 10s, 5m, 2h, 1d)")
+    .option("--level <level>", "minimum level (trace|debug|info|warn|error|fatal)")
+    .option("--json", "emit raw NDJSON lines instead of pretty formatting", false)
+    .action(async (options: { tail?: boolean; since?: string; level?: string; json?: boolean }) => {
+      try {
+        const level = validateLevel(options.level);
+        const sinceMs = options.since ? parseDuration(options.since) : undefined;
+        await showServiceLogs({
+          tail: options.tail === true,
+          level,
+          sinceMs,
+          json: options.json === true,
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("SERVICE_LOGS_ERROR", msg);
       }
     });
 
@@ -253,21 +286,21 @@ export function registerClientCommands(program: Command): void {
         }>;
 
         if (clients.length === 0) {
-          process.stderr.write("  No clients.\n");
+          print.line("  No clients.\n");
           return;
         }
 
-        process.stderr.write(`\n  Clients: ${clients.length}\n\n`);
+        print.line(`\n  Clients: ${clients.length}\n\n`);
         const header = `  ${"CLIENT".padEnd(20)} ${"HOST".padEnd(25)} ${"AGENTS".padEnd(8)} CONNECTED`;
-        process.stderr.write(`${header}\n`);
-        process.stderr.write(`  ${"─".repeat(header.length - 2)}\n`);
+        print.line(`${header}\n`);
+        print.line(`  ${"─".repeat(header.length - 2)}\n`);
         for (const c of clients) {
           const since = c.connectedAt ? timeSince(c.connectedAt) : "—";
-          process.stderr.write(
+          print.line(
             `  ${c.id.padEnd(20)} ${(c.hostname ?? "—").padEnd(25)} ${String(c.agentCount).padEnd(8)} ${since}\n`,
           );
         }
-        process.stderr.write("\n");
+        print.line("\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("CLIENT_LIST_ERROR", msg);
@@ -290,7 +323,7 @@ export function registerClientCommands(program: Command): void {
         if (!response.ok) {
           fail("DISCONNECT_ERROR", `Server returned ${response.status}`, 1);
         }
-        process.stderr.write(`  Client "${clientId}" disconnected.\n`);
+        print.line(`  Client "${clientId}" disconnected.\n`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("DISCONNECT_ERROR", msg);

--- a/packages/command/src/commands/config.ts
+++ b/packages/command/src/commands/config.ts
@@ -10,6 +10,7 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { Command } from "commander";
 import { promptMissingFields } from "../core/index.js";
+import { print } from "../core/output.js";
 
 type ScopeFlags = {
   server?: boolean;
@@ -60,10 +61,10 @@ export function registerConfigCommands(program: Command): void {
           : (serverConfigSchema as Record<string, unknown>);
         const role = flags.client ? "client" : "server";
         await promptMissingFields({ schema, role });
-        process.stderr.write("\n  Configuration saved.\n");
+        print.line("\n  Configuration saved.\n");
       } catch (error) {
         if ((error as { name?: string }).name === "ExitPromptError") {
-          process.stderr.write("\n  Cancelled.\n");
+          print.line("\n  Cancelled.\n");
           return;
         }
         throw error;
@@ -82,7 +83,7 @@ export function registerConfigCommands(program: Command): void {
       else if (/^\d+$/.test(value)) parsed = Number(value);
 
       setConfigValue(path, key, parsed);
-      process.stderr.write(`  Set ${key} in ${path}\n`);
+      print.line(`  Set ${key} in ${path}\n`);
     });
 
   addScopeOptions(config.command("get").description("Get a config value"))
@@ -92,11 +93,11 @@ export function registerConfigCommands(program: Command): void {
       const { path, schema } = resolveConfigPath(flags);
       const value = getConfigValue(path, key);
       if (value === undefined) {
-        process.stderr.write(`  ${key}: (not set)\n`);
+        print.line(`  ${key}: (not set)\n`);
       } else {
         const isSecret = isSecretField(schema, key) && !flags.showSecrets;
         const display = isSecret ? "***" : String(value);
-        process.stderr.write(`  ${key}: ${display}\n`);
+        print.line(`  ${key}: ${display}\n`);
       }
     });
 
@@ -106,12 +107,12 @@ export function registerConfigCommands(program: Command): void {
       const { path, schema } = resolveConfigPath(flags);
       const values = readConfigFile(path);
       if (Object.keys(values).length === 0) {
-        process.stderr.write(`  No config found at ${path}\n`);
+        print.line(`  No config found at ${path}\n`);
         return;
       }
-      process.stderr.write(`\n  Config: ${path}\n\n`);
+      print.line(`\n  Config: ${path}\n\n`);
       printFlat(values, schema, "", flags.showSecrets ?? false);
-      process.stderr.write("\n");
+      print.line("\n");
     });
 }
 
@@ -128,7 +129,7 @@ function printFlat(
     } else {
       const secret = isSecretField(schema, fullKey) && !showSecrets;
       const display = secret ? "***" : String(value);
-      process.stderr.write(`  ${fullKey.padEnd(30)} ${display}\n`);
+      print.line(`  ${fullKey.padEnd(30)} ${display}\n`);
     }
   }
 }

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -23,6 +23,7 @@ import {
   promptUpdate,
   saveCredentials,
 } from "../core/index.js";
+import { print } from "../core/output.js";
 
 type JwtPayload = {
   memberId?: unknown;
@@ -98,16 +99,16 @@ async function promptReplaceOrCancel(newMemberId: string, newServerUrl: string):
         ? `installed but not running${serviceStatus.detail ? ` — ${serviceStatus.detail}` : ""}`
         : "not installed";
 
-  process.stderr.write("\n");
-  process.stderr.write("  \u26a0\ufe0f  This computer is already connected to the Hub under another account.\n\n");
-  process.stderr.write(`       Existing account:  ${existingMember}\n`);
+  print.line("\n");
+  print.line("  \u26a0\ufe0f  This computer is already connected to the Hub under another account.\n\n");
+  print.line(`       Existing account:  ${existingMember}\n`);
   if (existingOrg) {
-    process.stderr.write(`       Organization:      ${existingOrg.slice(0, 8)}\n`);
+    print.line(`       Organization:      ${existingOrg.slice(0, 8)}\n`);
   }
-  process.stderr.write(`       Server:            ${existing.serverUrl}\n`);
-  process.stderr.write(`       Background service: ${serviceLine}\n\n`);
-  process.stderr.write("     Replacing only affects THIS computer. Your agents, messages, and\n");
-  process.stderr.write("     settings on the Hub itself are untouched.\n\n");
+  print.line(`       Server:            ${existing.serverUrl}\n`);
+  print.line(`       Background service: ${serviceLine}\n\n`);
+  print.line("     Replacing only affects THIS computer. Your agents, messages, and\n");
+  print.line("     settings on the Hub itself are untouched.\n\n");
 
   const choice = await select<"replace" | "cancel">({
     message: "How would you like to continue?",
@@ -132,15 +133,15 @@ async function promptReplaceOrCancel(newMemberId: string, newServerUrl: string):
 }
 
 function printIsolationGuide(newServerUrl: string): void {
-  process.stderr.write("\n  Cancelled. The existing account on this computer is untouched.\n\n");
-  process.stderr.write("  To run this new account alongside it (advanced — no background service):\n\n");
-  process.stderr.write('    export FIRST_TREE_HUB_HOME="$HOME/.first-tree/hub-<label>"\n');
-  process.stderr.write(`    first-tree-hub client connect ${newServerUrl} --token <token>\n`);
-  process.stderr.write("    first-tree-hub client start\n\n");
-  process.stderr.write("  Notes:\n");
-  process.stderr.write("    - Run the commands in a FRESH terminal (the isolated home must be set first).\n");
-  process.stderr.write("    - In isolated mode the client stays online only while that terminal runs.\n");
-  process.stderr.write("    - The main account's background service is not affected.\n\n");
+  print.line("\n  Cancelled. The existing account on this computer is untouched.\n\n");
+  print.line("  To run this new account alongside it (advanced — no background service):\n\n");
+  print.line('    export FIRST_TREE_HUB_HOME="$HOME/.first-tree/hub-<label>"\n');
+  print.line(`    first-tree-hub client connect ${newServerUrl} --token <token>\n`);
+  print.line("    first-tree-hub client start\n\n");
+  print.line("  Notes:\n");
+  print.line("    - Run the commands in a FRESH terminal (the isolated home must be set first).\n");
+  print.line("    - In isolated mode the client stays online only while that terminal runs.\n");
+  print.line("    - The main account's background service is not affected.\n\n");
 }
 
 /**
@@ -169,7 +170,7 @@ async function authenticateWithToken(
  * Authenticate via interactive username/password login.
  */
 async function authenticateInteractive(url: string): Promise<{ accessToken: string; refreshToken: string }> {
-  process.stderr.write("\n  Log in to Hub:\n");
+  print.line("\n  Log in to Hub:\n");
 
   const username = await input({ message: "  Username:" });
   const pw = await password({ message: "  Password:" });
@@ -241,10 +242,10 @@ export function registerConnectCommand(parent: Command): void {
         // 4. Write server URL and credentials.
         const clientConfigPath = join(DEFAULT_CONFIG_DIR, "client.yaml");
         setConfigValue(clientConfigPath, "server.url", url);
-        process.stderr.write(`\n  \u2713 Server configured: ${url}\n`);
+        print.line(`\n  \u2713 Server configured: ${url}\n`);
 
         saveCredentials({ ...tokens, serverUrl: url });
-        process.stderr.write("  \u2713 Authenticated\n");
+        print.line("  \u2713 Authenticated\n");
 
         // Touch config + client.id so the background service picks up the
         // persisted clientId on its first launch (see #99).
@@ -254,29 +255,27 @@ export function registerConnectCommand(parent: Command): void {
           schema: clientConfigSchema,
           role: "client",
         });
-        process.stderr.write(`  \u2713 Connected as this computer (id: ${config.client.id})\n`);
+        print.line(`  \u2713 Connected as this computer (id: ${config.client.id})\n`);
 
         // 5. Install background service (default) OR run inline (--no-service).
         const shouldInstallService = options.service !== false && isServiceSupported();
 
         if (shouldInstallService) {
           const info = installClientService();
-          process.stderr.write(
-            `  \u2713 Installed as a background service (${info.platform}) — you can close this terminal\n\n`,
-          );
-          process.stderr.write(`    Unit:  ${info.unitPath}\n`);
-          process.stderr.write(`    Logs:  ${info.logDir}\n`);
+          print.line(`  \u2713 Installed as a background service (${info.platform}) — you can close this terminal\n\n`);
+          print.line(`    Unit:  ${info.unitPath}\n`);
+          print.line(`    Logs:  ${info.logDir}\n`);
           if (info.state === "active" && info.detail) {
-            process.stderr.write(`    State: running (${info.detail})\n`);
+            print.line(`    State: running (${info.detail})\n`);
           }
-          process.stderr.write("\n");
+          print.line("\n");
           return;
         }
 
         if (options.service === false) {
-          process.stderr.write("  (--no-service) running inline — Ctrl+C to stop\n");
+          print.line("  (--no-service) running inline — Ctrl+C to stop\n");
         } else {
-          process.stderr.write(`  Background service not supported on ${process.platform}; running inline.\n`);
+          print.line(`  Background service not supported on ${process.platform}; running inline.\n`);
         }
 
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
@@ -302,7 +301,7 @@ export function registerConnectCommand(parent: Command): void {
 
         // Graceful shutdown
         const shutdown = async () => {
-          process.stderr.write("\n  Shutting down...\n");
+          print.line("\n  Shutting down...\n");
           runtime.unwatchAgentsDir();
           await runtime.stop();
           process.exit(0);
@@ -314,11 +313,11 @@ export function registerConnectCommand(parent: Command): void {
         await new Promise(() => {});
       } catch (error) {
         if ((error as { name?: string }).name === "ExitPromptError") {
-          process.stderr.write("\n  Cancelled.\n");
+          print.line("\n  Cancelled.\n");
           return;
         }
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error: ${msg}\n`);
+        print.line(`  Error: ${msg}\n`);
         process.exit(1);
       } finally {
         resetConfig();

--- a/packages/command/src/commands/onboard.ts
+++ b/packages/command/src/commands/onboard.ts
@@ -2,6 +2,7 @@ import { confirm, input, select } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import { formatCheckReport, loadOnboardState, onboardCheck, onboardCreate, saveOnboardState } from "../core/onboard.js";
+import { print } from "../core/output.js";
 import { isInteractive } from "../core/prompt.js";
 
 async function promptMissing(args: Record<string, unknown>): Promise<void> {
@@ -140,7 +141,7 @@ export function registerOnboardCommand(program: Command): void {
         if (args.check) {
           const items = await onboardCheck(args as Parameters<typeof onboardCheck>[0]);
           const report = formatCheckReport(items);
-          process.stderr.write(`\nOnboard Check: ${(args.id as string) ?? "(no id)"}\n\n${report}\n\n`);
+          print.line(`\nOnboard Check: ${(args.id as string) ?? "(no id)"}\n\n${report}\n\n`);
           const hasErrors = items.some((i) => i.status === "missing_required" || i.status === "error");
           if (hasErrors) {
             process.exit(1);
@@ -156,7 +157,7 @@ export function registerOnboardCommand(program: Command): void {
         const hasErrors = items.some((i) => i.status === "missing_required" || i.status === "error");
         if (hasErrors) {
           const report = formatCheckReport(items);
-          process.stderr.write(`\nOnboard Check: ${(args.id as string) ?? "(no id)"}\n\n${report}\n\n`);
+          print.line(`\nOnboard Check: ${(args.id as string) ?? "(no id)"}\n\n${report}\n\n`);
           fail("MISSING_PARAMS", "Required parameters are missing. See checklist above.");
         }
 
@@ -164,7 +165,7 @@ export function registerOnboardCommand(program: Command): void {
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (isInteractive()) {
-          process.stderr.write(`\n\u274C ${msg}\n\n`);
+          print.line(`\n\u274C ${msg}\n\n`);
           process.exit(1);
         }
         fail("ONBOARD_ERROR", msg);

--- a/packages/command/src/commands/server.ts
+++ b/packages/command/src/commands/server.ts
@@ -12,6 +12,7 @@ import {
   startServer,
   stopPostgres,
 } from "../core/index.js";
+import { print } from "../core/output.js";
 
 export function registerServerCommands(program: Command): void {
   const server = program.command("server").description("Manage First Tree Hub server");
@@ -28,7 +29,7 @@ export function registerServerCommands(program: Command): void {
         await startServer({ ...options, noInteractive: options.interactive === false });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`\n  Error: ${msg}\n\n`);
+        print.line(`\n  Error: ${msg}\n\n`);
         process.exit(1);
       }
     });
@@ -40,13 +41,13 @@ export function registerServerCommands(program: Command): void {
       try {
         const stopped = stopPostgres();
         if (stopped) {
-          process.stderr.write("  PostgreSQL container stopped.\n");
+          print.line("  PostgreSQL container stopped.\n");
         } else {
-          process.stderr.write("  No managed PostgreSQL container found.\n");
+          print.line("  No managed PostgreSQL container found.\n");
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error stopping PostgreSQL: ${msg}\n`);
+        print.line(`  Error stopping PostgreSQL: ${msg}\n`);
         process.exit(1);
       }
     });
@@ -55,7 +56,7 @@ export function registerServerCommands(program: Command): void {
     .command("doctor")
     .description("Check server environment readiness")
     .action(async () => {
-      process.stderr.write("\n  First Tree Hub Server Doctor\n\n");
+      print.line("\n  First Tree Hub Server Doctor\n\n");
       const results = [
         checkNodeVersion(),
         checkDocker(),
@@ -76,13 +77,17 @@ export function registerServerCommands(program: Command): void {
         const res = await fetch(`${url}/api/v1/health`);
         if (res.ok) {
           const data = await res.json();
-          console.log(JSON.stringify(data, null, 2));
+          // Emit the raw /api/v1/health payload — existing scripts consume
+          // `first-tree-hub server status | jq '.status'` and would break if
+          // we wrapped it in the `{ok, data}` envelope. The body is already
+          // JSON, so this is safe for both human and `--json` consumers.
+          process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
         } else {
-          process.stderr.write(`  Server returned ${res.status}\n`);
+          print.line(`  Server returned ${res.status}\n`);
           process.exit(1);
         }
       } catch {
-        process.stderr.write(`  Cannot connect to ${url}\n`);
+        print.line(`  Cannot connect to ${url}\n`);
         process.exit(1);
       }
     });
@@ -96,10 +101,10 @@ export function registerServerCommands(program: Command): void {
       try {
         const config = await initConfig({ schema: serverConfigSchema, role: "server" });
         const tableCount = await runMigrations(config.database.url);
-        process.stderr.write(`  Migrations complete (${tableCount} tables)\n`);
+        print.line(`  Migrations complete (${tableCount} tables)\n`);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error: ${msg}\n`);
+        print.line(`  Error: ${msg}\n`);
         process.exit(1);
       }
     });
@@ -124,13 +129,13 @@ export function registerServerCommands(program: Command): void {
           options.password,
         );
 
-        process.stderr.write(`  Admin user "${result.username}" created.\n`);
+        print.line(`  Admin user "${result.username}" created.\n`);
         if (!options.password) {
-          process.stderr.write(`  Password: ${result.password}  (save this — shown only once)\n`);
+          print.line(`  Password: ${result.password}  (save this — shown only once)\n`);
         }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`  Error: ${msg}\n`);
+        print.line(`  Error: ${msg}\n`);
         process.exit(1);
       }
     });

--- a/packages/command/src/commands/status.ts
+++ b/packages/command/src/commands/status.ts
@@ -7,13 +7,14 @@ import {
   readConfigFile,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { Command } from "commander";
+import { print } from "../core/output.js";
 
 export function registerStatusCommand(program: Command): void {
   program
     .command("status")
     .description("Global overview — server health + configured agents")
     .action(async () => {
-      process.stderr.write("\n");
+      print.line("\n");
 
       // Server status
       const serverConfig = readConfigFile(join(DEFAULT_CONFIG_DIR, "server.yaml"));
@@ -26,30 +27,30 @@ export function registerStatusCommand(program: Command): void {
         if (res.ok) {
           const data = (await res.json()) as { status: string; version?: string; uptime_seconds?: number };
           const uptime = data.uptime_seconds ? formatUptime(data.uptime_seconds) : "unknown";
-          process.stderr.write(`  Server:     ✓ running (${serverUrl}, uptime: ${uptime})\n`);
+          print.line(`  Server:     ✓ running (${serverUrl}, uptime: ${uptime})\n`);
         } else {
-          process.stderr.write(`  Server:     ✗ unhealthy (${res.status})\n`);
+          print.line(`  Server:     ✗ unhealthy (${res.status})\n`);
         }
       } catch {
-        process.stderr.write(`  Server:     ✗ not running (${serverUrl})\n`);
+        print.line(`  Server:     ✗ not running (${serverUrl})\n`);
       }
 
       // Database status
       const dbProvider = getNestedValue(serverConfig, "database.provider") ?? "unknown";
       const hasDbUrl = getNestedValue(serverConfig, "database.url") !== undefined;
-      process.stderr.write(`  Database:   ${hasDbUrl ? "✓ configured" : "✗ not configured"} (${dbProvider})\n`);
+      print.line(`  Database:   ${hasDbUrl ? "✓ configured" : "✗ not configured"} (${dbProvider})\n`);
 
       // Agents (client side)
       const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
       if (existsSync(agentsDir)) {
         try {
           const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
-          process.stderr.write(`  Agents:     ${agents.size} configured\n`);
+          print.line(`  Agents:     ${agents.size} configured\n`);
         } catch {
-          process.stderr.write("  Agents:     error reading config\n");
+          print.line("  Agents:     error reading config\n");
         }
       } else {
-        process.stderr.write("  Agents:     0 configured\n");
+        print.line("  Agents:     0 configured\n");
       }
 
       // Client config
@@ -57,12 +58,12 @@ export function registerStatusCommand(program: Command): void {
       if (existsSync(clientConfigPath)) {
         const clientConfig = readConfigFile(clientConfigPath);
         const clientServerUrl = getNestedValue(clientConfig, "server.url");
-        process.stderr.write(`  Client:     configured → ${clientServerUrl}\n`);
+        print.line(`  Client:     configured → ${clientServerUrl}\n`);
       } else {
-        process.stderr.write("  Client:     not configured\n");
+        print.line("  Client:     not configured\n");
       }
 
-      process.stderr.write("\n");
+      print.line("\n");
     });
 }
 

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -14,6 +14,7 @@ import {
 } from "@first-tree-hub/client";
 import { stringify as stringifyYaml } from "yaml";
 import { ensureFreshAccessToken } from "./bootstrap.js";
+import { print } from "./output.js";
 
 type AgentEntry = {
   name: string;
@@ -76,14 +77,14 @@ export class ClientRuntime {
     registerBuiltinHandlers();
 
     this.connection.on("auth:expired", () => {
-      process.stderr.write("  \u26A0\uFE0F  Access token expired — reconnecting after refresh...\n");
+      print.status("⚠️", "access token expired — reconnecting after refresh...");
     });
 
     // Surface transport-level errors (TLS resets, DNS hiccups, WS handshake
     // failures) to the operator. ClientConnection's own reconnect loop handles
     // recovery; the process-wide crash guard lives in ClientConnection itself.
     this.connection.on("error", (err) => {
-      process.stderr.write(`  \u26A0\uFE0F  Client connection error: ${err.message}\n`);
+      print.status("⚠️", `client connection error: ${err.message}`);
     });
 
     // Server tells us an agent has just been pinned to this client — mirror
@@ -127,19 +128,19 @@ export class ClientRuntime {
         currentVersion: this.options.currentVersion,
         ...this.options.update,
         isTTY: Boolean(process.stdout.isTTY),
-        log: (level, msg) => process.stderr.write(`  [update/${level}] ${msg}\n`),
+        log: (level, msg) => print.status(`[update/${level}]`, msg),
         getQuietGateSnapshot: () => this.aggregateQuietGate(),
       });
     }
 
     await this.connection.connect();
-    process.stderr.write(`  \u2713 Client registered: ${this.connection.clientId}\n`);
+    print.check(true, "client registered", this.connection.clientId);
 
     if (this.agents.length === 0) {
-      process.stderr.write("\n  No agents configured yet.\n");
-      process.stderr.write(
-        "  Add one with: first-tree-hub agent create <name> --type claude-code --client-id <id>\n\n",
-      );
+      print.blank();
+      print.status("", "no agents configured yet.");
+      print.status("", "add one with: first-tree-hub agent create <name> --type claude-code --client-id <id>");
+      print.blank();
       return;
     }
 
@@ -147,18 +148,17 @@ export class ClientRuntime {
       this.agents.map(async (agent) => {
         try {
           const identity = await agent.slot.start();
-          process.stderr.write(
-            `  \u2713 ${agent.name}: connected (agent: ${identity.displayName ?? identity.agentId})\n`,
-          );
+          print.check(true, `${agent.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
-          process.stderr.write(`  \u2717 ${agent.name}: connection failed \u2014 ${msg}\n`);
+          print.check(false, `${agent.name}: connection failed`, msg);
         }
       }),
     );
 
     const connected = this.agents.length;
-    process.stderr.write(`\n  ${connected} agent(s) running. Press Ctrl+C to stop.\n`);
+    print.blank();
+    print.status("", `${connected} agent(s) running. Press Ctrl+C to stop.`);
   }
 
   watchAgentsDir(agentsDir: string): void {
@@ -214,7 +214,8 @@ export class ClientRuntime {
         if (this.agentNames.has(name)) continue;
         if (this.agentIds.has(config.agentId)) continue;
 
-        process.stderr.write(`\n  New agent detected: ${name}\n`);
+        print.blank();
+        print.status("", `new agent detected: ${name}`);
         this.addAgent(name, config);
         this.startAgent(name);
       }
@@ -236,9 +237,7 @@ export class ClientRuntime {
     if (this.agentIds.has(message.agentId)) return;
 
     if (!this.agentsDir) {
-      process.stderr.write(
-        `  \u26A0\uFE0F  Agent pinned (${message.agentId}) but no agents dir set — cannot auto-register.\n`,
-      );
+      print.status("⚠️", `agent pinned (${message.agentId}) but no agents dir set — cannot auto-register.`);
       return;
     }
 
@@ -248,10 +247,10 @@ export class ClientRuntime {
       mkdirSync(agentDir, { recursive: true, mode: 0o700 });
       const yaml = stringifyYaml({ agentId: message.agentId, runtime: "claude-code" });
       writeFileSync(join(agentDir, "agent.yaml"), yaml, { mode: 0o600 });
-      process.stderr.write(`  \u2713 Auto-added agent "${localName}" (${message.agentId}) from server push.\n`);
+      print.check(true, `auto-added agent "${localName}"`, `${message.agentId} (from server push)`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`  \u2717 Failed to auto-add agent "${localName}": ${msg}\n`);
+      print.check(false, `failed to auto-add agent "${localName}"`, msg);
       return;
     }
 
@@ -298,11 +297,11 @@ export class ClientRuntime {
     entry.slot
       .start()
       .then((identity) => {
-        process.stderr.write(`  \u2713 ${name}: connected (agent: ${identity.displayName ?? identity.agentId})\n`);
+        print.check(true, `${name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
       })
       .catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`  \u2717 ${name}: connection failed \u2014 ${msg}\n`);
+        print.check(false, `${name}: connection failed`, msg);
       });
   }
 }

--- a/packages/command/src/core/doctor.ts
+++ b/packages/command/src/core/doctor.ts
@@ -9,7 +9,7 @@ import {
   resolveConfigReadonly,
   serverConfigSchema,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { blank } from "./output.js";
+import { blank, print } from "./output.js";
 
 export type CheckResult = {
   label: string;
@@ -200,16 +200,16 @@ export async function checkWebSocket(): Promise<CheckResult> {
 export function printResults(results: CheckResult[]): void {
   for (const r of results) {
     const icon = r.ok ? "\u2713" : "\u2717";
-    process.stderr.write(`  ${icon} ${r.label.padEnd(22)} ${r.detail}\n`);
+    print.line(`  ${icon} ${r.label.padEnd(22)} ${r.detail}\n`);
   }
 
   blank();
 
   const failures = results.filter((r) => !r.ok);
   if (failures.length === 0) {
-    process.stderr.write("  All checks passed.\n");
+    print.line("  All checks passed.\n");
   } else {
-    process.stderr.write(`  ${failures.length} issue(s) found.\n`);
+    print.line(`  ${failures.length} issue(s) found.\n`);
   }
   blank();
 }

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -61,6 +61,13 @@ export {
   resolveCliInvocation,
   uninstallClientService,
 } from "./service-install.js";
+export type { ServiceLogsOptions } from "./service-logs.js";
+export {
+  listLogFilesNewestFirst,
+  parseDuration,
+  showServiceLogs,
+  validateLevel,
+} from "./service-logs.js";
 export type { ExecuteUpdateResult, InstallMode } from "./update.js";
 // Self-update glue — exported so both `client start` and `client connect`
 // can pass identical prompt / install callbacks to the ClientRuntime.

--- a/packages/command/src/core/migrate-home.ts
+++ b/packages/command/src/core/migrate-home.ts
@@ -3,6 +3,7 @@ import {
   type HomeMigrationResult,
   migrateLegacyHome,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { print } from "./output.js";
 import { getClientServiceStatus, installClientService } from "./service-install.js";
 
 /**
@@ -38,7 +39,7 @@ export function runHomeMigration(): void {
     // first successful migration (or for fresh installs / custom homes) —
     // staying silent avoids noise on every CLI call.
     if (result.reason === "failed") {
-      process.stderr.write(
+      print.line(
         `[first-tree-hub] WARNING: failed to auto-migrate legacy home ${result.from} → ${result.to}: ${result.error ?? "unknown error"}\n` +
           `  Resolve manually: cp -R "${result.from}" "${result.to}"\n`,
       );
@@ -46,7 +47,7 @@ export function runHomeMigration(): void {
     return;
   }
 
-  process.stderr.write(
+  print.line(
     `[first-tree-hub] Copied client home to new layout: ${result.from} → ${result.to}\n` +
       `  (Legacy directory preserved as a backup — delete it manually once you've verified the new location works.)\n`,
   );
@@ -57,7 +58,7 @@ export function runHomeMigration(): void {
   // in service-install.ts).
   const runningAsService = process.argv.includes("--no-interactive");
   if (runningAsService) {
-    process.stderr.write(
+    print.line(
       `[first-tree-hub] Note: running as background service — skipped auto re-register to avoid self-termination.\n` +
         `  Run \`first-tree-hub client service install\` from a terminal to refresh log paths.\n`,
     );
@@ -71,10 +72,10 @@ export function runHomeMigration(): void {
 
   try {
     installClientService();
-    process.stderr.write(`[first-tree-hub] Re-registered background service with new home paths.\n`);
+    print.line(`[first-tree-hub] Re-registered background service with new home paths.\n`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(
+    print.line(
       `[first-tree-hub] WARNING: home migration succeeded but re-registering the background service failed: ${msg}\n` +
         `  Run \`first-tree-hub client service install\` to refresh log paths.\n`,
     );

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -6,6 +6,7 @@ import {
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { ensureFreshAccessToken, loadCredentials, resolveServerUrl, saveAgentConfig } from "./bootstrap.js";
+import { print } from "./output.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -174,7 +175,7 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
   if (args.role) metadata.role = args.role;
   if (args.domains) metadata.domains = args.domains.split(",").map((d) => d.trim());
 
-  process.stderr.write(`Creating agent "${args.id}"...\n`);
+  print.line(`Creating agent "${args.id}"...\n`);
   const primary = await createAgentViaAdmin(serverUrl, accessToken, {
     name: args.id,
     type: args.type,
@@ -183,7 +184,7 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
     metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     clientId: args.type === "human" ? undefined : args.clientId,
   });
-  process.stderr.write(`Agent "${args.id}" created (uuid ${primary.uuid}).\n`);
+  print.line(`Agent "${args.id}" created (uuid ${primary.uuid}).\n`);
 
   // For non-human agents, persist the local alias so `client start` can bind.
   if (args.type !== "human") {
@@ -192,7 +193,7 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
 
   let assistantUuid: string | null = null;
   if (args.assistant) {
-    process.stderr.write(`Creating assistant "${args.assistant}"...\n`);
+    print.line(`Creating assistant "${args.assistant}"...\n`);
     try {
       const assistant = await createAgentViaAdmin(serverUrl, accessToken, {
         name: args.assistant,
@@ -203,10 +204,10 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
       });
       assistantUuid = assistant.uuid;
       saveAgentConfig(args.assistant, assistant.uuid, "claude-code");
-      process.stderr.write(`Assistant "${args.assistant}" ready.\n`);
+      print.line(`Assistant "${args.assistant}" ready.\n`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`Warning: Failed to create assistant "${args.assistant}": ${msg}\n`);
+      print.line(`Warning: Failed to create assistant "${args.assistant}": ${msg}\n`);
     }
   }
 
@@ -218,11 +219,11 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
     const { bindFeishuBot } = await import("./feishu.js");
     const targetAgentUuid = args.type === "human" ? assistantUuid : primary.uuid;
     if (!targetAgentUuid) {
-      process.stderr.write(`Warning: Cannot bind Feishu bot — no runtime agent available for "${args.id}".\n`);
+      print.line(`Warning: Cannot bind Feishu bot — no runtime agent available for "${args.id}".\n`);
     } else {
-      process.stderr.write("Binding Feishu bot...\n");
+      print.line("Binding Feishu bot...\n");
       await bindFeishuBot(serverUrl, accessToken, targetAgentUuid, args.feishuBotAppId, args.feishuBotAppSecret);
-      process.stderr.write("Feishu bot bound.\n");
+      print.line("Feishu bot bound.\n");
     }
   }
 
@@ -237,29 +238,29 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
   }
 
   const typeLabel = args.type === "human" ? "Human" : args.type === "autonomous_agent" ? "Agent" : "Assistant";
-  process.stderr.write("\n\u2705 Onboard complete!\n\n");
-  process.stderr.write(`  ${typeLabel}:${" ".repeat(Math.max(1, 10 - typeLabel.length))}${args.id}\n`);
+  print.line("\n\u2705 Onboard complete!\n\n");
+  print.line(`  ${typeLabel}:${" ".repeat(Math.max(1, 10 - typeLabel.length))}${args.id}\n`);
   if (args.assistant) {
-    process.stderr.write(`  Assistant: ${args.assistant}\n`);
+    print.line(`  Assistant: ${args.assistant}\n`);
   }
   if (runtimeAgent) {
-    process.stderr.write(`  Config:    ${DEFAULT_HOME_DIR}/config/agents/${runtimeAgent}/agent.yaml\n`);
+    print.line(`  Config:    ${DEFAULT_HOME_DIR}/config/agents/${runtimeAgent}/agent.yaml\n`);
   }
   if (args.feishuBotAppId) {
-    process.stderr.write(`  Feishu:    bot bound (${args.feishuBotAppId})\n`);
+    print.line(`  Feishu:    bot bound (${args.feishuBotAppId})\n`);
   }
 
   if (args.type === "human") {
-    process.stderr.write("\n  Next step \u2014 bind your Feishu account:\n");
-    process.stderr.write(`    Send this message to the bot in Feishu:  /bind ${args.id}\n`);
+    print.line("\n  Next step \u2014 bind your Feishu account:\n");
+    print.line(`    Send this message to the bot in Feishu:  /bind ${args.id}\n`);
     if (!args.feishuBotAppId) {
-      process.stderr.write("    (requires a Feishu bot to be configured in the system)\n");
+      print.line("    (requires a Feishu bot to be configured in the system)\n");
     }
   }
 
   if (runtimeAgent) {
-    process.stderr.write("\n  Start the agent:\n");
-    process.stderr.write("    first-tree-hub client start\n");
+    print.line("\n  Start the agent:\n");
+    print.line("    first-tree-hub client start\n");
   }
-  process.stderr.write("\n");
+  print.line("\n");
 }

--- a/packages/command/src/core/output.ts
+++ b/packages/command/src/core/output.ts
@@ -1,9 +1,64 @@
-/** Print a styled status line to stderr (human-friendly output). */
-export function status(label: string, message: string): void {
+/**
+ * Print layer — the only place CLI code should write to stdout/stderr.
+ *
+ * Contract:
+ * - `print.result(data)` / `print.fail(...)` emit machine-readable JSON on
+ *   stdout / stderr respectively. Scripts pipe into `jq` and expect a clean
+ *   envelope, so nothing else may touch stdout.
+ * - `print.status` / `print.check` / `print.blank` / `print.line` are
+ *   human-friendly and go to stderr so they never pollute a redirected stdout.
+ *   In `--json` mode they are silenced — scripted consumers only care about
+ *   the envelope.
+ */
+
+let jsonMode = false;
+
+export function setJsonMode(enabled: boolean): void {
+  jsonMode = enabled;
+}
+
+export function isJsonMode(): boolean {
+  return jsonMode;
+}
+
+function result(data: unknown): void {
+  process.stdout.write(`${JSON.stringify({ ok: true, data })}\n`);
+}
+
+function fail(code: string, message: string, exitCode = 1): never {
+  process.stderr.write(`${JSON.stringify({ ok: false, error: { code, message } })}\n`);
+  process.exit(exitCode);
+}
+
+function status(label: string, message: string): void {
+  if (jsonMode) return;
   process.stderr.write(`  ${label.padEnd(20)} ${message}\n`);
 }
 
-/** Print a blank line to stderr. */
-export function blank(): void {
+function check(pass: boolean, label: string, detail = ""): void {
+  if (jsonMode) return;
+  const icon = pass ? "✓" : "✗";
+  const tail = detail ? ` ${detail}` : "";
+  process.stderr.write(`  ${icon} ${label.padEnd(22)}${tail}\n`);
+}
+
+function blank(): void {
+  if (jsonMode) return;
   process.stderr.write("\n");
 }
+
+/**
+ * Generic stderr writer for pre-formatted human text (multi-line tables,
+ * interactive prompts). Prefer `status` / `check` when the text fits; this
+ * exists so the `--json` mode gate can silence arbitrary human chatter.
+ */
+function line(text: string): void {
+  if (jsonMode) return;
+  process.stderr.write(text);
+}
+
+export const print = { result, fail, status, check, blank, line };
+
+// Backward-compatible named exports — callers that still import `status`
+// / `blank` directly keep working while the sweep to `print.*` completes.
+export { blank, status };

--- a/packages/command/src/core/server.ts
+++ b/packages/command/src/core/server.ts
@@ -8,7 +8,7 @@ import { buildApp } from "@first-tree-hub/server";
 import type { Config } from "@first-tree-hub/server/config";
 import { ensurePostgres, isDockerAvailable } from "./docker-postgres.js";
 import { runMigrations } from "./migrate.js";
-import { blank, status } from "./output.js";
+import { blank, print, status } from "./output.js";
 import { promptMissingFields } from "./prompt.js";
 import { COMMAND_VERSION } from "./version.js";
 
@@ -30,7 +30,7 @@ export type StartOptions = {
  * 7. Start Fastify server
  */
 export async function startServer(options: StartOptions): Promise<void> {
-  process.stderr.write(`\n  First Tree Hub v${COMMAND_VERSION}\n\n`);
+  print.line(`\n  First Tree Hub v${COMMAND_VERSION}\n\n`);
 
   // 1. Build CLI args
   const cliArgs: Record<string, unknown> = {};
@@ -115,7 +115,7 @@ export async function startServer(options: StartOptions): Promise<void> {
 
   // Graceful shutdown
   const shutdown = async () => {
-    process.stderr.write("\n  Shutting down...\n");
+    print.line("\n  Shutting down...\n");
     try {
       await app.close();
     } finally {
@@ -131,8 +131,8 @@ export async function startServer(options: StartOptions): Promise<void> {
   blank();
   status("Server", `running at http://${config.server.host}:${config.server.port}`);
   blank();
-  process.stderr.write("  Open the URL above in your browser to get started.\n");
-  process.stderr.write("  Press Ctrl+C to stop.\n\n");
+  print.line("  Open the URL above in your browser to get started.\n");
+  print.line("  Press Ctrl+C to stop.\n\n");
 }
 
 /**

--- a/packages/command/src/core/service-install.ts
+++ b/packages/command/src/core/service-install.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node
 import { homedir, userInfo } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { DEFAULT_HOME_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { print } from "./output.js";
 
 export type ServiceState = "active" | "inactive" | "not-installed" | "unknown";
 
@@ -106,8 +107,13 @@ function renderPlist(invocation: ResolvedBinary): string {
       : [invocation.program, ...invocation.args, "client", "start", "--no-interactive"];
 
   const argsXml = programArgs.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
-  const outLog = join(LOG_DIR, "client.out.log");
-  const errLog = join(LOG_DIR, "client.err.log");
+  // launchd's StandardOutPath / StandardErrorPath are the fallback sink — they
+  // only catch bare stdout/stderr (crash messages, third-party spam) because
+  // the client's own logger writes a rotating NDJSON file at `client.log`
+  // via FIRST_TREE_HUB_SERVICE_MODE. Naming these `.stdout.log` / `.stderr.log`
+  // keeps that role explicit for anyone inspecting the logs dir.
+  const stdoutFallback = join(LOG_DIR, "client.stdout.log");
+  const stderrFallback = join(LOG_DIR, "client.stderr.log");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
@@ -123,6 +129,8 @@ ${argsXml}
   <dict>
     <key>PATH</key>
     <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <key>FIRST_TREE_HUB_SERVICE_MODE</key>
+    <string>1</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -134,9 +142,9 @@ ${argsXml}
   <key>ThrottleInterval</key>
   <integer>10</integer>
   <key>StandardOutPath</key>
-  <string>${escapeXml(outLog)}</string>
+  <string>${escapeXml(stdoutFallback)}</string>
   <key>StandardErrorPath</key>
-  <string>${escapeXml(errLog)}</string>
+  <string>${escapeXml(stderrFallback)}</string>
 </dict>
 </plist>
 `;
@@ -213,9 +221,7 @@ function installLaunchd(): ServiceInfo {
     if (!notLoaded) {
       // Unexpected bootout error — surface it but don't fail; waitForLabelEvicted
       // will give it a final chance to clear.
-      process.stderr.write(
-        `    warning: launchctl bootout: ${bootoutRes.stderr || `exit ${bootoutRes.code ?? "unknown"}`}\n`,
-      );
+      print.line(`    warning: launchctl bootout: ${bootoutRes.stderr || `exit ${bootoutRes.code ?? "unknown"}`}\n`);
     }
   }
 
@@ -246,9 +252,7 @@ function installLaunchd(): ServiceInfo {
   // Step 4: enable. Non-fatal if it fails (service already bootstrapped).
   const enableRes = runCapture("launchctl", ["enable", `${target}/${LAUNCHD_LABEL}`], 5_000);
   if (!enableRes.ok) {
-    process.stderr.write(
-      `    warning: launchctl enable: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n`,
-    );
+    print.line(`    warning: launchctl enable: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n`);
   }
 
   const { state, detail } = launchdState();
@@ -267,7 +271,7 @@ function uninstallLaunchd(): ServiceInfo {
   const target = launchctlDomainTarget();
   const res = runCapture("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], 15_000);
   if (!res.ok && !/not find|no such|not loaded/i.test(res.stderr)) {
-    process.stderr.write(`    warning: bootout during uninstall: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
+    print.line(`    warning: bootout during uninstall: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
   }
   if (existsSync(plistPath)) rmSync(plistPath);
   return {
@@ -292,6 +296,9 @@ function renderSystemdUnit(invocation: ResolvedBinary): string {
       ? `${shellQuote(invocation.program)} client start --no-interactive`
       : `${shellQuote(invocation.program)} ${invocation.args.map(shellQuote).join(" ")} client start --no-interactive`;
 
+  // StandardOutput / StandardError are fallback sinks — the client itself
+  // writes a rotating NDJSON file at `client.log` when FIRST_TREE_HUB_SERVICE_MODE=1,
+  // so these only capture bare stdout/stderr (crashes, third-party spam).
   return `[Unit]
 Description=First Tree Hub Client
 After=network-online.target
@@ -302,9 +309,10 @@ Type=simple
 ExecStart=${execStart}
 Restart=always
 RestartSec=10
-StandardOutput=append:${join(LOG_DIR, "client.out.log")}
-StandardError=append:${join(LOG_DIR, "client.err.log")}
+StandardOutput=append:${join(LOG_DIR, "client.stdout.log")}
+StandardError=append:${join(LOG_DIR, "client.stderr.log")}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=FIRST_TREE_HUB_SERVICE_MODE=1
 
 [Install]
 WantedBy=default.target
@@ -368,14 +376,14 @@ function uninstallSystemd(): ServiceInfo {
   const unitPath = systemdUnitPath();
   const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000);
   if (!disableRes.ok && !/not found|no such|not loaded/i.test(disableRes.stderr)) {
-    process.stderr.write(
+    print.line(
       `    warning: systemctl disable during uninstall: ${disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`}\n`,
     );
   }
   if (existsSync(unitPath)) rmSync(unitPath);
   const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
   if (!reloadRes.ok) {
-    process.stderr.write(
+    print.line(
       `    warning: systemctl daemon-reload during uninstall: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}\n`,
     );
   }

--- a/packages/command/src/core/service-logs.ts
+++ b/packages/command/src/core/service-logs.ts
@@ -1,0 +1,247 @@
+import { createReadStream, existsSync, statSync, unwatchFile, watchFile } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { DEFAULT_HOME_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+import {
+  formatPrettyEntry,
+  LOG_LEVELS,
+  type LogLevel,
+  parseLogLevel,
+} from "@agent-team-foundation/first-tree-hub-shared/observability";
+import { print } from "./output.js";
+
+const LOG_DIR = join(DEFAULT_HOME_DIR, "logs");
+const PRIMARY_LOG = join(LOG_DIR, "client.log");
+// Supervisor (launchd / systemd) writes raw stdout/stderr here as a fallback,
+// capturing crash output that happens before pino takes over the stream, plus
+// anything third-party code writes to stderr directly. Operators need these
+// when diagnosing startup failures, so surface them alongside client.log.
+const FALLBACK_STDOUT = join(LOG_DIR, "client.stdout.log");
+const FALLBACK_STDERR = join(LOG_DIR, "client.stderr.log");
+
+/**
+ * Duration string → milliseconds. Accepts `10s`, `5m`, `2h`, `1d`; rejects
+ * everything else. Keeps the parser tiny rather than pulling in a library —
+ * the `--since` flag is the only consumer.
+ */
+export function parseDuration(input: string): number {
+  const match = /^(\d+)\s*(s|m|h|d)$/.exec(input.trim());
+  if (!match) {
+    throw new Error(`invalid duration "${input}" (expected e.g. 30s, 5m, 2h, 1d)`);
+  }
+  const value = Number(match[1]);
+  const unit = match[2];
+  const multipliers: Record<string, number> = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+  return value * (multipliers[unit as string] ?? 0);
+}
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+/** Rotated log files, newest-first. Missing files are silently skipped. */
+export function listLogFilesNewestFirst(): string[] {
+  const files: string[] = [];
+  if (existsSync(PRIMARY_LOG)) files.push(PRIMARY_LOG);
+  // Rotated files `.1`, `.2`, … are older as the index grows; rotation
+  // produces contiguous numbering, so the first miss means there are no more.
+  for (let i = 1; ; i++) {
+    const p = `${PRIMARY_LOG}.${i}`;
+    if (!existsSync(p)) break;
+    files.push(p);
+  }
+  return files;
+}
+
+/** Supervisor fallback files (raw stdout/stderr, not NDJSON). Missing files skipped. */
+export function listFallbackFiles(): string[] {
+  const files: string[] = [];
+  if (existsSync(FALLBACK_STDERR)) files.push(FALLBACK_STDERR);
+  if (existsSync(FALLBACK_STDOUT)) files.push(FALLBACK_STDOUT);
+  return files;
+}
+
+export type ServiceLogsOptions = {
+  /** If true, keep the stream open and print new lines as they arrive. */
+  tail: boolean;
+  /** Only show records with level >= this. Undefined = no filter. */
+  level?: LogLevel;
+  /** Only show records newer than this many milliseconds ago. */
+  sinceMs?: number;
+  /** Bypass pretty-printing; emit raw NDJSON lines to stdout. */
+  json: boolean;
+};
+
+function matchesFilters(
+  obj: Record<string, unknown>,
+  minLevel: number | undefined,
+  cutoffMs: number | undefined,
+): boolean {
+  if (minLevel !== undefined) {
+    const lvl = typeof obj.level === "number" ? obj.level : Number.NaN;
+    if (!Number.isFinite(lvl) || lvl < minLevel) return false;
+  }
+  if (cutoffMs !== undefined) {
+    const t = parseLogTime(obj.time);
+    if (t === null || t < cutoffMs) return false;
+  }
+  return true;
+}
+
+/** Logger writes `time` as a local-ish string (`YYYY-MM-DD HH:mm:ss`). */
+function parseLogTime(value: unknown): number | null {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return null;
+  // Local time formatter produces `YYYY-MM-DD HH:mm:ss` without tz offset.
+  // Node `Date.parse` needs a `T` separator to treat it as an ISO-like local
+  // timestamp; without it some platforms return NaN.
+  const iso = value.replace(" ", "T");
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function renderLine(line: string, json: boolean): string | null {
+  if (!line.trim()) return null;
+  if (json) return `${line}\n`;
+  try {
+    return formatPrettyEntry(line);
+  } catch {
+    return `${line}\n`;
+  }
+}
+
+function processLogLine(
+  line: string,
+  minLevel: number | undefined,
+  cutoffMs: number | undefined,
+  json: boolean,
+): string | null {
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    // Non-JSON lines survived from stderr fallbacks; pass them through in
+    // pretty mode, drop them in `--json` mode where they'd corrupt NDJSON.
+    return json ? null : `${line}\n`;
+  }
+  if (!matchesFilters(obj, minLevel, cutoffMs)) return null;
+  return renderLine(line, json);
+}
+
+async function readFileLines(
+  path: string,
+  minLevel: number | undefined,
+  cutoffMs: number | undefined,
+  json: boolean,
+): Promise<void> {
+  const rl = createInterface({ input: createReadStream(path, { encoding: "utf8" }) });
+  for await (const line of rl) {
+    const rendered = processLogLine(line, minLevel, cutoffMs, json);
+    if (rendered) process.stdout.write(rendered);
+  }
+}
+
+/**
+ * Read a supervisor fallback file (launchd / systemd stdout/stderr capture).
+ * These are plain text, not NDJSON: level and time filters don't apply, so we
+ * honour `--since` by dropping the whole file when its mtime predates the
+ * cutoff and otherwise pass every line through. In pretty mode each line is
+ * tagged with the source so operators can tell it apart from pino output; in
+ * `--json` mode we emit a synthetic record so NDJSON consumers keep one
+ * object per line.
+ */
+async function readFallbackFile(path: string, cutoffMs: number | undefined, json: boolean): Promise<void> {
+  try {
+    const mtime = statSync(path).mtimeMs;
+    if (cutoffMs !== undefined && mtime < cutoffMs) return;
+  } catch {
+    return;
+  }
+  const source = path.endsWith(".stderr.log") ? "supervisor:stderr" : "supervisor:stdout";
+  const rl = createInterface({ input: createReadStream(path, { encoding: "utf8" }) });
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    if (json) {
+      process.stdout.write(`${JSON.stringify({ source, line })}\n`);
+    } else {
+      process.stdout.write(`[${source}] ${line}\n`);
+    }
+  }
+}
+
+/**
+ * Print existing log history, applying filters. `--tail` then switches to
+ * follow mode and keeps printing new lines as the active file grows; rotation
+ * is not handled during the tail (a follow-up rotation will simply stop
+ * emitting new lines — operator can re-run the command).
+ */
+export async function showServiceLogs(options: ServiceLogsOptions): Promise<void> {
+  if (!existsSync(LOG_DIR)) {
+    print.status("logs", `directory not found: ${LOG_DIR}`);
+    return;
+  }
+
+  const minLevel = options.level ? LEVEL_RANK[options.level] : undefined;
+  const cutoffMs = options.sinceMs !== undefined ? Date.now() - options.sinceMs : undefined;
+
+  // Supervisor fallback files capture pre-pino bootstrap output and crash
+  // dumps — effectively the oldest context, so walk them first.
+  for (const f of listFallbackFiles()) {
+    await readFallbackFile(f, cutoffMs, options.json);
+  }
+
+  // Historical read: oldest-first so the terminal shows them in chronological
+  // order. listLogFilesNewestFirst returns active file + `.1` (newest rotated)
+  // + `.2` (older rotated) etc., so we reverse to walk oldest → newest.
+  const files = listLogFilesNewestFirst().reverse();
+  for (const f of files) {
+    await readFileLines(f, minLevel, cutoffMs, options.json);
+  }
+
+  if (!options.tail) return;
+  if (!existsSync(PRIMARY_LOG)) {
+    // Nothing to tail yet; wait for it to appear.
+    print.status("tail", "waiting for client.log to appear...");
+  }
+
+  await new Promise<void>((resolve) => {
+    let position = existsSync(PRIMARY_LOG) ? statSync(PRIMARY_LOG).size : 0;
+    const onChange = () => {
+      if (!existsSync(PRIMARY_LOG)) return;
+      const current = statSync(PRIMARY_LOG).size;
+      if (current < position) {
+        // Rotation happened — the writer moved our file to client.log.1 and
+        // opened a fresh client.log. Start reading the new file from 0.
+        position = 0;
+      }
+      if (current <= position) return;
+      const stream = createReadStream(PRIMARY_LOG, { start: position, end: current - 1, encoding: "utf8" });
+      position = current;
+      const rl = createInterface({ input: stream });
+      rl.on("line", (line) => {
+        const rendered = processLogLine(line, minLevel, cutoffMs, options.json);
+        if (rendered) process.stdout.write(rendered);
+      });
+    };
+    watchFile(PRIMARY_LOG, { interval: 500 }, onChange);
+    process.once("SIGINT", () => {
+      unwatchFile(PRIMARY_LOG, onChange);
+      resolve();
+    });
+  });
+}
+
+/** Validated flag parsers the CLI layer can reuse without re-doing the work. */
+export function validateLevel(value: string | undefined): LogLevel | undefined {
+  if (value === undefined) return undefined;
+  const parsed = parseLogLevel(value);
+  if (parsed.fellBack) {
+    throw new Error(`invalid --level "${value}" (expected one of ${LOG_LEVELS.join(", ")})`);
+  }
+  return parsed.level;
+}

--- a/packages/command/src/core/update-glue.ts
+++ b/packages/command/src/core/update-glue.ts
@@ -1,5 +1,6 @@
 import type { ExecuteUpdateFn, UpdatePromptFn } from "@first-tree-hub/client";
 import { confirm } from "@inquirer/prompts";
+import { print } from "./output.js";
 import { detectInstallMode, installGlobalLatest } from "./update.js";
 
 /** Reserved exit code that means "clean self-restart, service manager please bring me back". */
@@ -48,29 +49,29 @@ export function createExecuteUpdate({ managed }: { managed: boolean }): ExecuteU
   return async () => {
     const mode = detectInstallMode();
     if (mode === "source") {
-      process.stderr.write("  [update] Running from source checkout — self-update skipped. Use `git pull` instead.\n");
+      print.line("  [update] Running from source checkout — self-update skipped. Use `git pull` instead.\n");
       return { installed: false };
     }
     if (mode === "npx") {
-      process.stderr.write(
+      print.line(
         "  [update] Cannot self-update — not launched from a global npm install.\n  Run `npm i -g @agent-team-foundation/first-tree-hub` manually.\n",
       );
       return { installed: false };
     }
 
-    process.stderr.write("  [update] Running `npm install -g @agent-team-foundation/first-tree-hub@latest`...\n");
+    print.line("  [update] Running `npm install -g @agent-team-foundation/first-tree-hub@latest`...\n");
     const result = await installGlobalLatest();
     if (!result.ok) {
-      process.stderr.write(`  [update] Install failed: ${result.reason}\n`);
+      print.line(`  [update] Install failed: ${result.reason}\n`);
       return { installed: false };
     }
 
     const installed = result.installedVersion ?? "latest";
     if (managed) {
-      process.stderr.write(`  [update] Installed ${installed}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).\n`);
+      print.line(`  [update] Installed ${installed}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).\n`);
       process.exit(SELF_RESTART_EXIT_CODE);
     }
-    process.stderr.write(
+    print.line(
       `  [update] Installed ${installed}. Restart the client manually (Ctrl+C then \`first-tree-hub client start\`) to pick up the new version.\n`,
     );
     return { installed: true };

--- a/packages/command/src/core/update.ts
+++ b/packages/command/src/core/update.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import * as semver from "semver";
+import { print } from "./output.js";
 
 export type InstallMode = "global" | "npx" | "source";
 
@@ -86,7 +87,7 @@ export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
     child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => {
       stderrChunks.push(chunk);
-      process.stderr.write(chunk);
+      print.line(chunk.toString("utf8"));
     });
 
     child.on("error", (err) => {

--- a/packages/command/src/core/version.ts
+++ b/packages/command/src/core/version.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { print } from "./output.js";
 
 /**
  * Version of the consumer-facing `@agent-team-foundation/first-tree-hub`
@@ -55,7 +56,7 @@ export function resolveCommandVersion(moduleUrl: string = import.meta.url): stri
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== "ENOENT" && code !== "ENOTDIR") {
         const message = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`[first-tree-hub] warning: could not read ${dir}/package.json: ${message}\n`);
+        print.line(`[first-tree-hub] warning: could not read ${dir}/package.json: ${message}\n`);
       }
     }
     const parent = dirname(dir);

--- a/packages/server/src/observability/__tests__/logger.test.ts
+++ b/packages/server/src/observability/__tests__/logger.test.ts
@@ -12,8 +12,8 @@ function installSpySink(): { calls: SinkCall[]; restore: () => void } {
 }
 
 describe("logger ErrorSink bridging", () => {
-  // Silence stdout writes from the logger during tests.
-  // `vi.spyOn` on overloaded signatures (process.stdout.write) resists typing;
+  // Silence stderr writes from the logger during tests.
+  // `vi.spyOn` on overloaded signatures (process.stderr.write) resists typing;
   // the spy is only used to restore the mock so `unknown` is fine.
   let writeSpy: { mockRestore(): void } | undefined;
 
@@ -24,12 +24,12 @@ describe("logger ErrorSink bridging", () => {
     setErrorSink(null);
   });
 
-  function silenceStdout() {
-    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+  function silenceStderr() {
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
   }
 
   it("forwards error-level logs to the registered sink", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
@@ -46,7 +46,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("forwards fatal-level logs to the sink", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
@@ -58,7 +58,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("does NOT forward warn-level logs when bridgeToSpanLevel=error", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
@@ -69,7 +69,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("DOES forward warn-level logs when bridgeToSpanLevel=warn", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "warn" });
     const { calls, restore } = installSpySink();
 
@@ -81,7 +81,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("does NOT forward any level when bridgeToSpanLevel=off", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "off" });
     const { calls, restore } = installSpySink();
 
@@ -94,7 +94,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("does nothing when no sink is registered", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     setErrorSink(null);
 
@@ -103,7 +103,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("swallows sink exceptions without breaking the logging path", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     setErrorSink(() => {
       throw new Error("sink blew up");
@@ -114,7 +114,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("truncates overlong string values before handing them to the sink", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
@@ -132,7 +132,7 @@ describe("logger ErrorSink bridging", () => {
   });
 
   it("JSON-stringifies and truncates oversized object values", () => {
-    silenceStdout();
+    silenceStderr();
     applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     const { calls, restore } = installSpySink();
 
@@ -149,7 +149,7 @@ describe("logger ErrorSink bridging", () => {
 });
 
 describe("logger output format", () => {
-  // `vi.spyOn` on overloaded signatures (process.stdout.write) resists typing;
+  // `vi.spyOn` on overloaded signatures (process.stderr.write) resists typing;
   // the spy is only used to restore the mock so `unknown` is fine.
   let writeSpy: { mockRestore(): void } | undefined;
 
@@ -160,8 +160,8 @@ describe("logger output format", () => {
 
   it("emits NDJSON when format=json", () => {
     const chunks: string[] = [];
-    // process.stdout.write has multiple overloads; cast keeps the mock simple.
-    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+    // process.stderr.write has multiple overloads; the cast keeps the mock simple.
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: string | Uint8Array) => {
       chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
       return true;
     }) as never);
@@ -179,8 +179,8 @@ describe("logger output format", () => {
 
   it("emits human-readable pretty output when format=pretty", () => {
     const chunks: string[] = [];
-    // process.stdout.write has multiple overloads; cast keeps the mock simple.
-    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+    // process.stderr.write has multiple overloads; the cast keeps the mock simple.
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: string | Uint8Array) => {
       chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
       return true;
     }) as never);

--- a/packages/server/src/observability/logger.ts
+++ b/packages/server/src/observability/logger.ts
@@ -1,6 +1,8 @@
 import {
   createLoggerOutputStream,
   formatLocalTime,
+  LOG_REDACT_CENSOR,
+  LOG_REDACT_PATHS,
   type LogFormat,
   type LogLevel,
   parseLogLevel,
@@ -99,6 +101,7 @@ export const rootLogger = pino(
   {
     level: _level,
     timestamp: () => `,"time":"${formatLocalTime()}"`,
+    redact: { paths: [...LOG_REDACT_PATHS], censor: LOG_REDACT_CENSOR },
   },
   outputStream,
 );

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub-shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "First Tree Hub shared schemas, types, and configuration",
   "license": "MIT",

--- a/packages/shared/src/observability/__tests__/logger-core.test.ts
+++ b/packages/shared/src/observability/__tests__/logger-core.test.ts
@@ -1,0 +1,84 @@
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createLoggerOutputStream, LOG_REDACT_CENSOR, LOG_REDACT_PATHS } from "../logger-core.js";
+
+function collect(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
+
+describe("createLoggerOutputStream", () => {
+  it("defaults to process.stderr when no destination is provided", () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    try {
+      const stream = createLoggerOutputStream({ getFormat: () => "json" });
+      stream.write(`${JSON.stringify({ level: 30, time: "t", msg: "hi" })}\n`);
+      expect(stderrSpy).toHaveBeenCalled();
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    }
+  });
+
+  it("writes to the destination returned by getDestination", () => {
+    const { dest, read } = collect();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => dest,
+    });
+    stream.write(`${JSON.stringify({ level: 30, time: "t", msg: "hi" })}\n`);
+    expect(read()).toContain('"msg":"hi"');
+  });
+
+  it("re-evaluates getDestination on every write so targets can be swapped", () => {
+    const a = collect();
+    const b = collect();
+    let current = a.dest;
+    const stream = createLoggerOutputStream({
+      getFormat: () => "json",
+      getDestination: () => current,
+    });
+    stream.write(`${JSON.stringify({ level: 30, time: "t", msg: "one" })}\n`);
+    current = b.dest;
+    stream.write(`${JSON.stringify({ level: 30, time: "t", msg: "two" })}\n`);
+    expect(a.read()).toContain('"msg":"one"');
+    expect(a.read()).not.toContain('"msg":"two"');
+    expect(b.read()).toContain('"msg":"two"');
+    expect(b.read()).not.toContain('"msg":"one"');
+  });
+
+  it("applies pretty formatting when format=pretty", () => {
+    const { dest, read } = collect();
+    const stream = createLoggerOutputStream({
+      getFormat: () => "pretty",
+      getDestination: () => dest,
+    });
+    stream.write(`${JSON.stringify({ level: 30, time: "t", msg: "hi", module: "M" })}\n`);
+    const out = read();
+    expect(out).toContain("INFO");
+    expect(out).toContain("[M]");
+    expect(out).toContain("hi");
+  });
+});
+
+describe("LOG_REDACT_PATHS", () => {
+  it("covers the obvious sensitive field names", () => {
+    const paths = [...LOG_REDACT_PATHS];
+    for (const name of ["password", "token", "accessToken", "jwt", "secret", "apiKey", "authorization"]) {
+      expect(paths).toContain(name);
+      expect(paths).toContain(`*.${name}`);
+    }
+  });
+
+  it("has a stable censor string consumers can rely on", () => {
+    expect(LOG_REDACT_CENSOR).toBe("[REDACTED]");
+  });
+});

--- a/packages/shared/src/observability/index.ts
+++ b/packages/shared/src/observability/index.ts
@@ -7,6 +7,8 @@ export {
   LEVEL_LABELS,
   LOG_FORMATS,
   LOG_LEVELS,
+  LOG_REDACT_CENSOR,
+  LOG_REDACT_PATHS,
   type LogFormat,
   type LogLevel,
   logFormatSchema,
@@ -15,6 +17,7 @@ export {
   RESET,
   SKIP_KEYS,
 } from "./logger-core.js";
+export { captureDestination, recordingDestination, silentDestination } from "./testing.js";
 export {
   FIRST_TREE_HUB_ATTR,
   type FirstTreeHubAttrKey,

--- a/packages/shared/src/observability/logger-core.ts
+++ b/packages/shared/src/observability/logger-core.ts
@@ -55,6 +55,41 @@ export const DIM = "\x1b[2m";
 
 export const SKIP_KEYS = new Set(["level", "time", "msg", "module", "pid", "hostname", "v"]);
 
+/**
+ * Pino `redact.paths` entries applied to every root logger in Hub. Keeps the
+ * list short on purpose — pino's redact walks each path on every log call, so
+ * we target obvious sensitive field names plus a narrow set of nested forms
+ * (`*.foo` matches a single nesting level in pino v9).
+ *
+ * Values matching these paths are replaced with the censor string `[REDACTED]`.
+ */
+export const LOG_REDACT_PATHS: readonly string[] = [
+  "password",
+  "*.password",
+  "token",
+  "*.token",
+  "accessToken",
+  "*.accessToken",
+  "refreshToken",
+  "*.refreshToken",
+  "jwt",
+  "*.jwt",
+  "secret",
+  "*.secret",
+  "apiKey",
+  "*.apiKey",
+  "api_key",
+  "*.api_key",
+  "credentials",
+  "*.credentials",
+  "authorization",
+  "*.authorization",
+  "*.headers.cookie",
+  "*.headers.authorization",
+];
+
+export const LOG_REDACT_CENSOR = "[REDACTED]";
+
 export function formatPrettyEntry(json: string): string {
   const obj = JSON.parse(json) as Record<string, unknown>;
   const level = obj.level as number;
@@ -94,6 +129,13 @@ type CreateStreamOptions = {
   /** Getter so the format can change via applyConfig without rebuilding the stream. */
   getFormat: () => LogFormat;
   /**
+   * Getter for the output sink. Called on every log line so the caller can swap
+   * destinations at runtime (e.g. client swaps to a rotating file when running
+   * as a background service). Defaults to `process.stderr` — logs belong on
+   * stderr so stdout stays clean for CLI JSON output.
+   */
+  getDestination?: () => Writable;
+  /**
    * Optional hook invoked once per NDJSON record written by pino. Server uses
    * this to bridge error/fatal logs onto the active OTel span; client leaves
    * it undefined.
@@ -102,14 +144,16 @@ type CreateStreamOptions = {
 };
 
 export function createLoggerOutputStream(options: CreateStreamOptions): Writable {
+  const getDest = options.getDestination ?? (() => process.stderr);
   return new Writable({
     write(chunk, _, callback) {
       const text = chunk.toString();
+      const dest = getDest();
       try {
         if (options.getFormat() === "pretty") {
-          process.stdout.write(formatPrettyEntry(text));
+          dest.write(formatPrettyEntry(text));
         } else {
-          process.stdout.write(text);
+          dest.write(text);
         }
         if (options.onJsonEntry) {
           try {
@@ -120,7 +164,7 @@ export function createLoggerOutputStream(options: CreateStreamOptions): Writable
           }
         }
       } catch {
-        process.stdout.write(text);
+        dest.write(text);
       }
       callback();
     },

--- a/packages/shared/src/observability/testing.ts
+++ b/packages/shared/src/observability/testing.ts
@@ -1,0 +1,66 @@
+import { Writable } from "node:stream";
+import { createLoggerOutputStream, type LogFormat } from "./logger-core.js";
+
+/**
+ * Logger utilities for tests. Exported from
+ * `@agent-team-foundation/first-tree-hub-shared/observability` so both the
+ * client and server test suites can silence or record logs without each
+ * reinventing the pattern.
+ *
+ * Design: this module depends on `pino` indirectly — the returned objects
+ * are plain pino Loggers the caller constructs from their own `pino` import.
+ * We intentionally do NOT re-export `pino` from shared: shared must stay free
+ * of the pino runtime dep so it can be consumed by client-only or
+ * browser-bundling contexts without dragging the full logger stack in.
+ *
+ * The helpers here hand back the raw Writable sink — any caller already holds
+ * a pino dependency (client/server), so pairing is a one-liner.
+ */
+
+/** A Writable that discards every write. Used to back a silent pino. */
+export function silentDestination(): Writable {
+  return new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  });
+}
+
+/** A Writable backed by an in-memory array of parsed JSON records. */
+export function recordingDestination(): { dest: Writable; records: Array<Record<string, unknown>> } {
+  const records: Array<Record<string, unknown>> = [];
+  const dest = new Writable({
+    write(chunk, _enc, cb) {
+      try {
+        records.push(JSON.parse(chunk.toString()) as Record<string, unknown>);
+      } catch {
+        // pino writes one JSON record per call — non-JSON lines are from some
+        // other stream and are not useful in tests.
+      }
+      cb();
+    },
+  });
+  return { dest, records };
+}
+
+/**
+ * Produce a pino-compatible Writable that honours the format getter exactly
+ * like the real logger sink. Useful when the test cares about pretty rendering
+ * rather than the raw NDJSON payload.
+ */
+export function captureDestination(getFormat: () => LogFormat): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const wrapper = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  // Route the same chunks through the formatter used by production loggers so
+  // tests exercise the exact `[module] msg` layout they would see on stderr.
+  const inner = createLoggerOutputStream({
+    getFormat,
+    getDestination: () => wrapper,
+  });
+  return { dest: inner, read: () => chunks.join("") };
+}


### PR DESCRIPTION
## Summary

- Client runtime, WebSocket, session manager, and update manager now log via module-tagged pino loggers instead of ad-hoc `process.stderr.write` / string callbacks; every line carries `module` / `clientId` / `agentId` / `chatId` bindings where relevant.
- New `print.*` layer in `packages/command/src/core/output.ts` splits stdout (machine JSON envelope) from stderr (human status / checks). Global `--json` silences human chatter; `--verbose` forces `debug`. Log-level precedence: `--verbose > FIRST_TREE_HUB_LOG_LEVEL > --json (error) > warn`, and CLI overrides are pinned so `client start` can't downgrade them via `client.yaml`.
- Background-service mode writes a size-rotated NDJSON file at `~/.first-tree/hub/logs/client.log` (10 MB × 7 files) via a local `RotatingFileStream`. New `client service logs [--tail] [--since] [--level] [--json]` subcommand reads history + tails live, and also surfaces `client.stdout.log` / `client.stderr.log` supervisor fallbacks so pre-pino crash output stays visible.
- Fixes `logger-core.ts` writing pino output to **stdout** by default (the original reason CLI JSON could be corrupted by log bleed). Both client and server loggers now wire Pino `redact` paths so `authorization` / `token` / `accessToken` / `jwt` / `password` / `secret` / `apiKey` / `credentials` never appear in output.
- Tests default to silent; new `silentDestination` / `recordingDestination` / `captureDestination` helpers live in `@agent-team-foundation/first-tree-hub-shared/observability` for both client and server test suites.

## Versioning

- `packages/command`: `0.9.3 → 0.9.4` (consumer tarball)
- `packages/shared`: `0.2.0 → 0.2.1` (additive: new exports `LOG_REDACT_PATHS`, `LOG_REDACT_CENSOR`, `silentDestination`, `recordingDestination`, `captureDestination`)

## Test plan

- [x] `pnpm check` clean (428 files)
- [x] `pnpm typecheck` 9/9 tasks
- [x] `pnpm test` — shared / client / command / server suites all green (ran locally against tmp home to avoid clobbering prod client)
- [x] CLI smoke: `first-tree-hub --json status | jq .ok`, `first-tree-hub --verbose status`, `first-tree-hub server status | jq '.status'` shape unchanged (raw health payload, not `{ok,data}` envelope)
- [x] Bundle grep: `FIRST_TREE_HUB_SERVICE_MODE`, `LOG_REDACT_PATHS`, `client.stdout.log` / `client.stderr.log` all present in built command tarball
- [ ] Manual service install on macOS: verify `client.log` grows, `client.log.1` appears after rotation threshold, `client service logs --since 1h --level warn` filters correctly
- [ ] Manual foreground `client start`: verify redaction (no `token=` / `authorization=` in stderr), auth refresh events visible, reconnect backoff at `debug` not `info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)