### PR TITLE
feat(wizard): /welcome/connect screen + hide self-host CLI commands

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/server.ts
+++ b/packages/command/src/commands/server.ts
@@ -15,7 +15,14 @@ import {
 import { print } from "../core/output.js";
 
 export function registerServerCommands(program: Command): void {
-  const server = program.command("server").description("Manage First Tree Hub server");
+  // Self-host operator surface — kept functional but hidden from `--help`
+  // per M9 of docs/saas-onboarding-journey.md. SaaS users never run `server
+  // start` directly; the hub backend is operated by the host. Internal /
+  // enterprise operators can still discover and run the subcommands by
+  // typing them explicitly. Nothing is removed from the codebase.
+  const server = program
+    .command("server", { hidden: true })
+    .description("Self-host: manage the First Tree Hub server (advanced; hidden from default help)");
 
   server
     .command("start")

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -22,6 +22,7 @@ export async function createTestApp(): Promise<FastifyInstance> {
     server: {
       port: 0,
       host: "127.0.0.1",
+      publicUrl: undefined,
     },
     secrets: {
       jwtSecret: process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest",

--- a/packages/server/src/__tests__/wizard-connect.test.ts
+++ b/packages/server/src/__tests__/wizard-connect.test.ts
@@ -85,6 +85,32 @@ describe("Wizard Connect — server contract", () => {
     expect(body.command).toContain(body.token);
   });
 
+  it("POST /connect-tokens uses `server.publicUrl` when set (proxy-safe)", async () => {
+    // Inject the config field on the running app — the test framework
+    // doesn't let us re-`createTestApp` cheaply per-case. The handler
+    // reads `app.config.server.publicUrl` at request time so this works.
+    const original = app.config.server.publicUrl;
+    (app.config.server as { publicUrl?: string }).publicUrl = "https://hub.example.com";
+    try {
+      const id = `${Date.now()}c4`;
+      const signIn = await devSignIn({ githubId: id, login: `proxy-${id}` });
+      const ws = await createWorkspace(signIn.accessToken, `ws-proxy-${id}`);
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/connect-tokens",
+        headers: { authorization: `Bearer ${ws.accessToken}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ command: string }>();
+      // Configured URL wins over the request's `host` header (which would
+      // be 127.0.0.1:<random> for the test inject).
+      expect(body.command).toContain("https://hub.example.com");
+      expect(body.command).not.toContain("127.0.0.1");
+    } finally {
+      (app.config.server as { publicUrl?: string }).publicUrl = original;
+    }
+  });
+
   it("POST /connect-tokens refuses a rootless user-token (no workspace yet)", async () => {
     // Wizard never reaches Connect with a rootless token — RequireWorkspace
     // bounces them to /setup first. Pin the server-side guard so a

--- a/packages/server/src/__tests__/wizard-connect.test.ts
+++ b/packages/server/src/__tests__/wizard-connect.test.ts
@@ -1,0 +1,121 @@
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signOauthState } from "../services/auth-github.js";
+import { createTestApp } from "./helpers.js";
+
+/**
+ * Smoke tests for the two endpoints the SaaS wizard's Connect screen
+ * polls / calls. Both already existed before PR #4; this file pins
+ * the contract so a future change to /clients filtering or
+ * /connect-tokens shape doesn't silently break the Connect wizard.
+ *
+ * The wizard sequence under test:
+ *   1. Sign in (dev OAuth) → no membership → user-only token
+ *   2. Create workspace → per-org token
+ *   3. POST /connect-tokens → returns { token, expiresIn, command }
+ *   4. GET /clients → returns the user's clients (empty until first
+ *      `first-tree-hub connect` lands a row)
+ */
+describe("Wizard Connect — server contract", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  /** Re-uses the dev-callback flow from saas-onboarding-auth.test to seed a per-org user. */
+  async function devSignIn(opts: { githubId: string; login: string }) {
+    const { state } = await signOauthState(app.config.secrets.jwtSecret, "/");
+    const params = new URLSearchParams({
+      state,
+      login: opts.login,
+      github_id: opts.githubId,
+      email: `${opts.login}@example.local`,
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?${params.toString()}`,
+    });
+    if (res.statusCode !== 302) throw new Error(`dev sign-in failed: ${res.body}`);
+    const loc = res.headers.location ?? "";
+    const fragment = new URLSearchParams(loc.slice(loc.indexOf("#") + 1));
+    return {
+      accessToken: fragment.get("access") ?? "",
+      refreshToken: fragment.get("refresh") ?? "",
+    };
+  }
+
+  async function createWorkspace(token: string, slug: string) {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/workspaces/",
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: slug, displayName: `WS ${slug}` },
+    });
+    if (res.statusCode !== 200) throw new Error(`create failed: ${res.body}`);
+    return res.json<{ accessToken: string; refreshToken: string; workspace: { organizationId: string } }>();
+  }
+
+  it("POST /connect-tokens returns a JWT + expiresIn + a copy-pasteable CLI command", async () => {
+    const id = `${Date.now()}c1`;
+    const signIn = await devSignIn({ githubId: id, login: `connect-${id}` });
+    const ws = await createWorkspace(signIn.accessToken, `ws-${id}`);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/connect-tokens",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ token: string; expiresIn: number; command: string }>();
+    expect(body.token).toMatch(/^eyJ/);
+    // 10-minute connect-token TTL hard-coded in services/auth.ts. The
+    // wizard's "Token expires in 10 minutes" copy depends on this.
+    expect(body.expiresIn).toBe(600);
+    // The command is what the wizard renders verbatim — confirm shape
+    // so a server-side accidental refactor (e.g. dropping the host
+    // segment) gets caught here, not by a user pasting `first-tree-hub
+    // connect undefined` into their terminal.
+    expect(body.command).toMatch(/^first-tree-hub client connect https?:\/\/.+ --token /);
+    expect(body.command).toContain(body.token);
+  });
+
+  it("POST /connect-tokens refuses a rootless user-token (no workspace yet)", async () => {
+    // Wizard never reaches Connect with a rootless token — RequireWorkspace
+    // bounces them to /setup first. Pin the server-side guard so a
+    // misconfigured frontend doesn't accidentally surface a useless
+    // command.
+    const id = `${Date.now()}c2`;
+    const signIn = await devSignIn({ githubId: id, login: `rootless-${id}` });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/connect-tokens",
+      headers: { authorization: `Bearer ${signIn.accessToken}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("GET /clients returns an empty list for a freshly-created workspace", async () => {
+    // Wizard's polling loop sees this exact shape: an empty array until
+    // the user runs the `first-tree-hub connect` command on their box,
+    // at which point the `clients` row materialises and `status==='connected'`.
+    const id = `${Date.now()}c3`;
+    const signIn = await devSignIn({ githubId: id, login: `empty-${id}` });
+    const ws = await createWorkspace(signIn.accessToken, `ws-empty-${id}`);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/clients/",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const list = res.json<unknown[]>();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list).toHaveLength(0);
+  });
+});

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -55,10 +55,21 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       app.config.secrets.jwtSecret,
     );
 
-    // Build the CLI connect command using the request's origin (preserve port)
-    const proto = request.headers["x-forwarded-proto"] ?? request.protocol;
-    const host = request.headers["x-forwarded-host"] ?? request.headers.host ?? request.hostname;
-    const serverUrl = `${proto}://${host}`;
+    // Build the CLI connect command. Prefer the explicit `server.publicUrl`
+    // (deployments behind a CDN that strips forwarded headers); fall back
+    // to forwarded-proto/host or the request's own headers (self-host,
+    // direct access). Without the configured-first preference, a hub
+    // running behind a proxy that drops `x-forwarded-*` would advertise
+    // an unreachable `http://127.0.0.1:8000/...` to the wizard.
+    const configuredUrl = app.config.server.publicUrl;
+    let serverUrl: string;
+    if (configuredUrl) {
+      serverUrl = configuredUrl.replace(/\/+$/, "");
+    } else {
+      const proto = request.headers["x-forwarded-proto"] ?? request.protocol;
+      const host = request.headers["x-forwarded-host"] ?? request.headers.host ?? request.hostname;
+      serverUrl = `${proto}://${host}`;
+    }
     const command = `first-tree-hub client connect ${serverUrl} --token ${token}`;
 
     return { token, expiresIn, command };

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -23,6 +23,15 @@ export const serverConfigSchema = defineConfig({
   server: {
     port: field(z.number().default(8000), { env: "FIRST_TREE_HUB_PORT" }),
     host: field(z.string().default("127.0.0.1"), { env: "FIRST_TREE_HUB_HOST" }),
+    /**
+     * Public URL clients reach this hub on. Used to render the
+     * `first-tree-hub client connect <url>` command in the SaaS wizard
+     * and any other place that needs an absolute hub address. When unset,
+     * we fall back to the request's `x-forwarded-*` / `host` headers —
+     * fine for self-host, wrong behind a CDN that strips forwarded
+     * headers (would leak `http://127.0.0.1:8000` into the wizard).
+     */
+    publicUrl: field(z.string().optional(), { env: "FIRST_TREE_HUB_PUBLIC_URL" }),
   },
   secrets: {
     jwtSecret: field(z.string(), {

--- a/packages/web/src/api/clients.ts
+++ b/packages/web/src/api/clients.ts
@@ -2,11 +2,17 @@ import { api } from "./client.js";
 
 /**
  * Subset of `/api/v1/clients` the wizard cares about — full schema lives in
- * the admin clients page. The wizard only needs to know whether at least
- * one client owned by the current user is currently connected.
+ * the admin clients page. `userId` is preserved on purpose: the server's
+ * `/clients` admin scope returns every client in the org for `role==="admin"`
+ * users (so admins can see whose machine is whose on the regular admin
+ * page). The Connect wizard MUST then filter to the current user, or a
+ * fresh workspace creator (auto-admin) would falsely auto-advance the
+ * moment any peer's client connects. Filtering happens in
+ * `welcome-connect.tsx`.
  */
 export type ConnectedClientSummary = {
   id: string;
+  userId: string;
   status: "connected" | "disconnected";
   hostname: string | null;
   os: string | null;
@@ -18,6 +24,7 @@ export async function listMyClients(): Promise<ConnectedClientSummary[]> {
     await api.get<
       Array<{
         id: string;
+        userId: string;
         status: string;
         hostname: string | null;
         os: string | null;
@@ -26,6 +33,7 @@ export async function listMyClients(): Promise<ConnectedClientSummary[]> {
     >("/clients/");
   return rows.map((r) => ({
     id: r.id,
+    userId: r.userId,
     status: r.status === "connected" ? "connected" : "disconnected",
     hostname: r.hostname,
     os: r.os,
@@ -36,11 +44,12 @@ export async function listMyClients(): Promise<ConnectedClientSummary[]> {
 export type ConnectTokenResponse = {
   token: string;
   expiresIn: number;
-  /** Pre-baked `first-tree-hub connect <url> --token <…>` command for copy-paste. */
+  /** Pre-baked `first-tree-hub client connect <url> --token <…>` command for copy-paste. */
   command: string;
 };
 
 export async function generateConnectToken(): Promise<ConnectTokenResponse> {
-  // Mounted alongside `/me` (no `/me` prefix) — see packages/server/src/api/me.ts.
+  // Route is `/connect-tokens` (no `/me` prefix) — `meRoutes` mounts both
+  // `/me` and `/connect-tokens` at the empty prefix in `app.ts`.
   return api.post<ConnectTokenResponse>("/connect-tokens");
 }

--- a/packages/web/src/api/clients.ts
+++ b/packages/web/src/api/clients.ts
@@ -1,0 +1,46 @@
+import { api } from "./client.js";
+
+/**
+ * Subset of `/api/v1/clients` the wizard cares about — full schema lives in
+ * the admin clients page. The wizard only needs to know whether at least
+ * one client owned by the current user is currently connected.
+ */
+export type ConnectedClientSummary = {
+  id: string;
+  status: "connected" | "disconnected";
+  hostname: string | null;
+  os: string | null;
+  connectedAt: string | null;
+};
+
+export async function listMyClients(): Promise<ConnectedClientSummary[]> {
+  const rows =
+    await api.get<
+      Array<{
+        id: string;
+        status: string;
+        hostname: string | null;
+        os: string | null;
+        connectedAt: string | null;
+      }>
+    >("/clients/");
+  return rows.map((r) => ({
+    id: r.id,
+    status: r.status === "connected" ? "connected" : "disconnected",
+    hostname: r.hostname,
+    os: r.os,
+    connectedAt: r.connectedAt,
+  }));
+}
+
+export type ConnectTokenResponse = {
+  token: string;
+  expiresIn: number;
+  /** Pre-baked `first-tree-hub connect <url> --token <…>` command for copy-paste. */
+  command: string;
+};
+
+export async function generateConnectToken(): Promise<ConnectTokenResponse> {
+  // Mounted alongside `/me` (no `/me` prefix) — see packages/server/src/api/me.ts.
+  return api.post<ConnectTokenResponse>("/connect-tokens");
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -15,6 +15,7 @@ import { LoginPage } from "./pages/login.js";
 import { SettingsPage } from "./pages/settings.js";
 import { SetupPage } from "./pages/setup.js";
 import { SignupPage } from "./pages/signup.js";
+import { WelcomeConnectPage } from "./pages/welcome-connect.js";
 import { WorkspacePage } from "./pages/workspace/index.js";
 
 const queryClient = new QueryClient({
@@ -48,6 +49,11 @@ export function App() {
 
               {/* Per-org app shell: must have at least one membership. */}
               <Route element={<RequireWorkspace />}>
+                {/* Wizard pages live under /welcome/* and intentionally
+                    skip the regular Layout — they're a focused, single-
+                    column flow that the design doc spec'd as "screen
+                    centre, no nav". */}
+                <Route path="welcome/connect" element={<WelcomeConnectPage />} />
                 <Route
                   element={
                     <PulseProvider>

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -5,6 +5,7 @@ import { api, clearStoredTokens, getStoredTokens, setStoredTokens } from "../api
 import { listMyWorkspaces, switchOrganization as switchOrgApi } from "../api/workspaces.js";
 
 type MeResponse = {
+  user: { id: string } | null;
   member: { id: string; role: string; agentId: string };
 };
 
@@ -26,6 +27,13 @@ type AuthContextValue = {
   memberId: string | null;
   agentId: string | null;
   organizationId: string | null;
+  /**
+   * `users.id` of the signed-in user. Surfaced so wizard pages can
+   * filter org-wide query results to "my own rows" — admins on the
+   * Connect screen would otherwise see peers' connected clients and
+   * falsely auto-advance.
+   */
+  userId: string | null;
   /** Legacy username + password sign-in. Self-host path. */
   login: (username: string, password: string) => Promise<void>;
   /**
@@ -54,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [role, setRole] = useState<string | null>(null);
   const [memberId, setMemberId] = useState<string | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
   const [organizationId, setOrganizationId] = useState<string | null>(null);
   const [workspaces, setWorkspaces] = useState<WorkspaceListItem[] | null>(null);
 
@@ -64,6 +73,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setRole(null);
     setMemberId(null);
     setAgentId(null);
+    setUserId(null);
     setOrganizationId(null);
     setWorkspaces(null);
   }, []);
@@ -99,6 +109,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRole(null);
       setMemberId(null);
       setAgentId(null);
+      setUserId(null);
       return;
     }
 
@@ -108,6 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRole(data.member.role);
       setMemberId(data.member.id);
       setAgentId(data.member.agentId);
+      setUserId(data.user?.id ?? null);
     } catch {
       // /me failed despite memberships existing — leave member state null
       // and let the caller decide (typical case: token's organizationId
@@ -115,6 +127,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // can offer a switch-org prompt against the live workspaces list.
       setRole(null);
       setMemberId(null);
+      setUserId(null);
       setAgentId(null);
     }
   }, []);
@@ -173,6 +186,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         memberId,
         agentId,
         organizationId,
+        userId,
         login,
         signInWithTokens,
         switchWorkspace,

--- a/packages/web/src/pages/invite.tsx
+++ b/packages/web/src/pages/invite.tsx
@@ -61,7 +61,11 @@ export function InvitePage() {
     try {
       const res = await joinWorkspace({ tokenOrUrl: token });
       await signInWithTokens({ accessToken: res.accessToken, refreshToken: res.refreshToken });
-      navigate("/", { replace: true });
+      // Per design doc §4.3: invitees land in `/welcome` (skipping the
+      // `/setup` modal — they didn't need to pick a workspace, the
+      // invite already did). The wizard then runs Connect Computer →
+      // Create Agent for the freshly-joined workspace.
+      navigate("/welcome/connect", { replace: true });
     } catch (err) {
       setJoinError(err instanceof Error ? err.message : "Could not join workspace");
     } finally {

--- a/packages/web/src/pages/setup.tsx
+++ b/packages/web/src/pages/setup.tsx
@@ -49,9 +49,13 @@ export function SetupPage() {
           <CardDescription>Create your workspace, or join one your team has already set up.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          <CreateWorkspaceForm onSuccess={(t) => signInWithTokens(t).then(() => navigate("/", { replace: true }))} />
+          <CreateWorkspaceForm
+            onSuccess={(t) => signInWithTokens(t).then(() => navigate("/welcome/connect", { replace: true }))}
+          />
           <Divider />
-          <JoinWorkspaceForm onSuccess={(t) => signInWithTokens(t).then(() => navigate("/", { replace: true }))} />
+          <JoinWorkspaceForm
+            onSuccess={(t) => signInWithTokens(t).then(() => navigate("/welcome/connect", { replace: true }))}
+          />
         </CardContent>
       </Card>
     </div>

--- a/packages/web/src/pages/welcome-connect.tsx
+++ b/packages/web/src/pages/welcome-connect.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { type ConnectedClientSummary, generateConnectToken, listMyClients } from "../api/clients.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+import { StateDot } from "../components/ui/state-dot.js";
+
+/**
+ * `/welcome/connect` — first wizard screen per design doc §4.5.1.
+ *
+ * Three things on this screen:
+ *   1. Prerequisite checklist (manual: node + claude + claude auth).
+ *      The check is a copy-and-run shell snippet rather than a CLI
+ *      sub-command call — keeps the wizard portable across OSes
+ *      without us shelling out from the browser.
+ *   2. The one-line `first-tree-hub connect <url> --token <…>` command
+ *      with a Copy button. Token comes from `POST /me/connect-tokens`
+ *      and is single-use; we re-mint on demand if the user clicks
+ *      "Generate a new token".
+ *   3. Live polling of `/api/v1/clients` every 3s to detect that the
+ *      command landed. When `clients.length > 0 && status=="connected"`
+ *      we flip a checkmark and enable "Continue".
+ *
+ * "Continue" navigates to the workspace shell (`/`) until PR #5 wires
+ * the second wizard screen at `/welcome/agent` and onboarding-state
+ * persistence. Today an empty workspace lands the user on the same
+ * shell as a fully-configured one.
+ */
+const POLL_INTERVAL_MS = 3000;
+
+export function WelcomeConnectPage() {
+  const navigate = useNavigate();
+  const [tokenResp, setTokenResp] = useState<{ token: string; command: string } | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [tokenBusy, setTokenBusy] = useState(false);
+  const [clients, setClients] = useState<ConnectedClientSummary[] | null>(null);
+
+  // Mint the first connect token on mount. The token expires in 10
+  // minutes (CONNECT_TOKEN_EXPIRY in services/auth.ts) — if the user
+  // dawdles past that, the command will 401; we surface a "Generate
+  // a new token" affordance so they can recover without leaving the
+  // page.
+  useEffect(() => {
+    let cancelled = false;
+    void mintToken();
+    return () => {
+      cancelled = true;
+    };
+
+    async function mintToken() {
+      setTokenBusy(true);
+      setTokenError(null);
+      try {
+        const resp = await generateConnectToken();
+        if (!cancelled) setTokenResp({ token: resp.token, command: resp.command });
+      } catch (err) {
+        if (!cancelled) setTokenError(err instanceof Error ? err.message : "Could not generate token");
+      } finally {
+        if (!cancelled) setTokenBusy(false);
+      }
+    }
+  }, []);
+
+  // Poll the clients list. We don't WS-subscribe because the existing
+  // admin WS doesn't push `client:connected` to the wizard's session,
+  // and threading that through is more risk than the wizard warrants
+  // in this slice. Polling stops when at least one connected client
+  // appears — once detected, no further polls are scheduled.
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const list = await listMyClients();
+        if (cancelled) return;
+        setClients(list);
+        const anyConnected = list.some((c) => c.status === "connected");
+        if (!anyConnected) {
+          timer = setTimeout(poll, POLL_INTERVAL_MS);
+        }
+      } catch {
+        // Transient — try again on the next tick rather than blowing up
+        // the whole wizard. Errors are common while a fresh `connect`
+        // is racing the server's first registration write.
+        if (!cancelled) timer = setTimeout(poll, POLL_INTERVAL_MS);
+      }
+    };
+    void poll();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  const connected = clients?.find((c) => c.status === "connected") ?? null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle className="text-title">Connect your computer</CardTitle>
+          <CardDescription>
+            First Tree Hub runs your agents on your own machine via the agent CLI (Claude Code today; Codex and others
+            coming soon). One-time setup below.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <PrerequisiteSection />
+          <ConnectCommandSection
+            tokenResp={tokenResp}
+            tokenError={tokenError}
+            tokenBusy={tokenBusy}
+            onRegenerate={() => {
+              setTokenResp(null);
+              setTokenBusy(true);
+              setTokenError(null);
+              void generateConnectToken()
+                .then((r) => setTokenResp({ token: r.token, command: r.command }))
+                .catch((err) => setTokenError(err instanceof Error ? err.message : "Could not generate token"))
+                .finally(() => setTokenBusy(false));
+            }}
+          />
+          <ConnectionStatusSection connected={connected} />
+          <div className="flex justify-end">
+            <Button disabled={!connected} onClick={() => navigate("/", { replace: true })}>
+              Continue
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function PrerequisiteSection() {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-body font-medium">1. Check prerequisites</h3>
+      <p className="text-caption text-muted-foreground">
+        On macOS or Linux. Windows not supported in this milestone — use WSL.
+      </p>
+      <CodeBlock value={"node -v && claude --version && claude auth status"} />
+      <p className="text-caption text-muted-foreground">
+        All three should print without errors. Missing either? Install Node 20+ from{" "}
+        <a className="underline" href="https://nodejs.org" target="_blank" rel="noreferrer">
+          nodejs.org
+        </a>
+        , then{" "}
+        <a
+          className="underline"
+          href="https://docs.anthropic.com/claude/docs/claude-code"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Claude Code
+        </a>
+        .
+      </p>
+    </section>
+  );
+}
+
+function ConnectCommandSection({
+  tokenResp,
+  tokenError,
+  tokenBusy,
+  onRegenerate,
+}: {
+  tokenResp: { token: string; command: string } | null;
+  tokenError: string | null;
+  tokenBusy: boolean;
+  onRegenerate: () => void;
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-body font-medium">2. Run this command in a terminal</h3>
+      {tokenBusy && !tokenResp ? (
+        <div className="text-caption text-muted-foreground">Generating one-time token…</div>
+      ) : tokenError ? (
+        <div className="space-y-2">
+          <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{tokenError}</div>
+          <Button variant="outline" size="sm" onClick={onRegenerate} disabled={tokenBusy}>
+            Try again
+          </Button>
+        </div>
+      ) : tokenResp ? (
+        <>
+          <CodeBlock value={tokenResp.command} />
+          <p className="text-caption text-muted-foreground">
+            Token expires in 10 minutes. Trouble?{" "}
+            <button type="button" className="underline" onClick={onRegenerate} disabled={tokenBusy}>
+              Generate a new one
+            </button>
+            .
+          </p>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function ConnectionStatusSection({ connected }: { connected: ConnectedClientSummary | null }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-body font-medium">3. Wait for connection</h3>
+      {connected ? (
+        <div className="flex items-center gap-2 rounded-md border border-border bg-card p-3">
+          <StateDot state="idle" />
+          <div className="text-body">
+            Connected{connected.hostname ? ` from ${connected.hostname}` : ""}
+            {connected.os ? ` (${connected.os})` : ""}.
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 rounded-md border border-border bg-card p-3">
+          <StateDot state="working" />
+          <div className="text-body text-muted-foreground">Waiting for your computer to register…</div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CodeBlock({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API blocked (insecure context, missing permission) —
+      // fall back silently; the user can still select and copy.
+    }
+  };
+  return (
+    <div className="relative">
+      <pre className="overflow-x-auto rounded-md bg-[color:var(--bg-sunken)] p-3 text-caption font-mono">
+        <code>{value}</code>
+      </pre>
+      <Button type="button" variant="outline" size="sm" className="absolute right-2 top-2" onClick={onCopy}>
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/pages/welcome-connect.tsx
+++ b/packages/web/src/pages/welcome-connect.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { type ConnectedClientSummary, generateConnectToken, listMyClients } from "../api/clients.js";
+import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
 import { StateDot } from "../components/ui/state-dot.js";
@@ -27,13 +28,23 @@ import { StateDot } from "../components/ui/state-dot.js";
  * shell as a fully-configured one.
  */
 const POLL_INTERVAL_MS = 3000;
+/**
+ * After this long without seeing a connected client, surface a stale-token
+ * hint. The wizard can't see CLI-side failures directly (the CLI talks to
+ * `/auth/connect-token`, the wizard polls `/clients/`); this approximates
+ * P0-4 "失败恢复" from docs/saas-onboarding-journey.md §4.5.1 by giving
+ * the user a way out when the most likely failure (token expiry) bites.
+ */
+const STALE_BANNER_MS = 60_000;
 
 export function WelcomeConnectPage() {
   const navigate = useNavigate();
+  const { userId } = useAuth();
   const [tokenResp, setTokenResp] = useState<{ token: string; command: string } | null>(null);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [tokenBusy, setTokenBusy] = useState(false);
   const [clients, setClients] = useState<ConnectedClientSummary[] | null>(null);
+  const [stale, setStale] = useState(false);
 
   // Mint the first connect token on mount. The token expires in 10
   // minutes (CONNECT_TOKEN_EXPIRY in services/auth.ts) — if the user
@@ -64,8 +75,13 @@ export function WelcomeConnectPage() {
   // Poll the clients list. We don't WS-subscribe because the existing
   // admin WS doesn't push `client:connected` to the wizard's session,
   // and threading that through is more risk than the wizard warrants
-  // in this slice. Polling stops when at least one connected client
-  // appears — once detected, no further polls are scheduled.
+  // in this slice. Polling stops when at least one OF THE CALLER'S
+  // OWN clients is connected — admins (workspace creators) can see
+  // peers' clients on this endpoint, so we filter by `userId` to avoid
+  // a false-positive Continue when a teammate happens to be online.
+  // We also DON'T resume polling after disconnect: this is a one-shot
+  // wizard; a Ctrl-C after success is the user's choice and shouldn't
+  // bounce them back into the connect screen.
   useEffect(() => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -75,8 +91,8 @@ export function WelcomeConnectPage() {
         const list = await listMyClients();
         if (cancelled) return;
         setClients(list);
-        const anyConnected = list.some((c) => c.status === "connected");
-        if (!anyConnected) {
+        const anyConnectedMine = list.some((c) => c.status === "connected" && c.userId === userId);
+        if (!anyConnectedMine) {
           timer = setTimeout(poll, POLL_INTERVAL_MS);
         }
       } catch {
@@ -92,9 +108,21 @@ export function WelcomeConnectPage() {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
+  }, [userId]);
+
+  // Stale-token banner — fires once after STALE_BANNER_MS if the client
+  // still hasn't appeared. Cleared automatically the moment a connected
+  // own-client is detected.
+  useEffect(() => {
+    const timer = setTimeout(() => setStale(true), STALE_BANNER_MS);
+    return () => clearTimeout(timer);
   }, []);
 
-  const connected = clients?.find((c) => c.status === "connected") ?? null;
+  const connected = clients?.find((c) => c.status === "connected" && c.userId === userId) ?? null;
+  // Reset the stale banner the moment we see the user's client come online.
+  useEffect(() => {
+    if (connected && stale) setStale(false);
+  }, [connected, stale]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
@@ -112,10 +140,12 @@ export function WelcomeConnectPage() {
             tokenResp={tokenResp}
             tokenError={tokenError}
             tokenBusy={tokenBusy}
+            stale={stale && !connected}
             onRegenerate={() => {
               setTokenResp(null);
               setTokenBusy(true);
               setTokenError(null);
+              setStale(false);
               void generateConnectToken()
                 .then((r) => setTokenResp({ token: r.token, command: r.command }))
                 .catch((err) => setTokenError(err instanceof Error ? err.message : "Could not generate token"))
@@ -166,11 +196,14 @@ function ConnectCommandSection({
   tokenResp,
   tokenError,
   tokenBusy,
+  stale,
   onRegenerate,
 }: {
   tokenResp: { token: string; command: string } | null;
   tokenError: string | null;
   tokenBusy: boolean;
+  /** True when the wizard has been waiting unusually long without seeing the client land. */
+  stale: boolean;
   onRegenerate: () => void;
 }) {
   return (
@@ -188,6 +221,15 @@ function ConnectCommandSection({
       ) : tokenResp ? (
         <>
           <CodeBlock value={tokenResp.command} />
+          {stale && (
+            <div className="rounded-md border border-border bg-card p-2 text-caption">
+              Still waiting? Your token may have expired (10-minute window).{" "}
+              <button type="button" className="underline" onClick={onRegenerate} disabled={tokenBusy}>
+                Generate a new one
+              </button>
+              {" and try again."}
+            </div>
+          )}
           <p className="text-caption text-muted-foreground">
             Token expires in 10 minutes. Trouble?{" "}
             <button type="button" className="underline" onClick={onRegenerate} disabled={tokenBusy}>


### PR DESCRIPTION
## Summary

Fourth slice of the SaaS onboarding work (M3 + M9 of [`docs/saas-onboarding-journey.md`](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/saas-onboarding/docs/saas-onboarding-journey.md)). Builds on **PR #180**.

> **Stack on top of #180** — base is `feat/saas-onboarding-web`. After #180 merges, retarget to `main`.

### What's added

**Web — `/welcome/connect`** (wizard step 1, design doc §4.5.1):

1. **Prerequisite snippet** — copy-and-run `node -v && claude --version && claude auth status` plus install links. macOS / Linux only; explicit Windows / WSL banner.
2. **Pre-baked CLI command** — `first-tree-hub client connect <url> --token <…>` with a Copy button. Token comes from `POST /connect-tokens` and is single-use; "Generate a new one" handles the 10-min expiry case.
3. **Live polling** — every 3s of `/api/v1/clients`; flips to "Connected from <hostname>" once the user's own `first-tree-hub connect` lands. Filters by current user's `userId` so a workspace creator (auto-admin) doesn't auto-advance on a peer's connection.
4. **60-second stale banner** — "Still waiting? Your token may have expired" — approximates P0-4 *失败恢复* since the wizard can't directly see CLI-side 401s.

Routing: `/setup` and `/invite/:token` success paths now navigate to `/welcome/connect` (was `/`). Wizard sits inside `RequireWorkspace`. "Continue" navigates to `/` for now — PR #5 wires the second wizard screen at `/welcome/agent`.

**CLI — M9**: `server` command group is now `hidden: true`. SaaS users see a focused `--help`; subcommands continue to work when typed explicitly so internal/enterprise operators are unaffected.

**Server — `server.publicUrl` config**: new optional `FIRST_TREE_HUB_PUBLIC_URL` env. `/connect-tokens` prefers it over the request's `x-forwarded-*` / `host` headers. Without this a hub behind a CDN that strips forwarded headers would advertise `http://127.0.0.1:8000` to the wizard — unreachable from a user's laptop.

### Auth context

`AuthProvider` gains `userId` so wizard pages can filter org-wide query results to "my own rows" — the F1 fix above. Sourced from `/me` (extended with `user.id` projection); `null` for rootless users since `/me` is per-org.

### Versioning

`packages/command` 0.10.3 → 0.10.4 (CLI `server` group is now hidden — behavior change visible in `--help`).

### Test plan

- [x] 481/481 server tests passing (4 new — wizard endpoint contract: token shape, command pre-bake, rootless rejection, `publicUrl` precedence)
- [x] 45/45 web tests passing
- [x] `pnpm typecheck` + `pnpm check` clean
- [x] Manual: visited `/welcome/connect` after a fresh `/setup` create — token + command rendered, 3s polling visible in network tab, "Continue" remained disabled until a fake `clients` row was added
- [x] Pre-push code review — 1 HIGH (admin sees peers' clients) + 1 MEDIUM (proxy URL) + 3 LOW (stale banner, polling-no-resume comment, route comment) addressed

### Known follow-ups

- "Continue" navigates to `/` — PR #5 will flip to `/welcome/agent` and add `members.onboarding_state` write so the wizard isn't replayed.
- WS push for `client:connected` to the wizard's session is still polling-only — acceptable for the wizard's narrow window; flagged as a polish item for later.

### Out of scope (deferred)

- Wizard step 2 (Create Agent) + onboarding_state persistence + workspace switcher — PR #5
- `/admin` invite-link surfacing — PR #6
- ToS / mobile banner / Privacy / CLI upgrade hint — PR #6

https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV)_