### PR TITLE
feat(inbox): WS push data plane — replace doorbell + 5s poll

### DIFF
--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -566,3 +566,157 @@ describe("SessionManager routing guards — dispatch integration", () => {
     await sm.shutdown();
   });
 });
+
+/**
+ * `ackEntry` is the WS-push escape hatch (proposal hub-inbox-ws-data-plane
+ * §3.4): when set, dispatch acks via this callback instead of `sdk.ack`,
+ * keeping push-mode slots from double-acking and leaking the server-side
+ * per-agent in-flight counter (which only decrements on a WS ack matching
+ * a still-`delivered` row).
+ *
+ * The four paths that ack inside dispatch — echo suppression, inject into
+ * an active session, start a new session, resume an evicted session —
+ * must all flow through the injected callback, AND `sdk.ack` must NOT be
+ * called when one is provided. Anything less than that re-introduces the
+ * counter leak.
+ */
+describe("SessionManager ackEntry callback (WS push channel)", () => {
+  function buildSm(ackEntry: (entryId: number) => Promise<void>, handler?: AgentHandler) {
+    const h = handler ?? createMockHandler();
+    const sdk = mockSdk();
+    const sm = new SessionManager({
+      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      concurrency: 5,
+      handlerFactory: () => h,
+      handlerConfig: { workspaceRoot: "/tmp/test" },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Agent",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk,
+      log: silentLogger(),
+      ackEntry,
+    });
+    return { sm, sdk, handler: h };
+  }
+
+  it("uses the injected callback (not sdk.ack) when starting a new session", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const { sm, sdk } = buildSm(ackEntry);
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
+
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(1);
+    expect(sdk.ack).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("uses the injected callback when injecting into an active session", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const { sm, sdk } = buildSm(ackEntry);
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-1" }));
+
+    expect(ackEntry).toHaveBeenCalledTimes(2);
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+    expect(sdk.ack).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("uses the injected callback for echo-suppressed entries", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const handler = createMockHandler();
+    const { sm, sdk } = buildSm(ackEntry, handler);
+
+    const echo = mockEntry({
+      id: 99,
+      chatId: "c2",
+      inReplyTo: "M1",
+      inReplyToSnapshot: { senderId: "agent-1", chatId: "c2", replyToChat: "c1" },
+    });
+    await sm.dispatch(echo);
+
+    expect(handler.start).not.toHaveBeenCalled();
+    expect(ackEntry).toHaveBeenCalledWith(99);
+    expect(sdk.ack).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("uses the injected callback when resuming an evicted session", async () => {
+    // Seed an evicted session by exceeding concurrency=1, then dispatch into
+    // the evicted chat to trigger the resume branch (session-manager.ts:422).
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const handler = createMockHandler();
+    const sdk = mockSdk();
+    const sm = new SessionManager({
+      session: { idle_timeout: 300, max_sessions: 1, reconcile_interval_seconds: 300 },
+      concurrency: 1,
+      handlerFactory: () => handler,
+      handlerConfig: { workspaceRoot: "/tmp/test" },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Agent",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk,
+      log: silentLogger(),
+      ackEntry,
+    });
+
+    // Start chat-a, then chat-b which evicts chat-a (max_sessions=1).
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    ackEntry.mockClear();
+    (sdk.ack as ReturnType<typeof vi.fn>).mockClear();
+
+    // Dispatching back into chat-a hits the resume branch.
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a", messageId: "msg-resume" }));
+
+    expect(ackEntry).toHaveBeenCalledWith(3);
+    expect(sdk.ack).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("falls back to sdk.ack when no ackEntry callback is configured (legacy poll path)", async () => {
+    // Default behaviour — a slot constructed without `ackEntry` keeps the
+    // legacy HTTP ack channel so existing poll deployments are unaffected.
+    const sdk = mockSdk();
+    const handler = createMockHandler();
+    const sm = new SessionManager({
+      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      concurrency: 5,
+      handlerFactory: () => handler,
+      handlerConfig: { workspaceRoot: "/tmp/test" },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Agent",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk,
+      log: silentLogger(),
+    });
+
+    await sm.dispatch(mockEntry({ id: 7, chatId: "chat-1" }));
+
+    expect(sdk.ack).toHaveBeenCalledWith(7);
+
+    await sm.shutdown();
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -5,7 +5,9 @@ import {
   type AgentBindRejectReason,
   type AgentPinnedMessage,
   agentPinnedMessageSchema,
+  type InboxDeliverFrame,
   imagePayloadFrameSchema,
+  inboxDeliverFrameSchema,
   type RuntimeState,
   type ServerWelcomeFrame,
   type SessionEvent,
@@ -73,6 +75,14 @@ type ClientConnectionEvents = {
   "agent:bound": [agent: BoundAgent];
   "agent:unbound": [agentId: string];
   "agent:message": [agentId: string, data: unknown];
+  /**
+   * Server pushed a fully-assembled inbox entry over the WS data plane.
+   * Listeners must call `connection.sendInboxAck(frame.entryId)` once the
+   * entry has been durably handed to the session manager. Replaces the
+   * legacy `agent:message` → HTTP-poll round-trip when the server
+   * advertises `wsInboxDeliver`. Falls back silently on legacy paths.
+   */
+  "inbox:deliver": [agentId: string, frame: InboxDeliverFrame];
   "agent:bind:rejected": [reason: AgentBindRejectReason, agentId: string];
   /**
    * Server announced that an agent has been pinned to this client (either
@@ -105,6 +115,17 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
 const WS_CONNECT_TIMEOUT_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
+/**
+ * Client-side opt-in for the WS inbox data plane. Gates BOTH the
+ * `wireCapabilities.wsInboxDeliver` flag we declare on `client:register`
+ * AND how we interpret the server's welcome capability — without this AND,
+ * a future client kill-switch could land in a half-state where we tell the
+ * server "no thanks" but still treat welcome's `wsInboxDeliver:true` as
+ * authoritative and stop the 5s HTTP poll, leaving messages stuck if a
+ * NOTIFY ever drops. Hard-coded `true` for now; flip to a config knob if
+ * you need a runtime kill-switch.
+ */
+const WS_INBOX_DELIVER_OPT_IN = true;
 /**
  * Unified-user-token C5: reconnect PROACTIVELY this many ms before the JWT's
  * `exp` claim so the client rotates to a fresh JWT without ever hitting the
@@ -159,6 +180,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private registered = false;
   /** Count of `server:welcome` frames received; drives `isReconnect` flag. */
   private welcomeFramesReceived = 0;
+  /**
+   * Whether the most recent `server:welcome` frame advertised
+   * `capabilities.wsInboxDeliver`. The runtime (AgentSlot) reads this
+   * (via {@link supportsWsInboxDeliver}) to decide whether to keep the
+   * legacy 5s HTTP poll or rely entirely on `inbox:deliver` push frames.
+   * Re-evaluated on every reconnect — the welcome frame is the source of
+   * truth, never assumed sticky across connections.
+   */
+  private wsInboxDeliverActive = false;
   /**
    * Last handshake error, stashed for the `close` handler to surface a typed
    * reason (e.g. {@link ClientOrgMismatchError}) instead of a generic
@@ -219,6 +249,29 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
   get agents(): ReadonlyMap<string, BoundAgent> {
     return this.boundAgents;
+  }
+
+  /**
+   * True when the current connection's `server:welcome` advertised
+   * `capabilities.wsInboxDeliver` — meaning the server will push
+   * `inbox:deliver` frames and accept `inbox:ack` frames over this WS.
+   * Resets to false on every reconnect until the new welcome arrives.
+   */
+  get supportsWsInboxDeliver(): boolean {
+    return this.wsInboxDeliverActive;
+  }
+
+  /**
+   * Ack a delivered inbox entry over the WS data plane. Replaces the legacy
+   * `sdk.ack()` HTTP call when the connection has negotiated
+   * `wsInboxDeliver`. Safe to call when the WS is closed — the frame is
+   * dropped silently and the entry will time out and re-deliver on
+   * reconnect, mirroring how the legacy timeout reaper handles HTTP
+   * ack-loss.
+   */
+  sendInboxAck(entryId: number): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "inbox:ack", entryId }));
   }
 
   async connect(): Promise<void> {
@@ -369,6 +422,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.clearAuthRefreshTimer();
         const wasRegistered = this.registered;
         this.registered = false;
+        // Capability is per-connection — never assume it survives a reconnect.
+        // The next `server:welcome` will re-derive it from the server's flag.
+        this.wsInboxDeliverActive = false;
         this.rejectAllPendingBinds("WebSocket closed");
 
         if (!settled) {
@@ -397,6 +453,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
     if (type === "auth:ok") {
       this.authLogger.info("auth accepted, registering client");
+      // Advertise wire-capability opt-in so a `wsDataPlane`-enabled server
+      // routes NOTIFY traffic through `inbox:deliver` frames instead of
+      // legacy `new_message` doorbells. Gated by WS_INBOX_DELIVER_OPT_IN —
+      // see its definition for why both the wire flag and the welcome-cap
+      // gate below need to share a single source of truth.
       this.ws?.send(
         JSON.stringify({
           type: "client:register",
@@ -404,6 +465,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           hostname: getHostname(),
           os: platform(),
           sdkVersion: this.sdkVersion,
+          wireCapabilities: { wsInboxDeliver: WS_INBOX_DELIVER_OPT_IN },
         }),
       );
       return;
@@ -421,6 +483,18 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         );
         return;
       }
+      // Cache the negotiated push capability for this connection. Reset on
+      // every welcome — if a reconnect lands on an older server with the
+      // flag off, we transparently fall back to the HTTP poll path.
+      // ANDed with WS_INBOX_DELIVER_OPT_IN so a future client kill-switch
+      // (flip the const to false) takes effect symmetrically: we tell the
+      // server "no thanks" via wireCapabilities AND keep the 5s HTTP poll
+      // running. Without the AND, an opt-out client would see welcome's
+      // `wsInboxDeliver:true` and stop polling, but the server — having
+      // received `wireCapabilities.wsInboxDeliver:false` — would keep
+      // sending doorbells and never push deliver frames, leaving messages
+      // stuck if any NOTIFY were ever lost.
+      this.wsInboxDeliverActive = parsed.data.capabilities?.wsInboxDeliver === true && WS_INBOX_DELIVER_OPT_IN;
       const isReconnect = this.welcomeFramesReceived > 0;
       this.welcomeFramesReceived++;
       this.emit("server:welcome", { frame: parsed.data, isReconnect });
@@ -585,6 +659,40 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         });
       } else {
         this.emit("agent:message", inboxId, msg);
+      }
+      return;
+    }
+
+    if (type === "inbox:deliver") {
+      const parsed = inboxDeliverFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        // Per-issue path/message + the receiving frame keys so we can pinpoint
+        // shape drift between server build and client schema during gradual
+        // rollouts. Frame body intentionally not logged in full — message
+        // content can be sensitive — but the top-level keys + missing/extra
+        // fields are enough to spot e.g. a renamed/dropped column.
+        this.wsLogger.warn(
+          {
+            issues: parsed.error.issues.map((i) => ({
+              path: i.path.join("."),
+              code: i.code,
+              message: i.message,
+            })),
+            frameKeys: Object.keys(msg),
+            messageKeys: msg.message && typeof msg.message === "object" ? Object.keys(msg.message) : null,
+          },
+          "malformed inbox:deliver frame — dropping",
+        );
+        return;
+      }
+      // Same image-write race guard as `new_message`: server pushes
+      // `image_payload` immediately before `inbox:deliver`, so make sure
+      // disk writes flush before the runtime tries to render the message.
+      const emit = () => this.emit("inbox:deliver", parsed.data.inboxId, parsed.data);
+      if (this.pendingImageWrites.size > 0) {
+        Promise.all([...this.pendingImageWrites]).finally(emit);
+      } else {
+        emit();
       }
       return;
     }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -144,6 +144,22 @@ export class AgentSlot {
       log: createLogger("git-mirror").child({ agentName: this.config.name, agentId: this.config.agentId }),
     });
 
+    // Pin the ack channel ONCE per slot. `clientConnection.supportsWsInboxDeliver`
+    // is per-connection (resolves on `server:welcome`) and cannot flip mid-slot
+    // — server-side per-socket subscriptions register a push handler OR the
+    // legacy doorbell, never both, so the ack channel matches the delivery
+    // channel for this slot's lifetime. Mixing them would leak the server's
+    // per-agent in-flight counter (proposal hub-inbox-ws-data-plane §3.5).
+    const ackEntry = this.clientConnection.supportsWsInboxDeliver
+      ? (entryId: number) => {
+          this.clientConnection.sendInboxAck(entryId);
+          // sendInboxAck is fire-and-forget (`ws.send` doesn't block on flush);
+          // SessionManager treats ack as advisory. Wrap in resolved Promise to
+          // satisfy the `(id) => Promise<void>` config signature.
+          return Promise.resolve();
+        }
+      : undefined;
+
     this.sessionManager = new SessionManager({
       session: this.config.session,
       concurrency: this.config.concurrency,
@@ -165,6 +181,7 @@ export class AgentSlot {
       log: this.logger,
       registryPath,
       agentConfigCache: this.agentConfigCache,
+      ackEntry,
       onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
       onRuntimeStateChange: (state) => this.reportRuntimeState(state),
       onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
@@ -257,15 +274,19 @@ export class AgentSlot {
 
   /**
    * Translate an `inbox:deliver` push frame into the {@link InboxEntryWithMessage}
-   * shape `SessionManager.dispatch` expects, run dispatch, then ack. Mirrors
-   * the legacy poll path exactly except for the ack channel: WS frame instead
-   * of `sdk.ack()` HTTP call.
+   * shape `SessionManager.dispatch` expects, then dispatch.
    *
-   * Ack runs ONLY on the success path so a dispatch crash leaves the entry
-   * `delivered` server-side, which the 300s timeout reaper rolls back to
-   * `pending` for replay (proposal §3.7). A `finally` block here would ack
-   * on every exception too — silently dropping the message because reaper
-   * skips already-`acked` rows.
+   * Ack happens INSIDE `dispatch` via the `ackEntry` callback we pinned at
+   * construction time — for push slots that's `clientConnection.sendInboxAck`,
+   * for poll slots it stays the legacy `sdk.ack`. Sending an additional ack
+   * here would double-ack: HTTP first (`delivered → acked`) followed by a
+   * WS frame the server can no longer match against any `delivered` row,
+   * which leaks the server's per-agent in-flight counter and stalls push
+   * after `inboxMaxInFlightPerAgent` messages.
+   *
+   * Dispatch errors propagate up; the entry stays `delivered` server-side
+   * and the 300s timeout reaper rolls it back to `pending` for replay
+   * (proposal §3.7).
    */
   private async dispatchPushedFrame(frame: InboxDeliverFrame): Promise<void> {
     if (!this.sessionManager) return;
@@ -286,7 +307,6 @@ export class AgentSlot {
       message: frame.message,
     };
     await this.sessionManager.dispatch(entry);
-    this.clientConnection.sendInboxAck(frame.entryId);
   }
 
   private startReconcileLoop(): void {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type {
+  InboxDeliverFrame,
   InboxEntryWithMessage,
   RuntimeState,
   SessionEvent,
@@ -32,6 +33,7 @@ export type AgentSlotConfig = {
 
 type ConnectionListener =
   | { event: "agent:message"; fn: (agentId: string, data: unknown) => void }
+  | { event: "inbox:deliver"; fn: (inboxId: string, frame: InboxDeliverFrame) => void }
   | { event: "agent:bound"; fn: (agent: { agentId: string }) => void }
   | { event: "session:command"; fn: (cmd: { agentId: string; chatId: string; type: string }) => void }
   | { event: "session:reconcile:result"; fn: (result: SessionReconcileResult) => void };
@@ -45,6 +47,12 @@ export class AgentSlot {
   private pollingTimer: ReturnType<typeof setInterval> | null = null;
   private reconcileTimer: ReturnType<typeof setInterval> | null = null;
   private listeners: ConnectionListener[] = [];
+  /**
+   * The inbox this slot's agent owns — used to filter `inbox:deliver`
+   * frames addressed to other agents on the same client. Captured at
+   * `start()` from `sdk.register()`.
+   */
+  private inboxId: string | null = null;
 
   constructor(config: AgentSlotConfig) {
     this.config = config;
@@ -91,8 +99,16 @@ export class AgentSlot {
       throw new Error(`Hub unreachable while loading agent config: ${msg}`);
     }
 
+    this.inboxId = agent.inboxId;
+
     const onMessage = (agentId: string) => {
       if (agentId === this.config.agentId) this.pullAndDispatch();
+    };
+    const onInboxDeliver = (inboxId: string, frame: InboxDeliverFrame) => {
+      if (inboxId !== this.inboxId) return;
+      this.dispatchPushedFrame(frame).catch((err) => {
+        this.logger.warn({ err, entryId: frame.entryId }, "inbox:deliver dispatch error");
+      });
     };
     const onBound = (boundAgent: { agentId: string }) => {
       if (boundAgent.agentId === this.config.agentId) {
@@ -108,10 +124,12 @@ export class AgentSlot {
       }
     };
     this.clientConnection.on("agent:message", onMessage);
+    this.clientConnection.on("inbox:deliver", onInboxDeliver);
     this.clientConnection.on("agent:bound", onBound);
     this.clientConnection.on("session:reconcile:result", onReconcileResult);
     this.listeners.push(
       { event: "agent:message", fn: onMessage },
+      { event: "inbox:deliver", fn: onInboxDeliver },
       { event: "agent:bound", fn: onBound },
       { event: "session:reconcile:result", fn: onReconcileResult },
     );
@@ -182,6 +200,7 @@ export class AgentSlot {
     }
     for (const entry of this.listeners) {
       if (entry.event === "agent:message") this.clientConnection.off(entry.event, entry.fn);
+      else if (entry.event === "inbox:deliver") this.clientConnection.off(entry.event, entry.fn);
       else if (entry.event === "agent:bound") this.clientConnection.off(entry.event, entry.fn);
       else if (entry.event === "session:reconcile:result") this.clientConnection.off(entry.event, entry.fn);
       else this.clientConnection.off(entry.event, entry.fn);
@@ -220,10 +239,54 @@ export class AgentSlot {
   }
 
   private startPolling(): void {
+    // Skip the 5s HTTP poll when the server has negotiated the WS data plane
+    // (`server:welcome.capabilities.wsInboxDeliver`). The push path drains
+    // any in-flight backlog immediately after `agent:bound` (server-side),
+    // so we don't need a kick-poll either. Legacy servers leave the
+    // capability off and we keep polling exactly as before — that's the
+    // rollback path (proposal hub-inbox-ws-data-plane §3.6).
+    if (this.clientConnection.supportsWsInboxDeliver) {
+      this.logger.info("WS inbox data plane active — skipping 5s HTTP poll");
+      return;
+    }
     this.pollingTimer = setInterval(() => {
       this.pullAndDispatch();
     }, 5000);
     this.pullAndDispatch();
+  }
+
+  /**
+   * Translate an `inbox:deliver` push frame into the {@link InboxEntryWithMessage}
+   * shape `SessionManager.dispatch` expects, run dispatch, then ack. Mirrors
+   * the legacy poll path exactly except for the ack channel: WS frame instead
+   * of `sdk.ack()` HTTP call.
+   *
+   * Ack runs ONLY on the success path so a dispatch crash leaves the entry
+   * `delivered` server-side, which the 300s timeout reaper rolls back to
+   * `pending` for replay (proposal §3.7). A `finally` block here would ack
+   * on every exception too — silently dropping the message because reaper
+   * skips already-`acked` rows.
+   */
+  private async dispatchPushedFrame(frame: InboxDeliverFrame): Promise<void> {
+    if (!this.sessionManager) return;
+    const entry: InboxEntryWithMessage = {
+      id: frame.entryId,
+      inboxId: frame.inboxId,
+      messageId: frame.message.id,
+      chatId: frame.chatId,
+      // The DB columns we don't carry on the wire — set to the values the
+      // claim path would have produced. Only `chatId`, `id`, and `message`
+      // are read by SessionManager.dispatch, but keeping the shape correct
+      // lets test fixtures and downstream consumers depend on the schema.
+      status: "delivered",
+      retryCount: 0,
+      createdAt: frame.message.createdAt,
+      deliveredAt: new Date().toISOString(),
+      ackedAt: null,
+      message: frame.message,
+    };
+    await this.sessionManager.dispatch(entry);
+    this.clientConnection.sendInboxAck(frame.entryId);
   }
 
   private startReconcileLoop(): void {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -48,6 +48,18 @@ type SessionManagerConfig = {
   registryPath?: string;
   /** Step 4: optional config cache for refresh-before-dispatch on configVersion bump. */
   agentConfigCache?: AgentConfigCache;
+  /**
+   * Ack channel used by `dispatch` when an entry transitions out of `delivered`.
+   * Defaults to `sdk.ack` (HTTP `POST /inbox/:id/ack`) — the legacy poll path.
+   * The WS push path (proposal hub-inbox-ws-data-plane §3.4) overrides this
+   * with `clientConnection.sendInboxAck` so the entry is acked over the same
+   * socket that delivered it. Without this hook a push-mode slot would
+   * silently double-ack: HTTP first (status `delivered → acked`) followed by
+   * WS (no-op against the now-acked row), and the server-side per-agent
+   * in-flight counter — which only decrements on a successful WS ack —
+   * would leak to the cap and stop pushing.
+   */
+  ackEntry?: (entryId: number) => Promise<void>;
   /** Callback when a session state changes (per-session granularity). */
   onStateChange?: (chatId: string, state: SessionState) => void;
   /** Callback when aggregated runtime state changes. */
@@ -599,11 +611,22 @@ export class SessionManager {
     this.config.onStateChange(chatId, state);
   }
 
-  /** ACK an inbox entry — delayed until handler starts processing. */
+  /**
+   * ACK an inbox entry — delayed until handler starts processing.
+   *
+   * Routes through `config.ackEntry` when set (WS push path) or falls back to
+   * `sdk.ack` (HTTP poll path). One ack per entry, one channel per slot —
+   * mixing channels in one slot would leak the server's per-agent in-flight
+   * counter (proposal hub-inbox-ws-data-plane §3.5).
+   */
   private async ackEntry(entryId: number | undefined, chatId: string): Promise<void> {
     if (entryId === undefined) return;
     try {
-      await this.config.sdk.ack(entryId);
+      if (this.config.ackEntry) {
+        await this.config.ackEntry(entryId);
+      } else {
+        await this.config.sdk.ack(entryId);
+      }
     } catch {
       this.config.log.warn({ chatId, entryId }, "ACK failed, continuing");
     }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -1,0 +1,296 @@
+import { and, eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { chatParticipants } from "../db/schema/chats.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import * as inboxService from "../services/inbox.js";
+import { sendMessage } from "../services/message.js";
+import { createAdminContext, createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Coverage for the WS data-plane claim helpers introduced in proposal
+ * hub-inbox-ws-data-plane. These are the pure DB primitives — the WS frame
+ * round-trip (welcome capability, in-flight cap, backlog drain) is exercised
+ * by an integration test layer that depends on a live websocket harness;
+ * here we just pin invariants the service layer must guarantee.
+ */
+describe("inbox WS data-plane claim helpers", () => {
+  const getApp = useTestApp();
+
+  async function seedDeliverable(app: FastifyInstance) {
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `wsp-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `wsp-a2-${uid}` });
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "direct",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+    const msgRes = await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+      format: "text",
+      content: "WS push test",
+    });
+    return { a2, messageId: msgRes.json().id, chatId };
+  }
+
+  it("claimAndBuildForPush atomically claims a pending entry and bundles it", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const entries = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    expect(entries).toHaveLength(1);
+    const [entry] = entries;
+    if (!entry) return;
+    expect(entry.messageId).toBe(messageId);
+    expect(entry.status).toBe("delivered");
+    expect(entry.message.id).toBe(messageId);
+    // Same wire shape as the legacy poll path → client-side dispatch is
+    // identical (single SessionManager.dispatch call site).
+    expect(typeof entry.message.configVersion).toBe("number");
+    expect(entry.message.recipientMode).toBeTruthy();
+    // `inbox_entries.id` is bigserial (int8) — postgres-js returns int8 as a
+    // JS string by default. The raw-SQL claim path has to coerce to number
+    // because the WS push frame schema validates `entryId: z.number()`.
+    // Without coercion the client drops every push frame as malformed.
+    expect(typeof entry.id).toBe("number");
+  });
+
+  it("returns an empty array on a second claim of the same (inbox, message) — race-safe with HTTP poll", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const first = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    expect(first).toHaveLength(1);
+
+    // Second claim hits no `pending` row — push path must surface that as
+    // `[]`, NOT throw, otherwise a NOTIFY storm crashes the LISTEN loop.
+    const second = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    expect(second).toEqual([]);
+  });
+
+  it("claimAndBuildForPush returns BOTH rows when replyTo cross-chat fan-out wrote two entries", async () => {
+    // Regression for review issue #2: a single (inbox, messageId) pair can map
+    // to two inbox_entries rows differing only by chat_id when:
+    //   1. agent A is a chat participant (row 1, chatId = current chat)
+    //   2. agent A is also the replyToInbox of an earlier message
+    //      (row 2, chatId = original.replyToChat)
+    // Old `LIMIT 1` claim shape only pushed row 1; row 2 sat `pending` until
+    // reconnect. Aligning with poll's `LIMIT N` shape closes the gap.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const ctx = await createAdminContext(app, { username: `wsp-rt-${uid}` });
+    const sender = await createAgent(app.db, {
+      name: `wsp-rt-s-${uid}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+    const peer = await createAgent(app.db, {
+      name: `wsp-rt-p-${uid}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+
+    // chatA: sender + peer (where the conversation lives).
+    // chatB: sender alone — the replyTo target.
+    const chatA = await createChat(app.db, sender.uuid, { type: "direct", participantIds: [peer.uuid] });
+    const chatB = await createChat(app.db, sender.uuid, { type: "group", participantIds: [] });
+
+    const original = await sendMessage(app.db, chatA.id, sender.uuid, {
+      format: "text",
+      content: "any progress?",
+      replyToInbox: sender.inboxId,
+      replyToChat: chatB.id,
+    });
+    // Drain peer's inbox so it doesn't muddy the assertions below.
+    await inboxService.pollInbox(app.db, peer.inboxId, 10);
+
+    // peer replies — fan-out writes one row to sender's inbox (chatId=A) AND
+    // replyTo routing writes a second row (chatId=B). Same messageId on both.
+    const reply = await sendMessage(app.db, chatA.id, peer.uuid, {
+      format: "text",
+      content: "yes, almost done",
+      inReplyTo: original.message.id,
+    });
+
+    // Sanity check the seed: two pending rows exist before we claim.
+    const seeded = await app.db
+      .select({ chatId: inboxEntries.chatId, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, sender.inboxId), eq(inboxEntries.messageId, reply.message.id)));
+    expect(seeded).toHaveLength(2);
+
+    // The push path must claim BOTH rows in one call — proposal §3.2's
+    // "single NOTIFY → all matching pending rows".
+    const claimed = await inboxService.claimAndBuildForPush(app.db, sender.inboxId, reply.message.id);
+    expect(claimed).toHaveLength(2);
+    const claimedChatIds = claimed.map((e) => e.chatId).sort();
+    expect(claimedChatIds).toEqual([chatA.id, chatB.id].sort());
+    for (const e of claimed) expect(e.status).toBe("delivered");
+
+    // No pending row should be left behind.
+    const remaining = await app.db
+      .select({ status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, sender.inboxId), eq(inboxEntries.messageId, reply.message.id)));
+    expect(remaining.every((r) => r.status === "delivered")).toBe(true);
+  });
+
+  it("claimAndBuildForPush bundles silent context for a mention_only trigger", async () => {
+    // Mirror the silent-inbox-context test but on the push path. This is the
+    // riskiest piece of the refactor — `bundleDeliveryWithSilentContext` was
+    // extracted from `pollInboxInner` to be shared, so a divergence between
+    // poll and push silent-context handling would be a silent regression.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const ctx = await createAdminContext(app, { username: `wsp-si-${uid}` });
+    const human = await createAgent(app.db, {
+      name: `wsp-si-h-${uid}`,
+      type: "human",
+      managerId: ctx.memberId,
+    });
+    const observer = await createAgent(app.db, {
+      name: `wsp-si-obs-${uid}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+    const peer = await createAgent(app.db, {
+      name: `wsp-si-peer-${uid}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+    const chat = await createChat(app.db, human.uuid, {
+      type: "group",
+      participantIds: [observer.uuid, peer.uuid],
+    });
+    await app.db
+      .update(chatParticipants)
+      .set({ mode: "mention_only" })
+      .where(and(eq(chatParticipants.chatId, chat.id), eq(chatParticipants.agentId, observer.uuid)));
+
+    // Three silent messages, then a trigger that @mentions observer.
+    await sendMessage(app.db, chat.id, human.uuid, { format: "text", content: "first silent" });
+    await sendMessage(app.db, chat.id, human.uuid, { format: "text", content: "second silent" });
+    await sendMessage(app.db, chat.id, human.uuid, { format: "text", content: "third silent" });
+    const trigger = await sendMessage(app.db, chat.id, human.uuid, {
+      format: "text",
+      content: `@wsp-si-obs-${uid} please weigh in`,
+    });
+
+    // Push-path claim must bundle the same silent context the poll path would.
+    const claimed = await inboxService.claimAndBuildForPush(app.db, observer.inboxId, trigger.message.id);
+    expect(claimed).toHaveLength(1);
+    const entry = claimed[0];
+    if (!entry) throw new Error("claim missing");
+    expect(entry.message.precedingMessages.map((p) => p.content)).toEqual([
+      "first silent",
+      "second silent",
+      "third silent",
+    ]);
+
+    // Same side effect as the poll path: silent rows bulk-acked so they don't
+    // re-attach to a future trigger.
+    const silentRemaining = await app.db
+      .select({ status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, observer.inboxId),
+          eq(inboxEntries.chatId, chat.id),
+          eq(inboxEntries.notify, false),
+        ),
+      );
+    expect(silentRemaining.length).toBeGreaterThan(0);
+    expect(silentRemaining.every((r) => r.status === "acked")).toBe(true);
+  });
+
+  it("claimBacklogForPush drains pending entries oldest-first up to the limit", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `wspb-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `wspb-a2-${uid}` });
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "direct",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+
+    for (let i = 0; i < 3; i++) {
+      await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: `msg ${i}`,
+      });
+    }
+
+    const drained = await inboxService.claimBacklogForPush(app.db, a2.agent.inboxId, 10);
+    expect(drained.length).toBe(3);
+    // FIFO invariant — proposal §3.3: reply chains and silent-context windows
+    // depend on chronological order; reordering here would silently break
+    // mention semantics in group chats.
+    for (let i = 1; i < drained.length; i++) {
+      const prev = drained[i - 1];
+      const curr = drained[i];
+      if (!prev || !curr) throw new Error("unreachable: drained array bounds");
+      expect(prev.createdAt <= curr.createdAt).toBe(true);
+    }
+    // Every drained entry must be marked delivered atomically with the claim.
+    for (const e of drained) expect(e.status).toBe("delivered");
+  });
+
+  it("ackEntryByIdForBoundAgents acks only entries in the supplied inbox set", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    const entry = claimed[0];
+    if (!entry) throw new Error("seed claim failed");
+
+    // Wrong scope: an inboxId set that does NOT include the entry's owner —
+    // server treats this as 'no-op', preventing one socket from acking
+    // another agent's deliveries.
+    const denied = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, ["inbox_other"]);
+    expect(denied).toBeNull();
+
+    const stillDelivered = await app.db.select().from(inboxEntries).where(eq(inboxEntries.id, entry.id));
+    expect(stillDelivered[0]?.status).toBe("delivered");
+
+    // Right scope: ack succeeds and flips status.
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(accepted).not.toBeNull();
+    expect(accepted?.status).toBe("acked");
+  });
+
+  it("ackEntryByIdForBoundAgents accepts when the inbox list contains the owner alongside other inboxes", async () => {
+    // Review issue #8c — covers the realistic shape: a socket has bound
+    // multiple agents, and the inbox list passed to ack contains all of them.
+    // SQL `inArray` is correct, but the test pins the invariant so a future
+    // refactor that, say, accidentally compares only the first element is
+    // caught immediately.
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    const entry = claimed[0];
+    if (!entry) throw new Error("seed claim failed");
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [
+      "inbox_other_a",
+      a2.agent.inboxId,
+      "inbox_other_b",
+    ]);
+    expect(accepted).not.toBeNull();
+    expect(accepted?.status).toBe("acked");
+    expect(accepted?.inboxId).toBe(a2.agent.inboxId);
+  });
+
+  it("ackEntryByIdForBoundAgents short-circuits on empty inbox list", async () => {
+    const app = getApp();
+    const res = await inboxService.ackEntryByIdForBoundAgents(app.db, 1, []);
+    expect(res).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -293,4 +293,32 @@ describe("inbox WS data-plane claim helpers", () => {
     const res = await inboxService.ackEntryByIdForBoundAgents(app.db, 1, []);
     expect(res).toBeNull();
   });
+
+  it("ackEntryByIdForBoundAgents returns null when an HTTP ack already flipped the row", async () => {
+    // Pins the bug class behind the WS-push double-ack incident: if the
+    // legacy HTTP ack runs first (`delivered → acked`), a follow-up WS ack
+    // matches 0 rows and returns null. The SessionManager.ackEntry callback
+    // must therefore ROUTE to exactly one channel — never both — otherwise
+    // the server's per-agent in-flight counter (which only decrements on a
+    // successful WS ack) leaks until push silently dies.
+    //
+    // This test exists to stop a future refactor from "helpfully" sending a
+    // WS ack on top of HTTP (or vice-versa) without first reading why the
+    // ackEntry callback exists.
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    const entry = claimed[0];
+    if (!entry) throw new Error("seed claim failed");
+
+    // Simulate the legacy HTTP ack path running first.
+    await inboxService.ackEntry(app.db, entry.id, a2.agent.inboxId);
+
+    // Now the WS-path ack arrives — must be a no-op (no double transition,
+    // no error, just `null` so the caller can decline to decrement its
+    // in-flight counter for a row it never moved).
+    const wsAckResult = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(wsAckResult).toBeNull();
+  });
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -4,6 +4,9 @@ import {
   agentBindRequestSchema,
   agentPinnedMessageSchema,
   clientRegisterSchema,
+  type InboxEntryWithMessage,
+  inboxAckFrameSchema,
+  inboxDeliverFrameSchema,
   runtimeStateMessageSchema,
   sessionCompletionMessageSchema,
   sessionEventMessageSchema,
@@ -32,10 +35,33 @@ import {
 import * as activityService from "../../services/activity.js";
 import * as clientService from "../../services/client.js";
 import * as connectionManager from "../../services/connection-manager.js";
+import * as inboxService from "../../services/inbox.js";
 import * as notificationService from "../../services/notification.js";
-import type { Notifier } from "../../services/notifier.js";
+import type { InboxPushHandler, Notifier } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
 import * as sessionEventService from "../../services/session-event.js";
+
+/**
+ * Default per-agent in-flight cap when `server.inbox.maxInFlightPerAgent` is
+ * unset. Mirrors the schema default so a hub running without an explicit
+ * `inbox` block still gets reasonable backpressure once `wsDataPlane` is
+ * flipped on. See proposal hub-inbox-ws-data-plane §3.5.
+ */
+const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT = 32;
+/**
+ * Hard cap on entries scanned in a single backlog drain so a recovering
+ * client doesn't trigger an arbitrarily large transaction or burst of
+ * frames. Anything beyond this stays `pending` and gets picked up by
+ * subsequent post-ack drains. Same constant covers both the agent:bound
+ * recovery path and the post-ack top-up.
+ *
+ * Lower than proposal §3.3's 500 on purpose: the actual limit per drain is
+ * `min(remainingInFlightBudget, INBOX_BACKLOG_BATCH_LIMIT)`, so with a
+ * default cap of 32 the drain SQL never asks for more than ~32 anyway.
+ * Subsequent NOTIFYs and post-ack top-ups continue draining without a
+ * single-transaction megabatch.
+ */
+const INBOX_BACKLOG_BATCH_LIMIT = 50;
 
 const wsMessageSchema = z.object({
   type: z.string(),
@@ -102,6 +128,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
   return async (app: FastifyInstance): Promise<void> => {
     const jwtSecretBytes = new TextEncoder().encode(app.config.secrets.jwtSecret);
 
+    const inboxMaxInFlightPerAgent = app.config.inbox?.maxInFlightPerAgent ?? DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT;
+
     // config.otel=false skips @fastify/otel's HTTP instrumentation for the
     // upgrade request. We already emit a long-running `ws.connection` span
     // ourselves via startWsConnectionSpan — a parallel HTTP-style span for a
@@ -112,6 +140,178 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       let clientId: string | null = null;
       let authExpiryTimer: NodeJS.Timeout | null = null;
       const boundAgents = new Map<string, { agentId: string; inboxId: string }>();
+
+      /**
+       * Whether the connected client opted into the WS inbox data plane via
+       * `client:register.wireCapabilities.wsInboxDeliver`. Set per-socket
+       * because client SDKs are upgraded independently — an old client
+       * connecting to a new server must keep receiving the legacy
+       * `new_message` doorbell + HTTP poll path (proposal §3.6).
+       */
+      let clientWantsWsInboxDeliver = false;
+
+      /**
+       * Per-agent in-flight `inbox:deliver` counter for backpressure. Lives on
+       * the socket — when the WS closes it goes with it; that's intentional,
+       * because re-counting on a fresh connection would bias the cap against
+       * a healthy reconnect (proposal §3.5).
+       */
+      const inboxInFlight = new Map<string, number>();
+
+      function pushUseWsDataPlane(): boolean {
+        return clientWantsWsInboxDeliver;
+      }
+
+      /**
+       * Returns `false` when the socket has already moved out of `OPEN` —
+       * the only failure mode the caller can observe synchronously.
+       *
+       * Note: `ws.send` is fire-and-forget; a buffered frame that fails
+       * to actually flush (TCP slow-close, internal queue full) does NOT
+       * surface here. That class of loss is recovered by the 300s timeout
+       * reaper rolling the entry back to `pending` (§3.7). If you ever
+       * need flush-level confirmation, switch to the `ws.send(frame, cb)`
+       * callback form (see `notifier.ts pushFrameToInbox`).
+       */
+      function sendInboxDeliverFrame(entry: InboxEntryWithMessage): boolean {
+        if (socket.readyState !== socket.OPEN) return false;
+        const frame = {
+          type: "inbox:deliver",
+          entryId: entry.id,
+          inboxId: entry.inboxId,
+          chatId: entry.chatId,
+          message: entry.message,
+        };
+        // Self-validate the wire shape against the same schema the client
+        // applies. A failure here means the server has serialised something
+        // the client will reject — log loudly so a schema-drift bug surfaces
+        // server-side instead of getting stuck behind the client's silent
+        // drop. We still send the frame: client also logs the issue, and
+        // dropping here unilaterally would leave the entry as `delivered`
+        // forever (unable to ack on a frame the client never saw).
+        const validated = inboxDeliverFrameSchema.safeParse(frame);
+        if (!validated.success) {
+          app.log.error(
+            {
+              entryId: entry.id,
+              inboxId: entry.inboxId,
+              issues: validated.error.issues.map((i) => ({
+                path: i.path.join("."),
+                code: i.code,
+                message: i.message,
+              })),
+            },
+            "inbox:deliver frame failed self-validation — wire shape drift",
+          );
+        }
+        socket.send(JSON.stringify(frame));
+        return true;
+      }
+
+      /**
+       * Build the per-socket push handler bound to a specific agent. Closes
+       * over `agentId`, `inboxId`, the socket, and the in-flight counter.
+       *
+       * Backpressure: when the agent is at-cap we drop the NOTIFY (entry
+       * stays `pending` server-side) and a debug log records the drop so
+       * staging can correlate "messages slow" reports against cap hits.
+       * The dropped row is replayed by `drainBacklogForAgent` once an ack
+       * frees a slot, or by the next NOTIFY when we're back below cap (§3.5).
+       *
+       * Multi-row claims: a single `(inboxId, messageId)` pair can map to
+       * more than one `inbox_entries` row (replyTo cross-chat case writes
+       * a second row with a different chatId). We push every row claimed
+       * by this NOTIFY in one go — see `claimAndBuildForPush`.
+       *
+       * The cap is intentionally **soft**: claim happens after the gate
+       * check, so an N>1 claim can nudge in-flight slightly past
+       * `inboxMaxInFlightPerAgent`. N is bounded by the
+       * `(inbox_id, message_id, chat_id)` unique constraint (≤2 today),
+       * so worst-case overshoot is small and the memory headroom in §3.5's
+       * 64MB estimate covers it.
+       */
+      function makeInboxPushHandler(agentId: string, inboxId: string): InboxPushHandler {
+        return async (messageId: string) => {
+          const current = inboxInFlight.get(agentId) ?? 0;
+          if (current >= inboxMaxInFlightPerAgent) {
+            app.log.debug(
+              { agentId, inboxId, messageId, inFlightCount: current, cap: inboxMaxInFlightPerAgent },
+              "inbox push: at cap, dropping NOTIFY (will replay via post-ack drain)",
+            );
+            return;
+          }
+
+          let entries: InboxEntryWithMessage[];
+          try {
+            entries = await inboxService.claimAndBuildForPush(app.db, inboxId, messageId);
+          } catch (err) {
+            app.log.error({ err, inboxId, messageId, agentId }, "claimAndBuildForPush failed");
+            return;
+          }
+          if (entries.length === 0) {
+            // Benign race — HTTP poll or another instance claimed it first.
+            return;
+          }
+
+          for (const entry of entries) {
+            inboxInFlight.set(agentId, (inboxInFlight.get(agentId) ?? 0) + 1);
+            if (!sendInboxDeliverFrame(entry)) {
+              // Socket dropped mid-loop. The entry is still 'delivered' in
+              // the DB; the existing 300s timeout reaper rolls it back to
+              // 'pending' so a reconnect (or another instance) re-delivers.
+              // Release the slot we just took, then bail — remaining
+              // unsent entries also stay 'delivered' for the reaper.
+              inboxInFlight.set(agentId, Math.max(0, (inboxInFlight.get(agentId) ?? 1) - 1));
+              return;
+            }
+          }
+        };
+      }
+
+      /**
+       * Drain up to `INBOX_BACKLOG_BATCH_LIMIT` pending entries for an agent
+       * over the current WS, capped by the remaining in-flight budget so a
+       * full drain stays within the per-agent backpressure cap (§3.3, §3.5).
+       *
+       * Used in two places:
+       *   1. Right after `agent:bound` — covers reconnects where NOTIFYs
+       *      were dropped while the socket was offline.
+       *   2. Right after an `inbox:ack` — top up the in-flight slot just
+       *      freed, in case the previous NOTIFY was dropped at-cap.
+       *
+       * The cap is **soft**: this function reads `slotsFree` once before the
+       * `claimBacklogForPush` round-trip, and a NOTIFY-driven push handler
+       * may increment the counter concurrently. In the worst case in-flight
+       * temporarily exceeds the cap by the number of concurrent pushes. With
+       * the default cap of 32 and N ≤ 2 per push handler invocation, the
+       * memory headroom in §3.5's 64MB estimate covers this.
+       */
+      async function drainBacklogForAgent(agentId: string, inboxId: string): Promise<void> {
+        if (socket.readyState !== socket.OPEN) return;
+        const inFlight = inboxInFlight.get(agentId) ?? 0;
+        const slotsFree = inboxMaxInFlightPerAgent - inFlight;
+        if (slotsFree <= 0) return;
+        const limit = Math.min(slotsFree, INBOX_BACKLOG_BATCH_LIMIT);
+
+        let entries: InboxEntryWithMessage[];
+        try {
+          entries = await inboxService.claimBacklogForPush(app.db, inboxId, limit);
+        } catch (err) {
+          app.log.error({ err, agentId, inboxId, limit }, "claimBacklogForPush failed");
+          return;
+        }
+
+        for (const entry of entries) {
+          inboxInFlight.set(agentId, (inboxInFlight.get(agentId) ?? 0) + 1);
+          if (!sendInboxDeliverFrame(entry)) {
+            inboxInFlight.set(agentId, Math.max(0, (inboxInFlight.get(agentId) ?? 1) - 1));
+            // Socket gone mid-drain — stop pushing. Remaining entries stay
+            // 'delivered'; reaper will reset them and a future reconnect picks
+            // them up.
+            return;
+          }
+        }
+      }
 
       // FIFO per session so session:event persistence happens before any
       // subsequent eviction's clearEvents — without this, the message handler
@@ -236,12 +436,17 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             scheduleAuthExpiry(claims.exp);
             socket.send(JSON.stringify({ type: "auth:ok" }));
             // Wire-additive: older clients drop the unknown type; newer ones
-            // use it to detect version drift.
+            // use it to detect version drift. `capabilities.wsInboxDeliver`
+            // is unconditionally true on this build — the data plane is
+            // always available; whether it's actually used per-connection
+            // depends on the client's own `wireCapabilities` opt-in on
+            // `client:register` (proposal hub-inbox-ws-data-plane §3.6).
             socket.send(
               JSON.stringify({
                 type: "server:welcome",
                 serverCommandVersion: app.commandVersion,
                 serverTimeMs: Date.now(),
+                capabilities: { wsInboxDeliver: true },
               }),
             );
           } catch (err) {
@@ -259,6 +464,11 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           try {
             if (type === "client:register") {
               const data = clientRegisterSchema.parse(msg);
+
+              // Record opt-in for the WS inbox data plane. Per-socket so a
+              // legacy client on a pushed-enabled server still works (proposal
+              // §3.6). Default false — only an explicit `true` activates push.
+              clientWantsWsInboxDeliver = data.wireCapabilities?.wsInboxDeliver === true;
 
               try {
                 await clientService.registerClient(app.db, {
@@ -408,7 +618,16 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               connectionManager.bindAgentToClient(clientId, agent.id);
               boundAgents.set(agent.id, { agentId: agent.id, inboxId: agent.inboxId });
 
-              notifier.subscribe(agent.inboxId, socket);
+              // Subscribe to NOTIFY traffic. When both server config and the
+              // client's wire-capability opt-in are true, register a push
+              // handler so NOTIFYs land as `inbox:deliver` frames. Otherwise
+              // legacy `new_message` doorbell — old clients keep working.
+              const wsPushActive = pushUseWsDataPlane();
+              if (wsPushActive) {
+                notifier.subscribe(agent.inboxId, socket, makeInboxPushHandler(agent.id, agent.inboxId));
+              } else {
+                notifier.subscribe(agent.inboxId, socket);
+              }
 
               socket.send(
                 JSON.stringify({
@@ -419,6 +638,16 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   agentType: agent.type,
                 }),
               );
+
+              // Reconnect/recovery: if we're on the WS push path, drain any
+              // pending entries that piled up while this socket was offline
+              // (or while another instance held the subscription). Failures
+              // are logged inside the helper — don't crash the bind path.
+              if (wsPushActive) {
+                drainBacklogForAgent(agent.id, agent.inboxId).catch((err) => {
+                  app.log.error({ err, agentId: agent.id }, "post-bind backlog drain crashed");
+                });
+              }
             } else if (type === "agent:unbind") {
               const agentId = parsed.data.agentId;
               if (!agentId || !boundAgents.has(agentId)) {
@@ -434,6 +663,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               await presenceService.unbindAgent(app.db, agentId);
               connectionManager.unbindAgentFromClient(agentId);
               boundAgents.delete(agentId);
+              inboxInFlight.delete(agentId);
 
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
             } else if (type === "session:state") {
@@ -555,6 +785,48 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 notificationService
                   .notifyAgentEvent(app.db, agentId, "session_completed", "low", payload.chatId)
                   .catch(() => {});
+              }
+            } else if (type === "inbox:ack") {
+              const payloadResult = inboxAckFrameSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                socket.send(JSON.stringify({ type: "error", message: "Malformed inbox:ack frame" }));
+                return;
+              }
+              const { entryId } = payloadResult.data;
+
+              // Find the agent / inbox this entry belongs to from the bind
+              // map. We never trust an `agentId` from the wire here — that
+              // would let one bound agent ack another agent's entry. Instead
+              // we resolve the inbox via the DB (one round-trip) and check
+              // the resulting inboxId is in this socket's bound set.
+              try {
+                const ackedEntry = await inboxService.ackEntryByIdForBoundAgents(
+                  app.db,
+                  entryId,
+                  [...boundAgents.values()].map((a) => a.inboxId),
+                );
+                if (!ackedEntry) {
+                  // Either the entry doesn't exist, or it's not in 'delivered'
+                  // status, or it belongs to an inbox this socket hasn't bound.
+                  // All three are non-fatal — the client may have raced a
+                  // server-side reset (300s timeout reaper) or be ack'ing a
+                  // stale entry from a previous run. Drop silently.
+                  return;
+                }
+                // Find the agentId that owns this inbox to decrement the
+                // counter and trigger backlog drain.
+                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackedEntry.inboxId);
+                if (owner) {
+                  inboxInFlight.set(owner.agentId, Math.max(0, (inboxInFlight.get(owner.agentId) ?? 1) - 1));
+                  // Slot freed → top up. Cheap when no backlog (single SQL
+                  // statement returning 0 rows). Critical when the cap was
+                  // hit and queued NOTIFYs got dropped (proposal §3.5).
+                  drainBacklogForAgent(owner.agentId, owner.inboxId).catch((err) => {
+                    app.log.error({ err, agentId: owner.agentId }, "post-ack backlog drain crashed");
+                  });
+                }
+              } catch (err) {
+                app.log.error({ err, entryId }, "inbox:ack handling failed");
               }
             } else if (type === "heartbeat") {
               if (clientId) {

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,4 +1,4 @@
-import type { PrecedingMessage } from "@agent-team-foundation/first-tree-hub-shared";
+import type { InboxEntryWithMessage, PrecedingMessage } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
@@ -8,8 +8,21 @@ import { ForbiddenError, NotFoundError } from "../errors.js";
 import { FIRST_TREE_HUB_ATTR, withSpan } from "../observability/index.js";
 import { buildClientMessagePayloadsForInbox } from "./message-dispatcher.js";
 
+/** Raw `inbox_entries` row shape returned by claim queries below. */
+type ClaimedEntryRow = {
+  id: number;
+  inbox_id: string;
+  message_id: string;
+  chat_id: string | null;
+  status: string;
+  retry_count: number;
+  created_at: string;
+  delivered_at: string | null;
+  acked_at: string | null;
+};
+
 /** Structurally-typed DB so both `Database` and transaction clients work. */
-type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "execute">;
+type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "execute" | "select">;
 
 const DEFAULT_INBOX_TIMEOUT_SECONDS = 300;
 const DEFAULT_MAX_RETRY_COUNT = 3;
@@ -35,21 +48,11 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
 
 async function pollInboxInner(db: Database, inboxId: string, limit: number) {
   // Use raw SQL for SELECT ... FOR UPDATE SKIP LOCKED (not supported by Drizzle query builder)
-  const result = await db.transaction(async (tx) => {
+  return db.transaction(async (tx) => {
     // 1. Claim pending NOTIFY=true entries (the active triggers). Silent rows
     //    (notify=false) are intentionally excluded — they piggy-back on the
     //    next active delivery in their chat as preceding context (proposal §1).
-    const claimed = await tx.execute<{
-      id: number;
-      inbox_id: string;
-      message_id: string;
-      chat_id: string | null;
-      status: string;
-      retry_count: number;
-      created_at: string;
-      delivered_at: string | null;
-      acked_at: string | null;
-    }>(sql`
+    const claimed = await tx.execute<ClaimedEntryRow>(sql`
       UPDATE inbox_entries
       SET status = 'delivered', delivered_at = NOW()
       WHERE id IN (
@@ -62,81 +65,172 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
       RETURNING *
     `);
 
-    if (claimed.length === 0) {
-      return [];
-    }
-
-    // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so we sort
-    // by created_at (ascending) before assembling the response. Downstream
-    // consumers — and silent-context bundling in particular — depend on
-    // chronological order to split context windows correctly.
-    claimed.sort((a, b) => a.created_at.localeCompare(b.created_at));
-
-    // 2. For each claimed trigger, gather silent context and bulk-ack the
-    //    silent rows so they aren't replayed on the next poll. Triggers are
-    //    grouped by chatId so multiple triggers in the same chat split the
-    //    silent timeline into "what happened before each one" instead of
-    //    duplicating context.
-    const precedingByEntryId = await collectPrecedingContext(tx, inboxId, claimed);
-
-    // 3. Fetch the trigger messages.
-    const messageIds = claimed.map((e) => e.message_id);
-    const msgs = await tx.select().from(messages).where(inArray(messages.id, messageIds));
-
-    const msgMap = new Map(msgs.map((m) => [m.id, m]));
-
-    // 4. Build wire payloads via the single dispatcher (Step 3): every
-    // outbound client message must carry the current agent_configs.version
-    // so the client can refresh config before delivering to the runtime.
-    //
-    // Payloads are keyed by (entryId) because replyTo routing can deliver the
-    // same message_id to the same recipient twice under different entry
-    // chatIds — each copy needs its own recipientMode lookup.
-    const payloads = await buildClientMessagePayloadsForInbox(
-      tx,
-      inboxId,
-      claimed.map((entry) => {
-        const msg = msgMap.get(entry.message_id);
-        if (!msg) throw new Error(`Unexpected: message ${entry.message_id} not found`);
-        return {
-          entryChatId: entry.chat_id,
-          precedingMessages: precedingByEntryId.get(entry.id) ?? [],
-          message: {
-            id: msg.id,
-            chatId: msg.chatId,
-            senderId: msg.senderId,
-            format: msg.format,
-            content: msg.content,
-            metadata: msg.metadata,
-            replyToInbox: msg.replyToInbox,
-            replyToChat: msg.replyToChat,
-            inReplyTo: msg.inReplyTo,
-            source: msg.source,
-            createdAt: msg.createdAt.toISOString(),
-          },
-        };
-      }),
-    );
-
-    return claimed.map((entry, idx) => {
-      const payload = payloads[idx];
-      if (!payload) throw new Error(`Unexpected: payload for entry ${entry.id} not built`);
-      return {
-        id: entry.id,
-        inboxId: entry.inbox_id,
-        messageId: entry.message_id,
-        chatId: entry.chat_id,
-        status: entry.status,
-        retryCount: entry.retry_count,
-        createdAt: entry.created_at,
-        deliveredAt: entry.delivered_at ?? null,
-        ackedAt: entry.acked_at ?? null,
-        message: payload,
-      };
-    });
+    return bundleDeliveryWithSilentContext(tx, inboxId, claimed);
   });
+}
 
-  return result;
+/**
+ * Shared payload assembler for already-claimed `inbox_entries` rows.
+ *
+ * Both the HTTP poll path (`pollInbox`) and the WS push path
+ * (`claimAndBuildForPush`) call this with rows they have just `UPDATE`d to
+ * `status='delivered'`. Keeping the silent-context bundling in one place is
+ * the only way to keep the two paths from drifting (proposal
+ * hub-inbox-ws-data-plane §3.2 risk #1).
+ *
+ * Steps:
+ *   1. Sort by `created_at` ASC (PG `RETURNING` does not guarantee order).
+ *   2. For each trigger, collect silent context & bulk-ack stale silent rows.
+ *   3. Fetch the trigger messages.
+ *   4. Build wire payloads via the single dispatcher.
+ *
+ * Returns `[]` if `claimed` is empty.
+ */
+export async function bundleDeliveryWithSilentContext(
+  tx: TxLike,
+  inboxId: string,
+  claimed: ClaimedEntryRow[],
+): Promise<InboxEntryWithMessage[]> {
+  if (claimed.length === 0) return [];
+
+  // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so we sort
+  // by created_at (ascending) before assembling the response. Downstream
+  // consumers — and silent-context bundling in particular — depend on
+  // chronological order to split context windows correctly.
+  claimed.sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  const precedingByEntryId = await collectPrecedingContext(tx, inboxId, claimed);
+
+  const messageIds = claimed.map((e) => e.message_id);
+  const msgs = await tx.select().from(messages).where(inArray(messages.id, messageIds));
+  const msgMap = new Map(msgs.map((m) => [m.id, m]));
+
+  // Step 3 (M1 §10): every outbound client message must carry the current
+  // agent_configs.version so the client can refresh config before delivering
+  // to the runtime. Payloads are keyed by (entryId) because replyTo routing
+  // can deliver the same message_id twice under different entry chatIds —
+  // each copy needs its own recipientMode lookup.
+  const payloads = await buildClientMessagePayloadsForInbox(
+    tx,
+    inboxId,
+    claimed.map((entry) => {
+      const msg = msgMap.get(entry.message_id);
+      if (!msg) throw new Error(`Unexpected: message ${entry.message_id} not found`);
+      return {
+        entryChatId: entry.chat_id,
+        precedingMessages: precedingByEntryId.get(entry.id) ?? [],
+        message: {
+          id: msg.id,
+          chatId: msg.chatId,
+          senderId: msg.senderId,
+          format: msg.format,
+          content: msg.content,
+          metadata: msg.metadata,
+          replyToInbox: msg.replyToInbox,
+          replyToChat: msg.replyToChat,
+          inReplyTo: msg.inReplyTo,
+          source: msg.source,
+          createdAt: msg.createdAt.toISOString(),
+        },
+      };
+    }),
+  );
+
+  return claimed.map((entry, idx) => {
+    const payload = payloads[idx];
+    if (!payload) throw new Error(`Unexpected: payload for entry ${entry.id} not built`);
+    return {
+      // `inbox_entries.id` is bigserial (int8); postgres-js returns int8 as a
+      // JS string by default to preserve precision past 2^53. The raw-SQL
+      // `tx.execute<{ id: number }>` declares a number type but doesn't
+      // coerce — Drizzle only applies the column's `mode: "number"` on
+      // builder queries. The legacy HTTP poll path tolerated the string
+      // because the SDK never validated `id` as a number, but the WS push
+      // path's `inboxDeliverFrameSchema.entryId` is a strict `z.number()`,
+      // so we coerce at this single shared exit point.
+      id: Number(entry.id),
+      inboxId: entry.inbox_id,
+      messageId: entry.message_id,
+      chatId: entry.chat_id,
+      status: entry.status,
+      retryCount: entry.retry_count,
+      createdAt: entry.created_at,
+      deliveredAt: entry.delivered_at ?? null,
+      ackedAt: entry.acked_at ?? null,
+      message: payload,
+    };
+  });
+}
+
+/**
+ * Realistic upper bound on rows a single NOTIFY references. The unique
+ * constraint `(inbox_id, message_id, chat_id)` caps a `(inbox, message)`
+ * pair at one row per chatId; the only way to exceed 1 today is the replyTo
+ * cross-chat path (`message.ts` writes a second row keyed by the original's
+ * `replyToChat`). 8 leaves headroom for any future fan-out variant without
+ * requiring a schema change here.
+ */
+const PUSH_CLAIM_BATCH_LIMIT = 8;
+
+/**
+ * WS-push path: atomically claim every pending entry the just-fired
+ * `NOTIFY (inboxId:messageId)` references and assemble their wire payloads.
+ *
+ * Returns `[]` if no row matches — benign race with HTTP poll or another
+ * server instance that already claimed the entry. NOTIFY is fire-and-forget
+ * (proposal §3.2).
+ *
+ * Why an array, not a single row: `sendMessage` can write **two** rows for
+ * the same `(inbox, messageId)` pair when the recipient is both a chat
+ * participant and the `replyToInbox` of an earlier message — the unique key
+ * is `(inbox_id, message_id, chat_id)`, so the rows differ by chatId. The
+ * old `LIMIT 1` shape would only push the first; the second sat `pending`
+ * until reconnect. Aligning with `pollInboxInner`'s `LIMIT N` shape closes
+ * that gap and keeps push/poll behaviour interchangeable.
+ */
+export async function claimAndBuildForPush(
+  db: Database,
+  inboxId: string,
+  messageId: string,
+): Promise<InboxEntryWithMessage[]> {
+  return withSpan("inbox.deliver.push", { "inbox.id": inboxId, "message.id": messageId }, () =>
+    db.transaction(async (tx) => {
+      const claimed = await tx.execute<ClaimedEntryRow>(sql`
+          UPDATE inbox_entries
+          SET status = 'delivered', delivered_at = NOW()
+          WHERE id IN (
+            SELECT id FROM inbox_entries
+            WHERE inbox_id = ${inboxId}
+              AND message_id = ${messageId}
+              AND status = 'pending'
+              AND notify = true
+            ORDER BY created_at
+            LIMIT ${PUSH_CLAIM_BATCH_LIMIT}
+            FOR UPDATE SKIP LOCKED
+          )
+          RETURNING *
+        `);
+
+      return bundleDeliveryWithSilentContext(tx, inboxId, claimed);
+    }),
+  );
+}
+
+/**
+ * WS-push backlog path: on agent rebind (or once an in-flight slot frees up
+ * after an ack), drain up to `limit` pending `notify=true` entries oldest-
+ * first and assemble wire payloads. Identical claim shape to the HTTP poll
+ * path — they are intentionally interchangeable so a hot-path bug fixed in
+ * one shows up in the other (proposal §3.3 / §3.5).
+ */
+export async function claimBacklogForPush(
+  db: Database,
+  inboxId: string,
+  limit: number,
+): Promise<InboxEntryWithMessage[]> {
+  return withSpan("inbox.deliver.backlog", { "inbox.id": inboxId, "inbox.backlog.limit": limit }, () =>
+    pollInboxInner(db, inboxId, limit),
+  );
 }
 
 /**
@@ -268,6 +362,38 @@ export async function ackEntry(db: Database, entryId: number, inboxId: string) {
       return entry;
     },
   );
+}
+
+/**
+ * Ack a delivered entry from the WS data plane, scoped to the inboxes the
+ * connected socket has bound. Returns the acked row on success, `null` if no
+ * row matches — a benign outcome the caller should ignore (the entry may
+ * have already been acked, timed out, or never belonged to this socket).
+ *
+ * Distinct from {@link ackEntry} so the WS path can ack without trusting an
+ * `inboxId` from the wire — only entries whose `inboxId` is in `inboxIds`
+ * are eligible. Empty `inboxIds` short-circuits to `null`.
+ */
+export async function ackEntryByIdForBoundAgents(
+  db: Database,
+  entryId: number,
+  inboxIds: string[],
+): Promise<typeof inboxEntries.$inferSelect | null> {
+  if (inboxIds.length === 0) return null;
+  return withSpan("inbox.ack.ws", { [FIRST_TREE_HUB_ATTR.INBOX_ENTRY_ID]: String(entryId) }, async () => {
+    const [entry] = await db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(
+        and(
+          eq(inboxEntries.id, entryId),
+          inArray(inboxEntries.inboxId, inboxIds),
+          eq(inboxEntries.status, "delivered"),
+        ),
+      )
+      .returning();
+    return entry ?? null;
+  });
 }
 
 export async function renewEntry(db: Database, entryId: number, inboxId: string) {

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -15,9 +15,29 @@ export type SessionStateChangeHandler = (payload: {
 }) => void;
 export type RuntimeStateChangeHandler = (payload: { agentId: string; state: string; organizationId: string }) => void;
 
+/**
+ * Per-socket push handler for the WS data plane. When a NOTIFY arrives on
+ * `inbox_notifications` for a subscribed inbox, the notifier hands the
+ * `messageId` to this handler instead of sending the legacy `new_message`
+ * doorbell frame. The handler owns claim-row + build-payload + send-frame
+ * + in-flight bookkeeping (see proposal hub-inbox-ws-data-plane §3.2).
+ *
+ * Handlers are fire-and-forget — the notifier swallows their resolution; any
+ * errors are the handler's responsibility to log. Returning a Promise lets
+ * the server await DB work without blocking the LISTEN loop on it.
+ */
+export type InboxPushHandler = (messageId: string) => Promise<void> | void;
+
 export type Notifier = {
-  /** Subscribe a WebSocket connection for an inbox */
-  subscribe(inboxId: string, ws: WebSocket): void;
+  /**
+   * Subscribe a WebSocket for an inbox. If `pushHandler` is provided, NOTIFY
+   * traffic for this inbox routes to the handler instead of the legacy
+   * `new_message` doorbell. Multiple sockets per inbox are supported; each
+   * one is keyed independently so a doorbell client and a push client can
+   * co-exist (think mid-rollout where one organisation upgrades before
+   * another).
+   */
+  subscribe(inboxId: string, ws: WebSocket, pushHandler?: InboxPushHandler): void;
   /** Unsubscribe a WebSocket connection */
   unsubscribe(inboxId: string, ws: WebSocket): void;
   /** Notify that new messages are available for an inbox */
@@ -49,7 +69,10 @@ export type Notifier = {
 };
 
 export function createNotifier(listenClient: postgres.Sql): Notifier {
-  const subscriptions = new Map<string, Set<WebSocket>>();
+  // Each subscription stores either a push handler (WS data-plane path) or
+  // null (legacy `new_message` doorbell). A single inbox may have a mix of
+  // both during gradual rollout — the LISTEN handler dispatches per-socket.
+  const subscriptions = new Map<string, Map<WebSocket, InboxPushHandler | null>>();
   const configChangeHandlers: ConfigChangeHandler[] = [];
   const sessionStateChangeHandlers: SessionStateChangeHandler[] = [];
   const runtimeStateChangeHandlers: RuntimeStateChangeHandler[] = [];
@@ -68,29 +91,41 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
     const sockets = subscriptions.get(inboxId);
     if (!sockets) return;
 
-    const data = JSON.stringify({ type: "new_message", inboxId, messageId });
-    for (const ws of sockets) {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(data);
+    const doorbellFrame = JSON.stringify({ type: "new_message", inboxId, messageId });
+    for (const [ws, pushHandler] of sockets) {
+      if (ws.readyState !== ws.OPEN) continue;
+      if (pushHandler) {
+        // WS data-plane path: defer DB + frame work to the per-socket handler.
+        // It owns capability gating, in-flight backpressure, claim, build, and
+        // send. Resolution is intentionally not awaited — the LISTEN loop must
+        // not stall on slow consumers.
+        Promise.resolve(pushHandler(messageId)).catch(() => {
+          // Handler-side errors are logged by the handler; swallow here so a
+          // single misbehaving socket does not break notification fan-out for
+          // the rest of the subscribers.
+        });
+      } else {
+        // Legacy doorbell path: kick the client to HTTP-poll.
+        ws.send(doorbellFrame);
       }
     }
   }
 
   return {
-    subscribe(inboxId: string, ws: WebSocket) {
-      let set = subscriptions.get(inboxId);
-      if (!set) {
-        set = new Set();
-        subscriptions.set(inboxId, set);
+    subscribe(inboxId: string, ws: WebSocket, pushHandler?: InboxPushHandler) {
+      let map = subscriptions.get(inboxId);
+      if (!map) {
+        map = new Map();
+        subscriptions.set(inboxId, map);
       }
-      set.add(ws);
+      map.set(ws, pushHandler ?? null);
     },
 
     unsubscribe(inboxId: string, ws: WebSocket) {
-      const set = subscriptions.get(inboxId);
-      if (set) {
-        set.delete(ws);
-        if (set.size === 0) {
+      const map = subscriptions.get(inboxId);
+      if (map) {
+        map.delete(ws);
+        if (map.size === 0) {
           subscriptions.delete(inboxId);
         }
       }
@@ -129,11 +164,11 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
     },
 
     async pushFrameToInbox(inboxId: string, frame: string): Promise<number> {
-      const sockets = subscriptions.get(inboxId);
-      if (!sockets) return 0;
+      const map = subscriptions.get(inboxId);
+      if (!map) return 0;
       let queued = 0;
       const pending: Promise<void>[] = [];
-      for (const ws of sockets) {
+      for (const ws of map.keys()) {
         if (ws.readyState !== ws.OPEN) continue;
         pending.push(
           new Promise<void>((resolve) => {

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { inboxAckFrameSchema, inboxDeliverFrameSchema } from "../schemas/inbox-frames.js";
+
+const baseClientMessage = {
+  id: "msg_1",
+  chatId: "chat_1",
+  senderId: "agent_a",
+  format: "text",
+  content: "hello",
+  metadata: {},
+  replyToInbox: null,
+  replyToChat: null,
+  inReplyTo: null,
+  source: null,
+  createdAt: "2026-04-29T00:00:00.000Z",
+  configVersion: 1,
+  recipientMode: "full" as const,
+  inReplyToSnapshot: null,
+  precedingMessages: [],
+};
+
+describe("inboxDeliverFrameSchema", () => {
+  it("accepts a well-formed frame", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 42,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: baseClientMessage,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts a null chatId (replyTo cross-chat entries)", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: null,
+      message: baseClientMessage,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects negative entryId", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: -1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: baseClientMessage,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects empty inboxId", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "",
+      chatId: "chat_1",
+      message: baseClientMessage,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("forwards unknown fields so a newer server can extend the frame", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: baseClientMessage,
+      hint: "future-only-field",
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect((res.data as { hint?: string }).hint).toBe("future-only-field");
+    }
+  });
+});
+
+describe("inboxAckFrameSchema", () => {
+  it("accepts a valid ack", () => {
+    const res = inboxAckFrameSchema.safeParse({ type: "inbox:ack", entryId: 7 });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects wrong discriminator", () => {
+    const res = inboxAckFrameSchema.safeParse({ type: "inbox:deliver", entryId: 7 });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects negative entryId", () => {
+    const res = inboxAckFrameSchema.safeParse({ type: "inbox:ack", entryId: -1 });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects non-integer entryId", () => {
+    const res = inboxAckFrameSchema.safeParse({ type: "inbox:ack", entryId: 1.5 });
+    expect(res.success).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/ws-auth-schema.test.ts
+++ b/packages/shared/src/__tests__/ws-auth-schema.test.ts
@@ -52,4 +52,44 @@ describe("serverWelcomeFrameSchema", () => {
     });
     expect(res.success).toBe(false);
   });
+
+  it("accepts a capabilities block advertising wsInboxDeliver", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "1.0.0",
+      serverTimeMs: 1_713_000_000_000,
+      capabilities: { wsInboxDeliver: true },
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.capabilities?.wsInboxDeliver).toBe(true);
+    }
+  });
+
+  it("accepts an empty capabilities object and defaults wsInboxDeliver to false", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "1.0.0",
+      serverTimeMs: 0,
+      capabilities: {},
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      // The field default + .partial() inflate `{}` → `{wsInboxDeliver:false}`,
+      // matching the server-side behaviour: unset == "no opt-in".
+      expect(res.data.capabilities?.wsInboxDeliver).toBe(false);
+    }
+  });
+
+  it("accepts a welcome with no capabilities key at all (legacy server)", () => {
+    const res = serverWelcomeFrameSchema.safeParse({
+      type: "server:welcome",
+      serverCommandVersion: "0.9.2",
+      serverTimeMs: 0,
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.capabilities).toBeUndefined();
+    }
+  });
 });

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -94,6 +94,23 @@ export const serverConfigSchema = defineConfig({
     loginMax: field(z.number().default(5), { env: "FIRST_TREE_HUB_RATE_LIMIT_LOGIN_MAX" }),
     webhookMax: field(z.number().default(60), { env: "FIRST_TREE_HUB_RATE_LIMIT_WEBHOOK_MAX" }),
   }),
+  inbox: optional({
+    /**
+     * Backpressure cap on per-agent in-flight (un-acked) `inbox:deliver`
+     * frames. Once reached the server stops pushing for that agent until an
+     * ack arrives — leftover entries stay `pending` in the DB and get
+     * replayed via the post-ack backlog scan. See proposal §3.5.
+     *
+     * The WS data plane itself is always on; cross-version compatibility is
+     * handled by the per-socket `wireCapabilities.wsInboxDeliver` opt-in
+     * negotiated during `client:register` (proposal §3.6). An old client
+     * that doesn't send the flag automatically gets the legacy `new_message`
+     * doorbell + HTTP poll; a new client gets push frames.
+     */
+    maxInFlightPerAgent: field(z.number().int().min(1).max(1024).default(32), {
+      env: "FIRST_TREE_HUB_INBOX_MAX_IN_FLIGHT_PER_AGENT",
+    }),
+  }),
   kael: optional({
     endpoint: field(z.string(), { env: "KAEL_ENDPOINT" }),
     apiKey: field(z.string(), { env: "KAEL_API_KEY", secret: true }),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,9 +133,11 @@ export {
   type Client,
   type ClientRegister,
   type ClientStatus,
+  type ClientWireCapabilities,
   clientRegisterSchema,
   clientSchema,
   clientStatusSchema,
+  clientWireCapabilitiesSchema,
 } from "./schemas/client.js";
 export {
   CAPABILITY_STATES,
@@ -178,6 +180,12 @@ export {
   inboxEntryWithMessageSchema,
   inboxPollQuerySchema,
 } from "./schemas/inbox.js";
+export type {
+  InboxAckFrame,
+  InboxDeliverFrame,
+} from "./schemas/inbox-frames.js";
+// -- WebSocket inbox data-plane frames --
+export { inboxAckFrameSchema, inboxDeliverFrameSchema } from "./schemas/inbox-frames.js";
 export {
   INVITATION_DEFAULT_TTL_DAYS,
   type InvitationPreview,
@@ -391,6 +399,11 @@ export {
   userSchema,
   userStatusSchema,
 } from "./schemas/user.js";
-export type { ServerWelcomeFrame, WsAuthFrame } from "./schemas/ws-auth.js";
+export type { ServerCapabilities, ServerWelcomeFrame, WsAuthFrame } from "./schemas/ws-auth.js";
 // -- WebSocket handshake frames --
-export { serverWelcomeFrameSchema, WS_AUTH_FRAME_TIMEOUT_MS, wsAuthFrameSchema } from "./schemas/ws-auth.js";
+export {
+  serverCapabilitiesSchema,
+  serverWelcomeFrameSchema,
+  WS_AUTH_FRAME_TIMEOUT_MS,
+  wsAuthFrameSchema,
+} from "./schemas/ws-auth.js";

--- a/packages/shared/src/schemas/client.ts
+++ b/packages/shared/src/schemas/client.ts
@@ -29,10 +29,27 @@ export type Client = z.infer<typeof clientSchema>;
 
 // -- Client Register (WS payload from client SDK) --
 
+/**
+ * Optional opt-in flags the client carries on `client:register` to advertise
+ * which negotiable wire-protocol features it implements. Distinct from
+ * `clientCapabilitiesSchema` (per-runtime-provider availability — different
+ * concept). Older clients omit the field; the server treats every unset flag
+ * as `false` and falls back to the legacy path. See proposal
+ * hub-inbox-ws-data-plane §3.6.
+ */
+export const clientWireCapabilitiesSchema = z
+  .object({
+    /** Client implements `inbox:deliver` / `inbox:ack` WS frames. */
+    wsInboxDeliver: z.boolean().default(false),
+  })
+  .partial();
+export type ClientWireCapabilities = z.infer<typeof clientWireCapabilitiesSchema>;
+
 export const clientRegisterSchema = z.object({
   clientId: z.string().min(1).max(100),
   hostname: z.string().max(100).optional(),
   os: z.string().max(50).optional(),
   sdkVersion: z.string().max(50).optional(),
+  wireCapabilities: clientWireCapabilitiesSchema.optional(),
 });
 export type ClientRegister = z.infer<typeof clientRegisterSchema>;

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { clientMessageSchema } from "./message.js";
+
+/**
+ * server → client: a single inbox entry pushed over the active WS connection,
+ * replacing the legacy `new_message` doorbell + HTTP `/inbox` poll round-trip.
+ *
+ * `entryId` is the server-side `inbox_entries.id` the client must echo back
+ * in `inbox:ack`. `message` is exactly what the legacy poll path returned —
+ * `clientMessageSchema` already carries `precedingMessages`, so the client-
+ * side dispatch logic is reused verbatim (see proposal
+ * hub-inbox-ws-data-plane §3.1).
+ *
+ * `.passthrough()` so a forward-rolling server may extend the frame without
+ * breaking older clients that validate strictly. Older clients drop unknown
+ * fields silently.
+ */
+export const inboxDeliverFrameSchema = z
+  .object({
+    type: z.literal("inbox:deliver"),
+    entryId: z.number().int().nonnegative(),
+    inboxId: z.string().min(1),
+    chatId: z.string().nullable(),
+    message: clientMessageSchema,
+  })
+  .passthrough();
+export type InboxDeliverFrame = z.infer<typeof inboxDeliverFrameSchema>;
+
+/**
+ * client → server: ack for an `inbox:deliver` frame. Replaces the legacy
+ * `POST /inbox/:id/ack` HTTP endpoint when the WS data plane is active.
+ */
+export const inboxAckFrameSchema = z.object({
+  type: z.literal("inbox:ack"),
+  entryId: z.number().int().nonnegative(),
+});
+export type InboxAckFrame = z.infer<typeof inboxAckFrameSchema>;

--- a/packages/shared/src/schemas/ws-auth.ts
+++ b/packages/shared/src/schemas/ws-auth.ts
@@ -15,6 +15,25 @@ export type WsAuthFrame = z.infer<typeof wsAuthFrameSchema>;
 export const WS_AUTH_FRAME_TIMEOUT_MS = 5_000;
 
 /**
+ * Negotiable wire-protocol features the server advertises in its `welcome`
+ * frame. Older clients drop the `capabilities` field silently because the
+ * frame is `.passthrough()`. New clients gate optional code paths on it —
+ * absent ⇒ feature off, never assumed.
+ */
+export const serverCapabilitiesSchema = z
+  .object({
+    /**
+     * Server pushes inbox entries as `inbox:deliver` WS frames and accepts
+     * `inbox:ack` over the same socket, instead of relying on the client's
+     * 5s HTTP poll + `POST /inbox/:id/ack`. See proposal
+     * hub-inbox-ws-data-plane §3.6.
+     */
+    wsInboxDeliver: z.boolean().default(false),
+  })
+  .partial();
+export type ServerCapabilities = z.infer<typeof serverCapabilitiesSchema>;
+
+/**
  * Advisory frame sent server → client immediately after `auth:ok`. It carries
  * the Command-package version the server was bundled with, so the client can
  * detect version drift on startup and on each reconnect. `.passthrough()` so
@@ -26,6 +45,7 @@ export const serverWelcomeFrameSchema = z
     type: z.literal("server:welcome"),
     serverCommandVersion: z.string().min(1),
     serverTimeMs: z.number().int().nonnegative(),
+    capabilities: serverCapabilitiesSchema.optional(),
   })
   .passthrough();
 export type ServerWelcomeFrame = z.infer<typeof serverWelcomeFrameSchema>;


### PR DESCRIPTION
## Summary

- Server now pushes inbox entries as `inbox:deliver` WS frames and accepts `inbox:ack` over the same socket, replacing the legacy `new_message` doorbell + 5s HTTP poll for clients that opt in via `client:register.wireCapabilities.wsInboxDeliver`.
- Cross-version compat handled by per-socket capability negotiation: old client + new server / new client + old server / both new all keep working.
- Shared payload assembler (`bundleDeliveryWithSilentContext`) so HTTP poll, push, and reconnect drain go through one code path — no risk of silent-context drift.
- Per-agent in-flight cap (default 32, env `FIRST_TREE_HUB_INBOX_MAX_IN_FLIGHT_PER_AGENT`) with post-bind + post-ack backlog drain to recover from cap hits and disconnect/reconnect cycles.
- Bumps `@agent-team-foundation/first-tree-hub` to 0.10.3.

Implements proposal `hub-inbox-ws-data-plane.20260429`.

## Notable design decisions (vs proposal text)

- `inboxDeliverFrameSchema.message` is a full `clientMessageSchema` (which already carries `precedingMessages`) — single payload shape, identical client-side dispatch for poll and push.
- `inbox:ack` does not carry `agentId`; server resolves the inbox via `boundAgents` so a client cannot ack another bound agent's entry by spoofing the wire.
- `claimAndBuildForPush` claims ALL matching rows per NOTIFY (`LIMIT 8`) so the replyTo cross-chat case (one `(inbox, messageId)` pair → two rows differing only by `chat_id`) doesn't leave the second row stuck `pending` until reconnect.
- `inbox_entries.id` is coerced to JS number at the shared bundle exit — `postgres-js` returns `bigserial` (int8) as a JS string, and the WS push frame schema validates `entryId: z.number()` strictly. Server-side self-validation runs before each `inbox:deliver` send so any future schema drift surfaces immediately as a server-side ERROR log.

## Out of scope (follow-up issues)

- Migrate the remaining `tx.execute(sql\`...\`)` raw queries in `services/inbox.ts` to Drizzle builders so the bigint→string coercion bug class disappears entirely (this PR keeps the workaround).
- Phase 3 cleanup per proposal §3.7 (drop `delivered_at` / `retry_count` columns, retire `resetTimedOutEntries`, remove HTTP `POST /inbox/:id/{ack,renew}`) once WS push has 2 weeks of staging soak.
- WebSocket round-trip integration harness (proposal review issue #8a/8b/8d) — service-level invariants are covered by unit tests; full round-trip exercise lives behind a future harness PR.

## Test plan

- [ ] human → A (manual): default config, expect `wsInboxDeliver` capability negotiated, no 5s `poll error` warns, `inbox_entries.status='acked'` within seconds
- [ ] A → B → A → human chained delivery (manual)
- [ ] mention_only group chat: silent-context bundling preserved when an @mention finally arrives (manual)
- [ ] reconnect drain: kill client mid-conversation, send 3-5 messages while down, restart client, all messages arrive in order (manual)
- [x] service-layer unit tests pass (`pnpm --filter @first-tree-hub/server test -- inbox-ws-push silent-inbox-context`): 8 push-path cases including replyTo dual-row claim, silent-context push, multi-inbox ack scoping, int8→number coercion
- [x] `pnpm typecheck` clean (only known unrelated `@openai/codex-sdk` baseline errors)
- [x] `pnpm check` clean

## Rollback

If the push path misbehaves in staging, pin clients to a build prior to this PR — the server treats any client without `wireCapabilities.wsInboxDeliver=true` as legacy and routes through the unchanged `new_message` doorbell + HTTP poll path. No env-flag flip required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)