### PR TITLE
chore(ci): add CODEOWNERS to enforce reviewer gate on main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for first-tree-hub.
+# Every PR targeting main requires approval from at least one of the listed owners.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+* @baixiaohang @yuezengwu


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` listing `@baixiaohang` and `@yuezengwu` as repo-wide owners.
- Pairs with a branch protection update (applied separately via API) that will require **one CODEOWNER approval** before merging to main, with both owners listed as bypass actors so their own PRs can ship without review.

## Why
We want every external/contributor PR to main to be approved by at least one of the two maintainers, while keeping merge velocity for the maintainers themselves. CODEOWNERS is the GitHub-native primitive that scopes "who counts as a required reviewer" per path; here it is applied repo-wide.

## Follow-up (after this lands)
Update branch protection on `main`:
- `required_approving_review_count`: 0 → 1
- `require_code_owner_reviews`: false → true
- `bypass_pull_request_allowances.users`: [`baixiaohang`, `yuezengwu`]
- Other settings (CI checks, force-push block, `enforce_admins: true`) preserved.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, run the protection update API call
- [ ] Verify with a throwaway PR from a non-CODEOWNER that approval from one of the two owners is required
- [ ] Verify a CODEOWNER-authored PR can be merged without review (CI still required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)