### PR TITLE
fix(chat): let local Claude agent actually see uploaded images

### DIFF
--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfigPayload, SessionEvent } from "@agent-team-foundation/first-tree-hub-shared";
@@ -64,6 +65,12 @@ function isImageFileContent(content: unknown): content is ImageFileContent {
   );
 }
 
+/** chat_id values are DB-generated UUIDs; reject anything else so we never
+ * traverse out of the images dir if the field is ever tampered with. */
+function sanitizeChatId(chatId: string): string {
+  return /^[a-zA-Z0-9-]+$/.test(chatId) ? chatId : "unknown";
+}
+
 /**
  * Write an inline base64 image to a temp file so Claude Code's native Read tool
  * can pick it up. Claude Code loads image files as multimodal content blocks —
@@ -74,12 +81,12 @@ function isImageFileContent(content: unknown): content is ImageFileContent {
  * The temp directory is per-chat so files are discoverable during the session;
  * the OS reclaims them on restart.
  */
-function writeImageToTempFile(content: ImageFileContent, chatId: string): string {
-  const dir = join(tmpdir(), "first-tree-hub", "images", chatId);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+async function writeImageToTempFile(content: ImageFileContent, chatId: string): Promise<string> {
+  const dir = join(tmpdir(), "first-tree-hub", "images", sanitizeChatId(chatId));
+  await mkdir(dir, { recursive: true });
   const ext = MIME_TO_EXT[content.mimeType];
   const path = join(dir, `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`);
-  writeFileSync(path, Buffer.from(content.data, "base64"));
+  await writeFile(path, Buffer.from(content.data, "base64"));
   return path;
 }
 
@@ -297,16 +304,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   /** Worktrees materialised for this session — each entry removed on shutdown. */
   const ownedWorktrees: Array<{ url: string; path: string; branchName: string }> = [];
 
-  function toSDKUserMessage(message: SessionMessage, sessionId: string): SDKUserMessage {
-    // Image file message: write to temp file and reference by path so Claude
-    // Code's native Read tool reads it as multimodal input. The `@path` syntax
-    // asks the model to auto-read the file when starting the turn.
+  async function toSDKUserMessage(message: SessionMessage, sessionId: string): Promise<SDKUserMessage> {
+    // Image file message: write to a temp file and ask the model to open it
+    // with its Read tool. Read loads image files as multimodal content blocks
+    // — this is the reliable path; sending `{ type: "image" }` blocks through
+    // the SDK does not forward images to the underlying model in practice.
     if (message.format === "file" && isImageFileContent(message.content)) {
       const { filename } = message.content;
       try {
-        const imagePath = writeImageToTempFile(message.content, message.chatId);
+        const imagePath = await writeImageToTempFile(message.content, message.chatId);
         const prefix = message.senderId ? `[From: ${message.senderId}]\n\n` : "";
-        const text = `${prefix}Attached image (filename: ${filename}). Please read it: @${imagePath}`;
+        const text = `${prefix}An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`;
         return {
           type: "user",
           message: {
@@ -317,8 +325,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           session_id: sessionId,
         };
       } catch (err) {
-        // Fall through to text fallback on filesystem error.
-        const fallbackText = `[Image attachment "${filename}" failed to materialise: ${err instanceof Error ? err.message : String(err)}]`;
+        // Fall through to text fallback on filesystem error. Avoid leaking
+        // raw fs error messages (they contain absolute paths).
+        const fallbackText = `[Image attachment "${filename}" failed to materialise]`;
+        ctx?.log(`Failed to write image to temp file: ${err instanceof Error ? err.message : String(err)}`);
         return {
           type: "user",
           message: {
@@ -714,7 +724,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
       );
       spawnQuery(claudeSessionId, sessionCtx);
-      const sdkMsg = toSDKUserMessage(message, claudeSessionId);
+      const sdkMsg = await toSDKUserMessage(message, claudeSessionId);
       inputController?.push(sdkMsg);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
@@ -741,7 +751,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
       spawnQuery(sessionId, sessionCtx, sessionId);
       if (message) {
-        inputController?.push(toSDKUserMessage(message, sessionId));
+        inputController?.push(await toSDKUserMessage(message, sessionId));
       }
 
       sessionCtx.log(`Session resumed (${sessionId})`);
@@ -763,8 +773,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         .catch((err) => {
           sessionCtx.log(`maybeSwitchConfig errored: ${err instanceof Error ? err.message : String(err)}`);
         })
-        .finally(() => {
-          inputController?.push(toSDKUserMessage(message, sid));
+        .finally(async () => {
+          try {
+            const sdkMsg = await toSDKUserMessage(message, sid);
+            inputController?.push(sdkMsg);
+          } catch (err) {
+            sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
+          }
         });
     },
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfigPayload, SessionEvent } from "@agent-team-foundation/first-tree-hub-shared";
 import { deriveRepoLocalPath } from "@agent-team-foundation/first-tree-hub-shared";
@@ -37,6 +38,13 @@ const SUPPORTED_IMAGE_MIMES: ReadonlySet<SupportedImageMime> = new Set<Supported
   "image/webp",
 ]);
 
+const MIME_TO_EXT: Record<SupportedImageMime, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
 /** Shape of a `format: "file"` image message's content (base64-encoded). */
 type ImageFileContent = {
   data: string; // base64 (no prefix)
@@ -54,6 +62,25 @@ function isImageFileContent(content: unknown): content is ImageFileContent {
     typeof c.filename === "string" &&
     SUPPORTED_IMAGE_MIMES.has(c.mimeType as SupportedImageMime)
   );
+}
+
+/**
+ * Write an inline base64 image to a temp file so Claude Code's native Read tool
+ * can pick it up. Claude Code loads image files as multimodal content blocks —
+ * going through the filesystem is more reliable than trying to feed an
+ * `{ type: "image" }` block through the SDK, which does not consistently
+ * forward multimodal arrays to the underlying model.
+ *
+ * The temp directory is per-chat so files are discoverable during the session;
+ * the OS reclaims them on restart.
+ */
+function writeImageToTempFile(content: ImageFileContent, chatId: string): string {
+  const dir = join(tmpdir(), "first-tree-hub", "images", chatId);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const ext = MIME_TO_EXT[content.mimeType];
+  const path = join(dir, `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`);
+  writeFileSync(path, Buffer.from(content.data, "base64"));
+  return path;
 }
 
 function extractContentBlocks(message: unknown): unknown[] {
@@ -271,33 +298,37 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   const ownedWorktrees: Array<{ url: string; path: string; branchName: string }> = [];
 
   function toSDKUserMessage(message: SessionMessage, sessionId: string): SDKUserMessage {
-    // Image file message → multimodal content blocks (text + image)
+    // Image file message: write to temp file and reference by path so Claude
+    // Code's native Read tool reads it as multimodal input. The `@path` syntax
+    // asks the model to auto-read the file when starting the turn.
     if (message.format === "file" && isImageFileContent(message.content)) {
-      const { data, mimeType, filename } = message.content;
-      const prefix = message.senderId ? `[From: ${message.senderId}]\n\n` : "";
-      const content = [
-        {
-          type: "text" as const,
-          text: `${prefix}[Attached image: ${filename}]`,
-        },
-        {
-          type: "image" as const,
-          source: {
-            type: "base64" as const,
-            media_type: mimeType,
-            data,
+      const { filename } = message.content;
+      try {
+        const imagePath = writeImageToTempFile(message.content, message.chatId);
+        const prefix = message.senderId ? `[From: ${message.senderId}]\n\n` : "";
+        const text = `${prefix}Attached image (filename: ${filename}). Please read it: @${imagePath}`;
+        return {
+          type: "user",
+          message: {
+            role: "user",
+            content: text,
           },
-        },
-      ];
-      return {
-        type: "user",
-        message: {
-          role: "user",
-          content,
-        },
-        parent_tool_use_id: null,
-        session_id: sessionId,
-      };
+          parent_tool_use_id: null,
+          session_id: sessionId,
+        };
+      } catch (err) {
+        // Fall through to text fallback on filesystem error.
+        const fallbackText = `[Image attachment "${filename}" failed to materialise: ${err instanceof Error ? err.message : String(err)}]`;
+        return {
+          type: "user",
+          message: {
+            role: "user",
+            content: message.senderId ? `[From: ${message.senderId}]\n\n${fallbackText}` : fallbackText,
+          },
+          parent_tool_use_id: null,
+          session_id: sessionId,
+        };
+      }
     }
 
     // Default: text content


### PR DESCRIPTION
## Problem
After #146 merged (URL upload → inline base64), the base64 data was reaching the agent but the agent still couldn't understand image content. Root cause: Claude Agent SDK does not consistently forward multimodal \`{ type: \"image\" }\` content blocks from \`SDKUserMessage\` to the underlying model process.

## Fix
Use Claude Code's **native image flow** instead:
1. Client-side handler decodes base64 to a per-chat temp file under \`\$TMPDIR/first-tree-hub/images/{chatId}/\`
2. Pass the file via \`@path\` syntax in the text prompt
3. Claude Code's built-in Read tool loads the image as multimodal content — this is the path Claude Code actually expects

## Changes
- \`packages/client/src/handlers/claude-code.ts\`: when \`format: \"file\"\` with image mime type arrives, write temp file and emit text prompt with \`@path\` reference
- Fallback to text placeholder if filesystem write fails

## Test plan
- [x] Lint + typecheck pass
- [ ] End-to-end: upload image in chat, verify agent references the image content in its response

🤖 Generated with [Claude Code](https://claude.com/claude-code)