### PR TITLE
feat(web): align agents list panels and trim unused columns

### DIFF
--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -1,7 +1,7 @@
 import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
 import { AGENT_TYPES } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
-import { Filter, Plus, Search } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { getActivityOverview, type RuntimeAgent } from "../api/activity.js";
@@ -32,8 +32,6 @@ const agentTypeValues = Object.values(AGENT_TYPES);
 
 type RuntimeInfo = {
   runtimeState: string | null;
-  activeSessions: number | null;
-  totalSessions: number | null;
 };
 
 function sortByName(agents: Agent[]): Agent[] {
@@ -48,8 +46,6 @@ function pickRuntime(agent: Agent, map: Map<string, RuntimeAgent>): RuntimeInfo 
   const r = map.get(agent.uuid);
   return {
     runtimeState: r?.runtimeState ?? null,
-    activeSessions: r?.activeSessions ?? null,
-    totalSessions: r?.totalSessions ?? null,
   };
 }
 
@@ -169,9 +165,6 @@ export function AgentsPage() {
         }
         right={
           <div className="flex items-center gap-1.5">
-            <Button variant="outline" size="xs">
-              Import
-            </Button>
             <Button size="xs" onClick={() => setCreateDialogOpen(true)}>
               <Plus className="h-3 w-3" />
               New agent
@@ -247,9 +240,6 @@ export function AgentsPage() {
               </option>
             ))}
           </select>
-          <Button variant="ghost" size="xs" className="text-label">
-            <Filter className="h-3 w-3" /> Columns
-          </Button>
         </div>
 
         {isLoading ? (
@@ -269,6 +259,7 @@ export function AgentsPage() {
               resolveAgentName={resolveAgentName}
               resolveMemberName={resolveMemberName}
               navigate={navigate}
+              showOwner={false}
               emptyLabel={
                 myAgents.length === 0
                   ? "No agents yet — create one to get started"
@@ -294,7 +285,17 @@ export function AgentsPage() {
                 resolveAgentName={resolveAgentName}
                 resolveMemberName={resolveMemberName}
                 navigate={navigate}
+                showOwner
                 emptyLabel="No agents match the current filter"
+                breakdown={
+                  <StateBreakdown
+                    items={[
+                      { state: "working", count: countByRuntime(teamAgents, runtimeMap, "working") },
+                      { state: "blocked", count: countByRuntime(teamAgents, runtimeMap, "blocked") },
+                      { state: "error", count: countByRuntime(teamAgents, runtimeMap, "error") },
+                    ]}
+                  />
+                }
               />
             )}
           </>
@@ -342,6 +343,7 @@ function AgentsPanel({
   emptyLabel,
   breakdown,
   className,
+  showOwner,
 }: {
   title: string;
   agents: Agent[];
@@ -352,6 +354,7 @@ function AgentsPanel({
   emptyLabel: string;
   breakdown?: ReactNode;
   className?: string;
+  showOwner: boolean;
 }) {
   return (
     <Panel className={className}>
@@ -368,9 +371,8 @@ function AgentsPanel({
               <DenseTableHead>Display</DenseTableHead>
               <DenseTableHead>Type</DenseTableHead>
               <DenseTableHead>Delegate</DenseTableHead>
-              <DenseTableHead>Owner</DenseTableHead>
+              {showOwner && <DenseTableHead>Owner</DenseTableHead>}
               <DenseTableHead>Runtime</DenseTableHead>
-              <DenseTableHead>Sessions</DenseTableHead>
               <DenseTableHead>Status</DenseTableHead>
               <DenseTableHead>Created</DenseTableHead>
             </DenseTableRow>
@@ -384,6 +386,7 @@ function AgentsPanel({
                 resolveAgentName={resolveAgentName}
                 resolveMemberName={resolveMemberName}
                 navigate={navigate}
+                showOwner={showOwner}
               />
             ))}
           </DenseTableBody>
@@ -424,14 +427,16 @@ function AgentRow({
   resolveAgentName,
   resolveMemberName,
   navigate,
+  showOwner,
 }: {
   agent: Agent;
   runtime: RuntimeInfo;
   resolveAgentName: (mention: string | null | undefined) => string;
   resolveMemberName: (id: string | null | undefined) => string;
   navigate: NavigateFn;
+  showOwner: boolean;
 }) {
-  const { runtimeState, activeSessions, totalSessions } = runtime;
+  const { runtimeState } = runtime;
   const isKnownState =
     runtimeState === "idle" ||
     runtimeState === "working" ||
@@ -453,9 +458,11 @@ function AgentRow({
       >
         {agent.delegateMention ? resolveAgentName(agent.delegateMention) : "—"}
       </DenseTableCell>
-      <DenseTableCell className="text-label" style={{ color: "var(--fg-2)" }}>
-        {resolveMemberName(agent.managerId)}
-      </DenseTableCell>
+      {showOwner && (
+        <DenseTableCell className="text-label" style={{ color: "var(--fg-2)" }}>
+          {resolveMemberName(agent.managerId)}
+        </DenseTableCell>
+      )}
       <DenseTableCell>
         {runtimeState && isKnownState ? (
           <span className="inline-flex items-center gap-1.5">
@@ -467,18 +474,6 @@ function AgentRow({
         ) : (
           <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
             —
-          </span>
-        )}
-      </DenseTableCell>
-      <DenseTableCell>
-        {activeSessions === null && totalSessions === null ? (
-          <span className="mono text-label" style={{ color: "var(--fg-4)" }}>
-            —
-          </span>
-        ) : (
-          <span className="mono tnum text-label">
-            <span style={{ color: "var(--fg-2)" }}>{activeSessions ?? 0}</span>
-            <span style={{ color: "var(--fg-4)" }}> / {totalSessions ?? 0}</span>
           </span>
         )}
       </DenseTableCell>


### PR DESCRIPTION
## Summary

- Drops `Import` and `Columns` buttons from the agents list header (neither was wired up).
- Removes the `Sessions` column from both `My agents` and `Team agents` panels, along with the now-unused `activeSessions` / `totalSessions` fields on `RuntimeInfo`.
- Makes the `Owner` column opt-in via a new `showOwner` prop on `AgentsPanel`: hidden on `My agents` (owner is always the current user), visible on `Team agents`.
- Adds the same `StateBreakdown` summary on `Team agents` that already lived on `My agents`, so the two panels share header chrome.
- Both panels continue to use a single `AgentsPanel` / `AgentRow` implementation, so column widths, row height, table header, panel border, status badge, empty state and loading state stay identical between the two — "cover the title and they look like the same component," per the handoff.

Addresses handoff 1/2 from analyst-agent.

## Test plan

- [x] `pnpm check` (biome, 450 files)
- [x] `pnpm typecheck` (web + server + shared + client + command, 9 packages)
- [x] Local Vite dev server: verified by owner in the browser before commit
- [ ] CI (biome + typecheck + build) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)