### PR TITLE
feat(runtime): multi-runtime support — codex peer to claude-code

### DIFF
--- a/docs/runtime-provider-design.md
+++ b/docs/runtime-provider-design.md
@@ -1,0 +1,735 @@
+# Agent Runtime Provider 接入设计
+
+> **草稿 / 中文版。** 为了便于团队快速评审，本文档临时以中文撰写。讨论收敛后将重写为英文版本，以符合仓库 "English everywhere on GitHub" 约定。
+
+**状态：** 草稿 — 待评审
+**范围：** 引入 `runtimeProvider` 抽象层，把 Hub 现有"硬编码 Claude Code"演进为多 runtime 多态。第一个新接入是 OpenAI Codex CLI（基于官方 `@openai/codex-sdk@0.125.0`）。
+**预研基础：** 私人 plan 文件 `~/.claude/plans/1-local-computer-agent-runtime-hazy-alpaca.md` —— 含 Phase A 离线 SDK shape 探针、Phase B 端到端 9 项行为验证、6 条 footgun、UX 决策 U1–U6 已敲定。
+
+---
+
+## 术语约定
+
+| 概念 | 用词 | 含义 |
+|---|---|---|
+| Runtime 多态选择 | **runtime provider** | 一种 LLM CLI runtime 的标识，Hub 端 zod literal union（U5）。当前枚举：`"claude-code"` \| `"codex"`。未来追加 `"devin"` / 自研。 |
+| 数据库列 | `agents.runtime_provider` | snake_case；权威字段 |
+| TypeScript 字段 | `runtimeProvider` | camelCase；wire / Zod / JS |
+| Client 能力 | **capabilities** | client 启动探测后上报的 "我装了哪些 SDK + 鉴权状态" 快照 |
+| 切 client / 切 provider | **re-bind** | 统一术语；走同一个对话框（U2） |
+| Hub 内部 LLM 子进程承接者 | **handler** | 既有概念，每个 runtime provider 对应一个 handler factory |
+
+---
+
+## 背景
+
+Hub 现状是「单一 Claude Code 硬编码 + 注册表多态机制半就位」：
+
+- `registerHandler(type, factory)` 在 [packages/client/src/runtime/handler.ts:170](../packages/client/src/runtime/handler.ts) 已经在
+- `agent_presence.runtimeType` 字段 schema 注释里早就预留 `"claude-code" | "codex" | "devin"`，但只有 claude-code 一个实现
+- 本地 `agent.yaml::runtime` 字段默认 `"claude-code"`，Hub 端无对应权威字段
+- 配置 schema [packages/shared/src/schemas/agent-runtime-config.ts](../packages/shared/src/schemas/agent-runtime-config.ts) 五字段（prompt / model / mcpServers / env / gitRepos）以 Claude 为中心
+- Web Setup section 已有 `SetupRuntimeKind = "claude-code" | "kael"`，**但 §12.1 检查发现 `kael` 是 IM 平台（与 Feishu/Slack 平级），不是 runtime kind 占位** —— P4 必须把这个类型重命名 `RuntimeProvider` 并移除 kael
+
+OpenAI 在 2026 年发布的 `@openai/codex-sdk@0.125.0` 与 `@anthropic-ai/claude-agent-sdk` 模式高度对称（startThread / runStreamed / resumeThread / AbortSignal），让 Codex 接入可以**镜像 Claude handler 模式**而不需要自己 spawn + 解析 JSONL。SDK 包内捆绑 `@openai/codex@0.125.0` 二进制（runtime dep 严格 pinned），无须用户外部安装。
+
+Phase A + Phase B 实测确认了 9 项关键行为，落实了 6 条 footgun，所有不确定项已扫除。
+
+---
+
+## 目标
+
+1. **runtime provider 成为一等公民**。Hub 端 schema / DB / API / UI / Client / Handler 五层一致。
+2. **一台 client 多 runtime 共存**。client 启动时探测装了哪些 SDK + 鉴权状态，主动上报；UI 可视化"哪台机器能跑什么"。
+3. **agent 选 runtime 与选 computer 原子绑定**。创建强制选；切换走统一 re-bind 对话框（U2）。
+4. **Codex 作为 first-class runtime provider 接入**。Handler 镜像 Claude 模式；配置 schema discriminated union（claude-code variant + codex variant）；UI 暴露 Codex-only 字段。
+5. **不破坏 Claude 现状**。0 行 Claude handler 代码逻辑改动；Claude 配置 row 默认按 `"claude-code"` variant 解析。
+6. **服务层兜底约束**。无 FK / CHECK / triggers，约束在 service（"Integrity in service layer"）。
+7. **放宽 R-RUN（scope expansion）**。当前规则锁定 `agents.client_id` 不可变（要换 client 必须 delete + recreate）。本次设计明确把 client + runtime provider 视为 agent binding 的一组属性，可通过 re-bind 流程一起改。session 处理与 owner / org 校验在 service 层兜底。
+
+---
+
+## 非目标
+
+- 引入 `CliRunner` / `EventMapper` 通用抽象（YAGNI；SDK 已经把进程 + 事件流抽象掉了）
+- 上移 App Server JSON-RPC 协议（`thread/steer` / `thread/fork` 等当前用不到）
+- 跨 client 共享 session（Codex rollout 永远本地）
+- 把 Claude Code handler 重写到新抽象之上（保留现状）
+- 一对多 binding（agent 同时绑多个 client）
+- 自动 runtime fallback（codex 未鉴权时 fallback 到 claude-code）
+
+---
+
+## 1. 现状（精简，详见 plan §1–§7）
+
+### 1.1 多态机制半就位
+
+| 层 | 状态 |
+|---|---|
+| Handler 注册 | `registerHandler` / `getHandlerFactory` 已就位（单例 Map） |
+| 注册入口 | [packages/client/src/handlers/index.ts](../packages/client/src/handlers/index.ts) 仅注册 `"claude-code"` |
+| `AgentHandler` 接口 | 5 方法稳定，扩展 0 改 |
+| Runtime 选择字段 | 仅本地 `agent.yaml::runtime`，Hub 端无权威字段 |
+| Web UI | `SetupRuntimeKind` 已半成型（**kael 非 runtime 占位，是 IM 平台**；P4 重命名 + 清理） |
+
+### 1.2 业务层 LLM-agnostic（无须改造）
+
+- SessionManager / InputController / ResultSink / agent-io / workspace / bootstrap 全部跟具体 LLM 无关
+- 新 handler 直接注入即可复用
+
+### 1.3 Codex SDK 关键事实
+
+- `@openai/codex-sdk@0.125.0`，80KB，依赖 `@openai/codex@0.125.0` 严格 pinned（包内捆绑二进制）
+- ESM only，Node ≥ 18
+- 单 dist 文件，`Codex` / `Thread` 两个 runtime export，其余全是 type-only
+- Thread 无 close / dispose，**靠 AbortSignal**
+- `env` 提供时不继承 process.env（footgun F1）
+- `resumeThread(id)` 不继承首轮 ThreadOptions（footgun F2）
+
+### 1.4 Hub 配置 schema
+
+[packages/shared/src/schemas/agent-runtime-config.ts](../packages/shared/src/schemas/agent-runtime-config.ts)：5 字段 superset，存于 `agent_configs.payload` JSONB，乐观锁版本控制。
+
+---
+
+## 2. 数据模型设计
+
+### 2.1 实体关系
+
+```
+Member
+  └─ owns ─→ Client (local computer)
+                ├─ supports many → RuntimeProvider (claude-code | codex | ...)
+                └─ hosts many   → Agent
+                                    └─ pinned to one → RuntimeProvider ∈ Client.capabilities
+```
+
+四条核心约束（plan §11.1）：
+1. 一个 Client 上可同时支持多种 runtime provider
+2. 一个 Agent 任一时刻绑 1 个 Client + 1 个 runtime provider
+3. Agent 选的 provider 必须在 Client 当前 capabilities 集合内
+4. Provider 选择跟 Client 绑定**原子**完成
+
+### 2.2 表 / 列 改动（增量）
+
+实际仓库迁移路径是 `packages/server/drizzle/`，最新已用编号 **0025_inbox_silent_entries.sql**。本设计的两条迁移用 **0026 / 0027**。
+
+#### 2.2.1 `agents` — 新列 `runtime_provider` + 放宽 R-RUN
+
+**现状**：[packages/server/src/db/schema/agents.ts:44](../packages/server/src/db/schema/agents.ts#L44) 把 `client_id` 标注为 "set at creation time and never changes (Rule R-RUN)"，目前换 client 必须 delete + recreate。
+
+**本次改动**：
+1. 加 `runtime_provider` 列
+2. **放宽 R-RUN**：允许 service 层在 re-bind 流程中改 `client_id` + `runtime_provider`（一对原子改动）
+
+| 字段 | 类型 | 默认值 | 备注 |
+|---|---|---|---|
+| `runtime_provider` | text NOT NULL | `'claude-code'` | snake_case；现有行 backfill 默认值 |
+
+**R-RUN 放宽细则**（在 service `rebindAgent({ clientId, runtimeProvider, force })` 里）：
+- 新 clientId 必须属于同一 owner（manager_id）+ 同一 organization
+- 新 runtimeProvider 必须 ∈ `keys(newClient.capabilities)`（force 可绕过）
+- 当前活跃 sessions 在 re-bind 提交前 suspend（[packages/server/src/services/agent-session.ts](../packages/server/src/services/agent-session.ts) 协同）
+- agents.client_id FK ON DELETE 行为不变（仍 RESTRICT）
+
+迁移策略：单步（Hub 是 stop-migrate-restart 模型，参见 [drizzle/0020](../packages/server/drizzle/0020_unified_user_token.sql) 注释；C10 检查门确认）：
+- **0026**：单字段 — `agents.runtime_provider` NOT NULL DEFAULT `'claude-code'` + backfill。`clients.capabilities` 复用现有 `clients.metadata` jsonb（C 方案，无 SQL 改动），由 zod schema 与 service 层校验子键 `metadata.capabilities` 的形状
+
+#### 2.2.2 `agent_configs.payload` — discriminated union（**无 migration，纯 schema 改动**）
+
+[packages/server/src/db/schema/agent-configs.ts](../packages/server/src/db/schema/agent-configs.ts) 现状已是 jsonb 任意 payload，**SQL 层无需任何改动**。改动全在 zod schema [packages/shared/src/schemas/agent-runtime-config.ts](../packages/shared/src/schemas/agent-runtime-config.ts)：
+
+| Variant | kind 值 | 共享字段 | Variant-only 字段 |
+|---|---|---|---|
+| Claude | `"claude-code"` | prompt / model / mcpServers / env / gitRepos | （保持不变） |
+| Codex | `"codex"` | 同上 | 不在本期暴露（按用户偏好 §6） |
+
+**Zod 解析路径**（C3 修订）：
+
+`z.discriminatedUnion("kind", [...])` 严格要求 `kind` 字段存在；旧行没 `kind` 会 parse 失败。用 `z.preprocess` 包一层在 parse 前补默认值：
+
+```
+agentRuntimeConfigPayloadSchema = z.preprocess(
+  (input) => {
+    if (input && typeof input === "object" && !("kind" in input)) {
+      return { ...input, kind: "claude-code" };
+    }
+    return input;
+  },
+  z.discriminatedUnion("kind", [claudePayloadSchema, codexPayloadSchema]),
+)
+```
+
+写侧：每次 PATCH 后服务把 `kind` 写回 payload；老行被读到 + 写回时自然落地 kind 字段。**不需要 SQL UPDATE / 软窗口**（C1 修订）。
+
+服务层硬约束：`payload.kind === agents.runtime_provider`，不一致 reject。
+
+#### 2.2.3 `clients.metadata.capabilities` — 复用现有 `clients.metadata` jsonb（C 方案）
+
+[clients.ts:39](../packages/server/src/db/schema/clients.ts#L39) 现有 `metadata jsonb` 字段（nullable，无 default）几乎闲置，仅 [client service](../packages/server/src/services/client.ts) 透传一处。**复用为 capabilities 容器**，避免新加列：
+
+| 路径 | 形态 | 备注 |
+|---|---|---|
+| `clients.metadata.capabilities` | jsonb 子键 | 形状与 §2.3 zod schema 一致（含每 provider 的 state / sdkVersion 等） |
+
+**SQL 改动**：无（不动 metadata 列定义）。
+**Read 兜底**：service 提取 `client.metadata?.capabilities ?? {}`。
+**Write 路径**：`PATCH /api/v1/clients/:clientId/capabilities` endpoint 写入 `metadata.capabilities` 子键，不影响其他 metadata 子键（如 future 集成扩展）。
+**约束**：service 层用 zod 校验 `metadata.capabilities` 子键的形状（独立 `clientCapabilitiesSchema`，不污染 metadata 顶层 schema）。
+**查询**：未来若要 "列出装了 codex 的 client"，加 expression index `((metadata->'capabilities'->'codex'))`（post-MVP）。
+
+JSONB 形状（zod 单独定义于 shared）：
+
+```
+{
+  "claude-code": {
+    state: "ok" | "missing" | "unauthenticated" | "error",
+    available: boolean,            // 派生：state ∈ {ok, unauthenticated}
+    authenticated: boolean,        // 派生：state === "ok"
+    sdkVersion: string?,           // 仅 available 时填
+    authMethod: "api_key" | "oauth" | "none",
+    error: string?,                // 仅 state === "error" 时填
+    detectedAt: ISO8601 timestamp
+  },
+  "codex": {
+    state: "ok" | "missing" | "unauthenticated" | "error",
+    available: boolean,
+    authenticated: boolean,
+    sdkVersion: string?,           // 仅 available 时填
+    authMethod: "auth_json" | "api_key" | "none",
+    error: string?,
+    detectedAt: ISO8601 timestamp
+  }
+  // 未来 provider 自然扩展
+}
+```
+
+`state` 是权威字段；`available` / `authenticated` 是派生 boolean，保留方便简单查询。UI 用 `state` 决定图标 / 文案。
+
+迁移：0026 同时加该列，老 client 上线后自然填充。
+
+#### 2.2.4 `agent_presence.runtime_type` — 现状保持 + mismatch reject
+
+[agent-presence.ts](../packages/server/src/db/schema/agent-presence.ts) 字段已存在。语义分工：
+- `agents.runtime_provider`（**配置权威**）：用户期望的 runtime
+- `agent_presence.runtime_type`（**运行时实际**）：client 当前实际跑的 runtime
+
+[agent-bind frame schema](../packages/shared/src/schemas/presence.ts) 已经包含 `runtimeType` + `runtimeVersion`，无需新增协议字段。
+
+**Mismatch 处理（Gap-1 + B2 修订）**：
+- `presenceService.bindAgent({ agentId, runtimeType, ... })` 调用前，service 层加校验：`runtimeType === agents.runtime_provider`
+- 不一致时返回 `agent:bind:rejected` 帧 reason = `runtime_provider_mismatch`；这要求 [shared/schemas/presence.ts:62](../packages/shared/src/schemas/presence.ts#L62) 的 `AGENT_BIND_REJECT_REASONS` 加新枚举值 + `agentBindRejectReasonSchema` 同步扩展
+- Client 收到该 reject reason 后走 repair path：通过 member-scoped admin API 重 fetch 权威 `runtime_provider`，重写本地 `agent.yaml`，重新 spawn handler，再次 bind
+- 一致时正常写入 `agent_presence.runtime_type`，长期一致是健康信号
+
+### 2.3 Capabilities 探测协议
+
+| 维度 | 决定 |
+|---|---|
+| 时机 | client 启动 ClientConnection.connect 之前 |
+| 探测方式 | **独立 capability modules**（C2 修订；不扩展 [HandlerFactory](../packages/client/src/runtime/handler.ts#L149) 接口）：每个 provider 一个 `<provider>-capability.ts` 模块导出 `probeCapability(): Promise<CapabilityEntry>`；`capabilities.ts` 编排器调用所有内置 modules 汇总 |
+| 上报路径 | client → server，**`PATCH /api/v1/clients/:clientId/capabilities`**（B4 修订）；走 memberAuth；service 层校验 `clients.user_id === jwt.userId` 才允许 update |
+| 鉴权 | member JWT（不存在 client token，已由 PR #95 / 0020 unified-user-token 废弃） |
+| 重新探测触发 | 启动时 + 鉴权状态变更（监听 `~/.codex/auth.json` mtime / ANTHROPIC_API_KEY env 变化）+ TTL 5 分钟兜底 |
+| 静默失败保护 | 探测异常不阻塞启动；exception → `state="error", error=<msg>` |
+| Stale 处理 | client offline 时仍读上次 capabilities，UI 显示 `last reported X ago` |
+
+### 2.4 服务层约束（"Integrity in service layer"）
+
+无 FK / CHECK / triggers。所有约束在 service：
+
+| 约束 | 实现位置 |
+|---|---|
+| `agents.runtime_provider ∈ keys(client.metadata.capabilities)` | Agent service `createAgent` / `updateAgent` |
+| `agent_configs.payload.kind === agents.runtime_provider` | AgentConfig service `patchConfig` |
+| Capabilities mismatch 默认 block，可 force（U3） | Service layer `force: boolean` 参数 |
+| Client capabilities update 鉴权 | memberAuth + service 校验 `clients.user_id === jwt.userId`（B4 修订；不存在 client token） |
+| Re-bind 时 sessions 暂停 | 跨 service 协同：Agent + Inbox + Presence |
+
+### 2.5 Schema 形态（U5）
+
+shared 包定义：
+
+```
+runtimeProviderSchema = z.enum(["claude-code", "codex"])
+type RuntimeProvider = z.infer<typeof runtimeProviderSchema>
+```
+
+新增 provider = 改这一行 union + 新增 handler 文件 + 新增 capabilities probe；schema 演进零迁移。
+
+---
+
+## 3. UX 设计
+
+### 3.1 创建 Agent
+
+| 步骤 | 字段 | 行为 |
+|---|---|---|
+| 1 | Display name / type | 跟现状一致 |
+| 2 | Local Computer | 必选；列出 member 的 clients；显示 online + capabilities 摘要 |
+| 3 | Runtime provider | 字段在 Computer 选定后激活；列表 = `keys(client.metadata.capabilities)` ∪ hub 端硬编码 future（灰色禁用 + 安装指引） |
+| 默认值 | 优先 claude-code（向后兼容），否则按 capabilities 第一个 available + authenticated |
+| Lock | 创建后 provider 与 client 一起锁定（locked after creation rhetoric 跟现有一致） |
+
+### 3.2 Re-bind Agent（统一对话框，U2）
+
+切 Computer / 切 Runtime / 都改 → 走同一个对话框。
+
+| 字段 | 行为 |
+|---|---|
+| Computer | 下拉框，预填当前；切换时显示新 client capabilities 摘要 |
+| Runtime provider | radio 列表 = 选中 Computer 的 capabilities；不支持的灰禁 + 安装提示 |
+| 警告 1（永远显示） | "Current sessions on `<from>` will be suspended. Chat history is preserved." |
+| 警告 2（仅 provider 切换时显示） | "Some config fields won't transfer between providers (claude permission_mode dropped, codex sandboxMode reset to default)." |
+| Re-bind 按钮 | 选择对比当前无变化时 disabled |
+| Force 选项（U3） | mismatch 时显示 "Override capability check"，需用户确认 |
+
+### 3.3 Settings → Computers 能力一览
+
+每台 client 一行卡片，显示：
+- online / offline + last seen
+- 各 runtime provider 的 available + sdkVersion + authenticated + authMethod
+- 未装的 runtime provider 灰色 + 安装指引链接
+
+UX 目标：一页看完用户所有 computer 的能力分布，引导后续 agent 创建/迁移决策。
+
+### 3.4 Codex 未鉴权状态（U6）
+
+`available=true, authenticated=false` 时：
+- Re-bind 对话框：选项可见但带 "⚠ Click for instructions" 提示
+- Settings 页 Computers 一览：单独 surface "Run `codex login` on this computer" 引导
+- 创建 agent 后：handler 启动时若仍未鉴权，turn 失败但不 crash agent；用户能看到 error message
+
+---
+
+## 4. Codex Handler 实现
+
+### 4.1 模块结构（增量）
+
+| 路径 | 状态 | 内容 |
+|---|---|---|
+| `packages/client/src/handlers/codex.ts` | **新建** | Codex handler factory，~250 行（vs Claude 959 行） |
+| `packages/client/src/handlers/index.ts` | 修改 | 注册 `"codex"` factory |
+| `packages/client/src/runtime/bootstrap.ts` | 修改 | 把 `generateClaudeMd` 改名为 `generateAgentBriefing(format: "claude" \| "agents-md")`，新增 `AGENTS.md` 写出分支（Codex 默认读取）；**写 `.first-tree-workspace` 空文件作为 codex project root marker（Gap-2）**，避免 codex 向上 walk 文件系统找 AGENTS.md |
+| `packages/client/src/runtime/capabilities/index.ts` | **新建** | `probeCapabilities()` 编排：调用每个 provider 的 capability module 汇总（C2 修订；放 capabilities/ 子目录，独立模块不扩展 HandlerFactory） |
+| `packages/client/src/runtime/capabilities/codex.ts` | **新建** | Codex SDK import 试 + 鉴权探测（CODEX_API_KEY / `~/.codex/auth.json`） |
+| `packages/client/src/runtime/capabilities/claude-code.ts` | **新建** | Claude SDK 探测（与 codex.ts 平级） |
+
+注意：**不需要** `codex-executable.ts` —— SDK 包内捆绑二进制，`codexPathOverride` 默认即可（详见 plan §10.5）。
+
+### 4.2 SDK 集成要点
+
+| 维度 | 决定 |
+|---|---|
+| SDK 包 | `@openai/codex-sdk@^0.125.0`（**stable latest as of 2026-04-28**；0.126.x 仍处 alpha 不固定），加入 `packages/client/package.json` 依赖 |
+| 调用模式 | `new Codex(opts).startThread(threadOpts).runStreamed(input, { signal })` |
+| Resume | 持久化 `thread.id` + 首轮 ThreadOptions 在 hub session state；每次 resume 重传（footgun F2） |
+| Shutdown | 不依赖手动信号；调用 `abortController.abort()`（footgun F6） |
+| Inject | 单 turn run-to-completion 不支持中途 inject；buffer 消息，turn 完成后自动 resumeThread().run(buffered) |
+
+### 4.3 ThreadOptions 默认值
+
+| 字段 | 默认值 | 理由 |
+|---|---|---|
+| `model` | `"gpt-5-codex"`（或 SDK 默认） | 单一推荐 |
+| `sandboxMode` | `"workspace-write"` | 跟 Claude `bypassPermissions` 信任域对齐；agent workspace 是隔离区 |
+| `approvalPolicy` | `"never"` | hub 已假设 client = 信任域，不弹 approval |
+| `modelReasoningEffort` | `"high"` | minimal 与默认工具不兼容（footgun F3）；high 给最佳推理 |
+| `webSearchEnabled` | `false` | hub 已有自己的 MCP 工具策略；避免 minimal 兼容问题（footgun F3） |
+| `additionalDirectories` | `gitRepos[].localPath` | 把 hub `gitRepos` 字段映射进去 |
+| `skipGitRepoCheck` | `true` | workspace 是 hub 自管目录，不一定 git init |
+| `workingDirectory` | hub-acquired workspace 路径 | 复用 `acquireWorkspace` |
+| `config.project_root_markers` | `["first-tree-workspace"]` | **Gap-2**：让 codex 把 walk-up 截在 workspace；配合 bootstrap 写的 `.first-tree-workspace` 空文件 |
+
+### 4.4 配置字段映射
+
+Hub 5 字段（`agentRuntimeConfigPayloadShape`）→ Codex SDK：
+
+| Hub 字段 | Codex 注入方式 |
+|---|---|
+| `prompt.append` | 拼到 user prompt 前缀（Codex 没有独立 system prompt 字段；`<context>...</context>` 包裹） |
+| `model` | `ThreadOptions.model`，alias 翻译表（claude alias `"opus"` → codex `"gpt-5-codex"`） |
+| `mcpServers[]` | 翻译为 `CodexOptions.config.mcp_servers.<name>.{command,args,url,headers}`（TOML 路径式 nested object） |
+| `env[]` | 透传到 `CodexOptions.env`，必须 explicit merge process.env（footgun F1） |
+| `gitRepos[]` | gitMirrorManager 在 workspace 下材化 worktree；额外塞进 `additionalDirectories` |
+
+### 4.5 SessionEvent 翻译
+
+Codex `ThreadEvent` → hub `SessionEvent`：
+
+| Codex Event | Hub SessionEvent | 备注 |
+|---|---|---|
+| `thread.started` | （记录 `thread.id`） | 触发 `setRuntimeState("working")` |
+| `turn.started` | （内部） | — |
+| `item.started` / `item.updated` | 暂忽略（仅终态发） | 与 Claude handler 当前流式策略一致 |
+| `item.completed: agent_message` | `assistant_text` | text payload |
+| `item.completed: command_execution` | `tool_call` (status, command, exit_code) | hub UI 显示为 bash 工具 |
+| `item.completed: file_change` | `tool_call` (changes[]) | 翻译为 file ops 列表 |
+| `item.completed: mcp_tool_call` | `tool_call` (server, tool, arguments, result) | 直接 1:1 |
+| `item.completed: reasoning` | （可选 surface） | hub 当前不显示 Claude 的 thinking blocks，对齐做法 |
+| `item.completed: web_search` / `todo_list` | `tool_call` | 通用包装 |
+| `item.completed: error` | `error` | 非 fatal |
+| `turn.completed` | `turn_end` + usage 上报 | — |
+| `turn.failed` | `error` | — |
+| `error` | `error` | fatal |
+
+### 4.6 Footgun 处理
+
+| # | Footgun | 处理 |
+|---|---|---|
+| F1 | `env` 不继承 process.env | `buildAgentEnv` explicit merge `process.env` |
+| F2 | `resumeThread` 不继承 ThreadOptions | session state 持久化首轮 options，每次 resume 重传 |
+| F3 | `minimal` reasoning + 默认工具不兼容 | 默认值 `"high"` + `webSearchEnabled: false` |
+| F4 | sandbox 拦截不发 `command_execution` event | UI 不依赖该事件枚举所有命令尝试；assistant_text 文本是补充信号 |
+| F5 | MCP server 启动失败静默 | handler `start()` 启动后等 N 秒检查 codex 自报的 MCP 状态，写入 client 日志（P3） |
+| F6 | Thread 无 close | shutdown 用 AbortController.abort() |
+
+---
+
+## 5. 阶段推进
+
+| Phase | 范围 | CC effort | 可发布性 |
+|---|---|---|---|
+| **P1 — Schema + Migration** | shared 包加 `runtimeProviderSchema` + `clientCapabilitiesSchema` + agent-runtime-config discriminated union；server 仅加 `agents.runtime_provider` 列（C 方案：clients.capabilities 走 `metadata.capabilities` 子键）；service 校验逻辑 | ~1 CC 半天 | DB 可发布；不带 UI；老 client 不受影响 |
+| **P2 — Capabilities 上报** | client 端 `probeCapabilities()`；启动时 + auth 变化时 → PATCH `/api/v1/clients/:clientId/capabilities`；server 端 endpoint（memberAuth + user_id 校验） | ~1 CC 半天 | client 上线后 capabilities 自动填充 |
+| **P3 — Codex Handler** | `codex.ts` handler + SDK 依赖 + bootstrap 加 `AGENTS.md`；index.ts 注册 | ~1.5 CC 半天 | client 端可跑 codex；UI 还没；用户走 API 设 `runtime_provider="codex"` 才能用 |
+| **P4 — UI runtime selector + Re-bind** | agent-detail / setup-section 加 runtime picker；re-bind dialog；Computers 能力一览 | ~2 CC 半天 | 完整可用 |
+| **P5 — Codex 独有字段（可选，按需）** | `agent_configs.payload` codex variant 加 `sandboxMode` / `approvalPolicy` / `modelReasoningEffort`；UI 条件渲染 | ~1 CC 半天 | 增强；不阻塞 P4 |
+
+**总计 P1–P4 = ~5.5 CC 半天**（不含 P5）。
+
+> CC 半天定义：在私人 plan §10.8 已经把 handler 估到 ~250 行（vs Claude 959）；其他工作量按现仓库类似改动经验估。
+
+---
+
+## 6. 迁移与回滚
+
+### 6.1 Forward path（向前）
+
+| Step | 改动 | 风险 |
+|---|---|---|
+| 0026 migration | 单步、单列：`agents.runtime_provider` NOT NULL DEFAULT `'claude-code'` + backfill。`clients.capabilities` 走 `metadata.capabilities` 子键（C 方案，无 SQL 改动） | 低（stop-migrate-restart 模型，无 rolling deploy 间隙问题） |
+| `command` 包发布 | tarball bump（按 docs/versioning-and-publishing.md 规则） | 低 |
+| 老 client 兼容 | 老 client 没 capabilities 上报 → server 容忍 `'{}'`，UI 显示 "Capabilities not yet reported" | 低 |
+| Schema discriminated union | 读端兼容：missing `kind` → `"claude-code"`；写端补 `kind` | 低 |
+
+### 6.2 Backward path（回滚）
+
+如发现严重问题：
+
+| 阶段 | 回滚方式 |
+|---|---|
+| P1 已上线 | 不回滚 schema（NOT NULL flip 后）；通过 service 屏蔽 codex provider 选项 |
+| P2 已上线 | client 停止 capabilities 上报无影响（默认 `'{}'`） |
+| P3 已上线 | UI / API 屏蔽 `runtime_provider="codex"`；已配 codex 的 agent 退到 claude-code（service 层 force 改回） |
+| P4 已上线 | 同 P3 + 隐藏 UI runtime picker（feature flag） |
+
+### 6.3 Feature flag
+
+P3 / P4 上线时建议加 hub config flag `codexRuntimeEnabled`（默认 false → true 切换），能在事故时快速关停 codex provider。
+
+---
+
+## 7. 风险与开放问题
+
+继承私人 plan §11.8 + §10.7 的合并集：
+
+| # | 项 | 严重 | 缓解 |
+|---|---|---|---|
+| R-DM1 | client capabilities 上报与 agent 创建 race | 中 | UI 等 client online + capabilities `detectedAt` 不为空（loading） |
+| R-DM2 | 离线 client capabilities 时效 | 低 | UI "stale, last reported X ago"；force 选项 |
+| R-DM3 | hub 端硬编码"未装"列表 | 低 | runtime provider 主表（小，纯展示） |
+| R-DM4 | 鉴权状态频繁变化 | 低 | 文件 mtime watch + 5min TTL 兜底 |
+| R-DM6 | `agent.yaml` `runtime` 与 hub 权威分歧 | 低 | client 启动时若不一致 → warning log + 以 hub 为准 |
+| F1–F6 | SDK footgun | 中 | §4.6 已处理 |
+| R-CD1 | Codex SDK 0.x 版本变动风险 | 中 | pin minor，每次升级前重跑 Phase B 9 项 |
+| R-CD2 | OpenAI Responses API endpoint 变动 | 低 | SDK 版本对齐时一并升级 |
+
+### 已敲定的设计点（之前的开放问题）
+
+1. **`runtime_provider` schema 演进策略**：✅ **决定：保持 zod literal union**，YAGNI。新增 provider = 改一行 union + 新增 handler 文件 + 新增 capability probe，无需运行时 schema 表。
+2. **Capabilities probe 失败模式细分**：✅ **决定：单独区分** probe 抛错 vs unauthenticated。capability entry 增加显式状态字段 `state: "ok" | "missing" | "unauthenticated" | "error"`，UI 用不同图标呈现。`available` / `authenticated` 两个 boolean 仍然保留（向后兼容简单查询），但 `state` 是真值：
+   - `ok` = available + authenticated
+   - `missing` = SDK 未装 / 二进制缺失
+   - `unauthenticated` = SDK 装了但鉴权失败
+   - `error` = probe 抛错（写入 `error: string`）
+3. **Re-bind 时 codex thread 数据保留**：✅ **决定：保留**。旧 `~/.codex/sessions/<id>/` rollout 文件不立即清理（用户日后可能回退）。**Post-MVP** 加 7 天定时清理任务（cron job 检查 mtime）。
+4. **Multi-tenant 视角**：✅ **决定：`clients.metadata.capabilities` 仅 owner 可见**，与 `clients` 表现有 RBAC 一致（`userId == jwt.userId`）。Capabilities 包含 SDK 版本与鉴权方式，属于半敏感信息。
+
+---
+
+## 8. 验证
+
+### 8.1 已完成（plan Phase A + Phase B）
+
+| 项 | 结果 |
+|---|---|
+| SDK 类型 / 包结构 | 全部对齐（plan §10.1–§10.5） |
+| 流式事件 schema | B1 通过 |
+| CODEX_HOME 隔离 | B2 通过 |
+| resumeThread 跨实例 | B3 通过（footgun F2 已记录） |
+| Sandbox + Approval | B4 通过（footgun F4 已记录） |
+| ReasoningEffort | B5 通过（footgun F3 已记录） |
+| MCP 注入接口 | B6 通过（footgun F5 已记录） |
+| AbortSignal | B7 通过（0 孤儿） |
+| local_image 输入 | B8 通过 |
+| API key 三层路径 | B9 通过 |
+
+### 8.2 实施期需做（P1–P4 合并验证）
+
+| 阶段 | 验证项 |
+|---|---|
+| P1 | shared zod schema 单元测试；agent_configs discriminated union 读写兼容；mismatch reject |
+| P2 | client 启动 capabilities 上报；offline 后再上线刷新；auth 变化触发上报 |
+| P3 | 端到端：创建 codex agent → 发消息 → 收到回复；resume 跨进程；abort 中断；MCP 配置生效 |
+| P4 | UI 流：创建 agent + 选 codex；re-bind dialog 切 provider；Settings → Computers 显示 capabilities；force override 路径 |
+
+### 8.3 回归测试
+
+不破坏 Claude path：
+- 老 agent_configs 行（无 `payload.kind`）能继续读 + 编辑
+- 老 client（无 capabilities 上报）老 agent 能继续工作
+- 现有 Claude handler 0 行逻辑改动（仅 capabilities probe 模块新加）
+
+---
+
+## 9. 实施顺序与文件清单
+
+### 9.1 P1 (shared + server)
+
+| 文件 | 改动 |
+|---|---|
+| `packages/shared/src/schemas/runtime-provider.ts` | **新建** — `runtimeProviderSchema = z.enum([...])` |
+| `packages/shared/src/schemas/client-capabilities.ts` | **新建** — capabilities JSONB shape |
+| `packages/shared/src/schemas/agent-runtime-config.ts` | 改 — `z.preprocess` 包 `discriminatedUnion("kind", [...])`，缺失 kind 默认补 `"claude-code"`（C3 修订） |
+| `packages/shared/src/schemas/agent.ts` | 加 `runtimeProvider` 字段 |
+| `packages/server/src/db/schema/agents.ts` | 加 `runtimeProvider` 列 |
+| `packages/server/src/db/schema/clients.ts` | **不动列定义**（C 方案：复用 `metadata.capabilities` 子键） |
+| `packages/server/drizzle/0026_runtime_provider.sql` | **新建** — 单步、单列：`agents.runtime_provider NOT NULL DEFAULT 'claude-code'` + backfill；`clients` 表无 SQL 改动（drizzle-kit 生成） |
+| `packages/server/src/services/agent.ts` | 加 `runtime_provider ∈ capabilities` 校验；**B1 修订**：`createAgent` / `rebindAgent` 推送 `agent:pinned` 时填 `runtimeProvider` 字段 |
+| `packages/server/src/services/agent-config.ts` | 加 `payload.kind === runtime_provider` 校验 |
+| `packages/server/src/api/agent/ws-client.ts` | **B2 修订**：`agent:bind` handler 在 `presenceService.bindAgent` 前加 `runtimeType === agents.runtime_provider` 校验，不一致返回 `agent:bind:rejected` reason `runtime_provider_mismatch` |
+
+### 9.2 P2 (client capabilities + Hub 权威启动同步)
+
+| 文件 | 改动 |
+|---|---|
+| `packages/client/src/runtime/capabilities/index.ts` | **新建** — `probeCapabilities()` 编排（C2 修订：放 capabilities/ 子目录，独立模块不扩展 HandlerFactory） |
+| `packages/client/src/runtime/capabilities/claude-code.ts` | **新建** — `probeCapability()` Claude SDK 探测 |
+| `packages/client/src/runtime/capabilities/codex.ts` | **新建** — `probeCapability()` Codex SDK 探测 |
+| `packages/client/src/runtime/runtime.ts` | 修改 — **B3 修订**：startup 用 member JWT 调 `GET /api/v1/clients/me/agents` 拉权威 `runtime_provider`，覆盖本地 yaml；`getHandlerFactory(authoritativeProvider)` 选 handler；后续 probe + 上报 capabilities |
+| `packages/client/src/sdk.ts` | 修改 — 新增 `updateCapabilities()` + `listMyAgents()` SDK methods |
+| `packages/command/src/core/client-runtime.ts` | **B1 修订**：[L248](../packages/command/src/core/client-runtime.ts#L248) `handleAgentPinned` 用 `message.runtimeProvider` 替代硬编码 `"claude-code"`，写入本地 `agent.yaml::runtime` |
+| `packages/client/src/runtime/repair.ts` | **新建** — bind reject reason `runtime_provider_mismatch` 处理：member JWT 拉权威值 → 重写 yaml → 关 handler instance → spawn 正确 handler → 重新 bind |
+| `packages/server/src/api/clients.ts` | 修改 — PATCH `/api/v1/clients/:clientId/capabilities` 路由（memberAuth + service 层 `clients.user_id === jwt.userId` 校验） |
+
+### 9.3 P3 (Codex handler)
+
+| 文件 | 改动 |
+|---|---|
+| `packages/client/package.json` | 加 dep `@openai/codex-sdk@^0.125.0` |
+| `packages/command/package.json` | **Gap-4**：build 脚本加 `--external @openai/codex-sdk` flag（与 `@anthropic-ai/claude-agent-sdk` 对称处理）；codex SDK 包内 codex 二进制随 npm install 自然就位 |
+| `packages/client/src/handlers/codex.ts` | **新建** — handler factory |
+| `packages/client/src/handlers/index.ts` | 修改 — 注册 codex |
+| `packages/client/src/runtime/bootstrap.ts` | 修改 — `generateAgentBriefing(format)` + `AGENTS.md` 写出 |
+| `packages/client/src/__tests__/codex-handler.test.ts` | **新建** — 单元测试 + fixtures |
+
+### 9.4 P4 (Web UI)
+
+| 文件 | 改动 |
+|---|---|
+| `packages/web/src/pages/agent-detail/setup-section.tsx` | 把 `SetupRuntimeKind = "claude-code" \| "kael"` 改为 `RuntimeProvider = "claude-code" \| "codex"`（**Gap-3**：移除 kael，因 kael 是 IM 平台不是 runtime kind）；渲染 capabilities |
+| `packages/web/src/components/new-agent-dialog.tsx` | **Gap-3**：把 `Runtime = "claude-code" \| "kael"` 类型改为 `RuntimeProvider`；移除 kael；加 codex |
+| `packages/web/src/pages/agents.tsx` | **Gap-3**：`handleCreated` 函数签名 `runtime: "claude-code" \| "kael"` → `runtimeProvider: RuntimeProvider`；移除 kael 分支 |
+| `packages/web/src/pages/agent-detail.tsx:410` | **Gap-3**：清理"kael" runtime 注释与误用 |
+| `packages/web/src/pages/agent-detail/re-bind-dialog.tsx` | **新建** — 统一 re-bind 对话框 |
+| `packages/web/src/pages/settings/computers-section.tsx` | **新建** — Computers 能力一览 |
+| `packages/web/src/api/agents.ts` | 加 `rebindAgent({ clientId, runtimeProvider, force })` |
+| `packages/web/src/api/clients.ts` | 加 `getCapabilities(clientId)` |
+
+**注**：`packages/web/src/pages/binding-form.tsx` 与 `bindings.tsx` 的 `kael` 是另一种语义（IM 平台 binding，与 Feishu/Slack 平级），**保持不动**。
+
+---
+
+## 10. 文档与跟进
+
+- 本设计文档（待评审通过后重写英文版）
+- 评审通过后更新：
+  - [docs/cli-reference.md](cli-reference.md) — 加 `agent config set-runtime` 命令（如新增）
+  - [docs/claim-agent-guide.md](claim-agent-guide.md) — 加 codex 相关章节
+  - 新建 `docs/codex-onboarding.md`（codex login 引导 + 鉴权说明，对应 U6）
+- Phase 推进时分别开 PR：每个 Phase 一 PR，`packages/command` 版本按规则 bump
+
+---
+
+## 12. 实施前检查门（Pre-Implementation Gate）
+
+> 在 P1 启动前对仓库现有事实做的全面核查（C1–C11）。下方仅记 **会改设计** 与 **会简化设计** 的关键发现；完整检查项 + 路径详情见 plan §12 / 各 Explore agent 报告。
+
+### 12.1 ⚠️ Critical（必须更新设计的发现）
+
+**C6-A — Web 中 `"kael"` 是 IM 平台不是 LLM runtime**
+
+[packages/web/src/components/new-agent-dialog.tsx:55](../packages/web/src/components/new-agent-dialog.tsx#L55) 与 [packages/web/src/pages/agents.tsx:147](../packages/web/src/pages/agents.tsx#L147) 现有 `type Runtime = "claude-code" | "kael"`，但 [packages/web/src/pages/binding-form.tsx](../packages/web/src/pages/binding-form.tsx) 中 `kael` 是与 feishu / slack 平级的 **外部 IM 平台**（带 `kaelUserId` / `kaelProjectId` 字段）。
+
+**两个 kael 概念不同**：UI 一处把它当 runtime kind，绝大多数地方当 IM platform。
+
+**对设计的影响**：
+- 我们的 `runtime_provider` zod literal union 只包括 `"claude-code" | "codex"`，**绝不**包括 `"kael"`
+- P4 UI 改造时必须把 `Runtime` 类型重命名为 `RuntimeProvider`，把 `kael` **从 union 移除**（kael 在 IM binding 维度处理，跟 LLM runtime 无关）
+- 这是 scope 项，需在 P4 文件清单加一条："清理 new-agent-dialog.tsx + agents.tsx 的 kael runtime 误用"
+
+**C7-A — Codex AGENTS.md 行为：directory walk-up 到 git root**
+
+deepwiki 抓取 codex 源码确认：codex 从 cwd 向上 walk 找 AGENTS.md，直到 project root（默认 `.git` marker）。**Hub workspace 不一定 git init**，可能 walk 到文件系统根，拾起不期望的 AGENTS.md（如 hub 本身 repo 的）。
+
+**对设计的影响**：
+- `bootstrapWorkspace` 必须确保 workspace 是 codex 认可的 project root
+- 两条路径任选其一：
+  - **(a) `git init` workspace**（轻量；workspace 已经是 hub 自管目录，empty git repo 无副作用）
+  - **(b) `project_root_markers` 配置**：在 `CodexOptions.config` 加自定义 marker 如 `["first-tree-workspace"]`，bootstrap 写一个空文件 `.first-tree-workspace`
+- 推荐 **(b)** —— 不引入 git 概念，且 marker 文件可作为 workspace 自识别
+
+§4.1 模块清单需新增：bootstrap 写 `.first-tree-workspace` marker；`CodexOptions.config.project_root_markers = ["first-tree-workspace"]`
+
+**C10 — Hub 不走 rolling deploy，single migration 即可**
+
+[packages/server/drizzle/0020_unified_user_token.sql](../packages/server/drizzle/0020_unified_user_token.sql) 注释明确："operators stop SDK/CLI processes, run migration, restart" — Hub 是 stop-migrate-restart 模型。
+
+**对设计的影响**：
+- §2.2.1 / §6.1 / §9.1 拆 0026 + 0027 两步迁移是**过度设计**
+- 改为：**单步 0026 直接 `NOT NULL DEFAULT 'claude-code'`** + backfill
+- 节省一次 release 周期
+
+### 12.2 ✓ Important（简化设计的发现）
+
+**C3-A — `agent:bind` 帧已经带 `runtimeType`**
+
+[packages/shared/src/schemas/presence.ts:55-59](../packages/shared/src/schemas/presence.ts#L55) 现状：
+
+```
+agentBindRequestSchema = z.object({
+  agentId: z.string().min(1),
+  runtimeType: z.string().max(50),
+  runtimeVersion: z.string().max(50).optional(),
+})
+```
+
+**对设计的影响**：
+- 不需要改 `agent:bind` frame schema
+- client 上报的 `runtimeType` 直接对应我们的 `runtime_provider` —— 命名差异在 §12.4 单独处理
+- `presenceService.bindAgent` 已经写入 `agent_presence.runtime_type`，对接现有路径
+
+**C5-A — agent_configs 历史从未有 `kind` 字段**
+
+迁移 0019 起的 payload 形态：`{prompt, model, mcpServers, env, gitRepos}`，**所有现存行都没 `kind`**。
+
+**对设计的影响**：
+- 读侧默认补 `kind="claude-code"` 是唯一兼容路径
+- 不需要 SQL UPDATE 批量补 kind（service 层每次 PATCH 时回写就够了）
+- 软窗口可以去掉
+
+**C9 — tsdown 已经把 Anthropic SDK 设为 `--external`**
+
+[packages/command/package.json](../packages/command/package.json) build 命令：`tsdown ... --external @anthropic-ai/claude-agent-sdk && node scripts/embed-assets.mjs`
+
+**对设计的影响**：
+- 加 `@openai/codex-sdk` 到 dependencies + 加 `--external @openai/codex-sdk` build flag
+- 包内 codex 二进制随 npm install 自然就位（与 Anthropic SDK 同模式）
+- 不需要改 embed-assets.mjs
+
+### 12.3 ✓ Confirmed（验证设计假设）
+
+| 项 | 结论 |
+|---|---|
+| **C1** R-RUN enforcement | 4 处：service / middleware / WS handler / schema 注释。放宽实际改动 ~250-310 行 |
+| **C2** updateAgent schema | 已允许 clientId 字段，仅 service 层 reject —— 删 4 行 immutability 检查 + 新加 `rebindAgent` 函数即可 |
+| **C7-Q2** CODEX_HOME 在 cwd 子目录 | 安全：codex 不扫 home 作 project content；sandbox 允许写 home 但每 chat 独立避免 race |
+| **C11** 老 client 兼容 | server 走 `passthrough()`；新增 `client:capabilities` 帧老 client 不发即可 |
+
+### 12.4 ⚠️ 设计漏掉的 4 个细节（必须补）
+
+**Gap-1 — `runtime_type` (presence) 与 `runtime_provider` (agents) 命名分工要明文写**
+
+§2.2.4 现有的"二者解耦"描述不足以指导实施。需明确写入 §12.5 决策：
+
+- `agents.runtime_provider`（**配置权威**）：用户期望该 agent 跑哪种 runtime
+- `agent_presence.runtime_type`（**运行时实际**）：client 当前实际跑的 runtime
+- **mismatch 行为**：client 上报 `runtime_type` 与 hub `runtime_provider` 不一致时，`presenceService.bindAgent` **拒绝绑定**，触发 client 重启 handler 或重 fetch config
+
+**Gap-2 — workspace project root marker（继 C7-A）**
+
+`bootstrapWorkspace` 加一步：写一个 `.first-tree-workspace` 空文件作为 codex 的 project root marker。
+
+**Gap-3 — Web "kael" runtime 误用清理列入 P4**
+
+P4 文件清单加一行：清理 new-agent-dialog.tsx + agents.tsx 的 `Runtime = "claude-code" | "kael"` 类型，重命名为 `RuntimeProvider` 并移除 kael。
+
+**Gap-4 — tsdown `--external @openai/codex-sdk`**
+
+P3 文件清单加一行：[packages/command/package.json](../packages/command/package.json) build 脚本添加 `--external @openai/codex-sdk` flag。
+
+### 12.5 检查门最终决策
+
+| 项 | 处理 |
+|---|---|
+| 0026 + 0027 拆两步 | **取消**，合并为单步 0026 `NOT NULL DEFAULT 'claude-code'` |
+| `bootstrapWorkspace` 写 `.first-tree-workspace` marker | **加** |
+| `CodexOptions.config.project_root_markers = ["first-tree-workspace"]` | **加** |
+| `runtime_type` ↔ `runtime_provider` mismatch reject | **加 service 层校验** |
+| Web `Runtime = "claude-code" \| "kael"` 类型 | **重命名为 RuntimeProvider 并移除 kael**（P4） |
+| `--external @openai/codex-sdk` | **加** P3 build 配置 |
+
+### 12.6 §6.1 修订
+
+原"0026 + 0027 两步"改为单步：
+
+| Step | 改动 | 风险 |
+|---|---|---|
+| 0026 migration | 一次性、单列：`agents.runtime_provider` NOT NULL DEFAULT `'claude-code'` + backfill。`clients.capabilities` 走 `metadata.capabilities` 子键（C 方案，无 SQL 改动） | 低（stop-migrate-restart 模型，无 rolling deploy 间隙问题） |
+
+`packages/server/drizzle/0027_runtime_provider_not_null.sql` 从 §9.1 文件清单中**删除**。
+
+### 12.8 Codex 二轮 review 反馈（已落实）
+
+Codex agent 对前述设计做了 review，提出 4 个 critical gap + 3 个矛盾。逐项核实全部成立，已修订。
+
+| # | 反馈 | 修订位置 |
+|---|---|---|
+| **B1** | `agent:pinned` 帧漏 `runtimeProvider`，[client-runtime.ts:248](../packages/command/src/core/client-runtime.ts#L248) 硬编码 `runtime: "claude-code"` 会让 codex agent 落地成 Claude | §9.1 文件清单加 [shared/schemas/agent.ts:177](../packages/shared/src/schemas/agent.ts#L177) `agentPinnedMessageSchema` 加字段；§9.1 加 [command/src/core/client-runtime.ts:248](../packages/command/src/core/client-runtime.ts#L248) 改用 `message.runtimeProvider` |
+| **B2** | `RUNTIME_PROVIDER_MISMATCH` 不在 [presence.ts:62](../packages/shared/src/schemas/presence.ts#L62) reject enum 内，"reject reason 未注册" | §2.2.4 修订；§9.1 加 enum 扩展 |
+| **B3** | Hub 权威启动路径未完整：[runtime.ts:70](../packages/client/src/runtime/runtime.ts#L70) bind 前就选 handler，alias 过期会循环 reject | §4 加 startup repair path（见下） |
+| **B4** | `PATCH /clients/me/capabilities` + "client token only" 与现状矛盾（PR #95 后只有 member JWT） | §2.3 修订为 `PATCH /clients/:clientId/capabilities` + memberAuth + `clients.user_id === jwt.userId` 校验 |
+| **C1** | `payload.kind` 软窗口表述前后矛盾 | §2.2.2 删除"两周软窗口" |
+| **C2** | capability probe 扩展 [handler.ts:149](../packages/client/src/runtime/handler.ts#L149) HandlerFactory 接口 vs 独立模块 | §2.3 改为独立 `<provider>-capability.ts` modules |
+| **C3** | `z.discriminatedUnion("kind", [...])` 不能 parse 老行 | §2.2.2 改用 `z.preprocess` 补默认 `kind` |
+
+### 12.9 Hub 权威启动路径（B3 完整方案）
+
+针对 [runtime.ts:70](../packages/client/src/runtime/runtime.ts#L70) "bind 前选 handler" 的问题，三层互补：
+
+| 层 | 时机 | 机制 |
+|---|---|---|
+| **预取** | client 启动后 / connect 前 | 用 member JWT 调 `GET /api/v1/clients/me/agents`（**新建** endpoint，返回该 client 上所有 pinned agent + 权威 `runtime_provider`），覆盖本地 `agent.yaml::runtime` |
+| **推送** | server → client，每次 client connect 后立即推 | 复用现有 `agent:pinned` 帧（B1 修订加 `runtimeProvider` 字段），server 在 client connect 时为每个 pinned agent 重新发一遍（不仅在 admin UI 创建时发） |
+| **Repair** | bind reject reason `runtime_provider_mismatch` | client 收到后用 member JWT 重 fetch 权威值，重写本地 yaml，关掉错的 handler instance，按权威值 spawn 正确 handler，再次 bind |
+
+预取 + 推送二选一够用，加 repair 兜底。**推荐组合**：以预取为主路径（简单），repair 为容错；推送可作 P3 增量优化。
+
+### 12.10 检查门通过状态
+
+| 检查项 | 状态 |
+|---|---|
+| C1 R-RUN enforcement | ✓ Confirmed + 改动量估清 |
+| C2 agents service 现状 | ✓ Confirmed |
+| C3 AgentHandler / WS frame | ✓ Confirmed + 简化（runtimeType 已存在） |
+| C4 runtime_type writers | ✓ Confirmed + Gap-1 补 |
+| C5 agent_configs payload 形态 | ✓ Confirmed + 简化（无软窗口） |
+| C6 Web kael 现状 | ⚠ Critical — Gap-3 补到 P4 |
+| C7 Codex AGENTS.md + CODEX_HOME | ⚠ Critical — Gap-2 补 |
+| C8 CODEX_HOME 副作用 | ✓ Safe |
+| C9 tsdown bundling | ✓ Confirmed + Gap-4 补到 P3 |
+| C10 Migration cadence | ⚠ Critical — 单步合并 |
+| C11 老 client 兼容 | ✓ Safe |
+
+**Gate 决议**：上述 4 个 Gap 落实到 §6.1 / §9.1 / §4.1 后，**P1 可以启动**。

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "@openai/codex-sdk": "^0.125.0",
     "pino": "^9.5.0",
     "semver": "^7.6.3",
     "ws": "^8.20.0",

--- a/packages/client/src/__tests__/agent-config-cache.test.ts
+++ b/packages/client/src/__tests__/agent-config-cache.test.ts
@@ -8,6 +8,7 @@ function makeConfig(version: number, urls: string[] = []): AgentRuntimeConfig {
     agentId: "agent-1",
     version,
     payload: {
+      kind: "claude-code",
       prompt: { append: "" },
       model: "",
       mcpServers: [],

--- a/packages/client/src/__tests__/builtin-handlers.test.ts
+++ b/packages/client/src/__tests__/builtin-handlers.test.ts
@@ -23,4 +23,25 @@ describe("Built-in Handlers", () => {
     expect(typeof handler.suspend).toBe("function");
     expect(typeof handler.shutdown).toBe("function");
   });
+
+  it("registers codex handler", () => {
+    registerBuiltinHandlers();
+
+    const factory = getHandlerFactory("codex");
+    expect(factory).toBeDefined();
+    expect(typeof factory).toBe("function");
+  });
+
+  it("codex factory returns a valid session-oriented handler", () => {
+    registerBuiltinHandlers();
+
+    const factory = getHandlerFactory("codex");
+    const handler = factory({ workspaceRoot: "/tmp/test" });
+    expect(handler).toBeDefined();
+    expect(typeof handler.start).toBe("function");
+    expect(typeof handler.resume).toBe("function");
+    expect(typeof handler.inject).toBe("function");
+    expect(typeof handler.suspend).toBe("function");
+    expect(typeof handler.shutdown).toBe("function");
+  });
 });

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -1,0 +1,202 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { probeClaudeCodeCapability } from "../runtime/capabilities/claude-code.js";
+import { probeCodexCapability } from "../runtime/capabilities/codex.js";
+import { probeCapabilities } from "../runtime/capabilities/index.js";
+
+/**
+ * Capability probes are the only on-machine input the runtime gate uses
+ * to decide if an agent can bind. These tests pin the auth-detection
+ * branches we shipped:
+ *   - claude-code: ANTHROPIC_API_KEY → ok/api_key; OAuth marker file
+ *     `~/.claude.json::oauthAccount.accountUuid` → ok/oauth; neither →
+ *     unauthenticated.
+ *   - codex: CODEX_API_KEY → ok/api_key; presence of
+ *     `${CODEX_HOME}/auth.json` → ok/auth_json; neither → unauthenticated.
+ *
+ * The probes always include a `state` ∈ {ok, unauthenticated, missing,
+ * error} and a matching `available` flag — the server-side gate keys off
+ * those, so a regression that flips the boolean would silently allow or
+ * deny binds. These tests run with isolated HOME / CODEX_HOME so they
+ * don't read the developer's real auth files.
+ */
+
+function snapshotEnv(keys: string[]): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const k of keys) out[k] = process.env[k];
+  return out;
+}
+
+function restoreEnv(prev: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(prev)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe("probeClaudeCodeCapability", () => {
+  let tmpHome: string;
+  let prev: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "ft-cap-claude-"));
+    prev = snapshotEnv(["HOME", "ANTHROPIC_API_KEY"]);
+    process.env.HOME = tmpHome;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    restoreEnv(prev);
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("`ok` + api_key when ANTHROPIC_API_KEY is set (no OAuth file required)", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test-12345";
+    const entry = await probeClaudeCodeCapability();
+    expect(entry.state).toBe("ok");
+    expect(entry.available).toBe(true);
+    expect(entry.authenticated).toBe(true);
+    expect(entry.authMethod).toBe("api_key");
+  });
+
+  it("`ok` + oauth when ~/.claude.json has `oauthAccount.accountUuid`", async () => {
+    writeFileSync(join(tmpHome, ".claude.json"), JSON.stringify({ oauthAccount: { accountUuid: "acc-abc-123" } }));
+    const entry = await probeClaudeCodeCapability();
+    expect(entry.state).toBe("ok");
+    expect(entry.authMethod).toBe("oauth");
+  });
+
+  it("`unauthenticated` when no API key and no OAuth marker", async () => {
+    const entry = await probeClaudeCodeCapability();
+    expect(entry.state).toBe("unauthenticated");
+    expect(entry.available).toBe(true);
+    expect(entry.authenticated).toBe(false);
+    expect(entry.authMethod).toBe("none");
+  });
+
+  it("treats a `~/.claude.json` without `accountUuid` as unauthenticated (the canonical login signal)", async () => {
+    writeFileSync(
+      join(tmpHome, ".claude.json"),
+      // Realistic shape: file exists (CLI was run) but no oauthAccount yet.
+      JSON.stringify({ otherStuff: "settings", oauthAccount: { someOtherField: true } }),
+    );
+    const entry = await probeClaudeCodeCapability();
+    expect(entry.state).toBe("unauthenticated");
+  });
+
+  it("returns a non-null `sdkVersion` when the SDK package.json is reachable (smoke-only)", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    const entry = await probeClaudeCodeCapability();
+    // The repo includes @anthropic-ai/claude-agent-sdk as a dep, so this
+    // should resolve. Don't pin a specific version — bumping the dep
+    // would invalidate the test for no good reason.
+    expect(typeof entry.sdkVersion === "string" || entry.sdkVersion === null).toBe(true);
+  });
+});
+
+describe("probeCodexCapability", () => {
+  let tmpHome: string;
+  let prev: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "ft-cap-codex-"));
+    prev = snapshotEnv(["CODEX_HOME", "CODEX_API_KEY"]);
+    process.env.CODEX_HOME = tmpHome;
+    delete process.env.CODEX_API_KEY;
+  });
+
+  afterEach(() => {
+    restoreEnv(prev);
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("`ok` + api_key when CODEX_API_KEY is set", async () => {
+    process.env.CODEX_API_KEY = "ck-test-12345";
+    const entry = await probeCodexCapability();
+    expect(entry.state).toBe("ok");
+    expect(entry.authMethod).toBe("api_key");
+  });
+
+  it("`ok` + auth_json when $CODEX_HOME/auth.json exists", async () => {
+    writeFileSync(join(tmpHome, "auth.json"), JSON.stringify({ token: "x" }));
+    const entry = await probeCodexCapability();
+    expect(entry.state).toBe("ok");
+    expect(entry.authMethod).toBe("auth_json");
+  });
+
+  it("`unauthenticated` when neither env nor auth.json is present", async () => {
+    // tmpHome is empty by default.
+    const entry = await probeCodexCapability();
+    expect(entry.state).toBe("unauthenticated");
+    expect(entry.available).toBe(true);
+    expect(entry.authMethod).toBe("none");
+  });
+
+  it("falls back to ~/.codex/auth.json when CODEX_HOME is unset", async () => {
+    delete process.env.CODEX_HOME;
+    // Hijack HOME so the codex probe doesn't read the developer's real auth.
+    const homePrev = process.env.HOME;
+    const fakeHome = mkdtempSync(join(tmpdir(), "ft-cap-codex-home-"));
+    process.env.HOME = fakeHome;
+    try {
+      mkdirSync(join(fakeHome, ".codex"), { recursive: true });
+      writeFileSync(join(fakeHome, ".codex", "auth.json"), "{}");
+      const entry = await probeCodexCapability();
+      expect(entry.state).toBe("ok");
+      expect(entry.authMethod).toBe("auth_json");
+    } finally {
+      if (homePrev === undefined) delete process.env.HOME;
+      else process.env.HOME = homePrev;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("probeCapabilities (aggregator)", () => {
+  let tmpHome: string;
+  let tmpCodexHome: string;
+  let prev: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "ft-cap-agg-h-"));
+    tmpCodexHome = mkdtempSync(join(tmpdir(), "ft-cap-agg-c-"));
+    prev = snapshotEnv(["HOME", "ANTHROPIC_API_KEY", "CODEX_HOME", "CODEX_API_KEY"]);
+    process.env.HOME = tmpHome;
+    process.env.CODEX_HOME = tmpCodexHome;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CODEX_API_KEY;
+  });
+
+  afterEach(() => {
+    restoreEnv(prev);
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpCodexHome, { recursive: true, force: true });
+  });
+
+  it("returns one entry per built-in provider, each with a valid state", async () => {
+    const caps = await probeCapabilities();
+    expect(Object.keys(caps).sort()).toEqual(["claude-code", "codex"]);
+    for (const k of ["claude-code", "codex"] as const) {
+      const entry = caps[k];
+      if (!entry) throw new Error(`missing entry for ${k}`);
+      expect(["ok", "unauthenticated", "missing", "error"]).toContain(entry.state);
+      expect(typeof entry.available).toBe("boolean");
+      expect(typeof entry.detectedAt).toBe("string");
+    }
+  });
+
+  it("unauthenticated machine reports both providers as state=unauthenticated", async () => {
+    const caps = await probeCapabilities();
+    expect(caps["claude-code"]?.state).toBe("unauthenticated");
+    expect(caps.codex?.state).toBe("unauthenticated");
+  });
+
+  it("setting ANTHROPIC_API_KEY flips claude-code to ok without disturbing codex", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    const caps = await probeCapabilities();
+    expect(caps["claude-code"]?.state).toBe("ok");
+    expect(caps.codex?.state).toBe("unauthenticated");
+  });
+});

--- a/packages/client/src/__tests__/claude-code-config.test.ts
+++ b/packages/client/src/__tests__/claude-code-config.test.ts
@@ -5,6 +5,7 @@ describe("claude-code handler helpers (Step 6)", () => {
   describe("mapMcpServers", () => {
     it("maps stdio server with args", () => {
       const out = mapMcpServers({
+        kind: "claude-code",
         prompt: { append: "" },
         model: "",
         env: [],
@@ -16,6 +17,7 @@ describe("claude-code handler helpers (Step 6)", () => {
 
     it("maps http server with headers", () => {
       const out = mapMcpServers({
+        kind: "claude-code",
         prompt: { append: "" },
         model: "",
         env: [],
@@ -33,6 +35,7 @@ describe("claude-code handler helpers (Step 6)", () => {
 
     it("maps sse server", () => {
       const out = mapMcpServers({
+        kind: "claude-code",
         prompt: { append: "" },
         model: "",
         env: [],
@@ -45,6 +48,7 @@ describe("claude-code handler helpers (Step 6)", () => {
     it("returns empty record when no servers", () => {
       expect(
         mapMcpServers({
+          kind: "claude-code",
           prompt: { append: "" },
           model: "",
           env: [],

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -1,0 +1,79 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { bootstrapWorkspace, FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+
+describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
+  let workspacePath: string;
+
+  beforeEach(() => {
+    workspacePath = mkdtempSync(join(tmpdir(), "first-tree-codex-bootstrap-"));
+  });
+
+  afterEach(() => {
+    rmSync(workspacePath, { recursive: true, force: true });
+  });
+
+  it("writes the .first-tree-workspace marker for every workspace", () => {
+    bootstrapWorkspace({
+      workspacePath,
+      identity: {
+        agentId: "agent-1",
+        inboxId: "inbox_agent-1",
+        displayName: "Tester",
+        type: "personal_assistant",
+        delegateMention: null,
+        metadata: {},
+      },
+      contextTreePath: null,
+      serverUrl: "http://hub.test",
+      chatId: "chat-1",
+    });
+
+    expect(existsSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER))).toBe(true);
+  });
+
+  it("writes AGENTS.md when briefing.format='agents-md'", () => {
+    bootstrapWorkspace({
+      workspacePath,
+      identity: {
+        agentId: "agent-1",
+        inboxId: "inbox_agent-1",
+        displayName: "Tester",
+        type: "personal_assistant",
+        delegateMention: null,
+        metadata: {},
+      },
+      contextTreePath: null,
+      serverUrl: "http://hub.test",
+      chatId: "chat-1",
+      briefing: { format: "agents-md", content: "# Hello\n\nFollow your team's playbook.\n" },
+    });
+
+    const agentsPath = join(workspacePath, "AGENTS.md");
+    expect(existsSync(agentsPath)).toBe(true);
+    const text = readFileSync(agentsPath, "utf-8");
+    expect(text).toContain("Hello");
+    expect(text).toContain("Follow your team's playbook.");
+  });
+
+  it("does not write AGENTS.md when no briefing is supplied (claude-code path)", () => {
+    bootstrapWorkspace({
+      workspacePath,
+      identity: {
+        agentId: "agent-1",
+        inboxId: "inbox_agent-1",
+        displayName: "Tester",
+        type: "personal_assistant",
+        delegateMention: null,
+        metadata: {},
+      },
+      contextTreePath: null,
+      serverUrl: "http://hub.test",
+      chatId: "chat-1",
+    });
+
+    expect(existsSync(join(workspacePath, "AGENTS.md"))).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/codex-thread-options.test.ts
+++ b/packages/client/src/__tests__/codex-thread-options.test.ts
@@ -1,0 +1,61 @@
+import type { AgentRuntimeConfigPayload } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { buildCodexThreadOptions } from "../handlers/codex.js";
+
+/**
+ * Codex CLI's two auth modes accept different model slugs:
+ *   - ChatGPT-account auth rejects the `gpt-5-codex` family.
+ *   - API-key auth accepts the wider set.
+ * Hub therefore stores `model: ""` by default and lets the CLI pick. The
+ * handler must respect that — emitting `model` only when the operator
+ * actively chose one, otherwise omitting it from `ThreadOptions`. A
+ * regression here would silently break ChatGPT-auth users at first turn
+ * (the symptom we hit before this fix: "turn completed with no message").
+ */
+function basePayload(overrides: Partial<AgentRuntimeConfigPayload> = {}): AgentRuntimeConfigPayload {
+  return {
+    kind: "codex",
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    ...overrides,
+  };
+}
+
+describe("buildCodexThreadOptions", () => {
+  it("omits `model` when payload.model is empty (auth-mode-agnostic default)", () => {
+    const opts = buildCodexThreadOptions(basePayload({ model: "" }), "/tmp/wsk");
+    expect("model" in opts).toBe(false);
+  });
+
+  it("passes `model` through when the operator explicitly set one", () => {
+    const opts = buildCodexThreadOptions(basePayload({ model: "gpt-5.5" }), "/tmp/wsk");
+    expect(opts.model).toBe("gpt-5.5");
+  });
+
+  it("pins the auth-friendly defaults the SDK requires", () => {
+    const opts = buildCodexThreadOptions(basePayload(), "/tmp/wsk");
+    expect(opts.workingDirectory).toBe("/tmp/wsk");
+    expect(opts.skipGitRepoCheck).toBe(true);
+    expect(opts.sandboxMode).toBe("workspace-write");
+    expect(opts.approvalPolicy).toBe("never");
+    // Footgun F3: minimal reasoning is incompatible with default tools.
+    expect(opts.modelReasoningEffort).toBe("high");
+    expect(opts.webSearchEnabled).toBe(false);
+  });
+
+  it("derives additionalDirectories from gitRepos (with deriveRepoLocalPath fallback)", () => {
+    const opts = buildCodexThreadOptions(
+      basePayload({
+        gitRepos: [
+          { url: "https://github.com/foo/bar.git" },
+          { url: "https://github.com/baz/qux.git", localPath: "custom-path" },
+        ],
+      }),
+      "/tmp/wsk",
+    );
+    expect(opts.additionalDirectories).toEqual(["/tmp/wsk/bar", "/tmp/wsk/custom-path"]);
+  });
+});

--- a/packages/client/src/__tests__/repair.test.ts
+++ b/packages/client/src/__tests__/repair.test.ts
@@ -1,0 +1,25 @@
+import { AGENT_BIND_REJECT_REASONS } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { decideRepairForBindReject } from "../runtime/repair.js";
+
+/**
+ * `decideRepairForBindReject` is a tiny dispatch table, but it sits on the
+ * agent-bind hot path: the wrong action shape ("ignore" instead of "restart"
+ * — or vice versa) silently swallows the runtime-mismatch repair, so we
+ * pin the table here.
+ */
+describe("decideRepairForBindReject", () => {
+  it("returns `restart` for runtime_provider_mismatch (P2 minimal repair)", () => {
+    expect(decideRepairForBindReject(AGENT_BIND_REJECT_REASONS.RUNTIME_PROVIDER_MISMATCH)).toEqual({ kind: "restart" });
+  });
+
+  it.each([
+    ["wrong_client", AGENT_BIND_REJECT_REASONS.WRONG_CLIENT],
+    ["not_owned", AGENT_BIND_REJECT_REASONS.NOT_OWNED],
+    ["agent_suspended", AGENT_BIND_REJECT_REASONS.AGENT_SUSPENDED],
+    ["wrong_org", AGENT_BIND_REJECT_REASONS.WRONG_ORG],
+    ["unknown_agent", AGENT_BIND_REJECT_REASONS.UNKNOWN_AGENT],
+  ] as const)("returns `ignore` for %s (no client-side repair has been wired up)", (_label, reason) => {
+    expect(decideRepairForBindReject(reason)).toEqual({ kind: "ignore" });
+  });
+});

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -1,0 +1,570 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type AgentRuntimeConfigPayload,
+  deriveRepoLocalPath,
+  type SessionEvent,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { Codex, type Input, type Thread, type ThreadEvent, type ThreadOptions } from "@openai/codex-sdk";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
+import { bootstrapWorkspace, FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { acquireWorkspace } from "../runtime/workspace.js";
+
+/**
+ * Codex SDK does not export its `CodexConfigObject` type, so reproduce the
+ * minimal shape we need (`mcp_servers.<name>.{...}`, `project_root_markers`).
+ * Mirrors the recursive structure from the SDK's `dist/index.d.ts`.
+ */
+type CodexConfigValue = string | number | boolean | CodexConfigValue[] | CodexConfigObject;
+type CodexConfigObject = { [key: string]: CodexConfigValue };
+
+const ASSISTANT_TEXT_EVENT_LIMIT = 8000;
+const RESULT_PREVIEW_LIMIT = 400;
+
+type Worktree = { url: string; path: string; branchName: string };
+
+/**
+ * Build the per-turn `ThreadOptions` Codex consumes. Exported so unit tests
+ * can lock the auth-mode-friendly defaults (notably `model` only set when
+ * the operator chose one).
+ */
+export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, workspaceCwd: string): ThreadOptions {
+  const additionalDirectories: string[] = [];
+  for (const repo of payload.gitRepos) {
+    const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
+    if (!localPath) continue;
+    additionalDirectories.push(join(workspaceCwd, localPath));
+  }
+  // Only pin a model when the operator explicitly set one in the agent
+  // config — leaving it unset lets the Codex CLI choose a default that
+  // matches the user's auth mode (e.g. ChatGPT-account auth rejects the
+  // `gpt-5-codex` family, while API-key auth accepts it). Hard-coding a
+  // default here would force one auth mode and silently fail on the other.
+  const opts: ThreadOptions = {
+    workingDirectory: workspaceCwd,
+    skipGitRepoCheck: true,
+    sandboxMode: "workspace-write",
+    approvalPolicy: "never",
+    modelReasoningEffort: "high",
+    webSearchEnabled: false,
+    additionalDirectories,
+  };
+  if (payload.model) opts.model = payload.model;
+  return opts;
+}
+
+/**
+ * Codex Handler — session-oriented handler using `@openai/codex-sdk`.
+ *
+ * Each instance owns one Thread for one chat. Each turn is a fresh
+ * `runStreamed()` call (Codex CLI is run-to-completion per turn). Inject
+ * during an active turn buffers messages and runs them as a follow-up turn
+ * the moment the current one completes.
+ *
+ * Key footguns observed end-to-end (private plan §10.7):
+ *   - F1: providing `env` to Codex SDK does NOT inherit `process.env`; we
+ *         explicitly merge.
+ *   - F2: `resumeThread(id)` does NOT inherit `ThreadOptions`; we re-pass
+ *         them every time.
+ *   - F3: `modelReasoningEffort: "minimal"` is incompatible with default
+ *         tools; we default to `"high"` with `webSearchEnabled: false`.
+ *   - F6: `Thread` has no close/dispose — shutdown is exclusively
+ *         `AbortController.abort()`.
+ */
+export const createCodexHandler: HandlerFactory = (config) => {
+  const workspaceRoot = config.workspaceRoot as string;
+  const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
+  const gitMirrorManager = (config.gitMirrorManager as GitMirrorManager | undefined) ?? null;
+  const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
+
+  let cwd: string | null = null;
+  let codex: Codex | null = null;
+  let thread: Thread | null = null;
+  let threadId: string | null = null;
+  let currentAbort: AbortController | null = null;
+  let currentTurnPromise: Promise<void> | null = null;
+  let ctx: SessionContext | null = null;
+  let drainScheduled = false;
+  const queuedMessages: SessionMessage[] = [];
+  const ownedWorktrees: Worktree[] = [];
+
+  function buildEnv(sessionCtx: SessionContext): Record<string, string> {
+    // Footgun F1: when `CodexOptions.env` is provided the SDK does NOT
+    // inherit `process.env`, so HOME/PATH/etc. would be missing. Start by
+    // explicitly cloning every defined parent var.
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === "string") env[k] = v;
+    }
+    const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
+    if (payload) {
+      for (const e of payload.env) env[e.key] = e.value;
+    }
+    const merged = sessionCtx.buildAgentEnv(env);
+    // The Hub envelope returns `Record<string, string | undefined>`; trim out
+    // undefined values so the SDK doesn't see them.
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(merged)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  }
+
+  function buildCodexConfig(payload: AgentRuntimeConfigPayload): CodexConfigObject {
+    const cfg: CodexConfigObject = {
+      // Gap-2: anchor codex's project-root walk-up at the workspace marker
+      // we wrote in bootstrap, so `AGENTS.md` is read from this workspace
+      // instead of leaking up to the operator's repo or HOME.
+      project_root_markers: [FIRST_TREE_WORKSPACE_MARKER],
+    };
+    if (payload.mcpServers.length === 0) return cfg;
+
+    const mcpServers: CodexConfigObject = {};
+    for (const m of payload.mcpServers) {
+      if (m.transport === "stdio") {
+        mcpServers[m.name] = { command: m.command, args: m.args ?? [] };
+      } else {
+        // http / sse — codex's TOML schema accepts url + optional headers.
+        const entry: CodexConfigObject = { url: m.url };
+        if (m.headers) entry.headers = m.headers;
+        mcpServers[m.name] = entry;
+      }
+    }
+    cfg.mcp_servers = mcpServers;
+    return cfg;
+  }
+
+  function buildAgentBriefing(payload: AgentRuntimeConfigPayload): string {
+    const lines: string[] = [];
+    lines.push("# Agent Briefing");
+    lines.push("");
+    if (payload.prompt.append.trim()) {
+      lines.push(payload.prompt.append.trim());
+      lines.push("");
+    }
+    lines.push("Refer to `.agent/identity.json` for your agent identity, `.agent/tools.md` for the");
+    lines.push("first-tree-hub SDK reference, and `.agent/context/` for organisational context");
+    lines.push("(when configured).");
+    return lines.join("\n").concat("\n");
+  }
+
+  function toCodexInput(message: SessionMessage, sessionCtx: SessionContext): Promise<Input> {
+    return sessionCtx.formatInboundContent(message).then((text) => text);
+  }
+
+  async function prepareGitWorktrees(
+    payload: AgentRuntimeConfigPayload,
+    workspaceCwd: string,
+    chatId: string,
+  ): Promise<void> {
+    if (!gitMirrorManager) return;
+    for (const repo of payload.gitRepos) {
+      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
+      if (!localPath) continue;
+      const targetPath = join(workspaceCwd, localPath);
+      if (existsSync(targetPath)) continue;
+      try {
+        await gitMirrorManager.ensureMirror(repo.url);
+        await gitMirrorManager.fetchMirror(repo.url);
+        const result = await gitMirrorManager.createWorktree({
+          url: repo.url,
+          ref: repo.ref,
+          targetPath,
+          sessionKey: chatId,
+        });
+        ownedWorktrees.push({ url: repo.url, path: targetPath, branchName: result.branchName });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        ctx?.log(`codex git materialisation skipped (${repo.url}): ${msg}`);
+      }
+    }
+  }
+
+  function emitToolCall(
+    sessionCtx: SessionContext,
+    payload: {
+      toolUseId: string;
+      name: string;
+      args: unknown;
+      status: "ok" | "error" | "pending";
+      resultPreview?: string;
+    },
+  ): void {
+    const event: SessionEvent = {
+      kind: "tool_call",
+      payload: {
+        toolUseId: payload.toolUseId,
+        name: payload.name,
+        args: payload.args,
+        status: payload.status,
+        ...(payload.resultPreview ? { resultPreview: payload.resultPreview.slice(0, RESULT_PREVIEW_LIMIT) } : {}),
+      },
+    };
+    sessionCtx.emitEvent(event);
+  }
+
+  function processItem(item: ThreadEvent extends { item: infer I } ? I : never, sessionCtx: SessionContext): string {
+    // Returns any text the assistant message added so the runTurn loop can
+    // accumulate the full final response.
+    return processItemImpl(item as never, sessionCtx);
+  }
+
+  function processItemImpl(item: import("@openai/codex-sdk").ThreadItem, sessionCtx: SessionContext): string {
+    switch (item.type) {
+      case "agent_message": {
+        sessionCtx.emitEvent({
+          kind: "assistant_text",
+          payload: { text: item.text.slice(0, ASSISTANT_TEXT_EVENT_LIMIT) },
+        });
+        return item.text;
+      }
+      case "command_execution": {
+        const status =
+          item.status === "completed"
+            ? ("ok" as const)
+            : item.status === "failed"
+              ? ("error" as const)
+              : ("pending" as const);
+        emitToolCall(sessionCtx, {
+          toolUseId: item.id,
+          name: "command",
+          args: { command: item.command },
+          status,
+          resultPreview: item.aggregated_output,
+        });
+        return "";
+      }
+      case "file_change": {
+        const status = item.status === "completed" ? ("ok" as const) : ("error" as const);
+        emitToolCall(sessionCtx, {
+          toolUseId: item.id,
+          name: "file_change",
+          args: { changes: item.changes },
+          status,
+        });
+        return "";
+      }
+      case "mcp_tool_call": {
+        const status =
+          item.status === "completed"
+            ? ("ok" as const)
+            : item.status === "failed"
+              ? ("error" as const)
+              : ("pending" as const);
+        const resultPreview = item.error
+          ? `error: ${item.error.message}`
+          : item.result
+            ? JSON.stringify(item.result.structured_content ?? item.result.content)
+            : undefined;
+        emitToolCall(sessionCtx, {
+          toolUseId: item.id,
+          name: `mcp:${item.server}/${item.tool}`,
+          args: item.arguments,
+          status,
+          resultPreview,
+        });
+        return "";
+      }
+      case "web_search": {
+        emitToolCall(sessionCtx, {
+          toolUseId: item.id,
+          name: "web_search",
+          args: { query: item.query },
+          status: "ok",
+        });
+        return "";
+      }
+      case "todo_list": {
+        // Codex's running plan / scratchpad — render as a tool_call so the UI
+        // surfaces it without needing a dedicated event kind.
+        emitToolCall(sessionCtx, {
+          toolUseId: item.id,
+          name: "todo_list",
+          args: { items: item.items },
+          status: "ok",
+        });
+        return "";
+      }
+      case "reasoning": {
+        // Hide reasoning content for parity with how claude-code suppresses
+        // thinking blocks; surface a presence-only marker instead.
+        sessionCtx.emitEvent({ kind: "thinking", payload: {} });
+        return "";
+      }
+      case "error": {
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "tool", message: item.message },
+        });
+        return "";
+      }
+      default:
+        return "";
+    }
+  }
+
+  async function runTurn(input: Input, sessionCtx: SessionContext): Promise<void> {
+    const activeThread = thread;
+    if (!activeThread) return;
+
+    const abort = new AbortController();
+    currentAbort = abort;
+    sessionCtx.setRuntimeState("working");
+
+    let accumulated = "";
+    const promise = (async () => {
+      try {
+        const streamed = await activeThread.runStreamed(input, { signal: abort.signal });
+        for await (const event of streamed.events) {
+          if (abort.signal.aborted) break;
+          sessionCtx.touch();
+          if (event.type === "thread.started") {
+            threadId = event.thread_id;
+          } else if (event.type === "turn.started") {
+            // No-op — runtime state already "working".
+          } else if (event.type === "item.completed") {
+            accumulated += processItem(event.item as never, sessionCtx);
+          } else if (event.type === "item.started" || event.type === "item.updated") {
+            // Stream-only intermediate states — claude-code likewise emits
+            // events on terminal items only; codex's run-to-completion model
+            // means the terminal item carries the full payload.
+          } else if (event.type === "turn.completed") {
+            sessionCtx.emitEvent({
+              kind: "turn_end",
+              payload: { status: "success" },
+            });
+          } else if (event.type === "turn.failed") {
+            sessionCtx.emitEvent({
+              kind: "error",
+              payload: { source: "sdk", message: event.error.message },
+            });
+            sessionCtx.emitEvent({
+              kind: "turn_end",
+              payload: { status: "error" },
+            });
+          } else if (event.type === "error") {
+            sessionCtx.emitEvent({
+              kind: "error",
+              payload: { source: "sdk", message: event.message },
+            });
+          }
+        }
+      } catch (err) {
+        if (abort.signal.aborted) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: msg } });
+        sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+      }
+    })();
+
+    currentTurnPromise = promise;
+    try {
+      await promise;
+    } finally {
+      currentAbort = null;
+      currentTurnPromise = null;
+    }
+
+    if (accumulated.trim()) {
+      try {
+        await sessionCtx.forwardResult(accumulated);
+      } catch (err) {
+        sessionCtx.log(`codex forwardResult failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      sessionCtx.reportSessionCompletion();
+    }
+    sessionCtx.setRuntimeState("idle");
+
+    // Drain queued messages — schedules at most one follow-up at a time so
+    // a runaway inject loop can't recurse into stack overflow.
+    if (queuedMessages.length > 0 && !drainScheduled) {
+      drainScheduled = true;
+      setImmediate(() => {
+        drainScheduled = false;
+        const drained = queuedMessages.splice(0);
+        if (drained.length === 0 || !ctx || !thread) return;
+        void mergeAndRun(drained, ctx);
+      });
+    }
+  }
+
+  async function mergeAndRun(drained: SessionMessage[], sessionCtx: SessionContext): Promise<void> {
+    const inputs: string[] = [];
+    for (const m of drained) {
+      try {
+        inputs.push(await sessionCtx.formatInboundContent(m));
+      } catch (err) {
+        sessionCtx.log(`codex inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (inputs.length === 0) return;
+    await runTurn(inputs.join("\n\n"), sessionCtx);
+  }
+
+  return {
+    async start(message, sessionCtx) {
+      ctx = sessionCtx;
+      cwd = await acquireWorkspace(workspaceRoot, sessionCtx.chatId);
+
+      let payload: AgentRuntimeConfigPayload | null = null;
+      if (agentConfigCache) {
+        payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
+      }
+      if (!payload) {
+        payload = {
+          kind: "codex",
+          prompt: { append: "" },
+          model: "",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+        };
+      }
+
+      bootstrapWorkspace({
+        workspacePath: cwd,
+        identity: sessionCtx.agent,
+        contextTreePath,
+        serverUrl: sessionCtx.sdk.serverUrl,
+        chatId: sessionCtx.chatId,
+        briefing: { format: "agents-md", content: buildAgentBriefing(payload) },
+      });
+
+      await prepareGitWorktrees(payload, cwd, sessionCtx.chatId);
+
+      codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
+      thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
+
+      const input = await toCodexInput(message, sessionCtx);
+      await runTurn(input, sessionCtx);
+
+      // Codex assigns thread_id via `thread.started` during the first turn;
+      // fall back to whatever `Thread` exposes if the event was missed.
+      if (!threadId) {
+        threadId = thread.id ?? null;
+      }
+      if (!threadId) {
+        throw new Error("codex did not assign a thread id during the first turn");
+      }
+      return threadId;
+    },
+
+    async resume(message, sessionId, sessionCtx) {
+      ctx = sessionCtx;
+      cwd = await acquireWorkspace(workspaceRoot, sessionCtx.chatId);
+
+      let payload: AgentRuntimeConfigPayload | null = null;
+      if (agentConfigCache) {
+        payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
+      }
+      if (!payload) {
+        payload = {
+          kind: "codex",
+          prompt: { append: "" },
+          model: "",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+        };
+      }
+
+      // Idempotent — if `.agent/identity.json` already exists this rewrites
+      // it with the fresh agent identity, but won't churn unrelated state.
+      bootstrapWorkspace({
+        workspacePath: cwd,
+        identity: sessionCtx.agent,
+        contextTreePath,
+        serverUrl: sessionCtx.sdk.serverUrl,
+        chatId: sessionCtx.chatId,
+        briefing: { format: "agents-md", content: buildAgentBriefing(payload) },
+      });
+
+      await prepareGitWorktrees(payload, cwd, sessionCtx.chatId);
+
+      codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
+      // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —
+      // re-pass them every time.
+      thread = codex.resumeThread(sessionId, buildCodexThreadOptions(payload, cwd));
+      threadId = sessionId;
+
+      if (message) {
+        const input = await toCodexInput(message, sessionCtx);
+        await runTurn(input, sessionCtx);
+      }
+      return sessionId;
+    },
+
+    inject(message) {
+      // Fire-and-forget — Codex turns are run-to-completion, so the message
+      // is buffered and drained on the next available turn. If the thread
+      // isn't running anything right now, schedule a turn immediately.
+      if (currentTurnPromise) {
+        queuedMessages.push(message);
+        return;
+      }
+      const sessionCtx = ctx;
+      if (!sessionCtx || !thread) return;
+      void (async () => {
+        try {
+          const input = await toCodexInput(message, sessionCtx);
+          await runTurn(input, sessionCtx);
+        } catch (err) {
+          sessionCtx.log(`codex inject failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })();
+    },
+
+    async suspend() {
+      currentAbort?.abort();
+      try {
+        await currentTurnPromise;
+      } catch {
+        // swallowed — abort raises AbortError on the streaming iterator
+      }
+      currentAbort = null;
+      currentTurnPromise = null;
+      thread = null;
+      codex = null;
+    },
+
+    async shutdown() {
+      // suspend() releases the active turn; this method then frees workspace
+      // + worktrees so a fresh chat doesn't pick up stale state.
+      currentAbort?.abort();
+      try {
+        await currentTurnPromise;
+      } catch {
+        /*ignore*/
+      }
+      currentAbort = null;
+      currentTurnPromise = null;
+      thread = null;
+      codex = null;
+
+      if (gitMirrorManager) {
+        for (const wt of ownedWorktrees) {
+          try {
+            await gitMirrorManager.removeWorktree({ url: wt.url, path: wt.path, branchName: wt.branchName });
+          } catch (err) {
+            ctx?.log(`codex worktree cleanup failed (${wt.path}): ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+        ownedWorktrees.length = 0;
+      }
+
+      if (cwd && existsSync(cwd)) {
+        try {
+          rmSync(cwd, { recursive: true, force: true });
+        } catch (err) {
+          ctx?.log(`codex workspace cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      cwd = null;
+      threadId = null;
+      ctx = null;
+      queuedMessages.length = 0;
+    },
+  } satisfies AgentHandler;
+};

--- a/packages/client/src/handlers/index.ts
+++ b/packages/client/src/handlers/index.ts
@@ -1,6 +1,7 @@
 import { registerHandler } from "../runtime/handler.js";
 import { createClaudeCodeHandler } from "./claude-code.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
+import { createCodexHandler } from "./codex.js";
 
 /** Register all built-in handlers. Call once at startup. */
 export function registerBuiltinHandlers(): void {
@@ -15,4 +16,8 @@ export function registerBuiltinHandlers(): void {
   registerHandler("claude-code", (config) =>
     createClaudeCodeHandler({ ...config, claudeCodeExecutable: resolution.path }),
   );
+  // Codex SDK bundles the codex CLI binary inside the npm package — no PATH
+  // resolution needed. The handler factory consumes the same HandlerConfig
+  // (workspaceRoot / agentConfigCache / gitMirrorManager / contextTreePath).
+  registerHandler("codex", (config) => createCodexHandler(config));
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,6 +16,10 @@ export {
 // Runtime
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
 export { AgentSlot } from "./runtime/agent-slot.js";
+// Capabilities
+export { probeClaudeCodeCapability } from "./runtime/capabilities/claude-code.js";
+export { probeCodexCapability } from "./runtime/capabilities/codex.js";
+export { probeCapabilities } from "./runtime/capabilities/index.js";
 export type { AgentSlotYamlConfig, RuntimeConfig, SessionConfig } from "./runtime/config.js";
 export { loadRuntimeConfig } from "./runtime/config.js";
 export { Deduplicator } from "./runtime/deduplicator.js";

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -80,7 +80,14 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
         config: {
           agentId,
           version: 0,
-          payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+          payload: {
+            kind: "claude-code",
+            prompt: { append: "" },
+            model: "",
+            mcpServers: [],
+            env: [],
+            gitRepos: [],
+          },
           updatedAt: "",
           updatedBy: "",
         },

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -116,22 +116,48 @@ export async function syncContextTree(
   }
 }
 
+/**
+ * Marker file written into every workspace so the Codex CLI's project-root
+ * detection (configured via `project_root_markers: ["first-tree-workspace"]`)
+ * stops at the workspace boundary instead of walking up the filesystem and
+ * loading an unintended `AGENTS.md` from the operator's home or repo root.
+ */
+export const FIRST_TREE_WORKSPACE_MARKER = ".first-tree-workspace";
+
+export type AgentBriefingFormat = "claude" | "agents-md";
+
+export type AgentBriefing = {
+  format: AgentBriefingFormat;
+  /** Pre-rendered markdown to materialise as the briefing file. */
+  content: string;
+};
+
 export type BootstrapOptions = {
   workspacePath: string;
   identity: AgentIdentity;
   contextTreePath: string | null;
   serverUrl: string;
   chatId: string;
+  /**
+   * Provider-specific runtime briefing materialised at the workspace root.
+   * `agents-md` writes `AGENTS.md` (Codex reads it from the project root via
+   * the marker); `claude` is a no-op file-write because Claude Code receives
+   * the system prompt through the SDK option directly.
+   */
+  briefing?: AgentBriefing;
 };
 
 /**
- * Bootstrap a workspace with .agent/ directory files.
+ * Bootstrap a workspace with `.agent/` directory files plus the workspace
+ * root marker (and an optional provider-specific briefing).
  *
- * Writes identity.json, context/self.md (if context tree available), and tools.md.
- * Designed to be called on every handler start() and conditionally on resume().
+ * Writes identity.json, context/agent-instructions.md (if context tree
+ * available), tools.md, the `.first-tree-workspace` marker, and — for
+ * Codex — `AGENTS.md`. Idempotent: safe to call on every handler start()
+ * and on resume().
  */
 export function bootstrapWorkspace(options: BootstrapOptions): void {
-  const { workspacePath, identity, contextTreePath, serverUrl, chatId } = options;
+  const { workspacePath, identity, contextTreePath, serverUrl, chatId, briefing } = options;
   const agentDir = join(workspacePath, ".agent");
   const contextDir = join(agentDir, "context");
 
@@ -172,8 +198,18 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
     }
   }
 
-  // 4. Write tools.md (static SDK reference)
+  // 3. Write tools.md (static SDK reference)
   writeFileSync(join(agentDir, "tools.md"), generateToolsDoc(), "utf-8");
+
+  // 4. Workspace-root marker — gates Codex's AGENTS.md walk-up so the agent
+  //    sees the briefing in this workspace and not whatever sits in the
+  //    operator's HOME / git root.
+  writeFileSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
+
+  // 5. Provider-specific briefing
+  if (briefing?.format === "agents-md") {
+    writeFileSync(join(workspacePath, "AGENTS.md"), briefing.content, "utf-8");
+  }
 }
 
 export type InstallFirstTreeIntegrationExec = (

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CapabilityEntry } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Top-level marker file Claude Code writes after a successful OAuth login.
+ * Path is platform-agnostic (`~/.claude.json`); the access token itself lives
+ * in the platform credential store (macOS Keychain entry "Claude Code-
+ * credentials", or libsecret on Linux), so we treat the presence of an
+ * `oauthAccount.accountUuid` field as the canonical "logged in" signal.
+ */
+const CLAUDE_PROFILE_PATH = () => join(homedir(), ".claude.json");
+
+function hasClaudeOAuthAccount(): boolean {
+  try {
+    const path = CLAUDE_PROFILE_PATH();
+    if (!existsSync(path)) return false;
+    const raw = readFileSync(path, "utf-8");
+    const obj = JSON.parse(raw) as { oauthAccount?: { accountUuid?: unknown } };
+    return typeof obj.oauthAccount?.accountUuid === "string" && obj.oauthAccount.accountUuid.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function readSdkVersion(): Promise<string | null> {
+  // The Anthropic SDK does not expose `./package.json` via `exports` and only
+  // ships ESM `default` (no CJS `require` condition). Use ESM resolution, then
+  // walk up from the entry file to the package root.
+  try {
+    const entryUrl = await import.meta.resolve("@anthropic-ai/claude-agent-sdk");
+    let dir = dirname(fileURLToPath(entryUrl));
+    for (let depth = 0; depth < 8; depth += 1) {
+      const candidate = join(dir, "package.json");
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as { name?: unknown; version?: unknown };
+        if (pkg.name === "@anthropic-ai/claude-agent-sdk" && typeof pkg.version === "string") return pkg.version;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function detectAuth(): { authenticated: boolean; method: "api_key" | "oauth" | "none" } {
+  if (process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.length > 0) {
+    return { authenticated: true, method: "api_key" };
+  }
+  if (hasClaudeOAuthAccount()) {
+    return { authenticated: true, method: "oauth" };
+  }
+  return { authenticated: false, method: "none" };
+}
+
+/**
+ * Probe whether the Claude Code runtime is usable on this machine.
+ *
+ * `state` is the authoritative field; `available` and `authenticated` are
+ * derived booleans kept around for simple consumers (e.g. capability lookup
+ * in service-layer guards).
+ */
+export async function probeClaudeCodeCapability(): Promise<CapabilityEntry> {
+  const detectedAt = new Date().toISOString();
+  try {
+    let sdkPresent = false;
+    try {
+      await import("@anthropic-ai/claude-agent-sdk");
+      sdkPresent = true;
+    } catch {
+      sdkPresent = false;
+    }
+
+    if (!sdkPresent) {
+      return {
+        state: "missing",
+        available: false,
+        authenticated: false,
+        sdkVersion: null,
+        authMethod: "none",
+        detectedAt,
+      };
+    }
+
+    const sdkVersion = await readSdkVersion();
+    const auth = detectAuth();
+    if (!auth.authenticated) {
+      return {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion,
+        authMethod: "none",
+        detectedAt,
+      };
+    }
+    return {
+      state: "ok",
+      available: true,
+      authenticated: true,
+      sdkVersion,
+      authMethod: auth.method,
+      detectedAt,
+    };
+  } catch (err) {
+    return {
+      state: "error",
+      available: false,
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      error: err instanceof Error ? err.message : String(err),
+      detectedAt,
+    };
+  }
+}

--- a/packages/client/src/runtime/capabilities/codex.ts
+++ b/packages/client/src/runtime/capabilities/codex.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CapabilityEntry } from "@agent-team-foundation/first-tree-hub-shared";
+
+function codexAuthPath(): string {
+  const home = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+  return join(home, "auth.json");
+}
+
+async function readSdkVersion(): Promise<string | null> {
+  // The codex-sdk only exports `.` (no `./package.json` and no CJS `require`
+  // condition), so `createRequire(...).resolve` fails in CJS context. Use
+  // ESM's `import.meta.resolve`, then walk up from the entry file to the
+  // package's own package.json.
+  try {
+    const entryUrl = await import.meta.resolve("@openai/codex-sdk");
+    let dir = dirname(fileURLToPath(entryUrl));
+    for (let depth = 0; depth < 8; depth += 1) {
+      const candidate = join(dir, "package.json");
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as { name?: unknown; version?: unknown };
+        if (pkg.name === "@openai/codex-sdk" && typeof pkg.version === "string") return pkg.version;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function detectAuth(): { authenticated: boolean; method: "api_key" | "auth_json" | "none" } {
+  if (process.env.CODEX_API_KEY && process.env.CODEX_API_KEY.length > 0) {
+    return { authenticated: true, method: "api_key" };
+  }
+  if (existsSync(codexAuthPath())) {
+    return { authenticated: true, method: "auth_json" };
+  }
+  return { authenticated: false, method: "none" };
+}
+
+/**
+ * Probe whether the OpenAI Codex runtime is usable on this machine.
+ * Treats `~/.codex/auth.json` (set by `codex login`) as the canonical local
+ * auth source; CODEX_API_KEY env shortcuts that for ephemeral use.
+ */
+export async function probeCodexCapability(): Promise<CapabilityEntry> {
+  const detectedAt = new Date().toISOString();
+  try {
+    let sdkPresent = false;
+    try {
+      await import("@openai/codex-sdk");
+      sdkPresent = true;
+    } catch {
+      sdkPresent = false;
+    }
+
+    if (!sdkPresent) {
+      return {
+        state: "missing",
+        available: false,
+        authenticated: false,
+        sdkVersion: null,
+        authMethod: "none",
+        detectedAt,
+      };
+    }
+
+    const sdkVersion = await readSdkVersion();
+    const auth = detectAuth();
+    if (!auth.authenticated) {
+      return {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion,
+        authMethod: "none",
+        detectedAt,
+      };
+    }
+    return {
+      state: "ok",
+      available: true,
+      authenticated: true,
+      sdkVersion,
+      authMethod: auth.method,
+      detectedAt,
+    };
+  } catch (err) {
+    return {
+      state: "error",
+      available: false,
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      error: err instanceof Error ? err.message : String(err),
+      detectedAt,
+    };
+  }
+}

--- a/packages/client/src/runtime/capabilities/index.ts
+++ b/packages/client/src/runtime/capabilities/index.ts
@@ -1,0 +1,40 @@
+import type { ClientCapabilities, RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
+import { probeClaudeCodeCapability } from "./claude-code.js";
+import { probeCodexCapability } from "./codex.js";
+
+/**
+ * Run every built-in capability probe and aggregate the results.
+ *
+ * Each provider gets its own module under this directory; the orchestrator
+ * is intentionally simple — adding a new provider means importing the new
+ * probe here and registering its key. The probe modules themselves are
+ * deliberately not part of the `HandlerFactory` interface so capability
+ * detection stays decoupled from runtime instantiation (so we can probe
+ * whether a runtime is usable before spawning anything).
+ */
+export async function probeCapabilities(): Promise<ClientCapabilities> {
+  const probes: Array<readonly [RuntimeProvider, ReturnType<typeof probeClaudeCodeCapability>]> = [
+    ["claude-code", probeClaudeCodeCapability()],
+    ["codex", probeCodexCapability()],
+  ];
+
+  const out: ClientCapabilities = {};
+  await Promise.all(
+    probes.map(async ([provider, p]) => {
+      try {
+        out[provider] = await p;
+      } catch (err) {
+        out[provider] = {
+          state: "error",
+          available: false,
+          authenticated: false,
+          sdkVersion: null,
+          authMethod: "none",
+          error: err instanceof Error ? err.message : String(err),
+          detectedAt: new Date().toISOString(),
+        };
+      }
+    }),
+  );
+  return out;
+}

--- a/packages/client/src/runtime/repair.ts
+++ b/packages/client/src/runtime/repair.ts
@@ -1,0 +1,24 @@
+import { AGENT_BIND_REJECT_REASONS, type AgentBindRejectReason } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Outcome the bind-reject repair flow asks the caller to perform after
+ * rewriting authoritative state.
+ */
+export type RepairAction = { kind: "restart" } | { kind: "ignore" };
+
+/**
+ * P2 minimal repair: when a bind is rejected with `runtime_provider_mismatch`,
+ * the connecting client is running the wrong handler for the agent. The full
+ * fix requires re-fetching the authoritative provider, rewriting the local
+ * agent YAML, and respawning the slot with the right handler factory.
+ *
+ * For now (P2), we surface a `restart` action so the operator restarts the
+ * client process. Auto-repair (yaml rewrite + slot swap) lives behind a
+ * follow-up that needs handler-factory hot-swap support.
+ */
+export function decideRepairForBindReject(reason: AgentBindRejectReason): RepairAction {
+  if (reason === AGENT_BIND_REJECT_REASONS.RUNTIME_PROVIDER_MISMATCH) {
+    return { kind: "restart" };
+  }
+  return { kind: "ignore" };
+}

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -4,8 +4,10 @@ import {
   type AgentRuntimeConfig,
   type Chat,
   type ChatParticipantDetail,
+  type ClientCapabilities,
   type InboxEntryWithMessage,
   type Message,
+  type RuntimeProvider,
   type SendMessage,
   type SendToAgent,
 } from "@agent-team-foundation/first-tree-hub-shared";
@@ -103,6 +105,27 @@ export class FirstTreeHubSDK {
 
   async fetchAgentConfig(): Promise<AgentRuntimeConfig> {
     return this.requestJson<AgentRuntimeConfig>("/api/v1/agent/config");
+  }
+
+  /**
+   * Member-scoped: report this client's runtime-provider capabilities. The
+   * server stores them under `clients.metadata.capabilities` after checking
+   * that the connected member owns the client.
+   */
+  async updateCapabilities(clientId: string, capabilities: ClientCapabilities): Promise<void> {
+    await this.requestVoid(`/api/v1/clients/${encodeURIComponent(clientId)}/capabilities`, {
+      method: "PATCH",
+      body: JSON.stringify({ capabilities }),
+    });
+  }
+
+  /**
+   * Member-scoped: every agent pinned to a client owned by the calling user.
+   * Used by client startup to reconcile the local `agent.yaml::runtime` with
+   * the authoritative `agents.runtime_provider` before spawning handlers.
+   */
+  async listMyAgents(): Promise<Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider }>> {
+    return this.requestJson("/api/v1/clients/me/agents");
   }
 
   async isHubReachable(timeoutMs = 3_000): Promise<boolean> {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",
-    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk && node scripts/embed-assets.mjs",
+    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk && node scripts/embed-assets.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "@openai/codex-sdk": "^0.125.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/packages/command/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/packages/command/src/__tests__/runtime-provider-reconcile.test.ts
@@ -1,0 +1,208 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { reconcileLocalRuntimeProviders, uploadClientCapabilities } from "../core/runtime-provider-reconcile.js";
+
+/**
+ * Two CLI helpers, both fetch-driven against the hub:
+ *   - `reconcileLocalRuntimeProviders` rewrites local `agent.yaml::runtime`
+ *     when it disagrees with `agents.runtime_provider` (hub authoritative).
+ *   - `uploadClientCapabilities` PATCHes the per-machine probe results to
+ *     `clients.metadata.capabilities`.
+ *
+ * Both are best-effort on the CLI startup path, so these tests pin the
+ * happy/unhappy contracts and verify the YAML round-trip is non-lossy
+ * (other keys preserved). Without coverage, a regression that drops
+ * `agentId` or rewrites every yaml unconditionally would only surface at
+ * production startup.
+ */
+describe("reconcileLocalRuntimeProviders", () => {
+  let agentsDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "ft-hub-reconcile-"));
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  function seedAgentDir(name: string, yamlContent: Record<string, unknown>): string {
+    const dir = join(agentsDir, name);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "agent.yaml");
+    writeFileSync(
+      path,
+      Object.entries(yamlContent)
+        .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+        .join("\n"),
+    );
+    return path;
+  }
+
+  it("rewrites agent.yaml when hub says a different runtime_provider", async () => {
+    const yamlPath = seedAgentDir("alpha", { agentId: "agent-1", runtime: "claude-code", workspaceLabel: "alpha-ws" });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-1", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      agentsDir,
+    });
+
+    const after = parseYaml(readFileSync(yamlPath, "utf-8")) as Record<string, unknown>;
+    expect(after.runtime).toBe("codex");
+    // Sibling keys must survive the rewrite.
+    expect(after.agentId).toBe("agent-1");
+    expect(after.workspaceLabel).toBe("alpha-ws");
+  });
+
+  it("leaves agent.yaml untouched when runtime already matches hub", async () => {
+    const yamlPath = seedAgentDir("beta", { agentId: "agent-2", runtime: "codex" });
+    const before = readFileSync(yamlPath, "utf-8");
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-2", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      agentsDir,
+    });
+
+    expect(readFileSync(yamlPath, "utf-8")).toBe(before);
+  });
+
+  it("ignores local agents that aren't pinned to this user (hub returns no entry)", async () => {
+    const yamlPath = seedAgentDir("gamma", { agentId: "stale-agent", runtime: "claude-code" });
+    const before = readFileSync(yamlPath, "utf-8");
+    fetchMock.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    await reconcileLocalRuntimeProviders({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      agentsDir,
+    });
+
+    expect(readFileSync(yamlPath, "utf-8")).toBe(before);
+  });
+
+  it("throws when hub returns a non-OK status (caller wraps best-effort)", async () => {
+    fetchMock.mockResolvedValue(new Response("server down", { status: 500 }));
+    await expect(
+      reconcileLocalRuntimeProviders({
+        serverUrl: "http://hub.test",
+        accessToken: "tok",
+        agentsDir,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+
+  it("warns + skips an agent with malformed yaml without aborting the whole pass", async () => {
+    const goodPath = seedAgentDir("good", { agentId: "agent-good", runtime: "claude-code" });
+    const badDir = join(agentsDir, "broken");
+    mkdirSync(badDir, { recursive: true });
+    writeFileSync(join(badDir, "agent.yaml"), ":\n\t-broken: yaml: [");
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-good", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    const logs: Array<[string, string]> = [];
+    await reconcileLocalRuntimeProviders({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      agentsDir,
+      log: (level, msg) => logs.push([level, msg]),
+    });
+
+    // `good` still got reconciled despite the sibling parse failure.
+    const after = parseYaml(readFileSync(goodPath, "utf-8")) as { runtime?: string };
+    expect(after.runtime).toBe("codex");
+    expect(logs.some(([level, msg]) => level === "warn" && /broken/.test(msg))).toBe(true);
+  });
+});
+
+describe("uploadClientCapabilities", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("PATCHes /clients/:id/capabilities with the snapshot", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await uploadClientCapabilities({
+      serverUrl: "http://hub.test",
+      accessToken: "tok-xyz",
+      clientId: "cli-1",
+      capabilities: {
+        "claude-code": {
+          state: "ok",
+          available: true,
+          authenticated: true,
+          sdkVersion: "0.2.84",
+          authMethod: "oauth",
+          detectedAt: "2026-04-29T00:00:00Z",
+        },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error("fetch was not called");
+    const [url, init] = call as [string, RequestInit];
+    expect(url).toBe("http://hub.test/api/v1/clients/cli-1/capabilities");
+    expect(init.method).toBe("PATCH");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-xyz");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(String(init.body));
+    expect(body.capabilities["claude-code"].state).toBe("ok");
+  });
+
+  it("URL-encodes the clientId so paths with `/` or unicode survive", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    await uploadClientCapabilities({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      clientId: "weird/client id",
+      capabilities: {},
+    });
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error("fetch was not called");
+    const url = call[0] as string;
+    expect(url).toBe("http://hub.test/api/v1/clients/weird%2Fclient%20id/capabilities");
+  });
+
+  it("throws on non-OK status so the caller can log + continue", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 403 }));
+    await expect(
+      uploadClientCapabilities({
+        serverUrl: "http://hub.test",
+        accessToken: "tok",
+        clientId: "cli-1",
+        capabilities: {},
+      }),
+    ).rejects.toThrow(/403/);
+  });
+});

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -252,6 +252,7 @@ export function registerAgentCommands(program: Command): void {
             name,
             type: options.type,
             clientId: options.clientId,
+            runtimeProvider: options.runtime,
           };
           if (options.displayName) createBody.displayName = options.displayName;
 

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -14,6 +14,7 @@ import {
   applyClientLoggerConfig,
   ClientOrgMismatchError,
   configureClientLoggerForService,
+  probeCapabilities,
 } from "@first-tree-hub/client";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
@@ -35,7 +36,9 @@ import {
   printResults,
   promptMissingFields,
   promptUpdate,
+  reconcileLocalRuntimeProviders,
   resolveServerUrl,
+  uploadClientCapabilities,
 } from "../core/index.js";
 import { print } from "../core/output.js";
 import { registerConnectCommand } from "./connect.js";
@@ -95,6 +98,27 @@ export function registerClientCommands(program: Command): void {
           const msg = err instanceof Error ? err.message : String(err);
           print.status("⚠️", `agent-dir migration skipped: ${msg}`);
         }
+
+        // Pre-flight runtime-provider reconciliation: probe local runtime SDKs
+        // and rewrite any local `agent.yaml::runtime` whose value drifted from
+        // the authoritative `agents.runtime_provider` (so the spawn loop sees
+        // up-to-date config). The capabilities upload itself runs AFTER WS
+        // registration — see post-start block — because the `clients` row is
+        // created lazily during the `client:register` handshake.
+        let probedCapabilities: Awaited<ReturnType<typeof probeCapabilities>> | null = null;
+        try {
+          const accessToken = await ensureFreshAccessToken();
+          probedCapabilities = await probeCapabilities();
+          await reconcileLocalRuntimeProviders({
+            serverUrl: config.server.url,
+            accessToken,
+            agentsDir,
+            log: (level, msg) => print.status(level === "warn" ? "⚠️" : "•", msg),
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `runtime-provider reconcile skipped: ${msg}`);
+        }
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
         print.line(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
@@ -118,6 +142,25 @@ export function registerClientCommands(program: Command): void {
         }
 
         await runtime.start();
+
+        // Post-register capabilities upload — the `clients` row only exists
+        // after the `client:register` WS handshake, so we run the PATCH here
+        // instead of pre-flight. Best-effort: a transient failure logs and
+        // moves on; agents still bind, and a subsequent restart retries.
+        if (probedCapabilities) {
+          try {
+            const accessToken = await ensureFreshAccessToken();
+            await uploadClientCapabilities({
+              serverUrl: config.server.url,
+              accessToken,
+              clientId: config.client.id,
+              capabilities: probedCapabilities,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            print.status("⚠️", `capabilities upload skipped: ${msg}`);
+          }
+        }
 
         // Watch agents config dir for hot-add
         runtime.watchAgentsDir(agentsDir);

--- a/packages/command/src/commands/connect.ts
+++ b/packages/command/src/commands/connect.ts
@@ -10,7 +10,7 @@ import {
   resetConfigMeta,
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { ClientOrgMismatchError } from "@first-tree-hub/client";
+import { ClientOrgMismatchError, probeCapabilities } from "@first-tree-hub/client";
 import { input, password, select } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
@@ -27,7 +27,9 @@ import {
   loadCredentials,
   migrateLocalAgentDirs,
   promptUpdate,
+  reconcileLocalRuntimeProviders,
   saveCredentials,
+  uploadClientCapabilities,
 } from "../core/index.js";
 import { print } from "../core/output.js";
 
@@ -299,6 +301,25 @@ export function registerConnectCommand(parent: Command): void {
           const msg = err instanceof Error ? err.message : String(err);
           print.status("⚠️", `agent-dir migration skipped: ${msg}`);
         }
+
+        // Pre-flight: probe local SDKs and reconcile local YAMLs against the
+        // authoritative `agents.runtime_provider`. The capabilities upload runs
+        // AFTER WS register (post-start block) because the `clients` row is
+        // created lazily during the `client:register` handshake.
+        let probedCapabilities: Awaited<ReturnType<typeof probeCapabilities>> | null = null;
+        try {
+          const accessToken = await ensureFreshAccessToken();
+          probedCapabilities = await probeCapabilities();
+          await reconcileLocalRuntimeProviders({
+            serverUrl: config.server.url,
+            accessToken,
+            agentsDir,
+            log: (level, msg) => print.status(level === "warn" ? "⚠️" : "•", msg),
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `runtime-provider reconcile skipped: ${msg}`);
+        }
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
         // `connect --no-service` runs inline until Ctrl+C — no supervisor,
@@ -317,6 +338,23 @@ export function registerConnectCommand(parent: Command): void {
         }
 
         await runtime.start();
+
+        // Post-register capabilities upload — see client.ts for the rationale.
+        if (probedCapabilities) {
+          try {
+            const accessToken = await ensureFreshAccessToken();
+            await uploadClientCapabilities({
+              serverUrl: config.server.url,
+              accessToken,
+              clientId: config.client.id,
+              capabilities: probedCapabilities,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            print.status("⚠️", `capabilities upload skipped: ${msg}`);
+          }
+        }
+
         runtime.watchAgentsDir(agentsDir);
 
         // Graceful shutdown

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -245,7 +245,7 @@ export class ClientRuntime {
     const agentDir = join(this.agentsDir, localName);
     try {
       mkdirSync(agentDir, { recursive: true, mode: 0o700 });
-      const yaml = stringifyYaml({ agentId: message.agentId, runtime: "claude-code" });
+      const yaml = stringifyYaml({ agentId: message.agentId, runtime: message.runtimeProvider });
       writeFileSync(join(agentDir, "agent.yaml"), yaml, { mode: 0o600 });
       print.check(true, `auto-added agent "${localName}"`, `${message.agentId} (from server push)`);
     } catch (err) {

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -59,6 +59,8 @@ export {
 export { blank, status } from "./output.js";
 // Interactive prompts
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
+// Pre-flight runtime-provider reconciliation (P2 — capabilities + YAML rewrite)
+export { reconcileLocalRuntimeProviders, uploadClientCapabilities } from "./runtime-provider-reconcile.js";
 export type { StartOptions } from "./server.js";
 export { startServer } from "./server.js";
 // Background service install (launchd / systemd --user)

--- a/packages/command/src/core/runtime-provider-reconcile.ts
+++ b/packages/command/src/core/runtime-provider-reconcile.ts
@@ -1,0 +1,91 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ClientCapabilities, RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+type LogFn = (level: "info" | "warn", msg: string) => void;
+
+type AuthoritativePinnedAgent = {
+  agentId: string;
+  clientId: string;
+  runtimeProvider: RuntimeProvider;
+};
+
+/**
+ * Pre-flight reconciliation called before the agents loop spawns. Pulls
+ * authoritative `runtime_provider` for every agent the calling user owns and
+ * rewrites any local `agent.yaml` whose `runtime` field disagrees. Best-
+ * effort: a transient hub failure logs and falls back to the local YAML
+ * value (the in-band repair path catches any remaining drift on first bind).
+ */
+export async function reconcileLocalRuntimeProviders(opts: {
+  serverUrl: string;
+  accessToken: string;
+  agentsDir: string;
+  log?: LogFn;
+}): Promise<void> {
+  const res = await fetch(`${opts.serverUrl}/api/v1/clients/me/agents`, {
+    headers: { Authorization: `Bearer ${opts.accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`hub returned ${res.status} on /clients/me/agents`);
+  }
+  const items = (await res.json()) as AuthoritativePinnedAgent[];
+  const byAgentId = new Map(items.map((it) => [it.agentId, it]));
+
+  if (!existsSync(opts.agentsDir)) return;
+  const subdirs = readdirSync(opts.agentsDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  for (const subdir of subdirs) {
+    const yamlPath = join(opts.agentsDir, subdir.name, "agent.yaml");
+    if (!existsSync(yamlPath)) continue;
+    let parsed: { agentId?: string; runtime?: string } & Record<string, unknown>;
+    try {
+      const raw = readFileSync(yamlPath, "utf-8");
+      parsed = parseYaml(raw) ?? {};
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      opts.log?.("warn", `agent ${subdir.name}: cannot parse yaml — ${msg}`);
+      continue;
+    }
+    if (!parsed.agentId) continue;
+    const auth = byAgentId.get(parsed.agentId);
+    if (!auth) continue;
+    if (parsed.runtime === auth.runtimeProvider) continue;
+
+    const next = { ...parsed, runtime: auth.runtimeProvider };
+    try {
+      writeFileSync(yamlPath, stringifyYaml(next), { mode: 0o600 });
+      opts.log?.(
+        "info",
+        `agent ${parsed.agentId}: yaml runtime "${parsed.runtime ?? "(unset)"}" → "${auth.runtimeProvider}" (hub authoritative)`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      opts.log?.("warn", `agent ${parsed.agentId}: failed to rewrite yaml — ${msg}`);
+    }
+  }
+}
+
+/**
+ * Member-scoped capabilities upload. Server stores the snapshot under
+ * `clients.metadata.capabilities`. Best-effort: failure does not block
+ * client startup since capabilities only matter for UI / admin checks.
+ */
+export async function uploadClientCapabilities(opts: {
+  serverUrl: string;
+  accessToken: string;
+  clientId: string;
+  capabilities: ClientCapabilities;
+}): Promise<void> {
+  const res = await fetch(`${opts.serverUrl}/api/v1/clients/${encodeURIComponent(opts.clientId)}/capabilities`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${opts.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ capabilities: opts.capabilities }),
+  });
+  if (!res.ok) {
+    throw new Error(`hub returned ${res.status} on PATCH /clients/${opts.clientId}/capabilities`);
+  }
+}

--- a/packages/server/drizzle/0026_runtime_provider.sql
+++ b/packages/server/drizzle/0026_runtime_provider.sql
@@ -1,0 +1,10 @@
+-- Add runtime_provider to agents.
+--
+-- Tags each agent with the runtime that drives it (e.g. "claude-code", "codex").
+-- DEFAULT 'claude-code' backfills every existing row so the NOT NULL constraint
+-- is safe to land in a single step. Hub deploys are stop-migrate-restart, not
+-- rolling, so we don't need a two-phase add (nullable → backfill → not null).
+--
+-- Capabilities reporting reuses the existing `clients.metadata` jsonb column
+-- under the `capabilities` subkey (Option C); no SQL change for clients.
+ALTER TABLE "agents" ADD COLUMN "runtime_provider" text DEFAULT 'claude-code' NOT NULL;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1777420800000,
       "tag": "0025_inbox_silent_entries",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0026_runtime_provider",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/admin-clients-capabilities.test.ts
+++ b/packages/server/src/__tests__/admin-clients-capabilities.test.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+/**
+ * `PATCH /api/v1/clients/:clientId/capabilities` is the upload entry point
+ * for the per-machine runtime probe results. It must:
+ *   - persist the snapshot under `clients.metadata.capabilities` while
+ *     preserving sibling `metadata.*` keys (Option C),
+ *   - reject malformed payloads at the schema layer (400),
+ *   - 404 when the caller does not own the client (assertClientOwner).
+ */
+describe("PATCH /clients/:clientId/capabilities", () => {
+  const getApp = useTestApp();
+
+  function makeEntry(state: "ok" | "missing" = "ok") {
+    return {
+      state,
+      available: state === "ok",
+      authenticated: state === "ok",
+      sdkVersion: state === "ok" ? "1.2.3" : null,
+      authMethod: state === "ok" ? "api_key" : "none",
+      detectedAt: new Date().toISOString(),
+    };
+  }
+
+  it("persists the capabilities snapshot under clients.metadata.capabilities", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+
+    // Pre-seed an unrelated metadata key — we expect it to survive the
+    // capabilities write (the service deep-merges, not overwrites).
+    await app.db
+      .update(clients)
+      .set({ metadata: { siblingKey: "preserve-me" } })
+      .where(eq(clients.id, ctx.clientId));
+
+    const payload = {
+      capabilities: {
+        "claude-code": makeEntry("ok"),
+        codex: makeEntry("missing"),
+      },
+    };
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/clients/${ctx.clientId}/capabilities`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload,
+    });
+    expect(res.statusCode).toBe(204);
+
+    const [row] = await app.db
+      .select({ metadata: clients.metadata })
+      .from(clients)
+      .where(eq(clients.id, ctx.clientId))
+      .limit(1);
+    const meta = (row?.metadata ?? {}) as Record<string, unknown>;
+    expect(meta.siblingKey).toBe("preserve-me");
+    const caps = meta.capabilities as Record<string, { state: string; sdkVersion: string | null }>;
+    expect(caps["claude-code"]?.state).toBe("ok");
+    expect(caps["claude-code"]?.sdkVersion).toBe("1.2.3");
+    expect(caps.codex?.state).toBe("missing");
+    expect(caps.codex?.sdkVersion).toBeNull();
+  });
+
+  it("rejects an invalid capability state with 400", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/clients/${ctx.clientId}/capabilities`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: {
+        capabilities: {
+          "claude-code": {
+            state: "pending", // <- not in the schema enum
+            available: true,
+            authenticated: false,
+            authMethod: "none",
+            detectedAt: new Date().toISOString(),
+          },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("404s on an unknown clientId (assertClientOwner rejects before service call)", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/clients/cli-does-not-exist/capabilities`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: { capabilities: { "claude-code": makeEntry("ok") } },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/agent-capability-gate.test.ts
+++ b/packages/server/src/__tests__/agent-capability-gate.test.ts
@@ -1,0 +1,206 @@
+import type { CapabilityEntry, RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
+import { createAgent, rebindAgent } from "../services/agent.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+/**
+ * Coverage for the post-0026 capability gate in `services/agent.ts`:
+ *
+ *   - `clientCapabilitiesReported` distinguishes "never probed" (allow,
+ *     unknown) from "probed but missing this provider" (block).
+ *   - `clientSupportsRuntimeProvider` requires `entry.available === true` —
+ *     i.e. `state` ∈ {ok, unauthenticated}. `missing` / `error` blocks
+ *     unless `force: true`.
+ *
+ * The gate is invoked from `createAgent` (creation pre-flight) and
+ * `rebindAgent` (re-pin). Both paths get one happy / one blocked / one
+ * forced case so a regression in either call site fails this suite.
+ */
+
+function entry(state: CapabilityEntry["state"]): CapabilityEntry {
+  // The `available` field follows `state` — `ok`/`unauthenticated` keep the
+  // SDK reachable; `missing`/`error` mark it unusable. Mirrors the probes.
+  const available = state === "ok" || state === "unauthenticated";
+  return {
+    state,
+    available,
+    authenticated: state === "ok",
+    sdkVersion: available ? "1.0.0-test" : null,
+    authMethod: state === "ok" ? "api_key" : "none",
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+async function setCapabilities(
+  app: { db: import("../db/connection.js").Database },
+  clientId: string,
+  caps: Partial<Record<RuntimeProvider, CapabilityEntry>>,
+): Promise<void> {
+  await app.db
+    .update(clients)
+    .set({ metadata: { capabilities: caps } })
+    .where(eq(clients.id, clientId));
+}
+
+describe("Agent capability gate (services/agent.ts)", () => {
+  const getApp = useTestApp();
+
+  it("allows creation when client has not reported capabilities yet (unknown ⇒ allow)", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    // ctx.clientId is freshly seeded — metadata is null.
+    const created = await createAgent(app.db, {
+      name: `cap-gate-empty-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+    expect(created.runtimeProvider).toBe("claude-code");
+  });
+
+  it("allows creation when reported capability state is `ok`", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setCapabilities(app, ctx.clientId, { "claude-code": entry("ok") });
+
+    const created = await createAgent(app.db, {
+      name: `cap-gate-ok-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+    expect(created.runtimeProvider).toBe("claude-code");
+  });
+
+  it("allows creation when reported state is `unauthenticated` (available SDK, user fixes login)", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setCapabilities(app, ctx.clientId, { codex: entry("unauthenticated") });
+
+    const created = await createAgent(app.db, {
+      name: `cap-gate-unauth-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "codex",
+    });
+    expect(created.runtimeProvider).toBe("codex");
+  });
+
+  it("blocks creation when reported state is `missing`", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    // Probe always emits an entry per built-in provider — `missing` here is
+    // *reported*, not absent. The pre-fix code accepted this; we now reject.
+    await setCapabilities(app, ctx.clientId, {
+      "claude-code": entry("ok"),
+      codex: entry("missing"),
+    });
+
+    await expect(
+      createAgent(app.db, {
+        name: `cap-gate-missing-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+      }),
+    ).rejects.toThrow(/does not have runtime provider "codex" available/i);
+  });
+
+  it("blocks creation when reported state is `error`", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setCapabilities(app, ctx.clientId, { "claude-code": entry("error") });
+
+    await expect(
+      createAgent(app.db, {
+        name: `cap-gate-error-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+        runtimeProvider: "claude-code",
+      }),
+    ).rejects.toThrow(/does not have runtime provider "claude-code" available/i);
+  });
+
+  it("`force: true` bypasses the gate even when the SDK is reported missing", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setCapabilities(app, ctx.clientId, { codex: entry("missing") });
+
+    const created = await createAgent(
+      app.db,
+      {
+        name: `cap-gate-force-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+      },
+      { force: true },
+    );
+    expect(created.runtimeProvider).toBe("codex");
+  });
+
+  it("skips the gate for human agents (no client pinning)", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    // Even with capabilities saying nothing is available, a human agent has
+    // no clientId — the gate must short-circuit before any client lookup.
+    await setCapabilities(app, ctx.clientId, {
+      "claude-code": entry("missing"),
+      codex: entry("missing"),
+    });
+
+    const human = await createAgent(app.db, {
+      name: `cap-gate-human-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      managerId: ctx.memberId,
+    });
+    expect(human.clientId).toBeNull();
+  });
+
+  it("rebindAgent enforces the gate against the new client", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setCapabilities(app, ctx.clientId, { "claude-code": entry("ok") });
+
+    const agent = await createAgent(app.db, {
+      name: `cap-gate-rebind-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+
+    // Now mark the same client as "missing codex" and try to rebind to codex.
+    await setCapabilities(app, ctx.clientId, {
+      "claude-code": entry("ok"),
+      codex: entry("missing"),
+    });
+
+    await expect(
+      rebindAgent(app.db, agent.uuid, {
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+      }),
+    ).rejects.toThrow(/does not have runtime provider "codex" available/i);
+
+    // After upgrading the report to `unauthenticated` (SDK installed),
+    // the same rebind succeeds.
+    await setCapabilities(app, ctx.clientId, {
+      "claude-code": entry("ok"),
+      codex: entry("unauthenticated"),
+    });
+    const rebound = await rebindAgent(app.db, agent.uuid, {
+      clientId: ctx.clientId,
+      runtimeProvider: "codex",
+    });
+    expect(rebound.runtimeProvider).toBe("codex");
+  });
+});

--- a/packages/server/src/__tests__/ws-bind-runtime-mismatch.test.ts
+++ b/packages/server/src/__tests__/ws-bind-runtime-mismatch.test.ts
@@ -1,0 +1,204 @@
+import { AGENT_BIND_REJECT_REASONS } from "@agent-team-foundation/first-tree-hub-shared";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import { createAgent } from "../services/agent.js";
+import { resolveDefaultOrgId } from "../services/organization.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestApp } from "./helpers.js";
+
+/**
+ * The bind handshake compares `bindRequest.runtimeType` against
+ * `agents.runtime_provider`; a drift triggers
+ * `agent:bind:rejected { reason: "runtime_provider_mismatch" }` so the
+ * client repair path can re-fetch authoritative state and respawn the
+ * right handler. This test pins that contract — without it, a regression
+ * silently lets a claude-code client bind to a codex-pinned agent (or
+ * vice versa) and we'd only notice at the first message.
+ */
+describe("Agent WS — runtime provider mismatch on bind", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signMemberJwt(userId: string, memberId: string, orgId: string): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ sub: userId, memberId, organizationId: orgId, role: "admin", type: "access" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(secret);
+  }
+
+  async function seedCodexAgent(suffix: string) {
+    const orgId = await resolveDefaultOrgId(app.db);
+    const userId = uuidv7();
+    const memberId = uuidv7();
+    const clientId = `cli-rtmm-${suffix}-${crypto.randomUUID().slice(0, 6)}`;
+
+    const agent = await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: userId,
+        username: `rtmm-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        passwordHash: "x",
+        displayName: "Mismatch Tester",
+      });
+
+      const human = await createAgent(tx as unknown as typeof app.db, {
+        name: `rtmm-human-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: "Mismatch Human",
+        source: "admin-api",
+        managerId: memberId,
+        organizationId: orgId,
+      });
+
+      await tx
+        .insert(members)
+        .values({ id: memberId, userId, organizationId: orgId, agentId: human.uuid, role: "admin" });
+      await tx.insert(clients).values({ id: clientId, userId, organizationId: orgId, status: "connected" });
+
+      // The capability gate would normally block creating a codex agent
+      // against a client that hasn't reported codex availability. We
+      // bypass it with `force: true` because this test isn't about the
+      // gate — it's about the bind-time mismatch detection.
+      return createAgent(
+        tx as unknown as typeof app.db,
+        {
+          name: `rtmm-codex-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+          type: "autonomous_agent",
+          displayName: "Codex Agent",
+          source: "admin-api",
+          managerId: memberId,
+          clientId,
+          organizationId: orgId,
+          runtimeProvider: "codex",
+        },
+        { force: true },
+      );
+    });
+
+    const token = await signMemberJwt(userId, memberId, orgId);
+    return { agent, token, clientId };
+  }
+
+  function waitForFrame(ws: WebSocket, match: (m: unknown) => boolean, timeoutMs = 5000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for frame (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          if (match(msg)) {
+            clearTimeout(timer);
+            ws.off("message", onMessage);
+            resolve(msg);
+          }
+        } catch {
+          // ignore non-JSON frames
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  async function openClientSocket(seed: { token: string; clientId: string }): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(JSON.stringify({ type: "auth", token: seed.token }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:ok");
+    ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:registered");
+    return ws;
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it("rejects bind when bindRequest.runtimeType differs from agents.runtime_provider", async () => {
+    const seed = await seedCodexAgent("rej");
+    const ws = await openClientSocket(seed);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          type: "agent:bind",
+          agentId: seed.agent.uuid,
+          ref: "bind-mismatch",
+          runtimeType: "claude-code", // <- agent is `codex` in DB
+          runtimeVersion: "0.0.0",
+        }),
+      );
+
+      const msg = (await waitForFrame(ws, (m) => (m as { type?: string }).type === "agent:bind:rejected")) as {
+        type: string;
+        ref: string;
+        reason: string;
+      };
+
+      expect(msg.ref).toBe("bind-mismatch");
+      expect(msg.reason).toBe(AGENT_BIND_REJECT_REASONS.RUNTIME_PROVIDER_MISMATCH);
+
+      // Confirm the agent did not transition to bound — DB stays
+      // unbound, so a follow-up bind with the right runtime can succeed.
+      const [row] = await app.db
+        .select({ clientId: agents.clientId })
+        .from(agents)
+        .where(eq(agents.uuid, seed.agent.uuid))
+        .limit(1);
+      expect(row?.clientId).toBe(seed.clientId); // pinned, not yet "presence-bound" (presence is separate)
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("accepts bind once runtimeType matches the pinned runtime_provider", async () => {
+    const seed = await seedCodexAgent("ok");
+    const ws = await openClientSocket(seed);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          type: "agent:bind",
+          agentId: seed.agent.uuid,
+          ref: "bind-match",
+          runtimeType: "codex",
+          runtimeVersion: "0.0.0",
+        }),
+      );
+
+      const msg = (await waitForFrame(ws, (m) => {
+        const t = (m as { type?: string }).type;
+        return t === "agent:bound" || t === "agent:bind:rejected";
+      })) as { type: string; ref: string; reason?: string };
+
+      expect(msg.type).toBe("agent:bound");
+      expect(msg.ref).toBe("bind-match");
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+});

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -146,7 +146,9 @@ describe("Agent WS — session event protocol (S10)", () => {
         type: "agent:bind",
         agentId: seed.agent.uuid,
         ref: "bind-1",
-        runtimeType: "test",
+        // Match the seeded agent's `runtime_provider` (defaults to claude-code)
+        // so the post-0026 RUNTIME_PROVIDER_MISMATCH check passes.
+        runtimeType: "claude-code",
         runtimeVersion: "0.0.0",
       }),
     );

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -3,6 +3,7 @@ import {
   agentTypeSchema,
   createAgentSchema,
   paginationQuerySchema,
+  rebindAgentSchema,
   updateAgentSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, gt, ne } from "drizzle-orm";
@@ -42,6 +43,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     displayName: string | null;
     type: string;
     clientId: string | null;
+    runtimeProvider: string;
   }): void {
     if (!agent.clientId) return;
     const parsed = agentPinnedMessageSchema.safeParse({
@@ -50,6 +52,7 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
       name: agent.name,
       displayName: agent.displayName,
       agentType: agent.type,
+      runtimeProvider: agent.runtimeProvider,
     });
     if (!parsed.success) {
       // Schema drift between server and shared types is a contract bug — log
@@ -172,6 +175,24 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
     if (before && before.clientId === null && agent.clientId !== null) {
       notifyClientAgentPinned(agent);
     }
+    return {
+      ...agent,
+      createdAt: agent.createdAt.toISOString(),
+      updatedAt: agent.updatedAt.toISOString(),
+    };
+  });
+
+  /**
+   * Rebind an agent to a new client and/or runtime provider. Re-runs owner /
+   * org / capability checks atomically. Capability mismatch can be overridden
+   * with `force: true` (e.g. client offline, capabilities stale).
+   */
+  app.patch<{ Params: { uuid: string } }>("/:uuid/rebind", async (request) => {
+    const scope = memberScope(request);
+    await assertCanManage(app.db, scope, request.params.uuid);
+    const body = rebindAgentSchema.parse(request.body);
+    const agent = await agentService.rebindAgent(app.db, request.params.uuid, body);
+    notifyClientAgentPinned(agent);
     return {
       ...agent,
       createdAt: agent.createdAt.toISOString(),

--- a/packages/server/src/api/admin/clients.ts
+++ b/packages/server/src/api/admin/clients.ts
@@ -1,3 +1,4 @@
+import { updateClientCapabilitiesSchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance } from "fastify";
 import { memberScope } from "../../services/access-control.js";
 import * as activityService from "../../services/activity.js";
@@ -34,13 +35,39 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
     }));
   });
 
-  // GET /clients/:clientId — single client, owner-scoped.
+  // GET /clients/me/agents — every agent pinned to a client owned by the
+  // calling user. Used by client startup to reconcile authoritative
+  // `agents.runtime_provider` before spawning handlers (B3 layer 1).
+  app.get("/me/agents", async (request) => {
+    const scope = memberScope(request);
+    const agents = await clientService.listMyPinnedAgents(app.db, {
+      userId: scope.userId,
+      organizationId: scope.organizationId,
+    });
+    return agents;
+  });
+
+  // PATCH /clients/:clientId/capabilities — owner-scoped capability snapshot
+  // upload. Stored under `clients.metadata.capabilities` (Option C).
+  app.patch<{ Params: { clientId: string } }>("/:clientId/capabilities", async (request, reply) => {
+    const scope = memberScope(request);
+    await clientService.assertClientOwner(app.db, request.params.clientId, scope);
+    const body = updateClientCapabilitiesSchema.parse(request.body);
+    await clientService.updateClientCapabilities(app.db, request.params.clientId, body.capabilities);
+    return reply.status(204).send();
+  });
+
+  // GET /clients/:clientId — single client, owner-scoped. Includes the
+  // `capabilities` snapshot from `metadata.capabilities` (Option C, P2).
   app.get<{ Params: { clientId: string } }>("/:clientId", async (request) => {
     const scope = memberScope(request);
     await clientService.assertClientOwner(app.db, request.params.clientId, scope);
     const client = await clientService.getClient(app.db, request.params.clientId);
     // assertClientOwner already 404'd on missing/not-yours; the row is present.
     if (!client) throw new Error("unreachable: client missing after owner check");
+    const metadata = (client.metadata ?? {}) as Record<string, unknown>;
+    const capabilities =
+      metadata.capabilities && typeof metadata.capabilities === "object" ? metadata.capabilities : {};
     return {
       id: client.id,
       userId: client.userId,
@@ -50,6 +77,7 @@ export async function adminClientRoutes(app: FastifyInstance): Promise<void> {
       os: client.os,
       connectedAt: serializeDate(client.connectedAt),
       lastSeenAt: client.lastSeenAt.toISOString(),
+      capabilities,
     };
   });
 

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -304,6 +304,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     name: agent.name,
                     displayName: agent.displayName,
                     agentType: agent.type,
+                    runtimeProvider: agent.runtimeProvider,
                   });
                   if (!parsed.success) {
                     app.log.warn(
@@ -337,6 +338,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   inboxId: agents.inboxId,
                   status: agents.status,
                   clientId: agents.clientId,
+                  runtimeProvider: agents.runtimeProvider,
                   clientUserId: clients.userId,
                   managerUserId: members.userId,
                 })
@@ -384,6 +386,15 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 return;
               } else if (!agent.clientUserId || agent.clientUserId !== session.userId) {
                 sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.NOT_OWNED);
+                return;
+              }
+
+              // Reject if the connecting client is running a different runtime
+              // provider than the one pinned on the agent. The client repair
+              // path will re-fetch authoritative state and respawn the right
+              // handler before retrying the bind.
+              if (bindRequest.runtimeType !== agent.runtimeProvider) {
+                sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.RUNTIME_PROVIDER_MISMATCH);
                 return;
               }
 

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -37,11 +37,17 @@ export const agents = pgTable(
     managerId: text("manager_id").notNull(),
     /**
      * Physical client this agent is pinned to. Nullable for human agents (no
-     * runtime); for every non-human agent the column is set at creation time
-     * and never changes (Rule R-RUN). Moving a non-human agent to a different
-     * client requires delete + recreate in this milestone.
+     * runtime). For non-human agents this used to be immutable (Rule R-RUN);
+     * post-0026 it is re-bindable via `agentService.rebindAgent`, which runs
+     * owner / org / capability checks atomically.
      */
     clientId: text("client_id").references(() => clients.id, { onDelete: "restrict" }),
+    /**
+     * Runtime provider that drives this agent (e.g. `"claude-code"`, `"codex"`).
+     * NOT NULL; defaults to `"claude-code"` for backward compatibility with
+     * rows created before 0026.
+     */
+    runtimeProvider: text("runtime_provider").notNull().default("claude-code"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -2,13 +2,16 @@ import type {
   AgentType,
   AgentVisibility,
   CreateAgent,
+  RebindAgent,
+  RuntimeProvider,
   UpdateAgent,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import {
   AGENT_NAME_REGEX,
   AGENT_STATUSES,
   AGENT_VISIBILITY,
-  DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+  DEFAULT_RUNTIME_PROVIDER,
+  defaultRuntimeConfigPayload,
   isReservedAgentName,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, count, desc, eq, lt, ne } from "drizzle-orm";
@@ -34,6 +37,43 @@ import { resolveDefaultOrgId } from "./organization.js";
  */
 const RESERVED_AGENT_NAME_PREFIX = "__";
 
+/**
+ * True iff `clients.metadata.capabilities` is a non-empty object — i.e. the
+ * client has reported at least one runtime probe result. Used to distinguish
+ * "we don't know what's installed yet" (empty / never reported) from
+ * "client explicitly reports this provider is missing".
+ */
+function clientCapabilitiesReported(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const meta = metadata as Record<string, unknown>;
+  const caps = meta.capabilities;
+  if (!caps || typeof caps !== "object") return false;
+  return Object.keys(caps as Record<string, unknown>).length > 0;
+}
+
+/**
+ * Inspect a `clients.metadata.capabilities` blob (jsonb) for a specific
+ * runtime provider entry. Capabilities live under the `metadata.capabilities`
+ * subkey (Option C); the column is unstructured at the DB layer, so we
+ * defensively narrow before key access.
+ *
+ * "Supports" requires the entry's SDK to be **available** — `state: "ok"` or
+ * `state: "unauthenticated"`. A `missing` or `error` entry is *reported* but
+ * not usable, so we explicitly reject those rather than treating mere key
+ * presence as support. Auth state is left to the user to fix at runtime
+ * (the re-bind dialog surfaces an `unauthenticated` hint).
+ */
+function clientSupportsRuntimeProvider(metadata: unknown, provider: RuntimeProvider): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const meta = metadata as Record<string, unknown>;
+  const caps = meta.capabilities;
+  if (!caps || typeof caps !== "object") return false;
+  const entry = (caps as Record<string, unknown>)[provider];
+  if (!entry || typeof entry !== "object") return false;
+  const available = (entry as { available?: unknown }).available;
+  return available === true;
+}
+
 /** Default visibility per agent type. */
 function defaultVisibility(type: AgentType): AgentVisibility {
   switch (type) {
@@ -58,6 +98,53 @@ function defaultVisibility(type: AgentType): AgentVisibility {
  *   - When a non-human agent IS created with a `clientId`, the pinned client
  *     must already be owned by the manager's user (Rule R-RUN).
  */
+/**
+ * Check that a client's reported capabilities show the given runtime provider
+ * as **available** (SDK installed, regardless of auth state).
+ *
+ * Tri-state semantics by `clients.metadata.capabilities` shape:
+ *   - empty / absent — client hasn't probed yet (newly registered or pre-P2
+ *     install). Treat as "unknown" and allow; the in-band repair path
+ *     (RUNTIME_PROVIDER_MISMATCH on bind) catches actual incompatibility.
+ *   - reported, entry shows `state: ok | unauthenticated` (i.e. `available:
+ *     true`) — allow.
+ *   - reported, entry missing OR `state: missing | error` — block unless
+ *     `force` is set. We deliberately do NOT treat mere key presence as
+ *     support: probeCapabilities() always emits an entry per built-in
+ *     provider, including `{ state: "missing" }` for absent SDKs.
+ *
+ * Skipped entirely for human agents (no clientId) and when `force` is set
+ * (e.g. operator overrides for an offline client).
+ */
+async function ensureClientSupportsRuntimeProvider(
+  db: Database,
+  clientId: string | null,
+  runtimeProvider: RuntimeProvider,
+  options: { force?: boolean } = {},
+): Promise<void> {
+  if (clientId === null) return;
+  if (options.force) return;
+
+  const [client] = await db
+    .select({ metadata: clients.metadata })
+    .from(clients)
+    .where(eq(clients.id, clientId))
+    .limit(1);
+  if (!client) return; // resolveAgentClient validates existence elsewhere
+
+  // Best-effort: if the client never reported capabilities, allow and let
+  // the runtime path catch real mismatches at bind time.
+  if (!clientCapabilitiesReported(client.metadata)) return;
+
+  if (!clientSupportsRuntimeProvider(client.metadata, runtimeProvider)) {
+    throw new BadRequestError(
+      `Client "${clientId}" does not have runtime provider "${runtimeProvider}" available. ` +
+        "Install the matching SDK on that machine and re-run capability detection, " +
+        "or retry with `force: true` if the client is offline / capabilities are stale.",
+    );
+  }
+}
+
 async function resolveAgentClient(
   db: Database,
   data: { clientId?: string; managerId: string; type: string },
@@ -132,9 +219,14 @@ async function resolveFallbackManagerId(db: Database, orgId: string): Promise<st
   return row.id;
 }
 
-export async function createAgent(db: Database, data: CreateAgent & { managerId?: string }) {
+export async function createAgent(
+  db: Database,
+  data: CreateAgent & { managerId?: string },
+  options: { force?: boolean } = {},
+) {
   const uuid = uuidv7();
   const name = data.name ?? null;
+  const runtimeProvider: RuntimeProvider = data.runtimeProvider ?? DEFAULT_RUNTIME_PROVIDER;
   if (name?.startsWith(RESERVED_AGENT_NAME_PREFIX)) {
     throw new BadRequestError(
       `Agent name "${name}" is reserved — names starting with "${RESERVED_AGENT_NAME_PREFIX}" are Hub-internal`,
@@ -197,6 +289,8 @@ export async function createAgent(db: Database, data: CreateAgent & { managerId?
     type: data.type,
   });
 
+  await ensureClientSupportsRuntimeProvider(db, clientId, runtimeProvider, { force: options.force });
+
   // Check organization-level agent quota.
   // NOTE: TOCTOU race — concurrent requests may both pass the check. Acceptable for Phase 1;
   // enforce with a DB-level CHECK constraint or SELECT ... FOR UPDATE in Phase 2 if needed.
@@ -243,6 +337,7 @@ export async function createAgent(db: Database, data: CreateAgent & { managerId?
         metadata: data.metadata ?? {},
         managerId,
         clientId,
+        runtimeProvider,
       })
       .returning();
 
@@ -253,7 +348,7 @@ export async function createAgent(db: Database, data: CreateAgent & { managerId?
       .values({
         agentId: agent.uuid,
         version: 1,
-        payload: DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+        payload: defaultRuntimeConfigPayload(runtimeProvider),
         updatedBy: "system",
       })
       .onConflictDoNothing();
@@ -350,6 +445,7 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
       metadata: agents.metadata,
       managerId: agents.managerId,
       clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
       createdAt: agents.createdAt,
       updatedAt: agents.updatedAt,
       presenceStatus: agentPresence.status,
@@ -400,6 +496,7 @@ export async function listAgentsForAdmin(db: Database, scope: MemberScope, limit
       metadata: agents.metadata,
       managerId: agents.managerId,
       clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
       createdAt: agents.createdAt,
       updatedAt: agents.updatedAt,
       presenceStatus: agentPresence.status,
@@ -453,6 +550,7 @@ export async function listAgentsForMember(
       metadata: agents.metadata,
       managerId: agents.managerId,
       clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
       createdAt: agents.createdAt,
       updatedAt: agents.updatedAt,
       presenceStatus: agentPresence.status,
@@ -477,16 +575,18 @@ export async function listAgentsForMember(
 export async function updateAgent(db: Database, uuid: string, data: UpdateAgent) {
   const agent = await getAgent(db, uuid);
 
-  // `clientId` is one-shot: NULL → ID is allowed (admin claiming an unbound
-  // agent for a known client). ID → null and ID → another ID are not —
-  // moving a running agent requires delete + recreate.
+  // `clientId` is one-shot via this entry: NULL → ID is allowed (admin
+  // claiming an unbound agent for a known client). Cross-client moves go
+  // through `rebindAgent`, which runs owner / org / capability checks
+  // atomically. ID → null is never allowed.
   if (data.clientId !== undefined) {
     if (data.clientId === null) {
       throw new BadRequestError("clientId cannot be cleared — once bound, an agent stays bound to its client");
     }
     if (agent.clientId !== null && agent.clientId !== data.clientId) {
       throw new BadRequestError(
-        "clientId is immutable once set — delete and re-create the agent on the target client to move it",
+        "clientId is immutable through this entry — cross-client moves go through rebindAgent " +
+          "(PATCH /admin/agents/:agentId/rebind), which runs owner / org / capability checks atomically.",
       );
     }
   }
@@ -531,6 +631,52 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
   }
 
   const [updated] = await db.update(agents).set(updates).where(eq(agents.uuid, agent.uuid)).returning();
+
+  if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+  return updated;
+}
+
+/**
+ * Atomically re-bind an agent to a new client and/or runtime provider.
+ *
+ * Validations: agent must exist and not be human; new client must belong to
+ * the same owner (manager.userId) and same organization; client must report
+ * the requested runtime provider in its capabilities (skipped under `force`).
+ *
+ * Intended caller: PATCH /admin/agents/:agentId/rebind. The Web "Re-bind"
+ * dialog routes both same-client runtime-only switches and cross-client
+ * moves through this single entry.
+ *
+ * NOTE: active sessions on the previous client are not auto-suspended in P1.
+ * P3 will wire in cross-service coordination (inbox + presence + session)
+ * so the destination client can resume cleanly.
+ */
+export async function rebindAgent(db: Database, uuid: string, data: RebindAgent) {
+  const agent = await getAgent(db, uuid);
+  if (agent.type === "human") {
+    throw new BadRequestError("Human agents have no runtime — they cannot be re-bound to a client.");
+  }
+
+  const newClientId = await resolveAgentClient(db, {
+    clientId: data.clientId,
+    managerId: agent.managerId,
+    type: agent.type,
+  });
+  if (newClientId === null) {
+    throw new BadRequestError("Rebind requires a non-null clientId.");
+  }
+
+  await ensureClientSupportsRuntimeProvider(db, newClientId, data.runtimeProvider, { force: data.force });
+
+  const [updated] = await db
+    .update(agents)
+    .set({
+      clientId: newClientId,
+      runtimeProvider: data.runtimeProvider,
+      updatedAt: new Date(),
+    })
+    .where(eq(agents.uuid, uuid))
+    .returning();
 
   if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
   return updated;

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -1,10 +1,15 @@
+import {
+  type ClientCapabilities,
+  clientCapabilitiesSchema,
+  type RuntimeProvider,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
-import { ClientOrgMismatchError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { BadRequestError, ClientOrgMismatchError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { runtimeFieldsReset } from "./presence.js";
 
 /**
@@ -159,9 +164,75 @@ export async function listActiveAgentsPinnedToClient(db: Database, clientId: str
       name: agents.name,
       displayName: agents.displayName,
       type: agents.type,
+      runtimeProvider: agents.runtimeProvider,
     })
     .from(agents)
     .where(and(eq(agents.clientId, clientId), ne(agents.status, "deleted")));
+}
+
+/**
+ * Member-scoped: every active agent pinned to a client owned by this user
+ * within the given organization. Used by client startup to reconcile its
+ * local YAML against the authoritative `agents.runtime_provider`.
+ */
+export async function listMyPinnedAgents(
+  db: Database,
+  scope: { userId: string; organizationId: string },
+): Promise<Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider }>> {
+  const rows = await db
+    .select({
+      agentId: agents.uuid,
+      clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
+    })
+    .from(agents)
+    .innerJoin(clients, eq(agents.clientId, clients.id))
+    .where(
+      and(
+        eq(clients.userId, scope.userId),
+        eq(clients.organizationId, scope.organizationId),
+        ne(agents.status, "deleted"),
+      ),
+    );
+  return rows
+    .filter((r): r is { agentId: string; clientId: string; runtimeProvider: string } => r.clientId !== null)
+    .map((r) => ({
+      agentId: r.agentId,
+      clientId: r.clientId,
+      runtimeProvider: r.runtimeProvider as RuntimeProvider,
+    }));
+}
+
+/**
+ * Replace this client's capabilities snapshot. Capabilities live under
+ * `clients.metadata.capabilities` (Option C — no dedicated column); other
+ * `metadata` subkeys are preserved on merge.
+ *
+ * Caller is expected to have already passed `assertClientOwner`.
+ */
+export async function updateClientCapabilities(
+  db: Database,
+  clientId: string,
+  capabilities: ClientCapabilities,
+): Promise<void> {
+  const parsed = clientCapabilitiesSchema.safeParse(capabilities);
+  if (!parsed.success) {
+    throw new BadRequestError(`Invalid capabilities payload: ${parsed.error.message}`);
+  }
+
+  const [client] = await db
+    .select({ metadata: clients.metadata })
+    .from(clients)
+    .where(eq(clients.id, clientId))
+    .limit(1);
+  if (!client) {
+    throw new NotFoundError(`Client "${clientId}" not found`);
+  }
+
+  const baseMetadata = (client.metadata ?? {}) as Record<string, unknown>;
+  const merged = { ...baseMetadata, capabilities: parsed.data };
+
+  await db.update(clients).set({ metadata: merged }).where(eq(clients.id, clientId));
 }
 
 /**

--- a/packages/server/src/services/config-service.ts
+++ b/packages/server/src/services/config-service.ts
@@ -6,11 +6,13 @@ import {
   ENV_REDACTED_PLACEHOLDER,
   type EnvEntry,
   isRedactedEnvValue,
+  type RuntimeProvider,
   type UpdateAgentRuntimeConfig,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agents } from "../db/schema/agents.js";
 import { ConflictError, NotFoundError } from "../errors.js";
 import { decryptValue, encryptValue, isEncryptedValue } from "./crypto.js";
 import type { Notifier } from "./notifier.js";
@@ -111,13 +113,17 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
     current: AgentRuntimeConfigPayload,
     patch: Partial<AgentRuntimeConfigPayload>,
   ): AgentRuntimeConfigPayload {
-    const next: AgentRuntimeConfigPayload = {
+    const next = {
+      // `kind` is pinned to `agents.runtime_provider` and never patchable
+      // from the config side; preserve the current value here and let
+      // `commitWrite` re-sync it against the authoritative source.
+      kind: current.kind,
       prompt: patch.prompt ?? current.prompt,
       model: patch.model ?? current.model,
       mcpServers: patch.mcpServers ?? current.mcpServers,
       env: patch.env ? mergeEnv(current.env, patch.env) : current.env,
       gitRepos: patch.gitRepos ?? current.gitRepos,
-    };
+    } as AgentRuntimeConfigPayload;
     return next;
   }
 
@@ -142,7 +148,24 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
     if (!row) {
       throw new NotFoundError(`Agent config "${agentId}" not found`);
     }
-    return row;
+    // Parse via zod so legacy payloads written before 0026 (no `kind`)
+    // are normalized to claude-code by preprocess. The authoritative kind
+    // is re-synced on every commit from agents.runtime_provider; the
+    // read-side default is a back-compat conversion only.
+    const payload = agentRuntimeConfigPayloadSchema.parse(row.payload);
+    return { ...row, payload };
+  }
+
+  async function readRuntimeProviderFor(agentId: string): Promise<RuntimeProvider> {
+    const [row] = await db
+      .select({ runtimeProvider: agents.runtimeProvider })
+      .from(agents)
+      .where(eq(agents.uuid, agentId))
+      .limit(1);
+    if (!row) {
+      throw new NotFoundError(`Agent "${agentId}" not found`);
+    }
+    return row.runtimeProvider as RuntimeProvider;
   }
 
   async function commitWrite(
@@ -157,10 +180,15 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
         `Agent config "${agentId}" version mismatch: expected ${expectedVersion}, got ${current.version}`,
       );
     }
+    // Re-sync `kind` with the authoritative agents.runtime_provider on
+    // every commit so a re-bind to a different provider lands on the
+    // correct discriminator next read.
+    const provider = await readRuntimeProviderFor(agentId);
     const merged = applyPatch(current.payload, patch);
+    const synced = { ...merged, kind: provider } as AgentRuntimeConfigPayload;
     // Validate the fully-merged payload — guards against e.g. duplicate env keys
     // introduced by the merge that the patch alone wouldn't catch.
-    const validated = agentRuntimeConfigPayloadSchema.parse(merged);
+    const validated = agentRuntimeConfigPayloadSchema.parse(synced);
 
     const [updated] = await db
       .update(agentConfigs)
@@ -300,7 +328,10 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
 
     async dryRun(agentId, patch) {
       const row = await readRow(agentId);
-      const next = agentRuntimeConfigPayloadSchema.parse(applyPatch(row.payload, patch));
+      const provider = await readRuntimeProviderFor(agentId);
+      const merged = applyPatch(row.payload, patch);
+      const synced = { ...merged, kind: provider } as AgentRuntimeConfigPayload;
+      const next = agentRuntimeConfigPayloadSchema.parse(synced);
       const diff = computeDiff(row.payload, next);
       return {
         current: { ...rowToConfig(row), payload: redact(row.payload) },
@@ -337,7 +368,7 @@ function computeDiff(
   b: AgentRuntimeConfigPayload,
 ): AgentRuntimeConfigDryRunResult["diff"] {
   const out: AgentRuntimeConfigDryRunResult["diff"] = [];
-  const fields: Array<keyof AgentRuntimeConfigPayload> = ["prompt", "model", "mcpServers", "env", "gitRepos"];
+  const fields = ["prompt", "model", "mcpServers", "env", "gitRepos"] as const;
   for (const f of fields) {
     const before = a[f];
     const after = b[f];

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -97,6 +97,7 @@ describe("Phase 2: displayName is non-null on the wire", () => {
     metadata: {},
     managerId: "mem-1",
     clientId: null,
+    runtimeProvider: "claude-code" as const,
     createdAt: "2026-04-24T00:00:00.000Z",
     updatedAt: "2026-04-24T00:00:00.000Z",
   };

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   agentRuntimeConfigPayloadSchema,
   DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+  DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD,
+  defaultRuntimeConfigPayload,
 } from "../schemas/agent-runtime-config.js";
 
 /**
@@ -30,5 +32,53 @@ describe("agent runtime config — default model", () => {
     // must not silently replace it with the default.
     const parsed = agentRuntimeConfigPayloadSchema.parse({ model: "" });
     expect(parsed.model).toBe("");
+  });
+});
+
+/**
+ * Codex defaults sit on a different invariant than claude-code: the Codex
+ * CLI's ChatGPT-account auth rejects `gpt-5-codex` (the SDK's compile-time
+ * default), so Hub leaves `model` empty and lets the CLI pick a slug that
+ * matches the user's auth mode. Pin it here so a well-meaning "set a sane
+ * default" change doesn't quietly break ChatGPT-auth users.
+ */
+describe("agent runtime config — codex defaults", () => {
+  it("DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD.model is empty (defer to CLI auth-mode default)", () => {
+    expect(DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD.model).toBe("");
+    expect(DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD.kind).toBe("codex");
+  });
+
+  it("defaultRuntimeConfigPayload(provider) selects the matching variant", () => {
+    expect(defaultRuntimeConfigPayload("claude-code")).toMatchObject({
+      kind: "claude-code",
+      model: "opus",
+    });
+    expect(defaultRuntimeConfigPayload("codex")).toMatchObject({
+      kind: "codex",
+      model: "",
+    });
+  });
+
+  it("returns a distinct top-level object on each call (callers can mutate safely at top level)", () => {
+    // Implementation is a shallow spread, so nested arrays still share
+    // identity — pin the top-level guarantee only, since that's all
+    // current callers rely on (they replace fields, not mutate them).
+    const a = defaultRuntimeConfigPayload("claude-code");
+    const b = defaultRuntimeConfigPayload("claude-code");
+    expect(a).not.toBe(b);
+    a.model = "haiku";
+    expect(b.model).toBe("opus");
+  });
+
+  it("schema accepts an explicit codex payload (kind discriminator)", () => {
+    const parsed = agentRuntimeConfigPayloadSchema.parse({
+      kind: "codex",
+      model: "gpt-5.5",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+    });
+    expect(parsed.kind).toBe("codex");
+    expect(parsed.model).toBe("gpt-5.5");
   });
 });

--- a/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
+++ b/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPABILITY_STATES,
+  capabilityEntrySchema,
+  clientCapabilitiesSchema,
+  DEFAULT_RUNTIME_PROVIDER,
+  RUNTIME_PROVIDERS,
+  runtimeProviderSchema,
+  updateClientCapabilitiesSchema,
+} from "../index.js";
+
+/**
+ * Lock the public surface of the two new schemas added in 0026:
+ *   - `runtimeProviderSchema` is the discriminator everything else keys off
+ *     (agent rows, payload kind, capability map). A typo in the enum here
+ *     would let invalid runtime ids drift into the DB.
+ *   - `capabilityEntrySchema` and `clientCapabilitiesSchema` define the
+ *     wire format of the `PATCH /clients/:id/capabilities` upload — pinned
+ *     here so a server change can't silently relax validation.
+ */
+describe("runtimeProviderSchema", () => {
+  it("accepts both built-in providers", () => {
+    expect(runtimeProviderSchema.parse("claude-code")).toBe("claude-code");
+    expect(runtimeProviderSchema.parse("codex")).toBe("codex");
+  });
+
+  it("rejects unknown providers", () => {
+    expect(() => runtimeProviderSchema.parse("gemini")).toThrow();
+    expect(() => runtimeProviderSchema.parse("")).toThrow();
+  });
+
+  it("RUNTIME_PROVIDERS constants match the schema", () => {
+    expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.CLAUDE_CODE)).toBe("claude-code");
+    expect(runtimeProviderSchema.parse(RUNTIME_PROVIDERS.CODEX)).toBe("codex");
+  });
+
+  it("DEFAULT_RUNTIME_PROVIDER is claude-code (existing rows pre-0026 have no kind)", () => {
+    expect(DEFAULT_RUNTIME_PROVIDER).toBe("claude-code");
+  });
+});
+
+describe("capabilityEntrySchema", () => {
+  it("CAPABILITY_STATES enumerates the four documented states", () => {
+    expect(Object.values(CAPABILITY_STATES).sort()).toEqual(["error", "missing", "ok", "unauthenticated"].sort());
+  });
+
+  it("accepts a fully-formed `ok` entry", () => {
+    const parsed = capabilityEntrySchema.parse({
+      state: "ok",
+      available: true,
+      authenticated: true,
+      sdkVersion: "0.2.84",
+      authMethod: "oauth",
+      detectedAt: new Date().toISOString(),
+    });
+    expect(parsed.state).toBe("ok");
+    expect(parsed.sdkVersion).toBe("0.2.84");
+  });
+
+  it("accepts `missing` with null sdkVersion + auth_method=none", () => {
+    const parsed = capabilityEntrySchema.parse({
+      state: "missing",
+      available: false,
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      detectedAt: new Date().toISOString(),
+    });
+    expect(parsed.state).toBe("missing");
+    expect(parsed.sdkVersion).toBeNull();
+  });
+
+  it("rejects an invalid state value", () => {
+    expect(() =>
+      capabilityEntrySchema.parse({
+        state: "pending",
+        available: true,
+        authenticated: false,
+        authMethod: "none",
+        detectedAt: new Date().toISOString(),
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an invalid authMethod value", () => {
+    expect(() =>
+      capabilityEntrySchema.parse({
+        state: "ok",
+        available: true,
+        authenticated: true,
+        authMethod: "magic-link", // <- not in the enum
+        detectedAt: new Date().toISOString(),
+      }),
+    ).toThrow();
+  });
+});
+
+describe("clientCapabilitiesSchema + updateClientCapabilitiesSchema", () => {
+  it("accepts a record keyed by arbitrary provider strings (forwards-compat)", () => {
+    // Schema-level: the record key is `z.string()` so future providers don't
+    // require a server schema bump; the *server* layer separately constrains
+    // capability lookups to known RuntimeProvider keys.
+    const parsed = clientCapabilitiesSchema.parse({
+      "claude-code": {
+        state: "ok",
+        available: true,
+        authenticated: true,
+        sdkVersion: "0.2.84",
+        authMethod: "oauth",
+        detectedAt: new Date().toISOString(),
+      },
+      "future-provider": {
+        state: "missing",
+        available: false,
+        authenticated: false,
+        sdkVersion: null,
+        authMethod: "none",
+        detectedAt: new Date().toISOString(),
+      },
+    });
+    expect(Object.keys(parsed)).toContain("future-provider");
+  });
+
+  it("updateClientCapabilitiesSchema requires top-level `capabilities` field", () => {
+    expect(() => updateClientCapabilitiesSchema.parse({})).toThrow();
+    expect(() => updateClientCapabilitiesSchema.parse({ capabilities: {} })).not.toThrow();
+  });
+
+  it("rejects malformed entries inside the capabilities map", () => {
+    expect(() =>
+      updateClientCapabilitiesSchema.parse({
+        capabilities: {
+          "claude-code": { state: "broken" }, // <- missing required fields, invalid state
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,8 @@ export {
   createAgentSchema,
   isReservedAgentName,
   RESERVED_AGENT_NAMES,
+  type RebindAgent,
+  rebindAgentSchema,
   type UpdateAgent,
   updateAgentSchema,
 } from "./schemas/agent.js";
@@ -70,7 +72,9 @@ export {
   agentRuntimeConfigSchema,
   type ClientMessagePayload,
   DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+  DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD,
   type DryRunAgentRuntimeConfig,
+  defaultRuntimeConfigPayload,
   deriveRepoLocalPath,
   dryRunAgentRuntimeConfigSchema,
   ENV_REDACTED_PLACEHOLDER,
@@ -131,6 +135,19 @@ export {
   clientSchema,
   clientStatusSchema,
 } from "./schemas/client.js";
+export {
+  CAPABILITY_STATES,
+  type CapabilityAuthMethod,
+  type CapabilityEntry,
+  type CapabilityState,
+  type ClientCapabilities,
+  capabilityAuthMethodSchema,
+  capabilityEntrySchema,
+  capabilityStateSchema,
+  clientCapabilitiesSchema,
+  type UpdateClientCapabilities,
+  updateClientCapabilitiesSchema,
+} from "./schemas/client-capabilities.js";
 export {
   type PaginationQuery,
   paginatedResponse,
@@ -248,6 +265,12 @@ export {
   pulseBucketSchema,
   pulseTickSchema,
 } from "./schemas/pulse.js";
+export {
+  DEFAULT_RUNTIME_PROVIDER,
+  RUNTIME_PROVIDERS,
+  type RuntimeProvider,
+  runtimeProviderSchema,
+} from "./schemas/runtime-provider.js";
 export {
   type AssistantTextEventPayload,
   assistantTextEventPayload,

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
+import type { runtimeProviderSchema } from "./runtime-provider.js";
 
 /**
- * Agent runtime configuration — M1 (Claude Code only).
+ * Agent runtime configuration.
  *
  * Defines the 5 user-tunable field groups that the Hub centrally manages
  * and pushes down to the client runtime: prompt append, model, MCP servers,
- * env vars, and Git repos.
+ * env vars, and Git repos. Tagged by `kind` (a runtime provider) so future
+ * provider-specific fields can land on a dedicated variant.
  *
  * NOTE: do not co-locate with `packages/shared/src/config/` — that namespace
  * is reserved for the local YAML config (`agent.yaml` / server / client) and
@@ -68,9 +70,11 @@ export const gitRepoSchema = z.object({
 export type GitRepo = z.infer<typeof gitRepoSchema>;
 
 /**
- * Base shape (no refinements) — used for `.partial()` derivations such as the
- * PATCH payload schema. Zod 4 forbids `.partial()` on a refined object, so we
- * keep refinements on a separate full schema below.
+ * Untagged base shape — 5 user-tunable fields, no `kind` discriminator.
+ * Used for `.partial()` derivations on the PATCH side, where `kind` is
+ * pinned to `agents.runtime_provider` and never changes via config PATCH.
+ * Zod 4 forbids `.partial()` on a refined object, so we keep refinements
+ * on the tagged schema below.
  */
 export const agentRuntimeConfigPayloadShape = z.object({
   prompt: promptConfigSchema.default({ append: "" }),
@@ -85,7 +89,28 @@ export const agentRuntimeConfigPayloadShape = z.object({
   gitRepos: z.array(gitRepoSchema).default([]),
 });
 
-const payloadDuplicatesRefinement = (payload: z.infer<typeof agentRuntimeConfigPayloadShape>, ctx: z.RefinementCtx) => {
+/**
+ * Tagged variants — read-side, full payload including `kind`. Adding a new
+ * provider means adding a variant here, plus a handler factory and a
+ * capability probe module on the client side.
+ *
+ * Provider-specific fields (e.g. codex `sandboxMode`) belong on the
+ * matching variant, not on the base shape.
+ */
+const claudeRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
+  kind: z.literal("claude-code"),
+});
+const codexRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
+  kind: z.literal("codex"),
+});
+
+const taggedPayloadUnion = z.discriminatedUnion("kind", [
+  claudeRuntimeConfigPayloadShape,
+  codexRuntimeConfigPayloadShape,
+]);
+type TaggedPayload = z.infer<typeof taggedPayloadUnion>;
+
+const payloadDuplicatesRefinement = (payload: TaggedPayload, ctx: z.RefinementCtx) => {
   const seenMcp = new Set<string>();
   payload.mcpServers.forEach((server, idx) => {
     const lower = server.name.toLowerCase();
@@ -126,17 +151,72 @@ const payloadDuplicatesRefinement = (payload: z.infer<typeof agentRuntimeConfigP
   });
 };
 
-export const agentRuntimeConfigPayloadSchema = agentRuntimeConfigPayloadShape.superRefine(payloadDuplicatesRefinement);
+/**
+ * Read-side full payload schema. Rows persisted before 0026 do not carry
+ * `kind`; `z.preprocess` injects `"claude-code"` so they parse cleanly into
+ * the claude variant. The service layer separately enforces
+ * `payload.kind === agents.runtime_provider` on writes.
+ */
+export const agentRuntimeConfigPayloadSchema = z
+  .preprocess((input) => {
+    if (
+      input &&
+      typeof input === "object" &&
+      !Array.isArray(input) &&
+      !("kind" in (input as Record<string, unknown>))
+    ) {
+      return { ...(input as Record<string, unknown>), kind: "claude-code" };
+    }
+    return input;
+  }, taggedPayloadUnion)
+  .superRefine((payload, ctx) => {
+    payloadDuplicatesRefinement(payload as TaggedPayload, ctx);
+  });
 export type AgentRuntimeConfigPayload = z.infer<typeof agentRuntimeConfigPayloadSchema>;
 
-/** Default payload used when creating a fresh agent. */
+/** Default payload used when creating a fresh claude-code agent. */
 export const DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
+  kind: "claude-code",
   prompt: { append: "" },
   model: "opus",
   mcpServers: [],
   env: [],
   gitRepos: [],
 };
+
+/**
+ * Default payload for a fresh codex agent. Same 5 fields as claude-code.
+ * `model` is left empty by default so the Codex CLI picks one matching the
+ * user's auth mode — `gpt-5-codex` is rejected by ChatGPT-account auth, while
+ * an empty string lets the SDK fall through to its built-in default.
+ */
+export const DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
+  kind: "codex",
+  prompt: { append: "" },
+  model: "",
+  mcpServers: [],
+  env: [],
+  gitRepos: [],
+};
+
+/**
+ * Default payload selector by runtime provider.
+ */
+export function defaultRuntimeConfigPayload(
+  provider: z.infer<typeof runtimeProviderSchema>,
+): AgentRuntimeConfigPayload {
+  switch (provider) {
+    case "codex":
+      return { ...DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD };
+    case "claude-code":
+      return { ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD };
+    default: {
+      const _exhaustive: never = provider;
+      void _exhaustive;
+      return { ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD };
+    }
+  }
+}
 
 export const agentRuntimeConfigSchema = z.object({
   agentId: z.string(),

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { presenceStatusSchema } from "./presence.js";
+import { runtimeProviderSchema } from "./runtime-provider.js";
 
 export const AGENT_TYPES = {
   HUMAN: "human",
@@ -106,6 +107,12 @@ export const createAgentSchema = z.object({
    * (see `api/agent/ws-client.ts`). Human agents must omit it.
    */
   clientId: z.string().min(1).max(100).optional(),
+  /**
+   * Runtime provider that drives this agent. Defaults to `"claude-code"` at
+   * the service layer when omitted. Must match a provider available in the
+   * pinned client's reported capabilities (or be force-overridden).
+   */
+  runtimeProvider: runtimeProviderSchema.optional(),
 });
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 
@@ -125,13 +132,28 @@ export const updateAgentSchema = z.object({
   /** Admin-only: reassign the manager */
   managerId: z.string().nullable().optional(),
   /**
-   * One-shot bind. NULL → ID is allowed (admin claims an unbound agent for
-   * a known client); ID → another ID and ID → null are rejected by the
-   * service layer with explicit 400s.
+   * One-shot bind. NULL → ID still allowed (admin claims an unbound agent for
+   * a known client). ID → another ID and ID → null are rejected at the
+   * service layer; cross-client moves go through `rebindAgent`, which runs
+   * owner / org / capability checks atomically.
    */
   clientId: z.string().min(1).max(100).nullable().optional(),
 });
 export type UpdateAgent = z.infer<typeof updateAgentSchema>;
+
+/**
+ * Service-level rebind input. Admin / owner re-binds an agent to a new
+ * client and/or a new runtime provider in one atomic operation.
+ *
+ * `force` bypasses the capability-match check (e.g. when the client is
+ * offline and capabilities are stale).
+ */
+export const rebindAgentSchema = z.object({
+  clientId: z.string().min(1).max(100),
+  runtimeProvider: runtimeProviderSchema,
+  force: z.boolean().optional(),
+});
+export type RebindAgent = z.infer<typeof rebindAgentSchema>;
 
 export const agentSchema = z.object({
   uuid: z.string(),
@@ -156,6 +178,8 @@ export const agentSchema = z.object({
   managerId: z.string().nullable(),
   /** Physical client this agent is pinned to. NULL for human agents only. */
   clientId: z.string().nullable(),
+  /** Which runtime provider drives this agent. NOT NULL post-0026. */
+  runtimeProvider: runtimeProviderSchema,
   presenceStatus: presenceStatusSchema.optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -185,5 +209,11 @@ export const agentPinnedMessageSchema = z.object({
    */
   displayName: z.string(),
   agentType: agentTypeSchema,
+  /**
+   * Authoritative runtime provider for this agent (post-0026). Older clients
+   * that omit this field on parse are tolerated by the consumer side, which
+   * falls back to `"claude-code"` for legacy compatibility.
+   */
+  runtimeProvider: runtimeProviderSchema,
 });
 export type AgentPinnedMessage = z.infer<typeof agentPinnedMessageSchema>;

--- a/packages/shared/src/schemas/client-capabilities.ts
+++ b/packages/shared/src/schemas/client-capabilities.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const CAPABILITY_STATES = {
+  OK: "ok",
+  MISSING: "missing",
+  UNAUTHENTICATED: "unauthenticated",
+  ERROR: "error",
+} as const;
+
+export const capabilityStateSchema = z.enum(["ok", "missing", "unauthenticated", "error"]);
+export type CapabilityState = z.infer<typeof capabilityStateSchema>;
+
+export const capabilityAuthMethodSchema = z.enum(["api_key", "oauth", "auth_json", "none"]);
+export type CapabilityAuthMethod = z.infer<typeof capabilityAuthMethodSchema>;
+
+export const capabilityEntrySchema = z.object({
+  state: capabilityStateSchema,
+  available: z.boolean(),
+  authenticated: z.boolean(),
+  sdkVersion: z.string().nullable().optional(),
+  authMethod: capabilityAuthMethodSchema,
+  error: z.string().nullable().optional(),
+  detectedAt: z.string(),
+});
+export type CapabilityEntry = z.infer<typeof capabilityEntrySchema>;
+
+/**
+ * Capabilities snapshot keyed by runtime provider name. Recorded as a plain
+ * `Record<string, CapabilityEntry>` — every entry is optional (a client may
+ * report only the runtimes it actually probed) and the key set evolves
+ * naturally as new providers ship without a schema migration. Service-layer
+ * lookups (`agents.runtime_provider ∈ keys(capabilities)`) treat the keys
+ * as `RuntimeProvider` strings.
+ */
+export const clientCapabilitiesSchema = z.record(z.string(), capabilityEntrySchema);
+export type ClientCapabilities = z.infer<typeof clientCapabilitiesSchema>;
+
+export const updateClientCapabilitiesSchema = z.object({
+  capabilities: clientCapabilitiesSchema,
+});
+export type UpdateClientCapabilities = z.infer<typeof updateClientCapabilitiesSchema>;

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -65,6 +65,7 @@ export const AGENT_BIND_REJECT_REASONS = {
   AGENT_SUSPENDED: "agent_suspended",
   WRONG_ORG: "wrong_org",
   UNKNOWN_AGENT: "unknown_agent",
+  RUNTIME_PROVIDER_MISMATCH: "runtime_provider_mismatch",
 } as const;
 
 export const agentBindRejectReasonSchema = z.enum([
@@ -73,6 +74,7 @@ export const agentBindRejectReasonSchema = z.enum([
   "agent_suspended",
   "wrong_org",
   "unknown_agent",
+  "runtime_provider_mismatch",
 ]);
 export type AgentBindRejectReason = z.infer<typeof agentBindRejectReasonSchema>;
 

--- a/packages/shared/src/schemas/runtime-provider.ts
+++ b/packages/shared/src/schemas/runtime-provider.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Runtime provider — which LLM CLI runtime drives an agent. New providers
+ * extend the union here, then register a handler factory and capability
+ * probe module on the client side.
+ */
+export const RUNTIME_PROVIDERS = {
+  CLAUDE_CODE: "claude-code",
+  CODEX: "codex",
+} as const;
+
+export const runtimeProviderSchema = z.enum(["claude-code", "codex"]);
+export type RuntimeProvider = z.infer<typeof runtimeProviderSchema>;
+
+export const DEFAULT_RUNTIME_PROVIDER: RuntimeProvider = "claude-code";

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -1,3 +1,4 @@
+import type { ClientCapabilities } from "@agent-team-foundation/first-tree-hub-shared";
 import { api } from "./client.js";
 
 export type AgentType = "human" | "personal_assistant" | "autonomous_agent";
@@ -52,6 +53,20 @@ export function listClients(): Promise<HubClient[]> {
 
 export function getClient(clientId: string): Promise<HubClient> {
   return api.get<HubClient>(`/clients/${clientId}`);
+}
+
+/**
+ * Fetch this client's reported runtime-provider capabilities. Returns the
+ * client's full row plus its `metadata.capabilities` blob (Option C). Used
+ * by the Settings → Computers section to surface SDK install + auth state
+ * per provider.
+ */
+export type ClientWithCapabilities = HubClient & {
+  capabilities: ClientCapabilities;
+};
+
+export function getClientCapabilities(clientId: string): Promise<ClientWithCapabilities> {
+  return api.get<ClientWithCapabilities>(`/clients/${clientId}`);
 }
 
 export function disconnectClient(clientId: string): Promise<{ disconnected: boolean; agentIds: string[] }> {

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -1,4 +1,4 @@
-import type { Agent, CreateAgent, UpdateAgent } from "@agent-team-foundation/first-tree-hub-shared";
+import type { Agent, CreateAgent, RebindAgent, UpdateAgent } from "@agent-team-foundation/first-tree-hub-shared";
 import { api } from "./client.js";
 
 type PaginatedAgents = {
@@ -52,6 +52,16 @@ export function checkAgentNameAvailability(name: string): Promise<AgentNameAvail
 
 export function updateAgent(uuid: string, data: UpdateAgent): Promise<Agent> {
   return api.patch<Agent>(`/admin/agents/${encodeURIComponent(uuid)}`, data);
+}
+
+/**
+ * Re-bind an agent to a new client and/or a new runtime provider. The Hub
+ * runs owner / org / capability checks atomically; pass `force: true` to
+ * bypass the capability match (e.g. when the destination client is offline
+ * and `clients.metadata.capabilities` is stale).
+ */
+export function rebindAgent(uuid: string, data: RebindAgent): Promise<Agent> {
+  return api.patch<Agent>(`/admin/agents/${encodeURIComponent(uuid)}/rebind`, data);
 }
 
 export function deleteAgent(uuid: string): Promise<void> {

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -3,6 +3,7 @@ import {
   AGENT_NAME_REGEX,
   type Agent,
   isReservedAgentName,
+  type RuntimeProvider,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
@@ -52,7 +53,9 @@ function issuesToFieldErrors(issues: ValidationIssue[] | undefined): FieldErrors
  *   - delegateMention, visibility, clientId = not surfaced
  */
 
-type Runtime = "claude-code" | "kael";
+// Runtime selection sources its values from `RuntimeProvider`; new providers
+// extend the union in `@agent-team-foundation/first-tree-hub-shared` and the
+// dialog picks them up automatically.
 
 /**
  * Full slugification — lowercase, ASCII-only, strip leading/trailing
@@ -100,7 +103,7 @@ function availabilityReasonMessage(reason: "invalid" | "reserved" | "taken"): st
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: (agent: Agent, runtime: Runtime) => void;
+  onCreated: (agent: Agent, runtimeProvider: RuntimeProvider) => void;
 };
 
 type Step = "form" | "pick-computer";
@@ -115,7 +118,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const [displayName, setDisplayName] = useState("");
   const [name, setName] = useState("");
   const [nameDirty, setNameDirty] = useState(false);
-  const [runtime, setRuntime] = useState<Runtime>("claude-code");
+  const [runtime, setRuntime] = useState<RuntimeProvider>("claude-code");
 
   const [step, setStep] = useState<Step>("form");
   const [candidateClients, setCandidateClients] = useState<HubClient[]>([]);
@@ -199,6 +202,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
         type: "personal_assistant",
         displayName: effectiveDisplay,
         clientId: opts.clientId,
+        runtimeProvider: runtime,
       });
     },
     onSuccess: (agent) => {
@@ -259,11 +263,6 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
     setClientErrors(errs);
     if (Object.keys(errs).length > 0) return;
     if (availability.status === "bad") return;
-
-    if (runtime !== "claude-code") {
-      createMut.mutate({ clientId: undefined });
-      return;
-    }
 
     setProbing(true);
     try {
@@ -477,20 +476,29 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                 <div>
                   <div className="text-body font-medium">Claude Code</div>
                   <div className="text-caption text-muted-foreground">
-                    Runs on your computer, can access your local files. (default)
+                    Anthropic's Claude Code on the bound computer. (default)
                   </div>
                 </div>
               </label>
               <label
-                className="flex items-start gap-3 rounded-md border border-border p-3 cursor-not-allowed opacity-60"
-                title="Coming soon"
+                className={
+                  runtime === "codex"
+                    ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
+                    : "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
+                }
               >
-                <input type="radio" name="runtime" disabled className="mt-1" />
+                <input
+                  type="radio"
+                  name="runtime"
+                  checked={runtime === "codex"}
+                  onChange={() => setRuntime("codex")}
+                  className="mt-1"
+                />
                 <div>
-                  <div className="text-body font-medium">
-                    Kael <span className="ml-1 text-caption font-normal text-muted-foreground">— coming soon</span>
+                  <div className="text-body font-medium">Codex</div>
+                  <div className="text-caption text-muted-foreground">
+                    OpenAI Codex CLI on the bound computer. Run <code>codex login</code> on the host once.
                   </div>
-                  <div className="text-caption text-muted-foreground">Ready to go, runs in the cloud.</div>
                 </div>
               </label>
             </div>

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1,3 +1,4 @@
+import type { RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link2, MessageSquare, Play } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -38,9 +39,10 @@ import { IdentitySection } from "./agent-detail/identity-section.js";
 import { McpSection } from "./agent-detail/mcp-section.js";
 import { ModelSection } from "./agent-detail/model-section.js";
 import { PromptSection } from "./agent-detail/prompt-section.js";
+import { ReBindDialog } from "./agent-detail/re-bind-dialog.js";
 import { SaveBar, sectionAnchorId } from "./agent-detail/save-bar.js";
 import { SectionDivider, SectionShell } from "./agent-detail/section-shell.js";
-import { type SetupRuntimeKind, SetupSection } from "./agent-detail/setup-section.js";
+import { SetupSection } from "./agent-detail/setup-section.js";
 import { deriveSaveHint } from "./agent-detail/status-bar.js";
 import { useConfigDraft } from "./agent-detail/use-config-draft.js";
 
@@ -209,6 +211,7 @@ export function AgentDetailPage() {
   const [bindClientOpen, setBindClientOpen] = useState(false);
   const [bindClientSelected, setBindClientSelected] = useState<string>("");
   const [bindClientError, setBindClientError] = useState<string | null>(null);
+  const [reBindOpen, setReBindOpen] = useState(false);
   const clientsQuery = useQuery({
     queryKey: ["clients"],
     queryFn: listClients,
@@ -405,13 +408,12 @@ export function AgentDetailPage() {
     : null;
   const boundClientLabel: string | null = boundClientId ? (boundClient?.hostname ?? boundClientId) : null;
 
-  // Runtime kind label for the Setup "Where it runs" card. The agent schema
-  // does not currently carry a first-class runtime field; we derive from
-  // `runtimeType` when the backend reports it ("kael"), otherwise treat the
-  // agent as Claude Code, which matches today's only shipping runtime.
-  const setupRuntimeKind: SetupRuntimeKind = runtimeType === "kael" ? "kael" : "claude-code";
-  const contextRuntimeLabel =
-    setupRuntimeKind === "kael" ? "Kael" : setupRuntimeKind === "claude-code" ? "Claude Code" : (runtimeType ?? "—");
+  // Runtime provider label for the Setup "Where it runs" card. The agent
+  // schema carries the authoritative `runtimeProvider` field post-0026; the
+  // legacy `runtimeType` from presence is the *running* shape and may lag
+  // briefly during a re-bind.
+  const setupRuntimeProvider: RuntimeProvider = agent.runtimeProvider ?? "claude-code";
+  const contextRuntimeLabel = setupRuntimeProvider === "codex" ? "Codex" : "Claude Code";
 
   return (
     <div className="-m-6 flex" style={{ minHeight: "calc(100vh - var(--sp-10))" }}>
@@ -606,11 +608,12 @@ export function AgentDetailPage() {
                 )}
                 {cfgQuery.data && (
                   <SetupSection
-                    runtimeKind={setupRuntimeKind}
+                    runtimeProvider={setupRuntimeProvider}
                     computerLabel={boundClientLabel}
                     canBindComputer={isUnclaimed && agent.status === "active"}
                     bindComputerPending={bindClientMutation.isPending}
                     onBindComputer={() => setBindClientOpen(true)}
+                    onRebind={agent.clientId ? () => setReBindOpen(true) : undefined}
                     modelSlot={
                       <ModelSection
                         value={draft.draft.model}
@@ -618,6 +621,7 @@ export function AgentDetailPage() {
                         onChange={draft.setModel}
                         onRevert={draft.revertModel}
                         disabled={agent.status !== "active"}
+                        provider={setupRuntimeProvider}
                       />
                     }
                   />
@@ -820,6 +824,8 @@ export function AgentDetailPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ReBindDialog open={reBindOpen} onOpenChange={setReBindOpen} agent={agent} />
     </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -1,3 +1,7 @@
+import type { RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
+import { Check, ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Button } from "../../components/ui/button.js";
 import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
 
@@ -14,17 +18,63 @@ export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
   { value: "haiku", label: "haiku", hint: "fastest" },
 ];
 
+/**
+ * Codex CLI model slugs baked into `@openai/codex@0.125.0` — extracted from
+ * the bundled binary's config schema. ChatGPT-account auth restricts which
+ * are usable at runtime (gpt-5.5 works; older slugs reject); API-key auth
+ * accepts the wider set. The picker lists all and lets the runtime surface
+ * actual permission errors instead of pre-validating per auth mode.
+ */
+export const CODEX_MODEL_OPTIONS: ModelOption[] = [
+  { value: "gpt-5.5", label: "gpt-5.5", hint: "latest" },
+  { value: "gpt-5.4", label: "gpt-5.4" },
+  { value: "gpt-5.4-mini", label: "gpt-5.4-mini", hint: "fastest" },
+  { value: "gpt-5.3-codex", label: "gpt-5.3-codex", hint: "coding-specialized" },
+  { value: "gpt-5.2", label: "gpt-5.2" },
+];
+
+const MODEL_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, ModelOption[]> = {
+  "claude-code": CLAUDE_MODEL_OPTIONS,
+  codex: CODEX_MODEL_OPTIONS,
+};
+
+const MODEL_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
+  "claude-code":
+    "Choose which Claude model powers this agent. Aliases (opus / sonnet / haiku) follow the CLI's latest-in-family mapping and may shift across releases. Applies to new sessions immediately; active sessions switch on their next message. Unset falls back to the operator's local ~/.claude/settings.json model preference, then the CLI default.",
+  codex:
+    "Pick a Codex model. Slugs come from the Codex CLI bundled with @openai/codex-sdk; ChatGPT-account auth currently only accepts gpt-5.5, while API-key auth accepts the wider set. Applies to new sessions immediately; active sessions switch on their next message. Unset lets the codex CLI choose a model that matches the user's auth mode.",
+};
+
 export type ModelSectionProps = {
   value: string;
   baseline: string;
   onChange: (v: string) => void;
   onRevert: () => void;
   disabled?: boolean;
+  /** Runtime this agent runs on — drives the option list and help copy. */
+  provider?: RuntimeProvider;
 };
 
-export function ModelSection({ value, baseline, onChange, onRevert, disabled }: ModelSectionProps) {
+const UNSET_OPTION: ModelOption = { value: "", label: "(unset — inherits local)" };
+
+export function ModelSection({
+  value,
+  baseline,
+  onChange,
+  onRevert,
+  disabled,
+  provider = "claude-code",
+}: ModelSectionProps) {
   const dirty = value !== baseline;
-  const hasExtra = !CLAUDE_MODEL_OPTIONS.some((o) => o.value === value) && value !== "";
+  const presetOptions = MODEL_OPTIONS_BY_PROVIDER[provider];
+
+  const items = useMemo<ModelOption[]>(() => {
+    const list: ModelOption[] = [UNSET_OPTION, ...presetOptions];
+    if (value !== "" && !presetOptions.some((o) => o.value === value)) {
+      list.push({ value, label: value, hint: "custom" });
+    }
+    return list;
+  }, [presetOptions, value]);
 
   return (
     <Panel
@@ -56,28 +106,143 @@ export function ModelSection({ value, baseline, onChange, onRevert, disabled }: 
         )}
       </PanelHeader>
       <PanelBody className="space-y-2">
-        <select
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          className="flex h-9 w-full max-w-md rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-1 text-body shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
-        >
-          {value === "" && <option value="">(unset — inherits local)</option>}
-          {CLAUDE_MODEL_OPTIONS.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-              {o.hint ? ` — ${o.hint}` : ""}
-            </option>
-          ))}
-          {hasExtra && <option value={value}>{value} — custom</option>}
-        </select>
-        <p className="text-caption text-muted-foreground">
-          Choose which Claude model powers this agent. Aliases (opus / sonnet / haiku) follow the CLI's latest-in-family
-          mapping and may shift across releases. Applies to new sessions immediately; active sessions switch on their
-          next message. Unset falls back to the operator's local <code>~/.claude/settings.json</code> model preference,
-          then the CLI default.
-        </p>
+        <ModelDropdown items={items} value={value} onChange={onChange} disabled={disabled} />
+        <p className="text-caption text-muted-foreground">{MODEL_HELP_BY_PROVIDER[provider]}</p>
       </PanelBody>
     </Panel>
+  );
+}
+
+/**
+ * Custom listbox-style dropdown — built on top of a button + absolutely
+ * positioned listbox so we can theme the popup (native `<select>` popups are
+ * OS-controlled and unstylable). Anchors to the trigger via `top: 100%`,
+ * dismisses on click-outside or Escape.
+ */
+function ModelDropdown({
+  items,
+  value,
+  onChange,
+  disabled,
+}: {
+  items: ModelOption[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [popupRect, setPopupRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+  const selected = items.find((o) => o.value === value) ?? items[0];
+
+  const computePosition = useCallback(() => {
+    const t = triggerRef.current;
+    if (!t) return;
+    const r = t.getBoundingClientRect();
+    setPopupRect({ top: r.bottom + 4, left: r.left, width: r.width });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+  }, [open, computePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (popupRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    const onReflow = () => computePosition();
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onReflow, true);
+    window.addEventListener("resize", onReflow);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onReflow, true);
+      window.removeEventListener("resize", onReflow);
+    };
+  }, [open, computePosition]);
+
+  return (
+    <div className="max-w-md">
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="mono flex h-9 w-full items-center justify-between rounded-[var(--radius-input)] border border-input bg-transparent pl-3 pr-2 py-1 text-body shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50 hover:border-ring transition-colors cursor-pointer"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="truncate" style={{ color: selected?.value === "" ? "var(--fg-3)" : undefined }}>
+          {selected?.label ?? value}
+        </span>
+        <ChevronDown
+          className="ml-2 h-3.5 w-3.5 transition-transform"
+          style={{ color: "var(--fg-3)", transform: open ? "rotate(180deg)" : undefined }}
+        />
+      </button>
+      {open &&
+        popupRect &&
+        createPortal(
+          <div
+            ref={popupRef}
+            className="fixed z-50 overflow-hidden rounded-[var(--radius-input)] py-1"
+            style={{
+              top: popupRect.top,
+              left: popupRect.left,
+              width: popupRect.width,
+              background: "var(--bg-raised)",
+              border: "var(--hairline) solid var(--border)",
+              boxShadow: "var(--shadow-md)",
+              maxHeight: 280,
+              overflowY: "auto",
+            }}
+          >
+            {items.map((o) => {
+              const active = o.value === value;
+              return (
+                <button
+                  key={o.value || "__unset"}
+                  type="button"
+                  onClick={() => {
+                    onChange(o.value);
+                    setOpen(false);
+                  }}
+                  className="mono flex w-full items-center gap-2 cursor-pointer px-3 py-1.5 text-body text-left hover:bg-accent/40 transition-colors focus-visible:outline-none focus-visible:bg-accent/40"
+                  style={{
+                    background: active ? "var(--bg-hover)" : undefined,
+                    color: o.value === "" ? "var(--fg-3)" : undefined,
+                  }}
+                >
+                  <Check
+                    className="h-3.5 w-3.5 flex-shrink-0"
+                    style={{ visibility: active ? "visible" : "hidden", color: "var(--state-idle)" }}
+                  />
+                  <span className="flex-1 truncate">{o.label}</span>
+                  {o.hint && (
+                    <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+                      {o.hint}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
@@ -1,0 +1,254 @@
+import {
+  type Agent,
+  type CapabilityEntry,
+  type ClientCapabilities,
+  RUNTIME_PROVIDERS,
+  type RuntimeProvider,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { type ClientWithCapabilities, getClientCapabilities, type HubClient, listClients } from "../../api/activity.js";
+import { rebindAgent } from "../../api/agents.js";
+import { ApiError } from "../../api/client.js";
+import { Button } from "../../components/ui/button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+import { Label } from "../../components/ui/label.js";
+
+const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+const PROVIDER_ORDER: RuntimeProvider[] = [RUNTIME_PROVIDERS.CLAUDE_CODE, RUNTIME_PROVIDERS.CODEX];
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agent: Agent;
+};
+
+/**
+ * Unified Re-bind dialog (UX U2): switching computer or runtime provider —
+ * or both at once — flow through this component. The single dialog keeps a
+ * consistent confirm + warning model regardless of whether the operator
+ * changes the bound client, the runtime provider, or both.
+ */
+export function ReBindDialog({ open, onOpenChange, agent }: Props) {
+  const queryClient = useQueryClient();
+  const currentClientId = agent.clientId;
+  const currentProvider = agent.runtimeProvider;
+
+  const [selectedClientId, setSelectedClientId] = useState<string | null>(currentClientId);
+  const [selectedProvider, setSelectedProvider] = useState<RuntimeProvider>(currentProvider);
+  const [force, setForce] = useState(false);
+
+  const clientsQuery = useQuery({
+    queryKey: ["clients-rebind"],
+    queryFn: listClients,
+    enabled: open,
+  });
+
+  const candidateClients = clientsQuery.data ?? [];
+
+  // Lazily fetch full capabilities for every candidate client so the runtime
+  // picker can grey-out missing providers.
+  const capabilityQueries = useQueries({
+    queries: candidateClients.map((c) => ({
+      queryKey: ["client-capabilities", c.id],
+      queryFn: () => getClientCapabilities(c.id),
+      enabled: open,
+    })),
+  });
+  const capabilitiesByClient = useMemo(() => {
+    const map = new Map<string, ClientCapabilities>();
+    capabilityQueries.forEach((q, idx) => {
+      const c = candidateClients[idx];
+      if (!c) return;
+      const data = q.data as ClientWithCapabilities | undefined;
+      if (data?.capabilities) map.set(c.id, data.capabilities);
+    });
+    return map;
+  }, [capabilityQueries, candidateClients]);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedClientId(currentClientId);
+      setSelectedProvider(currentProvider);
+      setForce(false);
+    }
+  }, [open, currentClientId, currentProvider]);
+
+  const selectedCapabilities: ClientCapabilities | null = selectedClientId
+    ? (capabilitiesByClient.get(selectedClientId) ?? null)
+    : null;
+
+  const providerEntry: CapabilityEntry | null = selectedCapabilities?.[selectedProvider] ?? null;
+  const capabilityMissing = !providerEntry || providerEntry.state === "missing" || providerEntry.state === "error";
+  const canSubmit =
+    !!selectedClientId &&
+    (selectedClientId !== currentClientId || selectedProvider !== currentProvider) &&
+    (!capabilityMissing || force);
+
+  const providerChanged = selectedProvider !== currentProvider;
+  const clientChanged = selectedClientId !== currentClientId;
+
+  const rebindMut = useMutation({
+    mutationFn: () => {
+      if (!selectedClientId) throw new Error("clientId required");
+      return rebindAgent(agent.uuid, {
+        clientId: selectedClientId,
+        runtimeProvider: selectedProvider,
+        force: capabilityMissing && force ? true : undefined,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agent", agent.uuid] });
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      onOpenChange(false);
+    },
+  });
+
+  const errorMessage =
+    rebindMut.error instanceof ApiError
+      ? rebindMut.error.message
+      : rebindMut.error instanceof Error
+        ? rebindMut.error.message
+        : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Re-bind agent</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+            Currently:{" "}
+            <span className="mono">{describeCurrent(currentClientId, candidateClients, currentProvider)}</span>
+          </p>
+
+          <div className="space-y-2">
+            <Label>Computer</Label>
+            <select
+              value={selectedClientId ?? ""}
+              onChange={(e) => setSelectedClientId(e.target.value || null)}
+              className="w-full rounded-[var(--radius-input)] border border-input bg-background px-3 py-2 text-body"
+            >
+              {candidateClients.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {clientLabel(c)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Runtime</Label>
+            <div className="space-y-2">
+              {PROVIDER_ORDER.map((provider) => {
+                const entry = selectedCapabilities?.[provider] ?? null;
+                const enabled = !!entry && entry.state !== "missing";
+                const checked = selectedProvider === provider;
+                return (
+                  <label
+                    key={provider}
+                    className={
+                      checked
+                        ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
+                        : enabled
+                          ? "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
+                          : "flex items-start gap-3 rounded-md border border-border p-3 opacity-60"
+                    }
+                  >
+                    <input
+                      type="radio"
+                      name="rebind-runtime"
+                      checked={checked}
+                      onChange={() => setSelectedProvider(provider)}
+                      className="mt-1"
+                    />
+                    <div>
+                      <div className="text-body font-medium">{PROVIDER_LABEL[provider]}</div>
+                      <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+                        {capabilityCaption(entry, provider)}
+                      </div>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          {(clientChanged || providerChanged) && (
+            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-caption space-y-1">
+              <p>
+                <span className="font-medium">Heads up:</span> active sessions on the previous computer are suspended at
+                re-bind. Chat history is preserved.
+              </p>
+              {providerChanged && (
+                <p>
+                  Some configuration fields don't transfer between providers (e.g. claude permission_mode is dropped;
+                  codex sandboxMode resets to default).
+                </p>
+              )}
+            </div>
+          )}
+
+          {capabilityMissing && (
+            <label className="flex items-start gap-2 text-caption" style={{ color: "var(--fg-2)" }}>
+              <input type="checkbox" checked={force} onChange={(e) => setForce(e.target.checked)} className="mt-0.5" />
+              <span>
+                Override capability check — pick this if the destination computer is offline or the SDK was just
+                installed and capabilities haven't refreshed yet.
+              </span>
+            </label>
+          )}
+
+          {errorMessage && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-body text-destructive">
+              {errorMessage}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={rebindMut.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => rebindMut.mutate()} disabled={!canSubmit || rebindMut.isPending}>
+            {rebindMut.isPending ? "Re-binding…" : "Re-bind"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function clientLabel(c: HubClient): string {
+  const head = c.hostname ?? c.id;
+  return `${head} · ${c.status}`;
+}
+
+function describeCurrent(currentClientId: string | null, clients: HubClient[], provider: RuntimeProvider): string {
+  const c = currentClientId ? clients.find((row) => row.id === currentClientId) : null;
+  const clientName = c?.hostname ?? currentClientId ?? "(unbound)";
+  return `${clientName} · ${PROVIDER_LABEL[provider]}`;
+}
+
+const UNAUTH_HINT: Record<RuntimeProvider, string> = {
+  "claude-code": "Run `claude login` (or set ANTHROPIC_API_KEY) on the computer.",
+  codex: "Run `codex login` (or set CODEX_API_KEY) on the computer.",
+};
+
+function capabilityCaption(entry: CapabilityEntry | null, provider: RuntimeProvider): string {
+  if (!entry) return "Not reported on this computer.";
+  switch (entry.state) {
+    case "ok":
+      return `Installed${entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, authenticated.`;
+    case "unauthenticated":
+      return `Installed${entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated. ${UNAUTH_HINT[provider]}`;
+    case "missing":
+      return "SDK not installed on this computer.";
+    case "error":
+      return entry.error ? `Probe error: ${entry.error}` : "Probe error.";
+  }
+}

--- a/packages/web/src/pages/agent-detail/setup-section.tsx
+++ b/packages/web/src/pages/agent-detail/setup-section.tsx
@@ -1,42 +1,44 @@
+import type { RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
 import { Link2, Lock, Play } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "../../components/ui/button.js";
 import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
 
 /**
- * Setup section — immutable "where it runs" pick, bind-computer banner, and a
- * slot for the Model editor. Two of the three settings (runtime kind, bound
- * computer) are fixed after creation; this section surfaces those facts in a
- * single place before the operator reaches the editable Model control below.
+ * Setup section — "where it runs" pick (locked here, re-bindable via the
+ * unified Re-bind dialog), bind-computer banner, and a slot for the Model
+ * editor. Surfaces the runtime provider + bound computer pair in a single
+ * place before the operator reaches the editable Model control below.
  */
 
-export type SetupRuntimeKind = "claude-code" | "kael";
-
 export type SetupSectionProps = {
-  runtimeKind: SetupRuntimeKind;
+  runtimeProvider: RuntimeProvider;
   /** Display label of the bound computer; null when no computer is bound yet. */
   computerLabel: string | null;
   /** Whether the "Bind computer" CTA should be shown (only when no client is bound and agent is active). */
   canBindComputer: boolean;
   bindComputerPending?: boolean;
   onBindComputer?: () => void;
+  /** When set, the bound-computer card surfaces a "Re-bind" button that
+   *  opens the unified ReBindDialog (UX U2). Available only on bound agents. */
+  onRebind?: () => void;
   /** Slot for the Model dropdown — we reuse the existing ModelSection via composition. */
   modelSlot: ReactNode;
 };
 
-const RUNTIME_COPY: Record<SetupRuntimeKind, { name: string; caption: string }> = {
+const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> = {
   "claude-code": {
     name: "Claude Code",
-    caption: "Anthropic's Claude Code runtime. Fixed after creation — create a new agent to switch.",
+    caption: "Anthropic's Claude Code runtime. Re-bind via the agent's settings to switch computer or runtime.",
   },
-  kael: {
-    name: "Kael",
-    caption: "Kael runtime (coming soon). Fixed after creation — create a new agent to switch.",
+  codex: {
+    name: "Codex",
+    caption: "OpenAI's Codex CLI runtime. Re-bind via the agent's settings to switch computer or runtime.",
   },
 };
 
 export function SetupSection(props: SetupSectionProps) {
-  const copy = RUNTIME_COPY[props.runtimeKind];
+  const copy = RUNTIME_COPY[props.runtimeProvider];
   return (
     <div className="space-y-3">
       <RuntimeCard name={copy.name} caption={copy.caption} locked />
@@ -46,6 +48,7 @@ export function SetupSection(props: SetupSectionProps) {
         canBindComputer={props.canBindComputer}
         bindPending={props.bindComputerPending ?? false}
         onBindComputer={props.onBindComputer}
+        onRebind={props.onRebind}
       />
 
       {props.modelSlot}
@@ -87,6 +90,7 @@ function ComputerCard(props: {
   canBindComputer: boolean;
   bindPending: boolean;
   onBindComputer: (() => void) | undefined;
+  onRebind: (() => void) | undefined;
 }) {
   const bound = !!props.computerLabel;
   return (
@@ -97,6 +101,12 @@ function ComputerCard(props: {
           <Button size="xs" variant="outline" onClick={props.onBindComputer} disabled={props.bindPending}>
             <Link2 className="h-3 w-3" />
             {props.bindPending ? "Binding…" : "Bind computer"}
+          </Button>
+        )}
+        {bound && props.onRebind && (
+          <Button size="xs" variant="outline" onClick={props.onRebind}>
+            <Link2 className="h-3 w-3" />
+            Re-bind
           </Button>
         )}
       </PanelHeader>

--- a/packages/web/src/pages/agents.tsx
+++ b/packages/web/src/pages/agents.tsx
@@ -1,4 +1,4 @@
-import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
+import type { Agent, RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shared";
 import { AGENT_TYPES } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
 import { Plus, Search } from "lucide-react";
@@ -144,13 +144,17 @@ export function AgentsPage() {
   const filteredMy = myAgents.filter((a) => matchesPill(a) && matchesSearch(a));
   const filteredTeam = teamAgents.filter((a) => matchesPill(a) && matchesSearch(a));
 
-  function handleCreated(agent: Agent, runtime: "claude-code" | "kael") {
+  function handleCreated(agent: Agent, runtimeProvider: RuntimeProvider) {
     setCreateDialogOpen(false);
     if (agent.clientId) {
       navigate(`/?a=${agent.uuid}`);
       return;
     }
-    if (runtime === "claude-code") {
+    // Local-runtime providers (claude-code / codex) need a follow-up
+    // step that points the operator at `client connect` so the new
+    // agent finds a host. Future cloud-only runtimes can short-circuit
+    // straight to the agent detail.
+    if (runtimeProvider === "claude-code" || runtimeProvider === "codex") {
       setLastStepAgent(agent);
       return;
     }

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -1,11 +1,19 @@
+import {
+  type CapabilityEntry,
+  type ClientCapabilities,
+  RUNTIME_PROVIDERS,
+  type RuntimeProvider,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, ChevronDown, ChevronRight, Copy, Terminal, Trash2, Unplug } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
+  type ClientWithCapabilities,
   type ConnectTokenResponse,
   disconnectClient,
   generateConnectToken,
   getActivityOverview,
+  getClientCapabilities,
   type HubClient,
   listClients,
   type RuntimeAgent,
@@ -364,6 +372,125 @@ export function ClientsPage() {
   );
 }
 
+const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+const PROVIDER_ORDER: RuntimeProvider[] = [RUNTIME_PROVIDERS.CLAUDE_CODE, RUNTIME_PROVIDERS.CODEX];
+
+const PROVIDER_INSTALL_HINT: Record<RuntimeProvider, string> = {
+  "claude-code": "Run `npm install -g @anthropic-ai/claude-code` on this computer.",
+  codex: "Install the OpenAI Codex CLI on this computer.",
+};
+
+const PROVIDER_UNAUTH_HINT: Record<RuntimeProvider, string> = {
+  "claude-code": "Run `claude login` (or set ANTHROPIC_API_KEY) on the computer.",
+  codex: "Run `codex login` (or set CODEX_API_KEY) on the computer.",
+};
+
+/**
+ * Lazy-loaded runtime-provider capability matrix shown inside the expanded
+ * row of the Computers table. We only fetch when the row is open so the
+ * /clients listing stays cheap on large fleets — capabilities are reported by
+ * the client at startup and stored under `clients.metadata.capabilities`.
+ */
+function CapabilityMatrix({ clientId, enabled }: { clientId: string; enabled: boolean }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["client-capabilities", clientId],
+    queryFn: () => getClientCapabilities(clientId),
+    enabled,
+  });
+  const capabilities: ClientCapabilities | null = (data as ClientWithCapabilities | undefined)?.capabilities ?? null;
+  return (
+    <>
+      <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>Runtimes</UppercaseLabel>
+      {isLoading && !capabilities ? (
+        <div className="text-body" style={{ color: "var(--fg-3)" }}>
+          Loading…
+        </div>
+      ) : capabilities && Object.keys(capabilities).length === 0 ? (
+        <div className="text-body" style={{ color: "var(--fg-3)" }}>
+          Capabilities not yet reported. Reconnect this computer to refresh.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {PROVIDER_ORDER.map((provider) => (
+            <ProviderRow
+              key={provider}
+              provider={provider}
+              entry={capabilities ? (capabilities[provider] ?? null) : null}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: CapabilityEntry | null }) {
+  const label = PROVIDER_LABEL[provider];
+  if (!entry) {
+    return (
+      <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
+        <span className="mono font-medium" style={{ minWidth: 180 }}>
+          {label}
+        </span>
+        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+          not reported · {PROVIDER_INSTALL_HINT[provider]}
+        </span>
+      </div>
+    );
+  }
+  switch (entry.state) {
+    case "ok":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="mono font-medium" style={{ minWidth: 180 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-idle)" }}>
+            ✓ {entry.sdkVersion ? `v${entry.sdkVersion} · ` : ""}authenticated ({entry.authMethod})
+          </span>
+        </div>
+      );
+    case "unauthenticated":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="mono font-medium" style={{ minWidth: 180 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-blocked)" }}>
+            ⚠ installed{entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated ·{" "}
+            {PROVIDER_UNAUTH_HINT[provider]}
+          </span>
+        </div>
+      );
+    case "missing":
+      return (
+        <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
+          <span className="mono font-medium" style={{ minWidth: 180 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+            ✗ not installed · {PROVIDER_INSTALL_HINT[provider]}
+          </span>
+        </div>
+      );
+    case "error":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="mono font-medium" style={{ minWidth: 180 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-error)" }}>
+            error · {entry.error ?? "probe failed"}
+          </span>
+        </div>
+      );
+  }
+}
+
 function ClientRow({
   client,
   boundAgents,
@@ -442,7 +569,8 @@ function ClientRow({
         <tr style={{ background: "var(--bg-sunken)" }}>
           <DenseTableCell />
           <DenseTableCell colSpan={colSpan - 1} style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-3_5)" }}>
-            <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>
+            <CapabilityMatrix clientId={client.id} enabled={isExpanded} />
+            <UppercaseLabel style={{ display: "block", marginTop: "var(--sp-3)", marginBottom: 6 }}>
               Bound agents · {boundAgents.length}
             </UppercaseLabel>
             {boundAgents.length === 0 ? (

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -1,19 +1,19 @@
 import { PageHeader } from "../components/ui/page-header.js";
-import { Tab, TabBar } from "../components/ui/tab-bar.js";
 import { BindingsPage } from "./bindings.js";
 
 /**
  * User-facing Settings page. Post hub-ui-polish split: every signed-in member
  * sees `/settings` (Bindings is scoped per-role by the server). Admin-only
  * organization controls (Members, org system config) moved to `/admin`.
+ *
+ * Computer-level info (registered machines + their runtime-provider capability
+ * matrix) lives on `/clients`, not here, so the operator answers "which
+ * machines can run what" in one place.
  */
 export function SettingsPage() {
   return (
     <div className="-m-6">
       <PageHeader title="Settings" subtitle="Per-member controls" />
-      <TabBar>
-        <Tab active>Bindings</Tab>
-      </TabBar>
       <div style={{ padding: "var(--sp-4) var(--sp-5) var(--sp-7)" }}>
         <BindingsPage />
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.84
         version: 0.2.84(zod@4.3.6)
+      '@openai/codex-sdk':
+        specifier: ^0.125.0
+        version: 0.125.0
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -81,6 +84,9 @@ importers:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
         version: 1.59.0
+      '@openai/codex-sdk':
+        specifier: ^0.125.0
+        version: 0.125.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1289,6 +1295,51 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@openai/codex-sdk@0.125.0':
+    resolution: {integrity: sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.125.0':
+    resolution: {integrity: sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.125.0-darwin-arm64':
+    resolution: {integrity: sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.125.0-darwin-x64':
+    resolution: {integrity: sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.125.0-linux-arm64':
+    resolution: {integrity: sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.125.0-linux-x64':
+    resolution: {integrity: sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.125.0-win32-arm64':
+    resolution: {integrity: sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.125.0-win32-x64':
+    resolution: {integrity: sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@opentelemetry/api-logs@0.203.0':
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
@@ -4870,6 +4921,37 @@ snapshots:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@openai/codex-sdk@0.125.0':
+    dependencies:
+      '@openai/codex': 0.125.0
+
+  '@openai/codex@0.125.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.125.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.125.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.125.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.125.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.125.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.125.0-win32-x64'
+
+  '@openai/codex@0.125.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.125.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.125.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.125.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.125.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.125.0-win32-x64':
     optional: true
 
   '@opentelemetry/api-logs@0.203.0':


### PR DESCRIPTION
## Summary
- Adds OpenAI Codex as a first-class agent runtime alongside Claude Code, with per-machine capability probing, a server-side availability gate, in-band repair on WS bind mismatch, and per-agent runtime selection in the web UI.
- Migration 0026 adds `agents.runtime_provider` (NOT NULL, default `claude-code`); pre-existing rows back-fill to `claude-code` so the change is non-breaking on rollout.
- Web `/clients` gains a runtime capability matrix (lazy-loaded per row), and per-agent panels expose a provider/model selector + re-bind dialog. Settings now only renders Bindings (capability info moved to `/clients`).

## Notable design points
- **Capability semantics** — probes emit `state ∈ {ok, unauthenticated, missing, error}` with a derived `available` flag. Server `ensureClientSupportsRuntimeProvider` keys off `available === true`, so a reported `missing`/`error` blocks creation/rebind even if the entry exists, while `unauthenticated` is allowed (operator fixes login on the machine).
- **Codex auth-mode default** — Codex CLI's two auth modes accept different model slugs (`gpt-5-codex` family is rejected by ChatGPT-account auth). Hub stores `model: ""` by default and `buildCodexThreadOptions` only emits the field when the operator chose one, letting the SDK pick a slug that matches the runtime auth mode.
- **In-band repair** — bind handshake compares `runtimeType` against `agents.runtime_provider`; mismatch returns `agent:bind:rejected { reason: "runtime_provider_mismatch" }` and the client `decideRepairForBindReject` returns a `restart` action (P2 minimal — full hot-swap is a follow-up).
- **CLI flow** — `agent create --runtime <provider>` now forwards the choice to the server; `client start` runs `reconcileLocalRuntimeProviders` pre-flight (rewrites stale `agent.yaml::runtime`) and `uploadClientCapabilities` after WS register (the `clients` row is created lazily in the register handshake).

## Test plan
- [x] `pnpm check` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 898 cases pass (server 476, client 234, shared 130, command 58)
- [x] 8 new test files cover: server capability gate (state branches × create/rebind × force × human skip), WS bind mismatch handshake, `PATCH /clients/:id/capabilities` API, runtime-provider + capability schemas, capability probes (claude-code OAuth/API key/unauth + codex API key/auth.json/HOME fallback), codex `buildCodexThreadOptions` model-empty-vs-set, `decideRepairForBindReject` table, `reconcileLocalRuntimeProviders` + `uploadClientCapabilities`
- [ ] Manual: create a codex agent on a client that probed `state: ok` for codex → bind succeeds end-to-end
- [ ] Manual: create a codex agent on a client that reported codex `missing` → POST returns 400 with availability error; `--force` overrides
- [ ] Manual: existing claude-code agents bind unchanged after applying migration 0026
- [ ] Manual: agent UI re-bind dialog displays provider-correct unauthenticated hint (`claude login` vs `codex login`)

## Versioning
Bumps `@agent-team-foundation/first-tree-hub` 0.10.1 → 0.10.2 (consumer-facing CLI tarball; new SDK dep added). Private packages (`shared`/`server`/`client`/`web`) unchanged per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)