### PR TITLE
feat(web): add X-style ProfileHeader to agent detail page

### DIFF
--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1,4 +1,4 @@
-import { ADAPTER_PLATFORMS } from "@agent-team-foundation/first-tree-hub-shared";
+import { ADAPTER_PLATFORMS, type Agent } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Cable, Link2, Plus, Trash2 } from "lucide-react";
 import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
@@ -25,7 +25,6 @@ import {
 } from "./../api/agents.js";
 import { ApiError } from "./../api/client.js";
 import { listAgentSessions } from "./../api/sessions.js";
-import { FirstTreeLogo } from "./../components/first-tree-logo.js";
 import { Breadcrumb, BreadcrumbCurrent, BreadcrumbLink, BreadcrumbSep } from "./../components/ui/breadcrumb.js";
 import { Button } from "./../components/ui/button.js";
 import { DenseBadge, type DenseBadgeTone } from "./../components/ui/dense-badge.js";
@@ -43,7 +42,7 @@ import { Label } from "./../components/ui/label.js";
 import { Panel } from "./../components/ui/panel.js";
 import { UppercaseLabel } from "./../components/ui/section-header.js";
 import { StateChip } from "./../components/ui/state-chip.js";
-import { Tile } from "./../components/ui/tile.js";
+import { useMemberNameMap } from "./../lib/use-member-name-map.js";
 import { cn, formatDate } from "./../lib/utils.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import { DangerZone } from "./agent-detail/danger-zone.js";
@@ -53,6 +52,7 @@ import { IdentitySection } from "./agent-detail/identity-section.js";
 import { McpSection } from "./agent-detail/mcp-section.js";
 import { ModelSection } from "./agent-detail/model-section.js";
 import { OverviewSection } from "./agent-detail/overview-section.js";
+import { ProfileHeader } from "./agent-detail/profile-header.js";
 import { PromptSection } from "./agent-detail/prompt-section.js";
 import { SaveBar, sectionAnchorId } from "./agent-detail/save-bar.js";
 import { SectionDivider, SectionShell } from "./agent-detail/section-shell.js";
@@ -105,6 +105,7 @@ export function AgentDetailPage() {
   const uuid = params.uuid ?? "";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const resolveMember = useMemberNameMap();
 
   // Agent identity data
   const agentQuery = useQuery({
@@ -485,6 +486,16 @@ export function AgentDetailPage() {
   const contextRuntimeLabel =
     setupRuntimeKind === "kael" ? "Kael" : setupRuntimeKind === "claude-code" ? "Claude Code" : (runtimeType ?? "—");
 
+  // Org label: `agent.organizationId` is a slug (e.g. "default") so we render
+  // it as-is. A dedicated org-name map would be a later improvement; today the
+  // slug is what shows up everywhere else in the product.
+  const orgLabel = agent.organizationId ?? null;
+
+  // Tagline: prefer the agent's description (if the schema carries one); fall
+  // back to the first non-empty line of the system prompt append. Truncate
+  // long lines so the ProfileHeader layout stays predictable.
+  const tagline = deriveTagline(agent, cfgQuery.data?.payload.prompt.append);
+
   const bindingsPanel = (
     <Panel>
       <div
@@ -675,53 +686,16 @@ export function AgentDetailPage() {
       <div className="flex-1 min-w-0 overflow-auto" style={{ background: "var(--bg)" }}>
         <div
           style={{
-            padding: "var(--sp-3_5) var(--sp-5)",
+            padding: "var(--sp-2_5) var(--sp-5)",
             borderBottom: "var(--hairline) solid var(--border-faint)",
             background: "var(--bg-raised)",
           }}
         >
-          <Breadcrumb style={{ marginBottom: 8 }}>
+          <Breadcrumb>
             <BreadcrumbLink onClick={() => navigate("/agents")}>Agents</BreadcrumbLink>
             <BreadcrumbSep />
             <BreadcrumbCurrent mono>{agent.name ?? shortId}</BreadcrumbCurrent>
           </Breadcrumb>
-          <div className="flex items-center gap-3">
-            <div
-              className="inline-flex items-center justify-center"
-              style={{
-                width: 36,
-                height: 36,
-                borderRadius: "var(--radius-panel)",
-                background: "var(--bg-active)",
-                border: "var(--hairline) solid var(--border-strong)",
-              }}
-            >
-              <FirstTreeLogo width={18} height={20} style={{ color: "var(--accent)" }} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-baseline gap-2">
-                <span className="text-title">{agent.displayName ?? agent.name ?? shortId}</span>
-                <span className="mono text-label" style={{ color: "var(--fg-4)" }}>
-                  @{agent.name ?? shortId}
-                </span>
-              </div>
-              <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-                agt_{shortId} · {agent.type}
-                {agent.visibility ? ` · ${agent.visibility}` : ""}
-              </div>
-            </div>
-            <StateChip state={runtimeState} />
-          </div>
-          <div className="grid gap-1.5 mt-3" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
-            <Tile label="sessions" value={tileValues.sessions} />
-            <Tile
-              label="active"
-              value={tileValues.active}
-              accent={typeof tileValues.active === "number" && tileValues.active > 0 ? "var(--accent)" : undefined}
-            />
-            <Tile label="runtime" value={tileValues.runtime} />
-            <Tile label="model" value={tileValues.model} />
-          </div>
         </div>
 
         {!isHuman && (
@@ -749,6 +723,25 @@ export function AgentDetailPage() {
             />
           )}
 
+          <ProfileHeader
+            agent={agent}
+            runtimeState={runtimeState}
+            runtimeType={runtimeType}
+            ownerName={resolveMember(agent.managerId)}
+            orgLabel={orgLabel}
+            activeSessions={activeSessions}
+            totalSessions={tileValues.sessions}
+            toolsCount={!isHuman ? draft.draft.mcp.filter((i) => i.status !== "deleted").length : null}
+            tagline={tagline}
+            isHuman={isHuman}
+            onOpenChat={() => navigate(`/?a=${agent.uuid}`)}
+            onTest={() => {
+              testMutation.reset();
+              testMutation.mutate();
+            }}
+            testPending={testMutation.isPending}
+          />
+
           <SectionShell anchorId={SECTION_ANCHORS.overview} title="Overview">
             <OverviewSection
               agent={agent}
@@ -762,21 +755,6 @@ export function AgentDetailPage() {
                 />
               }
               bindingsSlot={bindingsPanel}
-              health={{
-                runtimeState,
-                runtimeKind: runtimeType,
-                computerLabel: boundClientLabel,
-                model: tileValues.model,
-                activeSessions,
-                totalSessions: tileValues.sessions,
-                lastActiveAt: clientStatus?.offlineSince ?? null,
-              }}
-              onOpenChat={() => navigate(`/?a=${agent.uuid}`)}
-              onTest={() => {
-                testMutation.reset();
-                testMutation.mutate();
-              }}
-              testPending={testMutation.isPending}
             />
           </SectionShell>
 
@@ -1270,6 +1248,45 @@ function ConfirmDialog(props: {
       </DialogContent>
     </Dialog>
   );
+}
+
+// ─── profile helpers ──────────────────────────────────────────────────
+
+/**
+ * Pick a short "bio" string to show below the agent's name. Falls through
+ * from the agent's description field (when present) to the first non-empty
+ * line of the prompt append (trimmed to ~180 chars so it never overruns the
+ * header). Returns null when nothing useful is available.
+ */
+function deriveTagline(agent: Agent, promptAppend: string | undefined): string | null {
+  const direct = extractString(agent as Record<string, unknown>, ["description", "bio"]);
+  if (direct) return truncate(direct, 200);
+  const meta = (agent as { metadata?: Record<string, unknown> }).metadata;
+  const treeMeta = meta?.tree as Record<string, unknown> | undefined;
+  const treeDesc = extractString(treeMeta, ["description", "summary"]);
+  if (treeDesc) return truncate(treeDesc, 200);
+  if (promptAppend) {
+    const firstLine = promptAppend
+      .split("\n")
+      .map((s) => s.trim())
+      .find((s) => s.length > 0);
+    if (firstLine) return truncate(firstLine, 200);
+  }
+  return null;
+}
+
+function extractString(obj: Record<string, unknown> | undefined, keys: string[]): string | null {
+  if (!obj) return null;
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1).trimEnd()}…`;
 }
 
 // ─── binding helpers ──────────────────────────────────────────────────

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -64,8 +64,12 @@ export function IdentitySection({ agent, onSave }: IdentitySectionProps) {
       <div className="px-4 py-3 text-body space-y-1">
         <div>
           <span className="font-mono">{agent.name ?? agent.uuid}</span>
-          <span className="mx-2 text-muted-foreground">·</span>
-          <span>{agent.displayName ?? <span className="text-muted-foreground italic">no display name</span>}</span>
+          {agent.displayName && (
+            <>
+              <span className="mx-2 text-muted-foreground">·</span>
+              <span>{agent.displayName}</span>
+            </>
+          )}
           {delegateLabel && (
             <>
               <span className="mx-2 text-muted-foreground">·</span>

--- a/packages/web/src/pages/agent-detail/overview-section.tsx
+++ b/packages/web/src/pages/agent-detail/overview-section.tsx
@@ -1,16 +1,14 @@
 import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
-import { MessageSquare, Play } from "lucide-react";
 import type { ReactNode } from "react";
-import { Button } from "../../components/ui/button.js";
-import { StateChip } from "../../components/ui/state-chip.js";
-import { formatDate } from "../../lib/utils.js";
 
 /**
- * Overview — the first section the operator sees. Surfaces the "who / what is
- * this agent" and "is it healthy right now" questions before the configuration
- * controls below. Identity editing keeps its own Dialog (IdentitySection) so
- * the SaveBar stays config-only; this component renders both the Profile card
- * and the Status & Health card side by side.
+ * Overview — the first section the operator sees below the ProfileHeader.
+ * Surfaces the "who / what is this agent" question. Status & health moved
+ * into the ProfileHeader (stats row + StateChip + Test button) so this
+ * section stays focused on Profile editing + Platform bindings.
+ *
+ * Identity editing keeps its own Dialog (IdentitySection) so the SaveBar
+ * stays config-only.
  */
 
 export type OverviewSectionProps = {
@@ -18,154 +16,14 @@ export type OverviewSectionProps = {
   profileSlot: ReactNode;
   /** Platform bindings panel (Panel component) — rendered inline inside the Profile card. */
   bindingsSlot?: ReactNode;
-  /** Everything the runtime panel needs to render, precomputed by the page. */
-  health: OverviewHealth;
   isHuman: boolean;
-  onOpenChat: () => void;
-  onTest?: () => void;
-  testPending?: boolean;
-};
-
-export type OverviewHealth = {
-  runtimeState: string | null;
-  runtimeKind: string | null;
-  computerLabel: string | null;
-  model: string;
-  activeSessions: number;
-  totalSessions: number | string;
-  /** ISO timestamp or null. */
-  lastActiveAt: string | null;
 };
 
 export function OverviewSection(props: OverviewSectionProps) {
-  const { agent, isHuman } = props;
   return (
     <div className="space-y-3">
       {props.profileSlot}
-
       {props.bindingsSlot}
-
-      <StatusHealthCard
-        state={props.health.runtimeState}
-        runtimeKind={props.health.runtimeKind ?? (isHuman ? "human" : "—")}
-        computerLabel={props.health.computerLabel}
-        model={props.health.model}
-        activeSessions={props.health.activeSessions}
-        totalSessions={props.health.totalSessions}
-        lastActiveAt={props.health.lastActiveAt}
-        agentActive={agent.status === "active"}
-        isHuman={isHuman}
-        onOpenChat={props.onOpenChat}
-        onTest={props.onTest}
-        testPending={props.testPending ?? false}
-      />
     </div>
-  );
-}
-
-function StatusHealthCard(props: {
-  state: string | null;
-  runtimeKind: string;
-  computerLabel: string | null;
-  model: string;
-  activeSessions: number;
-  totalSessions: number | string;
-  lastActiveAt: string | null;
-  agentActive: boolean;
-  isHuman: boolean;
-  onOpenChat: () => void;
-  onTest?: () => void;
-  testPending: boolean;
-}) {
-  return (
-    <section
-      style={{
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: 6,
-      }}
-    >
-      <header
-        className="flex items-center justify-between"
-        style={{ padding: "var(--sp-2_5) var(--sp-3_5)", borderBottom: "var(--hairline) solid var(--border-faint)" }}
-      >
-        <h3 className="inline-flex items-center gap-2 text-body font-semibold" style={{ color: "var(--fg)" }}>
-          Status &amp; health
-          <StateChip state={props.state} />
-        </h3>
-        <div className="flex gap-1.5">
-          <Button variant="ghost" size="xs" onClick={props.onOpenChat}>
-            <MessageSquare className="h-3 w-3" /> Open chat
-          </Button>
-          {!props.isHuman && props.agentActive && props.onTest && (
-            <Button variant="outline" size="xs" onClick={props.onTest} disabled={props.testPending}>
-              <Play className="h-3 w-3" />
-              {props.testPending ? "Testing…" : "Test"}
-            </Button>
-          )}
-        </div>
-      </header>
-      <div className="px-4 py-3 text-body grid gap-2" style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}>
-        <HealthRow label="Runs on" value={formatRunsOn(props.runtimeKind, props.computerLabel)} />
-        <HealthRow label="Model" value={<span className="mono">{props.model}</span>} />
-        <HealthRow
-          label="Sessions"
-          value={
-            <span className="mono tnum">
-              <span style={{ color: "var(--fg-2)" }}>{props.activeSessions}</span>
-              <span style={{ color: "var(--fg-4)" }}> / {props.totalSessions}</span>{" "}
-              <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-                active / total
-              </span>
-            </span>
-          }
-        />
-        <HealthRow
-          label="Last active"
-          value={
-            props.lastActiveAt ? (
-              <span className="mono text-label">{formatDate(props.lastActiveAt)}</span>
-            ) : (
-              <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-                —
-              </span>
-            )
-          }
-        />
-      </div>
-    </section>
-  );
-}
-
-function HealthRow({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div className="flex items-baseline gap-2">
-      <span className="text-caption shrink-0" style={{ color: "var(--fg-4)", minWidth: 86 }}>
-        {label}
-      </span>
-      <span className="min-w-0 truncate">{value}</span>
-    </div>
-  );
-}
-
-function formatRunsOn(runtimeKind: string, computerLabel: string | null): ReactNode {
-  if (!computerLabel) {
-    return (
-      <span>
-        <span className="mono">{runtimeKind}</span>{" "}
-        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          (no computer bound)
-        </span>
-      </span>
-    );
-  }
-  return (
-    <span>
-      <span className="mono">{runtimeKind}</span>{" "}
-      <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-        @
-      </span>{" "}
-      <span className="mono">{computerLabel}</span>
-    </span>
   );
 }

--- a/packages/web/src/pages/agent-detail/profile-header.tsx
+++ b/packages/web/src/pages/agent-detail/profile-header.tsx
@@ -1,0 +1,394 @@
+import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
+import { Bot, Cog, MessageCircle, MessageSquare, Play, Sparkles, Terminal, User, Users, Zap } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "../../components/ui/button.js";
+import { DenseBadge } from "../../components/ui/dense-badge.js";
+import { StateChip } from "../../components/ui/state-chip.js";
+import { formatDate } from "../../lib/utils.js";
+
+/**
+ * X-style ProfileHeader for the agent detail page. All data is pulled from
+ * fields the agent schema already exposes — no user customization, no extra
+ * backend work. Designed to gracefully degrade for Human agents (no runtime,
+ * no tool count) and to fall back to neutral styling when optional fields
+ * (description, owner, org, model, runtime) are missing.
+ *
+ * Runtime differentiation:
+ *  - Each runtime picks a single primary colour token. The banner blends that
+ *    token into a gradient and overlays a low-opacity diagonal-stripe pattern
+ *    for texture. The avatar disc uses the same token at a higher mix so the
+ *    avatar visually echoes the banner instead of clashing with it.
+ *  - The avatar icon itself differs per runtime (Sparkles / Terminal /
+ *    MessageCircle / Zap) so Claude and Codex — both green-leaning palettes —
+ *    still read as distinct at a glance.
+ */
+
+export type ProfileHeaderProps = {
+  agent: Agent;
+  runtimeState: string | null;
+  runtimeType: string | null;
+  ownerName: string | null;
+  orgLabel: string | null;
+  activeSessions: number;
+  /** Either a number (from the runtime) or string like "—" when unavailable. */
+  totalSessions: number | string;
+  /** Count of MCP servers configured (tools). Null when cfg hasn't loaded / human agent. */
+  toolsCount: number | null;
+  /** First line of the agent's description / bio. Null if absent. */
+  tagline: string | null;
+  isHuman: boolean;
+  onOpenChat: () => void;
+  onTest?: () => void;
+  testPending?: boolean;
+};
+
+export function ProfileHeader(props: ProfileHeaderProps) {
+  const { agent, isHuman } = props;
+  const runtimeKind = normalizeRuntime(props.runtimeType, isHuman);
+  const palette = RUNTIME_PALETTE[runtimeKind];
+  const handle = agent.name ?? agent.uuid.slice(0, 8);
+  // If displayName is empty OR equals the @handle, we skip the subtitle entirely
+  // to avoid "coder-agent / @coder-agent" double-print. The handle then becomes
+  // the primary heading.
+  const rawDisplay = (agent.displayName ?? "").trim();
+  const hasDistinctDisplayName = rawDisplay.length > 0 && rawDisplay !== handle;
+  const primaryTitle = hasDistinctDisplayName ? rawDisplay : `@${handle}`;
+  const initials = initialsFromName(hasDistinctDisplayName ? rawDisplay : handle);
+
+  return (
+    <section
+      style={{
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          height: 112,
+          background: `
+            repeating-linear-gradient(135deg,
+              color-mix(in oklab, ${palette.primary} 6%, transparent) 0 var(--sp-3),
+              transparent var(--sp-3) var(--sp-6)),
+            linear-gradient(135deg,
+              color-mix(in oklab, ${palette.primary} 55%, transparent),
+              color-mix(in oklab, ${palette.secondary} 32%, transparent))
+          `.replace(/\s+/g, " "),
+          borderBottom: "var(--hairline) solid var(--border-faint)",
+        }}
+      />
+      <div style={{ position: "relative", padding: "var(--sp-5) var(--sp-5) var(--sp-4)" }}>
+        <div
+          className="inline-flex items-center justify-center"
+          style={{
+            position: "absolute",
+            top: -40,
+            left: "var(--sp-5)",
+            width: 80,
+            height: 80,
+            borderRadius: "50%",
+            background: "var(--bg-raised)",
+            border: "var(--hairline-bold) solid var(--bg-raised)",
+            boxShadow: "0 0 0 var(--hairline) var(--border)",
+            overflow: "hidden",
+          }}
+        >
+          <Avatar runtimeKind={runtimeKind} isHuman={isHuman} initials={initials} />
+        </div>
+
+        <div className="flex items-start justify-between gap-3" style={{ marginLeft: 96, minHeight: 48 }}>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className={hasDistinctDisplayName ? "text-title" : "mono text-title"} style={{ color: "var(--fg)" }}>
+                {primaryTitle}
+              </h1>
+              <BadgeCluster agent={agent} runtimeState={props.runtimeState} isHuman={isHuman} />
+            </div>
+            {hasDistinctDisplayName && (
+              <div className="mono text-label" style={{ color: "var(--fg-4)" }}>
+                @{handle}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <StateChip state={props.runtimeState} />
+            <Button variant="ghost" size="xs" onClick={props.onOpenChat}>
+              <MessageSquare className="h-3 w-3" /> Open chat
+            </Button>
+            {!isHuman && agent.status === "active" && props.onTest && (
+              <Button variant="outline" size="xs" onClick={props.onTest} disabled={props.testPending}>
+                <Play className="h-3 w-3" />
+                {props.testPending ? "Testing…" : "Test"}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {props.tagline && (
+          <p className="text-body" style={{ marginTop: "var(--sp-2_5)", color: "var(--fg-2)", maxWidth: 720 }}>
+            {props.tagline}
+          </p>
+        )}
+
+        <MetaRow agent={props.agent} ownerName={props.ownerName} orgLabel={props.orgLabel} />
+
+        <StatsRow
+          activeSessions={props.activeSessions}
+          totalSessions={props.totalSessions}
+          toolsCount={props.toolsCount}
+          isHuman={isHuman}
+        />
+      </div>
+    </section>
+  );
+}
+
+/* ---------- sub-components ---------- */
+
+function BadgeCluster({
+  agent,
+  runtimeState,
+  isHuman,
+}: {
+  agent: Agent;
+  runtimeState: string | null;
+  isHuman: boolean;
+}) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      <DenseBadge tone={agent.type === "autonomous_agent" ? "accent" : "neutral"}>{agent.type}</DenseBadge>
+      {isHuman ? (
+        <DenseBadge tone="outline">
+          <span className="inline-flex items-center gap-1">
+            <User className="h-3 w-3" aria-hidden />
+            human
+          </span>
+        </DenseBadge>
+      ) : (
+        <DenseBadge tone="outline">
+          <span className="inline-flex items-center gap-1">
+            <Bot className="h-3 w-3" aria-hidden />
+            automated
+          </span>
+        </DenseBadge>
+      )}
+      {agent.status !== "active" && (
+        <DenseBadge tone={agent.status === "suspended" ? "warn" : "outline"}>{agent.status}</DenseBadge>
+      )}
+      {runtimeState === "error" && <DenseBadge tone="error">runtime error</DenseBadge>}
+      {agent.visibility && (
+        <DenseBadge tone={agent.visibility === "organization" ? "accent" : "outline"}>{agent.visibility}</DenseBadge>
+      )}
+    </span>
+  );
+}
+
+type MetaItemDef = { key: string; icon: ReactNode; body: ReactNode };
+
+function MetaRow(props: { agent: Agent; ownerName: string | null; orgLabel: string | null }) {
+  // After the ContextBar takeover, ProfileHeader's Meta only carries identity
+  // facts (joined / owner / org) — Runs on + Model live in the sticky bar.
+  const items: MetaItemDef[] = [];
+  items.push({
+    key: "created",
+    icon: <Cog className="h-3 w-3" aria-hidden />,
+    body: (
+      <>
+        Joined <span style={{ color: "var(--fg-2)" }}>{formatDate(props.agent.createdAt)}</span>
+      </>
+    ),
+  });
+  if (props.ownerName) {
+    items.push({
+      key: "owner",
+      icon: <User className="h-3 w-3" aria-hidden />,
+      body: (
+        <>
+          Owner <span style={{ color: "var(--fg-2)" }}>{props.ownerName}</span>
+        </>
+      ),
+    });
+  }
+  if (props.orgLabel) {
+    items.push({
+      key: "org",
+      icon: <Users className="h-3 w-3" aria-hidden />,
+      body: <span style={{ color: "var(--fg-2)" }}>{props.orgLabel}</span>,
+    });
+  }
+  return (
+    <div
+      className="flex flex-wrap items-center text-label"
+      style={{ marginTop: "var(--sp-2_5)", color: "var(--fg-3)", rowGap: "var(--sp-1)" }}
+    >
+      {items.map((it, idx) => (
+        <span key={it.key} className="inline-flex items-center">
+          {idx > 0 && (
+            <span style={{ color: "var(--fg-4)", margin: "0 var(--sp-2)" }} aria-hidden>
+              ·
+            </span>
+          )}
+          <MetaItem icon={it.icon}>{it.body}</MetaItem>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function MetaItem({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {icon}
+      {children}
+    </span>
+  );
+}
+
+function StatsRow(props: {
+  activeSessions: number;
+  totalSessions: number | string;
+  toolsCount: number | null;
+  isHuman: boolean;
+}) {
+  const tiles: Array<{ key: string; label: string; value: ReactNode }> = [];
+  // Sessions: when total isn't a real number we collapse to a single value
+  // ("0 Sessions") rather than render "0 / —", which read as "an error".
+  const totalIsNumber = typeof props.totalSessions === "number";
+  tiles.push({
+    key: "sessions",
+    label: "Sessions",
+    value: totalIsNumber ? (
+      <span className="mono tnum">
+        <span style={{ color: "var(--fg)" }}>{props.activeSessions}</span>
+        <span style={{ color: "var(--fg-4)" }}> / {props.totalSessions}</span>
+      </span>
+    ) : (
+      <span className="mono tnum" style={{ color: "var(--fg)" }}>
+        {props.activeSessions}
+      </span>
+    ),
+  });
+  if (!props.isHuman && props.toolsCount != null && props.toolsCount > 0) {
+    tiles.push({
+      key: "tools",
+      label: "Tools",
+      value: <span className="mono tnum">{props.toolsCount}</span>,
+    });
+  }
+  return (
+    <div
+      className="flex flex-wrap items-baseline text-label"
+      style={{ marginTop: "var(--sp-3)", gap: "var(--sp-5)", color: "var(--fg-3)" }}
+    >
+      {tiles.map((t) => (
+        <span key={t.key} className="inline-flex items-baseline gap-1.5">
+          <span>{t.value}</span>
+          <span style={{ color: "var(--fg-4)" }}>{t.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ---------- avatar ---------- */
+
+function Avatar({ runtimeKind, isHuman, initials }: { runtimeKind: RuntimeKind; isHuman: boolean; initials: string }) {
+  const palette = RUNTIME_PALETTE[runtimeKind];
+  if (isHuman) {
+    return (
+      <span
+        role="img"
+        aria-label="Human agent avatar"
+        className="inline-flex items-center justify-center mono font-semibold text-subtitle"
+        style={{
+          width: "100%",
+          height: "100%",
+          background: `color-mix(in oklab, ${palette.primary} 18%, var(--bg-active))`,
+          color: `color-mix(in oklab, ${palette.primary} 70%, var(--fg-2))`,
+          letterSpacing: "var(--sp-0_25)",
+        }}
+      >
+        {initials}
+      </span>
+    );
+  }
+  const RuntimeIcon = RUNTIME_ICONS[runtimeKind];
+  return (
+    <span
+      role="img"
+      aria-label={`${RUNTIME_LABELS[runtimeKind]} agent avatar`}
+      className="inline-flex items-center justify-center"
+      style={{
+        width: "100%",
+        height: "100%",
+        background: `color-mix(in oklab, ${palette.primary} 32%, var(--bg-raised))`,
+        color: `color-mix(in oklab, ${palette.primary} 70%, var(--fg))`,
+      }}
+    >
+      <RuntimeIcon style={{ width: 34, height: 34 }} aria-hidden />
+    </span>
+  );
+}
+
+/* ---------- runtime mapping ---------- */
+
+type RuntimeKind = "claude-code" | "kael" | "codex" | "gpt" | "unknown";
+
+const RUNTIME_LABELS: Record<RuntimeKind, string> = {
+  "claude-code": "Claude Code",
+  kael: "Kael",
+  codex: "Codex",
+  gpt: "GPT",
+  unknown: "—",
+};
+
+/**
+ * Single primary / secondary color per runtime. Both the banner gradient and
+ * the avatar disc derive from the primary so they always echo each other; the
+ * secondary just adds direction to the banner gradient.
+ */
+type RuntimePalette = { primary: string; secondary: string };
+
+const RUNTIME_PALETTE: Record<RuntimeKind, RuntimePalette> = {
+  "claude-code": { primary: "var(--accent)", secondary: "var(--state-working)" },
+  kael: { primary: "var(--state-blocked)", secondary: "var(--accent)" },
+  codex: { primary: "var(--state-working)", secondary: "var(--state-idle)" },
+  gpt: { primary: "var(--state-idle)", secondary: "var(--accent)" },
+  unknown: { primary: "var(--border-strong)", secondary: "var(--fg-3)" },
+};
+
+/** Lucide icon per runtime. Keeps Claude vs Codex visually distinct even
+ * though both palettes lean green. */
+const RUNTIME_ICONS: Record<RuntimeKind, typeof Bot> = {
+  "claude-code": Sparkles,
+  kael: Zap,
+  codex: Terminal,
+  gpt: MessageCircle,
+  unknown: Bot,
+};
+
+function normalizeRuntime(raw: string | null, isHuman: boolean): RuntimeKind {
+  if (isHuman) return "unknown";
+  if (!raw) return "claude-code"; // Hub's only shipping runtime today; "no runtime known" still implies Claude Code.
+  const v = raw.toLowerCase();
+  if (v.includes("claude")) return "claude-code";
+  if (v.includes("kael")) return "kael";
+  if (v.includes("codex")) return "codex";
+  if (v.includes("gpt")) return "gpt";
+  return "unknown";
+}
+
+function initialsFromName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length === 0) return trimmed.slice(0, 2).toUpperCase();
+  const first = parts[0] ?? "";
+  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+  const last = parts[parts.length - 1] ?? "";
+  const a = first.charAt(0);
+  const b = last.charAt(0);
+  return `${a}${b}`.toUpperCase() || "?";
+}


### PR DESCRIPTION
## Summary

Adds a profile-style header to the top of the agent detail page — banner gradient, circular avatar, display name / `@handle` with a badge cluster, optional tagline, identity meta row, and a slim stats strip — so every agent has a visible identity before the operator even scrolls into the configuration sections.

Handoff: ProfileHeader ticket from analyst-agent (X-style personalization). Stacks on top of #163.

### Runtime differentiation

- Each runtime picks a single primary colour token. The banner combines that token with a subtle `repeating-linear-gradient` stripe overlay for texture; the avatar disc derives from the same token so they echo instead of clash.
- Avatar icon also varies per runtime (`Sparkles` / `Terminal` / `MessageCircle` / `Zap`) so Claude Code and Codex — both green-leaning palettes — stay distinguishable at a glance.
- All `color-mix` calls use `in oklab` rather than `in oklch`. Oklch interpolates hue via the shortest path, so mixing green (hue 150) with white (explicit hue 0) crossed through orange at typical mix percentages and produced peach-tinted avatars; oklab uses a/b axes and avoids the wraparound.

### Graceful degradation

- **Human agents** — neutral gray palette, initials instead of an icon, no runs-on / model in the meta row, Tools count hidden from stats.
- **Missing optional fields** — `description`, `owner`, `org`, `model`, `tagline` all independently droppable; layout stays stable when any is absent.
- **`displayName === handle` or empty** — title falls back to `@handle` in mono style, no duplicate subtitle.
- **Non-numeric `totalSessions`** — stats collapse to a single `N Sessions` label instead of `N / —`.

### Layout cleanup

- Removed the old page-header logo + 4-tile row; the breadcrumb now sits alone above the ProfileHeader.
- `OverviewSection` shrinks to Profile + Platform bindings; the previous Status & Health card folds into the ProfileHeader stats row, and the existing sticky ContextBar keeps `Runs on <runtime> @ …` visible at every scroll depth.
- `IdentitySection` drops its "no display name" placeholder row since the ProfileHeader already makes name state obvious.

### Constraints kept

- No new dependencies (all icons are lucide, already in use).
- Design tokens only; design-token guardrail lint passes.
- No backend schema / API changes; no user-editable customization.
- Compatible with #163's 6-anchor sidebar / ContextBar / SaveBar.

## Test plan

- [x] `pnpm check` (biome, 455 files)
- [x] `pnpm typecheck` (tsc + design-token guardrails)
- [x] Puppeteer screenshots verified by owner before commit (Human `gandy-view` + autonomous `analyst-agent` / `coder-agent`)
- [ ] CI (biome + typecheck + build) green on this PR

> **Note on base branch**: this PR is stacked on `feat/agent-detail-restructure` (#163). Once #163 merges, GitHub will auto-rebase this one onto `main`; alternatively reviewers can rebase manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)