### PR TITLE
fix(server): symmetric session summary + emoji-safe truncation

### DIFF
--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -20,7 +20,10 @@ function extractSummary(content: unknown, maxLen = SUMMARY_MAX_LENGTH): string |
   } else if (typeof content === "string") {
     text = content;
   }
-  return text ? text.slice(0, maxLen) : null;
+  if (!text) return null;
+  // Slice by code points, not UTF-16 units, to avoid splitting surrogate pairs
+  // (emoji, etc.) which would render as garbled characters in the UI.
+  return Array.from(text).slice(0, maxLen).join("");
 }
 
 export type SessionListItem = {
@@ -215,6 +218,7 @@ export async function listAllSessions(
       state: agentChatSessions.state,
       updatedAt: agentChatSessions.updatedAt,
       chatCreatedAt: chats.createdAt,
+      chatTopic: chats.topic,
     })
     .from(agentChatSessions)
     .innerJoin(chats, eq(agentChatSessions.chatId, chats.id))
@@ -237,6 +241,22 @@ export async function listAllSessions(
       : [];
   const runtimeMap = new Map(presenceRows.map((r) => [r.agentId, r.runtimeState]));
 
+  // Batch-fetch first message per chat for summary (parity with listAgentSessions)
+  const chatIds = [...new Set(items.map((r) => r.chatId))];
+  const firstMessages =
+    chatIds.length > 0
+      ? await db
+          .selectDistinctOn([messages.chatId], { chatId: messages.chatId, content: messages.content })
+          .from(messages)
+          .where(inArray(messages.chatId, chatIds))
+          .orderBy(messages.chatId, messages.createdAt)
+      : [];
+  const summaryMap = new Map<string, string>();
+  for (const row of firstMessages) {
+    const summary = extractSummary(row.content);
+    if (summary) summaryMap.set(row.chatId, summary);
+  }
+
   const last = items[items.length - 1];
   const nextCursor = hasMore && last ? last.updatedAt.toISOString() : null;
 
@@ -249,8 +269,8 @@ export async function listAllSessions(
       startedAt: r.chatCreatedAt.toISOString(),
       lastActivityAt: r.updatedAt.toISOString(),
       messageCount: 0, // Omit per-session message count in global list for performance
-      summary: null, // Omit summary in global list for performance
-      topic: null, // Omit topic in global list for performance
+      summary: summaryMap.get(r.chatId) ?? null,
+      topic: r.chatTopic ?? null,
     })),
     nextCursor,
   };


### PR DESCRIPTION
## Summary

Follow-up to #130 with two polish items:

- **API symmetry** — `listAllSessions` now returns `summary` and `topic` like `listAgentSessions`. Frontends no longer need to branch on which endpoint they called.
- **Emoji-safe truncation** — `extractSummary` slices by Unicode code points (`Array.from`) instead of UTF-16 code units, preventing mojibake when the 50-char cap lands mid-surrogate-pair.

## Why

Discussion on top of #130 flagged two concerns:

1. **Contract asymmetry** between the two list endpoints — cheap to fix now, breaking change if left in place.
2. **Mojibake risk** — `String.prototype.slice` on UTF-16 can split emoji; the fix is one line and the bug is user-visible.

The third item raised — non-text message fallback — turned out to be **already correct**: `extractSummary` returns `null` for card/file/task/unknown payloads, and the UI already falls back to `Chat · <chatId>`. Skipped to avoid over-design.

## Test plan

- [x] `pnpm check` (biome) — clean
- [x] `pnpm typecheck` — 9/9 tasks pass
- [x] `pnpm --filter @first-tree-hub/server test` — 382/382 pass
- [ ] Manual: hit `/admin/sessions` and verify `items[].summary` is populated on chats that have messages

## Risk

- **Perf**: `listAllSessions` now issues one extra batched `SELECT DISTINCT ON` against `messages`, capped by pagination limit (`max 100`). Mirrors `listAgentSessions`; no new index needed — the existing `idx_messages_chat_time` covers it.
- **No unit tests added** for `extractSummary` code-point behavior or the new `listAllSessions` summary path. The function is an internal helper and I kept the diff tight; happy to add Vitest cases if reviewers prefer.
- **Markdown first messages** will surface raw markdown (`## Hello…`) in the summary. Known, low priority — can be post-processed later if noisy in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)