### PR TITLE
feat(saas): admin invite link + ToS/Privacy + mobile banner + CLI drift hint

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -260,6 +260,14 @@ export function registerConnectCommand(parent: Command): void {
       try {
         const url = serverUrl.replace(/\/+$/, "");
 
+        // 0. Pre-auth version-drift hint. Run BEFORE auth + creds + service
+        // install so a "your CLI is too old" warning surfaces while the
+        // user can still abort cleanly. /health is unauthenticated, so
+        // moving the check up costs nothing. Network failures stay
+        // silent — the connect itself can still succeed against a
+        // healthy hub even if /health timed out.
+        await warnIfCliBehind(url);
+
         // 1. Pre-auth account-switch gate (token path).
         //
         // Connect tokens are single-use. If we authed first and the user
@@ -306,15 +314,6 @@ export function registerConnectCommand(parent: Command): void {
 
         saveCredentials({ ...tokens, serverUrl: url });
         print.line("  \u2713 Authenticated\n");
-
-        // 4b. Version-drift hint. The runtime UpdateManager handles this
-        // for `client start`, but `connect` is a one-shot \u2014 no welcome
-        // frame, no manager. Best-effort GET /health surfaces the
-        // server's commandVersion so we can warn before the user goes
-        // off and runs an outdated CLI for the next week. Network
-        // failures are silent \u2014 the connect already succeeded in step
-        // 2 so a /health hiccup is operator noise, not user-actionable.
-        await warnIfCliBehind(url);
 
         // Touch config + client.id so the background service picks up the
         // persisted clientId on its first launch (see #99).

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -196,6 +196,60 @@ async function authenticateInteractive(url: string): Promise<{ accessToken: stri
   return (await loginRes.json()) as { accessToken: string; refreshToken: string };
 }
 
+/**
+ * One-shot version drift hint for the SaaS onboarding flow. We compare
+ * the CLI's bundled `COMMAND_VERSION` against `commandVersion` returned
+ * by `GET /health`. Older local CLI → emit a warning telling the user
+ * how to upgrade. Same-version or newer → silent. Network failures →
+ * silent (the connect itself already succeeded; a /health hiccup
+ * isn't user-actionable here).
+ *
+ * The runtime path uses `client/src/runtime/update-manager.ts` instead
+ * (driven by the `server:welcome` WS frame on long-running `client
+ * start`); this is the gap-filler for one-shot subcommands.
+ */
+async function warnIfCliBehind(serverUrl: string): Promise<void> {
+  try {
+    const res = await fetch(`${serverUrl}/api/v1/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as { commandVersion?: string };
+    const serverVersion = body.commandVersion;
+    if (!serverVersion || serverVersion === COMMAND_VERSION) return;
+    if (semverCompare(serverVersion, COMMAND_VERSION) <= 0) return;
+    print.line(
+      `\n  ⚠ Your CLI is ${COMMAND_VERSION}; the server is on ${serverVersion}.\n` +
+        `    Upgrade with: npm install -g @agent-team-foundation/first-tree-hub@latest\n\n`,
+    );
+  } catch {
+    // Silent — see doc-comment.
+  }
+}
+
+/**
+ * Lightweight `a > b` compare without dragging in semver — `connect.ts`
+ * deliberately stays dep-free. Returns negative when `a < b`, 0 when
+ * equal, positive when `a > b`. Treats anything beyond major.minor.patch
+ * (pre-release tags) as "equal-ish" — good enough for the warn path.
+ */
+function semverCompare(a: string, b: string): number {
+  const partsA = a
+    .split(/[.-]/)
+    .slice(0, 3)
+    .map((s) => Number.parseInt(s, 10) || 0);
+  const partsB = b
+    .split(/[.-]/)
+    .slice(0, 3)
+    .map((s) => Number.parseInt(s, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const ai = partsA[i] ?? 0;
+    const bi = partsB[i] ?? 0;
+    if (ai !== bi) return ai - bi;
+  }
+  return 0;
+}
+
 export function registerConnectCommand(parent: Command): void {
   parent
     .command("connect <server-url>")
@@ -252,6 +306,15 @@ export function registerConnectCommand(parent: Command): void {
 
         saveCredentials({ ...tokens, serverUrl: url });
         print.line("  \u2713 Authenticated\n");
+
+        // 4b. Version-drift hint. The runtime UpdateManager handles this
+        // for `client start`, but `connect` is a one-shot \u2014 no welcome
+        // frame, no manager. Best-effort GET /health surfaces the
+        // server's commandVersion so we can warn before the user goes
+        // off and runs an outdated CLI for the next week. Network
+        // failures are silent \u2014 the connect already succeeded in step
+        // 2 so a /health hiccup is operator noise, not user-actionable.
+        await warnIfCliBehind(url);
 
         // Touch config + client.id so the background service picks up the
         // persisted clientId on its first launch (see #99).

--- a/packages/server/src/__tests__/admin-invite-link.test.ts
+++ b/packages/server/src/__tests__/admin-invite-link.test.ts
@@ -1,0 +1,129 @@
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signOauthState } from "../services/auth-github.js";
+import { createTestApp } from "./helpers.js";
+
+/**
+ * Server contract for the /admin invite-link panel surface (M6 / P0-2):
+ * `/me` returns `workspace.inviteUrl` for admins, `null` for members.
+ * The link itself uses `server.publicUrl` when configured (proxy-safe)
+ * and falls back to the request's host header otherwise.
+ */
+describe("Admin invite link — surfaced via /me workspace.inviteUrl", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  async function devSignIn(opts: { githubId: string; login: string }) {
+    const { state } = await signOauthState(app.config.secrets.jwtSecret, "/");
+    const params = new URLSearchParams({
+      state,
+      login: opts.login,
+      github_id: opts.githubId,
+      email: `${opts.login}@example.local`,
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?${params.toString()}`,
+    });
+    if (res.statusCode !== 302) throw new Error(`dev sign-in failed: ${res.body}`);
+    const loc = res.headers.location ?? "";
+    const fragment = new URLSearchParams(loc.slice(loc.indexOf("#") + 1));
+    return { accessToken: fragment.get("access") ?? "" };
+  }
+
+  it("admin sees the workspace invite URL; members see null", async () => {
+    // Admin path: workspace creator is auto-admin.
+    const id = `${Date.now()}il1`;
+    const adminSignIn = await devSignIn({ githubId: id, login: `admin-${id}` });
+    const ws = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/workspaces/",
+      headers: { authorization: `Bearer ${adminSignIn.accessToken}` },
+      payload: { name: `il-${id}`, displayName: `IL ${id}` },
+    });
+    const adminWs = ws.json<{ accessToken: string; workspace: { organizationId: string } }>();
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${adminWs.accessToken}` },
+    });
+    const body = me.json<{ workspace: { inviteUrl: string | null } | null }>();
+    expect(body.workspace).not.toBeNull();
+    expect(body.workspace?.inviteUrl).toMatch(/\/invite\/[A-Za-z0-9_-]+$/);
+
+    // Member path: read the org's invite_token off the DB so the joiner
+    // can use it, then verify the joiner's /me hides the URL.
+    const { organizations } = await import("../db/schema/organizations.js");
+    const { eq } = await import("drizzle-orm");
+    const [org] = await app.db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, adminWs.workspace.organizationId))
+      .limit(1);
+    const token = org?.inviteToken ?? "";
+
+    const memberId = `${Date.now()}il2`;
+    const memberSignIn = await devSignIn({ githubId: memberId, login: `mem-${memberId}` });
+    const join = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/workspaces/join",
+      headers: { authorization: `Bearer ${memberSignIn.accessToken}` },
+      payload: { tokenOrUrl: token },
+    });
+    const memberWs = join.json<{ accessToken: string }>();
+
+    const memberMe = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${memberWs.accessToken}` },
+    });
+    const memberBody = memberMe.json<{ workspace: { inviteUrl: string | null } | null }>();
+    expect(memberBody.workspace).not.toBeNull();
+    // Critical: members must NOT see the invite URL — they could re-share
+    // it without admin oversight, and v1 has no per-link revocation.
+    expect(memberBody.workspace?.inviteUrl).toBeNull();
+  });
+
+  it("admin invite URL uses server.publicUrl when configured (proxy-safe)", async () => {
+    const original = app.config.server.publicUrl;
+    (app.config.server as { publicUrl?: string }).publicUrl = "https://hub.example.com";
+    try {
+      const id = `${Date.now()}il3`;
+      const signIn = await devSignIn({ githubId: id, login: `il3-${id}` });
+      const ws = await app.inject({
+        method: "POST",
+        url: "/api/v1/me/workspaces/",
+        headers: { authorization: `Bearer ${signIn.accessToken}` },
+        payload: { name: `il3-${id}`, displayName: `IL3 ${id}` },
+      });
+      const adminWs = ws.json<{ accessToken: string }>();
+      const me = await app.inject({
+        method: "GET",
+        url: "/api/v1/me",
+        headers: { authorization: `Bearer ${adminWs.accessToken}` },
+      });
+      const body = me.json<{ workspace: { inviteUrl: string | null } | null }>();
+      expect(body.workspace?.inviteUrl).toMatch(/^https:\/\/hub\.example\.com\/invite\//);
+      expect(body.workspace?.inviteUrl).not.toContain("127.0.0.1");
+    } finally {
+      (app.config.server as { publicUrl?: string }).publicUrl = original;
+    }
+  });
+
+  it("/health exposes commandVersion so `client connect` can warn on drift", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/v1/health" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ status: string; commandVersion: string }>();
+    expect(body.status).toBe("ok");
+    expect(body.commandVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/server/src/__tests__/health.test.ts
+++ b/packages/server/src/__tests__/health.test.ts
@@ -8,6 +8,11 @@ describe("GET /api/v1/health", () => {
     const app = getApp();
     const res = await app.inject({ method: "GET", url: "/api/v1/health" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: "ok", db: "connected" });
+    // `commandVersion` is part of the response since the SaaS-onboarding
+    // CLI-drift check (`first-tree-hub client connect`) reads it to warn
+    // the user when the local CLI is older than the server. See
+    // packages/command/src/commands/connect.ts::warnIfCliBehind.
+    expect(res.json()).toMatchObject({ status: "ok", db: "connected" });
+    expect((res.json() as { commandVersion: string }).commandVersion).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/packages/server/src/__tests__/saas-onboarding-auth.test.ts
+++ b/packages/server/src/__tests__/saas-onboarding-auth.test.ts
@@ -379,9 +379,11 @@ describe("SaaS auth — GitHub OAuth + workspaces + switch-org (dev mode)", () =
     const location = start.headers.location ?? "";
     expect(location).toContain("/api/v1/auth/github/dev-callback");
     expect(location).not.toContain("evil.com");
-    // The state JWT carries the (sanitized) `next` — decode the redirect
-    // URL and confirm the embedded next is "/".
-    const stateParam = new URL(location).searchParams.get("state") ?? "";
+    // The state JWT carries the (sanitized) `next` — pluck it out via a
+    // base-anchored URL parse since the redirect Location is relative
+    // (keeps the SPA on the originating host through Vite proxies in
+    // dev). The base host is irrelevant — we only inspect query params.
+    const stateParam = new URL(location, "http://example").searchParams.get("state") ?? "";
     expect(stateParam.length).toBeGreaterThan(20);
   });
 

--- a/packages/server/src/api/auth-github.ts
+++ b/packages/server/src/api/auth-github.ts
@@ -99,8 +99,12 @@ export async function authGithubRoutes(app: FastifyInstance): Promise<void> {
         email: query.dev_email ?? "devuser@example.local",
         display_name: query.dev_login ?? "Dev User",
       });
-      const url = `${origin.proto}://${origin.host}/api/v1/auth/github/dev-callback?${params.toString()}`;
-      return reply.redirect(url, 302);
+      // Relative redirect — keeps the browser on the originating host so a
+      // Vite-proxied dev setup (frontend on :5173 → backend on :8000) works
+      // without needing a manual `FIRST_TREE_HUB_PUBLIC_URL` override. The
+      // production /callback path uses an absolute URL because GitHub
+      // bounces the browser there with the host in the redirect_uri.
+      return reply.redirect(`/api/v1/auth/github/dev-callback?${params.toString()}`, 302);
     }
 
     const redirectUri = resolveRedirectUri(oauth.redirectUri, origin);

--- a/packages/server/src/api/health.ts
+++ b/packages/server/src/api/health.ts
@@ -5,9 +5,16 @@ export async function healthRoutes(app: FastifyInstance): Promise<void> {
   app.get("/health", async () => {
     try {
       await app.db.execute(sql`SELECT 1`);
-      return { status: "ok", db: "connected" };
+      // `commandVersion` is the version of the `command` package that
+      // bundled this server. The CLI's `client connect` reads it on
+      // first contact so it can warn (M8 P2 in
+      // docs/saas-onboarding-journey.md) when the locally-installed
+      // CLI is older than what the server expects — the WS-driven
+      // UpdateManager only kicks in for the long-running `client
+      // start` runtime, not for one-shot subcommands like `connect`.
+      return { status: "ok", db: "connected", commandVersion: app.commandVersion };
     } catch {
-      return { status: "degraded", db: "disconnected" };
+      return { status: "degraded", db: "disconnected", commandVersion: app.commandVersion };
     }
   });
 }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from "fastify";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { requireMember } from "../middleware/require-identity.js";
 import * as authService from "../services/auth.js";
@@ -65,6 +66,34 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       );
     const hasConnectedClientElsewhere = (elsewhere[0]?.count ?? 0) > 0;
 
+    // Workspace info — display name + (admin-only) invite URL. The
+    // share link is admin-only because v1 doesn't support per-link
+    // revocation; surfacing it to a member would let them re-share
+    // it without admin oversight, exactly the leak vector the design
+    // doc §2.3 calls out.
+    const [orgRow] = await app.db
+      .select({
+        name: organizations.name,
+        displayName: organizations.displayName,
+        inviteToken: organizations.inviteToken,
+      })
+      .from(organizations)
+      .where(eq(organizations.id, m.organizationId))
+      .limit(1);
+    let inviteUrl: string | null = null;
+    if (m.role === "admin" && orgRow?.inviteToken) {
+      const configuredUrl = app.config.server.publicUrl;
+      let base: string;
+      if (configuredUrl) {
+        base = configuredUrl.replace(/\/+$/, "");
+      } else {
+        const proto = request.headers["x-forwarded-proto"] ?? request.protocol;
+        const host = request.headers["x-forwarded-host"] ?? request.headers.host ?? request.hostname;
+        base = `${proto}://${host}`;
+      }
+      inviteUrl = `${base}/invite/${orgRow.inviteToken}`;
+    }
+
     return {
       user: user ?? null,
       member: {
@@ -75,6 +104,15 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
         onboardingState: memberRow?.onboardingState ?? null,
       },
       agent: agent ?? null,
+      workspace: orgRow
+        ? {
+            id: m.organizationId,
+            name: orgRow.name,
+            displayName: orgRow.displayName,
+            /** Public invite URL. Admin-only; null for non-admin callers. */
+            inviteUrl,
+          }
+        : null,
       wizard: {
         hasConnectedClientElsewhere,
       },

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -11,6 +11,7 @@ import { AgentsPage } from "./pages/agents.js";
 import { AuthCallbackPage } from "./pages/auth-callback.js";
 import { ClientsPage } from "./pages/clients.js";
 import { InvitePage } from "./pages/invite.js";
+import { PrivacyPage, TermsPage } from "./pages/legal.js";
 import { LoginPage } from "./pages/login.js";
 import { SettingsPage } from "./pages/settings.js";
 import { SetupPage } from "./pages/setup.js";
@@ -41,6 +42,8 @@ export function App() {
             <Route path="/signup" element={<SignupPage />} />
             <Route path="/auth/github/complete" element={<AuthCallbackPage />} />
             <Route path="/invite/:token" element={<InvitePage />} />
+            <Route path="/terms" element={<TermsPage />} />
+            <Route path="/privacy" element={<PrivacyPage />} />
 
             {/* Authenticated but workspace-less surface: lets a freshly
                 OAuthed user create or join a workspace. RequireAuth

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -12,6 +12,12 @@ type MeResponse = {
     agentId: string;
     onboardingState: OnboardingState | null;
   };
+  workspace: {
+    id: string;
+    name: string;
+    displayName: string;
+    inviteUrl: string | null;
+  } | null;
   wizard: { hasConnectedClientElsewhere: boolean };
 };
 
@@ -55,6 +61,13 @@ type AuthContextValue = {
    * wizard auto-advances Step 1 when this is true.
    */
   hasConnectedClientElsewhere: boolean;
+  /**
+   * Public invite URL for the current workspace. Server returns it only
+   * when the caller is an admin (members can't surface a re-shareable
+   * link without admin oversight; v1 has no per-link revocation).
+   * `null` for non-admin callers and for rootless tokens.
+   */
+  inviteUrl: string | null;
   /** Legacy username + password sign-in. Self-host path. */
   login: (username: string, password: string) => Promise<void>;
   /**
@@ -86,6 +99,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [userId, setUserId] = useState<string | null>(null);
   const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
   const [hasConnectedClientElsewhere, setHasConnectedClientElsewhere] = useState(false);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
   const [organizationId, setOrganizationId] = useState<string | null>(null);
   const [workspaces, setWorkspaces] = useState<WorkspaceListItem[] | null>(null);
 
@@ -101,6 +115,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setWorkspaces(null);
     setOnboardingState(null);
     setHasConnectedClientElsewhere(false);
+    setInviteUrl(null);
   }, []);
 
   /**
@@ -137,6 +152,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUserId(null);
       setOnboardingState(null);
       setHasConnectedClientElsewhere(false);
+      setInviteUrl(null);
       return;
     }
 
@@ -149,6 +165,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUserId(data.user?.id ?? null);
       setOnboardingState(data.member.onboardingState ?? null);
       setHasConnectedClientElsewhere(data.wizard?.hasConnectedClientElsewhere ?? false);
+      setInviteUrl(data.workspace?.inviteUrl ?? null);
     } catch {
       // /me failed despite memberships existing — leave member state null
       // and let the caller decide (typical case: token's organizationId
@@ -159,6 +176,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUserId(null);
       setOnboardingState(null);
       setHasConnectedClientElsewhere(false);
+      setInviteUrl(null);
       setAgentId(null);
     }
   }, []);
@@ -220,6 +238,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         userId,
         onboardingState,
         hasConnectedClientElsewhere,
+        inviteUrl,
         login,
         signInWithTokens,
         switchWorkspace,

--- a/packages/web/src/components/mobile-banner.tsx
+++ b/packages/web/src/components/mobile-banner.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "first-tree-hub:mobile-banner-dismissed";
+const MOBILE_MAX_WIDTH_PX = 768;
+
+/**
+ * Top banner that fires on phone-sized viewports — M8 P2 in
+ * docs/saas-onboarding-journey.md. First Tree Hub's wizard requires
+ * pasting a CLI command into a real terminal; we don't try to make
+ * that work on a phone. The banner just sets expectations: "switch
+ * to a desktop browser to finish setup."
+ *
+ * Dismiss is sticky via localStorage so the banner doesn't pop back
+ * up on every navigation. Re-renders cheap; the effect runs once
+ * on mount to read the storage value.
+ */
+export function MobileBanner() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const dismissed = window.localStorage.getItem(STORAGE_KEY) === "1";
+    const isMobile = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH_PX}px)`).matches;
+    setShow(!dismissed && isMobile);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed inset-x-0 top-0 z-50 flex items-start justify-between gap-2 border-b border-border bg-card text-body"
+      style={{ padding: "var(--sp-2) var(--sp-3)" }}
+    >
+      <div>
+        <strong>Best on desktop.</strong> First Tree Hub's setup wizard needs a terminal — switch to a laptop browser to
+        connect your machine.
+      </div>
+      <button
+        type="button"
+        className="text-caption underline"
+        style={{ color: "var(--fg-3)" }}
+        onClick={() => {
+          window.localStorage.setItem(STORAGE_KEY, "1");
+          setShow(false);
+        }}
+        aria-label="Dismiss mobile banner"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/mobile-banner.tsx
+++ b/packages/web/src/components/mobile-banner.tsx
@@ -17,11 +17,24 @@ const MOBILE_MAX_WIDTH_PX = 768;
 export function MobileBanner() {
   const [show, setShow] = useState(false);
 
+  // Subscribe to viewport changes (resize, orientation flip) so the
+  // banner appears / disappears as the user crosses the mobile-width
+  // threshold within a session. A one-shot `matches` read on mount
+  // would freeze the banner state to the initial viewport, which
+  // means a tablet rotated landscape would still see it and a
+  // resized desktop window would never catch it.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const dismissed = window.localStorage.getItem(STORAGE_KEY) === "1";
-    const isMobile = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH_PX}px)`).matches;
-    setShow(!dismissed && isMobile);
+    if (dismissed) {
+      setShow(false);
+      return;
+    }
+    const mql = window.matchMedia(`(max-width: ${MOBILE_MAX_WIDTH_PX}px)`);
+    const apply = () => setShow(mql.matches);
+    apply();
+    mql.addEventListener("change", apply);
+    return () => mql.removeEventListener("change", apply);
   }, []);
 
   if (!show) return null;

--- a/packages/web/src/pages/admin/invite-link-panel.tsx
+++ b/packages/web/src/pages/admin/invite-link-panel.tsx
@@ -1,0 +1,59 @@
+import { Copy } from "lucide-react";
+import { useState } from "react";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { Panel } from "../../components/ui/panel.js";
+import { SectionHeader } from "../../components/ui/section-header.js";
+
+/**
+ * `/admin` Members tab — workspace public share link (M6 / P0-2 in
+ * docs/saas-onboarding-journey.md). Shown only to admin callers; the
+ * server's `/me` route already gates the field, so a non-admin will
+ * see `inviteUrl === null` here and the panel is omitted.
+ *
+ * v1 has no per-link revocation: a leaked link can only be invalidated
+ * by deleting the workspace. The copy text says so explicitly so an
+ * admin doesn't paste it into a public Slack channel without knowing
+ * the trade-off. Token rotation is the design doc's deferred v2 work.
+ */
+export function InviteLinkPanel() {
+  const { inviteUrl } = useAuth();
+  const [copied, setCopied] = useState(false);
+
+  if (!inviteUrl) return null;
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API blocked (insecure context, missing permission) —
+      // user can still select and copy the visible value below.
+    }
+  };
+
+  return (
+    <Panel>
+      <SectionHeader>Workspace invite link</SectionHeader>
+      <div className="space-y-2" style={{ padding: "var(--sp-2)" }}>
+        <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+          Anyone with this link can sign in via GitHub and join this workspace as a member. Treat it like a password —
+          v1 doesn't support rotating it; share it through a private channel.
+        </p>
+        <div
+          className="flex items-center gap-2 rounded-md border border-border"
+          style={{ padding: "var(--sp-1) var(--sp-2)", background: "var(--bg-sunken)" }}
+        >
+          <code className="flex-1 truncate text-caption font-mono" style={{ color: "var(--fg)" }}>
+            {inviteUrl}
+          </code>
+          <Button type="button" variant="outline" size="sm" onClick={onCopy}>
+            <Copy className="h-3 w-3" />
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/packages/web/src/pages/legal.tsx
+++ b/packages/web/src/pages/legal.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+
+/**
+ * Placeholder Terms of Service / Privacy pages — M8 P2 in
+ * docs/saas-onboarding-journey.md. The legal text isn't drafted yet;
+ * the routes exist so /signup's footer links don't 404 and the SaaS
+ * landing page reads as a real product instead of an unfinished SPA.
+ *
+ * Both pages share the same shell: card with a title, a one-paragraph
+ * placeholder body, and a back link. Drafting the actual policies is
+ * a non-engineering task tracked separately.
+ */
+
+export function TermsPage() {
+  return (
+    <LegalShell
+      title="Terms of Service"
+      body="Final terms are still being drafted. Until they're posted here, your use of First Tree Hub is governed by your usage agreement with the workspace administrator who invited you (path B) or by the standard Anthropic API usage terms for the underlying Claude API calls (path A)."
+    />
+  );
+}
+
+export function PrivacyPage() {
+  return (
+    <LegalShell
+      title="Privacy"
+      body="Final privacy notice is still being drafted. In the meantime: First Tree Hub stores your GitHub identity (numeric ID + login + primary email), your workspace memberships, and metadata about agent runs (no transcript content). All agent execution happens on your own machine via the agent CLI; no run output is uploaded to the hub. Email is contact-only — we do not use it for ads, marketing, or sale to third parties."
+    />
+  );
+}
+
+function LegalShell({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle className="text-title">{title}</CardTitle>
+          <CardDescription>Placeholder while final wording is reviewed.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-body" style={{ color: "var(--fg)" }}>
+            {body}
+          </p>
+          <p className="text-caption">
+            <Link to="/signup" className="underline">
+              Back to sign in
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/pages/members.tsx
+++ b/packages/web/src/pages/members.tsx
@@ -27,6 +27,7 @@ import { Label } from "../components/ui/label.js";
 import { Panel } from "../components/ui/panel.js";
 import { SectionHeader, UppercaseLabel } from "../components/ui/section-header.js";
 import { formatDate } from "../lib/utils.js";
+import { InviteLinkPanel } from "./admin/invite-link-panel.js";
 
 const roleValues = Object.values(MEMBER_ROLES);
 
@@ -102,6 +103,7 @@ export function MembersPage() {
 
   return (
     <>
+      <InviteLinkPanel />
       <Panel>
         <SectionHeader
           right={

--- a/packages/web/src/pages/signup.tsx
+++ b/packages/web/src/pages/signup.tsx
@@ -1,5 +1,6 @@
-import { Navigate, useSearchParams } from "react-router";
+import { Link, Navigate, useSearchParams } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
+import { MobileBanner } from "../components/mobile-banner.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
 
@@ -39,6 +40,7 @@ export function SignupPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background">
+      <MobileBanner />
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-title">First Tree Hub</CardTitle>
@@ -54,7 +56,15 @@ export function SignupPage() {
             <a href={startUrl}>Continue with GitHub</a>
           </Button>
           <p className="text-caption text-muted-foreground text-center">
-            By continuing, you agree to our terms — privacy and tos pages coming soon.
+            By continuing, you agree to our{" "}
+            <Link to="/terms" className="underline">
+              Terms
+            </Link>
+            {" and "}
+            <Link to="/privacy" className="underline">
+              Privacy
+            </Link>{" "}
+            policies.
           </p>
         </CardContent>
       </Card>

--- a/packages/web/src/pages/welcome-connect.tsx
+++ b/packages/web/src/pages/welcome-connect.tsx
@@ -4,6 +4,7 @@ import { Navigate, useNavigate } from "react-router";
 import { type ConnectedClientSummary, generateConnectToken, listMyClients } from "../api/clients.js";
 import { setOnboardingState } from "../api/onboarding.js";
 import { useAuth } from "../auth/auth-context.js";
+import { MobileBanner } from "../components/mobile-banner.js";
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
 import { StateDot } from "../components/ui/state-dot.js";
@@ -164,6 +165,7 @@ export function WelcomeConnectPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
+      <MobileBanner />
       <Card className="w-full max-w-2xl">
         <CardHeader>
           <CardTitle className="text-title">Connect your computer</CardTitle>


### PR DESCRIPTION
## Summary

Sixth and **final** slice of the SaaS onboarding work (M6 + M8 of [`docs/saas-onboarding-journey.md`](https://github.com/agent-team-foundation/first-tree-hub/blob/feat/saas-onboarding/docs/saas-onboarding-journey.md)). Builds on **PR #184**.

> **Stack on top of #184** — base is `feat/saas-onboarding-wizard-agent`. After #184 merges, retarget to `main`. With this PR merged the entire SaaS onboarding journey M0–M9 ships.

### What's added

**Server**
- `GET /me` returns `workspace.{id, name, displayName, inviteUrl}`. The invite URL is admin-only (members get `null`) — design doc §2.3 says only admins surface the share link, since v1 has no per-link revocation.
- `GET /health` returns `commandVersion` so one-shot CLI subcommands can detect version drift without WS.

**Web — `/admin` Members tab** (M6 / P0-2)
- New `InviteLinkPanel` component renders only when `useAuth().inviteUrl` is non-null. Copy button + leak-warning copy ("Treat it like a password — v1 doesn't support rotating it; share it through a private channel"). Non-admins never see the panel.

**Web — legal placeholders** (M8)
- `/terms` and `/privacy` — placeholder pages, "drafting in progress" header. Linked from `/signup` footer so the SaaS landing reads as a real product.

**Web — mobile banner** (M8)
- `MobileBanner` mounted on `/signup` and `/welcome/connect` (the two pages that genuinely need a desktop terminal). Sticky-dismissed via localStorage. Subscribes to matchMedia change events so resize / orientation flip reflows correctly.

**CLI — version drift hint** (M8 P2)
- `client connect` runs `warnIfCliBehind` against `GET /health` BEFORE auth so a too-old CLI prints an upgrade hint while the user can still abort cleanly. Best-effort — network failures are silent. Lightweight inline semver compare avoids dragging the `semver` dep into `connect.ts`.

### Versioning

`packages/command` 0.10.5 → 0.10.6 (per CLAUDE.md).

### Test plan

- [x] 488/488 server tests passing (3 new — admin/member invite-URL visibility, publicUrl precedence on URL, /health version field)
- [x] 45/45 web tests passing
- [x] `pnpm typecheck` + `pnpm check` clean
- [x] Manual: created workspace as admin → /admin → invite link panel renders + copy works; verified invite URL omitted for member-role caller
- [x] Pre-push code review — 2 MEDIUM findings (MobileBanner resize listener, warnIfCliBehind pre-auth ordering) addressed in second commit; everything else accepted as low / design trade-off

### Known follow-ups (deferred, tracked separately)

- Final ToS / Privacy wording (non-engineering).
- Refresh `useAuth` when role changes (member → admin promotion needs a manual /me refetch today; live update is a polish item).
- `semver` dep + cache-control on `/health` if version-fingerprinting becomes a concern.
- Workspace-switcher a11y (arrow keys, `aria-activedescendant`).

### Out of scope

None — this PR closes out the design doc's milestone set.

https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeznMPZ48C8oaSf8f59shV)_