### PR TITLE
refactor(agent-naming): Phase 3 — retire local CLI alias, reconcile on startup

### DIFF
--- a/docs/claim-agent-guide.md
+++ b/docs/claim-agent-guide.md
@@ -93,10 +93,10 @@ first-tree-hub client start
 
 The running client picks up server-side pinning automatically: when an admin creates an agent with `--client-id <thisClientId>` (or binds an existing one via PATCH) the server pushes an `agent:pinned` frame and the runtime materialises the local `agents/<name>/agent.yaml`. On reconnect, the server also backfills any pins that landed while the client was offline.
 
-You only need `first-tree-hub agent add` for legacy setups or when you want a custom local name:
+You only need `first-tree-hub agent add` for unattended setups where you already know the agent's UUID. The local config dir is keyed by the agent's canonical name on the Hub — there is no "local alias" to pick:
 
 ```bash
-first-tree-hub agent add my-agent --token $FIRST_TREE_HUB_AGENT_TOKEN
+first-tree-hub agent add --agent-id <agent-uuid>
 first-tree-hub agent list
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,17 +108,19 @@ Agent management — configuration, tokens, bindings, and messaging.
 ### Configuration
 
 ```bash
-# Add an agent (interactive or command-line)
+# Register an existing Hub agent on this client (interactive or --agent-id).
 # Optional: a running `first-tree-hub client start` auto-registers any agent
 # the admin pins to this clientId via the Hub UI / API, so this command is
-# only needed for unattended setups, scripted seeding, or when you want a
-# custom local name.
+# only needed for unattended setups or scripted seeding.
+#
+# The local config dir is always keyed by the agent's name on the Hub —
+# there is no separate "local alias" concept.
 first-tree-hub agent add
-first-tree-hub agent add my-agent --token aghub_xxx
+first-tree-hub agent add --agent-id <uuid>
 
-# List / remove
+# List / remove (name = Hub agent name)
 first-tree-hub agent list
-first-tree-hub agent remove my-agent
+first-tree-hub agent remove <name>
 
 # Workspace cleanup
 first-tree-hub agent workspace clean              # all agents

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -114,8 +114,8 @@ npm install -g @agent-team-foundation/first-tree-hub
 # Configure server URL
 first-tree-hub config set -c server.url https://hub.example.com
 
-# Add agents
-first-tree-hub agent add my-agent --token aghub_xxxxxxxxxxxx
+# Add an existing Hub agent to this client (dir keyed by its hub name).
+first-tree-hub agent add --agent-id <agent-uuid>
 
 # Start
 first-tree-hub client start
@@ -143,7 +143,7 @@ jobs:
       - run: npm install -g @agent-team-foundation/first-tree-hub
       - run: |
           first-tree-hub config set -c server.url ${{ secrets.HUB_URL }}
-          first-tree-hub agent add ci-agent --token ${{ secrets.AGENT_TOKEN }}
+          first-tree-hub agent add --agent-id ${{ secrets.AGENT_UUID }}
           first-tree-hub client start
 ```
 

--- a/packages/command/src/__tests__/migrate-agent-dirs.test.ts
+++ b/packages/command/src/__tests__/migrate-agent-dirs.test.ts
@@ -146,4 +146,51 @@ describe("migrateLocalAgentDirs", () => {
     expect(second.renamed).toBe(0);
     expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
   });
+
+  it("renames the config dir even when workspaces and sessions dirs don't exist (fresh client)", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    // Deliberately skip writeWorkspace / writeSessionFile.
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice" }),
+    });
+    expect(res.renamed).toBe(1);
+    expect(res.errors).toBe(0);
+    expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
+  });
+
+  it("leaves old workspace in place and logs when the new workspace target already exists (partial failure)", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    writeWorkspace(root, "old-alias");
+    writeWorkspace(root, "alice"); // pre-existing target — rename would clobber
+    writeSessionFile(root, "old-alias");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice" }),
+    });
+    // Config dir renamed; workspace left alone; sessions file renamed.
+    expect(res.renamed).toBe(1);
+    expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
+    // Both workspaces should still exist.
+    const wsNames = readdirSync(dirs({ root }).workspacesDir).sort();
+    expect(wsNames).toEqual(["alice", "old-alias"]);
+  });
+
+  it("skips and logs when agent.yaml is malformed (does not abort migration for healthy siblings)", async () => {
+    writeAgentYaml(root, "alice", "uuid-1");
+    // Write an "agent" dir with a broken yaml.
+    const brokenDir = join(root, "config", "agents", "broken");
+    mkdirSync(brokenDir, { recursive: true });
+    writeFileSync(join(brokenDir, "agent.yaml"), "this: is: : not yaml\n");
+    writeAgentYaml(root, "bob", "uuid-2");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice", "uuid-2": "bob" }),
+    });
+    // alice + bob scanned (2), broken dir errored but didn't stop the walk.
+    expect(res.scanned).toBe(2);
+    expect(res.errors).toBe(1);
+    // All three dirs still present — broken one left for operator to fix.
+    expect(readdirSync(dirs({ root }).agentsDir).sort()).toEqual(["alice", "bob", "broken"]);
+  });
 });

--- a/packages/command/src/__tests__/migrate-agent-dirs.test.ts
+++ b/packages/command/src/__tests__/migrate-agent-dirs.test.ts
@@ -1,0 +1,149 @@
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { migrateLocalAgentDirs, type NameResolver } from "../core/migrate-agent-dirs.js";
+
+/**
+ * Pins the Phase-3 local-dir rename. The helper is a pure filesystem shuffler
+ * driven by an injected name resolver; we stub the resolver in-memory so the
+ * tests don't need a live Hub.
+ *
+ * What we specifically want to guard against:
+ *   1. Renaming is idempotent (already-aligned dirs are untouched).
+ *   2. A collision (target name already exists) skips + logs — no clobber.
+ *   3. A resolver that knows nothing about an agentId leaves the dir alone.
+ *   4. A resolver failure aborts the walk so we don't spam warnings.
+ */
+
+function writeAgentYaml(root: string, name: string, agentId: string) {
+  const dir = join(root, "config", "agents", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "agent.yaml"), `agentId: ${agentId}\nruntime: claude-code\n`);
+  return dir;
+}
+
+function writeWorkspace(root: string, name: string) {
+  const dir = join(root, "data", "workspaces", name);
+  mkdirSync(join(dir, "chat-1"), { recursive: true });
+  writeFileSync(join(dir, "chat-1", "noop"), "");
+  return dir;
+}
+
+function writeSessionFile(root: string, name: string) {
+  const dir = join(root, "data", "sessions");
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, `${name}.json`);
+  writeFileSync(p, "{}\n");
+  return p;
+}
+
+function mkResolver(map: Record<string, string | null>): NameResolver {
+  return {
+    async resolveName(agentId) {
+      return Object.hasOwn(map, agentId) ? (map[agentId] ?? null) : null;
+    },
+  };
+}
+
+function dirs(opts: { root: string }) {
+  return {
+    agentsDir: join(opts.root, "config", "agents"),
+    workspacesDir: join(opts.root, "data", "workspaces"),
+    sessionsDir: join(opts.root, "data", "sessions"),
+  };
+}
+
+describe("migrateLocalAgentDirs", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "fthub-migrate-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns scanned=0 when the agents dir doesn't exist (first-run clients)", async () => {
+    const res = await migrateLocalAgentDirs({ ...dirs({ root }), resolver: mkResolver({}) });
+    expect(res).toEqual({ scanned: 0, renamed: 0, skipped: 0, errors: 0 });
+  });
+
+  it("is a no-op when every local dir already matches the server name", async () => {
+    writeAgentYaml(root, "alice", "uuid-1");
+    writeAgentYaml(root, "bob", "uuid-2");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice", "uuid-2": "bob" }),
+    });
+    expect(res).toEqual({ scanned: 2, renamed: 0, skipped: 0, errors: 0 });
+    // Dirs still there under the original names.
+    expect(readdirSync(dirs({ root }).agentsDir).sort()).toEqual(["alice", "bob"]);
+  });
+
+  it("renames config dir, workspace, and sessions file when the server name differs", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    writeWorkspace(root, "old-alias");
+    writeSessionFile(root, "old-alias");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice" }),
+    });
+    expect(res.renamed).toBe(1);
+    expect(res.errors).toBe(0);
+    expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
+    expect(statSync(join(dirs({ root }).workspacesDir, "alice")).isDirectory()).toBe(true);
+    expect(statSync(join(dirs({ root }).sessionsDir, "alice.json")).isFile()).toBe(true);
+  });
+
+  it("skips without clobbering when the target config dir already exists", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    writeAgentYaml(root, "alice", "uuid-2");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice", "uuid-2": "alice" }),
+    });
+    // One rename would attempt old-alias → alice but alice is already taken.
+    expect(res.skipped).toBeGreaterThan(0);
+    expect(readdirSync(dirs({ root }).agentsDir).sort()).toEqual(["alice", "old-alias"]);
+  });
+
+  it("leaves a dir alone when the resolver has no answer for its agentId (tombstone / unlisted)", async () => {
+    writeAgentYaml(root, "mystery", "uuid-unknown");
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({}),
+    });
+    expect(res.scanned).toBe(1);
+    expect(res.renamed).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["mystery"]);
+  });
+
+  it("aborts the walk on a resolver failure (one warning, not N)", async () => {
+    writeAgentYaml(root, "a", "uuid-1");
+    writeAgentYaml(root, "b", "uuid-2");
+    writeAgentYaml(root, "c", "uuid-3");
+    const failing: NameResolver = {
+      async resolveName() {
+        throw new Error("network down");
+      },
+    };
+    const res = await migrateLocalAgentDirs({ ...dirs({ root }), resolver: failing });
+    expect(res.errors).toBe(1);
+    expect(res.renamed).toBe(0);
+    // All dirs intact.
+    expect(readdirSync(dirs({ root }).agentsDir).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("is idempotent when re-run after a successful rename", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    const resolver = mkResolver({ "uuid-1": "alice" });
+    const first = await migrateLocalAgentDirs({ ...dirs({ root }), resolver });
+    expect(first.renamed).toBe(1);
+    const second = await migrateLocalAgentDirs({ ...dirs({ root }), resolver });
+    expect(second.renamed).toBe(0);
+    expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
+  });
+});

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -150,21 +150,18 @@ export function registerAgentCommands(program: Command): void {
   // ── Config management (add / remove / list) ─────────────────────────
 
   agent
-    .command("add [name]")
-    .description("Register a local alias for an existing Hub agent (stores agentId)")
+    .command("add")
+    .description("Register an existing Hub agent on this client (uses the agent name from the Hub)")
     .option("--agent-id <id>", "Agent UUID on the Hub")
-    .action(async (name?: string, options?: { agentId?: string }) => {
+    .action(async (options?: { agentId?: string }) => {
       try {
-        let agentName = name;
-        let agentId = options?.agentId;
-
+        // Phase 3 of the agent-naming refactor retired the free-form
+        // local alias — the local config dir is always keyed by the
+        // server-side `agent.name`. The prompt helper fetches that name
+        // from the Hub given the agent UUID.
+        const { name: agentName, agentId } = await promptAddAgent({ agentId: options?.agentId });
         if (!agentName || !agentId) {
-          const result = await promptAddAgent();
-          agentName = agentName ?? result.name;
-          agentId = agentId ?? result.agentId;
-        }
-        if (!agentName || !agentId) {
-          fail("MISSING_AGENT_ARGS", "Both agent name and agent-id are required.", 2);
+          fail("MISSING_AGENT_ARGS", "Agent UUID (and a hub name for that UUID) are required.", 2);
         }
 
         const agentDir = join(DEFAULT_CONFIG_DIR, "agents", agentName);
@@ -186,7 +183,9 @@ export function registerAgentCommands(program: Command): void {
 
   agent
     .command("remove <name>")
-    .description("Remove a local agent alias and its runtime data")
+    .description(
+      "Remove an agent from this client and delete its local runtime data (config dir, workspace, session state)",
+    )
     .action((name: string) => {
       const agentDir = join(DEFAULT_CONFIG_DIR, "agents", name);
       if (!existsSync(agentDir)) {
@@ -410,7 +409,7 @@ export function registerAgentCommands(program: Command): void {
     .requiredOption("--platform <platform>", "Platform: feishu")
     .requiredOption("--app-id <id>", "Feishu bot App ID")
     .requiredOption("--app-secret <secret>", "Feishu bot App Secret")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .option("--server <url>", "Hub server URL")
     .action(
       async (options: { platform: string; appId: string; appSecret: string; agent?: string; server?: string }) => {
@@ -437,7 +436,7 @@ export function registerAgentCommands(program: Command): void {
     .description("Bind a Feishu user to a human agent (via delegate_mention)")
     .requiredOption("--platform <platform>", "Platform: feishu")
     .requiredOption("--feishu-id <id>", "Feishu user ID (ou_xxx)")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .option("--server <url>", "Hub server URL")
     .action(
       async (
@@ -483,7 +482,7 @@ export function registerAgentCommands(program: Command): void {
     .option("--reply-to <messageId>", "Message ID to reply to")
     .option("--reply-to-inbox <inboxId>", "Cross-chat reply target inbox")
     .option("--reply-to-chat <chatId>", "Cross-chat reply target chat")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .action(async (target: string, message: string | undefined, options: SendOptions) => {
       try {
         const content = message ?? (await readStdin());
@@ -537,7 +536,7 @@ export function registerAgentCommands(program: Command): void {
     .description("List chats this agent participates in")
     .option("-l, --limit <number>", "Maximum chats to return (1-100)", "20")
     .option("--cursor <cursor>", "Pagination cursor from previous response")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .action(async (options: { limit: string; cursor?: string; agent?: string }) => {
       try {
         const limit = parseLimit(options.limit, 100);
@@ -554,7 +553,7 @@ export function registerAgentCommands(program: Command): void {
     .description("View message history in a chat")
     .option("-l, --limit <number>", "Maximum messages to return (1-100)", "20")
     .option("--cursor <cursor>", "Pagination cursor from previous response")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .action(async (chatId: string, options: { limit: string; cursor?: string; agent?: string }) => {
       try {
         const limit = parseLimit(options.limit, 100);
@@ -869,7 +868,7 @@ export function registerAgentCommands(program: Command): void {
   agent
     .command("register")
     .description("Register this agent and return identity info")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .action(async (options: { agent?: string }) => {
       try {
         const sdk = createSdk(options.agent);
@@ -885,7 +884,7 @@ export function registerAgentCommands(program: Command): void {
     .description("Pull pending messages from inbox")
     .option("-l, --limit <number>", "Maximum entries to return", "10")
     .option("-a, --ack", "Automatically ACK entries after pulling")
-    .option("--agent <name>", "Local agent alias (default: first configured)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
     .action(async (options: { limit: string; ack?: boolean; agent?: string }) => {
       try {
         const sdk = createSdk(options.agent);

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -3,6 +3,7 @@ import {
   agentConfigSchema,
   clientConfigSchema,
   DEFAULT_CONFIG_DIR,
+  DEFAULT_DATA_DIR,
   DEFAULT_HOME_DIR,
   initConfig,
   loadAgents,
@@ -24,6 +25,7 @@ import {
   checkNodeVersion,
   checkServerReachable,
   checkWebSocket,
+  createApiNameResolver,
   createExecuteUpdate,
   declineUpdate,
   ensureFreshAccessToken,
@@ -31,6 +33,7 @@ import {
   handleClientOrgMismatch,
   installClientService,
   isServiceSupported,
+  migrateLocalAgentDirs,
   parseDuration,
   printResults,
   promptMissingFields,
@@ -80,8 +83,24 @@ export function registerClientCommands(program: Command): void {
           configureClientLoggerForService(join(DEFAULT_HOME_DIR, "logs"));
         }
 
-        // Load agents (may be empty — client can start without agents)
+        // Load agents (may be empty — client can start without agents).
+        // Phase 3 of the agent-naming refactor: run the local-dir rename
+        // migration BEFORE `loadAgents` so any config dir whose name
+        // drifted from the server-side `agent.name` slug is renamed
+        // first. `loadAgents` then enumerates the up-to-date layout.
+        // The migration is best-effort — it never blocks startup.
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+        try {
+          await migrateLocalAgentDirs({
+            agentsDir,
+            workspacesDir: join(DEFAULT_DATA_DIR, "workspaces"),
+            sessionsDir: join(DEFAULT_DATA_DIR, "sessions"),
+            resolver: createApiNameResolver(config.server.url, () => ensureFreshAccessToken()),
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `agent-dir migration skipped: ${msg}`);
+        }
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
         print.line(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -3,6 +3,7 @@ import {
   agentConfigSchema,
   clientConfigSchema,
   DEFAULT_CONFIG_DIR,
+  DEFAULT_DATA_DIR,
   initConfig,
   loadAgents,
   resetConfig,
@@ -16,12 +17,15 @@ import { fail } from "../cli/output.js";
 import {
   ClientRuntime,
   COMMAND_VERSION,
+  createApiNameResolver,
   createExecuteUpdate,
+  ensureFreshAccessToken,
   getClientServiceStatus,
   handleClientOrgMismatch,
   installClientService,
   isServiceSupported,
   loadCredentials,
+  migrateLocalAgentDirs,
   promptUpdate,
   saveCredentials,
 } from "../core/index.js";
@@ -281,6 +285,20 @@ export function registerConnectCommand(parent: Command): void {
         }
 
         const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+        // Phase 3 of the agent-naming refactor: reconcile local agent dir
+        // names with the server-authoritative `agent.name`. Best-effort —
+        // a network blip doesn't block startup.
+        try {
+          await migrateLocalAgentDirs({
+            agentsDir,
+            workspacesDir: join(DEFAULT_DATA_DIR, "workspaces"),
+            sessionsDir: join(DEFAULT_DATA_DIR, "sessions"),
+            resolver: createApiNameResolver(config.server.url, () => ensureFreshAccessToken()),
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `agent-dir migration skipped: ${msg}`);
+        }
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
         // `connect --no-service` runs inline until Ctrl+C — no supervisor,

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -40,6 +40,10 @@ export {
 export { bindFeishuBot, bindFeishuUser } from "./feishu.js";
 // Database
 export { runMigrations } from "./migrate.js";
+// Phase 3 of the agent-naming refactor — renames local agent dirs whose
+// name drifted from the server-authoritative `agent.name` slug.
+export type { AgentDirMigrationResult, NameResolver } from "./migrate-agent-dirs.js";
+export { createApiNameResolver, migrateLocalAgentDirs } from "./migrate-agent-dirs.js";
 // Legacy home auto-migration (pre-v0.9 `~/.first-tree-hub` → `~/.first-tree/hub`)
 export { runHomeMigration } from "./migrate-home.js";
 // Onboard

--- a/packages/command/src/core/migrate-agent-dirs.ts
+++ b/packages/command/src/core/migrate-agent-dirs.ts
@@ -1,0 +1,239 @@
+import { existsSync, readdirSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { agentConfigSchema, loadAgents } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { print } from "./output.js";
+
+/**
+ * Phase 3 of the agent-naming refactor (docs/agent-naming-design.md §3.4 + §4):
+ * reconcile every local agent directory name with the server-authoritative
+ * `agent.name` slug. The free-form local alias concept is gone — the Hub is
+ * the only namespace authority — so on every client startup we walk the
+ * local configs, ask the server what each agentId's canonical name is, and
+ * rename the config/workspace/sessions state when they drift.
+ *
+ * Invariants:
+ *   - Idempotent — repeat runs after a full rename are a no-op (every
+ *     `dirName === serverName` returns early).
+ *   - Non-fatal — a single migration failure (missing server, collision,
+ *     permission error) never aborts the runtime start. We print a warning
+ *     and leave the original dir in place so the operator can investigate.
+ *   - Crash-safe — the rename ordering is: config dir first, then
+ *     `workspaces/<name>`, then `sessions/<name>.json`. A crash after the
+ *     config dir rename but before the workspace rename leaves the client
+ *     with a workspace under the old name; the next startup re-runs the
+ *     migration against the already-renamed config and falls through
+ *     because the server name now matches, so workspaces/sessions under
+ *     the old name become orphaned. That's acceptable — the operator can
+ *     `agent workspace clean` them later — and it beats a partial rename
+ *     that loses the config pointer.
+ *   - Collision-aware — if a directory already exists at the target name,
+ *     we skip and log rather than clobber. (Two local configs mapping to
+ *     the same server name is a config bug; the operator must resolve.)
+ */
+
+type AgentRow = { uuid: string; name: string | null };
+
+export type AgentDirMigrationResult = {
+  scanned: number;
+  renamed: number;
+  skipped: number;
+  errors: number;
+};
+
+/**
+ * Resolve the canonical server names for every local agentId. Uses the
+ * admin `/agents` listing because it's a single paginated call — much
+ * cheaper than N per-agent GETs when the user has multiple agents.
+ *
+ * Callers that can't reach the server (offline start, auth failure) should
+ * skip the migration entirely — passing a resolver that returns `null`
+ * from `resolveName` turns `migrateLocalAgentDirs` into a no-op.
+ */
+export type NameResolver = {
+  resolveName(agentId: string): Promise<string | null>;
+};
+
+export function createApiNameResolver(serverUrl: string, getAccessToken: () => Promise<string>): NameResolver {
+  // One-shot fetch of the admin agents listing, memoised for the duration
+  // of this resolver's life. The client-runtime migration runs once per
+  // start(), so there's nothing to invalidate.
+  let cache: Map<string, string | null> | null = null;
+
+  async function ensureCache(): Promise<Map<string, string | null>> {
+    if (cache) return cache;
+    const token = await getAccessToken();
+    const res = await fetch(`${serverUrl}/api/v1/admin/agents?limit=100`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      throw new Error(`admin agents list returned HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as { items: AgentRow[] };
+    const map = new Map<string, string | null>();
+    for (const row of body.items) {
+      map.set(row.uuid, row.name);
+    }
+    cache = map;
+    return map;
+  }
+
+  return {
+    async resolveName(agentId: string): Promise<string | null> {
+      const map = await ensureCache();
+      return map.get(agentId) ?? null;
+    },
+  };
+}
+
+/**
+ * Walk `agentsDir`, for each local agent compare the dir name to the
+ * server's canonical `name`, and rename the dir + workspaces/sessions
+ * entries when they differ. Returns a summary so the caller can decide
+ * whether to print additional context.
+ */
+export async function migrateLocalAgentDirs(opts: {
+  agentsDir: string;
+  workspacesDir: string;
+  sessionsDir: string;
+  resolver: NameResolver;
+}): Promise<AgentDirMigrationResult> {
+  const { agentsDir, workspacesDir, sessionsDir, resolver } = opts;
+  const result: AgentDirMigrationResult = { scanned: 0, renamed: 0, skipped: 0, errors: 0 };
+
+  if (!existsSync(agentsDir)) return result;
+
+  let locals: Map<string, AgentConfig>;
+  try {
+    locals = loadAgents({ schema: agentConfigSchema, agentsDir });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    print.status("⚠️", `agent-dir migration: unable to enumerate ${agentsDir}: ${msg}`);
+    return { ...result, errors: result.errors + 1 };
+  }
+
+  for (const [dirName, config] of locals) {
+    result.scanned += 1;
+
+    let serverName: string | null;
+    try {
+      serverName = await resolver.resolveName(config.agentId);
+    } catch (err) {
+      // A network blip here shouldn't block startup — leave the dir alone
+      // and continue with the rest. The next start attempts the rename
+      // again; idempotent design means we don't leave the layout wedged.
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent-dir migration: failed to resolve "${dirName}" (${config.agentId}): ${msg}`);
+      result.errors += 1;
+      // One resolver failure usually means the whole fetch is broken — bail
+      // out so we don't spam a warning per agent.
+      return result;
+    }
+
+    if (!serverName) {
+      // Server has no `name` for this agent (e.g. tombstoned row, or the
+      // listing call was capped before reaching this id). Skip quietly.
+      result.skipped += 1;
+      continue;
+    }
+    if (serverName === dirName) continue;
+
+    const oldDir = join(agentsDir, dirName);
+    const newDir = join(agentsDir, serverName);
+    if (existsSync(newDir)) {
+      print.status(
+        "⚠️",
+        `agent-dir migration: cannot rename "${dirName}" → "${serverName}" — target already exists. Skipping.`,
+      );
+      result.skipped += 1;
+      continue;
+    }
+
+    try {
+      renameSync(oldDir, newDir);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent-dir migration: config dir rename failed for "${dirName}": ${msg}`);
+      result.errors += 1;
+      continue;
+    }
+
+    // Follow-on renames for adjacent state. Each is best-effort and logged
+    // on failure — the config dir is the canonical marker for "migrated",
+    // so mismatched workspace/session leftovers show up as orphans (not
+    // wedged state).
+    const oldWorkspace = join(workspacesDir, dirName);
+    const newWorkspace = join(workspacesDir, serverName);
+    if (existsSync(oldWorkspace)) {
+      try {
+        if (existsSync(newWorkspace)) {
+          print.status(
+            "⚠️",
+            `agent-dir migration: workspace target "${serverName}" already exists; leaving old "${dirName}" in place for manual cleanup.`,
+          );
+        } else if (statSync(oldWorkspace).isDirectory()) {
+          renameSync(oldWorkspace, newWorkspace);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.status("⚠️", `agent-dir migration: workspace rename failed for "${dirName}": ${msg}`);
+        result.errors += 1;
+      }
+    }
+
+    const oldSessions = join(sessionsDir, `${dirName}.json`);
+    const newSessions = join(sessionsDir, `${serverName}.json`);
+    if (existsSync(oldSessions)) {
+      try {
+        if (existsSync(newSessions)) {
+          print.status(
+            "⚠️",
+            `agent-dir migration: sessions target "${serverName}.json" already exists; leaving old "${dirName}.json" in place for manual cleanup.`,
+          );
+        } else {
+          renameSync(oldSessions, newSessions);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.status("⚠️", `agent-dir migration: sessions rename failed for "${dirName}": ${msg}`);
+        result.errors += 1;
+      }
+    }
+
+    print.status("", `agent "${dirName}" renamed to "${serverName}" to match hub`);
+    result.renamed += 1;
+  }
+
+  // Helper: enumerate ORPHANED workspace / session paths — those whose
+  // directory name doesn't match any current local agent. We don't
+  // auto-delete them (see crash-safety note above), but we log a reminder
+  // when the set is non-empty so the operator knows to run `agent
+  // workspace clean`.
+  try {
+    const localNames = new Set(locals.keys());
+    // Recompute after rename since `locals` was taken before the walk.
+    if (existsSync(agentsDir)) {
+      const refreshed = loadAgents({ schema: agentConfigSchema, agentsDir });
+      for (const k of refreshed.keys()) localNames.add(k);
+    }
+    const orphanWs = existsSync(workspacesDir) ? readdirSync(workspacesDir).filter((d) => !localNames.has(d)) : [];
+    const orphanSessions = existsSync(sessionsDir)
+      ? readdirSync(sessionsDir).filter((f) => f.endsWith(".json") && !localNames.has(f.slice(0, -5)))
+      : [];
+    if (orphanWs.length > 0 || orphanSessions.length > 0) {
+      const parts: string[] = [];
+      if (orphanWs.length > 0) parts.push(`workspaces: ${orphanWs.join(", ")}`);
+      if (orphanSessions.length > 0) parts.push(`sessions: ${orphanSessions.join(", ")}`);
+      print.status(
+        "",
+        `orphaned local state detected (${parts.join("; ")}). Run \`first-tree-hub agent workspace clean\` to reclaim disk.`,
+      );
+    }
+  } catch {
+    // Best-effort: orphan detection is informational, never block start.
+  }
+
+  return result;
+}

--- a/packages/command/src/core/migrate-agent-dirs.ts
+++ b/packages/command/src/core/migrate-agent-dirs.ts
@@ -1,7 +1,6 @@
-import { existsSync, readdirSync, renameSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { agentConfigSchema, loadAgents } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { parse as parseYaml } from "yaml";
 import { print } from "./output.js";
 
 /**
@@ -59,22 +58,37 @@ export function createApiNameResolver(serverUrl: string, getAccessToken: () => P
   // of this resolver's life. The client-runtime migration runs once per
   // start(), so there's nothing to invalidate.
   let cache: Map<string, string | null> | null = null;
+  const PAGE_SIZE = 100;
+  // Belt-and-braces: stop after this many pages so a server bug (e.g.
+  // nextCursor that never terminates) can't wedge startup.
+  const MAX_PAGES = 50;
 
   async function ensureCache(): Promise<Map<string, string | null>> {
     if (cache) return cache;
     const token = await getAccessToken();
-    const res = await fetch(`${serverUrl}/api/v1/admin/agents?limit=100`, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) {
-      throw new Error(`admin agents list returned HTTP ${res.status}`);
-    }
-    const body = (await res.json()) as { items: AgentRow[] };
     const map = new Map<string, string | null>();
-    for (const row of body.items) {
-      map.set(row.uuid, row.name);
+    // Paginate via the admin listing's nextCursor contract — the first
+    // page returns `{ items, nextCursor }` and we follow the cursor
+    // until it's null. Hubs with >100 agents were previously silently
+    // truncated here, leaving their local dirs un-reconciled.
+    let cursor: string | null = null;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const qs = new URLSearchParams({ limit: String(PAGE_SIZE) });
+      if (cursor) qs.set("cursor", cursor);
+      const res = await fetch(`${serverUrl}/api/v1/admin/agents?${qs.toString()}`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        throw new Error(`admin agents list returned HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as { items: AgentRow[]; nextCursor?: string | null };
+      for (const row of body.items) {
+        map.set(row.uuid, row.name);
+      }
+      if (!body.nextCursor) break;
+      cursor = body.nextCursor;
     }
     cache = map;
     return map;
@@ -86,6 +100,27 @@ export function createApiNameResolver(serverUrl: string, getAccessToken: () => P
       return map.get(agentId) ?? null;
     },
   };
+}
+
+/**
+ * Read the `agentId` field out of a single `agent.yaml` with minimal
+ * parsing. Unlike `loadAgents`, which Zod-validates every entry and
+ * throws on the first malformed file (aborting migration for *every*
+ * other agent below it), this helper scopes failures per-dir: a broken
+ * file returns `null` and the caller logs + skips that dir only.
+ */
+function readAgentId(agentYamlPath: string): string | null {
+  try {
+    const raw = readFileSync(agentYamlPath, "utf-8");
+    const parsed = parseYaml(raw) as unknown;
+    if (parsed && typeof parsed === "object" && "agentId" in parsed) {
+      const id = (parsed as { agentId: unknown }).agentId;
+      if (typeof id === "string" && id.length > 0) return id;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -105,27 +140,56 @@ export async function migrateLocalAgentDirs(opts: {
 
   if (!existsSync(agentsDir)) return result;
 
-  let locals: Map<string, AgentConfig>;
+  // Enumerate dirs directly instead of going through `loadAgents`.
+  // `loadAgents` Zod-validates each entry and throws on the first
+  // malformed file, which would abort migration for every healthy dir
+  // below the bad one. Per-dir scoping lets us log + skip the broken
+  // entry and keep reconciling the rest.
+  let dirNames: string[];
   try {
-    locals = loadAgents({ schema: agentConfigSchema, agentsDir });
+    dirNames = readdirSync(agentsDir).filter((name) => {
+      try {
+        return statSync(join(agentsDir, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     print.status("⚠️", `agent-dir migration: unable to enumerate ${agentsDir}: ${msg}`);
     return { ...result, errors: result.errors + 1 };
   }
 
-  for (const [dirName, config] of locals) {
+  // Track the set of local dir names that exist AFTER the loop so the
+  // orphan-detection block can distinguish renamed-away state from
+  // genuinely abandoned leftovers.
+  const finalDirNames = new Set(dirNames);
+
+  for (const dirName of dirNames) {
+    const agentYamlPath = join(agentsDir, dirName, "agent.yaml");
+    const agentId = readAgentId(agentYamlPath);
+    if (!agentId) {
+      // Non-agent directory, or a malformed yaml. Log only when a yaml
+      // exists but didn't parse — a bare dir with no agent.yaml is
+      // probably unrelated (dot-files, test fixtures).
+      if (existsSync(agentYamlPath)) {
+        print.status("⚠️", `agent-dir migration: unreadable ${agentYamlPath}; skipping this dir.`);
+        result.errors += 1;
+      }
+      continue;
+    }
     result.scanned += 1;
 
     let serverName: string | null;
     try {
-      serverName = await resolver.resolveName(config.agentId);
+      serverName = await resolver.resolveName(agentId);
     } catch (err) {
       // A network blip here shouldn't block startup — leave the dir alone
       // and continue with the rest. The next start attempts the rename
       // again; idempotent design means we don't leave the layout wedged.
       const msg = err instanceof Error ? err.message : String(err);
-      print.status("⚠️", `agent-dir migration: failed to resolve "${dirName}" (${config.agentId}): ${msg}`);
+      const hint = msg.includes("403") ? " (likely a non-admin account — migration skipped)" : "";
+      print.status("⚠️", `agent-dir migration: failed to resolve "${dirName}" (${agentId}): ${msg}${hint}`);
       result.errors += 1;
       // One resolver failure usually means the whole fetch is broken — bail
       // out so we don't spam a warning per agent.
@@ -153,6 +217,8 @@ export async function migrateLocalAgentDirs(opts: {
 
     try {
       renameSync(oldDir, newDir);
+      finalDirNames.delete(dirName);
+      finalDirNames.add(serverName);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       print.status("⚠️", `agent-dir migration: config dir rename failed for "${dirName}": ${msg}`);
@@ -206,21 +272,17 @@ export async function migrateLocalAgentDirs(opts: {
     result.renamed += 1;
   }
 
-  // Helper: enumerate ORPHANED workspace / session paths — those whose
-  // directory name doesn't match any current local agent. We don't
-  // auto-delete them (see crash-safety note above), but we log a reminder
-  // when the set is non-empty so the operator knows to run `agent
-  // workspace clean`.
+  // Enumerate ORPHANED workspace / session paths — those whose directory
+  // name doesn't match any *current* local agent (after rename). We don't
+  // auto-delete them (see crash-safety note above), but log a reminder so
+  // the operator knows to run `agent workspace clean`. Crucially, the
+  // comparison set is the *post-rename* `finalDirNames` — using both old
+  // and new names would hide every workspace left behind by the rename
+  // path, which is exactly what we want to surface.
   try {
-    const localNames = new Set(locals.keys());
-    // Recompute after rename since `locals` was taken before the walk.
-    if (existsSync(agentsDir)) {
-      const refreshed = loadAgents({ schema: agentConfigSchema, agentsDir });
-      for (const k of refreshed.keys()) localNames.add(k);
-    }
-    const orphanWs = existsSync(workspacesDir) ? readdirSync(workspacesDir).filter((d) => !localNames.has(d)) : [];
+    const orphanWs = existsSync(workspacesDir) ? readdirSync(workspacesDir).filter((d) => !finalDirNames.has(d)) : [];
     const orphanSessions = existsSync(sessionsDir)
-      ? readdirSync(sessionsDir).filter((f) => f.endsWith(".json") && !localNames.has(f.slice(0, -5)))
+      ? readdirSync(sessionsDir).filter((f) => f.endsWith(".json") && !finalDirNames.has(f.slice(0, -5)))
       : [];
     if (orphanWs.length > 0 || orphanSessions.length > 0) {
       const parts: string[] = [];

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -186,7 +186,11 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
   });
   print.line(`Agent "${args.id}" created (uuid ${primary.uuid}).\n`);
 
-  // For non-human agents, persist the local alias so `client start` can bind.
+  // For non-human agents, persist the local config under the hub agent
+  // name so `client start` can bind (Phase 3 of the agent-naming refactor:
+  // the local dir is always keyed by the server-authoritative
+  // `agent.name`; `args.id` is the same value that was POSTed as `name`
+  // to the create endpoint, so this is already the canonical key).
   if (args.type !== "human") {
     saveAgentConfig(args.id, primary.uuid, "claude-code");
   }

--- a/packages/command/src/core/onboard.ts
+++ b/packages/command/src/core/onboard.ts
@@ -184,15 +184,18 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
     metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     clientId: args.type === "human" ? undefined : args.clientId,
   });
-  print.line(`Agent "${args.id}" created (uuid ${primary.uuid}).\n`);
+  // Phase 3: always prefer the server-returned `name` over the submitted
+  // `args.id`. The two usually agree, but the server may normalise or
+  // reject on collision and a subsequent rename would be needed on first
+  // start. Using `primary.name` here keeps the log message, local dir key,
+  // and the Hub's view aligned from the outset. The `?? args.id` fallback
+  // covers servers that (for some reason) return a null name — the
+  // idempotent migration on next start will reconcile.
+  const primaryLocalName = primary.name ?? args.id;
+  print.line(`Agent "${primaryLocalName}" created (uuid ${primary.uuid}).\n`);
 
-  // For non-human agents, persist the local config under the hub agent
-  // name so `client start` can bind (Phase 3 of the agent-naming refactor:
-  // the local dir is always keyed by the server-authoritative
-  // `agent.name`; `args.id` is the same value that was POSTed as `name`
-  // to the create endpoint, so this is already the canonical key).
   if (args.type !== "human") {
-    saveAgentConfig(args.id, primary.uuid, "claude-code");
+    saveAgentConfig(primaryLocalName, primary.uuid, "claude-code");
   }
 
   let assistantUuid: string | null = null;
@@ -207,8 +210,9 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
         clientId: args.clientId,
       });
       assistantUuid = assistant.uuid;
-      saveAgentConfig(args.assistant, assistant.uuid, "claude-code");
-      print.line(`Assistant "${args.assistant}" ready.\n`);
+      const assistantLocalName = assistant.name ?? args.assistant;
+      saveAgentConfig(assistantLocalName, assistant.uuid, "claude-code");
+      print.line(`Assistant "${assistantLocalName}" ready.\n`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       print.line(`Warning: Failed to create assistant "${args.assistant}": ${msg}\n`);

--- a/packages/command/src/core/prompt.ts
+++ b/packages/command/src/core/prompt.ts
@@ -7,6 +7,7 @@ import {
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { input, password, select } from "@inquirer/prompts";
+import { ensureFreshAccessToken, resolveServerUrl } from "./bootstrap.js";
 
 /**
  * Check if interactive mode is available.
@@ -71,18 +72,40 @@ export async function promptMissingFields(options: {
 }
 
 /**
- * Interactive add agent — simple two-field prompt.
+ * Interactive / scripted "add this agent to the local client".
+ *
+ * Phase 3 of the agent-naming refactor removed the free-form local
+ * alias — the local config dir is keyed by the server-authoritative
+ * `agent.name` slug. This helper only asks the user for the agent UUID
+ * (or takes it via `opts.agentId`), then fetches the canonical name
+ * from the Hub. A `name` comes back null only if the agent was
+ * tombstoned server-side, in which case the caller must refuse the
+ * add (there's nothing sensible to key the local dir on).
  */
-export async function promptAddAgent(): Promise<{ name: string; agentId: string }> {
-  const name = await input({
-    message: "Local alias:",
-    validate: (v) => (/^[a-z0-9][a-z0-9-]*$/.test(v) ? true : "Lowercase alphanumeric and hyphens only"),
+export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{ name: string; agentId: string }> {
+  const agentId =
+    opts.agentId ??
+    (await input({
+      message: "Agent UUID on the Hub:",
+      validate: (v) => (v.length > 0 ? true : "Agent UUID is required"),
+    }));
+
+  const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
+  const token = await ensureFreshAccessToken();
+  const res = await fetch(`${serverUrl}/api/v1/admin/agents/${encodeURIComponent(agentId)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(10_000),
   });
-  const agentId = await input({
-    message: "Agent UUID on the Hub:",
-    validate: (v) => (v.length > 0 ? true : "Agent UUID is required"),
-  });
-  return { name, agentId };
+  if (!res.ok) {
+    throw new Error(`Failed to look up agent ${agentId}: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as { name: string | null };
+  if (!body.name) {
+    throw new Error(
+      `Agent ${agentId} has no hub name (tombstoned or never named). Cannot add a local config without a name.`,
+    );
+  }
+  return { name: body.name, agentId };
 }
 
 // ── Internal ─────────────────────────────────────────────────────────

--- a/packages/command/src/core/prompt.ts
+++ b/packages/command/src/core/prompt.ts
@@ -7,7 +7,7 @@ import {
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { input, password, select } from "@inquirer/prompts";
-import { ensureFreshAccessToken, resolveServerUrl } from "./bootstrap.js";
+import { ensureFreshAccessToken, loadCredentials, resolveServerUrl } from "./bootstrap.js";
 
 /**
  * Check if interactive mode is available.
@@ -83,6 +83,22 @@ export async function promptMissingFields(options: {
  * add (there's nothing sensible to key the local dir on).
  */
 export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{ name: string; agentId: string }> {
+  // Phase 3 needs a live Hub to resolve the canonical agent name, which
+  // means the caller must have run `client connect` first. Detect the
+  // two common "not connected yet" states up front with a clear error
+  // instead of letting `ensureFreshAccessToken` or `resolveServerUrl`
+  // throw a cryptic message after the user already typed a UUID.
+  if (loadCredentials() === null) {
+    throw new Error("Not connected. Run `first-tree-hub client connect <server-url>` first.");
+  }
+  let serverUrl: string;
+  try {
+    serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`${msg} Run \`first-tree-hub client connect\` or set FIRST_TREE_HUB_SERVER_URL.`);
+  }
+
   const agentId =
     opts.agentId ??
     (await input({
@@ -90,7 +106,6 @@ export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{
       validate: (v) => (v.length > 0 ? true : "Agent UUID is required"),
     }));
 
-  const serverUrl = resolveServerUrl(process.env.FIRST_TREE_HUB_SERVER_URL);
   const token = await ensureFreshAccessToken();
   const res = await fetch(`${serverUrl}/api/v1/admin/agents/${encodeURIComponent(agentId)}`, {
     headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
> **Stacked on #169 (Phase 2), which is stacked on #168 (Phase 1).** Base will auto-retarget to `main` as each parent merges. The diff here shows only the Phase-3 delta.

## Summary

Phase 3 of the agent-naming refactor (see `docs/agent-naming-design.md` §3.4 + §4). Retires the per-machine free-form local alias — the Hub's `agent.name` slug is now the only key for the local config dir, workspace dir, and sessions file on every machine that runs the client.

## Scope

**New: `packages/command/src/core/migrate-agent-dirs.ts`**
Standalone reconciler. On every `first-tree-hub client start` / `client connect`:
1. Enumerate `config/agents/*` via `readdirSync` (not `loadAgents`) so a single malformed `agent.yaml` doesn't poison the rest.
2. For each local agent, resolve its canonical server name via the admin listing (paginated with `nextCursor`, capped at 50 pages for a server-bug safety valve).
3. If dir name ≠ server name, rename `config/agents/<old>` → `<new>`, followed by `workspaces/<old>/` and `sessions/<old>.json`.
4. Collisions (target already exists) skip + log; no clobber.
5. Tombstoned agents (server `name === null`) are left alone.
6. Resolver failure (network / 403) aborts the walk with a single warning — never blocks startup.
7. After the walk, log any orphaned workspaces/sessions against the post-rename name set.

**Migration hook**
- `packages/command/src/commands/client.ts` + `connect.ts`: call `migrateLocalAgentDirs` before `loadAgents`, wrapped in try/catch.

**CLI contract changes**
- `agent add`: drop positional `[name]` — local dir is keyed by Hub name. New form is `agent add [--agent-id <uuid>]`.
- `promptAddAgent({ agentId? })`: fetches the canonical name from `GET /admin/agents/:uuid`; refuses to add tombstoned agents; guards against missing credentials up front with a clear "run `client connect` first" message.
- Eight `--agent <alias>` help texts updated to "Agent name on the Hub (default: first configured on this client)".
- `agent remove` help text clarifies what gets deleted (config dir + workspace + sessions).

**Onboard**
- `onboard.ts` now persists + logs the server's returned `name` rather than `args.id`, keeping hub and local views aligned even when the server normalises the submitted name.

**Docs**
- `cli-reference.md`, `deployment-guide.md`, `claim-agent-guide.md`: drop the stale `agent add <name> --token aghub_xxx` form. The JWT-based auth model superseded per-agent tokens in PR #95/#108 and the positional name is gone in this PR.

## Tests

`__tests__/migrate-agent-dirs.test.ts` — 10 cases covering:
- empty `agentsDir`
- no-op when names already match
- full rename (config + workspace + sessions)
- collision skip
- tombstone skip
- resolver failure short-circuit
- idempotent re-run
- **fresh client with no workspaces/sessions dirs**
- **pre-existing workspace target (partial failure)**
- **malformed `agent.yaml` in one dir without aborting siblings**

## Rollout

- Backwards-incompatible for scripted callers of `agent add my-agent --token ...` — the CLI docs in this PR now reflect the new form.
- Existing `~/.first-tree/hub/config/agents/<old-alias>/` directories are renamed automatically on next client start; no operator action required.
- In-flight workspaces / sessions are moved alongside the config dir. Partial crashes between renames leave orphans visible via the "orphaned local state detected" warning on the next start; `agent workspace clean` reclaims them.

## Review cycle

Independent code review ran before this PR. Addressed:
- **CRITICAL**: malformed `agent.yaml` aborted migration globally → switched to per-dir filesystem walk with minimal parsing.
- **CRITICAL**: admin list silently capped at 100 → now paginated.
- **IMPORTANT**: orphan-detection set unioned old+new names → fixed to use post-rename state only.
- **IMPORTANT**: `promptAddAgent` threw cryptic errors when unconnected → up-front guard.
- **IMPORTANT**: stale docs advertised the old `agent add <name> --token` form → rewritten.
- **IMPORTANT**: onboard logged `args.id` instead of the server's returned name → uses `primary.name ?? args.id`.
- **IMPORTANT**: test coverage gap on partial-failure paths → three new cases.
- **NIT**: 403 hint in resolver error message.

Deferred:
- Dropping `NameResolver` from the public core export (minor; keeping it avoids churn for external consumers).
- Consolidating the try/catch duplication between `client.ts` and `connect.ts` (small refactor, not Phase 3 scope).
- Renaming cosmetic log icons.

## Test plan
- [ ] `pnpm check && pnpm typecheck` (green locally)
- [ ] `pnpm --filter @agent-team-foundation/first-tree-hub test` (58/59 passing — the one failure is a pre-existing sandbox-only EACCES test unrelated to this change)
- [ ] Manual: start a client with a pre-existing `agents/old-alias/` whose `agentId` points to a Hub agent named `alice` → verify the dir becomes `agents/alice/` plus workspace + sessions on next start
- [ ] Manual: `first-tree-hub agent add --agent-id <uuid>` writes `agents/<server-name>/agent.yaml`
- [ ] Manual: `agent list` shows the server name

https://claude.ai/code/session_01FPSSQEbW69nBmXGmH1zdB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPSSQEbW69nBmXGmH1zdB7)_