### PR TITLE
refactor(agent-naming): Phase 2 (redo) — require displayName + drop nullable fallback

### DIFF
--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -35,7 +35,11 @@ describe("resolveSenderLabel", () => {
   const ps = [
     mkParticipant("agent-a", "alice", "Alice Smith"),
     mkParticipant("agent-b", null, "Bob Only"),
-    mkParticipant("agent-c", null),
+    // Pre-Phase-2 nullable displayName is gone, but `""` is still a
+    // reachable DB state (the temporary DEFAULT '' added by migration
+    // 0024 catches old INSERTs during a rolling deploy). Keep the
+    // "both falsy" coverage by pinning the empty-string branch.
+    mkParticipant("agent-c", null, ""),
   ];
 
   it("returns the participant name when available", () => {
@@ -46,13 +50,11 @@ describe("resolveSenderLabel", () => {
     expect(resolveSenderLabel("agent-b", ps)).toBe("Bob Only");
   });
 
-  it("falls back to the raw senderId when the name is null (displayName post-Phase 2 is non-null but may be synthetic)", () => {
-    // Post-Phase 2 displayName is guaranteed non-null at the DB level, so
-    // the prior "both null" case is unreachable. The next best fallback
-    // `resolveSenderLabel` covers is still the raw senderId for rows whose
-    // displayName was synthesised from the agentId; the `mkParticipant`
-    // helper mirrors that (`agent-${agentId}`).
-    expect(resolveSenderLabel("agent-c", ps)).toBe("agent-agent-c");
+  it("falls back to the raw senderId when name is null and displayName is empty", () => {
+    // Covers the `return senderId` branch inside the participant-match
+    // loop (runtime/agent-io.ts) — still reachable for rows that came
+    // in under the migration 0024 rollout default.
+    expect(resolveSenderLabel("agent-c", ps)).toBe("agent-c");
   });
 
   it("returns the raw senderId when not present among participants (stale cache / ex-member)", () => {

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -9,14 +9,16 @@ import {
 import type { SessionMessage } from "../runtime/handler.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
-function mkParticipant(agentId: string, name: string | null, displayName: string | null = null): ChatParticipantDetail {
+function mkParticipant(agentId: string, name: string | null, displayName?: string): ChatParticipantDetail {
   return {
     agentId,
     role: "member",
     mode: "full",
     joinedAt: new Date().toISOString(),
     name,
-    displayName,
+    // Post-Phase 2 the wire shape requires a non-null display name; fall
+    // back to a synthetic label when the caller doesn't provide one.
+    displayName: displayName ?? `agent-${agentId}`,
     type: "autonomous_agent",
   };
 }
@@ -33,7 +35,7 @@ describe("resolveSenderLabel", () => {
   const ps = [
     mkParticipant("agent-a", "alice", "Alice Smith"),
     mkParticipant("agent-b", null, "Bob Only"),
-    mkParticipant("agent-c", null, null),
+    mkParticipant("agent-c", null),
   ];
 
   it("returns the participant name when available", () => {
@@ -44,8 +46,13 @@ describe("resolveSenderLabel", () => {
     expect(resolveSenderLabel("agent-b", ps)).toBe("Bob Only");
   });
 
-  it("falls back to the raw senderId when name and displayName are both null", () => {
-    expect(resolveSenderLabel("agent-c", ps)).toBe("agent-c");
+  it("falls back to the raw senderId when the name is null (displayName post-Phase 2 is non-null but may be synthetic)", () => {
+    // Post-Phase 2 displayName is guaranteed non-null at the DB level, so
+    // the prior "both null" case is unreachable. The next best fallback
+    // `resolveSenderLabel` covers is still the raw senderId for rows whose
+    // displayName was synthesised from the agentId; the `mkParticipant`
+    // helper mirrors that (`agent-${agentId}`).
+    expect(resolveSenderLabel("agent-c", ps)).toBe("agent-agent-c");
   });
 
   it("returns the raw senderId when not present among participants (stale cache / ex-member)", () => {
@@ -156,7 +163,7 @@ describe("buildAgentEnv", () => {
       agent: {
         agentId: "agent-a",
         inboxId: "inbox-a",
-        displayName: null,
+        displayName: "agent-a",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},
@@ -178,7 +185,7 @@ describe("buildAgentEnv", () => {
       agent: {
         agentId: "agent-a",
         inboxId: "inbox-a",
-        displayName: null,
+        displayName: "agent-a",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},

--- a/packages/client/src/__tests__/claude-code-bootstrap.test.ts
+++ b/packages/client/src/__tests__/claude-code-bootstrap.test.ts
@@ -250,25 +250,9 @@ describe("CLAUDE.md generation", () => {
     expect(md).toContain("Use the SDK.");
   });
 
-  it("renders displayName in the identity banner", () => {
-    // Post-Phase 2 of the agent-naming refactor, `displayName` is guaranteed
-    // non-null — the server defaults to the agent name (or "Unnamed Agent")
-    // when the caller omits it. The "uses agentId when displayName is null"
-    // case this test used to cover is unreachable; the behaviour we still
-    // care about is that whatever label is present shows up verbatim.
-    const workspace = join(tmpBase, "ws-display-name");
-    mkdirSync(join(workspace, ".agent", "context"), { recursive: true });
-
-    const identity: AgentIdentity = {
-      agentId: "my-agent",
-      inboxId: "inbox-my-agent",
-      displayName: "my-agent",
-      type: "autonomous_agent",
-      delegateMention: null,
-      metadata: {},
-    };
-
-    const md = generateClaudeMd(workspace, identity, null);
-    expect(md).toContain("You are my-agent, an autonomous agent");
-  });
+  // The pre-Phase-2 "uses agentId when displayName is null" case is now
+  // unreachable (server enforces NOT NULL + a default), and the coverage
+  // it pinned — that the identity banner renders `displayName` verbatim —
+  // is already covered by the "generates autonomous_agent template" test
+  // above. Intentionally no test here.
 });

--- a/packages/client/src/__tests__/claude-code-bootstrap.test.ts
+++ b/packages/client/src/__tests__/claude-code-bootstrap.test.ts
@@ -250,14 +250,19 @@ describe("CLAUDE.md generation", () => {
     expect(md).toContain("Use the SDK.");
   });
 
-  it("uses agentId when displayName is null", () => {
-    const workspace = join(tmpBase, "ws-no-name");
+  it("renders displayName in the identity banner", () => {
+    // Post-Phase 2 of the agent-naming refactor, `displayName` is guaranteed
+    // non-null — the server defaults to the agent name (or "Unnamed Agent")
+    // when the caller omits it. The "uses agentId when displayName is null"
+    // case this test used to cover is unreachable; the behaviour we still
+    // care about is that whatever label is present shows up verbatim.
+    const workspace = join(tmpBase, "ws-display-name");
     mkdirSync(join(workspace, ".agent", "context"), { recursive: true });
 
     const identity: AgentIdentity = {
       agentId: "my-agent",
       inboxId: "inbox-my-agent",
-      displayName: null,
+      displayName: "my-agent",
       type: "autonomous_agent",
       delegateMention: null,
       metadata: {},

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -50,7 +50,7 @@ function buildSink(fx: SinkFixtures) {
     agent: {
       agentId: ME,
       inboxId: "inbox-me",
-      displayName: null,
+      displayName: "test-agent",
       type: "autonomous_agent",
       delegateMention: null,
       metadata: {},
@@ -174,7 +174,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       agent: {
         agentId: ME,
         inboxId: "inbox-me",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -119,7 +119,7 @@ describe("SessionManager", () => {
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},
@@ -185,7 +185,7 @@ describe("SessionManager", () => {
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},
@@ -271,7 +271,7 @@ describe("SessionManager", () => {
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},
@@ -315,7 +315,7 @@ describe("SessionManager", () => {
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},
@@ -368,7 +368,7 @@ describe("SessionManager", () => {
       agentIdentity: {
         agentId: "agent-1",
         inboxId: "inbox-agent-1",
-        displayName: null,
+        displayName: "test-agent",
         type: "autonomous_agent",
         delegateMention: null,
         metadata: {},

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -33,7 +33,11 @@ export type ClientConnectionConfig = {
 
 export type BoundAgent = {
   agentId: string;
-  displayName: string | null;
+  /**
+   * Always populated post-Phase 2 of the agent-naming refactor — the
+   * `agent:pinned` WebSocket frame resolves the label server-side.
+   */
+  displayName: string;
   agentType: string;
   sdk: FirstTreeHubSDK;
 };
@@ -484,7 +488,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         });
         const agent: BoundAgent = {
           agentId,
-          displayName: (msg.displayName as string) ?? null,
+          // Phase 2: server always sends a non-null displayName; fall back to
+          // the agentId defensively so a schema-mismatched frame from an
+          // older server doesn't crash the runtime.
+          displayName: (msg.displayName as string | null) ?? agentId,
           agentType: (msg.agentType as string) ?? "personal_assistant",
           sdk,
         };

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -74,7 +74,7 @@ export class AgentSlot {
     this.sdk = sdk;
     const agent = await sdk.register();
 
-    this.logger.info({ displayName: agent.displayName ?? agent.agentId }, "agent bound");
+    this.logger.info({ displayName: agent.displayName }, "agent bound");
 
     if (agent.type === "human") {
       this.logger.info("server reports type=human — message processing disabled");

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -10,7 +10,13 @@ export type AgentIdentity = {
    * cross-chat `replyTo` envelopes without a per-call server round-trip.
    */
   inboxId: string;
-  displayName: string | null;
+  /**
+   * Always populated post-Phase 2 of the agent-naming refactor — the server
+   * enforces `agents.display_name NOT NULL` (migration 0024) and the
+   * `agent:pinned` WebSocket frame it emits resolves the fallback before
+   * sending, so the client no longer has to second-guess the value.
+   */
+  displayName: string;
   type: string;
   delegateMention: string | null;
   metadata: Record<string, unknown>;

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -34,7 +34,12 @@ export type RegisterResult = {
   agentId: string;
   inboxId: string;
   status: string;
-  displayName: string | null;
+  /**
+   * Always populated post-Phase 2 of the agent-naming refactor — the server
+   * guarantees `agents.display_name` is non-null (migration 0024 + service
+   * default) so the client doesn't need a fallback anymore.
+   */
+  displayName: string;
   type: string;
   delegateMention: string | null;
   metadata: Record<string, unknown>;

--- a/packages/server/drizzle/0024_display_name_not_null.sql
+++ b/packages/server/drizzle/0024_display_name_not_null.sql
@@ -1,19 +1,31 @@
 -- Phase 2 of the agent-naming refactor (docs/agent-naming-design.md §4).
 --
 -- Before this migration, `display_name` was nullable and the web layer
--- silently fell back to `name` for rendering. That left CLI, server logs,
--- and IM-bridge notifications looking at raw NULLs or placeholders. This
--- migration closes the gap by (a) backfilling every NULL row from the
--- agent's `name` (or `uuid` when both are NULL — only possible for
--- tombstoned rows whose name was cleared on delete) and (b) promoting the
--- column to NOT NULL so new rows can't recreate the hole.
+-- silently fell back to `name` for rendering. CLI, server logs, and IM
+-- bridges saw raw NULLs. This migration closes the gap in three steps:
 --
--- Deploy with the matching service change that defaults `display_name` to
--- `name` on create: without it, concurrent inserts during the rollout
--- window could fail the new constraint.
+--   1. Backfill every NULL row with a non-empty label — the agent's `name`
+--      when available, else the tombstone literal "[deleted agent]".
+--      Important: the third branch must NOT be `uuid`, because UUIDs would
+--      surface as human-visible strings in the chat roster and IM bridge.
+--      Only `status = 'deleted'` rows can have both `name` and
+--      `display_name` NULL (see `deleteAgent` in services/agent.ts), which
+--      is why the literal refers to deletion.
+--
+--   2. Add a temporary empty-string DEFAULT so any old server instance
+--      still running during a rolling deploy — i.e. code that doesn't yet
+--      default `display_name` in `createAgent` — can INSERT without
+--      violating the upcoming NOT NULL. The application code treats an
+--      empty string as "no display name" (the Zod read schema accepts it);
+--      a follow-up migration can drop the default once the code is fully
+--      rolled.
+--
+--   3. Promote the column to NOT NULL. Combined with the service-level
+--      default this closes the hole for new rows too.
 
 UPDATE "agents"
-SET "display_name" = COALESCE("display_name", "name", "uuid")
+SET "display_name" = COALESCE("display_name", "name", '[deleted agent]')
 WHERE "display_name" IS NULL;
 
+ALTER TABLE "agents" ALTER COLUMN "display_name" SET DEFAULT '';
 ALTER TABLE "agents" ALTER COLUMN "display_name" SET NOT NULL;

--- a/packages/server/drizzle/0024_display_name_not_null.sql
+++ b/packages/server/drizzle/0024_display_name_not_null.sql
@@ -1,0 +1,19 @@
+-- Phase 2 of the agent-naming refactor (docs/agent-naming-design.md §4).
+--
+-- Before this migration, `display_name` was nullable and the web layer
+-- silently fell back to `name` for rendering. That left CLI, server logs,
+-- and IM-bridge notifications looking at raw NULLs or placeholders. This
+-- migration closes the gap by (a) backfilling every NULL row from the
+-- agent's `name` (or `uuid` when both are NULL — only possible for
+-- tombstoned rows whose name was cleared on delete) and (b) promoting the
+-- column to NOT NULL so new rows can't recreate the hole.
+--
+-- Deploy with the matching service change that defaults `display_name` to
+-- `name` on create: without it, concurrent inserts during the rollout
+-- window could fail the new constraint.
+
+UPDATE "agents"
+SET "display_name" = COALESCE("display_name", "name", "uuid")
+WHERE "display_name" IS NULL;
+
+ALTER TABLE "agents" ALTER COLUMN "display_name" SET NOT NULL;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1777248000000,
       "tag": "0023_clients_org_scoping",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1777334400000,
+      "tag": "0024_display_name_not_null",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -15,7 +15,13 @@ export const agents = pgTable(
       .references(() => organizations.id),
     /** "human" | "personal_assistant" | "autonomous_agent" */
     type: text("type").notNull(),
-    displayName: text("display_name"),
+    /**
+     * Required human-readable label. Defaulted to `name` (or "Unnamed Agent"
+     * when both would be null) on create by the service layer — see Phase 2
+     * of the agent-naming refactor. Tombstoned rows (status="deleted") keep
+     * whatever value they had; only `name` is nulled on delete.
+     */
+    displayName: text("display_name").notNull(),
     /** Agent UUID to forward @mentions to (e.g. personal assistant) */
     delegateMention: text("delegate_mention"),
     /** Delivery address, auto-generated as inbox_{uuid} */

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -218,6 +218,15 @@ export async function createAgent(db: Database, data: CreateAgent & { managerId?
     }
   }
 
+  // Phase 2 of the agent-naming refactor promoted `display_name` to NOT NULL
+  // and standardized the fallback here so every surface (CLI, server logs,
+  // IM bridge, chat roster) sees a populated label without the web-only
+  // `useAgentNameMap` cascade. Precedence: explicit non-empty displayName →
+  // the agent name → a generic "Unnamed Agent" literal (only reached when
+  // the caller omitted both fields, which only happens for bootstrap /
+  // system-created agents).
+  const resolvedDisplayName = data.displayName?.trim() || name || "Unnamed Agent";
+
   try {
     const [agent] = await db
       .insert(agents)
@@ -226,7 +235,7 @@ export async function createAgent(db: Database, data: CreateAgent & { managerId?
         name,
         organizationId: orgId,
         type: data.type,
-        displayName: data.displayName ?? null,
+        displayName: resolvedDisplayName,
         delegateMention: data.delegateMention ?? null,
         inboxId,
         source: data.source ?? null,

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -313,7 +313,8 @@ export async function listChatsForMember(db: Database, memberId: string, humanAg
     .where(eq(agents.managerId, memberId));
 
   // Ensure human agent is included (it should be, but be safe)
-  const agentMap = new Map<string, { uuid: string; name: string | null; type: string; displayName: string | null }>();
+  // displayName is non-null post-Phase 2 (migration 0024 enforces it).
+  const agentMap = new Map<string, { uuid: string; name: string | null; type: string; displayName: string }>();
   for (const a of managedAgents) {
     agentMap.set(a.uuid, a);
   }
@@ -375,7 +376,7 @@ export async function listChatsForMember(db: Database, memberId: string, humanAg
 
   // Build grouped result: per agent, list of chats
   const result: Array<{
-    agent: { uuid: string; name: string | null; type: string; displayName: string | null };
+    agent: { uuid: string; name: string | null; type: string; displayName: string };
     chats: Array<{
       id: string;
       type: string | null;

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   AGENT_NAME_MAX_LENGTH,
   AGENT_NAME_REGEX,
+  agentSchema,
   createAgentSchema,
   isReservedAgentName,
   RESERVED_AGENT_NAMES,
+  updateAgentSchema,
 } from "../schemas/agent.js";
 
 /**
@@ -79,5 +81,53 @@ describe("createAgentSchema", () => {
     const tooLong = "a".repeat(AGENT_NAME_MAX_LENGTH + 1);
     const res = createAgentSchema.safeParse({ name: tooLong, type: "human" });
     expect(res.success).toBe(false);
+  });
+});
+
+describe("Phase 2: displayName is non-null on the wire", () => {
+  const baseRow = {
+    uuid: "uuid-1",
+    name: "alice",
+    organizationId: "org-1",
+    type: "human" as const,
+    delegateMention: null,
+    inboxId: "inbox_uuid-1",
+    status: "active",
+    visibility: "organization" as const,
+    metadata: {},
+    managerId: "mem-1",
+    clientId: null,
+    createdAt: "2026-04-24T00:00:00.000Z",
+    updatedAt: "2026-04-24T00:00:00.000Z",
+  };
+
+  it("agentSchema rejects a row with null displayName", () => {
+    const res = agentSchema.safeParse({ ...baseRow, displayName: null });
+    expect(res.success).toBe(false);
+  });
+
+  it("agentSchema accepts a non-null displayName", () => {
+    const res = agentSchema.safeParse({ ...baseRow, displayName: "Alice" });
+    expect(res.success).toBe(true);
+  });
+
+  it("updateAgentSchema rejects `displayName: null` (clearing the field is no longer allowed)", () => {
+    const res = updateAgentSchema.safeParse({ displayName: null });
+    expect(res.success).toBe(false);
+  });
+
+  it("updateAgentSchema rejects an empty-string displayName (min 1 char)", () => {
+    const res = updateAgentSchema.safeParse({ displayName: "" });
+    expect(res.success).toBe(false);
+  });
+
+  it("updateAgentSchema accepts a non-empty displayName", () => {
+    const res = updateAgentSchema.safeParse({ displayName: "Alice v2" });
+    expect(res.success).toBe(true);
+  });
+
+  it("updateAgentSchema accepts omitted displayName (leaves row untouched)", () => {
+    const res = updateAgentSchema.safeParse({});
+    expect(res.success).toBe(true);
   });
 });

--- a/packages/shared/src/__tests__/mentions.test.ts
+++ b/packages/shared/src/__tests__/mentions.test.ts
@@ -20,7 +20,9 @@ function mkParticipant(
     mode: extras.mode ?? "full",
     joinedAt: extras.joinedAt ?? new Date().toISOString(),
     name,
-    displayName: extras.displayName ?? null,
+    // ChatParticipantDetail.displayName is non-null post-Phase 2, so fall
+    // back to a synthetic label when the extras don't provide one.
+    displayName: extras.displayName ?? `agent-${agentId}`,
     type: extras.type ?? "autonomous_agent",
   };
 }

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -105,7 +105,14 @@ export type CreateAgent = z.infer<typeof createAgentSchema>;
 
 export const updateAgentSchema = z.object({
   type: agentTypeSchema.optional(),
-  displayName: z.string().max(200).nullable().optional(),
+  /**
+   * Phase 2 of the agent-naming refactor promoted `displayName` to NOT NULL
+   * at the DB level, so null is no longer an accepted update — clearing the
+   * label would violate the constraint. Callers that used to PATCH
+   * `{ displayName: null }` must omit the field (leaves the row untouched)
+   * or send a real string.
+   */
+  displayName: z.string().min(1).max(200).optional(),
   delegateMention: z.string().max(100).nullable().optional(),
   visibility: agentVisibilitySchema.optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
@@ -125,7 +132,12 @@ export const agentSchema = z.object({
   name: z.string().nullable(),
   organizationId: z.string(),
   type: agentTypeSchema,
-  displayName: z.string().nullable(),
+  /**
+   * Always populated post-Phase 2 (migration 0024 backfilled + `NOT NULL`).
+   * The shared type used to be nullable; old row-shape consumers were
+   * retired alongside the server service default.
+   */
+  displayName: z.string(),
   delegateMention: z.string().nullable(),
   inboxId: z.string(),
   status: z.string(),
@@ -160,7 +172,12 @@ export const agentPinnedMessageSchema = z.object({
   type: z.literal("agent:pinned"),
   agentId: z.string(),
   name: z.string().nullable(),
-  displayName: z.string().nullable(),
+  /**
+   * Always populated post-Phase 2 (agents.display_name is NOT NULL). Old
+   * clients that parsed the previous `nullable` variant still accept a
+   * non-null string, so tightening this here is wire-compatible.
+   */
+  displayName: z.string(),
   agentType: agentTypeSchema,
 });
 export type AgentPinnedMessage = z.infer<typeof agentPinnedMessageSchema>;

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -84,7 +84,13 @@ export const createAgentSchema = z.object({
     })
     .optional(),
   type: agentTypeSchema,
-  displayName: z.string().max(200).optional(),
+  /**
+   * Post-Phase 2 the DB enforces `NOT NULL`; the service layer defaults
+   * missing/empty values to `name` (or "Unnamed Agent") so callers can
+   * still omit this. Reject empty / whitespace-only strings at the edge
+   * so the silent server-side replacement doesn't mask a user typo.
+   */
+  displayName: z.string().min(1).max(200).optional(),
   delegateMention: z.string().max(100).optional(),
   organizationId: z.string().max(100).optional(),
   /** How this agent was created */

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -32,7 +32,12 @@ export type ChatParticipant = z.infer<typeof chatParticipantSchema>;
  */
 export const chatParticipantDetailSchema = chatParticipantSchema.extend({
   name: z.string().nullable(),
-  displayName: z.string().nullable(),
+  /**
+   * Non-null after Phase 2 of the agent-naming refactor — migration 0024
+   * enforces `agents.display_name NOT NULL`, so every participant resolves
+   * to a real label the client can render.
+   */
+  displayName: z.string(),
   type: z.string(),
 });
 export type ChatParticipantDetail = z.infer<typeof chatParticipantDetailSchema>;

--- a/packages/web/src/lib/use-agent-name-map.ts
+++ b/packages/web/src/lib/use-agent-name-map.ts
@@ -16,17 +16,17 @@ export function useAgentNameMap(): (uuid: string | null | undefined) => string {
     staleTime: 30_000,
   });
 
-  // Prefer `displayName` over `name` so chat/roster render friendly
-  // strings (e.g. "Alice Wang") instead of slug-form agent names
-  // (e.g. "alice"). The slug stays available as a fallback for agents
-  // with no display name set, and uuid as the last resort for soft-
-  // deleted rows (`name` is cleared on delete) or agents that never had
-  // either field populated.
+  // Post-Phase 2 of the agent-naming refactor, `displayName` is guaranteed
+  // non-null by the DB (migration 0024) and the service-level default.
+  // The old `a.displayName ?? a.name ?? a.uuid` fallback chain is gone \u2014
+  // any missing label now means the UUID isn't in the cached page (e.g.
+  // soft-deleted, org changed mid-session), which we surface as the raw
+  // uuid so the caller can at least render something stable.
   return useMemo(() => {
     const map = new Map<string, string>();
     if (data?.items) {
       for (const a of data.items) {
-        map.set(a.uuid, a.displayName ?? a.name ?? a.uuid);
+        map.set(a.uuid, a.displayName);
       }
     }
     return (uuid: string | null | undefined) => {
@@ -39,10 +39,12 @@ export function useAgentNameMap(): (uuid: string | null | undefined) => string {
 /**
  * Minimal identity pair surfaced to components that want to render the
  * full `<AgentChip>` (display name + `@name`) instead of a single string.
+ * `displayName` is non-null post-Phase 2 of the agent-naming refactor;
+ * `name` stays nullable because soft-deleted rows have it cleared.
  */
 export type AgentIdentity = {
   name: string | null;
-  displayName: string | null;
+  displayName: string;
 };
 
 /**

--- a/packages/web/src/pages/admin-all-agents.tsx
+++ b/packages/web/src/pages/admin-all-agents.tsx
@@ -70,9 +70,7 @@ export function AdminAllAgentsPage() {
                   onClick={() => navigate(`/agents/${encodeURIComponent(a.uuid)}`)}
                 >
                   <DenseTableCell>
-                    <span className="font-medium">
-                      {a.displayName ?? <span style={{ color: "var(--fg-4)" }}>—</span>}
-                    </span>
+                    <span className="font-medium">{a.displayName}</span>
                   </DenseTableCell>
                   <DenseTableCell>
                     {a.name ? (

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -723,7 +723,7 @@ export function AgentDetailPage() {
             </div>
             <div className="flex-1 min-w-0">
               <div className="flex items-baseline gap-2">
-                <span className="text-title">{agent.displayName ?? agent.name ?? shortId}</span>
+                <span className="text-title">{agent.displayName}</span>
                 <span className="mono text-label" style={{ color: "var(--fg-4)" }}>
                   @{agent.name ?? shortId}
                 </span>

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -64,9 +64,7 @@ export function IdentitySection({ agent, onSave }: IdentitySectionProps) {
       </header>
       <div className="px-4 py-3 text-body space-y-1">
         <div>
-          <span className="font-semibold">
-            {agent.displayName ?? <span className="text-muted-foreground italic">no display name</span>}
-          </span>
+          <span className="font-semibold">{agent.displayName}</span>
           {agent.name && <span className="ml-2 font-mono text-caption text-muted-foreground">@{agent.name}</span>}
           {delegateIdentity && (
             <>
@@ -124,7 +122,7 @@ type IdentityDialogProps = {
 
 function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialogProps) {
   const { memberId, role } = useAuth();
-  const [displayName, setDisplayName] = useState(agent.displayName ?? "");
+  const [displayName, setDisplayName] = useState(agent.displayName);
   const [delegateMention, setDelegateMention] = useState(agent.delegateMention ?? "");
   const [visibility, setVisibility] = useState(agent.visibility);
   const [saving, setSaving] = useState(false);
@@ -132,7 +130,7 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
 
   useEffect(() => {
     if (open) {
-      setDisplayName(agent.displayName ?? "");
+      setDisplayName(agent.displayName);
       setDelegateMention(agent.delegateMention ?? "");
       setVisibility(agent.visibility);
       setError(null);
@@ -156,10 +154,17 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
   async function submit(e: FormEvent) {
     e.preventDefault();
     setError(null);
+    // Display name is required after Phase 2 — reject empty locally so the
+    // server 400 doesn't bubble up as a mystery "validation failed".
+    const trimmed = displayName.trim();
+    if (!trimmed) {
+      setError("Display name is required.");
+      return;
+    }
     setSaving(true);
     try {
       const patch: UpdateAgent = {
-        displayName: displayName || null,
+        displayName: trimmed,
         delegateMention: delegateMention || null,
       };
       if (visibility !== agent.visibility) {

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -36,9 +36,12 @@ type RuntimeInfo = {
 };
 
 function sortByName(agents: Agent[]): Agent[] {
+  // Sort on displayName (the human label shown in every visible column)
+  // rather than the slug; falling back to name only when displayName is
+  // somehow empty (shouldn't happen post-Phase 2 but trivially cheap).
   return [...agents].sort((a, b) => {
-    const nameA = (a.name ?? a.displayName ?? "").toLowerCase();
-    const nameB = (b.name ?? b.displayName ?? "").toLowerCase();
+    const nameA = (a.displayName || a.name || "").toLowerCase();
+    const nameB = (b.displayName || b.name || "").toLowerCase();
     return nameA.localeCompare(nameB);
   });
 }
@@ -132,7 +135,7 @@ export function AgentsPage() {
     const owner = resolveMemberName(agent.managerId);
     return (
       (agent.name ?? "").toLowerCase().includes(q) ||
-      (agent.displayName ?? "").toLowerCase().includes(q) ||
+      agent.displayName.toLowerCase().includes(q) ||
       delegate.toLowerCase().includes(q) ||
       owner.toLowerCase().includes(q)
     );
@@ -449,7 +452,7 @@ function AgentRow({
   return (
     <DenseTableRow interactive onClick={() => navigate(`/agents/${agent.uuid}`)}>
       <DenseTableCell>
-        <span className="font-medium">{agent.displayName ?? <span style={{ color: "var(--fg-4)" }}>—</span>}</span>
+        <span className="font-medium">{agent.displayName}</span>
       </DenseTableCell>
       <DenseTableCell>
         {agent.name ? (
@@ -467,6 +470,9 @@ function AgentRow({
       </DenseTableCell>
       <DenseTableCell>
         {agent.delegateMention ? (
+          // AgentChip still accepts a nullable displayName so it can render
+          // a partial chip for soft-deleted delegate targets missing from
+          // the cached agents page — the cache lookup can genuinely miss.
           <AgentChip name={delegate?.name ?? null} displayName={delegate?.displayName ?? null} tone="accent" />
         ) : (
           <span style={{ color: "var(--fg-4)" }}>—</span>


### PR DESCRIPTION
> **Re-do of #169.** PR #169 was technically merged but its base was the stacked Phase-1 branch, not `main` — so the Phase-2 commits never landed in `main`. This PR cherry-picks the original two commits (`76dc857` + `a0a720f`) onto current `main` and targets `main` directly.

## Summary

Phase 2 of the agent-naming refactor (`docs/agent-naming-design.md`, included via #168). Promotes `agents.display_name` to `NOT NULL` and retires the nullable fallback that used to paper over missing labels only on the web. Every surface — CLI, server logs, IM bridge, chat roster — now sees a populated label without its own fallback.

## Scope

**Migration (`packages/server/drizzle/0024_display_name_not_null.sql`)**
- Backfill `COALESCE(display_name, name, '[deleted agent]')` for every NULL row. Not `uuid` — tombstoned rows must not surface UUIDs as human-visible labels; the literal mirrors `"Unnamed Agent"` used in the service default.
- Add a temporary `DEFAULT ''` then `SET NOT NULL`. The default catches any old-code INSERT that might land during a rolling deploy.
- `_journal.json` updated (idx 24).

**Schema (`packages/server/src/db/schema/agents.ts`)**
- `displayName: text("display_name").notNull()`.

**Service (`packages/server/src/services/agent.ts`)**
- `createAgent` defaults `displayName` to `data.displayName?.trim() || name || "Unnamed Agent"`.

**Zod (`packages/shared/src/schemas/*.ts`)**
- `createAgentSchema.displayName`: `z.string().min(1).max(200).optional()`.
- `updateAgentSchema.displayName`: `z.string().min(1).max(200).optional()` (null no longer accepted).
- `agentSchema.displayName`, `agentPinnedMessageSchema.displayName`, `chatParticipantDetailSchema.displayName`: `z.string()`.

**Web (`packages/web`)**
- `useAgentNameMap` drops the `displayName ?? name ?? uuid` cascade.
- `useAgentIdentityMap.AgentIdentity.displayName: string`.
- List + detail + admin + identity-edit pages drop unreachable fallback branches; edit dialog rejects empty locally.

**Client (`packages/client`)**
- `AgentIdentity`, `RegisterResult`, `BoundAgent` all have non-nullable `displayName`. Defensive `?? agentId` fallback retained on the WS parser for rolling-deploy mismatches.

**Tests**
- Shared: +6 Phase-2 cases.
- Client: fixtures updated; `resolveSenderLabel` test pins the empty-string branch.

## Rollout

Order matters:
1. Deploy the new server code (service default in place).
2. Apply migration 0024.
3. (Later, once fully rolled) drop the temporary `DEFAULT ''`.

## Test plan
- [x] `pnpm check && pnpm typecheck` (green locally)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` — 114 passing
- [x] `pnpm --filter @first-tree-hub/web test` — 32 passing
- [ ] CI: `@first-tree-hub/server test` against live Postgres
- [ ] Manual: agents list / detail / identity-edit dialog all show a label

https://claude.ai/code/session_01FPSSQEbW69nBmXGmH1zdB7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPSSQEbW69nBmXGmH1zdB7)_