### PR TITLE
feat(schema): SaaS onboarding M0 — users.email, auth_providers, invite_token, onboarding_state

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/drizzle/0026_saas_onboarding_schema.sql
+++ b/packages/server/drizzle/0026_saas_onboarding_schema.sql
@@ -4,10 +4,17 @@
 --
 --   1. users.email — primary contact email. Sourced from the GitHub OAuth
 --      provider on SaaS signup; legacy self-hosted rows have no email today,
---      so we backfill a per-row `<id>@noreply.local` placeholder before
---      adding NOT NULL + UNIQUE. The placeholder keeps the column populated
---      without surfacing a fake address — when a self-hosted user later
---      links GitHub via OAuth the real address takes over (PR #2).
+--      so we backfill a per-row `<id>@users.noreply.first-tree.ai`
+--      placeholder before adding NOT NULL + UNIQUE. The subdomain mirrors
+--      GitHub's `users.noreply.github.com` pattern — first-tree.ai is under
+--      our control so a real GitHub primary email cannot collide with a
+--      placeholder. When a self-hosted user later links GitHub via OAuth
+--      (PR #2) the real address takes over.
+--
+--      Identity resolution rule for the OAuth callback in PR #2:
+--      authenticate via `auth_providers.(provider, provider_user_id)` —
+--      never via `users.email`. Email is a contact field, not an identity
+--      key. This isolates the placeholder from the auth path.
 --   2. auth_providers — third-party identity binding. One row per
 --      (provider, provider_user_id) pointing at users.id. PR #2 will write
 --      to it on the GitHub callback path.
@@ -20,6 +27,33 @@
 --      members start at "connect" / "create_agent" / "completed".
 --
 -- See docs/saas-onboarding-journey.md §5 for the field-level rationale.
+--
+-- ──────────────── Operator note ────────────────
+--
+-- Drizzle wraps every migration file in a single transaction. The user/org
+-- ALTERs below — ADD COLUMN → UPDATE every row → SET NOT NULL → ADD UNIQUE
+-- (which builds a fresh B-tree) — all hold ACCESS EXCLUSIVE on the target
+-- table for the migration's duration. On a self-hosted DB with <1k rows
+-- this is sub-second. On a populated cloud DB (10k+ users or orgs) the
+-- UNIQUE index builds can hold the lock for several seconds, blocking all
+-- reads/writes against `users` / `organizations`.
+--
+-- Cloud runbook for sizable tables:
+--   1. Pause new migration application briefly.
+--   2. Outside any transaction, pre-create the unique indexes:
+--        CREATE UNIQUE INDEX CONCURRENTLY users_email_unique
+--          ON users (email);
+--        CREATE UNIQUE INDEX CONCURRENTLY organizations_invite_token_unique
+--          ON organizations (invite_token);
+--      (Backfill the columns first via a one-off UPDATE that lets the index
+--      see deterministic values; then SET NOT NULL.)
+--   3. Re-run `pnpm db:migrate`. Postgres will see the existing index and
+--      `ADD CONSTRAINT … UNIQUE` simply attaches to it (still wrapped in a
+--      tx, but the lock is held only long enough to register the
+--      constraint — no full rebuild).
+--
+-- The migration as written is the right shape for fresh installs and small
+-- self-hosted deployments. The runbook is for production cloud only.
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
@@ -28,7 +62,7 @@ ALTER TABLE "users" ADD COLUMN "email" text;
 
 --> statement-breakpoint
 UPDATE "users"
-   SET "email" = "id" || '@noreply.local'
+   SET "email" = "id" || '@users.noreply.first-tree.ai'
  WHERE "email" IS NULL;
 
 --> statement-breakpoint

--- a/packages/server/drizzle/0026_saas_onboarding_schema.sql
+++ b/packages/server/drizzle/0026_saas_onboarding_schema.sql
@@ -1,0 +1,88 @@
+-- SaaS onboarding schema (M0).
+--
+-- Adds the four data-model pieces the SaaS onboarding journey depends on:
+--
+--   1. users.email — primary contact email. Sourced from the GitHub OAuth
+--      provider on SaaS signup; legacy self-hosted rows have no email today,
+--      so we backfill a per-row `<id>@noreply.local` placeholder before
+--      adding NOT NULL + UNIQUE. The placeholder keeps the column populated
+--      without surfacing a fake address — when a self-hosted user later
+--      links GitHub via OAuth the real address takes over (PR #2).
+--   2. auth_providers — third-party identity binding. One row per
+--      (provider, provider_user_id) pointing at users.id. PR #2 will write
+--      to it on the GitHub callback path.
+--   3. organizations.invite_token + invite_token_created_at — per-workspace
+--      public share-link token (url-safe base64, 32 random bytes). Existing
+--      rows are backfilled with random tokens before NOT NULL + UNIQUE.
+--      Requires pgcrypto for `gen_random_bytes`.
+--   4. members.onboarding_state — nullable JSONB tracking wizard checkpoint
+--      per (user × workspace). Null for existing self-hosted rows; new SaaS
+--      members start at "connect" / "create_agent" / "completed".
+--
+-- See docs/saas-onboarding-journey.md §5 for the field-level rationale.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "email" text;
+
+--> statement-breakpoint
+UPDATE "users"
+   SET "email" = "id" || '@noreply.local'
+ WHERE "email" IS NULL;
+
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "email" SET NOT NULL;
+
+--> statement-breakpoint
+ALTER TABLE "users"
+	ADD CONSTRAINT "users_email_unique" UNIQUE ("email");
+
+--> statement-breakpoint
+CREATE TABLE "auth_providers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"provider_user_id" text NOT NULL,
+	"email_at_link" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_auth_providers_provider_user" UNIQUE ("provider", "provider_user_id")
+);
+
+--> statement-breakpoint
+ALTER TABLE "auth_providers"
+	ADD CONSTRAINT "auth_providers_user_id_users_id_fk"
+	FOREIGN KEY ("user_id") REFERENCES "users"("id")
+	ON DELETE cascade ON UPDATE no action;
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_auth_providers_user"
+	ON "auth_providers" ("user_id");
+
+--> statement-breakpoint
+ALTER TABLE "organizations" ADD COLUMN "invite_token" text;
+
+--> statement-breakpoint
+ALTER TABLE "organizations"
+	ADD COLUMN "invite_token_created_at" timestamp with time zone DEFAULT now() NOT NULL;
+
+--> statement-breakpoint
+-- Backfill: url-safe base64 of 32 random bytes, padding stripped. `gen_random_bytes`
+-- is volatile so each row evaluates independently — no collisions in practice.
+UPDATE "organizations"
+   SET "invite_token" = rtrim(
+       replace(replace(encode(gen_random_bytes(32), 'base64'), '+', '-'), '/', '_'),
+       '='
+     )
+ WHERE "invite_token" IS NULL;
+
+--> statement-breakpoint
+ALTER TABLE "organizations" ALTER COLUMN "invite_token" SET NOT NULL;
+
+--> statement-breakpoint
+ALTER TABLE "organizations"
+	ADD CONSTRAINT "organizations_invite_token_unique" UNIQUE ("invite_token");
+
+--> statement-breakpoint
+ALTER TABLE "members" ADD COLUMN "onboarding_state" jsonb;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777420800000,
       "tag": "0025_inbox_silent_entries",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0026_saas_onboarding_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -53,7 +53,7 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
       await tx.insert(users).values({
         id: userId,
         username: `pin-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
-        email: `${userId}@noreply.local`,
+        email: `${userId}@users.noreply.first-tree.ai`,
         passwordHash: "x",
         displayName: `Pin User ${suffix}`,
       });

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -53,6 +53,7 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
       await tx.insert(users).values({
         id: userId,
         username: `pin-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        email: `${userId}@noreply.local`,
         passwordHash: "x",
         displayName: `Pin User ${suffix}`,
       });

--- a/packages/server/src/__tests__/client-org-scoping.test.ts
+++ b/packages/server/src/__tests__/client-org-scoping.test.ts
@@ -6,6 +6,7 @@ import { organizations } from "../db/schema/organizations.js";
 import { ClientOrgMismatchError, ForbiddenError } from "../errors.js";
 import { createAgent } from "../services/agent.js";
 import { assertClientOwner, registerClient } from "../services/client.js";
+import { generateInviteToken } from "../services/organization.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
@@ -28,7 +29,12 @@ describe("clients: cross-org isolation", () => {
     const suffix = crypto.randomUUID().slice(0, 8);
     const [row] = await app.db
       .insert(organizations)
-      .values({ id: `org-${suffix}`, name: `other-${suffix}`, displayName: `Other ${suffix}` })
+      .values({
+        id: `org-${suffix}`,
+        name: `other-${suffix}`,
+        displayName: `Other ${suffix}`,
+        inviteToken: generateInviteToken(),
+      })
       .returning({ id: organizations.id });
     if (!row) throw new Error("failed to seed secondary organization");
     return row.id;

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -212,6 +212,7 @@ export async function createTestAdmin(app: FastifyInstance, opts: { username?: s
     await tx.insert(users).values({
       id: userId,
       username,
+      email: `${userId}@noreply.local`,
       passwordHash,
       displayName: "Test Admin",
     });

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -212,7 +212,7 @@ export async function createTestAdmin(app: FastifyInstance, opts: { username?: s
     await tx.insert(users).values({
       id: userId,
       username,
-      email: `${userId}@noreply.local`,
+      email: `${userId}@users.noreply.first-tree.ai`,
       passwordHash,
       displayName: "Test Admin",
     });

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -32,6 +32,7 @@ beforeEach(async () => {
       agent_presence,
       members,
       agents,
+      auth_providers,
       users,
       clients,
       processed_events,
@@ -40,9 +41,19 @@ beforeEach(async () => {
       organizations
     CASCADE
   `);
-  // Re-insert default organization with UUID PK (required by agents/chats FK constraints)
+  // Re-insert default organization with UUID PK (required by agents/chats FK
+  // constraints). `invite_token` is NOT NULL since migration 0026 — generate
+  // a fresh per-test token rather than hard-coding a stable value, which
+  // would conflict with any test that exercises the invite-link flow.
   await db.execute(
-    sql`INSERT INTO organizations (id, name, display_name) VALUES (${DEFAULT_ORG_ID}, 'default', 'Default Organization') ON CONFLICT DO NOTHING`,
+    sql`INSERT INTO organizations (id, name, display_name, invite_token)
+        VALUES (
+          ${DEFAULT_ORG_ID},
+          'default',
+          'Default Organization',
+          rtrim(replace(replace(encode(gen_random_bytes(32), 'base64'), '+', '-'), '/', '_'), '=')
+        )
+        ON CONFLICT DO NOTHING`,
   );
 });
 

--- a/packages/server/src/__tests__/task-chat-link.test.ts
+++ b/packages/server/src/__tests__/task-chat-link.test.ts
@@ -4,6 +4,7 @@ import { organizations } from "../db/schema/organizations.js";
 import { taskChats } from "../db/schema/tasks.js";
 import { createAgent } from "../services/agent.js";
 import { findOrCreateDirectChat } from "../services/chat.js";
+import { generateInviteToken } from "../services/organization.js";
 import * as taskService from "../services/task.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
@@ -59,7 +60,12 @@ describe("Task ↔ Chat linking", () => {
     const altOrgId = "01961234-0000-7000-8000-0000000000aa";
     await app.db
       .insert(organizations)
-      .values({ id: altOrgId, name: `alt-${Date.now()}`, displayName: "Alt" })
+      .values({
+        id: altOrgId,
+        name: `alt-${Date.now()}`,
+        displayName: "Alt",
+        inviteToken: generateInviteToken(),
+      })
       .onConflictDoNothing();
     // Use human type so createAgent doesn't require a client — this test is
     // about cross-org chat linking, not R-RUN pinning.

--- a/packages/server/src/__tests__/task-service.test.ts
+++ b/packages/server/src/__tests__/task-service.test.ts
@@ -97,10 +97,16 @@ describe("Task service", () => {
 
     // Create a second org and an agent there
     const { organizations } = await import("../db/schema/organizations.js");
+    const { generateInviteToken } = await import("../services/organization.js");
     const altOrgId = "01961234-0000-7000-8000-000000000099";
     await app.db
       .insert(organizations)
-      .values({ id: altOrgId, name: `alt-${Date.now()}`, displayName: "Alt" })
+      .values({
+        id: altOrgId,
+        name: `alt-${Date.now()}`,
+        displayName: "Alt",
+        inviteToken: generateInviteToken(),
+      })
       .onConflictDoNothing();
     // Use human type to avoid the R-RUN client pin requirement — this test
     // is about cross-org assignee rejection, not runtime pinning.

--- a/packages/server/src/__tests__/ws-admin-org-isolation.test.ts
+++ b/packages/server/src/__tests__/ws-admin-org-isolation.test.ts
@@ -52,7 +52,7 @@ describe("Admin WS — cross-org isolation (S0)", () => {
       await tx.insert(users).values({
         id: userId,
         username: `iso-admin-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
-        email: `${userId}@noreply.local`,
+        email: `${userId}@users.noreply.first-tree.ai`,
         passwordHash: "x",
         displayName: `Iso Admin ${suffix}`,
       });

--- a/packages/server/src/__tests__/ws-admin-org-isolation.test.ts
+++ b/packages/server/src/__tests__/ws-admin-org-isolation.test.ts
@@ -52,6 +52,7 @@ describe("Admin WS — cross-org isolation (S0)", () => {
       await tx.insert(users).values({
         id: userId,
         username: `iso-admin-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        email: `${userId}@noreply.local`,
         passwordHash: "x",
         displayName: `Iso Admin ${suffix}`,
       });

--- a/packages/server/src/__tests__/ws-admin-pulse-visibility.test.ts
+++ b/packages/server/src/__tests__/ws-admin-pulse-visibility.test.ts
@@ -38,6 +38,7 @@ describe("Admin WS — pulse:tick visibility filtering", () => {
       await tx.insert(users).values({
         id: userId,
         username: `pv-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        email: `${userId}@noreply.local`,
         passwordHash: "x",
         displayName: `PV ${suffix}`,
       });

--- a/packages/server/src/__tests__/ws-admin-pulse-visibility.test.ts
+++ b/packages/server/src/__tests__/ws-admin-pulse-visibility.test.ts
@@ -38,7 +38,7 @@ describe("Admin WS — pulse:tick visibility filtering", () => {
       await tx.insert(users).values({
         id: userId,
         username: `pv-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
-        email: `${userId}@noreply.local`,
+        email: `${userId}@users.noreply.first-tree.ai`,
         passwordHash: "x",
         displayName: `PV ${suffix}`,
       });

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -63,6 +63,7 @@ describe("Agent WS — session event protocol (S10)", () => {
       await tx.insert(users).values({
         id: userId,
         username: `evt-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        email: `${userId}@noreply.local`,
         passwordHash: "x",
         displayName: `Evt User ${suffix}`,
       });

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -63,7 +63,7 @@ describe("Agent WS — session event protocol (S10)", () => {
       await tx.insert(users).values({
         id: userId,
         username: `evt-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
-        email: `${userId}@noreply.local`,
+        email: `${userId}@users.noreply.first-tree.ai`,
         passwordHash: "x",
         displayName: `Evt User ${suffix}`,
       });

--- a/packages/server/src/db/schema/auth-providers.ts
+++ b/packages/server/src/db/schema/auth-providers.ts
@@ -1,0 +1,37 @@
+import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { users } from "./users.js";
+
+/**
+ * Third-party identity bindings (GitHub today, Google/Feishu future).
+ *
+ * One row per (provider, provider_user_id) pair — joining a provider account
+ * to a `users.id`. Lookup path on OAuth callback:
+ *   1. find row by (provider, provider_user_id)
+ *   2. if hit -> reuse user; if miss -> create user + this row in a tx.
+ *
+ * `email_at_link` snapshots the email returned by the provider at link time
+ * (audit only). The current email of record lives on `users.email`.
+ *
+ * See docs/saas-onboarding-journey.md §5.2.
+ */
+export const authProviders = pgTable(
+  "auth_providers",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /** "github" today; future: "google" | "feishu" */
+    provider: text("provider").notNull(),
+    /** Provider's stable opaque user ID (e.g. GitHub numeric ID as string). */
+    providerUserId: text("provider_user_id").notNull(),
+    /** Email returned by the provider at link time (audit only, may go stale). */
+    emailAtLink: text("email_at_link"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique("uq_auth_providers_provider_user").on(table.provider, table.providerUserId),
+    index("idx_auth_providers_user").on(table.userId),
+  ],
+);

--- a/packages/server/src/db/schema/auth-providers.ts
+++ b/packages/server/src/db/schema/auth-providers.ts
@@ -17,6 +17,7 @@ import { users } from "./users.js";
 export const authProviders = pgTable(
   "auth_providers",
   {
+    /** UUID v7, system-generated. Callers must supply via `uuidv7()` at insert time — matches the convention used by `users` and `organizations`. */
     id: text("id").primaryKey(),
     userId: text("user_id")
       .notNull()

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -6,6 +6,7 @@ export { agentChatSessions } from "./agent-chat-sessions.js";
 export { agentConfigs } from "./agent-configs.js";
 export { agentPresence } from "./agent-presence.js";
 export { agents } from "./agents.js";
+export { authProviders } from "./auth-providers.js";
 export { chatParticipants, chats } from "./chats.js";
 export { clients } from "./clients.js";
 export { inboxEntries } from "./inbox-entries.js";

--- a/packages/server/src/db/schema/members.ts
+++ b/packages/server/src/db/schema/members.ts
@@ -1,7 +1,19 @@
-import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { index, jsonb, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { organizations } from "./organizations.js";
 import { users } from "./users.js";
+
+/**
+ * Onboarding wizard progress, tracked per (user × workspace).
+ *
+ * Why per-membership and not per-user: a user already onboarded in workspace A
+ * who is invited to workspace B should not re-walk the Connect Computer screen
+ * — but the Create Agent screen still applies, since each workspace gets its
+ * own first agent. See P0-5 in docs/saas-onboarding-journey.md §6.1.
+ */
+export type OnboardingState = {
+  currentStep: "connect" | "create_agent" | "completed";
+};
 
 /** Organization membership. Links a user to an org with a role and a 1:1 human agent. */
 export const members = pgTable(
@@ -21,6 +33,8 @@ export const members = pgTable(
       .references(() => agents.uuid),
     /** "admin" | "member" */
     role: text("role").notNull(),
+    /** Onboarding wizard checkpoint; null = not started. See type docs above. */
+    onboardingState: jsonb("onboarding_state").$type<OnboardingState>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/packages/server/src/db/schema/members.ts
+++ b/packages/server/src/db/schema/members.ts
@@ -1,19 +1,8 @@
+import type { OnboardingState } from "@agent-team-foundation/first-tree-hub-shared";
 import { index, jsonb, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { organizations } from "./organizations.js";
 import { users } from "./users.js";
-
-/**
- * Onboarding wizard progress, tracked per (user × workspace).
- *
- * Why per-membership and not per-user: a user already onboarded in workspace A
- * who is invited to workspace B should not re-walk the Connect Computer screen
- * — but the Create Agent screen still applies, since each workspace gets its
- * own first agent. See P0-5 in docs/saas-onboarding-journey.md §6.1.
- */
-export type OnboardingState = {
-  currentStep: "connect" | "create_agent" | "completed";
-};
 
 /** Organization membership. Links a user to an org with a role and a 1:1 human agent. */
 export const members = pgTable(
@@ -33,7 +22,12 @@ export const members = pgTable(
       .references(() => agents.uuid),
     /** "admin" | "member" */
     role: text("role").notNull(),
-    /** Onboarding wizard checkpoint; null = not started. See type docs above. */
+    /**
+     * Onboarding wizard checkpoint; null = not started. Per (user × workspace)
+     * so a user already onboarded in workspace A skips the Connect screen
+     * when invited to workspace B (P0-5). Shape is the canonical
+     * `OnboardingState` type from `@agent-team-foundation/first-tree-hub-shared`.
+     */
     onboardingState: jsonb("onboarding_state").$type<OnboardingState>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/server/src/db/schema/organizations.ts
+++ b/packages/server/src/db/schema/organizations.ts
@@ -12,6 +12,16 @@ export const organizations = pgTable("organizations", {
   /** 0 = unlimited */
   maxMessagesPerMinute: integer("max_messages_per_minute").notNull().default(0),
   features: jsonb("features").$type<Record<string, unknown>>().notNull().default({}),
+  /**
+   * Public share-link token (url-safe base64, 32 random bytes). One per
+   * workspace; new joiners hit `/invite/<token>` to enroll. Generated on
+   * workspace create; rotation deferred to v2.
+   *
+   * See docs/saas-onboarding-journey.md §5.3.
+   */
+  inviteToken: text("invite_token").unique().notNull(),
+  /** Audit timestamp for the current invite_token (updated on rotate; rotation deferred). */
+  inviteTokenCreatedAt: timestamp("invite_token_created_at", { withTimezone: true }).notNull().defaultNow(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/packages/server/src/db/schema/users.ts
+++ b/packages/server/src/db/schema/users.ts
@@ -6,7 +6,7 @@ export const users = pgTable("users", {
   username: text("username").unique().notNull(),
   /**
    * Primary contact email. Sourced from the GitHub OAuth provider for SaaS
-   * users; legacy self-hosted rows are backfilled with a `<id>@noreply.local`
+   * users; legacy self-hosted rows are backfilled with a `<id>@users.noreply.first-tree.ai`
    * placeholder by migration 0026 and updated when the user later links a
    * provider. UNIQUE NOT NULL — see docs/saas-onboarding-journey.md §5.1.
    */

--- a/packages/server/src/db/schema/users.ts
+++ b/packages/server/src/db/schema/users.ts
@@ -4,6 +4,13 @@ import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 export const users = pgTable("users", {
   id: text("id").primaryKey(),
   username: text("username").unique().notNull(),
+  /**
+   * Primary contact email. Sourced from the GitHub OAuth provider for SaaS
+   * users; legacy self-hosted rows are backfilled with a `<id>@noreply.local`
+   * placeholder by migration 0026 and updated when the user later links a
+   * provider. UNIQUE NOT NULL — see docs/saas-onboarding-journey.md §5.1.
+   */
+  email: text("email").unique().notNull(),
   passwordHash: text("password_hash").notNull(),
   displayName: text("display_name").notNull(),
   avatarUrl: text("avatar_url"),

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -43,13 +43,16 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
     const userId = existingUser?.id ?? uuidv7();
     if (isNewUser && passwordHash) {
       // Legacy admin-API path: email isn't collected here. Use a per-user
-      // noreply placeholder so the UNIQUE NOT NULL constraint holds. SaaS
-      // signups go through the OAuth callback (PR #2), which writes the
-      // real GitHub email instead.
+      // noreply placeholder so the UNIQUE NOT NULL constraint holds. The
+      // subdomain mirrors GitHub's `users.noreply.github.com` pattern —
+      // since `first-tree.ai` is under our control no real GitHub primary
+      // email can collide with the placeholder. SaaS signups go through
+      // the OAuth callback (PR #2), which overwrites this with the real
+      // GitHub email.
       await tx.insert(users).values({
         id: userId,
         username: data.username,
-        email: `${userId}@noreply.local`,
+        email: `${userId}@users.noreply.first-tree.ai`,
         passwordHash,
         displayName: data.displayName,
       });

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -42,9 +42,14 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
     // Create user if needed
     const userId = existingUser?.id ?? uuidv7();
     if (isNewUser && passwordHash) {
+      // Legacy admin-API path: email isn't collected here. Use a per-user
+      // noreply placeholder so the UNIQUE NOT NULL constraint holds. SaaS
+      // signups go through the OAuth callback (PR #2), which writes the
+      // real GitHub email instead.
       await tx.insert(users).values({
         id: userId,
         username: data.username,
+        email: `${userId}@noreply.local`,
         passwordHash,
         displayName: data.displayName,
       });

--- a/packages/server/src/services/organization.ts
+++ b/packages/server/src/services/organization.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type { CreateOrganizationInput, UpdateOrganization } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, desc, eq, lt, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
@@ -5,6 +6,17 @@ import { agents } from "../db/schema/agents.js";
 import { organizations } from "../db/schema/organizations.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
+
+/**
+ * Generate a fresh public invite-link token: 32 random bytes encoded as
+ * url-safe base64 with padding stripped (43 chars). Workspace creation uses
+ * this so admins can immediately copy the share link from `/admin` → Members.
+ *
+ * See docs/saas-onboarding-journey.md §2.3.
+ */
+export function generateInviteToken(): string {
+  return randomBytes(32).toString("base64url");
+}
 
 /** UUID v7 regex pattern for distinguishing UUIDs from name slugs. */
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -39,6 +51,7 @@ export async function createOrganization(db: Database, data: CreateOrganizationI
         maxAgents: data.maxAgents ?? 0,
         maxMessagesPerMinute: data.maxMessagesPerMinute ?? 0,
         features: data.features ?? {},
+        inviteToken: generateInviteToken(),
       })
       .returning();
 
@@ -176,7 +189,12 @@ export async function ensureDefaultOrganization(db: Database) {
   const id = uuidv7();
   const [org] = await db
     .insert(organizations)
-    .values({ id, name: "default", displayName: "Default Organization" })
+    .values({
+      id,
+      name: "default",
+      displayName: "Default Organization",
+      inviteToken: generateInviteToken(),
+    })
     .onConflictDoNothing()
     .returning();
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -102,6 +102,13 @@ export {
   refreshTokenSchema,
 } from "./schemas/auth.js";
 export {
+  AUTH_PROVIDERS,
+  type AuthProvider,
+  type AuthProviderName,
+  authProviderNameSchema,
+  authProviderSchema,
+} from "./schemas/auth-provider.js";
+export {
   type AddParticipant,
   addParticipantSchema,
   CHAT_TYPES,
@@ -169,6 +176,11 @@ export {
   memberCreatedSchema,
   memberRoleSchema,
   memberSchema,
+  ONBOARDING_STEPS,
+  type OnboardingState,
+  type OnboardingStep,
+  onboardingStateSchema,
+  onboardingStepSchema,
   type UpdateMember,
   updateMemberSchema,
 } from "./schemas/member.js";

--- a/packages/shared/src/schemas/auth-provider.ts
+++ b/packages/shared/src/schemas/auth-provider.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/** Supported third-party identity providers. */
+export const AUTH_PROVIDERS = {
+  GITHUB: "github",
+} as const;
+
+export const authProviderNameSchema = z.enum(["github"]);
+export type AuthProviderName = z.infer<typeof authProviderNameSchema>;
+
+/**
+ * One row per (provider, provider_user_id) — links a third-party identity to
+ * a `users.id`. See docs/saas-onboarding-journey.md §5.2.
+ */
+export const authProviderSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  provider: authProviderNameSchema,
+  /** Provider's stable opaque user id (e.g. GitHub numeric id as string). */
+  providerUserId: z.string(),
+  /** Email returned by the provider at link time (audit only). */
+  emailAtLink: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type AuthProvider = z.infer<typeof authProviderSchema>;

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -33,7 +33,13 @@ export const memberSchema = z.object({
   organizationId: z.string(),
   agentId: z.string(),
   role: memberRoleSchema,
-  onboardingState: onboardingStateSchema.nullable(),
+  /**
+   * Wizard checkpoint. `.nullish()` because existing service projections
+   * (`listMembers`, `getMember`) do not yet select this column — PR #5
+   * adds the projection alongside the wizard-completion writes. Once that
+   * lands, tighten to `.nullable()`.
+   */
+  onboardingState: onboardingStateSchema.nullish(),
   createdAt: z.string(),
 });
 export type Member = z.infer<typeof memberSchema>;

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -8,12 +8,32 @@ export const MEMBER_ROLES = {
 export const memberRoleSchema = z.enum(["admin", "member"]);
 export type MemberRole = z.infer<typeof memberRoleSchema>;
 
+export const ONBOARDING_STEPS = {
+  CONNECT: "connect",
+  CREATE_AGENT: "create_agent",
+  COMPLETED: "completed",
+} as const;
+
+export const onboardingStepSchema = z.enum(["connect", "create_agent", "completed"]);
+export type OnboardingStep = z.infer<typeof onboardingStepSchema>;
+
+/**
+ * Wizard checkpoint, one per (user × workspace). Null on legacy rows and on
+ * fresh memberships before the wizard begins. See P0-5 in
+ * docs/saas-onboarding-journey.md §6.1.
+ */
+export const onboardingStateSchema = z.object({
+  currentStep: onboardingStepSchema,
+});
+export type OnboardingState = z.infer<typeof onboardingStateSchema>;
+
 export const memberSchema = z.object({
   id: z.string(),
   userId: z.string(),
   organizationId: z.string(),
   agentId: z.string(),
   role: memberRoleSchema,
+  onboardingState: onboardingStateSchema.nullable(),
   createdAt: z.string(),
 });
 export type Member = z.infer<typeof memberSchema>;

--- a/packages/shared/src/schemas/organization.ts
+++ b/packages/shared/src/schemas/organization.ts
@@ -49,6 +49,13 @@ export const organizationSchema = z.object({
   maxAgents: z.number(),
   maxMessagesPerMinute: z.number(),
   features: z.record(z.string(), z.unknown()),
+  /**
+   * Public invite share-link token (url-safe base64, 32 random bytes).
+   * Auto-generated on workspace create; only workspace admins surface it
+   * via `/admin` → Members. See docs/saas-onboarding-journey.md §5.3.
+   */
+  inviteToken: z.string(),
+  inviteTokenCreatedAt: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -11,6 +11,12 @@ export type UserStatus = z.infer<typeof userStatusSchema>;
 export const userSchema = z.object({
   id: z.string(),
   username: z.string(),
+  /**
+   * Primary contact email (UNIQUE NOT NULL since migration 0026). Sourced
+   * from GitHub OAuth for SaaS signups; legacy self-hosted users carry a
+   * `<id>@noreply.local` placeholder until they link a provider.
+   */
+  email: z.email(),
   displayName: z.string(),
   avatarUrl: z.string().nullable(),
   status: userStatusSchema,
@@ -21,6 +27,8 @@ export type User = z.infer<typeof userSchema>;
 
 export const createUserSchema = z.object({
   username: z.string().min(1).max(100),
+  /** Required for SaaS signups; self-host paths fall back to the noreply placeholder. */
+  email: z.email(),
   displayName: z.string().min(1).max(200),
   password: z.string().min(8).max(200),
 });


### PR DESCRIPTION
## Summary

First slice of the SaaS onboarding work tracked in [`docs/saas-onboarding-journey.md`](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/saas-onboarding/docs/saas-onboarding-journey.md) (M0). **Pure data-model groundwork** — no behavior change yet. PR #2 will write to these fields on the GitHub OAuth path.

### What's added

- **`users.email`** — UNIQUE NOT NULL. Sourced from GitHub OAuth on signup; legacy self-hosted rows are backfilled with `<id>@users.noreply.first-tree.ai` (subdomain we control, mirrors GitHub's `users.noreply.github.com` convention so a real GitHub primary email cannot collide).
- **`auth_providers`** — new table, one row per `(provider, provider_user_id)`, cascade-deletes on user deletion. Drives `findOrCreateUser` on the OAuth callback (PR #2). Identity resolution rule: PR #2 must look up users via `auth_providers`, never via `users.email`.
- **`organizations.invite_token` + `invite_token_created_at`** — workspace public share-link token (url-safe base64, 32 random bytes), generated at create time. Existing rows backfilled with random per-row tokens.
- **`members.onboarding_state`** — nullable JSONB tracking wizard checkpoint per `(user × workspace)` so a user already onboarded in workspace A skips the Connect screen when invited to workspace B (P0-5).

### Migration shape

`packages/server/drizzle/0026_saas_onboarding_schema.sql` is hand-written (matches the 0019+ pattern) and uses `pgcrypto` for backfill randomness. The migration file ships with an operator runbook block on lock-time: the default sequence is fine for fresh / small self-hosted DBs, and the runbook documents the `CREATE INDEX CONCURRENTLY` + `ADD CONSTRAINT … UNIQUE` pre-create pattern for sizable cloud tables.

### Code paths updated

- `services/organization.ts` — new `generateInviteToken()` helper; injects token in both `createOrganization` and `ensureDefaultOrganization`.
- `services/member.ts` — writes the noreply placeholder on the legacy admin-API path.
- Test fixtures (`__tests__/setup.ts` + 6 test files) — supply the new required columns. The truncate list now includes `auth_providers`.

### Versioning

- `packages/command` 0.10.0 → 0.10.1 (per CLAUDE.md: bump on every PR that touches `command/client/server/web/shared`).
- `shared` is `private: true` — not bumped.

### Test plan

- [x] Migration applies cleanly to a fresh DB
- [x] Migration applies cleanly on a populated DB (legacy users get unique placeholder emails; legacy orgs get unique invite tokens)
- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm check` (biome) — clean
- [x] Server tests — 463/463 passing
- [x] Web / shared tests — passing
- [x] Pre-push code-review pass — 5 medium/low findings addressed in second commit

### Out of scope (deferred to later PRs)

- GitHub OAuth flow + `findOrCreateUser` — PR #2
- Workspace create/join APIs + `/auth/switch-org` — PR #2
- `/signup` and `/setup` Web UI — PR #3
- Wizard screens — PR #4 / PR #5
- `/admin` invite-link surfacing — PR #6

### Deviation from design doc

§5.5 originally proposed deferring the email backfill until each user links a provider on next login. This PR backfills with a per-row placeholder up front so the column can be `NOT NULL` from day one — simpler invariant for downstream code, no behavioral difference for end users since the placeholder is never surfaced. Worth confirming this is acceptable before merge.

https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV)_