### PR TITLE
fix(ci): stabilize first-tree sync workflow

### DIFF
--- a/.github/workflows/first-tree-sync.yml
+++ b/.github/workflows/first-tree-sync.yml
@@ -9,8 +9,9 @@ on:
 
 jobs:
   tree-sync:
-    # Skip first-tree's own sync PRs so gardener never reviews itself.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'first-tree:sync') }}
+    # Skip fork PRs because GitHub withholds repo secrets there.
+    # Also skip first-tree's own sync PRs so gardener never reviews itself.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'first-tree:sync') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,42 +19,59 @@ jobs:
       pull-requests: write
     env:
       TREE_REPO_TOKEN: ${{ secrets.TREE_REPO_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GARDENER_CLASSIFIER_MODEL: ${{ secrets.GARDENER_CLASSIFIER_MODEL }}
+      GARDENER_CLASSIFIER: ${{ secrets.ANTHROPIC_API_KEY != '' && 'anthropic-api' || 'none' }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Checkout tree repo
-        uses: actions/checkout@v4
-        with:
-          repository: agent-team-foundation/first-tree-context
-          token: ${{ secrets.TREE_REPO_TOKEN }}
-          path: .first-tree-cache/tree
+      - name: Clone tree repo
+        shell: bash
+        run: |
+          set -euo pipefail
+          tree_repo_url="https://github.com/agent-team-foundation/first-tree-context.git"
+          tree_repo_dir=".first-tree-cache/tree"
+          mkdir -p "$(dirname "$tree_repo_dir")"
+          if GIT_TERMINAL_PROMPT=0 GIT_ASKPASS= SSH_ASKPASS= git \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            clone --depth 1 "$tree_repo_url" "$tree_repo_dir"; then
+            exit 0
+          fi
+
+          if [ -z "${TREE_REPO_TOKEN:-}" ]; then
+            echo "Anonymous tree clone failed and TREE_REPO_TOKEN is unset." >&2
+            exit 1
+          fi
+
+          rm -rf "$tree_repo_dir"
+          askpass_script="$RUNNER_TEMP/first-tree-git-askpass.sh"
+          cat >"$askpass_script" <<'EOF'
+          #!/bin/sh
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "$TREE_REPO_TOKEN" ;;
+          esac
+          EOF
+          chmod 700 "$askpass_script"
+          GIT_ASKPASS="$askpass_script" git -c credential.helper= clone --depth 1 "$tree_repo_url" "$tree_repo_dir"
+          rm -f "$askpass_script"
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
-      - name: Install CLIs (first-tree + claude)
-        # `npx -p first-tree first-tree …` (the gardener-install-workflow
-        # template's default) is flaky on Node 22 / newer npm — it
-        # fails with `first-tree: not found` after install. Install both
-        # globally instead.
-        #
-        # Gardener's verdict classifier is designed to shell out to the
-        # `claude` CLI (see first-tree sync.ts). Pre-install
-        # @anthropic-ai/claude-code so any future upstream CLI upgrade
-        # that wires a real classifier into `gardener comment` will
-        # authenticate via CLAUDE_CODE_OAUTH_TOKEN below without another
-        # workflow change.
-        run: npm install -g first-tree @anthropic-ai/claude-code
+      - name: Install first-tree CLI
+        run: npm install -g first-tree
 
       - name: Run first-tree gardener
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Bypass gardener's `gh api user` self-identification call —
           # GITHUB_TOKEN can't resolve /user reliably. Hardcoding the
           # bot identity is enough for the self-loop guard.


### PR DESCRIPTION
## Summary
- remove the brittle `claude` CLI install/OAuth path from `First-Tree Sync`
- force gardener onto the supported non-`claude` classifier path so missing `ANTHROPIC_API_KEY` no longer turns the workflow red
- harden the workflow for fork PRs and tree-repo checkout/auth

## Why
The current workflow was failing in GitHub Actions with `claude -p exited 1`. This repo currently has `TREE_REPO_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` configured, but no `ANTHROPIC_API_KEY` secret, so the safest fix is to stop depending on the `claude` binary entirely.

With this change, the workflow will:
- use `anthropic-api` when `ANTHROPIC_API_KEY` is configured later
- otherwise skip gardener classification cleanly instead of failing CI

## Validation
- YAML parsed successfully with Ruby
- the real GitHub PR checks are the source of truth for this workflow change