### PR TITLE
fix(web): drop lint:tokens from build so docker build works on Alpine

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && pnpm run lint:tokens && vite build",
+    "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit && pnpm run lint:tokens",
     "lint:tokens": "bash scripts/check-design-tokens.sh",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

- `packages/web/package.json` had `build` scripted as `tsc --noEmit && pnpm run lint:tokens && vite build`, landed in #150.
- `lint:tokens` invokes `bash scripts/check-design-tokens.sh`, but the production image is built from `node:24-alpine`, which ships only busybox `ash` — the `bash` shebang makes `pnpm build` fail inside `docker build` with `bash: not found`.
- Fix: drop `lint:tokens` from `build`. The guardrail still runs under `pnpm typecheck` (local + CI), so the quality gate is unchanged; `docker build` stays pure-artifact.
- Bumps `@agent-team-foundation/first-tree-hub` 0.9.6 → 0.9.7 per the `command` version policy.

## Test plan

- [x] `pnpm --filter @first-tree-hub/web build` passes locally
- [x] `pnpm --filter @first-tree-hub/web typecheck` still runs `lint:tokens`
- [ ] Docker build succeeds on CI / image registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)