### PR TITLE
feat(marketing): MVP landing site with Hero + Agent Gallery

### DIFF
--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="First Tree Hub — team infrastructure for AI agents. Register, message, and manage agents across runtimes and platforms." />
+    <meta name="theme-color" content="#0a0e1a" />
+    <title>First Tree Hub · Team infrastructure for AI agents</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@first-tree-hub/marketing",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "lucide-react": "^0.577.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router": "^7.13.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "vite": "^6.3.0"
+  }
+}

--- a/apps/marketing/src/content/agents.ts
+++ b/apps/marketing/src/content/agents.ts
@@ -1,0 +1,96 @@
+/**
+ * Hand-authored cards for the Agent Gallery. MVP is intentionally **not**
+ * wired to any live DB — the marketing site must work without a Hub server
+ * running, and the personas we feature here (analyst / coder /
+ * gandy-assistant) are stable team identities, not a reflection of an
+ * arbitrary org's roster.
+ *
+ * All three cards report runtime = "claude-code" because that's the truth
+ * today — Claude Code is the Hub's only shipping runtime. Visual variety
+ * between the cards comes from the per-card `accentHue` (a small hue shift
+ * within the cyan family) and the distinct lucide icon, not from inventing
+ * runtimes the project doesn't actually integrate with yet.
+ */
+
+import { MessageCircle, Sparkles, Terminal } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+
+export type AgentCard = {
+  /** Machine handle, rendered as `@handle`. */
+  handle: string;
+  /** Human-facing title. */
+  displayName: string;
+  /** Runtime — always Claude Code today. Left as a field so Kael / future
+   *  runtimes drop in without restructuring the card. */
+  runtime: "claude-code";
+  /** Hue (oklch degrees) used to differentiate this card's banner + avatar
+   *  within the Claude Code palette. Keep values in the 185–235 range so
+   *  everything still reads as cyan family. */
+  accentHue: number;
+  /** Role chip. */
+  role: string;
+  /** One-line tagline rendered under the avatar. */
+  tagline: string;
+  /** Hover-revealed bullets ("what I do"). Keep each under ~80 chars. */
+  whatIDo: readonly string[];
+  /** Example short exchange shown inside the hover panel. Two messages. */
+  sample: { from: string; body: string }[];
+  Icon: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+export const AGENTS: readonly AgentCard[] = [
+  {
+    handle: "analyst-agent",
+    displayName: "Analyst",
+    runtime: "claude-code",
+    accentHue: 210,
+    role: "Planner / product lead",
+    tagline: "Turns a vague ask into a sharp handoff ticket the rest of the team can execute.",
+    whatIDo: [
+      "Clarifies scope, acceptance criteria, and out-of-scope.",
+      "Produces trackable tickets with acceptance checks.",
+      "Mediates between humans and executor agents.",
+    ],
+    sample: [
+      { from: "gandy", body: "add an X-style header to the agent detail page" },
+      { from: "analyst", body: "6 sections, ProfileHeader, Human-agent fallback — handoff ticket 👇" },
+    ],
+    Icon: Sparkles,
+  },
+  {
+    handle: "coder-agent",
+    displayName: "Coder",
+    runtime: "claude-code",
+    accentHue: 195,
+    role: "Implementation",
+    tagline: "Ships the code: branches, tests, PRs, and screenshots before you ask for them.",
+    whatIDo: [
+      "Writes code against handoffs, runs `pnpm check + typecheck`.",
+      "Captures puppeteer screenshots for UI work.",
+      "Opens PRs with Conventional Commits.",
+    ],
+    sample: [
+      { from: "analyst", body: "ticket: ProfileHeader v2 — 7 fixes" },
+      { from: "coder", body: "shipped 🟢 PR #165, screenshots at /tmp/screenshot-agent/out/" },
+    ],
+    Icon: Terminal,
+  },
+  {
+    handle: "gandy-assistant",
+    displayName: "Assistant",
+    runtime: "claude-code",
+    accentHue: 230,
+    role: "Your personal delegate",
+    tagline: "Reads your inbox, drafts replies, files tasks. One mention = the team gets involved.",
+    whatIDo: [
+      "Routes messages to the right agent via @mentions.",
+      "Keeps track of open threads across Slack / Feishu.",
+      "Surfaces decisions that need a human.",
+    ],
+    sample: [
+      { from: "gandy", body: "what's pending today?" },
+      { from: "assistant", body: "2 PRs waiting review · 1 routine firing 2026-05-08" },
+    ],
+    Icon: MessageCircle,
+  },
+];

--- a/apps/marketing/src/content/links.ts
+++ b/apps/marketing/src/content/links.ts
@@ -1,0 +1,11 @@
+/**
+ * Central place for outbound links. Hardcoded for the MVP — wire these
+ * against real docs / quickstart URLs when they land. Every nav entry,
+ * CTA, and footer link pulls from here so rename-once applies everywhere.
+ */
+export const LINKS = {
+  repo: "https://github.com/agent-team-foundation/first-tree-hub",
+  docs: "https://github.com/agent-team-foundation/first-tree-hub#readme",
+  quickstart: "https://github.com/agent-team-foundation/first-tree-hub#common-commands",
+  cliReference: "https://github.com/agent-team-foundation/first-tree-hub/blob/main/docs/cli-reference.md",
+} as const;

--- a/apps/marketing/src/index.css
+++ b/apps/marketing/src/index.css
@@ -1,0 +1,167 @@
+/*
+ * Marketing site design tokens — intentionally **independent** from the
+ * dashboard palette in packages/web/. Dashboard stays green-teal; marketing
+ * is deep indigo + cyan + violet to land a distinct "tech product" feel
+ * when linking out to the GitHub project.
+ *
+ * All colour tokens use oklch so runtime theme shifts stay perceptually even.
+ * color-mix against these tokens MUST be done with `in oklab` (not oklch)
+ * to avoid hue wraparound — see the dashboard ProfileHeader fix for context.
+ */
+
+:root {
+  color-scheme: dark;
+
+  /* brand palette */
+  --m-bg: oklch(0.16 0.03 270);
+  --m-bg-raised: oklch(0.2 0.035 270);
+  --m-bg-sunken: oklch(0.13 0.025 270);
+  --m-bg-hover: oklch(0.24 0.04 270);
+  --m-border: oklch(0.32 0.04 270);
+  --m-border-strong: oklch(0.42 0.05 265);
+  --m-border-faint: oklch(0.26 0.035 270);
+
+  --m-fg: oklch(0.97 0.01 230);
+  --m-fg-2: oklch(0.82 0.015 230);
+  --m-fg-3: oklch(0.64 0.02 240);
+  --m-fg-4: oklch(0.48 0.03 250);
+
+  --m-accent: oklch(0.82 0.15 210);
+  --m-accent-dim: oklch(0.68 0.13 210);
+  --m-accent-soft: oklch(0.82 0.15 210 / 0.14);
+
+  --m-violet: oklch(0.72 0.22 300);
+  --m-violet-soft: oklch(0.72 0.22 300 / 0.2);
+
+  --m-danger: oklch(0.68 0.22 25);
+  --m-success: oklch(0.78 0.17 150);
+
+  /* spacing scale — minimal subset, marketing doesn't need the full
+   * dashboard system */
+  --m-sp-1: 0.25rem;
+  --m-sp-2: 0.5rem;
+  --m-sp-3: 0.75rem;
+  --m-sp-4: 1rem;
+  --m-sp-5: 1.25rem;
+  --m-sp-6: 1.5rem;
+  --m-sp-8: 2rem;
+  --m-sp-12: 3rem;
+  --m-sp-16: 4rem;
+  --m-sp-20: 5rem;
+
+  --m-radius: 12px;
+  --m-radius-lg: 20px;
+  --m-hairline: 1px;
+
+  --m-shell: 1120px;
+
+  /* body */
+  --m-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif;
+  --m-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--m-bg);
+  color: var(--m-fg);
+  font-family: var(--m-font);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  /* subtle star-field / grid texture to lift the flat background */
+  background-image:
+    radial-gradient(circle at 15% 18%, color-mix(in oklab, var(--m-accent) 14%, transparent) 0, transparent 38%),
+    radial-gradient(circle at 85% 4%, color-mix(in oklab, var(--m-violet) 12%, transparent) 0, transparent 42%),
+    linear-gradient(to bottom, color-mix(in oklab, var(--m-bg-raised) 35%, var(--m-bg)) 0%, var(--m-bg) 28%);
+  background-repeat: no-repeat;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+/* ---- shared utilities ---- */
+
+.m-shell {
+  max-width: var(--m-shell);
+  margin-inline: auto;
+  padding-inline: var(--m-sp-6);
+}
+
+.m-eyebrow {
+  font-family: var(--m-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--m-fg-4);
+}
+
+.m-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--m-sp-2);
+  padding: var(--m-sp-3) var(--m-sp-5);
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 14px;
+  border: var(--m-hairline) solid transparent;
+  transition:
+    transform 140ms ease,
+    background 140ms ease,
+    border-color 140ms ease;
+}
+
+.m-btn:hover {
+  transform: translateY(-1px);
+}
+
+.m-btn--primary {
+  background: var(--m-accent);
+  color: var(--m-bg);
+  border-color: var(--m-accent);
+}
+
+.m-btn--primary:hover {
+  background: color-mix(in oklab, var(--m-accent) 85%, var(--m-fg));
+}
+
+.m-btn--ghost {
+  background: transparent;
+  color: var(--m-fg-2);
+  border-color: var(--m-border);
+}
+
+.m-btn--ghost:hover {
+  background: var(--m-bg-hover);
+  border-color: var(--m-border-strong);
+}
+
+/* scroll-reveal animation hook */
+.m-reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 600ms ease,
+    transform 600ms ease;
+}
+
+.m-reveal[data-visible="true"] {
+  opacity: 1;
+  transform: none;
+}

--- a/apps/marketing/src/lib/use-reveal.ts
+++ b/apps/marketing/src/lib/use-reveal.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Tiny IntersectionObserver hook — sets `data-visible="true"` on the target
+ * the first time it enters the viewport, which the `.m-reveal` CSS class
+ * uses to fade + slide in. No motion library needed.
+ */
+export function useReveal<T extends HTMLElement>(): React.RefObject<T | null> {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            (entry.target as HTMLElement).dataset.visible = "true";
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.15 },
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, []);
+  return ref;
+}

--- a/apps/marketing/src/main.tsx
+++ b/apps/marketing/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter, Route, Routes } from "react-router";
+import { LandingPage } from "./pages/landing.js";
+import "./index.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("root element missing");
+
+// Base path aligns with vite.config.ts so GitHub Pages routing works.
+const BASENAME = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter basename={BASENAME || "/"}>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+      </Routes>
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/apps/marketing/src/pages/landing.tsx
+++ b/apps/marketing/src/pages/landing.tsx
@@ -1,0 +1,20 @@
+import { AgentGallery } from "../sections/agent-gallery.js";
+import { Hero } from "../sections/hero.js";
+import { StickyNav } from "../sections/sticky-nav.js";
+
+/**
+ * Single-route marketing landing page. MVP ships Hero + Agent Gallery;
+ * later sections (Architecture, How-it-works, Features, Community, Footer)
+ * layer in behind feature-branches without changing this file's shape.
+ */
+export function LandingPage() {
+  return (
+    <>
+      <StickyNav />
+      <main>
+        <Hero />
+        <AgentGallery />
+      </main>
+    </>
+  );
+}

--- a/apps/marketing/src/sections/agent-gallery.tsx
+++ b/apps/marketing/src/sections/agent-gallery.tsx
@@ -1,0 +1,265 @@
+import { useState } from "react";
+import { AGENTS, type AgentCard } from "../content/agents.js";
+import { useReveal } from "../lib/use-reveal.js";
+
+/**
+ * "Meet the team" — three ProfileHeader-style cards (banner / avatar /
+ * badges / tagline) with a hover panel that reveals "what I do" + a two-line
+ * sample exchange. Keyboard users get the same reveal via focus.
+ */
+export function AgentGallery() {
+  const ref = useReveal<HTMLDivElement>();
+  return (
+    <section id="agents" style={{ paddingBlock: "var(--m-sp-16)" }}>
+      <div className="m-shell">
+        <div className="m-reveal" ref={ref}>
+          <span className="m-eyebrow" style={{ color: "var(--m-violet)" }}>
+            ◈ meet the team
+          </span>
+          <h2
+            style={{
+              fontSize: "clamp(28px, 3vw, 38px)",
+              letterSpacing: "-0.02em",
+              fontWeight: 600,
+              marginTop: "var(--m-sp-3)",
+              marginBottom: "var(--m-sp-3)",
+            }}
+          >
+            Agents that actually talk to each other.
+          </h2>
+          <p style={{ color: "var(--m-fg-3)", maxWidth: 640, marginBottom: "var(--m-sp-8)", lineHeight: 1.55 }}>
+            Every agent registered with First Tree Hub gets a stable identity, an inbox, and a handle. Hover a card to
+            see how this team breaks down a request end-to-end.
+          </p>
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            gap: "var(--m-sp-5)",
+          }}
+        >
+          {AGENTS.map((a) => (
+            <AgentCardView key={a.handle} agent={a} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ---------- per-card ---------- */
+
+const RUNTIME_LABEL: Record<AgentCard["runtime"], string> = {
+  "claude-code": "Claude Code",
+};
+
+/**
+ * Each card gets a unique banner / avatar colour derived from its
+ * `accentHue` (oklch degrees). We stay inside the cyan family — chroma
+ * fixed, hue shifting by ±10° — so every agent still visually belongs to
+ * the same runtime without any of them looking identical.
+ */
+function cardPalette(hue: number): { primary: string; secondary: string; shadow: string } {
+  return {
+    primary: `oklch(0.82 0.15 ${hue})`,
+    secondary: `oklch(0.72 0.22 ${hue + 30})`, // nudge toward violet side for the gradient tail
+    shadow: `oklch(0.78 0.18 ${hue})`,
+  };
+}
+
+function AgentCardView({ agent }: { agent: AgentCard }) {
+  const ref = useReveal<HTMLElement>();
+  const [expanded, setExpanded] = useState(false);
+  const palette = cardPalette(agent.accentHue);
+  const runtimeLabel = RUNTIME_LABEL[agent.runtime];
+  const Icon = agent.Icon;
+
+  return (
+    <article
+      ref={ref}
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+      className="m-reveal"
+      style={{
+        position: "relative",
+        background: "var(--m-bg-raised)",
+        border: "var(--m-hairline) solid var(--m-border)",
+        borderRadius: "var(--m-radius-lg)",
+        overflow: "hidden",
+        transition: "transform 200ms ease, border-color 200ms ease, box-shadow 200ms ease",
+        transform: expanded ? "translateY(-4px)" : "none",
+        boxShadow: expanded
+          ? `0 20px 60px -20px color-mix(in oklab, ${palette.shadow} 55%, transparent)`
+          : "0 4px 18px -10px color-mix(in oklab, var(--m-bg-sunken) 100%, transparent)",
+        borderColor: expanded ? `color-mix(in oklab, ${palette.primary} 55%, var(--m-border))` : "var(--m-border)",
+        cursor: "pointer",
+        outline: "none",
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          height: 96,
+          background: `
+            repeating-linear-gradient(135deg,
+              color-mix(in oklab, ${palette.primary} 14%, transparent) 0 10px,
+              transparent 10px 20px),
+            linear-gradient(135deg,
+              color-mix(in oklab, ${palette.primary} 55%, transparent),
+              color-mix(in oklab, ${palette.secondary} 32%, transparent))
+          `.replace(/\s+/g, " "),
+        }}
+      />
+      <div style={{ position: "relative", padding: "var(--m-sp-5)" }}>
+        <span
+          role="img"
+          aria-label={`${runtimeLabel} agent avatar`}
+          style={{
+            position: "absolute",
+            top: -38,
+            left: "var(--m-sp-5)",
+            width: 72,
+            height: 72,
+            borderRadius: "50%",
+            background: `color-mix(in oklab, ${palette.primary} 30%, var(--m-bg-raised))`,
+            border: "3px solid var(--m-bg-raised)",
+            boxShadow: "0 0 0 1px var(--m-border)",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: `color-mix(in oklab, ${palette.primary} 75%, var(--m-fg))`,
+          }}
+        >
+          <Icon width={30} height={30} aria-hidden />
+        </span>
+
+        <div style={{ marginLeft: 88 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: "var(--m-sp-2)", flexWrap: "wrap" }}>
+            <span style={{ fontSize: 20, fontWeight: 600 }}>{agent.displayName}</span>
+            <span
+              style={{
+                fontFamily: "var(--m-font-mono)",
+                fontSize: 12,
+                color: "var(--m-fg-4)",
+              }}
+            >
+              @{agent.handle}
+            </span>
+          </div>
+          <div style={{ display: "flex", gap: "var(--m-sp-2)", marginTop: 6, flexWrap: "wrap" }}>
+            <Pill tone="accent">{runtimeLabel}</Pill>
+            <Pill tone="violet">{agent.role}</Pill>
+          </div>
+        </div>
+
+        <p
+          style={{
+            marginTop: "var(--m-sp-4)",
+            color: "var(--m-fg-2)",
+            fontSize: 14,
+            lineHeight: 1.55,
+            minHeight: 44,
+          }}
+        >
+          {agent.tagline}
+        </p>
+
+        <div
+          style={{
+            marginTop: "var(--m-sp-3)",
+            borderTop: "var(--m-hairline) solid var(--m-border-faint)",
+            paddingTop: "var(--m-sp-4)",
+            display: "grid",
+            gap: "var(--m-sp-3)",
+            maxHeight: expanded ? 340 : 0,
+            opacity: expanded ? 1 : 0,
+            overflow: "hidden",
+            transition: "max-height 260ms ease, opacity 260ms ease",
+          }}
+        >
+          <div>
+            <div className="m-eyebrow" style={{ marginBottom: "var(--m-sp-2)", color: "var(--m-fg-4)" }}>
+              What I do
+            </div>
+            <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: 6 }}>
+              {agent.whatIDo.map((line) => (
+                <li
+                  key={line}
+                  style={{
+                    fontSize: 13,
+                    color: "var(--m-fg-2)",
+                    paddingLeft: 16,
+                    position: "relative",
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      position: "absolute",
+                      left: 0,
+                      top: 7,
+                      width: 6,
+                      height: 6,
+                      borderRadius: 999,
+                      background: palette.primary,
+                    }}
+                  />
+                  {line}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <div className="m-eyebrow" style={{ marginBottom: "var(--m-sp-2)", color: "var(--m-fg-4)" }}>
+              Sample exchange
+            </div>
+            <div
+              style={{
+                background: "var(--m-bg-sunken)",
+                border: "var(--m-hairline) solid var(--m-border-faint)",
+                borderRadius: "var(--m-radius)",
+                padding: "var(--m-sp-3)",
+                display: "grid",
+                gap: 6,
+                fontFamily: "var(--m-font-mono)",
+                fontSize: 12,
+              }}
+            >
+              {agent.sample.map((line) => (
+                <div key={`${agent.handle}-${line.from}`} style={{ color: "var(--m-fg-2)", lineHeight: 1.5 }}>
+                  <span style={{ color: "var(--m-accent-dim)" }}>@{line.from}:</span> {line.body}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Pill({ tone, children }: { tone: "accent" | "violet"; children: React.ReactNode }) {
+  const color = tone === "accent" ? "var(--m-accent)" : "var(--m-violet)";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        fontSize: 11,
+        fontFamily: "var(--m-font-mono)",
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        color: color,
+        background: `color-mix(in oklab, ${color} 14%, transparent)`,
+        border: `var(--m-hairline) solid color-mix(in oklab, ${color} 40%, transparent)`,
+        borderRadius: 999,
+        padding: "2px 10px",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/marketing/src/sections/hero.tsx
+++ b/apps/marketing/src/sections/hero.tsx
@@ -1,0 +1,167 @@
+import { BookOpen, Github, Terminal } from "lucide-react";
+import { LINKS } from "../content/links.js";
+import { useReveal } from "../lib/use-reveal.js";
+
+// MVP: the stats strip is intentionally **not rendered** yet. This project is
+// brand new and any hand-picked number would read as marketing fluff to the
+// developer audience we're trying to pull. The component + constants stay in
+// the file so the follow-up — wiring `/api/v1/public/stats` into the strip —
+// is a one-line re-enable inside the Hero JSX plus a fetch hook.
+// TODO(live): hit /api/v1/public/stats and render <StatsStrip /> with real data.
+type Stat = { label: string; value: string };
+const SHOW_STATS_STRIP = false; // flip to true once the public endpoint lands
+const STATS: Stat[] = [
+  { label: "Agents registered", value: "—" },
+  { label: "Organizations", value: "—" },
+  { label: "Sessions (24h)", value: "—" },
+  { label: "Runtimes supported", value: "—" },
+];
+
+export function Hero() {
+  const ref = useReveal<HTMLDivElement>();
+  return (
+    <section id="top" style={{ paddingBlock: "var(--m-sp-20) var(--m-sp-16)" }}>
+      <div className="m-shell m-reveal" ref={ref}>
+        <span className="m-eyebrow" style={{ color: "var(--m-accent-dim)" }}>
+          ◇ Open source · infrastructure for agent teams
+        </span>
+        <h1
+          style={{
+            fontSize: "clamp(40px, 5.5vw, 68px)",
+            fontWeight: 600,
+            lineHeight: 1.05,
+            letterSpacing: "-0.03em",
+            marginTop: "var(--m-sp-4)",
+            marginBottom: "var(--m-sp-4)",
+            background: "linear-gradient(120deg, var(--m-fg) 0%, var(--m-accent) 45%, var(--m-violet) 95%)",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+            backgroundClip: "text",
+          }}
+        >
+          The team of agents
+          <br />
+          your team is missing.
+        </h1>
+
+        <p
+          style={{
+            fontSize: "clamp(17px, 1.6vw, 20px)",
+            lineHeight: 1.55,
+            maxWidth: 640,
+            color: "var(--m-fg-3)",
+            marginBottom: "var(--m-sp-8)",
+          }}
+        >
+          First Tree Hub is the open-source spine for coordinating AI agents — register them, message them, wire them
+          into Slack / Feishu, and manage everything from one dashboard. Postgres only. JWT only. No hidden magic.
+        </p>
+
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--m-sp-3)" }}>
+          <a href={LINKS.repo} target="_blank" rel="noreferrer" className="m-btn m-btn--primary">
+            <Github size={16} />
+            Star on GitHub
+          </a>
+          <a href={LINKS.quickstart} target="_blank" rel="noreferrer" className="m-btn m-btn--ghost">
+            <Terminal size={16} />
+            Quickstart
+          </a>
+          <a href={LINKS.docs} target="_blank" rel="noreferrer" className="m-btn m-btn--ghost">
+            <BookOpen size={16} />
+            Docs
+          </a>
+        </div>
+
+        {SHOW_STATS_STRIP && <StatsStrip />}
+      </div>
+
+      <HeroGlow />
+    </section>
+  );
+}
+
+function StatsStrip() {
+  return (
+    <div
+      style={{
+        marginTop: "var(--m-sp-12)",
+        display: "grid",
+        gridTemplateColumns: `repeat(${STATS.length}, minmax(0, 1fr))`,
+        gap: "var(--m-sp-1)",
+        border: "var(--m-hairline) solid var(--m-border)",
+        borderRadius: "var(--m-radius-lg)",
+        background: "color-mix(in oklab, var(--m-bg-raised) 80%, transparent)",
+        padding: "var(--m-sp-4)",
+        backdropFilter: "blur(8px)",
+      }}
+    >
+      {STATS.map((s, i) => (
+        <div
+          key={s.label}
+          style={{
+            padding: "var(--m-sp-3) var(--m-sp-4)",
+            borderLeft: i === 0 ? "none" : "var(--m-hairline) solid var(--m-border-faint)",
+          }}
+        >
+          <div
+            className="m-mono"
+            style={{
+              fontFamily: "var(--m-font-mono)",
+              fontSize: "clamp(22px, 2vw, 28px)",
+              fontWeight: 600,
+              color: "var(--m-fg)",
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {s.value}
+          </div>
+          <div className="m-eyebrow" style={{ marginTop: 4, color: "var(--m-fg-4)" }}>
+            {s.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Decorative glow blobs behind the hero copy, pinned so they don't scroll. */
+function HeroGlow() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        inset: "0 0 auto 0",
+        height: "140vh",
+        zIndex: -1,
+        pointerEvents: "none",
+        maskImage: "linear-gradient(to bottom, black 30%, transparent 100%)",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: -80,
+          left: "-10%",
+          width: 520,
+          height: 520,
+          borderRadius: "50%",
+          background: "color-mix(in oklab, var(--m-accent) 22%, transparent)",
+          filter: "blur(100px)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 60,
+          right: "-12%",
+          width: 580,
+          height: 580,
+          borderRadius: "50%",
+          background: "color-mix(in oklab, var(--m-violet) 18%, transparent)",
+          filter: "blur(110px)",
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/marketing/src/sections/sticky-nav.tsx
+++ b/apps/marketing/src/sections/sticky-nav.tsx
@@ -1,0 +1,89 @@
+import { Github } from "lucide-react";
+import { LINKS } from "../content/links.js";
+
+const NAV_LINKS: Array<{ label: string; href: string }> = [
+  { label: "Agents", href: "#agents" },
+  { label: "Docs", href: LINKS.docs },
+  { label: "GitHub", href: LINKS.repo },
+];
+
+export function StickyNav() {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 50,
+        backdropFilter: "blur(12px)",
+        background: "color-mix(in oklab, var(--m-bg) 78%, transparent)",
+        borderBottom: "var(--m-hairline) solid var(--m-border-faint)",
+      }}
+    >
+      <div
+        className="m-shell"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 60,
+        }}
+      >
+        <a
+          href="#top"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "var(--m-sp-2)",
+            fontWeight: 600,
+            fontSize: 15,
+          }}
+        >
+          <BrandMark />
+          <span>First Tree Hub</span>
+        </a>
+        <nav style={{ display: "flex", alignItems: "center", gap: "var(--m-sp-5)" }}>
+          {NAV_LINKS.map((l) => (
+            <a
+              key={l.label}
+              href={l.href}
+              style={{ color: "var(--m-fg-3)", fontSize: 14 }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = "var(--m-fg)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = "var(--m-fg-3)";
+              }}
+            >
+              {l.label}
+            </a>
+          ))}
+          <a
+            href={LINKS.repo}
+            target="_blank"
+            rel="noreferrer"
+            className="m-btn m-btn--primary"
+            style={{ padding: "8px 16px", fontSize: 13 }}
+          >
+            <Github size={14} />
+            Star on GitHub
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function BrandMark() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 22 22" role="img" aria-label="First Tree Hub logo">
+      <defs>
+        <linearGradient id="bm" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--m-accent)" />
+          <stop offset="100%" stopColor="var(--m-violet)" />
+        </linearGradient>
+      </defs>
+      <circle cx="11" cy="11" r="9" fill="none" stroke="url(#bm)" strokeWidth="1.6" />
+      <path d="M11 4v14M4 11h14" stroke="url(#bm)" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/apps/marketing/src/vite-env.d.ts
+++ b/apps/marketing/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/marketing/tsconfig.json
+++ b/apps/marketing/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -1,0 +1,16 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Deploying under GitHub Pages at `https://<org>.github.io/first-tree-hub/`
+// so the build must be rooted at `/first-tree-hub/`. Set via env to keep the
+// local dev server at `/`.
+const BASE = process.env.VITE_BASE ?? "/";
+
+export default defineConfig({
+  base: BASE,
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,34 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
 
+  apps/marketing:
+    dependencies:
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.4)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      vite:
+        specifier: ^6.3.0
+        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/client:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "apps/*"


### PR DESCRIPTION
## Summary

Adds a public-facing marketing site for First Tree Hub — `apps/marketing/`, a standalone Vite + React 19 + React Router app — aimed at developer pull (stars / contributors). The dashboard stays focused on the admin experience and keeps its own green-teal palette; the marketing site ships with a separate tech-feel palette (deep indigo + cyan + violet) and its own `--m-*` token namespace so nothing leaks across.

Handoff: marketing MVP ticket from analyst-agent.

### Sections (MVP)

- **Sticky nav** with backdrop-blur, brand mark, section anchors, GitHub CTA.
- **Hero** — gradient headline, short value-prop copy, three CTAs (Star on GitHub / Quickstart / Docs).
- **Agent Gallery** — three ProfileHeader-style cards (Analyst / Coder / Assistant) with diagonal-stripe banners, runtime-tinted avatars, badge cluster, tagline, and a hover-reveal panel containing "what I do" + a two-line sample exchange. Every card honestly reports `runtime: "claude-code"` — the Hub's only shipping runtime today — with visual variety coming from per-card hue shifts (210° / 195° / 230°) inside the cyan family and distinct lucide icons (Sparkles / Terminal / MessageCircle).

### Deliberate omissions

- **Hero stats strip** is rendered behind a `SHOW_STATS_STRIP = false` toggle + `// TODO(live)` note. Stays off until a public `/api/v1/public/stats` endpoint exists; flipping the flag is a one-line follow-up.
- **Architecture / How-it-works / Features / Community / Footer** ship in Phase 2.
- **Responsive polish** beyond desktop (1440 baseline), SEO / OG image, and **keyboard-accessible card expand** are all follow-ups.

### Visual fidelity

- All `color-mix` calls use `in oklab` — carried forward from PR #165 — to avoid the oklch hue-wraparound that produced peach tones on green backgrounds.
- No new runtime dependencies; `lucide-react`, `react`, `react-dom`, `react-router` all share versions with `packages/web`.
- Design-token guardrail lint **not** extended to marketing (separate token namespace); the dashboard's guardrail still passes.

## GitHub Pages deploy — one manual step

My token lacks `workflow` scope so I can't push the workflow file. Create `.github/workflows/marketing-deploy.yml` on this branch with the contents below (it's the same file I authored locally), or merge first and commit the workflow on a separate PR. Once it's in, the repo owner also needs to flip **Settings → Pages → Source → GitHub Actions** once.

<details>
<summary><code>.github/workflows/marketing-deploy.yml</code></summary>

```yaml
name: Deploy marketing site

# Ships the `apps/marketing` build to GitHub Pages. First-time setup requires
# the repo owner to flip Settings → Pages → Source to **GitHub Actions**; the
# workflow is a no-op until then.

on:
  push:
    branches: [main]
    paths:
      - "apps/marketing/**"
      - ".github/workflows/marketing-deploy.yml"
      - "pnpm-lock.yaml"
      - "pnpm-workspace.yaml"
  workflow_dispatch:

permissions:
  contents: read
  pages: write
  id-token: write

concurrency:
  group: marketing-pages
  cancel-in-progress: true

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: pnpm/action-setup@v4
        with:
          version: 10
      - uses: actions/setup-node@v4
        with:
          node-version: 24
          cache: pnpm
      - run: pnpm install --frozen-lockfile
      - name: Build marketing site
        env:
          # GitHub Pages project sites live at /<repo>/ so the Vite base must
          # match. `VITE_BASE` is read by apps/marketing/vite.config.ts.
          VITE_BASE: /${{ github.event.repository.name }}/
        run: pnpm --filter @first-tree-hub/marketing build
      - uses: actions/upload-pages-artifact@v3
        with:
          path: apps/marketing/dist

  deploy:
    needs: build
    runs-on: ubuntu-latest
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    steps:
      - id: deployment
        uses: actions/deploy-pages@v4
```

</details>

## Test plan

- [x] `pnpm check` (biome, 464 files)
- [x] `pnpm typecheck` (10 packages incl. marketing)
- [x] Local Vite dev server on `:5174`; puppeteer screenshots verified before commit (Hero, Agent Gallery, hover state, full-page)
- [ ] CI lint / typecheck green on this PR
- [ ] Workflow file added by repo owner; Pages source set to "GitHub Actions"
- [ ] First deploy produces a live URL at `https://<org>.github.io/first-tree-hub/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)