### PR TITLE
feat(wizard): /welcome/agent + onboarding-state persistence + workspace switcher

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/wizard-onboarding-state.test.ts
+++ b/packages/server/src/__tests__/wizard-onboarding-state.test.ts
@@ -1,0 +1,164 @@
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { clients as clientsTable } from "../db/schema/clients.js";
+import { signOauthState } from "../services/auth-github.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestApp } from "./helpers.js";
+
+/**
+ * Tests for the wizard's onboarding-state surface added in PR #5:
+ *   * /me returns `member.onboardingState` (the JSONB checkpoint) AND
+ *     `wizard.hasConnectedClientElsewhere` (cross-workspace skip signal
+ *     for P0-5).
+ *   * PATCH /me/onboarding-state writes the checkpoint, validating shape.
+ */
+describe("Wizard onboarding-state — /me + PATCH", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  async function devSignIn(opts: { githubId: string; login: string }) {
+    const { state } = await signOauthState(app.config.secrets.jwtSecret, "/");
+    const params = new URLSearchParams({
+      state,
+      login: opts.login,
+      github_id: opts.githubId,
+      email: `${opts.login}@example.local`,
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?${params.toString()}`,
+    });
+    if (res.statusCode !== 302) throw new Error(`dev sign-in failed: ${res.body}`);
+    const loc = res.headers.location ?? "";
+    const fragment = new URLSearchParams(loc.slice(loc.indexOf("#") + 1));
+    return { accessToken: fragment.get("access") ?? "", refreshToken: fragment.get("refresh") ?? "" };
+  }
+
+  async function createWs(token: string, slug: string) {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/workspaces/",
+      headers: { authorization: `Bearer ${token}` },
+      payload: { name: slug, displayName: `WS ${slug}` },
+    });
+    return res.json<{
+      accessToken: string;
+      refreshToken: string;
+      workspace: { organizationId: string; memberId: string };
+    }>();
+  }
+
+  it("/me returns null onboardingState for a fresh membership", async () => {
+    const id = `${Date.now()}o1`;
+    const signIn = await devSignIn({ githubId: id, login: `o1-${id}` });
+    const ws = await createWs(signIn.accessToken, `ws-${id}`);
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+    });
+    expect(me.statusCode).toBe(200);
+    const body = me.json<{
+      member: { onboardingState: null | { currentStep: string } };
+      wizard: { hasConnectedClientElsewhere: boolean };
+    }>();
+    expect(body.member.onboardingState).toBeNull();
+    expect(body.wizard.hasConnectedClientElsewhere).toBe(false);
+  });
+
+  it("PATCH /me/onboarding-state writes the checkpoint and /me reflects it", async () => {
+    const id = `${Date.now()}o2`;
+    const signIn = await devSignIn({ githubId: id, login: `o2-${id}` });
+    const ws = await createWs(signIn.accessToken, `ws-${id}`);
+
+    const patch = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/onboarding-state",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+      payload: { currentStep: "create_agent" },
+    });
+    expect(patch.statusCode).toBe(204);
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+    });
+    const body = me.json<{ member: { onboardingState: { currentStep: string } | null } }>();
+    expect(body.member.onboardingState).toEqual({ currentStep: "create_agent" });
+  });
+
+  it("PATCH /me/onboarding-state rejects an invalid currentStep value", async () => {
+    const id = `${Date.now()}o3`;
+    const signIn = await devSignIn({ githubId: id, login: `o3-${id}` });
+    const ws = await createWs(signIn.accessToken, `ws-${id}`);
+
+    const patch = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/onboarding-state",
+      headers: { authorization: `Bearer ${ws.accessToken}` },
+      payload: { currentStep: "not_a_real_step" },
+    });
+    expect(patch.statusCode).toBe(400);
+  });
+
+  it("hasConnectedClientElsewhere is true when the user has a connected client in ANOTHER workspace", async () => {
+    // Set up: user creates workspace A, then workspace B. Seed a connected
+    // client in A. Hit /me with the token scoped to B; the cross-workspace
+    // skip signal should fire.
+    const id = `${Date.now()}o4`;
+    const signIn = await devSignIn({ githubId: id, login: `o4-${id}` });
+
+    const wsA = await createWs(signIn.accessToken, `wsa-${id}`);
+    const wsB = await createWs(wsA.accessToken, `wsb-${id}`);
+
+    // Decode the token to fetch userId for the seed insert.
+    // Easier: just SELECT from members to get userId for either ws.
+    const { members } = await import("../db/schema/members.js");
+    const { eq } = await import("drizzle-orm");
+    const [memberA] = await app.db
+      .select({ userId: members.userId, organizationId: members.organizationId })
+      .from(members)
+      .where(eq(members.id, wsA.workspace.memberId))
+      .limit(1);
+    if (!memberA) throw new Error("seeded member missing");
+
+    // Insert a connected client owned by this user, scoped to ws A.
+    await app.db.insert(clientsTable).values({
+      id: `cli-elsewhere-${uuidv7().slice(-8)}`,
+      userId: memberA.userId,
+      organizationId: memberA.organizationId,
+      status: "connected",
+    });
+
+    // Now /me with the ws B token should report the elsewhere flag.
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${wsB.accessToken}` },
+    });
+    expect(me.statusCode).toBe(200);
+    const body = me.json<{ wizard: { hasConnectedClientElsewhere: boolean } }>();
+    expect(body.wizard.hasConnectedClientElsewhere).toBe(true);
+
+    // And /me on ws A itself should still report FALSE — the elsewhere
+    // signal explicitly excludes the current workspace so the wizard's
+    // own polling sees the local client.
+    const meA = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${wsA.accessToken}` },
+    });
+    const bodyA = meA.json<{ wizard: { hasConnectedClientElsewhere: boolean } }>();
+    expect(bodyA.wizard.hasConnectedClientElsewhere).toBe(false);
+  });
+});

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -1,11 +1,14 @@
-import { eq } from "drizzle-orm";
+import { onboardingStateSchema } from "@agent-team-foundation/first-tree-hub-shared";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { requireMember } from "../middleware/require-identity.js";
 import * as authService from "../services/auth.js";
 
-/** GET /me — returns current user + member + agent info. */
+/** GET /me — returns current user + member + agent info, plus wizard state. */
 export async function meRoutes(app: FastifyInstance): Promise<void> {
   app.get("/me", async (request) => {
     const m = requireMember(request);
@@ -32,6 +35,36 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       .where(eq(agents.uuid, m.agentId))
       .limit(1);
 
+    // Wizard state — per (user × workspace) checkpoint stored on
+    // `members.onboarding_state`. Surfaced here so the frontend can
+    // pick the wizard step in a single round-trip rather than
+    // hitting a separate /onboarding endpoint.
+    const [memberRow] = await app.db
+      .select({ onboardingState: members.onboardingState })
+      .from(members)
+      .where(eq(members.id, m.memberId))
+      .limit(1);
+
+    // Cross-workspace skip signal (P0-5 in docs/saas-onboarding-journey.md
+    // §6.1): if the user has a connected client in ANY of their other
+    // workspaces, they've already completed the Connect screen for that
+    // physical machine; the wizard for this workspace can skip Step 1.
+    // We deliberately exclude the current workspace from the check —
+    // if they're connected HERE, the regular wizard polling sees it
+    // and advances; the cross-workspace flag is for the brand-new
+    // membership case.
+    const elsewhere = await app.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(clients)
+      .where(
+        and(
+          eq(clients.userId, m.userId),
+          eq(clients.status, "connected"),
+          ne(clients.organizationId, m.organizationId),
+        ),
+      );
+    const hasConnectedClientElsewhere = (elsewhere[0]?.count ?? 0) > 0;
+
     return {
       user: user ?? null,
       member: {
@@ -39,9 +72,27 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
         organizationId: m.organizationId,
         role: m.role,
         agentId: m.agentId,
+        onboardingState: memberRow?.onboardingState ?? null,
       },
       agent: agent ?? null,
+      wizard: {
+        hasConnectedClientElsewhere,
+      },
     };
+  });
+
+  /**
+   * PATCH /me/onboarding-state — write the wizard checkpoint for the
+   * caller's current membership. We don't expose the full members table
+   * for self-service; only the onboarding_state column is writable, and
+   * only for the caller's own member row. The body is validated against
+   * `onboardingStateSchema` to keep the JSONB shape stable.
+   */
+  app.patch("/me/onboarding-state", async (request, reply) => {
+    const m = requireMember(request);
+    const body = onboardingStateSchema.parse(request.body);
+    await app.db.update(members).set({ onboardingState: body }).where(eq(members.id, m.memberId));
+    return reply.status(204).send();
   });
 
   /**

--- a/packages/web/src/api/onboarding.ts
+++ b/packages/web/src/api/onboarding.ts
@@ -1,0 +1,31 @@
+import type { OnboardingState } from "@agent-team-foundation/first-tree-hub-shared";
+import { api } from "./client.js";
+
+/**
+ * Persist the wizard checkpoint for the current member. Server validates
+ * the JSONB shape against `onboardingStateSchema`; bad input throws an
+ * `ApiError(400)`. The caller doesn't get a response body — `204 No
+ * Content` on success.
+ */
+export async function setOnboardingState(state: OnboardingState): Promise<void> {
+  await api.patch("/me/onboarding-state", state);
+}
+
+export type CreateAgentRequest = {
+  name: string;
+  displayName: string;
+  type: "autonomous_agent" | "personal_assistant";
+  /** Required so the new agent runs on the user's connected machine. */
+  clientId: string;
+};
+
+export type CreateAgentResponse = {
+  uuid: string;
+  name: string;
+  displayName: string;
+};
+
+/** Wraps `POST /admin/agents`. Wizard-side helper to keep the call site small. */
+export async function createWizardAgent(input: CreateAgentRequest): Promise<CreateAgentResponse> {
+  return api.post("/admin/agents/", input);
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -15,6 +15,7 @@ import { LoginPage } from "./pages/login.js";
 import { SettingsPage } from "./pages/settings.js";
 import { SetupPage } from "./pages/setup.js";
 import { SignupPage } from "./pages/signup.js";
+import { WelcomeAgentPage } from "./pages/welcome-agent.js";
 import { WelcomeConnectPage } from "./pages/welcome-connect.js";
 import { WorkspacePage } from "./pages/workspace/index.js";
 
@@ -54,6 +55,7 @@ export function App() {
                     column flow that the design doc spec'd as "screen
                     centre, no nav". */}
                 <Route path="welcome/connect" element={<WelcomeConnectPage />} />
+                <Route path="welcome/agent" element={<WelcomeAgentPage />} />
                 <Route
                   element={
                     <PulseProvider>

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -1,4 +1,4 @@
-import type { WorkspaceListItem } from "@agent-team-foundation/first-tree-hub-shared";
+import type { OnboardingState, WorkspaceListItem } from "@agent-team-foundation/first-tree-hub-shared";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import { login as loginApi } from "../api/auth.js";
 import { api, clearStoredTokens, getStoredTokens, setStoredTokens } from "../api/client.js";
@@ -6,7 +6,13 @@ import { listMyWorkspaces, switchOrganization as switchOrgApi } from "../api/wor
 
 type MeResponse = {
   user: { id: string } | null;
-  member: { id: string; role: string; agentId: string };
+  member: {
+    id: string;
+    role: string;
+    agentId: string;
+    onboardingState: OnboardingState | null;
+  };
+  wizard: { hasConnectedClientElsewhere: boolean };
 };
 
 type AuthContextValue = {
@@ -34,6 +40,21 @@ type AuthContextValue = {
    * falsely auto-advance.
    */
   userId: string | null;
+  /**
+   * Wizard checkpoint stored on `members.onboarding_state` for the
+   * current member. `null` either means this is a brand-new
+   * membership (wizard hasn't run yet) OR the token is rootless. The
+   * wizard pages use this together with `hasConnectedClientElsewhere`
+   * to pick the right step.
+   */
+  onboardingState: OnboardingState | null;
+  /**
+   * Cross-workspace skip signal (P0-5): the user has a connected client
+   * in some OTHER workspace, so the Connect screen for THIS workspace
+   * is redundant — they already proved the prerequisites work. The
+   * wizard auto-advances Step 1 when this is true.
+   */
+  hasConnectedClientElsewhere: boolean;
   /** Legacy username + password sign-in. Self-host path. */
   login: (username: string, password: string) => Promise<void>;
   /**
@@ -63,6 +84,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [memberId, setMemberId] = useState<string | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
+  const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
+  const [hasConnectedClientElsewhere, setHasConnectedClientElsewhere] = useState(false);
   const [organizationId, setOrganizationId] = useState<string | null>(null);
   const [workspaces, setWorkspaces] = useState<WorkspaceListItem[] | null>(null);
 
@@ -76,6 +99,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUserId(null);
     setOrganizationId(null);
     setWorkspaces(null);
+    setOnboardingState(null);
+    setHasConnectedClientElsewhere(false);
   }, []);
 
   /**
@@ -110,6 +135,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setMemberId(null);
       setAgentId(null);
       setUserId(null);
+      setOnboardingState(null);
+      setHasConnectedClientElsewhere(false);
       return;
     }
 
@@ -120,6 +147,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setMemberId(data.member.id);
       setAgentId(data.member.agentId);
       setUserId(data.user?.id ?? null);
+      setOnboardingState(data.member.onboardingState ?? null);
+      setHasConnectedClientElsewhere(data.wizard?.hasConnectedClientElsewhere ?? false);
     } catch {
       // /me failed despite memberships existing — leave member state null
       // and let the caller decide (typical case: token's organizationId
@@ -128,6 +157,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setRole(null);
       setMemberId(null);
       setUserId(null);
+      setOnboardingState(null);
+      setHasConnectedClientElsewhere(false);
       setAgentId(null);
     }
   }, []);
@@ -187,6 +218,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         agentId,
         organizationId,
         userId,
+        onboardingState,
+        hasConnectedClientElsewhere,
         login,
         signInWithTokens,
         switchWorkspace,

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -7,6 +7,7 @@ import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { NotificationBell } from "./notification-bell.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
+import { WorkspaceSwitcher } from "./workspace-switcher.js";
 
 const navTabs = [
   { to: "/", label: "Workspace", end: true, kbd: "⌘1" },
@@ -120,6 +121,15 @@ export function Layout() {
             <span>Jump to…</span>
             <span className="kbd">⌘K</span>
           </button>
+          <span
+            style={{
+              width: 1,
+              height: 18,
+              background: "var(--border)",
+              margin: "0 var(--sp-1)",
+            }}
+          />
+          <WorkspaceSwitcher />
           <span
             style={{
               width: 1,

--- a/packages/web/src/components/workspace-switcher.tsx
+++ b/packages/web/src/components/workspace-switcher.tsx
@@ -21,8 +21,9 @@ import { useAuth } from "../auth/auth-context.js";
  */
 export function WorkspaceSwitcher() {
   const navigate = useNavigate();
-  const { workspaces, organizationId, switchWorkspace } = useAuth();
+  const { workspaces, organizationId, switchWorkspace, refetchAll } = useAuth();
   const [open, setOpen] = useState(false);
+  const [switchError, setSwitchError] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
 
   // Close on outside click. Fires on every open-state mount; cleans up.
@@ -42,11 +43,7 @@ export function WorkspaceSwitcher() {
   // navigate to /setup directly.
   if (workspaces.length <= 1) {
     return (
-      <span
-        className="text-body"
-        style={{ color: "var(--fg-3)", padding: "var(--sp-1) var(--sp-2)" }}
-        aria-label="Workspace"
-      >
+      <span className="text-body" style={{ color: "var(--fg-3)", padding: "var(--sp-1) var(--sp-2)" }}>
         {current?.organizationDisplayName ?? "Workspace"}
       </span>
     );
@@ -76,6 +73,19 @@ export function WorkspaceSwitcher() {
           className="absolute right-0 z-10 mt-1 min-w-[14rem] rounded-md border border-border bg-card shadow-md"
           style={{ padding: "var(--sp-1)" }}
         >
+          {switchError && (
+            <div
+              role="alert"
+              className="rounded-md text-caption text-destructive"
+              style={{
+                padding: "var(--sp-1) var(--sp-2)",
+                marginBottom: "var(--sp-1)",
+                background: "color-mix(in srgb, var(--state-error) 12%, transparent)",
+              }}
+            >
+              {switchError}
+            </div>
+          )}
           {workspaces.map((w) => (
             <button
               key={w.organizationId}
@@ -83,17 +93,26 @@ export function WorkspaceSwitcher() {
               role="option"
               aria-selected={w.organizationId === organizationId}
               onClick={async () => {
-                setOpen(false);
-                if (w.organizationId === organizationId) return;
+                if (w.organizationId === organizationId) {
+                  setOpen(false);
+                  return;
+                }
+                setSwitchError(null);
                 try {
                   await switchWorkspace(w.organizationId);
+                  setOpen(false);
                   // Drop the user back at the workspace root so any
                   // route param scoped to the previous org (e.g.
                   // /agents/:uuid) doesn't 404 in the new context.
                   navigate("/", { replace: true });
-                } catch {
-                  // Swallow — refetchAll will surface the failure via
-                  // its own error path; no extra UI here.
+                } catch (err) {
+                  // Surface inline rather than dropping the failure on
+                  // the floor — the caller may have lost membership in
+                  // the target workspace (403 from /auth/switch-org).
+                  // Force a workspaces refetch so the dropdown reflects
+                  // the post-failure list.
+                  setSwitchError(err instanceof Error ? err.message : "Could not switch workspace");
+                  void refetchAll();
                 }
               }}
               className="block w-full text-left text-body transition-colors hover:bg-[color:var(--bg-sunken)]"

--- a/packages/web/src/components/workspace-switcher.tsx
+++ b/packages/web/src/components/workspace-switcher.tsx
@@ -1,0 +1,134 @@
+import { ChevronDown, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { useAuth } from "../auth/auth-context.js";
+
+/**
+ * Top-bar dropdown for switching between workspaces (P1-9 in
+ * docs/saas-onboarding-journey.md §6.2). Shows the current workspace's
+ * display name; clicking opens the list. Selecting a different
+ * workspace calls `switchWorkspace` (re-issues a per-org JWT pair),
+ * then `refetchAll` brings the in-memory state in line.
+ *
+ * "Create another workspace" link routes to `/setup` — the same modal
+ * the brand-new SaaS user sees, just rendered for an existing per-org
+ * caller. After /setup completes the auth-context is in the new
+ * workspace's per-org context.
+ *
+ * Hidden for users with exactly one workspace — there's nothing to
+ * switch to, and the "Create another" affordance lives on /setup
+ * which they can reach via a direct URL.
+ */
+export function WorkspaceSwitcher() {
+  const navigate = useNavigate();
+  const { workspaces, organizationId, switchWorkspace } = useAuth();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click. Fires on every open-state mount; cleans up.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    return () => window.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  if (!workspaces || workspaces.length === 0) return null;
+  const current = workspaces.find((w) => w.organizationId === organizationId);
+  // Hide for the single-workspace case — no useful switch and no clutter
+  // in the top bar. Users who want to create a second workspace can
+  // navigate to /setup directly.
+  if (workspaces.length <= 1) {
+    return (
+      <span
+        className="text-body"
+        style={{ color: "var(--fg-3)", padding: "var(--sp-1) var(--sp-2)" }}
+        aria-label="Workspace"
+      >
+        {current?.organizationDisplayName ?? "Workspace"}
+      </span>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center transition-colors text-body"
+        style={{
+          gap: 6,
+          padding: "var(--sp-1) var(--sp-2)",
+          color: "var(--fg)",
+          borderRadius: "var(--radius-input)",
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span>{current?.organizationDisplayName ?? "Workspace"}</span>
+        <ChevronDown className="h-3 w-3" />
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 z-10 mt-1 min-w-[14rem] rounded-md border border-border bg-card shadow-md"
+          style={{ padding: "var(--sp-1)" }}
+        >
+          {workspaces.map((w) => (
+            <button
+              key={w.organizationId}
+              type="button"
+              role="option"
+              aria-selected={w.organizationId === organizationId}
+              onClick={async () => {
+                setOpen(false);
+                if (w.organizationId === organizationId) return;
+                try {
+                  await switchWorkspace(w.organizationId);
+                  // Drop the user back at the workspace root so any
+                  // route param scoped to the previous org (e.g.
+                  // /agents/:uuid) doesn't 404 in the new context.
+                  navigate("/", { replace: true });
+                } catch {
+                  // Swallow — refetchAll will surface the failure via
+                  // its own error path; no extra UI here.
+                }
+              }}
+              className="block w-full text-left text-body transition-colors hover:bg-[color:var(--bg-sunken)]"
+              style={{
+                padding: "var(--sp-1) var(--sp-2)",
+                borderRadius: "var(--radius-input)",
+                color: w.organizationId === organizationId ? "var(--fg-3)" : "var(--fg)",
+                cursor: w.organizationId === organizationId ? "default" : "pointer",
+              }}
+            >
+              {w.organizationDisplayName}
+              <span className="ml-2 text-caption" style={{ color: "var(--fg-3)" }}>
+                {w.organizationName}
+              </span>
+            </button>
+          ))}
+          <div style={{ borderTop: "var(--hairline) solid var(--border)", marginTop: "var(--sp-1)" }} />
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              navigate("/setup");
+            }}
+            className="flex w-full items-center gap-2 text-body transition-colors hover:bg-[color:var(--bg-sunken)]"
+            style={{
+              padding: "var(--sp-1) var(--sp-2)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg-3)",
+            }}
+          >
+            <Plus className="h-3 w-3" />
+            Create or join another workspace
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/welcome-agent.tsx
+++ b/packages/web/src/pages/welcome-agent.tsx
@@ -25,7 +25,7 @@ import { Label } from "../components/ui/label.js";
  */
 export function WelcomeAgentPage() {
   const navigate = useNavigate();
-  const { onboardingState, refetchAll } = useAuth();
+  const { onboardingState, refetchAll, userId } = useAuth();
   const [name, setName] = useState("my-agent");
   const [clientId, setClientId] = useState<string | null>(null);
   const [clientError, setClientError] = useState<string | null>(null);
@@ -36,12 +36,19 @@ export function WelcomeAgentPage() {
   // already guaranteed at least one exists; we re-fetch here rather
   // than threading the value through navigation state so a refresh
   // mid-wizard works.
+  //
+  // The `userId` filter is critical: `/clients/` returns the WHOLE org
+  // for an admin caller (workspace creators are auto-admin), so the
+  // first connected client could be a teammate's machine. Pinning the
+  // new agent there would silently corrupt `agents.client_id` and the
+  // agent would never run from the user's perspective. Same filter as
+  // the polling loop on /welcome/connect post-PR-#4 fix.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
         const list = await listMyClients();
-        const connected = list.find((c) => c.status === "connected");
+        const connected = list.find((c) => c.status === "connected" && c.userId === userId);
         if (cancelled) return;
         if (!connected) {
           setClientError("No connected machine found. Go back to step 1.");
@@ -55,7 +62,7 @@ export function WelcomeAgentPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [userId]);
 
   // If the wizard is already marked completed (e.g. user refreshed
   // /welcome/agent post-completion), bounce them out — replaying the

--- a/packages/web/src/pages/welcome-agent.tsx
+++ b/packages/web/src/pages/welcome-agent.tsx
@@ -1,0 +1,139 @@
+import { ONBOARDING_STEPS } from "@agent-team-foundation/first-tree-hub-shared";
+import { type FormEvent, useEffect, useState } from "react";
+import { Navigate, useNavigate } from "react-router";
+import { listMyClients } from "../api/clients.js";
+import { createWizardAgent, setOnboardingState } from "../api/onboarding.js";
+import { useAuth } from "../auth/auth-context.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
+
+/**
+ * `/welcome/agent` — second wizard screen per design doc §4.5.2.
+ *
+ * Single-field form: agent name. We pin the new agent to the user's
+ * first connected client (must exist by step 2 — the polling on
+ * `/welcome/connect` only advanced when one appeared) and default the
+ * type to `autonomous_agent`. PR #6 / a follow-up can surface
+ * type/visibility toggles; the wizard's job is to get the user from
+ * "0 agents" to "1 agent" with minimum friction.
+ *
+ * On success: PATCH `/me/onboarding-state` to `completed` then navigate
+ * to `/`. The state write blocks the navigate so the regular shell
+ * doesn't re-bounce the user back into the wizard via stale state.
+ */
+export function WelcomeAgentPage() {
+  const navigate = useNavigate();
+  const { onboardingState, refetchAll } = useAuth();
+  const [name, setName] = useState("my-agent");
+  const [clientId, setClientId] = useState<string | null>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Resolve the user's first connected client. The Connect screen
+  // already guaranteed at least one exists; we re-fetch here rather
+  // than threading the value through navigation state so a refresh
+  // mid-wizard works.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await listMyClients();
+        const connected = list.find((c) => c.status === "connected");
+        if (cancelled) return;
+        if (!connected) {
+          setClientError("No connected machine found. Go back to step 1.");
+          return;
+        }
+        setClientId(connected.id);
+      } catch (err) {
+        if (!cancelled) setClientError(err instanceof Error ? err.message : "Could not load clients");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // If the wizard is already marked completed (e.g. user refreshed
+  // /welcome/agent post-completion), bounce them out — replaying the
+  // wizard would create a duplicate agent.
+  if (onboardingState?.currentStep === ONBOARDING_STEPS.COMPLETED) {
+    return <Navigate to="/" replace />;
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!clientId) return;
+    setSubmitError(null);
+    setBusy(true);
+    try {
+      await createWizardAgent({
+        name,
+        displayName: name,
+        type: "autonomous_agent",
+        clientId,
+      });
+      await setOnboardingState({ currentStep: ONBOARDING_STEPS.COMPLETED });
+      // Refetch member context so the in-memory `onboardingState` matches
+      // the server before the next route transition runs its gate check.
+      await refetchAll();
+      navigate("/", { replace: true });
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Could not create agent");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle className="text-title">Create your first agent</CardTitle>
+          <CardDescription>
+            One agent per task. Pick a name (you can rename later); we'll spin it up on your connected machine.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {clientError ? (
+            <div className="space-y-3">
+              <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{clientError}</div>
+              <Button variant="outline" onClick={() => navigate("/welcome/connect", { replace: true })}>
+                Back to step 1
+              </Button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="agent-name">Agent name</Label>
+                <Input
+                  id="agent-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.toLowerCase())}
+                  placeholder="my-agent"
+                  pattern="^[a-z0-9][a-z0-9_-]{0,63}$"
+                  required
+                  autoFocus
+                />
+                <p className="text-caption text-muted-foreground">
+                  Lowercase letters, digits, hyphens. Must start with a letter or digit.
+                </p>
+              </div>
+              {submitError && (
+                <div className="rounded-md bg-destructive/10 p-2 text-body text-destructive">{submitError}</div>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button type="submit" disabled={busy || !clientId}>
+                  {busy ? "Creating…" : "Create agent"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/pages/welcome-connect.tsx
+++ b/packages/web/src/pages/welcome-connect.tsx
@@ -1,6 +1,8 @@
+import { ONBOARDING_STEPS } from "@agent-team-foundation/first-tree-hub-shared";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { type ConnectedClientSummary, generateConnectToken, listMyClients } from "../api/clients.js";
+import { setOnboardingState } from "../api/onboarding.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
@@ -22,10 +24,14 @@ import { StateDot } from "../components/ui/state-dot.js";
  *      command landed. When `clients.length > 0 && status=="connected"`
  *      we flip a checkmark and enable "Continue".
  *
- * "Continue" navigates to the workspace shell (`/`) until PR #5 wires
- * the second wizard screen at `/welcome/agent` and onboarding-state
- * persistence. Today an empty workspace lands the user on the same
- * shell as a fully-configured one.
+ * "Continue" persists the wizard checkpoint to `members.onboarding_state`
+ * (`{ currentStep: "create_agent" }`) and navigates to `/welcome/agent`
+ * — so a refresh on Step 2 doesn't fall back to Step 1 through the
+ * auth-context's null state.
+ *
+ * Cross-workspace skip (P0-5): when the user already has a connected
+ * client in some other workspace, Step 1 is redundant; we write the
+ * `create_agent` checkpoint server-side and bounce to Step 2 on mount.
  */
 const POLL_INTERVAL_MS = 3000;
 /**
@@ -39,12 +45,41 @@ const STALE_BANNER_MS = 60_000;
 
 export function WelcomeConnectPage() {
   const navigate = useNavigate();
-  const { userId } = useAuth();
+  const { userId, onboardingState, hasConnectedClientElsewhere, refetchAll } = useAuth();
   const [tokenResp, setTokenResp] = useState<{ token: string; command: string } | null>(null);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [tokenBusy, setTokenBusy] = useState(false);
   const [clients, setClients] = useState<ConnectedClientSummary[] | null>(null);
   const [stale, setStale] = useState(false);
+
+  // P0-5: cross-workspace skip. The user already connected a machine
+  // for some other workspace they belong to — the prerequisites are
+  // proven, so we shouldn't make them re-walk Step 1. Persist the
+  // skip as an onboarding-state checkpoint so a refresh on this page
+  // doesn't bounce them back here, then advance to Step 2. The bounce
+  // happens AFTER auth-context loads (`onboardingState` is null while
+  // tokens are valid but /me hasn't returned yet).
+  const shouldSkipConnect = onboardingState === null && hasConnectedClientElsewhere;
+  useEffect(() => {
+    if (!shouldSkipConnect) return;
+    void (async () => {
+      try {
+        await setOnboardingState({ currentStep: ONBOARDING_STEPS.CREATE_AGENT });
+        await refetchAll();
+      } catch {
+        // Best-effort — if the write fails the user lands on Step 1
+        // anyway, which is correct fallback behavior.
+      }
+    })();
+  }, [shouldSkipConnect, refetchAll]);
+
+  // Honour the stored checkpoint regardless of polling state.
+  if (onboardingState?.currentStep === ONBOARDING_STEPS.COMPLETED) {
+    return <Navigate to="/" replace />;
+  }
+  if (onboardingState?.currentStep === ONBOARDING_STEPS.CREATE_AGENT) {
+    return <Navigate to="/welcome/agent" replace />;
+  }
 
   // Mint the first connect token on mount. The token expires in 10
   // minutes (CONNECT_TOKEN_EXPIRY in services/auth.ts) — if the user
@@ -154,7 +189,22 @@ export function WelcomeConnectPage() {
           />
           <ConnectionStatusSection connected={connected} />
           <div className="flex justify-end">
-            <Button disabled={!connected} onClick={() => navigate("/", { replace: true })}>
+            <Button
+              disabled={!connected}
+              onClick={async () => {
+                // Persist the checkpoint before navigating so a refresh
+                // on /welcome/agent doesn't fall back to /welcome/connect
+                // through the auth-context's null `onboardingState`.
+                try {
+                  await setOnboardingState({ currentStep: ONBOARDING_STEPS.CREATE_AGENT });
+                  await refetchAll();
+                } catch {
+                  // Best-effort — agent page also writes its own
+                  // checkpoint after a successful create.
+                }
+                navigate("/welcome/agent", { replace: true });
+              }}
+            >
               Continue
             </Button>
           </div>

--- a/packages/web/src/pages/welcome-connect.tsx
+++ b/packages/web/src/pages/welcome-connect.tsx
@@ -73,14 +73,6 @@ export function WelcomeConnectPage() {
     })();
   }, [shouldSkipConnect, refetchAll]);
 
-  // Honour the stored checkpoint regardless of polling state.
-  if (onboardingState?.currentStep === ONBOARDING_STEPS.COMPLETED) {
-    return <Navigate to="/" replace />;
-  }
-  if (onboardingState?.currentStep === ONBOARDING_STEPS.CREATE_AGENT) {
-    return <Navigate to="/welcome/agent" replace />;
-  }
-
   // Mint the first connect token on mount. The token expires in 10
   // minutes (CONNECT_TOKEN_EXPIRY in services/auth.ts) — if the user
   // dawdles past that, the command will 401; we surface a "Generate
@@ -158,6 +150,17 @@ export function WelcomeConnectPage() {
   useEffect(() => {
     if (connected && stale) setStale(false);
   }, [connected, stale]);
+
+  // Honour the stored checkpoint regardless of polling state. Placed AFTER
+  // all hook calls — the rules-of-hooks linter requires conditional
+  // returns to live below the top-level useState/useEffect sequence so
+  // call order stays stable across renders.
+  if (onboardingState?.currentStep === ONBOARDING_STEPS.COMPLETED) {
+    return <Navigate to="/" replace />;
+  }
+  if (onboardingState?.currentStep === ONBOARDING_STEPS.CREATE_AGENT) {
+    return <Navigate to="/welcome/agent" replace />;
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">


### PR DESCRIPTION
## Summary

Fifth slice of the SaaS onboarding work (M4 + M5 + M7 of [`docs/saas-onboarding-journey.md`](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/saas-onboarding/docs/saas-onboarding-journey.md)). Builds on **PR #181**.

> **Stack on top of #181** — base is `feat/saas-onboarding-wizard-connect`. After #181 merges, retarget to `main`.

### What's added

**Server**
- `GET /me` extended with `member.onboardingState` (the JSONB checkpoint from `members.onboarding_state`) and `wizard.hasConnectedClientElsewhere` (cross-workspace skip signal for P0-5). The "elsewhere" flag explicitly excludes the current workspace so the local Connect screen's polling stays canonical.
- `PATCH /me/onboarding-state` — writes the checkpoint, body validated against `onboardingStateSchema`. Self-service only — caller's own member row.

**Web — `/welcome/agent`** (wizard step 2 per design doc §4.5.2)
- Single-field form (agent name). Pins to the user's first connected client (filtered by `userId` so an admin doesn't accidentally pin to a teammate's machine), defaults to `autonomous_agent`. On success: PATCH `onboarding-state` to `completed`, refetch /me, navigate to `/`. Refresh-mid-wizard handled via stored state.

**Web — `/welcome/connect` updates**
- Cross-workspace skip on mount: when `hasConnectedClientElsewhere && state==null`, write `create_agent` checkpoint and bounce to step 2.
- "Continue" persists `create_agent` before navigating so a refresh on step 2 doesn't fall back through null state.
- Honour stored checkpoint regardless of polling state — `completed` → `/`, `create_agent` → `/welcome/agent`.

**Web — workspace switcher** (M7 P1-9)
- New `WorkspaceSwitcher` in `Layout`. Shows current workspace; expands to a list when the user belongs to >1. Selecting another workspace calls `switchWorkspace` (re-issues per-org JWT) and navigates to `/` so deep-link route params don't 404 in the new context. Single-workspace users see a static label, no clutter.
- "Create or join another workspace" shortcut routes to `/setup`.
- Surfaces switch-org failures inline so a 403 (e.g. user removed from the target workspace) doesn't disappear silently.

### Auth context

Adds `onboardingState` and `hasConnectedClientElsewhere`, refreshed together via the existing `refetchAll`. New API helpers `setOnboardingState` (PATCH) and `createWizardAgent` (POST `/admin/agents`).

### Versioning

`packages/command` 0.10.4 → 0.10.5 (per CLAUDE.md).

### Test plan

- [x] 485/485 server tests passing (4 new — `wizard-onboarding-state.test.ts` covers null/written/invalid + cross-workspace flag)
- [x] 45/45 web tests passing
- [x] `pnpm typecheck` + `pnpm check` clean
- [x] Manual: full onboarding flow (sign-in → /setup create → /welcome/connect → connect via CLI → /welcome/agent → create → /); cross-workspace skip exercised by manually flipping `hasConnectedClientElsewhere` via DB seed
- [x] Pre-push code review — 1 HIGH (agent screen pinning to peer's client), 1 MEDIUM (silent switcher failure), and a hook-order regression all addressed

### Known follow-ups (deferred)

- Workspace switcher a11y (arrow keys, `aria-activedescendant`, Esc-to-close) — flagged for follow-up.
- Empty-workspace spinner-then-empty (P1-10) — `WorkspacePage` already has an empty-state; the wizard PR doesn't add the spinner stage. Low priority.
- Reuse of the existing `NewAgentDialog` (per design doc M4) — wizard uses a deliberately narrower single-field form; calling that an intentional deviation from the doc.

### Out of scope (deferred)

- `/admin` invite-link surfacing — PR #6
- ToS / mobile banner / Privacy / CLI upgrade hint — PR #6

https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV)_