### PR TITLE
feat(web): SaaS sign-in entry — /signup + OAuth callback + /setup Create/Join modal + /invite landing

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/saas-onboarding-auth.test.ts
+++ b/packages/server/src/__tests__/saas-onboarding-auth.test.ts
@@ -35,9 +35,11 @@ describe("SaaS auth — GitHub OAuth + workspaces + switch-org (dev mode)", () =
 
   /**
    * Sign in via the dev-callback, returning the issued token pair + the
-   * `nextRoute` hint. Tests pass distinct `githubId`s so each call lands a
-   * fresh user; reusing the same id is the documented "second sign-in"
-   * idempotent path.
+   * `nextRoute` hint. The server 302-redirects to
+   * `/auth/github/complete#access=…&refresh=…&next=…` (fragment so the
+   * tokens never reach a server access log) — we read the Location header
+   * and parse the fragment ourselves rather than letting Fastify follow
+   * the redirect to a route that doesn't exist server-side.
    */
   async function devSignIn(opts: { githubId: string; login?: string; email?: string; next?: string }) {
     const next = opts.next ?? "/";
@@ -52,10 +54,20 @@ describe("SaaS auth — GitHub OAuth + workspaces + switch-org (dev mode)", () =
       method: "GET",
       url: `/api/v1/auth/github/dev-callback?${params.toString()}`,
     });
-    if (res.statusCode !== 200) {
+    if (res.statusCode !== 302) {
       throw new Error(`dev sign-in failed (${res.statusCode}): ${res.body}`);
     }
-    return res.json<{ accessToken: string; refreshToken: string; nextRoute: string }>();
+    const location = res.headers.location ?? "";
+    const hashIdx = location.indexOf("#");
+    if (hashIdx === -1) throw new Error(`dev sign-in redirect missing fragment: ${location}`);
+    const fragment = new URLSearchParams(location.slice(hashIdx + 1));
+    const accessToken = fragment.get("access");
+    const refreshToken = fragment.get("refresh");
+    const nextRoute = fragment.get("next");
+    if (!accessToken || !refreshToken || !nextRoute) {
+      throw new Error(`dev sign-in redirect missing fields: ${location}`);
+    }
+    return { accessToken, refreshToken, nextRoute };
   }
 
   it("dev sign-in for a brand-new user lands on /setup with a user-only token", async () => {
@@ -151,7 +163,7 @@ describe("SaaS auth — GitHub OAuth + workspaces + switch-org (dev mode)", () =
       method: "POST",
       url: "/api/v1/me/workspaces/join",
       headers: { authorization: `Bearer ${joinerSignIn.accessToken}` },
-      payload: { tokenOrUrl: `https://hub.first-tree.ai/invite/${inviteToken}` },
+      payload: { tokenOrUrl: `https://first-tree.staging.unispark.dev/invite/${inviteToken}` },
     });
     expect(join2.statusCode).toBe(200);
     expect(join2.json<{ alreadyMember: boolean }>().alreadyMember).toBe(true);

--- a/packages/server/src/api/auth-github.ts
+++ b/packages/server/src/api/auth-github.ts
@@ -1,3 +1,4 @@
+import { sanitizeNextPath } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { UnauthorizedError } from "../errors.js";
@@ -31,25 +32,15 @@ import {
  *      `POST /me/workspaces/join`, which is callable with either token type)
  */
 
-/**
- * Whitelist for relative `next` paths. We allow only forward-slash-prefixed
- * paths whose body is the URL-safe character set we'd ever generate. This
- * blocks every documented open-redirect bypass shape:
- *   * `//evil.com`     — protocol-relative URL
- *   * `/\evil.com`     — backslash that browsers normalise to `/`
- *   * `https://evil`   — absolute URL
- *   * `javascript:…`   — pseudo-protocol
- *   * `/foo@evil.com`  — userinfo-style host smuggling once concatenated
- * If the value fails to match the whitelist we silently downgrade to `/`
- * rather than throwing — the user reaches the sign-in page either way.
- */
-const SAFE_NEXT_PATH = /^\/(?![/\\])[A-Za-z0-9_\-./?=&%#]*$/;
-
+// `next` whitelist lives in `@agent-team-foundation/first-tree-hub-shared/safe-redirect`
+// so the SPA's fragment consumer (`/auth/github/complete`) applies the
+// same rule. Drift between the two = open-redirect or token-fixation
+// risk; co-locating the regex prevents that.
 const startQuerySchema = z.object({
   next: z
     .string()
     .optional()
-    .transform((v) => (v && SAFE_NEXT_PATH.test(v) ? v : "/")),
+    .transform((v) => sanitizeNextPath(v)),
   // Dev-stub overrides — ignored in production. The frontend doesn't normally
   // pass these; tests do, and a curl-based local dev workflow can.
   dev_login: z.string().optional(),

--- a/packages/server/src/api/auth-github.ts
+++ b/packages/server/src/api/auth-github.ts
@@ -166,10 +166,25 @@ export async function authGithubRoutes(app: FastifyInstance): Promise<void> {
 }
 
 /**
- * Resolve a GitHub profile to a user, then issue tokens scoped either to
- * the user's most-recent membership (if any) or to a rootless user token.
- * Returns the JSON shape `signInResponseSchema` documents — the frontend
- * stashes the tokens and follows `nextRoute`.
+ * Resolve a GitHub profile to a user, then 302-redirect the browser to the
+ * SPA's completion page with the tokens + `nextRoute` packed into the URL
+ * fragment.
+ *
+ * Why a fragment and not a JSON body or query string:
+ *   * JSON body: GitHub bounces the browser here via 302; a JSON response
+ *     would render as raw text in the address bar.
+ *   * Query string: tokens land in proxy / CDN / web-server access logs.
+ *   * Fragment: never transmitted to the server, only the SPA sees it; the
+ *     SPA immediately persists to localStorage and `replaceState`s the
+ *     fragment out of the browser history. This is the standard "implicit
+ *     grant" delivery shape for SPA-based OAuth on a Bearer-token API.
+ *
+ * The SPA route that consumes this fragment lives at
+ * `/auth/github/complete` — see `packages/web/src/pages/auth-callback.tsx`.
+ *
+ * Failure modes (token sign / DB error) bubble up and the global error
+ * handler turns them into a 500; the SPA's `/signup` page can detect via
+ * `?error=` and re-prompt.
  */
 async function completeSignIn(
   app: FastifyInstance,
@@ -201,11 +216,12 @@ async function completeSignIn(
   //     wizard-incomplete case via `members.onboarding_state` in PR #5)
   const nextRoute = next.startsWith("/invite/") ? next : membership ? "/" : "/setup";
 
-  return reply.send({
-    accessToken: tokens.accessToken,
-    refreshToken: tokens.refreshToken,
-    nextRoute,
+  const fragment = new URLSearchParams({
+    access: tokens.accessToken,
+    refresh: tokens.refreshToken,
+    next: nextRoute,
   });
+  return reply.redirect(`/auth/github/complete#${fragment.toString()}`, 302);
 }
 
 function readOrigin(request: FastifyRequest): { proto: string; host: string } {

--- a/packages/server/src/services/workspace-membership.ts
+++ b/packages/server/src/services/workspace-membership.ts
@@ -160,9 +160,11 @@ function mapWorkspaceConflict(err: unknown, slug: string): unknown {
 
 /**
  * Extract the bare invite token from either a full URL like
- * `https://hub.first-tree.ai/invite/abc123` or the bare `abc123` string.
- * Returns `null` when the input doesn't match either shape so callers can
- * surface a clear "doesn't look like a valid invite link" error.
+ * `https://first-tree.staging.unispark.dev/invite/abc123` (the current
+ * staging hub; production lands on `hub.first-tree.ai` once that domain
+ * is provisioned) or the bare `abc123` string. Returns `null` when the
+ * input doesn't match either shape so callers can surface a clear
+ * "doesn't look like a valid invite link" error.
  */
 export function extractInviteToken(tokenOrUrl: string): string | null {
   const trimmed = tokenOrUrl.trim();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,8 @@
 
 // -- Mention extraction (shared by server fan-out resolver and client auto-forward) --
 export { extractMentions, MENTION_REGEX, type MentionParticipant, scanMentionTokens } from "./mentions.js";
+// -- SaaS auth `next=` redirect whitelist (shared by `/auth/github/start` and the SPA fragment consumer) --
+export { SAFE_NEXT_PATH, sanitizeNextPath } from "./safe-redirect.js";
 export {
   ADAPTER_BIND_METHODS,
   ADAPTER_PLATFORMS,

--- a/packages/shared/src/safe-redirect.ts
+++ b/packages/shared/src/safe-redirect.ts
@@ -1,0 +1,26 @@
+/**
+ * Whitelist for `next` redirect targets used by the SaaS auth flow. Both
+ * the server (`/api/v1/auth/github/start` query) and the client
+ * (`/auth/github/complete` fragment consumer) MUST validate against this
+ * regex so a forged link can't bounce a victim off-origin while
+ * persisting the attacker's tokens.
+ *
+ * Only forward-slash-prefixed paths whose body matches the URL-safe
+ * character set are allowed. This blocks every documented bypass shape:
+ *
+ *   * `//evil.com`     — protocol-relative URL
+ *   * `/\evil.com`     — backslash that browsers normalise to `/`
+ *   * `https://evil`   — absolute URL
+ *   * `javascript:…`   — pseudo-protocol
+ *   * `/foo@evil.com`  — userinfo-style host smuggling once concatenated
+ *
+ * Callers that receive an invalid value should silently substitute `/`
+ * — the user reaches the app shell either way; refusing the request
+ * just adds friction without protection.
+ */
+export const SAFE_NEXT_PATH = /^\/(?![/\\])[A-Za-z0-9_\-./?=&%#]*$/;
+
+export function sanitizeNextPath(raw: string | undefined | null): string {
+  if (raw && SAFE_NEXT_PATH.test(raw)) return raw;
+  return "/";
+}

--- a/packages/web/src/api/workspaces.ts
+++ b/packages/web/src/api/workspaces.ts
@@ -1,0 +1,59 @@
+import type {
+  CreateWorkspaceRequest,
+  InvitePreview,
+  JoinWorkspaceRequest,
+  SwitchOrganizationRequest,
+  WorkspaceListItem,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { api } from "./client.js";
+
+/**
+ * Frontend client for the SaaS workspace + auth surface added by the
+ * server-side onboarding PR (`/me/workspaces*`, `/auth/switch-org`,
+ * `/invite/:token/preview`).
+ * Mirrors the backend routes one-to-one — no business logic here, the
+ * server is the source of truth for membership invariants.
+ */
+
+export type WorkspaceMutationResult = {
+  workspace: { organizationId: string; memberId: string; role: "admin" | "member" };
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type JoinWorkspaceResult = WorkspaceMutationResult & { alreadyMember: boolean };
+
+export async function listMyWorkspaces(): Promise<WorkspaceListItem[]> {
+  const { items } = await api.get<{ items: WorkspaceListItem[] }>("/me/workspaces/");
+  return items;
+}
+
+export async function createWorkspace(input: CreateWorkspaceRequest): Promise<WorkspaceMutationResult> {
+  return api.post<WorkspaceMutationResult>("/me/workspaces/", input);
+}
+
+export async function joinWorkspace(input: JoinWorkspaceRequest): Promise<JoinWorkspaceResult> {
+  return api.post<JoinWorkspaceResult>("/me/workspaces/join", input);
+}
+
+export async function switchOrganization(
+  input: SwitchOrganizationRequest,
+): Promise<{ accessToken: string; refreshToken: string }> {
+  return api.post("/auth/switch-org", input);
+}
+
+/**
+ * Public preview — no Authorization header. Designed to be called from the
+ * /invite/:token landing page so we can render "Join Acme Engineering"
+ * before forcing the user through GitHub OAuth.
+ */
+export async function previewInvite(token: string): Promise<InvitePreview> {
+  const res = await fetch(`/api/v1/invite/${encodeURIComponent(token)}/preview`);
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("This invite link isn't valid. Ask your admin for the correct link.");
+    }
+    throw new Error(`Invite preview failed (${res.status})`);
+  }
+  return (await res.json()) as InvitePreview;
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -2,14 +2,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
+import { RequireWorkspace } from "./auth/require-workspace.js";
 import { Layout } from "./components/layout.js";
 import { PulseProvider } from "./hooks/pulse-context.js";
 import { AdminPage } from "./pages/admin.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { AgentsPage } from "./pages/agents.js";
+import { AuthCallbackPage } from "./pages/auth-callback.js";
 import { ClientsPage } from "./pages/clients.js";
+import { InvitePage } from "./pages/invite.js";
 import { LoginPage } from "./pages/login.js";
 import { SettingsPage } from "./pages/settings.js";
+import { SetupPage } from "./pages/setup.js";
+import { SignupPage } from "./pages/signup.js";
 import { WorkspacePage } from "./pages/workspace/index.js";
 
 const queryClient = new QueryClient({
@@ -27,21 +32,36 @@ export function App() {
       <AuthProvider>
         <BrowserRouter>
           <Routes>
+            {/* Public surface — no auth required. /login is the legacy
+                username+password entry kept for self-host installs;
+                /signup is the SaaS GitHub OAuth funnel. */}
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/auth/github/complete" element={<AuthCallbackPage />} />
+            <Route path="/invite/:token" element={<InvitePage />} />
+
+            {/* Authenticated but workspace-less surface: lets a freshly
+                OAuthed user create or join a workspace. RequireAuth
+                enforces "has a token" without demanding per-org context. */}
             <Route element={<RequireAuth />}>
-              <Route
-                element={
-                  <PulseProvider>
-                    <Layout />
-                  </PulseProvider>
-                }
-              >
-                <Route index element={<WorkspacePage />} />
-                <Route path="agents" element={<AgentsPage />} />
-                <Route path="agents/:uuid" element={<AgentDetailPage />} />
-                <Route path="clients" element={<ClientsPage />} />
-                <Route path="settings" element={<SettingsPage />} />
-                <Route path="admin" element={<AdminPage />} />
+              <Route path="/setup" element={<SetupPage />} />
+
+              {/* Per-org app shell: must have at least one membership. */}
+              <Route element={<RequireWorkspace />}>
+                <Route
+                  element={
+                    <PulseProvider>
+                      <Layout />
+                    </PulseProvider>
+                  }
+                >
+                  <Route index element={<WorkspacePage />} />
+                  <Route path="agents" element={<AgentsPage />} />
+                  <Route path="agents/:uuid" element={<AgentDetailPage />} />
+                  <Route path="clients" element={<ClientsPage />} />
+                  <Route path="settings" element={<SettingsPage />} />
+                  <Route path="admin" element={<AdminPage />} />
+                </Route>
               </Route>
             </Route>
           </Routes>

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -36,8 +36,13 @@ type AuthContextValue = {
   signInWithTokens: (tokens: { accessToken: string; refreshToken: string }) => Promise<void>;
   /** Re-issue tokens scoped to a different workspace the caller belongs to. */
   switchWorkspace: (organizationId: string) => Promise<void>;
-  /** Force-refresh the workspaces list (after create / join). */
-  refetchWorkspaces: () => Promise<void>;
+  /**
+   * Force-refresh both the workspaces list AND the per-org member context
+   * (`/me`). Same payload as the first-mount fetch — name reflects that
+   * `refetchAll` doesn't ONLY touch `/me/workspaces`. Cheap workspaces-only
+   * refresh isn't surfaced today; PR #5's switcher will add one.
+   */
+  refetchAll: () => Promise<void>;
   logout: () => void;
 };
 
@@ -114,8 +119,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const refetchWorkspaces = refetchAll;
-
   const login = useCallback(
     async (username: string, password: string) => {
       const tokens = await loginApi(username, password);
@@ -173,7 +176,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         login,
         signInWithTokens,
         switchWorkspace,
-        refetchWorkspaces,
+        refetchAll,
         logout,
       }}
     >

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -1,17 +1,43 @@
+import type { WorkspaceListItem } from "@agent-team-foundation/first-tree-hub-shared";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import { login as loginApi } from "../api/auth.js";
 import { api, clearStoredTokens, getStoredTokens, setStoredTokens } from "../api/client.js";
+import { listMyWorkspaces, switchOrganization as switchOrgApi } from "../api/workspaces.js";
 
 type MeResponse = {
   member: { id: string; role: string; agentId: string };
 };
 
 type AuthContextValue = {
+  /** Token pair present in storage. Doesn't say anything about whether the user has a workspace. */
   isAuthenticated: boolean;
+  /**
+   * `true` when the stored token is a `type:"user"` JWT — sign-in succeeded
+   * but the user has no workspace yet. The router uses this to send the
+   * caller to `/setup` instead of the regular app shell. Distinct from
+   * `isAuthenticated` so we don't conflate "no token at all" with
+   * "token but no workspace".
+   */
+  isRootless: boolean;
+  /** Workspaces this user belongs to. `null` until the first fetch lands. */
+  workspaces: WorkspaceListItem[] | null;
+  /** Per-org member context. `null` when the token is rootless. */
   role: string | null;
   memberId: string | null;
   agentId: string | null;
+  organizationId: string | null;
+  /** Legacy username + password sign-in. Self-host path. */
   login: (username: string, password: string) => Promise<void>;
+  /**
+   * Persist a token pair issued by the OAuth callback / workspace create /
+   * workspace join flow, then refresh the in-memory state. Caller is
+   * responsible for navigating after this resolves.
+   */
+  signInWithTokens: (tokens: { accessToken: string; refreshToken: string }) => Promise<void>;
+  /** Re-issue tokens scoped to a different workspace the caller belongs to. */
+  switchWorkspace: (organizationId: string) => Promise<void>;
+  /** Force-refresh the workspaces list (after create / join). */
+  refetchWorkspaces: () => Promise<void>;
   logout: () => void;
 };
 
@@ -19,52 +45,115 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(() => !!getStoredTokens());
+  const [isRootless, setIsRootless] = useState(false);
   const [role, setRole] = useState<string | null>(null);
   const [memberId, setMemberId] = useState<string | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [organizationId, setOrganizationId] = useState<string | null>(null);
+  const [workspaces, setWorkspaces] = useState<WorkspaceListItem[] | null>(null);
 
   const logout = useCallback(() => {
     clearStoredTokens();
     setIsAuthenticated(false);
+    setIsRootless(false);
     setRole(null);
     setMemberId(null);
     setAgentId(null);
+    setOrganizationId(null);
+    setWorkspaces(null);
   }, []);
 
-  const fetchMe = useCallback(async () => {
+  /**
+   * Refresh in-memory state from the server. Order matters:
+   *   1. /me/workspaces — works for both rootless and per-org tokens.
+   *   2. If list is empty → rootless. Skip /me, set rootless flag, done.
+   *   3. List non-empty → fetch /me for member context.
+   *
+   * We MUST NOT call `/me` while rootless: the per-route memberAuthHook
+   * 401s on `type:"user"` tokens; the API client refreshes (also rootless)
+   * and re-tries; the second 401 trips `clearStoredTokens` + dispatches
+   * `auth:logout`, killing the otherwise-valid session. Filtering by the
+   * workspaces-list result avoids the loop.
+   */
+  const refetchAll = useCallback(async () => {
+    let list: WorkspaceListItem[];
+    try {
+      list = await listMyWorkspaces();
+    } catch {
+      // /me/workspaces failure is the only signal that the token itself
+      // is dead — bail to logout via the standard auth:logout cascade.
+      setWorkspaces([]);
+      return;
+    }
+    setWorkspaces(list);
+    const first = list[0];
+    setOrganizationId(first?.organizationId ?? null);
+
+    if (list.length === 0) {
+      setIsRootless(true);
+      setRole(null);
+      setMemberId(null);
+      setAgentId(null);
+      return;
+    }
+
+    setIsRootless(false);
     try {
       const data = await api.get<MeResponse>("/me");
       setRole(data.member.role);
       setMemberId(data.member.id);
       setAgentId(data.member.agentId);
     } catch {
-      // If /me fails, role stays null — UI falls back to hiding admin features
+      // /me failed despite memberships existing — leave member state null
+      // and let the caller decide (typical case: token's organizationId
+      // points at a workspace the user was just removed from). The UI
+      // can offer a switch-org prompt against the live workspaces list.
+      setRole(null);
+      setMemberId(null);
+      setAgentId(null);
     }
   }, []);
 
-  const login = useCallback(async (username: string, password: string) => {
-    const tokens = await loginApi(username, password);
-    setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
-    setIsAuthenticated(true);
-    // Fetch member info immediately after login
-    await api
-      .get<MeResponse>("/me")
-      .then((data) => {
-        setRole(data.member.role);
-        setMemberId(data.member.id);
-        setAgentId(data.member.agentId);
-      })
-      .catch(() => {});
-  }, []);
+  const refetchWorkspaces = refetchAll;
 
-  // Fetch member info on initial load if already authenticated
+  const login = useCallback(
+    async (username: string, password: string) => {
+      const tokens = await loginApi(username, password);
+      setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+      setIsAuthenticated(true);
+      await refetchAll();
+    },
+    [refetchAll],
+  );
+
+  const signInWithTokens = useCallback(
+    async (tokens: { accessToken: string; refreshToken: string }) => {
+      setStoredTokens(tokens);
+      setIsAuthenticated(true);
+      await refetchAll();
+    },
+    [refetchAll],
+  );
+
+  const switchWorkspace = useCallback(
+    async (orgId: string) => {
+      const tokens = await switchOrgApi({ organizationId: orgId });
+      setStoredTokens(tokens);
+      await refetchAll();
+    },
+    [refetchAll],
+  );
+
+  // First mount: if tokens are already stored, hydrate identity + workspaces.
   useEffect(() => {
-    if (isAuthenticated && !role) {
-      fetchMe();
+    if (isAuthenticated && workspaces === null) {
+      void refetchAll();
     }
-  }, [isAuthenticated, role, fetchMe]);
+  }, [isAuthenticated, workspaces, refetchAll]);
 
-  // Listen for auth failure dispatched by the API client
+  // Listen for auth failure dispatched by the API client. The client only
+  // dispatches `auth:logout` when refresh ALSO fails — by that point the
+  // session is genuinely dead, so we drop everything.
   useEffect(() => {
     const handler = () => logout();
     window.addEventListener("auth:logout", handler);
@@ -72,7 +161,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [logout]);
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, role, memberId, agentId, login, logout }}>
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        isRootless,
+        workspaces,
+        role,
+        memberId,
+        agentId,
+        organizationId,
+        login,
+        signInWithTokens,
+        switchWorkspace,
+        refetchWorkspaces,
+        logout,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/packages/web/src/auth/require-auth.tsx
+++ b/packages/web/src/auth/require-auth.tsx
@@ -1,10 +1,19 @@
-import { Navigate, Outlet } from "react-router";
+import { Navigate, Outlet, useLocation } from "react-router";
 import { useAuth } from "./auth-context.js";
 
+/**
+ * Gate any "logged-in user" route. Unauthed callers are bounced to
+ * `/signup` (SaaS-first GitHub OAuth) with a `next` carrying the path
+ * they were originally trying to reach — that lets the OAuth round-trip
+ * land them back where they wanted to go. Self-host installs reach
+ * `/login` directly via the user's bookmark; we don't auto-route there.
+ */
 export function RequireAuth() {
   const { isAuthenticated } = useAuth();
+  const location = useLocation();
   if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
+    const next = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/signup?next=${encodeURIComponent(next)}`} replace />;
   }
   return <Outlet />;
 }

--- a/packages/web/src/auth/require-workspace.tsx
+++ b/packages/web/src/auth/require-workspace.tsx
@@ -8,13 +8,20 @@ import { useAuth } from "./auth-context.js";
  * `RequireAuth` — `RequireAuth` enforces "any token", this layer
  * enforces "per-org token".
  *
- * `workspaces === null` means we haven't fetched yet — render nothing
- * rather than flashing the wrong UI; the auth-context's first-mount
- * effect populates it within a tick.
+ * `workspaces === null` means we haven't fetched yet. Render a centered
+ * "Loading…" instead of nothing — on a slow network the
+ * `/me/workspaces` round-trip can take hundreds of ms; a blank screen
+ * is worse UX than a clearly-pending one.
  */
 export function RequireWorkspace() {
   const { isRootless, workspaces } = useAuth();
-  if (workspaces === null) return null;
+  if (workspaces === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-body text-muted-foreground">Loading…</div>
+      </div>
+    );
+  }
   if (isRootless || workspaces.length === 0) {
     return <Navigate to="/setup" replace />;
   }

--- a/packages/web/src/auth/require-workspace.tsx
+++ b/packages/web/src/auth/require-workspace.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Outlet } from "react-router";
+import { useAuth } from "./auth-context.js";
+
+/**
+ * Routes inside the regular app shell only make sense once the caller has
+ * picked a workspace. A signed-in user with a rootless `type:"user"`
+ * token (no membership yet) is bounced to `/setup`. Used in tandem with
+ * `RequireAuth` — `RequireAuth` enforces "any token", this layer
+ * enforces "per-org token".
+ *
+ * `workspaces === null` means we haven't fetched yet — render nothing
+ * rather than flashing the wrong UI; the auth-context's first-mount
+ * effect populates it within a tick.
+ */
+export function RequireWorkspace() {
+  const { isRootless, workspaces } = useAuth();
+  if (workspaces === null) return null;
+  if (isRootless || workspaces.length === 0) {
+    return <Navigate to="/setup" replace />;
+  }
+  return <Outlet />;
+}

--- a/packages/web/src/pages/auth-callback.tsx
+++ b/packages/web/src/pages/auth-callback.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { useAuth } from "../auth/auth-context.js";
+import { parseAuthFragment } from "../utils/auth-fragment.js";
+
+/**
+ * `/auth/github/complete` — receives the OAuth result from the server's
+ * `/api/v1/auth/github/callback` 302. The server packs the access token,
+ * refresh token, and `nextRoute` into the URL fragment; we read them
+ * here, persist to localStorage via `signInWithTokens`, scrub the
+ * fragment from the browser history, and forward the user to the
+ * intended destination.
+ *
+ * Why a fragment: tokens never leave the browser (no proxy / CDN access
+ * log), and the SPA can clear them via `replaceState` before any
+ * subsequent page-refresh would bookmark them.
+ *
+ * Failure modes (no fragment, missing fields) bounce back to `/signup`
+ * with a generic `error=oauth_failed` so the user can retry — same
+ * shape as the server-side error path.
+ */
+export function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const { signInWithTokens } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    // Strict-mode mounts effects twice in dev — without this guard we'd
+    // try to consume the fragment twice and the second pass would land
+    // on the bounce-to-signup branch because the first pass already
+    // cleared the URL.
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    const fragment = parseAuthFragment(window.location.hash);
+    if (!fragment) {
+      setError("oauth_failed");
+      navigate("/signup?error=oauth_failed", { replace: true });
+      return;
+    }
+
+    // Scrub the fragment before any other render — no point persisting
+    // tokens in browser history once they're in localStorage.
+    window.history.replaceState({}, "", window.location.pathname);
+
+    void signInWithTokens({ accessToken: fragment.accessToken, refreshToken: fragment.refreshToken })
+      .then(() => navigate(fragment.next, { replace: true }))
+      .catch(() => {
+        setError("storage_failed");
+        navigate("/signup?error=storage_failed", { replace: true });
+      });
+  }, [navigate, signInWithTokens]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="text-body text-muted-foreground">
+        {error ? "Sign-in didn't complete. Redirecting…" : "Signing you in…"}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/auth-callback.tsx
+++ b/packages/web/src/pages/auth-callback.tsx
@@ -40,23 +40,42 @@ export function AuthCallbackPage() {
       return;
     }
 
-    // Scrub the fragment before any other render — no point persisting
-    // tokens in browser history once they're in localStorage.
-    window.history.replaceState({}, "", window.location.pathname);
-
     void signInWithTokens({ accessToken: fragment.accessToken, refreshToken: fragment.refreshToken })
-      .then(() => navigate(fragment.next, { replace: true }))
+      .then(() => {
+        // Scrub the fragment ONLY after the tokens are safely in storage.
+        // Doing it before the await means a `signInWithTokens` rejection
+        // (localStorage quota, private-mode Safari, transient
+        // /me/workspaces 5xx) would leave the tokens lost on the user —
+        // they'd have to redo the full GitHub OAuth round-trip just to
+        // recover. After-success scrub plus an inline-retry on failure
+        // (below) keeps the recovery path tractable.
+        window.history.replaceState({}, "", window.location.pathname);
+        navigate(fragment.next, { replace: true });
+      })
       .catch(() => {
+        // Don't navigate — leave the fragment in the URL so a page
+        // refresh re-runs this handler and can succeed once the
+        // transient cause clears.
         setError("storage_failed");
-        navigate("/signup?error=storage_failed", { replace: true });
       });
   }, [navigate, signInWithTokens]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="text-body text-muted-foreground">
-        {error ? "Sign-in didn't complete. Redirecting…" : "Signing you in…"}
-      </div>
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      {error ? (
+        <div className="text-center space-y-3 max-w-sm">
+          <div className="text-body text-destructive">Sign-in didn't complete.</div>
+          <div className="text-caption text-muted-foreground">
+            Refresh this page to try again, or{" "}
+            <a href="/signup" className="underline">
+              start over
+            </a>
+            .
+          </div>
+        </div>
+      ) : (
+        <div className="text-body text-muted-foreground">Signing you in…</div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/invite.tsx
+++ b/packages/web/src/pages/invite.tsx
@@ -32,11 +32,22 @@ export function InvitePage() {
 
   useEffect(() => {
     if (!token) return;
+    // `cancelled` flag rather than AbortController — `previewInvite` uses
+    // the shared `fetch` which doesn't expose a signal threading API
+    // here. Effect dropping the result of a stale request avoids the
+    // "set state on unmounted component" silent flash without needing
+    // to re-plumb the network layer.
+    let cancelled = false;
     previewInvite(token)
-      .then(setPreview)
+      .then((preview) => {
+        if (!cancelled) setPreview(preview);
+      })
       .catch((err: unknown) => {
-        setPreviewError(err instanceof Error ? err.message : "Could not load invite");
+        if (!cancelled) setPreviewError(err instanceof Error ? err.message : "Could not load invite");
       });
+    return () => {
+      cancelled = true;
+    };
   }, [token]);
 
   if (!token) {

--- a/packages/web/src/pages/invite.tsx
+++ b/packages/web/src/pages/invite.tsx
@@ -1,0 +1,120 @@
+import type { InvitePreview } from "@agent-team-foundation/first-tree-hub-shared";
+import { useEffect, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router";
+import { joinWorkspace, previewInvite } from "../api/workspaces.js";
+import { useAuth } from "../auth/auth-context.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+
+/**
+ * `/invite/:token` landing per design doc §4.3. Public preview first
+ * (workspace name visible without auth so the user knows what they're
+ * joining), then either:
+ *
+ *   * Not signed in → "Sign in with GitHub to join" — bounces through
+ *     `/signup?next=/invite/<token>`. The server preserves `next` across
+ *     OAuth and lands the user back here authed.
+ *   * Signed in → "Join Acme Engineering" → POST /me/workspaces/join,
+ *     swap tokens, redirect to `/`. Idempotent on the backend so a
+ *     re-clicked link doesn't 409.
+ *
+ * 404 from preview surfaces the design-doc string verbatim:
+ *   "This invite link isn't valid. Ask your admin for the correct link."
+ */
+export function InvitePage() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const { isAuthenticated, signInWithTokens } = useAuth();
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [joining, setJoining] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    previewInvite(token)
+      .then(setPreview)
+      .catch((err: unknown) => {
+        setPreviewError(err instanceof Error ? err.message : "Could not load invite");
+      });
+  }, [token]);
+
+  if (!token) {
+    return <Navigate to="/signup" replace />;
+  }
+
+  const handleJoin = async () => {
+    if (!token) return;
+    setJoinError(null);
+    setJoining(true);
+    try {
+      const res = await joinWorkspace({ tokenOrUrl: token });
+      await signInWithTokens({ accessToken: res.accessToken, refreshToken: res.refreshToken });
+      navigate("/", { replace: true });
+    } catch (err) {
+      setJoinError(err instanceof Error ? err.message : "Could not join workspace");
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  if (previewError) {
+    return (
+      <CenteredCard
+        title="Invite link unavailable"
+        description="This invite link isn't valid. Ask your admin for the correct link."
+      />
+    );
+  }
+
+  if (!preview) {
+    return <CenteredCard title="Loading invite…" description="" />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <CenteredCard
+        title={`Join ${preview.organizationDisplayName}`}
+        description="Sign in with GitHub to accept this invite."
+      >
+        <Button asChild className="w-full">
+          <a href={`/signup?next=${encodeURIComponent(`/invite/${token}`)}`}>Continue with GitHub</a>
+        </Button>
+      </CenteredCard>
+    );
+  }
+
+  return (
+    <CenteredCard
+      title={`Join ${preview.organizationDisplayName}`}
+      description={`You'll be added as a member of ${preview.organizationSlug}.`}
+    >
+      {joinError && <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{joinError}</div>}
+      <Button onClick={handleJoin} disabled={joining} className="w-full">
+        {joining ? "Joining…" : "Join workspace"}
+      </Button>
+    </CenteredCard>
+  );
+}
+
+function CenteredCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-title">{title}</CardTitle>
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+        {children && <CardContent className="space-y-4">{children}</CardContent>}
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/pages/setup.tsx
+++ b/packages/web/src/pages/setup.tsx
@@ -21,6 +21,13 @@ import { slugifyWorkspace } from "../utils/workspace-slug.js";
  * keeps them here. Existing per-org users hitting `/setup` directly
  * (e.g. via "+ Create another workspace" in PR #5) ALSO use this same
  * page; the layout / nav matters more than the gate.
+ *
+ * Deferred to the workspace-switcher PR: when a per-org user creates or
+ * joins from `/setup`, the success path silently overwrites their
+ * current per-org token with the new workspace's token — they "switch"
+ * without UI feedback. Today we land them on `/`; the switcher PR will
+ * surface a "Now in: <Workspace Name>" toast and let them choose
+ * whether to switch or stay in the original org.
  */
 export function SetupPage() {
   const navigate = useNavigate();

--- a/packages/web/src/pages/setup.tsx
+++ b/packages/web/src/pages/setup.tsx
@@ -1,0 +1,181 @@
+import { type FormEvent, useState } from "react";
+import { Navigate, useNavigate, useSearchParams } from "react-router";
+import type { ApiError } from "../api/client.js";
+import { createWorkspace, joinWorkspace } from "../api/workspaces.js";
+import { useAuth } from "../auth/auth-context.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
+import { slugifyWorkspace } from "../utils/workspace-slug.js";
+
+/**
+ * `/setup` — the Create / Join modal carrier per design doc §4.4. Two
+ * forms in one card, separated by an `or` divider. Both submit to the
+ * same `signInWithTokens` flow on success: the server returns a fresh
+ * per-org JWT pair scoped to the chosen workspace, and we drop the
+ * caller into `/welcome` (PR #4 wires the wizard) or `/` (regular app).
+ *
+ * This page is the only frontend gate for "user has no workspace yet" —
+ * `RequireAuth` lets them through, the route's own `isRootless` check
+ * keeps them here. Existing per-org users hitting `/setup` directly
+ * (e.g. via "+ Create another workspace" in PR #5) ALSO use this same
+ * page; the layout / nav matters more than the gate.
+ */
+export function SetupPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { isAuthenticated, signInWithTokens } = useAuth();
+
+  if (!isAuthenticated) {
+    // Same-domain bounce — preserve the original `next` so a deep-linked
+    // /invite that funneled here is honoured after sign-in.
+    const next = searchParams.get("next") ?? "/setup";
+    return <Navigate to={`/signup?next=${encodeURIComponent(next)}`} replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader className="text-center">
+          <CardTitle className="text-title">Get started with First Tree Hub</CardTitle>
+          <CardDescription>Create your workspace, or join one your team has already set up.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <CreateWorkspaceForm onSuccess={(t) => signInWithTokens(t).then(() => navigate("/", { replace: true }))} />
+          <Divider />
+          <JoinWorkspaceForm onSuccess={(t) => signInWithTokens(t).then(() => navigate("/", { replace: true }))} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Divider() {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 flex items-center">
+        <span className="w-full border-t border-border" />
+      </div>
+      <div className="relative flex justify-center">
+        <span className="bg-card px-2 text-caption uppercase text-muted-foreground">or</span>
+      </div>
+    </div>
+  );
+}
+
+type Tokens = { accessToken: string; refreshToken: string };
+
+function CreateWorkspaceForm({ onSuccess }: { onSuccess: (tokens: Tokens) => void }) {
+  const [displayName, setDisplayName] = useState("");
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Auto-suggest a slug from the display name so the user usually doesn't
+  // have to touch the second field. Lowercase, hyphenated, alphanumeric.
+  // Tracks the previously-derived slug so manual edits aren't clobbered
+  // by subsequent display-name typing.
+  const handleDisplayNameChange = (raw: string) => {
+    if (!name || name === slugifyWorkspace(displayName)) {
+      setName(slugifyWorkspace(raw));
+    }
+    setDisplayName(raw);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await createWorkspace({ name, displayName });
+      onSuccess({ accessToken: res.accessToken, refreshToken: res.refreshToken });
+    } catch (err) {
+      setError(translateError(err, "Could not create workspace"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <h3 className="text-body font-medium">I'm the admin · Create our workspace</h3>
+      <div className="space-y-2">
+        <Label htmlFor="ws-display-name">Workspace name</Label>
+        <Input
+          id="ws-display-name"
+          value={displayName}
+          onChange={(e) => handleDisplayNameChange(e.target.value)}
+          placeholder="Acme Engineering"
+          required
+          autoFocus
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="ws-slug" className="text-caption text-muted-foreground">
+          URL slug
+        </Label>
+        <Input
+          id="ws-slug"
+          value={name}
+          onChange={(e) => setName(e.target.value.toLowerCase())}
+          placeholder="acme-engineering"
+          pattern="^[a-z0-9][a-z0-9-]*$"
+          required
+        />
+      </div>
+      {error && <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{error}</div>}
+      <Button type="submit" disabled={busy} className="w-full">
+        {busy ? "Creating…" : "Create workspace"}
+      </Button>
+    </form>
+  );
+}
+
+function JoinWorkspaceForm({ onSuccess }: { onSuccess: (tokens: Tokens) => void }) {
+  const [tokenOrUrl, setTokenOrUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await joinWorkspace({ tokenOrUrl });
+      onSuccess({ accessToken: res.accessToken, refreshToken: res.refreshToken });
+    } catch (err) {
+      setError(translateError(err, "Could not join workspace"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <h3 className="text-body font-medium">I was invited · Join my team</h3>
+      <div className="space-y-2">
+        <Label htmlFor="invite-link">Paste the invite link your admin shared</Label>
+        <Input
+          id="invite-link"
+          value={tokenOrUrl}
+          onChange={(e) => setTokenOrUrl(e.target.value)}
+          placeholder="https://first-tree.staging.unispark.dev/invite/…"
+          required
+        />
+      </div>
+      {error && <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{error}</div>}
+      <Button type="submit" disabled={busy} variant="outline" className="w-full">
+        {busy ? "Joining…" : "Join workspace"}
+      </Button>
+    </form>
+  );
+}
+
+/** Surface the server's user-facing message; otherwise fall back to a generic. */
+function translateError(err: unknown, fallback: string): string {
+  if (err && typeof err === "object" && "message" in err && typeof (err as ApiError).message === "string") {
+    return (err as ApiError).message;
+  }
+  return fallback;
+}

--- a/packages/web/src/pages/signup.tsx
+++ b/packages/web/src/pages/signup.tsx
@@ -1,0 +1,63 @@
+import { Navigate, useSearchParams } from "react-router";
+import { useAuth } from "../auth/auth-context.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+
+/**
+ * `/signup` — single-button GitHub sign-in entry. Per the design doc §4.2:
+ * "页面只有一个大按钮：Continue with GitHub". This page never collects user
+ * input itself; the click 302-redirects through the server's
+ * `/api/v1/auth/github/start` endpoint so the OAuth state cookie can be
+ * set as part of the response.
+ *
+ * `?next=/invite/<token>` is preserved across the round-trip — the server
+ * embeds it in the state JWT and `completeSignIn` honours it after the
+ * GitHub callback so an invite-link click that bounces through sign-in
+ * lands the user on the invite acceptance page, not on `/setup`.
+ *
+ * `?error=` is the single failure surface — the server's redirect can land
+ * back on `/signup?error=oauth_failed` if the callback throws. Today we
+ * just surface a generic message; nicer mapping is a polish PR.
+ */
+export function SignupPage() {
+  const { isAuthenticated } = useAuth();
+  const [searchParams] = useSearchParams();
+  const next = searchParams.get("next") ?? "/";
+  const error = searchParams.get("error");
+
+  // Already signed in: jump them out of the entry funnel. The router-level
+  // gates take it from here (rootless → /setup; per-org → /).
+  if (isAuthenticated) {
+    return <Navigate to={next} replace />;
+  }
+
+  // Server-side `/start` builds the GitHub authorize URL (or the dev-stub
+  // bounce in non-production deployments) and sets the CSRF cookie. Anchor
+  // tag rather than fetch() because the response is a 302 — the browser
+  // follows naturally and the Set-Cookie header sticks.
+  const startUrl = `/api/v1/auth/github/start?next=${encodeURIComponent(next)}`;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-title">First Tree Hub</CardTitle>
+          <CardDescription>Sign in to your workspace</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-3 text-body text-destructive">
+              Sign-in didn't complete. Please try again.
+            </div>
+          )}
+          <Button asChild className="w-full">
+            <a href={startUrl}>Continue with GitHub</a>
+          </Button>
+          <p className="text-caption text-muted-foreground text-center">
+            By continuing, you agree to our terms — privacy and tos pages coming soon.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/utils/__tests__/auth-fragment.test.ts
+++ b/packages/web/src/utils/__tests__/auth-fragment.test.ts
@@ -39,4 +39,16 @@ describe("parseAuthFragment", () => {
   it("preserves the URL-decoded `next` so deep-links survive the round-trip", () => {
     expect(parseAuthFragment("#access=A&refresh=B&next=%2Finvite%2Fabc-123")?.next).toBe("/invite/abc-123");
   });
+
+  it("downgrades a malicious `next` to '/' to block fragment-based open redirects", () => {
+    // A crafted link like /auth/github/complete#access=…&refresh=…&next=//evil
+    // would otherwise land the user off-origin AFTER persisting the
+    // server-controlled tokens. Server-side `/start` validates `next`
+    // before it ever reaches the JWT — the same guard runs here so a
+    // bypass through a fabricated fragment is also blocked.
+    expect(parseAuthFragment("#access=A&refresh=B&next=%2F%2Fevil.com")?.next).toBe("/");
+    expect(parseAuthFragment("#access=A&refresh=B&next=%2F%5Cevil.com")?.next).toBe("/");
+    expect(parseAuthFragment("#access=A&refresh=B&next=https%3A%2F%2Fevil.com")?.next).toBe("/");
+    expect(parseAuthFragment("#access=A&refresh=B&next=javascript%3Aalert(1)")?.next).toBe("/");
+  });
 });

--- a/packages/web/src/utils/__tests__/auth-fragment.test.ts
+++ b/packages/web/src/utils/__tests__/auth-fragment.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseAuthFragment } from "../auth-fragment.js";
+
+describe("parseAuthFragment", () => {
+  it("extracts access + refresh + next from a well-formed fragment", () => {
+    expect(parseAuthFragment("#access=ACCESS&refresh=REFRESH&next=%2Fsetup")).toEqual({
+      accessToken: "ACCESS",
+      refreshToken: "REFRESH",
+      next: "/setup",
+    });
+  });
+
+  it("tolerates a fragment without the leading '#'", () => {
+    expect(parseAuthFragment("access=A&refresh=B&next=%2F")).toEqual({
+      accessToken: "A",
+      refreshToken: "B",
+      next: "/",
+    });
+  });
+
+  it("defaults `next` to '/' when the field is absent", () => {
+    expect(parseAuthFragment("#access=A&refresh=B")).toEqual({
+      accessToken: "A",
+      refreshToken: "B",
+      next: "/",
+    });
+  });
+
+  it("returns null for an empty fragment so callers can render a single error branch", () => {
+    expect(parseAuthFragment("")).toBeNull();
+    expect(parseAuthFragment("#")).toBeNull();
+  });
+
+  it("returns null when either token field is missing", () => {
+    expect(parseAuthFragment("#access=A&next=%2F")).toBeNull();
+    expect(parseAuthFragment("#refresh=B&next=%2F")).toBeNull();
+  });
+
+  it("preserves the URL-decoded `next` so deep-links survive the round-trip", () => {
+    expect(parseAuthFragment("#access=A&refresh=B&next=%2Finvite%2Fabc-123")?.next).toBe("/invite/abc-123");
+  });
+});

--- a/packages/web/src/utils/__tests__/workspace-slug.test.ts
+++ b/packages/web/src/utils/__tests__/workspace-slug.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { slugifyWorkspace } from "../workspace-slug.js";
+
+describe("slugifyWorkspace", () => {
+  it("lowercases and hyphenates the canonical case", () => {
+    expect(slugifyWorkspace("Acme Engineering")).toBe("acme-engineering");
+    expect(slugifyWorkspace("First Tree Hub")).toBe("first-tree-hub");
+  });
+
+  it("collapses runs of non-alphanumerics into a single hyphen", () => {
+    expect(slugifyWorkspace("a   b---c__d")).toBe("a-b-c-d");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugifyWorkspace("  Hello!  ")).toBe("hello");
+    expect(slugifyWorkspace("---startup---")).toBe("startup");
+  });
+
+  it("caps the slug at 50 characters to match the server constraint", () => {
+    const long = "a".repeat(80);
+    expect(slugifyWorkspace(long).length).toBe(50);
+  });
+
+  it("returns an empty string for inputs with no alphanumerics — UI handles that explicitly", () => {
+    expect(slugifyWorkspace("")).toBe("");
+    expect(slugifyWorkspace("!@#$%")).toBe("");
+    expect(slugifyWorkspace("李小明")).toBe("");
+  });
+
+  it("preserves digits and is idempotent on already-slugged input", () => {
+    expect(slugifyWorkspace("acme-7")).toBe("acme-7");
+    const slug = slugifyWorkspace("Hello World 2");
+    expect(slugifyWorkspace(slug)).toBe(slug);
+  });
+});

--- a/packages/web/src/utils/auth-fragment.ts
+++ b/packages/web/src/utils/auth-fragment.ts
@@ -1,9 +1,18 @@
+import { sanitizeNextPath } from "@agent-team-foundation/first-tree-hub-shared";
+
 /**
  * Parse the URL fragment delivered by the server's OAuth callback redirect.
  * Server packs `?access=…&refresh=…&next=…` into the fragment so the
  * tokens never leave the browser (no proxy / CDN access log records the
  * fragment). The SPA's `/auth/github/complete` page consumes this and
  * persists the tokens to localStorage.
+ *
+ * `next` is sanitised against the same `SAFE_NEXT_PATH` whitelist the
+ * server's `/start` route applies. Without the client-side check, a
+ * crafted link like `/auth/github/complete#access=…&refresh=…&next=//evil`
+ * could land the user off-origin AFTER persisting the (server-controlled)
+ * tokens — token-fixation via fragment. The whitelist rejects that and
+ * silently downgrades the malicious value to `/`.
  *
  * Returns `null` for any malformed fragment so callers can render a
  * single "didn't complete" branch instead of guarding each missing
@@ -22,9 +31,9 @@ export function parseAuthFragment(rawHash: string): AuthFragment | null {
   const accessToken = params.get("access");
   const refreshToken = params.get("refresh");
   if (!accessToken || !refreshToken) return null;
-  // `next` is optional — fall back to root rather than rejecting; the
-  // server always populates it but a forward-compat client should
-  // tolerate either shape.
-  const next = params.get("next") ?? "/";
-  return { accessToken, refreshToken, next };
+  return {
+    accessToken,
+    refreshToken,
+    next: sanitizeNextPath(params.get("next")),
+  };
 }

--- a/packages/web/src/utils/auth-fragment.ts
+++ b/packages/web/src/utils/auth-fragment.ts
@@ -1,0 +1,30 @@
+/**
+ * Parse the URL fragment delivered by the server's OAuth callback redirect.
+ * Server packs `?access=…&refresh=…&next=…` into the fragment so the
+ * tokens never leave the browser (no proxy / CDN access log records the
+ * fragment). The SPA's `/auth/github/complete` page consumes this and
+ * persists the tokens to localStorage.
+ *
+ * Returns `null` for any malformed fragment so callers can render a
+ * single "didn't complete" branch instead of guarding each missing
+ * field individually.
+ */
+export type AuthFragment = {
+  accessToken: string;
+  refreshToken: string;
+  next: string;
+};
+
+export function parseAuthFragment(rawHash: string): AuthFragment | null {
+  const hash = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+  if (!hash) return null;
+  const params = new URLSearchParams(hash);
+  const accessToken = params.get("access");
+  const refreshToken = params.get("refresh");
+  if (!accessToken || !refreshToken) return null;
+  // `next` is optional — fall back to root rather than rejecting; the
+  // server always populates it but a forward-compat client should
+  // tolerate either shape.
+  const next = params.get("next") ?? "/";
+  return { accessToken, refreshToken, next };
+}

--- a/packages/web/src/utils/workspace-slug.ts
+++ b/packages/web/src/utils/workspace-slug.ts
@@ -1,0 +1,15 @@
+/**
+ * Derive a URL-safe workspace slug from a free-text display name. Mirrors
+ * the constraints baked into `createWorkspaceRequestSchema` server-side:
+ * lowercase alphanumeric + hyphens, must start with alphanumeric, max 50
+ * chars. The output isn't guaranteed to satisfy the regex (e.g. an
+ * all-emoji input collapses to "") — UI uses it as an auto-suggest, not
+ * as a final validation gate; the server has the last word.
+ */
+export function slugifyWorkspace(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 50);
+}


### PR DESCRIPTION
## Summary

Third slice of the SaaS onboarding work (M2 frontend portion of [`docs/saas-onboarding-journey.md`](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/saas-onboarding/docs/saas-onboarding-journey.md)). Builds on **PR #179** (server auth API).

> **Stack on top of #179** — base is `feat/saas-onboarding-auth` so the workspace API is in place. After #179 merges, retarget to `main`.

### Server contract change carried in this PR

`/api/v1/auth/github/callback` (and the dev-mode `/dev-callback`) now **302-redirects with the access/refresh tokens + nextRoute packed into the URL fragment** instead of returning JSON. The browser-driven OAuth round-trip never sees a JSON body — fragment delivery keeps tokens out of proxy/CDN access logs and lets the SPA `replaceState` them out of browser history. PR #179's dev-callback tests updated to follow the redirect and parse the fragment.

### Frontend pages

| Route | Purpose |
|---|---|
| `/signup` | Single-button "Continue with GitHub" entry. Preserves `?next=/invite/<token>` across the OAuth round-trip. |
| `/auth/github/complete` | Consumes the URL fragment, persists tokens via `signInWithTokens`, scrubs the URL, forwards to `next`. |
| `/setup` | Create / Join modal. Auto-suggests slug from display name; surfaces server's user-facing error strings verbatim. |
| `/invite/:token` | Public preview ("Join Acme Engineering") via `/api/v1/invite/:token/preview`; routes unauthed callers through `/signup?next=/invite/:token`. |

### Routing + auth context

- `AuthProvider` gains `isRootless`, `workspaces`, `signInWithTokens`, `switchWorkspace`, `refetchAll`. Refresh logic restructured to avoid a 401 cascade on rootless tokens (calling `/me` with a `type:"user"` token would loop refresh→401→clearTokens; we now gate on `/me/workspaces` first).
- New `RequireWorkspace` route guard sends rootless callers to `/setup`.
- `RequireAuth` updated to redirect unauthed users to `/signup` (SaaS-first) with the original path preserved as `next`.

### Open-redirect / token-fixation defence

`SAFE_NEXT_PATH` whitelist moved into a new `@agent-team-foundation/first-tree-hub-shared/safe-redirect` module. **Both** the server's `/start` route AND the SPA's fragment consumer import the same gate so they cannot drift. Without the client-side check, a crafted link like `/auth/github/complete#access=…&refresh=…&next=//evil` could land a victim off-origin AFTER persisting the (server-controlled) tokens — token-fixation via fragment.

### Domain note

User-facing invite-link example uses `https://first-tree.staging.unispark.dev/invite/…` — the production `hub.first-tree.ai` host isn't provisioned yet; staging is live.

### Versioning

`packages/command` 0.10.2 → 0.10.3 (per CLAUDE.md: bump on every PR touching command/client/server/web/shared). `shared` is `private:true` — not bumped.

### Test plan

- [x] 477/477 server tests passing (PR #179's tests adapted to the new redirect)
- [x] 45/45 web tests passing (13 new pure-function tests covering `parseAuthFragment` + `slugifyWorkspace`, including the malicious-`next` sanitization contract)
- [x] `pnpm typecheck` clean
- [x] `pnpm check` (biome) clean
- [x] Pre-push code review — 4 medium findings addressed (fragment-scrub ordering, misleading `refetchWorkspaces` alias, missing client-side `next` whitelist, deferral note for the silent workspace-switch UX); 2 low findings addressed (InvitePage cancel guard, RequireWorkspace spinner)

### Known follow-ups (deferred)

- "Switching to <workspace>" toast when a per-org user creates / joins from `/setup` — folded into PR #5's workspace switcher.
- AuthCallbackPage / RequireWorkspace / setup-modal RTL tests — pure helpers are well-covered; integration coverage waits for an RTL setup.

### Out of scope (deferred to later PRs)

- Wizard `/welcome` screens — PR #4 / PR #5
- `members.onboarding_state` read/write — PR #5
- `/admin` invite-link surfacing — PR #6
- ToS / mobile banner / Privacy — PR #6

https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV)_