### PR TITLE
feat: add `start --service` + `service` subcommands + daemon (onboarding Phase 1b)

### DIFF
--- a/docs/quickstart-zh.md
+++ b/docs/quickstart-zh.md
@@ -15,17 +15,22 @@
 npm install -g @agent-team-foundation/first-tree-hub
 ```
 
-### 2. 启动（前台）
+### 2. 启动（选一种）
+
+| 操作模式 | 适合什么场景 | 关掉终端后还在跑吗？ |
+|----------|------------|--------------------|
+| `first-tree-hub start` | 在当前终端跑 Hub。临时试用、调启动问题、SSH、Windows。 | 仅 Postgres 容器；CLI 进程拥有 server + client，Ctrl+C 一起停。 |
+| `first-tree-hub start --service` | 让 Hub 跨重启后台运行。 | Postgres + 后台 daemon（server + client 在同一进程）。下次登录自动起。 |
+
+两条命令共享相同的安装期工作（Docker 预检 → Postgres → migrations → 自动建管理员），只在生命周期上不同：前台模式阻塞至 SIGINT；`--service` 安装 launchd plist (macOS) 或 systemd-user unit (Linux)，daemon 健康检查通过后即返回。
 
 ```bash
-first-tree-hub start
+first-tree-hub start              # 前台
+# or
+first-tree-hub start --service    # 后台服务
 ```
 
-执行流程一次性搞定：Docker 预检 → 拉起 Postgres 容器 → 跑 migrations → 自动建本机管理员（用户名/密码不会显示） → 嵌入式 Client 启动 → 浏览器自动打开 `http://127.0.0.1:8000`。
-
-终端保持运行，按 `Ctrl+C` 停 server + client（Postgres 容器保留；要一并停：`first-tree-hub server stop`）。
-
-> 想让 Hub 持续后台运行 / 重启后自动起？后台服务模式（`--service`，macOS launchd / Linux systemd-user）正在实现中。
+按 `Ctrl+C`（前台）或 `first-tree-hub service stop`（服务模式）停止；Postgres 容器保留，要一并停：`first-tree-hub server stop`。
 
 ### 3. 在 Web 里建第一个 agent
 
@@ -63,14 +68,29 @@ first-tree-hub start
 
 打开 `http://127.0.0.1:8000`。如果 localStorage 的 JWT 过期或不存在，Web `/login` 路由会自动调 loopback-only 的 `local-bootstrap` 端点重铸一对新的 token —— 不需要任何 CLI 命令。
 
+### 服务模式管理
+
+```bash
+first-tree-hub service status            # running / installed-but-stopped / not-installed
+first-tree-hub service logs -f           # 跟踪 daemon 日志（NDJSON）
+first-tree-hub service stop              # 停 daemon，不卸载
+first-tree-hub service uninstall         # 卸载 plist/unit（Postgres 与 ~/.first-tree/hub 保留）
+```
+
 ### 升级
 
 ```bash
 npm install -g @agent-team-foundation/first-tree-hub@latest
+
+# 前台：直接重新启动即可拾起新代码
 first-tree-hub start
+
+# 服务模式：必须先停再起，daemon 才会重新加载新 binary
+first-tree-hub service stop
+first-tree-hub start --service
 ```
 
-第二行重启 server，并应用任何新 migration。
+npm 不知道 launchd / systemd 的存在。前台直接重启拾起新代码并跑任何新 migration；服务模式下 `start --service` 在 daemon 已经在跑时是幂等的（只打开浏览器后退出），所以必须显式 `service stop` 一次再起，让 daemon 重新加载。如果忘记，旧 daemon 继续跑旧版，新一轮 migration 不会应用；下次重启时 schema 版本守卫会在 `service logs` 里抛出明确的版本不匹配错误。
 
 ## 托管：连别人架好的 Hub
 

--- a/packages/client/src/observability/logger.ts
+++ b/packages/client/src/observability/logger.ts
@@ -81,17 +81,22 @@ export function createLogger(module: string): pino.Logger {
  * The launchd / systemd unit files already set `StandardOutPath` /
  * `StandardError` as a fallback for crash-time stderr; this routes normal
  * operational logs into a size-rotated NDJSON file at
- * `<logDir>/client.log` so it doesn't grow unbounded. Must be called once
- * at `client start` when running under `FIRST_TREE_HUB_SERVICE_MODE=1`.
+ * `<logDir>/<basename>.log` so it doesn't grow unbounded. Must be called
+ * once at the supervised entry point when running under
+ * `FIRST_TREE_HUB_SERVICE_MODE=1`.
+ *
+ * `basename` defaults to `"client"` for the legacy `client connect
+ * --service` flow; the Hub daemon (Phase 1b) passes `"daemon"` so its
+ * logs land in a separate file from any concurrent client install.
  */
-export function configureClientLoggerForService(logDir: string): void {
+export function configureClientLoggerForService(logDir: string, basename = "client"): void {
   const stream = new RotatingFileStream({
-    path: join(logDir, "client.log"),
+    path: join(logDir, `${basename}.log`),
     maxBytes: SERVICE_LOG_MAX_BYTES,
     maxFiles: SERVICE_LOG_MAX_FILES,
   });
   // Pretty ANSI codes in a log file are noise; lock format to NDJSON and let
-  // `client service logs` pretty-print on read.
+  // `service logs` pretty-print on read.
   applyClientLoggerConfig({ format: "json", destination: stream });
 }
 

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/daemon-auth-3-tier.test.ts
+++ b/packages/command/src/__tests__/daemon-auth-3-tier.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/bootstrap.js", () => ({
+  loadCredentials: vi.fn(),
+  saveCredentials: vi.fn(),
+}));
+
+import { loadCredentials, saveCredentials } from "../core/bootstrap.js";
+import { __testing, obtainDaemonJWT } from "../core/daemon-auth.js";
+
+const { isLoopbackUrl } = __testing;
+
+const URL = "http://127.0.0.1:8000";
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature`;
+}
+
+const futureExp = () => Math.floor(Date.now() / 1000) + 3600;
+const pastExp = () => Math.floor(Date.now() / 1000) - 60;
+
+describe("isLoopbackUrl", () => {
+  it.each([
+    ["http://127.0.0.1:8000", true],
+    ["http://localhost:8000", true],
+    ["http://[::1]:8000", true],
+    ["https://127.0.0.1", true],
+    ["http://example.com", false],
+    ["http://10.0.0.5:8000", false],
+    ["http://192.168.1.1", false],
+    ["not-a-url", false],
+  ])("returns %s for %s", (url, expected) => {
+    expect(isLoopbackUrl(url)).toBe(expected);
+  });
+});
+
+describe("obtainDaemonJWT", () => {
+  const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+  beforeEach(() => {
+    vi.mocked(loadCredentials).mockReset();
+    vi.mocked(saveCredentials).mockReset();
+    fetchSpy.mockReset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  it("rejects non-loopback serverUrl outright", async () => {
+    await expect(obtainDaemonJWT("http://evil.com:8000")).rejects.toThrow(/non-loopback/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("tier 1: returns cached creds when access token is still valid", async () => {
+    const creds = { accessToken: jwt({ exp: futureExp() }), refreshToken: "r1", serverUrl: URL };
+    vi.mocked(loadCredentials).mockReturnValue(creds);
+
+    const out = await obtainDaemonJWT(URL);
+    expect(out).toEqual(creds);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(saveCredentials).not.toHaveBeenCalled();
+  });
+
+  it("tier 2: refreshes when cached access token is expired", async () => {
+    const cached = { accessToken: jwt({ exp: pastExp() }), refreshToken: "r1", serverUrl: URL };
+    vi.mocked(loadCredentials).mockReturnValue(cached);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ accessToken: jwt({ exp: futureExp() }) }), { status: 200 }),
+    );
+
+    const out = await obtainDaemonJWT(URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = fetchSpy.mock.calls[0]?.[0];
+    expect(String(url)).toContain("/auth/refresh");
+    expect(out.refreshToken).toBe("r1");
+    expect(saveCredentials).toHaveBeenCalledWith(out);
+  });
+
+  it("tier 3: falls through to local-bootstrap when refresh fails", async () => {
+    const cached = { accessToken: jwt({ exp: pastExp() }), refreshToken: "r1", serverUrl: URL };
+    vi.mocked(loadCredentials).mockReturnValue(cached);
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 401 })).mockResolvedValueOnce(
+      new Response(JSON.stringify({ accessToken: jwt({ exp: futureExp() }), refreshToken: "r2" }), {
+        status: 200,
+      }),
+    );
+
+    const out = await obtainDaemonJWT(URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/auth/local-bootstrap");
+    expect(out.refreshToken).toBe("r2");
+    expect(saveCredentials).toHaveBeenCalledWith(out);
+  });
+
+  it("tier 3: skips refresh when no cached creds and mints via local-bootstrap", async () => {
+    vi.mocked(loadCredentials).mockReturnValue(null);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ accessToken: jwt({ exp: futureExp() }), refreshToken: "fresh" }), {
+        status: 200,
+      }),
+    );
+
+    const out = await obtainDaemonJWT(URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/auth/local-bootstrap");
+    expect(out.refreshToken).toBe("fresh");
+    expect(saveCredentials).toHaveBeenCalledWith(out);
+  });
+
+  it("ignores cached creds bound to a different (or non-loopback) serverUrl", async () => {
+    // Stale `credentials.json` from a previous Hub install on a different
+    // port — fall through to bootstrap rather than replay the refresh
+    // token at whatever lives at that URL now.
+    const cached = {
+      accessToken: jwt({ exp: futureExp() }),
+      refreshToken: "stale",
+      serverUrl: "http://127.0.0.1:9999",
+    };
+    vi.mocked(loadCredentials).mockReturnValue(cached);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ accessToken: jwt({ exp: futureExp() }), refreshToken: "fresh" }), {
+        status: 200,
+      }),
+    );
+
+    const out = await obtainDaemonJWT(URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/auth/local-bootstrap");
+    expect(out.refreshToken).toBe("fresh");
+  });
+
+  it("throws when all three tiers fail", async () => {
+    vi.mocked(loadCredentials).mockReturnValue(null);
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 503 }));
+
+    await expect(obtainDaemonJWT(URL)).rejects.toThrow(/could not obtain a JWT/i);
+  });
+});

--- a/packages/command/src/__tests__/daemon-auth.test.ts
+++ b/packages/command/src/__tests__/daemon-auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "../core/daemon-auth.js";
+
+const { decodeExp, isExpired } = __testing;
+
+function jwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.signature-not-verified`;
+}
+
+describe("decodeExp", () => {
+  it("returns the exp claim when present", () => {
+    expect(decodeExp(jwt({ exp: 1234567890 }))).toBe(1234567890);
+  });
+
+  it("returns null when exp is missing", () => {
+    expect(decodeExp(jwt({ sub: "u1" }))).toBeNull();
+  });
+
+  it("returns null on malformed JWTs", () => {
+    expect(decodeExp("not.a.jwt")).toBeNull();
+    expect(decodeExp("only-one-segment")).toBeNull();
+    expect(decodeExp("")).toBeNull();
+  });
+});
+
+describe("isExpired", () => {
+  it("treats malformed tokens as expired", () => {
+    expect(isExpired("garbage")).toBe(true);
+  });
+
+  it("returns false when exp is well in the future", () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    expect(isExpired(jwt({ exp: future }))).toBe(false);
+  });
+
+  it("returns true when exp is already past", () => {
+    const past = Math.floor(Date.now() / 1000) - 60;
+    expect(isExpired(jwt({ exp: past }))).toBe(true);
+  });
+
+  it("treats tokens within the 30s leeway window as expired", () => {
+    const aboutToExpire = Math.floor(Date.now() / 1000) + 10;
+    expect(isExpired(jwt({ exp: aboutToExpire }))).toBe(true);
+  });
+});

--- a/packages/command/src/cli/index.ts
+++ b/packages/command/src/cli/index.ts
@@ -5,8 +5,10 @@ import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent.js";
 import { registerClientCommands } from "../commands/client.js";
 import { registerConfigCommands } from "../commands/config.js";
+import { registerDaemonCommand } from "../commands/daemon.js";
 import { registerOnboardCommand } from "../commands/onboard.js";
 import { registerServerCommands } from "../commands/server.js";
+import { registerServiceCommands } from "../commands/service.js";
 import { registerStartCommand } from "../commands/start.js";
 import { registerStatusCommand } from "../commands/status.js";
 import { runHomeMigration } from "../core/migrate-home.js";
@@ -53,9 +55,15 @@ program
   });
 
 // One-command start — Docker preflight, Postgres, migrations, auto-admin,
-// embedded ClientRuntime, browser auto-open. Foreground shape; --service
-// is added in a subsequent change (Phase 1b / C8).
+// embedded ClientRuntime, browser auto-open. Supports both foreground
+// (default) and `--service` (launchd / systemd-user background daemon).
 registerStartCommand(program);
+
+// Hub daemon entry (hidden) — invoked by launchd / systemd-user only.
+registerDaemonCommand(program);
+
+// Background-service management for the daemon installed by `start --service`.
+registerServiceCommands(program);
 
 // Core subsystems — `client` group mounts `connect` too.
 registerServerCommands(program);

--- a/packages/command/src/commands/daemon.ts
+++ b/packages/command/src/commands/daemon.ts
@@ -1,0 +1,206 @@
+import { join } from "node:path";
+import {
+  clientConfigSchema,
+  DEFAULT_CONFIG_DIR,
+  DEFAULT_HOME_DIR,
+  initConfig,
+  resetConfig,
+  resetConfigMeta,
+  setConfigValue,
+} from "@agent-team-foundation/first-tree-hub-shared/config";
+import { configureClientLoggerForService } from "@first-tree-hub/client";
+import { type Command, InvalidArgumentError } from "commander";
+import { saveCredentials } from "../core/bootstrap.js";
+import { ClientRuntime } from "../core/client-runtime.js";
+import { obtainDaemonJWT } from "../core/daemon-auth.js";
+import { createExecuteUpdate, promptUpdate } from "../core/index.js";
+import { print, status } from "../core/output.js";
+import { assertSchemaCurrent } from "../core/schema-version-guard.js";
+import { bootstrapServer } from "../core/server.js";
+import { COMMAND_VERSION } from "../core/version.js";
+
+type DaemonOptions = {
+  port?: number;
+  host?: string;
+  databaseUrl?: string;
+};
+
+function parsePortArg(value: string): number {
+  const n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 1 || n > 65_535) {
+    throw new InvalidArgumentError(`Invalid port: '${value}' (expected an integer 1..65535)`);
+  }
+  return n;
+}
+
+/**
+ * Hidden `first-tree-hub daemon` subcommand — the entry point launchd /
+ * systemd-user invokes after `start --service` installs the unit.
+ *
+ * Pattern B (Q11) — the daemon does NOT re-run install-time work
+ * (Postgres, migrations, createAdmin). Those are owned by the CLI parent.
+ * The daemon's only orchestration on every boot:
+ *
+ *   1. `assertSchemaCurrent` — fail-fast on version drift between the
+ *      bundled migrations and the live DB. Surfaces the upgrade-without-
+ *      restart bug in `service logs`.
+ *   2. `bootstrapServer` — telemetry init + buildApp (no migrations; the
+ *      bootstrap path runs `runMigrations` but it's a no-op when the DB
+ *      is already current, so the cost is negligible).
+ *   3. `app.listen`.
+ *   4. `obtainDaemonJWT` 3-tier recovery (Q9 / B2).
+ *   5. Embedded `ClientRuntime` startup.
+ *   6. Block until SIGTERM.
+ */
+export function registerDaemonCommand(program: Command): void {
+  program
+    .command("daemon", { hidden: true })
+    .description("Hub daemon entry point (invoked by launchd / systemd-user)")
+    .option("--port <number>", "Port (passed through from start --service)", parsePortArg)
+    .option("--host <address>", "Bind address")
+    .option("--database-url <url>", "External PostgreSQL URL")
+    .action(async (options: DaemonOptions) => {
+      try {
+        await runDaemon(options);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // The daemon's stderr is captured by launchd / systemd into the
+        // platform log; log the message so `service logs` shows it.
+        process.stderr.write(`first-tree-hub daemon error: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+}
+
+async function runDaemon(options: DaemonOptions): Promise<void> {
+  // Route the client logger to a rotating NDJSON file under the same logs/
+  // dir launchd / systemd capture stdout into. Done first so any later
+  // failure surfaces in `service logs`. The function is idempotent for
+  // direct (non-service) invocations; in non-service mode the operator
+  // sees raw stdout instead.
+  if (process.env.FIRST_TREE_HUB_SERVICE_MODE === "1") {
+    configureClientLoggerForService(join(DEFAULT_HOME_DIR, "logs"), "daemon");
+  }
+
+  print.line(`\n  First Tree Hub daemon v${COMMAND_VERSION}\n\n`);
+
+  // Step 1: schema-version guard. Run before bootstrapServer so we never
+  // build the fastify app against an unexpected schema.
+  const { url } = await resolveDatabaseUrl(options.databaseUrl);
+  await assertSchemaCurrent(url, COMMAND_VERSION);
+  status("Schema", "current");
+
+  // Step 2: bootstrap. `bootstrapServer` includes `runMigrations`, which
+  // is idempotent — by the time we reach here, the schema guard already
+  // confirmed it is a no-op. Keeping it in the path means a daemon that
+  // somehow gets ahead of its parent (downgrade) still applies pending
+  // migrations on its own; the schema guard pre-empts the more dangerous
+  // upgrade-without-restart case.
+  const { app, config, shutdownTelemetry } = await bootstrapServer({
+    port: options.port,
+    host: options.host,
+    databaseUrl: options.databaseUrl,
+    noInteractive: true,
+  });
+
+  await app.listen({ host: config.server.host, port: config.server.port });
+  status("Server", `listening at http://${config.server.host}:${config.server.port}`);
+
+  const serverUrl = `http://${normaliseDaemonHost(config.server.host)}:${config.server.port}`;
+  setConfigValue(join(DEFAULT_CONFIG_DIR, "client.yaml"), "server.url", serverUrl);
+  resetConfig();
+  resetConfigMeta();
+  const clientConfig = await initConfig({ schema: clientConfigSchema, role: "client" });
+
+  // Step 4: 3-tier JWT recovery (Q9). Persist the resulting pair so
+  // subsequent boots take the cached path.
+  const tokens = await obtainDaemonJWT(serverUrl);
+  saveCredentials(tokens);
+  status("Client", `connected as ${clientConfig.client.id}`);
+
+  const runtime = new ClientRuntime(clientConfig.server.url, clientConfig.client.id, {
+    currentVersion: COMMAND_VERSION,
+    update: {
+      updateConfig: clientConfig.update,
+      prompt: promptUpdate,
+      executeUpdate: createExecuteUpdate({ managed: true }),
+    },
+  });
+  const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+  await runtime.start();
+  runtime.watchAgentsDir(agentsDir);
+
+  await blockUntilSigterm(runtime, app, shutdownTelemetry);
+}
+
+function blockUntilSigterm(
+  runtime: ClientRuntime,
+  app: { close: () => Promise<unknown> },
+  shutdownTelemetry: () => Promise<void>,
+): Promise<never> {
+  return new Promise<never>(() => {
+    let triggered = false;
+    const onSignal = () => {
+      if (triggered) return;
+      triggered = true;
+      void (async () => {
+        let exitCode = 0;
+        try {
+          runtime.unwatchAgentsDir();
+        } catch {
+          exitCode = 1;
+        }
+        try {
+          await runtime.stop();
+        } catch {
+          exitCode = 1;
+        }
+        try {
+          await app.close();
+        } catch {
+          exitCode = 1;
+        }
+        try {
+          await shutdownTelemetry();
+        } catch {
+          exitCode = 1;
+        }
+        process.exit(exitCode);
+      })();
+    };
+    process.on("SIGINT", onSignal);
+    process.on("SIGTERM", onSignal);
+  });
+}
+
+/**
+ * The daemon binds whatever the unit file passes as `--port` (default
+ * 8000). Loopback dial-in for `local-bootstrap` must use 127.0.0.1 even if
+ * the bind address is wildcard.
+ */
+function normaliseDaemonHost(host: string): string {
+  if (host === "0.0.0.0" || host === "::" || host === "::0") return "127.0.0.1";
+  return host;
+}
+
+/**
+ * Resolve the database URL without mutating the config singleton, so the
+ * subsequent `bootstrapServer` call inside `runDaemon` performs the
+ * canonical (CLI-args-aware) `initConfig` itself.
+ */
+async function resolveDatabaseUrl(cliOverride: string | undefined): Promise<{ url: string }> {
+  if (cliOverride) return { url: cliOverride };
+  const { resolveConfigReadonly, serverConfigSchema } = await import(
+    "@agent-team-foundation/first-tree-hub-shared/config"
+  );
+  const cfg = resolveConfigReadonly({ schema: serverConfigSchema, role: "server" });
+  const db = cfg.database;
+  if (typeof db !== "object" || db === null) {
+    throw new Error("database.url is not configured. Run `first-tree-hub start --service` to (re)install.");
+  }
+  const url = Reflect.get(db, "url");
+  if (typeof url !== "string" || url.length === 0) {
+    throw new Error("database.url is not configured. Run `first-tree-hub start --service` to (re)install.");
+  }
+  return { url };
+}

--- a/packages/command/src/commands/service.ts
+++ b/packages/command/src/commands/service.ts
@@ -1,0 +1,121 @@
+import type { Command } from "commander";
+import {
+  getHubServiceStatus,
+  isHubServiceSupported,
+  stopHubService,
+  uninstallHubService,
+} from "../core/hub-service.js";
+import { print, status } from "../core/output.js";
+import { parseDuration, showServiceLogs, validateLevel } from "../core/service-logs.js";
+
+/**
+ * `first-tree-hub service` — manage the Hub daemon installed by
+ * `start --service`. Status, logs, stop, uninstall (Postgres / data dir
+ * untouched). `service install` is an alias for `start --service`.
+ */
+export function registerServiceCommands(program: Command): void {
+  const service = program
+    .command("service")
+    .description("Manage the Hub daemon (launchd / systemd-user)")
+    .action(() => {
+      service.help();
+    });
+
+  service
+    .command("install")
+    .description("Alias for `first-tree-hub start --service`")
+    .action(() => {
+      print.line(
+        "\n  Run `first-tree-hub start --service` instead — it bundles install-time work\n" +
+          "  (Docker preflight, Postgres, migrations, auto-admin) with the unit install.\n\n",
+      );
+      process.exit(2);
+    });
+
+  service
+    .command("status")
+    .description("Print whether the daemon is installed/running")
+    .action(() => {
+      if (!isHubServiceSupported()) {
+        print.line(`  Background services are not supported on ${process.platform}.\n`);
+        return;
+      }
+      const info = getHubServiceStatus();
+      switch (info.state) {
+        case "active":
+          status("Service", `running (${info.detail ?? info.label})`);
+          break;
+        case "inactive":
+          status("Service", `installed but not running${info.detail ? ` — ${info.detail}` : ""}`);
+          break;
+        case "not-installed":
+          status("Service", "not installed");
+          break;
+        default:
+          status("Service", "unknown");
+      }
+      print.line(`  Unit: ${info.unitPath}\n`);
+      print.line(`  Logs: ${info.logDir}\n\n`);
+    });
+
+  service
+    .command("logs")
+    .description("Stream / tail the daemon's NDJSON log files")
+    .option("-f, --follow", "follow new lines as they arrive")
+    .option("--level <level>", "minimum level (trace|debug|info|warn|error|fatal)")
+    .option("--since <duration>", "only lines newer than e.g. 30s, 5m, 2h, 1d")
+    .option("--json", "emit raw NDJSON lines instead of pretty-printed text")
+    .action(async (options: { follow?: boolean; level?: string; since?: string; json?: boolean }) => {
+      try {
+        await showServiceLogs({
+          variant: "daemon",
+          tail: options.follow === true,
+          level: validateLevel(options.level),
+          sinceMs: options.since ? parseDuration(options.since) : undefined,
+          json: options.json === true,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.line(`  Error: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+
+  service
+    .command("stop")
+    .description("Stop the running daemon (does not uninstall)")
+    .action(() => {
+      if (!isHubServiceSupported()) {
+        print.line(`  Background services are not supported on ${process.platform}.\n`);
+        process.exit(1);
+      }
+      try {
+        stopHubService();
+        status("Service", "stop signalled");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.line(`  Error: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+
+  service
+    .command("uninstall")
+    .description("Remove the daemon's launchd plist / systemd unit (Postgres untouched)")
+    .action(() => {
+      if (!isHubServiceSupported()) {
+        print.line(`  Background services are not supported on ${process.platform}.\n`);
+        return;
+      }
+      try {
+        const info = uninstallHubService();
+        status("Service", "uninstalled");
+        print.line(`  Removed: ${info.unitPath}\n`);
+        print.line("  (Postgres container and ~/.first-tree/hub left intact.)\n\n");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.line(`  Error: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/command/src/commands/start.ts
+++ b/packages/command/src/commands/start.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { userInfo } from "node:os";
 import { join } from "node:path";
@@ -12,6 +13,12 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { type Command, InvalidArgumentError } from "commander";
 import {
+  getHubServiceStatus,
+  installHubService,
+  isHubServiceSupported,
+  uninstallHubService,
+} from "../core/hub-service.js";
+import {
   bootstrapServer,
   ClientRuntime,
   COMMAND_VERSION,
@@ -19,6 +26,7 @@ import {
   createExecuteUpdate,
   hasUser,
   isDockerAvailable,
+  prepareInstallTime,
   promptUpdate,
   saveCredentials,
 } from "../core/index.js";
@@ -29,6 +37,7 @@ type StartCommandOptions = {
   host?: string;
   databaseUrl?: string;
   open?: boolean;
+  service?: boolean;
 };
 
 const DEFAULT_PORT = 8000;
@@ -43,14 +52,19 @@ const DEFAULT_PORT = 8000;
 export function registerStartCommand(program: Command): void {
   program
     .command("start")
-    .description("Run First Tree Hub in this terminal (foreground)")
+    .description("Run First Tree Hub (foreground), or install as a background service with --service")
     .option("--port <number>", "Server port (default: 8000)", parsePortArg)
     .option("--host <address>", "Bind address (default: 127.0.0.1)")
     .option("--database-url <url>", "Use an existing PostgreSQL (skip Docker)")
     .option("--no-open", "Do not auto-open the browser")
+    .option("--service", "Install Hub as a launchd / systemd-user background service")
     .action(async (options: StartCommandOptions) => {
       try {
-        await runStart(options);
+        if (options.service === true) {
+          await runStartService(options);
+        } else {
+          await runStart(options);
+        }
       } catch (err) {
         if (isAddressInUseError(err)) {
           const port = options.port ?? DEFAULT_PORT;
@@ -296,6 +310,139 @@ export function isAddressInUseError(err: unknown): boolean {
   if (typeof err !== "object" || err === null) return false;
   const code = Reflect.get(err, "code");
   return code === "EADDRINUSE";
+}
+
+/**
+ * Install Hub as a background service. Pattern B (Q11): the CLI parent
+ * runs install-time work (Docker, Postgres, migrations, auto-admin), then
+ * hands binding/listening off to the daemon via launchd / systemd-user.
+ *
+ * Flow:
+ *   1. Reject on unsupported platform (Windows for now).
+ *   2. Idempotency: if service already installed and running, skip
+ *      install + try to open the browser (Q13).
+ *   3. Pre-probe the port — same rationale as foreground; surfaces
+ *      cross-shape collision early (Q14).
+ *   4. Install-time orchestration via `prepareInstallTime`.
+ *   5. Auto-admin (Q1).
+ *   6. Install platform unit; daemon auto-starts via launchd/systemd-user.
+ *   7. Poll daemon `/healthz` for up to 10s (Q8).
+ *   8. On timeout: uninstall + tail stderr fallback log + exit 1 (no half-
+ *      installed state).
+ *   9. On success: open browser, print summary, exit 0.
+ */
+async function runStartService(options: StartCommandOptions): Promise<void> {
+  print.line(`\n  First Tree Hub v${COMMAND_VERSION} — installing as a service\n\n`);
+
+  if (!isHubServiceSupported()) {
+    throw new Error(
+      `Background service install is not supported on ${process.platform}. ` +
+        "Run `first-tree-hub start` (foreground) instead.",
+    );
+  }
+
+  const port = options.port ?? DEFAULT_PORT;
+  const browserUrl = `http://127.0.0.1:${port}`;
+
+  // Idempotency / cross-shape collision detection.
+  const existing = getHubServiceStatus();
+  if (existing.state === "active") {
+    print.line(`  Service is already running (${existing.detail ?? existing.label}).\n`);
+    if (shouldAutoOpenBrowser(options)) {
+      openBrowser(browserUrl);
+      print.line(`  Opening browser at ${browserUrl}\n\n`);
+    } else {
+      print.line(`  Open ${browserUrl} in your browser to get started.\n\n`);
+    }
+    return;
+  }
+
+  if (options.databaseUrl === undefined && !isDockerAvailable()) {
+    throw new Error(
+      "Docker is not available.\n\n" +
+        "  First Tree Hub needs PostgreSQL. Two options:\n\n" +
+        "  1. Install Docker → https://docs.docker.com/get-docker/\n" +
+        "     Then re-run: first-tree-hub start --service\n\n" +
+        "  2. Provide an existing PostgreSQL URL:\n" +
+        "     first-tree-hub start --service --database-url postgresql://user:pass@host:5432/db",
+    );
+  }
+
+  const requestedHost = options.host ?? "127.0.0.1";
+  await assertPortFree(requestedHost, port);
+
+  const serverConfig = await prepareInstallTime({
+    port: options.port,
+    host: options.host,
+    databaseUrl: options.databaseUrl,
+    noInteractive: false,
+  });
+
+  const adminCreated = await ensureLocalAdmin(serverConfig.database.url);
+  if (adminCreated) status("Local admin", "ready");
+
+  const info = installHubService({ port });
+  status("Service", `installed (${info.platform}, unit: ${info.unitPath})`);
+
+  const healthy = await pollHealth(`http://127.0.0.1:${port}/healthz`, 10_000);
+  if (!healthy) {
+    print.line("\n  Daemon failed health check. Tearing down install...\n\n");
+    const tail = readDaemonStderrTail(info.logDir, 20);
+    if (tail) {
+      print.line("  Last lines of daemon stderr:\n");
+      for (const line of tail) print.line(`    ${line}\n`);
+      print.line("\n");
+    }
+    try {
+      uninstallHubService();
+    } catch {
+      // Best effort — primary signal is the failed health check.
+    }
+    throw new Error("Daemon did not become healthy within 10s; service uninstalled.");
+  }
+
+  status("Service", "running");
+  blank();
+
+  if (shouldAutoOpenBrowser(options)) {
+    openBrowser(browserUrl);
+    print.line(`  Opening browser at ${browserUrl}\n`);
+  } else {
+    print.line(`  Open ${browserUrl} in your browser to get started.\n`);
+  }
+  print.line("\n  (Service runs in the background and auto-starts at next login.)\n");
+  print.line("  Manage via: first-tree-hub service [status|logs|stop|uninstall]\n\n");
+}
+
+async function pollHealth(url: string, deadlineMs: number): Promise<boolean> {
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < deadlineMs) {
+    attempt++;
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (res.ok) return true;
+    } catch {
+      // Connection refused / not yet listening — keep retrying.
+    }
+    await sleep(Math.min(500 + attempt * 100, 1_500));
+  }
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readDaemonStderrTail(logDir: string, lines: number): string[] | null {
+  const path = join(logDir, "daemon.stderr.log");
+  if (!existsSync(path)) return null;
+  try {
+    const content = readFileSync(path, "utf-8");
+    return content.trimEnd().split(/\r?\n/).slice(-lines);
+  } catch {
+    return null;
+  }
 }
 
 function parsePortArg(value: string): number {

--- a/packages/command/src/core/daemon-auth.ts
+++ b/packages/command/src/core/daemon-auth.ts
@@ -1,0 +1,127 @@
+import { loadCredentials, saveCredentials } from "./bootstrap.js";
+
+type Tokens = { accessToken: string; refreshToken: string; serverUrl: string };
+
+const REFRESH_LEEWAY_MS = 30_000;
+
+/** Decode a JWT payload without signature verification. */
+function decodeExp(token: string): number | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3 || !parts[1]) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString()) as { exp?: number };
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+function isExpired(token: string): boolean {
+  const exp = decodeExp(token);
+  if (exp === null) return true;
+  return exp * 1000 < Date.now() + REFRESH_LEEWAY_MS;
+}
+
+async function tryRefresh(creds: Tokens): Promise<Tokens | null> {
+  try {
+    const res = await fetch(`${creds.serverUrl}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: creds.refreshToken }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { accessToken: string; refreshToken?: string };
+    return {
+      ...creds,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken ?? creds.refreshToken,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function tryLocalBootstrap(serverUrl: string): Promise<Tokens | null> {
+  try {
+    const res = await fetch(`${serverUrl}/api/v1/auth/local-bootstrap`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { accessToken: string; refreshToken: string };
+    return { accessToken: data.accessToken, refreshToken: data.refreshToken, serverUrl };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Loopback-only origins the daemon trusts for refresh-token replay. Without
+ * this guard, a cached refresh token could be sent to whatever origin
+ * happens to be in `credentials.json` — including an attacker who briefly
+ * commandeered the same port. The loopback restriction is consistent with
+ * the design's local-mode trust boundary (Q7).
+ */
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    // Node's URL parser returns IPv6 hostnames bracketed (`[::1]`); the bare
+    // form arrives only when the caller already stripped brackets, so
+    // accept both.
+    const host = u.hostname.replace(/^\[|\]$/g, "");
+    if (host === "127.0.0.1" || host === "::1" || host === "localhost") return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Three-tier JWT recovery for the daemon (Q9 / B2):
+ *
+ *   1. If `credentials.json` holds a still-valid access token whose
+ *      `serverUrl` matches the daemon's bound URL AND is loopback → use.
+ *   2. Else attempt `/auth/refresh` with the cached refresh token.
+ *   3. Else fall through to `/auth/local-bootstrap` — same-process call,
+ *      the loopback gates trivially pass.
+ *
+ * On every successful step the new pair is persisted so subsequent boots
+ * pick up from step 1. The pollution argument is the design's: always
+ * going to local-bootstrap mints a fresh refresh-token row on every laptop
+ * sleep/wake.
+ *
+ * @throws when none of the three tiers can produce a token (e.g. the
+ *   server is down or refused all three paths).
+ */
+export async function obtainDaemonJWT(serverUrl: string): Promise<Tokens> {
+  if (!isLoopbackUrl(serverUrl)) {
+    throw new Error(`obtainDaemonJWT refuses non-loopback serverUrl ${serverUrl}`);
+  }
+
+  const cached = loadCredentials();
+  if (cached && cached.serverUrl === serverUrl && isLoopbackUrl(cached.serverUrl)) {
+    if (!isExpired(cached.accessToken)) return cached;
+    const refreshed = await tryRefresh(cached);
+    if (refreshed) {
+      saveCredentials(refreshed);
+      return refreshed;
+    }
+  }
+
+  const minted = await tryLocalBootstrap(serverUrl);
+  if (minted) {
+    saveCredentials(minted);
+    return minted;
+  }
+
+  throw new Error(
+    "Daemon could not obtain a JWT pair. Cached credentials are invalid, " +
+      "/auth/refresh failed, and /auth/local-bootstrap is unreachable. " +
+      "Inspect 'first-tree-hub service logs' for details.",
+  );
+}
+
+// Internal-only helpers exported for unit tests.
+export const __testing = { decodeExp, isExpired, isLoopbackUrl };

--- a/packages/command/src/core/hub-service.ts
+++ b/packages/command/src/core/hub-service.ts
@@ -1,0 +1,399 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { DEFAULT_HOME_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { print } from "./output.js";
+import type { ServiceInfo, ServiceState } from "./service-install.js";
+
+/**
+ * Hub-daemon service install — runs `first-tree-hub daemon` (server +
+ * embedded ClientRuntime in one process). Independent from the legacy
+ * `client.service` unit installed by `client connect --service`; the two
+ * shouldn't coexist on the same machine, but the labels are distinct so a
+ * stale client unit doesn't shadow the new Hub unit.
+ */
+
+const LAUNCHD_LABEL = "dev.first-tree-hub.daemon";
+const SYSTEMD_UNIT = "first-tree-hub-daemon.service";
+const DEFAULT_DAEMON_PORT = 8000;
+
+type ResolvedBinary = { kind: "bin"; program: string } | { kind: "node"; program: string; args: string[] };
+
+type ShellResult = { ok: true } | { ok: false; stderr: string; code: number | null };
+
+function runCapture(program: string, args: string[], timeoutMs: number): ShellResult {
+  const res = spawnSync(program, args, {
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status === 0) return { ok: true };
+  return { ok: false, stderr: (res.stderr ?? "").trim(), code: res.status };
+}
+
+function sleepSync(ms: number): void {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, ms);
+}
+
+function whichBin(name: string): string | null {
+  try {
+    const out = execFileSync(process.platform === "win32" ? "where" : "which", [name], {
+      encoding: "utf-8",
+      timeout: 3000,
+    })
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return out[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function logDir(): string {
+  return join(DEFAULT_HOME_DIR, "logs");
+}
+
+function ensureLogDir(): void {
+  mkdirSync(logDir(), { recursive: true, mode: 0o700 });
+}
+
+function resolveCli(): ResolvedBinary {
+  const bin = whichBin("first-tree-hub");
+  if (bin && isAbsolute(bin)) {
+    try {
+      return { kind: "bin", program: realpathSync(bin) };
+    } catch {
+      return { kind: "bin", program: bin };
+    }
+  }
+  const script = process.argv[1];
+  if (!script) throw new Error("Cannot resolve CLI entry point (process.argv[1] is empty).");
+  const scriptAbs = isAbsolute(script) ? script : join(process.cwd(), script);
+  return { kind: "node", program: process.execPath, args: [scriptAbs] };
+}
+
+// ── launchd (macOS) ─────────────────────────────────────────────────
+
+function launchdPlistPath(): string {
+  return join(homedir(), "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function launchctlDomainTarget(): string {
+  return `gui/${userInfo().uid}`;
+}
+
+function renderPlist(invocation: ResolvedBinary, port: number): string {
+  const programArgs: string[] =
+    invocation.kind === "bin"
+      ? [invocation.program, "daemon", "--port", String(port)]
+      : [invocation.program, ...invocation.args, "daemon", "--port", String(port)];
+  const argsXml = programArgs.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
+  const stdoutFallback = join(logDir(), "daemon.stdout.log");
+  const stderrFallback = join(logDir(), "daemon.stderr.log");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${argsXml}
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <key>FIRST_TREE_HUB_SERVICE_MODE</key>
+    <string>1</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(stdoutFallback)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(stderrFallback)}</string>
+</dict>
+</plist>
+`;
+}
+
+function waitForLabelEvicted(target: string, label: string, timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = spawnSync("launchctl", ["print", `${target}/${label}`], {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (res.status !== 0) return true;
+    sleepSync(200);
+  }
+  return false;
+}
+
+function launchdState(): { state: ServiceState; detail?: string } {
+  const plist = launchdPlistPath();
+  if (!existsSync(plist)) return { state: "not-installed" };
+  const res = spawnSync("launchctl", ["print", `${launchctlDomainTarget()}/${LAUNCHD_LABEL}`], {
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) return { state: "inactive", detail: "plist present but not loaded" };
+  const out = res.stdout ?? "";
+  const stateLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("state ="));
+  const pidLine = out.split(/\r?\n/).find((l) => l.trim().startsWith("pid ="));
+  if (stateLine?.includes("running")) {
+    const pid = pidLine?.split("=")[1]?.trim();
+    return { state: "active", detail: pid ? `pid ${pid}` : "running" };
+  }
+  return { state: "inactive", detail: stateLine?.trim() ?? "loaded" };
+}
+
+function installLaunchd(port: number): ServiceInfo {
+  const invocation = resolveCli();
+  ensureLogDir();
+  const plistPath = launchdPlistPath();
+  mkdirSync(dirname(plistPath), { recursive: true });
+  writeFileSync(plistPath, renderPlist(invocation, port), { mode: 0o644 });
+
+  const target = launchctlDomainTarget();
+
+  const bootoutRes = runCapture("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], 15_000);
+  if (!bootoutRes.ok && !/not find|no such|not loaded/i.test(bootoutRes.stderr)) {
+    print.line(`    warning: launchctl bootout: ${bootoutRes.stderr || `exit ${bootoutRes.code ?? "unknown"}`}\n`);
+  }
+  waitForLabelEvicted(target, LAUNCHD_LABEL, 10_000);
+
+  let lastErr: ShellResult | null = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const res = runCapture("launchctl", ["bootstrap", target, plistPath], 10_000);
+    if (res.ok) {
+      lastErr = null;
+      break;
+    }
+    lastErr = res;
+    if (attempt < 2) sleepSync(1_000);
+  }
+  if (lastErr) {
+    throw new Error(
+      `launchctl bootstrap failed: ${lastErr.stderr || `exit ${lastErr.code ?? "unknown"}`}\n` +
+        `    Recovery: \`launchctl bootout ${target}/${LAUNCHD_LABEL}\` then \`first-tree-hub start --service\`.`,
+    );
+  }
+
+  const enableRes = runCapture("launchctl", ["enable", `${target}/${LAUNCHD_LABEL}`], 5_000);
+  if (!enableRes.ok) {
+    print.line(`    warning: launchctl enable: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n`);
+  }
+
+  const { state, detail } = launchdState();
+  return { platform: "launchd", label: LAUNCHD_LABEL, unitPath: plistPath, logDir: logDir(), state, detail };
+}
+
+function uninstallLaunchd(): ServiceInfo {
+  const plistPath = launchdPlistPath();
+  const target = launchctlDomainTarget();
+  const res = runCapture("launchctl", ["bootout", `${target}/${LAUNCHD_LABEL}`], 15_000);
+  if (!res.ok && !/not find|no such|not loaded/i.test(res.stderr)) {
+    print.line(`    warning: bootout during uninstall: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
+  }
+  if (existsSync(plistPath)) rmSync(plistPath);
+  return {
+    platform: "launchd",
+    label: LAUNCHD_LABEL,
+    unitPath: plistPath,
+    logDir: logDir(),
+    state: "not-installed",
+  };
+}
+
+function stopLaunchd(): void {
+  const target = launchctlDomainTarget();
+  const res = runCapture("launchctl", ["kill", "SIGTERM", `${target}/${LAUNCHD_LABEL}`], 10_000);
+  if (!res.ok && !/not find|no such|not loaded/i.test(res.stderr)) {
+    print.line(`    warning: launchctl kill: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
+  }
+}
+
+// ── systemd --user (Linux) ──────────────────────────────────────────
+
+function systemdUnitPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(xdg, "systemd", "user", SYSTEMD_UNIT);
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_\-./:=]+$/.test(value)) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function renderSystemdUnit(invocation: ResolvedBinary, port: number): string {
+  const baseCmd =
+    invocation.kind === "bin"
+      ? shellQuote(invocation.program)
+      : `${shellQuote(invocation.program)} ${invocation.args.map(shellQuote).join(" ")}`;
+  const execStart = `${baseCmd} daemon --port ${port}`;
+  return `[Unit]
+Description=First Tree Hub Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${execStart}
+Restart=always
+RestartSec=10
+StandardOutput=append:${join(logDir(), "daemon.stdout.log")}
+StandardError=append:${join(logDir(), "daemon.stderr.log")}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=FIRST_TREE_HUB_SERVICE_MODE=1
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function systemdState(): { state: ServiceState; detail?: string } {
+  const unitPath = systemdUnitPath();
+  if (!existsSync(unitPath)) return { state: "not-installed" };
+  const res = spawnSync("systemctl", ["--user", "is-active", SYSTEMD_UNIT], {
+    encoding: "utf-8",
+    timeout: 5000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const out = (res.stdout ?? "").trim();
+  if (res.status === 0 && out === "active") return { state: "active", detail: "running" };
+  return { state: "inactive", detail: out || "unit present but not active" };
+}
+
+function installSystemd(port: number): ServiceInfo {
+  const invocation = resolveCli();
+  ensureLogDir();
+  const unitPath = systemdUnitPath();
+  mkdirSync(dirname(unitPath), { recursive: true });
+  writeFileSync(unitPath, renderSystemdUnit(invocation, port), { mode: 0o644 });
+
+  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  if (!reloadRes.ok) {
+    throw new Error(
+      `systemctl --user daemon-reload failed: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}`,
+    );
+  }
+  const enableRes = runCapture("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT], 10_000);
+  if (!enableRes.ok) {
+    throw new Error(
+      `systemctl --user enable --now ${SYSTEMD_UNIT} failed: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n` +
+        `    Recovery: \`systemctl --user stop ${SYSTEMD_UNIT}\` then \`first-tree-hub start --service\`.`,
+    );
+  }
+
+  const { state, detail } = systemdState();
+  return { platform: "systemd", label: SYSTEMD_UNIT, unitPath, logDir: logDir(), state, detail };
+}
+
+function uninstallSystemd(): ServiceInfo {
+  const unitPath = systemdUnitPath();
+  const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000);
+  if (!disableRes.ok && !/not found|no such|not loaded/i.test(disableRes.stderr)) {
+    print.line(
+      `    warning: systemctl disable during uninstall: ${disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`}\n`,
+    );
+  }
+  if (existsSync(unitPath)) rmSync(unitPath);
+  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  if (!reloadRes.ok) {
+    print.line(
+      `    warning: systemctl daemon-reload during uninstall: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}\n`,
+    );
+  }
+  return { platform: "systemd", label: SYSTEMD_UNIT, unitPath, logDir: logDir(), state: "not-installed" };
+}
+
+function stopSystemd(): void {
+  const res = runCapture("systemctl", ["--user", "stop", SYSTEMD_UNIT], 10_000);
+  if (!res.ok && !/not loaded/i.test(res.stderr)) {
+    print.line(`    warning: systemctl --user stop: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`);
+  }
+}
+
+// ── public API ──────────────────────────────────────────────────────
+
+export const HUB_DAEMON_DEFAULT_PORT = DEFAULT_DAEMON_PORT;
+
+export function isHubServiceSupported(): boolean {
+  return process.platform === "darwin" || process.platform === "linux";
+}
+
+export function installHubService(options: { port: number }): ServiceInfo {
+  if (process.platform === "darwin") return installLaunchd(options.port);
+  if (process.platform === "linux") return installSystemd(options.port);
+  throw new Error(
+    `Background service install is not supported on ${process.platform}. ` +
+      "Run `first-tree-hub start` (foreground) instead.",
+  );
+}
+
+export function getHubServiceStatus(): ServiceInfo {
+  if (process.platform === "darwin") {
+    const { state, detail } = launchdState();
+    return {
+      platform: "launchd",
+      label: LAUNCHD_LABEL,
+      unitPath: launchdPlistPath(),
+      logDir: logDir(),
+      state,
+      detail,
+    };
+  }
+  if (process.platform === "linux") {
+    const { state, detail } = systemdState();
+    return {
+      platform: "systemd",
+      label: SYSTEMD_UNIT,
+      unitPath: systemdUnitPath(),
+      logDir: logDir(),
+      state,
+      detail,
+    };
+  }
+  return {
+    platform: "unsupported",
+    label: "",
+    unitPath: "",
+    logDir: logDir(),
+    state: "not-installed",
+    detail: `platform ${process.platform} not supported`,
+  };
+}
+
+export function uninstallHubService(): ServiceInfo {
+  if (process.platform === "darwin") return uninstallLaunchd();
+  if (process.platform === "linux") return uninstallSystemd();
+  return getHubServiceStatus();
+}
+
+export function stopHubService(): void {
+  if (process.platform === "darwin") {
+    stopLaunchd();
+    return;
+  }
+  if (process.platform === "linux") {
+    stopSystemd();
+  }
+}

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -56,7 +56,7 @@ export { blank, status } from "./output.js";
 // Interactive prompts
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
 export type { ServerBootstrapResult, StartOptions } from "./server.js";
-export { bootstrapServer, startServer } from "./server.js";
+export { bootstrapServer, prepareInstallTime, startServer } from "./server.js";
 // Background service install (launchd / systemd --user)
 export type { ServiceInfo, ServiceState } from "./service-install.js";
 export {

--- a/packages/command/src/core/schema-version-guard.ts
+++ b/packages/command/src/core/schema-version-guard.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+type JournalEntry = { idx: number; tag: string; when: number };
+
+/**
+ * Resolve the migrations directory the way `runMigrations` does so the guard
+ * agrees with what the migrator would actually apply.
+ */
+function resolveMigrationsFolder(): string {
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const embeddedPath = join(cliDir, "..", "drizzle");
+  if (existsSync(embeddedPath)) return embeddedPath;
+  const serverDir = dirname(fileURLToPath(import.meta.resolve("@first-tree-hub/server/package.json")));
+  return join(serverDir, "drizzle");
+}
+
+function readJournal(): JournalEntry[] {
+  const journalPath = join(resolveMigrationsFolder(), "meta", "_journal.json");
+  const raw = JSON.parse(readFileSync(journalPath, "utf-8")) as { entries?: JournalEntry[] };
+  return raw.entries ?? [];
+}
+
+export type SchemaVersionMismatch = {
+  kind: "db-older" | "db-newer";
+  cliVersion: string;
+  expectedCount: number;
+  actualCount: number;
+  expectedTag: string;
+};
+
+export class SchemaVersionMismatchError extends Error {
+  readonly mismatch: SchemaVersionMismatch;
+  constructor(mismatch: SchemaVersionMismatch) {
+    super(formatSchemaMismatch(mismatch));
+    this.name = "SchemaVersionMismatchError";
+    this.mismatch = mismatch;
+  }
+}
+
+function formatSchemaMismatch(m: SchemaVersionMismatch): string {
+  if (m.kind === "db-older") {
+    return (
+      `Schema version mismatch. CLI v${m.cliVersion} expects ${m.expectedCount} ` +
+      `migrations through "${m.expectedTag}", DB has ${m.actualCount}. ` +
+      `Run 'first-tree-hub start --service' to apply pending migrations.`
+    );
+  }
+  return (
+    `Schema version mismatch. DB has ${m.actualCount} migrations applied, ` +
+    `CLI v${m.cliVersion} only knows ${m.expectedCount} (last "${m.expectedTag}"). ` +
+    `The CLI binary appears older than the database. Upgrade with ` +
+    `'npm install -g @agent-team-foundation/first-tree-hub@latest'.`
+  );
+}
+
+/**
+ * Compare the migrations bundled into the running CLI binary against the
+ * `__drizzle_migrations` table in the DB. This is the daemon's only
+ * orchestration on every boot (Q11 / Pattern B): if the operator
+ * `npm install`d a new tarball but didn't restart `start --service`, the
+ * mismatch surfaces in `service logs` instead of the daemon silently
+ * running stale code against a newer DB.
+ *
+ * The check is heuristic — drizzle's migration table stores SHA hashes, not
+ * tags, and rebuilding hashes here would duplicate too much of the
+ * migrator. Comparing counts is sufficient for the failure mode this guard
+ * is meant to catch (forgot-to-restart upgrade flow).
+ */
+export async function assertSchemaCurrent(databaseUrl: string, cliVersion: string): Promise<void> {
+  const journal = readJournal();
+  const expectedCount = journal.length;
+  const expectedTag = journal[journal.length - 1]?.tag ?? "<none>";
+
+  const client = postgres(databaseUrl, { max: 1 });
+  let actualCount: number;
+  try {
+    const rows = await client<Array<{ count: number }>>`
+      SELECT count(*)::int AS count FROM "__drizzle_migrations"
+    `;
+    actualCount = rows[0]?.count ?? 0;
+  } catch (err) {
+    // 42P01 = `relation "__drizzle_migrations" does not exist`. Happens when
+    // a daemon is invoked manually against a fresh DB (no parent CLI ran
+    // migrations first). Treat as the strongest "db-older" signal —
+    // actualCount=0 — so the message points the operator at
+    // `start --service`.
+    if (typeof err === "object" && err !== null && Reflect.get(err, "code") === "42P01") {
+      actualCount = 0;
+    } else {
+      throw err;
+    }
+  } finally {
+    await client.end();
+  }
+
+  if (actualCount === expectedCount) return;
+  throw new SchemaVersionMismatchError({
+    kind: actualCount < expectedCount ? "db-older" : "db-newer",
+    cliVersion,
+    expectedCount,
+    actualCount,
+    expectedTag,
+  });
+}

--- a/packages/command/src/core/server.ts
+++ b/packages/command/src/core/server.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { initConfig, serverConfigSchema } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { buildApp } from "@first-tree-hub/server";
 import type { Config } from "@first-tree-hub/server/config";
@@ -27,21 +28,17 @@ export type ServerBootstrapResult = {
 };
 
 /**
- * Build the server up to the point of `app.listen()` without actually
- * binding the port.
+ * Run install-time orchestration (Pattern B / Q11):
  *
- * The new `first-tree-hub start` command needs to perform the same
- * orchestration the legacy `server start` did (Docker, Postgres, migrations,
- * Web dist resolution, telemetry init, fastify build), but it also wants to
- * embed its own `ClientRuntime` against the same process before yielding to
- * `app.listen()`. Splitting the two phases lets the caller insert that step
- * cleanly — and lets a future daemon caller skip re-running install-time
- * work entirely (Pattern B / Q11). `startServer` below is now a thin wrapper
- * preserved for backward compatibility with the existing `server start`
- * command and external Hub consumers (e.g. context-tree).
+ *   1. Schema-driven prompts for missing required fields
+ *   2. Provision Postgres (or reuse) via the docker-pg auto-generator
+ *   3. Apply Drizzle migrations
+ *
+ * Used by `start --service` (Phase 1b), which hands off binding/listening
+ * to the daemon — and by `bootstrapServer`, which wraps this and adds the
+ * fastify build for foreground / `server start` callers.
  */
-export async function bootstrapServer(options: StartOptions): Promise<ServerBootstrapResult> {
-  // 1. Build CLI args
+export async function prepareInstallTime(options: StartOptions): Promise<ServerConfig> {
   const cliArgs: Record<string, unknown> = {};
   if (options.port !== undefined) cliArgs.server = { port: options.port };
   if (options.host !== undefined) {
@@ -51,7 +48,6 @@ export async function bootstrapServer(options: StartOptions): Promise<ServerBoot
     cliArgs.database = { url: options.databaseUrl, provider: "external" };
   }
 
-  // 2. Schema-driven interactive prompts for missing required fields
   await promptMissingFields({
     schema: serverConfigSchema as Record<string, unknown>,
     role: "server",
@@ -59,7 +55,6 @@ export async function bootstrapServer(options: StartOptions): Promise<ServerBoot
     noInteractive: options.noInteractive,
   });
 
-  // 3. docker-pg auto generator
   const autoGenerators = {
     "docker-pg": async () => {
       if (!isDockerAvailable()) {
@@ -92,12 +87,30 @@ export async function bootstrapServer(options: StartOptions): Promise<ServerBoot
 
   status("PostgreSQL", "ready");
 
-  // 4. Run migrations
   status("Database", "running migrations...");
   const tableCount = await runMigrations(serverConfig.database.url);
   status("Database", `initialized (${tableCount} tables)`);
 
-  // 5. Resolve web dist (build if needed)
+  return serverConfig;
+}
+
+/**
+ * Build the server up to the point of `app.listen()` without actually
+ * binding the port.
+ *
+ * The new `first-tree-hub start` command needs to perform the same
+ * orchestration the legacy `server start` did (Docker, Postgres, migrations,
+ * Web dist resolution, telemetry init, fastify build), but it also wants to
+ * embed its own `ClientRuntime` against the same process before yielding to
+ * `app.listen()`. Splitting the two phases lets the caller insert that step
+ * cleanly — and lets a future daemon caller skip re-running install-time
+ * work entirely (Pattern B / Q11). `startServer` below is now a thin wrapper
+ * preserved for backward compatibility with the existing `server start`
+ * command and external Hub consumers (e.g. context-tree).
+ */
+export async function bootstrapServer(options: StartOptions): Promise<ServerBootstrapResult> {
+  const serverConfig = await prepareInstallTime(options);
+
   const webDistPath = resolveWebDist();
   if (webDistPath) {
     status("Web", `serving from ${webDistPath}`);
@@ -105,7 +118,6 @@ export async function bootstrapServer(options: StartOptions): Promise<ServerBoot
     status("Web", "not available (web package not found)");
   }
 
-  // 6. Build app config
   const config: Config = {
     ...serverConfig,
     webDistPath: webDistPath ?? undefined,

--- a/packages/command/src/core/service-logs.ts
+++ b/packages/command/src/core/service-logs.ts
@@ -11,13 +11,22 @@ import {
 import { print } from "./output.js";
 
 const LOG_DIR = join(DEFAULT_HOME_DIR, "logs");
-const PRIMARY_LOG = join(LOG_DIR, "client.log");
-// Supervisor (launchd / systemd) writes raw stdout/stderr here as a fallback,
-// capturing crash output that happens before pino takes over the stream, plus
-// anything third-party code writes to stderr directly. Operators need these
-// when diagnosing startup failures, so surface them alongside client.log.
-const FALLBACK_STDOUT = join(LOG_DIR, "client.stdout.log");
-const FALLBACK_STDERR = join(LOG_DIR, "client.stderr.log");
+
+// Two service variants share this log reader: the legacy `client.service`
+// installed by `client connect --service` and the new Hub `daemon.service`
+// installed by `start --service`. Each variant gets its own primary +
+// supervisor-fallback file basenames so operators can keep both around
+// during the migration window without confusing diagnostics.
+type ServiceVariant = "client" | "daemon";
+
+function logFiles(variant: ServiceVariant) {
+  const base = variant;
+  return {
+    primary: join(LOG_DIR, `${base}.log`),
+    fallbackStdout: join(LOG_DIR, `${base}.stdout.log`),
+    fallbackStderr: join(LOG_DIR, `${base}.stderr.log`),
+  };
+}
 
 /**
  * Duration string → milliseconds. Accepts `10s`, `5m`, `2h`, `1d`; rejects
@@ -45,13 +54,14 @@ const LEVEL_RANK: Record<LogLevel, number> = {
 };
 
 /** Rotated log files, newest-first. Missing files are silently skipped. */
-export function listLogFilesNewestFirst(): string[] {
+export function listLogFilesNewestFirst(variant: ServiceVariant = "client"): string[] {
+  const { primary } = logFiles(variant);
   const files: string[] = [];
-  if (existsSync(PRIMARY_LOG)) files.push(PRIMARY_LOG);
+  if (existsSync(primary)) files.push(primary);
   // Rotated files `.1`, `.2`, … are older as the index grows; rotation
   // produces contiguous numbering, so the first miss means there are no more.
   for (let i = 1; ; i++) {
-    const p = `${PRIMARY_LOG}.${i}`;
+    const p = `${primary}.${i}`;
     if (!existsSync(p)) break;
     files.push(p);
   }
@@ -59,10 +69,11 @@ export function listLogFilesNewestFirst(): string[] {
 }
 
 /** Supervisor fallback files (raw stdout/stderr, not NDJSON). Missing files skipped. */
-export function listFallbackFiles(): string[] {
+export function listFallbackFiles(variant: ServiceVariant = "client"): string[] {
+  const { fallbackStdout, fallbackStderr } = logFiles(variant);
   const files: string[] = [];
-  if (existsSync(FALLBACK_STDERR)) files.push(FALLBACK_STDERR);
-  if (existsSync(FALLBACK_STDOUT)) files.push(FALLBACK_STDOUT);
+  if (existsSync(fallbackStderr)) files.push(fallbackStderr);
+  if (existsSync(fallbackStdout)) files.push(fallbackStdout);
   return files;
 }
 
@@ -75,6 +86,8 @@ export type ServiceLogsOptions = {
   sinceMs?: number;
   /** Bypass pretty-printing; emit raw NDJSON lines to stdout. */
   json: boolean;
+  /** Which service's log files to read. Defaults to the legacy "client". */
+  variant?: ServiceVariant;
 };
 
 function matchesFilters(
@@ -186,41 +199,42 @@ export async function showServiceLogs(options: ServiceLogsOptions): Promise<void
     return;
   }
 
+  const variant: ServiceVariant = options.variant ?? "client";
+  const { primary } = logFiles(variant);
   const minLevel = options.level ? LEVEL_RANK[options.level] : undefined;
   const cutoffMs = options.sinceMs !== undefined ? Date.now() - options.sinceMs : undefined;
 
   // Supervisor fallback files capture pre-pino bootstrap output and crash
   // dumps — effectively the oldest context, so walk them first.
-  for (const f of listFallbackFiles()) {
+  for (const f of listFallbackFiles(variant)) {
     await readFallbackFile(f, cutoffMs, options.json);
   }
 
   // Historical read: oldest-first so the terminal shows them in chronological
   // order. listLogFilesNewestFirst returns active file + `.1` (newest rotated)
   // + `.2` (older rotated) etc., so we reverse to walk oldest → newest.
-  const files = listLogFilesNewestFirst().reverse();
+  const files = listLogFilesNewestFirst(variant).reverse();
   for (const f of files) {
     await readFileLines(f, minLevel, cutoffMs, options.json);
   }
 
   if (!options.tail) return;
-  if (!existsSync(PRIMARY_LOG)) {
-    // Nothing to tail yet; wait for it to appear.
-    print.status("tail", "waiting for client.log to appear...");
+  if (!existsSync(primary)) {
+    print.status("tail", `waiting for ${variant}.log to appear...`);
   }
 
   await new Promise<void>((resolve) => {
-    let position = existsSync(PRIMARY_LOG) ? statSync(PRIMARY_LOG).size : 0;
+    let position = existsSync(primary) ? statSync(primary).size : 0;
     const onChange = () => {
-      if (!existsSync(PRIMARY_LOG)) return;
-      const current = statSync(PRIMARY_LOG).size;
+      if (!existsSync(primary)) return;
+      const current = statSync(primary).size;
       if (current < position) {
-        // Rotation happened — the writer moved our file to client.log.1 and
-        // opened a fresh client.log. Start reading the new file from 0.
+        // Rotation happened — the writer moved the active file to
+        // <variant>.log.1 and opened a fresh one. Start reading from 0.
         position = 0;
       }
       if (current <= position) return;
-      const stream = createReadStream(PRIMARY_LOG, { start: position, end: current - 1, encoding: "utf8" });
+      const stream = createReadStream(primary, { start: position, end: current - 1, encoding: "utf8" });
       position = current;
       const rl = createInterface({ input: stream });
       rl.on("line", (line) => {
@@ -228,9 +242,9 @@ export async function showServiceLogs(options: ServiceLogsOptions): Promise<void
         if (rendered) process.stdout.write(rendered);
       });
     };
-    watchFile(PRIMARY_LOG, { interval: 500 }, onChange);
+    watchFile(primary, { interval: 500 }, onChange);
     process.once("SIGINT", () => {
-      unwatchFile(PRIMARY_LOG, onChange);
+      unwatchFile(primary, onChange);
       resolve();
     });
   });


### PR DESCRIPTION
## Summary

Implements **Phase 1b** of the onboarding redesign ([docs/onboarding-redesign.md §5 / C8](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/first-tree-hub-onboarding/docs/onboarding-redesign.md#5-sequencing)) — the **service shape** that pairs with Phase 1a's foreground shape (#171). After install, the user picks one of two equally-supported shapes:

```
first-tree-hub start              # foreground (Phase 1a)
first-tree-hub start --service    # background daemon (this PR)
```

> **Base branch:** `feat/onboarding-phase-1a` (#171). Rebase onto `main` once 1a merges.

### What changed

- **New `first-tree-hub daemon` (hidden)** — invoked by launchd / systemd-user. Schema-version guard → `bootstrapServer` → `app.listen` → `obtainDaemonJWT` (B2/Q9 3-tier fallback: cached → `/auth/refresh` → `/auth/local-bootstrap`) → embedded `ClientRuntime` → SIGTERM-driven shutdown.

- **New `start --service` flow** — Pattern B (Q11): install-time work (Docker preflight, Postgres, migrations, auto-admin) runs in the **CLI parent**; binding/listening is handed off to the daemon. Parent polls `/healthz` for up to 10s (Q8); on timeout: `service uninstall` + tail last 20 lines of daemon stderr + exit 1 — **no half-installed state**.

- **New `service install/status/logs/stop/uninstall` subcommands.** `service logs` reuses the existing reader, parametrised on a `"client" | "daemon"` variant so the legacy `client.service` log path still works during the migration window.

- **New helpers:**
  - `prepareInstallTime(options)` — extracted from `bootstrapServer` so the `--service` shape can run install-time work without building fastify.
  - `obtainDaemonJWT(serverUrl)` — 3-tier B2/Q9 fallback. Refuses non-loopback `serverUrl`, ignores cached creds bound to a different URL.
  - `assertSchemaCurrent(databaseUrl, cliVersion)` / `SchemaVersionMismatchError` — daemon's only orchestration on every boot. Catches `42P01` (`__drizzle_migrations` table missing on a fresh DB) and treats as `db-older` with the same friendly message.

- **Cross-platform:** launchd plist (`~/Library/LaunchAgents/`, no sudo) on macOS; systemd `--user` unit (`~/.config/systemd/user/`) on Linux. Hub-daemon labels (`dev.first-tree-hub.daemon` / `first-tree-hub-daemon.service`) are distinct from the existing `client.service` labels so both can coexist.

- **`--port` propagates** into the unit's `ProgramArguments` / `ExecStart` so the daemon binds the same port across reboots.

- **Logger plumbing fix:** the daemon switches the client logger to a rotating NDJSON file (`<logDir>/daemon.log`) before any subsequent step, so `service logs` actually shows daemon output. `configureClientLoggerForService(logDir, basename)` is now parametrised by basename — legacy `client connect --service` keeps writing to `client.log`.

- **Loopback-trust hardening:** `obtainDaemonJWT` refuses any non-loopback `serverUrl`, both for the bound URL and for cached creds — without this, a stale `credentials.json` (e.g. left over from a previous Hub install on a different port) would get its refresh token replayed against whatever happens to live there now.

- **Docs:** `docs/quickstart-zh.md` gained a side-by-side "pick a shape" table, the service-management subsection, and an Upgrading subsection per D1 (with the correct two-step `service stop && start --service` upgrade flow — `start --service` is idempotent when the service is already running).

- **Version bump:** command `0.10.0 → 0.11.0`.

### Tests

- **`daemon-auth-3-tier.test.ts`** (13 cases) — exercises the full `obtainDaemonJWT` decision tree with `vi.mock`'d `loadCredentials`/`saveCredentials` and a stubbed `fetch`:
  - Tier 1 (cached + valid)
  - Tier 2 (refresh path) 
  - Tier 3 (local-bootstrap on refresh failure / on missing creds / on stale-URL creds)
  - All-tier failure
  - Loopback-URL refusal (`isLoopbackUrl` matrix: `127.0.0.1`, `localhost`, `[::1]`, plain `::1`, non-loopback rejection, malformed URL)

- **`daemon-auth.test.ts`** (8 cases) — pure helpers `decodeExp` / `isExpired` (30s leeway window).

- Integration paths (launchctl/systemctl, healthz polling) covered by manual smoke tests.

### Out of scope

- Hosted-scenario simplifications (C1/C3) → Phase 2.
- Phase 3 cleanup (D3, D4, C4) → separate PR.

### Code-review fixes folded into this commit

- Daemon now configures the client logger to write to `daemon.log` so `service logs` actually shows output (was a no-op pre-fix).
- `obtainDaemonJWT` rejects non-loopback URLs at entry and on cached-creds match.
- Schema-version guard catches `42P01` for fresh-DB / manual-daemon invocations.
- `--port` parser uses `parsePortArg` consistently across `start` and `daemon`.
- Removed dead try/catch wrapper in daemon entry.
- Quickstart upgrade subsection corrected — `start --service` is idempotent; user must `service stop && start --service` to actually pick up new code.

## Test plan

- [x] `pnpm check` — clean.
- [x] `pnpm typecheck` — clean across all packages.
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` — 97 passed.
- [x] New tests: 21 cases total (`daemon-auth.test.ts` 8 + `daemon-auth-3-tier.test.ts` 13) all green.
- [ ] Server tests (CI only — sandbox lacks Docker).
- [ ] Manual smoke on macOS: `start --service` → `service status` → browser opens → `service logs -f` → `service stop` → `service uninstall`.
- [ ] Manual smoke on Linux: same flow with systemd `--user`.

Independent code review run prior to push; CRITICAL/MAJOR findings folded into the commit (logger plumbing, loopback assertion, schema-guard 42P01 handling, port-parser consistency, dead-code removal, doc correction).


---
_Generated by [Claude Code](https://claude.ai/code/session_0129qNRB5Q4tMfvXGt6WekFg)_