### PR TITLE
fix(chat): move image bytes out of messages.content to prevent Prompt is too long

### DIFF
--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -5,6 +5,7 @@ import {
   type AgentBindRejectReason,
   type AgentPinnedMessage,
   agentPinnedMessageSchema,
+  imagePayloadFrameSchema,
   type RuntimeState,
   type ServerWelcomeFrame,
   type SessionEvent,
@@ -13,6 +14,7 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import WebSocket from "ws";
 import { createLogger, type pino } from "./observability/logger.js";
+import { writeImage } from "./runtime/image-store.js";
 import { type AccessTokenProvider, FirstTreeHubSDK } from "./sdk.js";
 
 export type ClientConnectionConfig = {
@@ -161,6 +163,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       reject: (err: Error) => void;
     }
   >();
+
+  /**
+   * In-flight image writes from recent `image_payload` frames. The server
+   * pushes `image_payload` immediately before firing the `new_message`
+   * notification, but WS message handlers run through EventEmitter (sync
+   * dispatch, no await), so the disk write can still race the HTTP poll
+   * that follows. Defer `new_message` emission until these settle.
+   */
+  private readonly pendingImageWrites = new Set<Promise<void>>();
 
   constructor(config: ClientConnectionConfig) {
     super();
@@ -504,9 +515,34 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       return;
     }
 
+    if (type === "image_payload") {
+      const parsed = imagePayloadFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn({ err: parsed.error.flatten() }, "malformed image_payload frame — dropping");
+        return;
+      }
+      const { imageId, chatId, mimeType, base64 } = parsed.data;
+      const write = writeImage({ chatId, imageId, mimeType, base64 })
+        .then(() => {})
+        .catch((err: unknown) => {
+          this.wsLogger.warn({ err, imageId, chatId }, "image_payload write failed");
+        });
+      this.pendingImageWrites.add(write);
+      write.finally(() => this.pendingImageWrites.delete(write));
+      return;
+    }
+
     if (type === "new_message") {
       const inboxId = msg.inboxId as string | undefined;
-      if (inboxId) {
+      if (!inboxId) return;
+      if (this.pendingImageWrites.size > 0) {
+        // Defer until recent image writes flush — the HTTP poll for this
+        // message would otherwise race the disk write and surface the
+        // "not available on this device" placeholder.
+        Promise.all([...this.pendingImageWrites]).finally(() => {
+          this.emit("agent:message", inboxId, msg);
+        });
+      } else {
         this.emit("agent:message", inboxId, msg);
       }
       return;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -3,8 +3,15 @@ import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from "node:
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentRuntimeConfigPayload, SessionEvent } from "@agent-team-foundation/first-tree-hub-shared";
-import { deriveRepoLocalPath } from "@agent-team-foundation/first-tree-hub-shared";
+import type {
+  AgentRuntimeConfigPayload,
+  SessionEvent,
+  SupportedImageMime,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import {
+  deriveRepoLocalPath,
+  SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import type { McpServerConfig, PermissionMode, Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
@@ -17,6 +24,7 @@ import type {
   SessionContext,
   SessionMessage,
 } from "../runtime/handler.js";
+import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { acquireWorkspace } from "../runtime/workspace.js";
 
@@ -30,14 +38,9 @@ type ToolResultBlock = { type: "tool_result"; tool_use_id: string; content: unkn
 type TextBlock = { type: "text"; text: string };
 type ThinkingBlock = { type: "thinking"; thinking?: string };
 
-/** MIME types supported by Claude's vision API. */
-type SupportedImageMime = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
-const SUPPORTED_IMAGE_MIMES: ReadonlySet<SupportedImageMime> = new Set<SupportedImageMime>([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-]);
+const SUPPORTED_IMAGE_MIMES: ReadonlySet<SupportedImageMime> = new Set<SupportedImageMime>(
+  SHARED_SUPPORTED_IMAGE_MIMES,
+);
 
 const MIME_TO_EXT: Record<SupportedImageMime, string> = {
   "image/png": "png",
@@ -46,15 +49,38 @@ const MIME_TO_EXT: Record<SupportedImageMime, string> = {
   "image/webp": "webp",
 };
 
-/** Shape of a `format: "file"` image message's content (base64-encoded). */
-type ImageFileContent = {
-  data: string; // base64 (no prefix)
+/** Post-refactor image message shape in `messages.content`: a reference only.
+ * The bytes arrive via the separate `image_payload` WS push and live on
+ * this client's local disk under `<dataDir>/chats/<chatId>/images/`. */
+type ImageRefContent = {
+  imageId: string;
   mimeType: SupportedImageMime;
   filename: string;
   size?: number;
 };
 
-function isImageFileContent(content: unknown): content is ImageFileContent {
+function isImageRefContent(content: unknown): content is ImageRefContent {
+  if (!content || typeof content !== "object") return false;
+  const c = content as Record<string, unknown>;
+  return (
+    typeof c.imageId === "string" &&
+    typeof c.mimeType === "string" &&
+    typeof c.filename === "string" &&
+    SUPPORTED_IMAGE_MIMES.has(c.mimeType as SupportedImageMime)
+  );
+}
+
+/** Legacy pre-refactor image content with base64 inlined into the message.
+ * Only exercised by messages that pre-date the image-out-of-messages PR —
+ * kept so a client upgraded mid-backlog can still read them. */
+type LegacyImageFileContent = {
+  data: string;
+  mimeType: SupportedImageMime;
+  filename: string;
+  size?: number;
+};
+
+function isLegacyImageFileContent(content: unknown): content is LegacyImageFileContent {
   if (!content || typeof content !== "object") return false;
   const c = content as Record<string, unknown>;
   return (
@@ -72,16 +98,11 @@ function sanitizeChatId(chatId: string): string {
 }
 
 /**
- * Write an inline base64 image to a temp file so Claude Code's native Read tool
- * can pick it up. Claude Code loads image files as multimodal content blocks —
- * going through the filesystem is more reliable than trying to feed an
- * `{ type: "image" }` block through the SDK, which does not consistently
- * forward multimodal arrays to the underlying model.
- *
- * The temp directory is per-chat so files are discoverable during the session;
- * the OS reclaims them on restart.
+ * Write a legacy inline-base64 image to a temp file so Claude Code's Read
+ * tool can pick it up. Only the legacy path — new messages go through the
+ * image_payload WS push which pre-writes to the data dir before delivery.
  */
-async function writeImageToTempFile(content: ImageFileContent, chatId: string): Promise<string> {
+async function writeLegacyImageToTempFile(content: LegacyImageFileContent, chatId: string): Promise<string> {
   const dir = join(tmpdir(), "first-tree-hub", "images", sanitizeChatId(chatId));
   await mkdir(dir, { recursive: true });
   const ext = MIME_TO_EXT[content.mimeType];
@@ -305,39 +326,66 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   const ownedWorktrees: Array<{ url: string; path: string; branchName: string }> = [];
 
   async function toSDKUserMessage(message: SessionMessage, sessionId: string): Promise<SDKUserMessage> {
-    // Image file message: write to a temp file and ask the model to open it
-    // with its Read tool. Read loads image files as multimodal content blocks
-    // — this is the reliable path; sending `{ type: "image" }` blocks through
-    // the SDK does not forward images to the underlying model in practice.
-    if (message.format === "file" && isImageFileContent(message.content)) {
-      const { filename } = message.content;
-      try {
-        const imagePath = await writeImageToTempFile(message.content, message.chatId);
-        const prefix = message.senderId ? `[From: ${message.senderId}]\n\n` : "";
-        const text = `${prefix}An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`;
+    // Image messages — two supported shapes:
+    //   1. imageRef: `{imageId, mimeType, filename, size}` — new path. Bytes
+    //      live on local disk, delivered via the `image_payload` WS push.
+    //   2. legacy inline: `{data, mimeType, filename, size}` — pre-refactor
+    //      messages still pending at rollout time. Decode once and drop the
+    //      temp path into the prompt.
+    //
+    // Either way we direct the model at a real file path because Claude Code's
+    // native Read tool loads images as multimodal content blocks — the SDK
+    // does not reliably forward `{ type: "image" }` blocks to the underlying
+    // model.
+    if (message.format === "file") {
+      const prefix = message.senderId ? `[From: ${message.senderId}]\n\n` : "";
+
+      if (isImageRefContent(message.content)) {
+        const { imageId, mimeType, filename } = message.content;
+        const imagePath = findImagePath(message.chatId, imageId, mimeType);
+        if (imagePath) {
+          const text = `${prefix}An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`;
+          return {
+            type: "user",
+            message: { role: "user", content: text },
+            parent_tool_use_id: null,
+            session_id: sessionId,
+          };
+        }
+        // Bytes never reached this client (offline during the image_payload
+        // push, or sending server lived on another instance). Treat as the
+        // "not available on this device" case so the session keeps moving.
+        const fallbackText = `[Image "${filename}" not available on this device]`;
         return {
           type: "user",
-          message: {
-            role: "user",
-            content: text,
-          },
+          message: { role: "user", content: `${prefix}${fallbackText}` },
           parent_tool_use_id: null,
           session_id: sessionId,
         };
-      } catch (err) {
-        // Fall through to text fallback on filesystem error. Avoid leaking
-        // raw fs error messages (they contain absolute paths).
-        const fallbackText = `[Image attachment "${filename}" failed to materialise]`;
-        ctx?.log(`Failed to write image to temp file: ${err instanceof Error ? err.message : String(err)}`);
-        return {
-          type: "user",
-          message: {
-            role: "user",
-            content: message.senderId ? `[From: ${message.senderId}]\n\n${fallbackText}` : fallbackText,
-          },
-          parent_tool_use_id: null,
-          session_id: sessionId,
-        };
+      }
+
+      if (isLegacyImageFileContent(message.content)) {
+        const { filename } = message.content;
+        try {
+          const imagePath = await writeLegacyImageToTempFile(message.content, message.chatId);
+          const text = `${prefix}An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`;
+          return {
+            type: "user",
+            message: { role: "user", content: text },
+            parent_tool_use_id: null,
+            session_id: sessionId,
+          };
+        } catch (err) {
+          // Avoid leaking raw fs error messages (they contain absolute paths).
+          const fallbackText = `[Image attachment "${filename}" failed to materialise]`;
+          ctx?.log(`Failed to write image to temp file: ${err instanceof Error ? err.message : String(err)}`);
+          return {
+            type: "user",
+            message: { role: "user", content: `${prefix}${fallbackText}` },
+            parent_tool_use_id: null,
+            session_id: sessionId,
+          };
+        }
       }
     }
 

--- a/packages/client/src/runtime/image-store.ts
+++ b/packages/client/src/runtime/image-store.ts
@@ -1,0 +1,48 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { IMAGE_MIME_TO_EXT, type SupportedImageMime } from "@agent-team-foundation/first-tree-hub-shared";
+import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+
+/** UUIDs are the only shape we generate for imageId, but accept the same
+ * loose character set as chatId sanitisers elsewhere so a malformed field
+ * can never break out of the images dir. */
+function sanitize(segment: string): string {
+  return /^[a-zA-Z0-9-]+$/.test(segment) ? segment : "unknown";
+}
+
+function imageDir(chatId: string): string {
+  return join(DEFAULT_DATA_DIR, "chats", sanitize(chatId), "images");
+}
+
+export function imagePath(chatId: string, imageId: string, mimeType: SupportedImageMime): string {
+  const ext = IMAGE_MIME_TO_EXT[mimeType];
+  return join(imageDir(chatId), `${sanitize(imageId)}.${ext}`);
+}
+
+/**
+ * Locate a previously-written image file on disk. Returns null when the
+ * file is missing — caller should surface the "image not available on
+ * this device" placeholder in that case.
+ */
+export function findImagePath(chatId: string, imageId: string, mimeType: SupportedImageMime): string | null {
+  const p = imagePath(chatId, imageId, mimeType);
+  return existsSync(p) ? p : null;
+}
+
+/**
+ * Persist image bytes to `<dataDir>/chats/<chatId>/images/<imageId>.<ext>`.
+ * Idempotent — rewriting the same imageId is a no-op overwrite.
+ */
+export async function writeImage(params: {
+  chatId: string;
+  imageId: string;
+  mimeType: SupportedImageMime;
+  base64: string;
+}): Promise<string> {
+  const dir = imageDir(params.chatId);
+  await mkdir(dir, { recursive: true });
+  const path = imagePath(params.chatId, params.imageId, params.mimeType);
+  await writeFile(path, Buffer.from(params.base64, "base64"));
+  return path;
+}

--- a/packages/server/src/__tests__/pulse-aggregator.test.ts
+++ b/packages/server/src/__tests__/pulse-aggregator.test.ts
@@ -27,6 +27,7 @@ function makeMockNotifier(): {
     notifyConfigChange: vi.fn(async () => {}),
     notifySessionStateChange: vi.fn(async () => {}),
     notifyRuntimeStateChange: vi.fn(async () => {}),
+    pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
     onSessionStateChange: vi.fn(),
     onRuntimeStateChange: vi.fn((handler: RuntimeStateChangeHandler) => {

--- a/packages/server/src/api/admin/chats.ts
+++ b/packages/server/src/api/admin/chats.ts
@@ -12,6 +12,7 @@ import { requireAdminRoleHook } from "../../middleware/member-auth.js";
 import { requireMember } from "../../middleware/require-identity.js";
 import { assertChatAccess, memberScope } from "../../services/access-control.js";
 import { ensureParticipant, joinChat, leaveChat, listChatsForMember } from "../../services/chat.js";
+import { prepareImageOutbound } from "../../services/image-broadcast.js";
 import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 import { resolveDefaultOrgId, resolveOrganization } from "../../services/organization.js";
@@ -240,11 +241,13 @@ export async function adminChatRoutes(app: FastifyInstance): Promise<void> {
     await assertChatAccess(app.db, scope, chatId);
     await ensureParticipant(app.db, chatId, member.agentId);
 
+    // Image messages: push the bytes to participant clients over WS and
+    // rewrite `content` to a reference before it reaches the DB. Non-image
+    // messages fall through unchanged.
+    const prepared = await prepareImageOutbound(app.db, app.notifier, chatId, { ...body, source: "hub_ui" });
+
     // Send message as the member's linked agent, always with source=hub_ui
-    const result = await sendMessage(app.db, chatId, member.agentId, {
-      ...body,
-      source: "hub_ui",
-    });
+    const result = await sendMessage(app.db, chatId, member.agentId, prepared);
 
     // Notify recipients via PG NOTIFY
     notifyRecipients(app.notifier, result.recipients, result.message.id);

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
 import * as chatService from "../../services/chat.js";
+import { prepareImageOutbound } from "../../services/image-broadcast.js";
 import * as messageService from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
 
@@ -23,11 +24,12 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
     const identity = requireAgent(request);
     await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const body = sendMessageSchema.parse(request.body);
+    const prepared = await prepareImageOutbound(app.db, app.notifier, request.params.chatId, body);
     const { message: msg, recipients } = await messageService.sendMessage(
       app.db,
       request.params.chatId,
       identity.uuid,
-      body,
+      prepared,
     );
 
     notifyRecipients(app.notifier, recipients, msg.id);

--- a/packages/server/src/services/image-broadcast.ts
+++ b/packages/server/src/services/image-broadcast.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import {
+  type ImagePayloadFrame,
+  type ImageRefContent,
+  imageInlineContentSchema,
+  type SendMessage,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants } from "../db/schema/chats.js";
+import type { Notifier } from "./notifier.js";
+
+/**
+ * Intercepts outbound image messages. If `data.content` carries an inline
+ * base64 image (legacy-style payload from the web), we:
+ *
+ *   1. Generate / adopt an `imageId`
+ *   2. Push the bytes as an `image_payload` WS frame to every participant
+ *      agent's inbox — best-effort, local instance only, no PG NOTIFY
+ *   3. Return a copy of `data` whose `content` is just the reference
+ *      {imageId, mimeType, filename, size}
+ *
+ * Non-image messages are returned unchanged. Missing-subscriber / wrong-
+ * instance cases are acceptable loss per the image-out-of-messages design
+ * (the reference-only message still lands in the DB; clients that missed
+ * the bytes surface a "not available on this device" placeholder).
+ */
+export async function prepareImageOutbound(
+  db: Database,
+  notifier: Notifier,
+  chatId: string,
+  data: SendMessage,
+): Promise<SendMessage> {
+  if (data.format !== "file") return data;
+  const parsed = imageInlineContentSchema.safeParse(data.content);
+  if (!parsed.success) return data;
+
+  const inline = parsed.data;
+  const imageId = inline.imageId ?? randomUUID();
+
+  const frame: ImagePayloadFrame = {
+    type: "image_payload",
+    imageId,
+    chatId,
+    base64: inline.data,
+    mimeType: inline.mimeType,
+    filename: inline.filename,
+    ...(inline.size !== undefined ? { size: inline.size } : {}),
+  };
+  const serialised = JSON.stringify(frame);
+
+  const rows = await db
+    .select({ inboxId: agents.inboxId })
+    .from(chatParticipants)
+    .innerJoin(agents, eq(chatParticipants.agentId, agents.uuid))
+    .where(eq(chatParticipants.chatId, chatId));
+
+  await Promise.all(rows.map((row) => notifier.pushFrameToInbox(row.inboxId, serialised)));
+
+  const ref: ImageRefContent = {
+    imageId,
+    mimeType: inline.mimeType,
+    filename: inline.filename,
+    ...(inline.size !== undefined ? { size: inline.size } : {}),
+  };
+
+  return {
+    ...data,
+    content: ref,
+  };
+}

--- a/packages/server/src/services/image-broadcast.ts
+++ b/packages/server/src/services/image-broadcast.ts
@@ -9,6 +9,7 @@ import { eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatParticipants } from "../db/schema/chats.js";
+import { messages } from "../db/schema/messages.js";
 import type { Notifier } from "./notifier.js";
 
 /**
@@ -17,9 +18,18 @@ import type { Notifier } from "./notifier.js";
  *
  *   1. Generate / adopt an `imageId`
  *   2. Push the bytes as an `image_payload` WS frame to every participant
- *      agent's inbox — best-effort, local instance only, no PG NOTIFY
+ *      agent's inbox — plus the reply-to inbox when this is a cross-chat
+ *      reply (matches sendMessage's extra fan-out). Best-effort, local
+ *      instance only, no PG NOTIFY.
  *   3. Return a copy of `data` whose `content` is just the reference
  *      {imageId, mimeType, filename, size}
+ *
+ * The push is fire-and-forget: `ws.send()` queues the frame into the socket's
+ * send buffer synchronously, which is the only ordering guarantee we need
+ * — the subsequent `new_message` notification travels a strictly slower PG
+ * NOTIFY round trip, so the image lands first on the wire. Awaiting the TCP
+ * flush here would put a slow subscriber's backpressure on the sender's
+ * HTTP response for a feature that is already best-effort.
  *
  * Non-image messages are returned unchanged. Missing-subscriber / wrong-
  * instance cases are acceptable loss per the image-out-of-messages design
@@ -50,13 +60,13 @@ export async function prepareImageOutbound(
   };
   const serialised = JSON.stringify(frame);
 
-  const rows = await db
-    .select({ inboxId: agents.inboxId })
-    .from(chatParticipants)
-    .innerJoin(agents, eq(chatParticipants.agentId, agents.uuid))
-    .where(eq(chatParticipants.chatId, chatId));
-
-  await Promise.all(rows.map((row) => notifier.pushFrameToInbox(row.inboxId, serialised)));
+  const inboxIds = await collectTargetInboxes(db, chatId, data.inReplyTo);
+  for (const inboxId of inboxIds) {
+    notifier.pushFrameToInbox(inboxId, serialised).catch(() => {
+      // Best-effort side channel; downstream already surfaces a placeholder
+      // when the bytes never arrived on a given client.
+    });
+  }
 
   const ref: ImageRefContent = {
     imageId,
@@ -69,4 +79,30 @@ export async function prepareImageOutbound(
     ...data,
     content: ref,
   };
+}
+
+/**
+ * Mirror `sendMessage`'s fan-out set: every participant of the current
+ * chat, plus the original requester's inbox when this message is a cross-
+ * chat reply (see `services/message.ts` replyTo routing).
+ */
+async function collectTargetInboxes(db: Database, chatId: string, inReplyTo: string | undefined): Promise<string[]> {
+  const participants = await db
+    .select({ inboxId: agents.inboxId })
+    .from(chatParticipants)
+    .innerJoin(agents, eq(chatParticipants.agentId, agents.uuid))
+    .where(eq(chatParticipants.chatId, chatId));
+
+  const set = new Set(participants.map((p) => p.inboxId));
+
+  if (inReplyTo) {
+    const [original] = await db
+      .select({ replyToInbox: messages.replyToInbox })
+      .from(messages)
+      .where(eq(messages.id, inReplyTo))
+      .limit(1);
+    if (original?.replyToInbox) set.add(original.replyToInbox);
+  }
+
+  return [...set];
 }

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -28,6 +28,14 @@ export type Notifier = {
   notifySessionStateChange(agentId: string, chatId: string, state: string, organizationId: string): Promise<void>;
   /** Notify that an agent runtime state has changed (idle/working/error/…). Payload is org-scoped so admin consumers can filter. */
   notifyRuntimeStateChange(agentId: string, state: string, organizationId: string): Promise<void>;
+  /**
+   * Push a raw JSON frame to every socket currently subscribed to `inboxId`
+   * on **this server instance only**. Unlike `notify`, does not fan out
+   * across PG NOTIFY — used for payloads that are too large for NOTIFY
+   * (image bytes) and where cross-instance loss is acceptable. Returns the
+   * number of sockets the frame was queued to.
+   */
+  pushFrameToInbox(inboxId: string, frame: string): Promise<number>;
   /** Register a handler for config change notifications */
   onConfigChange(handler: ConfigChangeHandler): void;
   /** Register a handler for session state change notifications */
@@ -118,6 +126,26 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       } catch {
         // fire-and-forget
       }
+    },
+
+    async pushFrameToInbox(inboxId: string, frame: string): Promise<number> {
+      const sockets = subscriptions.get(inboxId);
+      if (!sockets) return 0;
+      let queued = 0;
+      const pending: Promise<void>[] = [];
+      for (const ws of sockets) {
+        if (ws.readyState !== ws.OPEN) continue;
+        pending.push(
+          new Promise<void>((resolve) => {
+            ws.send(frame, (err) => {
+              if (!err) queued += 1;
+              resolve();
+            });
+          }),
+        );
+      }
+      await Promise.all(pending);
+      return queued;
     },
 
     onConfigChange(handler: ConfigChangeHandler) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -129,6 +129,18 @@ export {
   paginationQuerySchema,
 } from "./schemas/common.js";
 export {
+  IMAGE_MIME_TO_EXT,
+  type ImageInlineContent,
+  type ImagePayloadFrame,
+  type ImageRefContent,
+  imageInlineContentSchema,
+  imagePayloadFrameSchema,
+  imageRefContentSchema,
+  SUPPORTED_IMAGE_MIMES,
+  type SupportedImageMime,
+  supportedImageMimeSchema,
+} from "./schemas/image-payload.js";
+export {
   INBOX_ENTRY_STATUSES,
   type InboxEntry,
   type InboxEntryStatus,

--- a/packages/shared/src/schemas/image-payload.ts
+++ b/packages/shared/src/schemas/image-payload.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+/**
+ * MIME types the web + client image paths recognise. Kept in sync with
+ * Claude's vision API (see packages/client/src/handlers/claude-code.ts).
+ */
+export const SUPPORTED_IMAGE_MIMES = ["image/png", "image/jpeg", "image/gif", "image/webp"] as const;
+export const supportedImageMimeSchema = z.enum(SUPPORTED_IMAGE_MIMES);
+export type SupportedImageMime = z.infer<typeof supportedImageMimeSchema>;
+
+export const IMAGE_MIME_TO_EXT: Record<SupportedImageMime, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+/**
+ * Legacy inbound shape: an image message with base64 bytes inlined into
+ * `messages.content`. Web still uploads in this shape so no new endpoint is
+ * needed; the server extracts the bytes, broadcasts them as an `image_payload`
+ * WS frame, then rewrites `content` to {@link imageRefContentSchema} before
+ * the DB insert.
+ */
+export const imageInlineContentSchema = z.object({
+  data: z.string().min(1),
+  mimeType: supportedImageMimeSchema,
+  filename: z.string().min(1),
+  size: z.number().int().nonnegative().optional(),
+  /** Optional caller-supplied id (UUID v4). Server generates one if absent. */
+  imageId: z.string().uuid().optional(),
+});
+export type ImageInlineContent = z.infer<typeof imageInlineContentSchema>;
+
+/**
+ * What gets persisted to `messages.content` for image messages post-refactor.
+ * The bytes live on each client's local disk (keyed by imageId) and in the
+ * originating browser's IndexedDB — never in the DB.
+ */
+export const imageRefContentSchema = z.object({
+  imageId: z.string().uuid(),
+  mimeType: supportedImageMimeSchema,
+  filename: z.string().min(1),
+  size: z.number().int().nonnegative().optional(),
+});
+export type ImageRefContent = z.infer<typeof imageRefContentSchema>;
+
+/**
+ * Server → client WS frame carrying the full image bytes for an image
+ * message. Pushed before the corresponding `new_message` notification so
+ * the client has the file on disk by the time it polls the message.
+ *
+ * Best-effort: if the target client WS lives on a different server
+ * instance (or is offline), the frame is lost and the reference message
+ * will surface a "not available on this device" placeholder downstream.
+ */
+export const imagePayloadFrameSchema = z.object({
+  type: z.literal("image_payload"),
+  imageId: z.string().uuid(),
+  chatId: z.string(),
+  base64: z.string().min(1),
+  mimeType: supportedImageMimeSchema,
+  filename: z.string().min(1),
+  size: z.number().int().nonnegative().optional(),
+});
+export type ImagePayloadFrame = z.infer<typeof imagePayloadFrameSchema>;

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -39,10 +39,9 @@ export function sendChatMessage(chatId: string, content: string): Promise<Messag
 }
 
 /**
- * File message content — embedded directly in the message (no server-side storage).
- * `data` is a base64-encoded string (without the `data:...;base64,` prefix).
- * This keeps messages self-contained so they can be forwarded to any agent (local
- * Claude client, Kael cloud, Feishu, etc.) without requiring URL access.
+ * Legacy inline shape — historical messages persisted before the
+ * image-out-of-messages refactor. Still understood by the renderer but no
+ * longer produced on send.
  */
 export type FileMessageContent = {
   data: string; // base64 (no prefix)
@@ -51,7 +50,25 @@ export type FileMessageContent = {
   size: number;
 };
 
-export function sendFileMessage(chatId: string, content: FileMessageContent): Promise<Message> {
+/**
+ * Post-refactor persisted shape. Bytes live in the sender's IndexedDB + on
+ * each online agent client's local disk — never in the server DB.
+ */
+export type ImageRefContent = {
+  imageId: string;
+  mimeType: string;
+  filename: string;
+  size?: number;
+};
+
+/**
+ * Inline shape sent over the wire. Server accepts the optional `imageId`
+ * (so the sender can write to IndexedDB ahead of the POST round-trip) and
+ * rewrites `content` to {@link ImageRefContent} before the DB insert.
+ */
+type SendFileMessageBody = FileMessageContent & { imageId?: string };
+
+export function sendFileMessage(chatId: string, content: SendFileMessageBody): Promise<Message> {
   return api.post<Message>(`/admin/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "file",
     content,

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-browser image cache keyed by imageId. Images sent from THIS browser
+ * live here so we can render historical messages without refetching bytes
+ * from the server — the server-side DB only stores a reference.
+ *
+ * Cross-device / incognito / a different browser → cache miss → the UI
+ * falls back to a "not available on this device" placeholder. This is the
+ * accepted trade-off of the image-out-of-messages design (bytes live on
+ * the sender's device + on each online agent client, never on the server).
+ */
+
+const DB_NAME = "first-tree-hub-images";
+const DB_VERSION = 1;
+const STORE = "images";
+
+type Stored = {
+  imageId: string;
+  base64: string;
+  mimeType: string;
+  createdAt: number;
+};
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve(null);
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: "imageId" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+    req.onblocked = () => resolve(null);
+  });
+  return dbPromise;
+}
+
+export async function putImage(params: { imageId: string; base64: string; mimeType: string }): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    const tx = db.transaction(STORE, "readwrite");
+    const store = tx.objectStore(STORE);
+    const entry: Stored = {
+      imageId: params.imageId,
+      base64: params.base64,
+      mimeType: params.mimeType,
+      createdAt: Date.now(),
+    };
+    store.put(entry);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+    tx.onabort = () => resolve();
+  });
+}
+
+export async function getImage(imageId: string): Promise<{ base64: string; mimeType: string } | null> {
+  const db = await openDb();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE, "readonly");
+    const store = tx.objectStore(STORE);
+    const req = store.get(imageId);
+    req.onsuccess = () => {
+      const row = req.result as Stored | undefined;
+      if (!row) {
+        resolve(null);
+        return;
+      }
+      resolve({ base64: row.base64, mimeType: row.mimeType });
+    };
+    req.onerror = () => resolve(null);
+  });
+}

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -43,10 +43,20 @@ function openDb(): Promise<IDBDatabase | null> {
   return dbPromise;
 }
 
+/**
+ * Persist image bytes keyed by imageId. Rejects when IndexedDB is unavailable
+ * (incognito, disabled) or the write itself fails (quota, aborted). Since
+ * the server stores only a reference to these bytes, callers MUST treat a
+ * rejection as a send-blocking error — posting the reference without a local
+ * cache entry means the sender's own tab will immediately render the
+ * "not available on this device" placeholder for the image it just sent.
+ */
 export async function putImage(params: { imageId: string; base64: string; mimeType: string }): Promise<void> {
   const db = await openDb();
-  if (!db) return;
-  await new Promise<void>((resolve) => {
+  if (!db) {
+    throw new Error("Image storage unavailable (IndexedDB disabled or blocked)");
+  }
+  await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);
     const entry: Stored = {
@@ -57,8 +67,8 @@ export async function putImage(params: { imageId: string; base64: string; mimeTy
     };
     store.put(entry);
     tx.oncomplete = () => resolve();
-    tx.onerror = () => resolve();
-    tx.onabort = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error("Image storage write failed"));
+    tx.onabort = () => reject(tx.error ?? new Error("Image storage write aborted"));
   });
 }
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "react-router";
 import {
   type FileMessageContent,
   getChat,
+  type ImageRefContent,
   listChatMessages,
   type MessageWithDelivery,
   readFileAsBase64,
@@ -12,6 +13,7 @@ import {
   sendChatMessage,
   sendFileMessage,
 } from "../../../api/chats.js";
+import { getImage, putImage } from "../../../api/image-store.js";
 import {
   agentSessionsQueryKey,
   asAssistantTextPayload,
@@ -594,12 +596,14 @@ function TextRow({
             marginTop: 2,
           }}
         >
-          {msg.format === "file" && isImageContent(msg.content) ? (
+          {msg.format === "file" && isInlineImageContent(msg.content) ? (
             <img
-              src={`data:${(msg.content as FileMessageContent).mimeType};base64,${(msg.content as FileMessageContent).data}`}
-              alt={(msg.content as FileMessageContent).filename ?? "image"}
+              src={`data:${msg.content.mimeType};base64,${msg.content.data}`}
+              alt={msg.content.filename ?? "image"}
               style={{ maxWidth: 320, borderRadius: "var(--radius-panel)", marginTop: 4 }}
             />
+          ) : msg.format === "file" && isImageRefContent(msg.content) ? (
+            <ImageFromRef content={msg.content} />
           ) : msg.format === "text" ? (
             <Markdown>{typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}</Markdown>
           ) : (
@@ -622,10 +626,68 @@ function TextRow({
   );
 }
 
-function isImageContent(content: unknown): content is FileMessageContent {
+function isInlineImageContent(content: unknown): content is FileMessageContent {
   if (typeof content !== "object" || content === null) return false;
   const c = content as Record<string, unknown>;
   return typeof c.data === "string" && typeof c.mimeType === "string" && (c.mimeType as string).startsWith("image/");
+}
+
+function isImageRefContent(content: unknown): content is ImageRefContent {
+  if (typeof content !== "object" || content === null) return false;
+  const c = content as Record<string, unknown>;
+  return (
+    typeof c.imageId === "string" &&
+    typeof c.mimeType === "string" &&
+    (c.mimeType as string).startsWith("image/") &&
+    typeof c.filename === "string"
+  );
+}
+
+/**
+ * Render an image whose bytes live in per-browser IndexedDB. Cache hit →
+ * inline preview; miss → placeholder text (cross-device or cleared cache).
+ */
+function ImageFromRef({ content }: { content: ImageRefContent }) {
+  const [state, setState] = useState<{ kind: "loading" } | { kind: "hit"; src: string } | { kind: "miss" }>({
+    kind: "loading",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    getImage(content.imageId).then((hit) => {
+      if (cancelled) return;
+      if (hit) {
+        setState({ kind: "hit", src: `data:${hit.mimeType};base64,${hit.base64}` });
+      } else {
+        setState({ kind: "miss" });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [content.imageId]);
+
+  if (state.kind === "hit") {
+    return (
+      <img
+        src={state.src}
+        alt={content.filename}
+        style={{ maxWidth: 320, borderRadius: "var(--radius-panel)", marginTop: 4 }}
+      />
+    );
+  }
+  if (state.kind === "miss") {
+    return (
+      <span className="text-label" style={{ color: "var(--fg-3)", fontStyle: "italic" }}>
+        [Image "{content.filename}" not available on this device]
+      </span>
+    );
+  }
+  return (
+    <span className="text-label" style={{ color: "var(--fg-4)" }}>
+      …
+    </span>
+  );
 }
 
 type PendingImage = {
@@ -727,11 +789,17 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
       try {
         for (const img of images) {
           const data = await readFileAsBase64(img.file);
+          const imageId = crypto.randomUUID();
+          // Write to IndexedDB before the POST so the sending tab can render
+          // its own message via the imageRef shape immediately on refetch,
+          // even if the server write races ahead of the response.
+          await putImage({ imageId, base64: data, mimeType: img.file.type });
           await sendFileMessage(chatId, {
             data,
             mimeType: img.file.type,
             filename: img.file.name,
             size: img.file.size,
+            imageId,
           });
           URL.revokeObjectURL(img.previewUrl);
         }


### PR DESCRIPTION
## Summary

- Stop inlining pasted-image base64 into `messages.content` (root cause of Claude SDK `Prompt is too long` — history replay on resume accumulates the bytes into the context window every turn).
- Image bytes now live **only** on the sending browser's IndexedDB and each online agent client's local disk (`<dataDir>/chats/<chatId>/images/<imageId>.<ext>`). The DB only stores a reference `{imageId, mimeType, filename, size}`.
- New WS frame `image_payload` pushes bytes from server → participant clients **before** the `new_message` notification fires. Client defers `new_message` dispatch until the in-flight disk write completes so the downstream HTTP poll finds the file on disk.

## Why

Root-cause PR: #146 (2038df9) moved image storage from URL to base64 inline. That fixed portability (feishu/kael/etc forwarding) but every Claude SDK resume now replays the base64 bytes through the prompt → `Prompt is too long` on ~20-image chats. Internal users started hitting it this week.

Design decisions confirmed with Gandy:
- **No server-side storage** — bytes never touch the DB or disk on the server.
- **No cross-device fan-out** — web IndexedDB is sender-only; other browsers show a placeholder.
- **No migration** — internal trial, old polluted chats stay as-is; users who hit the bug start a new chat. See "Known limitation" below.

## Test plan

- [ ] Paste an image in the hub UI → agent receives the message, uses Read tool to open `<dataDir>/chats/<chatId>/images/<uuid>.png`, responds based on content.
- [ ] DB `messages` row for that message: `content` is just `{imageId, mimeType, filename, size}` — no `data` field, no base64.
- [ ] Paste 20+ images over one chat → agent continues to respond; no `Prompt is too long`.
- [ ] Restart the client → historical image messages still readable from local disk (file persists under `~/.first-tree/hub/data/chats/<chatId>/images/`).
- [ ] Refresh / reopen the same browser tab → image previews render from IndexedDB.
- [ ] Open the chat in a different browser (or incognito) → `[Image "foo.png" not available on this device]` placeholder. No white screen, no error.
- [ ] Verify non-image messages (text, markdown, task, reference) still flow through unchanged.
- [ ] `pnpm typecheck` clean, `pnpm check` (biome) clean, `pnpm test` green (382 tests in server pass).

## Risk

**Cross-instance delivery loss** — `Notifier.pushFrameToInbox` is local-instance only (no PG NOTIFY — 8KB limit can't carry image bytes). Multi-instance deploys would lose image_payload for clients whose WS lives on a different server. The design accepts this: the reference message still lands in the DB, client surfaces the placeholder. Current deployment is single-instance, so this is latent risk only.

**Known limitation (rollout)** — existing polluted chats (where base64 is already in `messages.content` and in the client's `~/.claude/projects/*/*.jsonl` replay log) will continue to hit `Prompt is too long`. Mitigation per Gandy: ship an internal note saying "old image chats may still break — start a new chat." No migration script, no DB cleanup, no forced SDK session reset. If this turns out to be too painful in practice, we can revisit with a one-shot reset (option d) later.

**No new unit tests** for the WS integration — the write path (web → server → client → disk) is cross-package async work that's awkward to unit test. Existing typecheck + 382-test server suite all pass. Manual QA covers the risk surface (see test plan).

**Backward compat** — both the server ingress and the client handler accept both shapes (legacy inline + new imageRef), so mid-rollout messages work either way. The legacy branches are narrow and can be removed in a follow-up once the queue drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)