### PR TITLE
feat(onboarding): rename default team + redesign invite page + replace auto-popup with banner

### DIFF
--- a/packages/server/src/__tests__/invitations.test.ts
+++ b/packages/server/src/__tests__/invitations.test.ts
@@ -133,7 +133,7 @@ describe("Invitation lifecycle", () => {
       url: "/api/v1/auth/github/dev-callback?githubId=999&login=other-org-admin",
     });
     const { organizations } = await import("../db/schema/organizations.js");
-    const orgs = await app.db.select().from(organizations).where(eq(organizations.name, "other-org-admin-personal"));
+    const orgs = await app.db.select().from(organizations).where(eq(organizations.name, "other-org-admin"));
     const otherOrgRow = orgs[0];
     if (!otherOrgRow) throw new Error("expected other org row");
     const otherOrgId = otherOrgRow.id;

--- a/packages/server/src/__tests__/invitations.test.ts
+++ b/packages/server/src/__tests__/invitations.test.ts
@@ -158,8 +158,17 @@ describe("Invitation lifecycle", () => {
 
     const preview = await app.inject({ method: "GET", url: `/api/v1/invite/${token}/preview` });
     expect(preview.statusCode).toBe(200);
-    const body = preview.json<{ organizationName: string; role: string }>();
+    const body = preview.json<{ organizationName: string; role: string; expiresAt: string | null }>();
     expect(body.role).toBe("member");
+    // expiresAt is exposed so the invite page can render an "Expires in N days" hint.
+    // Default invitations carry a 7-day TTL (services/invitation.ts), so this is a string,
+    // not null. Parse to verify it's a valid future ISO timestamp.
+    expect(typeof body.expiresAt).toBe("string");
+    if (body.expiresAt) {
+      const parsed = Date.parse(body.expiresAt);
+      expect(Number.isFinite(parsed)).toBe(true);
+      expect(parsed).toBeGreaterThan(Date.now());
+    }
   });
 
   it("public preview 404s for revoked tokens", async () => {

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -37,11 +37,13 @@ describe("GitHub OAuth onboarding flow", () => {
     expect(ids).toHaveLength(1);
     expect(ids[0]?.provider).toBe("github");
 
-    // Personal team was minted.
-    const orgs = await app.db.select().from(organizations).where(eq(organizations.name, "octocat-personal"));
+    // Default team was minted — slug is the GitHub login (no `-personal` suffix).
+    const orgs = await app.db.select().from(organizations).where(eq(organizations.name, "octocat"));
     expect(orgs).toHaveLength(1);
     const orgRow = orgs[0];
-    if (!orgRow) throw new Error("expected personal org row");
+    if (!orgRow) throw new Error("expected default org row");
+    // Display name is the GitHub real name, not "<user>'s Personal Team".
+    expect(orgRow.displayName).toBe("Octo Cat");
 
     // The new user is its admin.
     const memberRows = await app.db.select().from(members).where(eq(members.organizationId, orgRow.id));
@@ -64,7 +66,7 @@ describe("GitHub OAuth onboarding flow", () => {
     expect(ids).toHaveLength(1);
   });
 
-  it("disambiguates personal team slug on collision", async () => {
+  it("disambiguates default team slug on collision", async () => {
     const app = getApp();
     await app.inject({
       method: "GET",
@@ -75,8 +77,9 @@ describe("GitHub OAuth onboarding flow", () => {
       url: "/api/v1/auth/github/dev-callback?githubId=2&login=duplicate",
     });
     const orgs = await app.db.select().from(organizations);
-    const personals = orgs.filter((o) => o.name.startsWith("duplicate-personal"));
-    expect(personals.length).toBeGreaterThanOrEqual(2);
+    // First sign-in claims `duplicate`; second gets `duplicate-XXXX` (4-char hex).
+    const claims = orgs.filter((o) => o.name === "duplicate" || /^duplicate-[a-f0-9]{4}$/.test(o.name));
+    expect(claims.length).toBeGreaterThanOrEqual(2);
   });
 
   it("rejects /dev-callback in production", async () => {

--- a/packages/server/src/services/invitation.ts
+++ b/packages/server/src/services/invitation.ts
@@ -141,6 +141,7 @@ export async function previewInvitation(db: Database, token: string) {
     organizationName: org.name,
     organizationDisplayName: org.displayName,
     role: inv.role,
+    expiresAt: inv.expiresAt ? inv.expiresAt.toISOString() : null,
   };
 }
 

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -97,19 +97,20 @@ type CreatePersonalTeamInput = {
 };
 
 /**
- * Create a fresh "personal team" org for a brand-new user, plus the
- * matching admin membership + 1:1 human agent. Slug strategy:
+ * Create a fresh default team org for a brand-new user, plus the matching
+ * admin membership + 1:1 human agent. Slug strategy:
  *
- *   - First try: `${login}-personal`
+ *   - First try: `${login}` (lowercased, sanitized)
  *   - On collision: append a 4-char hex disambiguator
  *
- * The display name is `{user}'s Personal Team` so it reads sensibly in the
- * UI; the user can rename via Settings later (proposal §"Personal team
- * visual降级").
+ * Display name is the user's GitHub real name (or login as fallback). No
+ * "Personal Team" suffix — the user might invite teammates later, and we
+ * don't want a label that reads like a private sandbox to be the team name
+ * other members see. Users rename freely via Settings.
  */
 export async function createPersonalTeam(db: Database, input: CreatePersonalTeamInput) {
-  const baseSlug = sanitizeOrgSlug(`${input.loginSeed}-personal`);
-  const displayName = `${input.userDisplayName}'s Personal Team`;
+  const baseSlug = sanitizeOrgSlug(input.loginSeed);
+  const displayName = input.userDisplayName;
 
   const orgId = uuidv7();
   const slug = await insertOrgWithSlugRetry(db, orgId, baseSlug, displayName);

--- a/packages/shared/src/schemas/invitation.ts
+++ b/packages/shared/src/schemas/invitation.ts
@@ -14,12 +14,18 @@ export const INVITATION_DEFAULT_TTL_DAYS = 7;
  * Surfaces just enough for the recipient to recognise the team they're
  * joining; intentionally omits anything internal (memberCount, member
  * emails, billing) so an attacker can't enumerate via leaked tokens.
+ *
+ * `expiresAt` is exposed because the invite page renders an "Expires in N
+ * days" hint — the recipient should know how urgent the link is. Knowing
+ * the link's TTL doesn't help an attacker beyond what stealing the token
+ * itself already gives them.
  */
 export const invitationPreviewSchema = z.object({
   organizationId: z.string(),
   organizationName: z.string(),
   organizationDisplayName: z.string(),
   role: z.string(),
+  expiresAt: z.string().nullable(),
 });
 export type InvitationPreview = z.infer<typeof invitationPreviewSchema>;
 

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { NotificationBell } from "./notification-bell.js";
+import { OnboardingBanner } from "./onboarding-banner.js";
 import { OnboardingModal } from "./onboarding-modal.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
 import { UserMenu } from "./user-menu.js";
@@ -143,6 +144,8 @@ export function Layout() {
           <UserMenu />
         </div>
       </header>
+
+      <OnboardingBanner />
 
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
       <OnboardingModal />

--- a/packages/web/src/components/onboarding-banner.tsx
+++ b/packages/web/src/components/onboarding-banner.tsx
@@ -1,0 +1,81 @@
+import { Sparkles, X } from "lucide-react";
+import { useOnboardingState } from "../hooks/use-onboarding-state.js";
+
+/**
+ * Top-of-layout reminder shown to any signed-in user whose onboarding
+ * wizard hasn't completed and who hasn't dismissed the banner. Replaces
+ * the prior auto-popup modal — this is gentle, non-blocking, and the
+ * user retains control (Get started or dismiss).
+ *
+ * Banner is rendered globally (every layout-rooted page), not just the
+ * workspace, because "set up your first agent" is not a workspace-specific
+ * task. Visibility is computed in `useOnboardingState`.
+ */
+export function OnboardingBanner() {
+  const { bannerVisible, openModal, dismissBanner } = useOnboardingState();
+  if (!bannerVisible) return null;
+
+  return (
+    <aside
+      role="status"
+      aria-label="Onboarding tip"
+      className="shrink-0 flex items-center justify-between"
+      style={{
+        height: 44,
+        padding: "0 var(--sp-3)",
+        borderBottom: "var(--hairline) solid var(--border)",
+        background: "var(--bg-raised)",
+      }}
+    >
+      <div className="flex items-center" style={{ gap: 8 }}>
+        <Sparkles className="h-3.5 w-3.5" style={{ color: "var(--primary)" }} />
+        <span className="text-body" style={{ color: "var(--fg)" }}>
+          Set up your first agent
+        </span>
+      </div>
+      <div className="flex items-center" style={{ gap: 4 }}>
+        <button
+          type="button"
+          onClick={openModal}
+          className="inline-flex items-center text-body font-medium transition-colors"
+          style={{
+            padding: "var(--sp-1) var(--sp-2_5)",
+            borderRadius: "var(--radius-input)",
+            background: "var(--primary)",
+            color: "var(--primary-foreground)",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.opacity = "0.9";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.opacity = "1";
+          }}
+        >
+          Get started
+        </button>
+        <button
+          type="button"
+          onClick={dismissBanner}
+          aria-label="Dismiss"
+          className="inline-flex items-center justify-center transition-colors"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg-3)",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = "var(--bg-hover)";
+            e.currentTarget.style.color = "var(--fg)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "transparent";
+            e.currentTarget.style.color = "var(--fg-3)";
+          }}
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -95,11 +95,17 @@ export function OnboardingModal() {
         navigate(`/?a=${encodeURIComponent(agent.uuid)}&c=${encodeURIComponent(chat.id)}`, { replace: true });
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to create agent");
-        // Bounce back to the previous step so the user can retry.
-        setLocalStep(step === "connect" ? "connect" : "name");
+        // Always fall back to the name step so the user sees the error and
+        // chooses whether to retry. NOT the connect step — `finishOnboarding`
+        // is only ever entered when `step === "create_agent"` (i.e. a client
+        // is registered), so a "connect" fallback would put the user back in
+        // a now-pointless install screen AND would let the auto-advance
+        // effect immediately re-fire `finishOnboarding`, looping on
+        // persistent errors (name collision, server 500, quota).
+        setLocalStep("name");
       }
     },
-    [refreshMe, closeModal, navigate, step],
+    [refreshMe, closeModal, navigate],
   );
 
   // When user submits the name input.

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -1,183 +1,236 @@
 import type { OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { createAgentChat } from "../api/chats.js";
 import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { useOnboardingState } from "../hooks/use-onboarding-state.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog.js";
 import { Input } from "./ui/input.js";
+import { Label } from "./ui/label.js";
 
 /**
- * Two-step onboarding wizard, presented as a dismissible modal that
- * floats over the dashboard. Replaces the dedicated `/welcome` route.
+ * Onboarding stepper modal — opened only by user action (banner button or
+ * EmptyState "Resume setup"). Two surfaces, one outcome:
  *
- * Step is read from `/me`'s `wizard.step` (an inference over
- * clients + agents); polling automatically advances the modal as
- * the user makes progress in their terminal.
+ *   Step 1 "Name" — single input. Captures the agent name BEFORE asking
+ *                   the user to install anything. The CLI install becomes
+ *                   *motivated* ("Connect a computer to run …") instead of
+ *                   the modal's first impression being a shell command.
  *
- * Copy adapts to the join path (solo signup vs invite redemption),
- * pulled from the sessionStorage flag the OAuth-complete page sets.
+ *   Step 2 "Connect" — only shown when no client is registered yet. Once
+ *                      the wizard advances (server detects a checked-in
+ *                      client), the modal proceeds automatically: it POSTs
+ *                      the agent (with the name from Step 1), opens a chat
+ *                      with that agent, and navigates the user into the
+ *                      workspace's chat view. Modal closes; the user lands
+ *                      in front of an empty input box and types whatever
+ *                      they actually want to ask their agent.
+ *
+ * If the user already has a client (returning user with deleted agent,
+ * second sign-in, etc.), Step 2 is skipped — Step 1 leads straight into
+ * agent creation + chat + navigate.
+ *
+ * Magic moment is deliberately NOT a pre-filled "Hello!" message — that's
+ * a fake demo. The user types their own first message into the real
+ * workspace, exactly as they will every day after.
  */
 export function OnboardingModal() {
-  const { isOpen, close, joinPath, step } = useOnboardingState();
+  const { modalOpen, closeModal, joinPath, step } = useOnboardingState();
   const { refreshMe, organizationId } = useAuth();
+  const navigate = useNavigate();
   const [orgs, setOrgs] = useState<OrgBrief[]>([]);
 
+  const [agentName, setAgentName] = useState("");
+  const [localStep, setLocalStep] = useState<"name" | "connect" | "creating">("name");
+  const [token, setToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Reset local state on open. Server-driven `step` may already be
+  // `create_agent` (returning user with a connected client) — we still
+  // start at "name" so the user always picks the agent name first.
   useEffect(() => {
-    if (!isOpen) return;
+    if (!modalOpen) return;
+    setAgentName("");
+    setLocalStep("name");
+    setToken(null);
+    setError(null);
+  }, [modalOpen]);
+
+  useEffect(() => {
+    if (!modalOpen) return;
     void (async () => {
       try {
         const list = await api.get<OrgBrief[]>("/me/organizations");
         setOrgs(list);
       } catch {
-        // best-effort
+        // best-effort; greeting falls back to generic copy
       }
     })();
-  }, [isOpen]);
+  }, [modalOpen]);
 
-  const currentOrg = orgs.find((o) => o.id === organizationId);
-  const teamName = currentOrg?.displayName ?? "";
+  const teamName = orgs.find((o) => o.id === organizationId)?.displayName ?? "";
+  const greeting = joinPath === "invite" && teamName ? `You've joined ${teamName}.` : "Set up your first agent";
 
-  const greeting = joinPath === "invite" && teamName ? `You've joined ${teamName}.` : "Welcome — let's get you set up.";
-
-  // Solo (default-team) sign-ins: surface a single explanatory line so the
-  // user knows the auto-provisioned default team isn't a system mistake —
-  // they can rename or invite teammates later.
-  const showDefaultTeamHint = step === "connect" && joinPath !== "invite";
-
-  return (
-    <Dialog open={isOpen} onOpenChange={(next) => !next && close()}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{greeting}</DialogTitle>
-          <DialogDescription>
-            {step === "connect"
-              ? "Connect a computer, then create your first agent."
-              : step === "create_agent"
-                ? "One more step: create your first agent."
-                : "All set!"}
-          </DialogDescription>
-        </DialogHeader>
-        {showDefaultTeamHint && (
-          <p className="text-label text-muted-foreground" style={{ margin: 0 }}>
-            We've created your personal team. You can rename it, invite teammates, or join an existing team later.
-          </p>
-        )}
-        {step === "connect" && <ConnectStep onAdvance={refreshMe} />}
-        {step === "create_agent" && <CreateAgentStep onAdvance={refreshMe} />}
-      </DialogContent>
-    </Dialog>
+  // Memoized so the auto-advance effect's dep list stays stable —
+  // recreating the function each render would refire the effect spuriously.
+  const finishOnboarding = useCallback(
+    async (name: string): Promise<void> => {
+      setLocalStep("creating");
+      setError(null);
+      try {
+        const trimmed = name.trim();
+        const agent = await api.post<{ uuid: string }>("/admin/agents", {
+          name: trimmed,
+          type: "autonomous_agent",
+          displayName: trimmed,
+        });
+        const chat = await createAgentChat(agent.uuid);
+        await refreshMe();
+        closeModal();
+        // Land the user inside the freshly-created chat with an empty input —
+        // the natural place to send a real first message.
+        navigate(`/?a=${encodeURIComponent(agent.uuid)}&c=${encodeURIComponent(chat.id)}`, { replace: true });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create agent");
+        // Bounce back to the previous step so the user can retry.
+        setLocalStep(step === "connect" ? "connect" : "name");
+      }
+    },
+    [refreshMe, closeModal, navigate, step],
   );
-}
 
-function ConnectStep({ onAdvance }: { onAdvance: () => Promise<void> }) {
-  const [token, setToken] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  // When user submits the name input.
+  const onSubmitName = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!agentName.trim()) return;
+    if (step === "connect") {
+      // Need a client first. Surface Step 2.
+      setLocalStep("connect");
+    } else {
+      // Already has a client — go straight to creation.
+      await finishOnboarding(agentName);
+    }
+  };
 
+  // Lazy-load a connect token once we know we'll show Step 2.
   useEffect(() => {
+    if (localStep !== "connect" || token) return;
     let cancelled = false;
     void (async () => {
       try {
-        const r = await api.post<{ token: string; expiresIn: number; command: string }>("/connect-tokens", {});
+        const r = await api.post<{ token: string; expiresIn: number }>("/connect-tokens", {});
         if (!cancelled) setToken(r.token);
-      } catch {
-        // surfaced inline
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to generate connect token");
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [localStep, token]);
 
-  // Poll /me every 3s so the modal advances when the client checks in.
+  // While in Step 2, poll /me every 3s. When the wizard advances to
+  // `create_agent` (server saw a client), kick off agent + chat creation
+  // automatically.
   useEffect(() => {
+    if (localStep !== "connect") return;
     let stopped = false;
     const tick = async () => {
       if (stopped) return;
-      await onAdvance();
+      await refreshMe();
     };
     const handle = setInterval(tick, 3000);
     return () => {
       stopped = true;
       clearInterval(handle);
     };
-  }, [onAdvance]);
+  }, [localStep, refreshMe]);
 
-  const command = token ? `npm install -g @agent-team-foundation/first-tree-hub\nfirst-tree-hub connect ${token}` : "";
-
-  return (
-    <div className="space-y-3" style={{ minWidth: 0, maxWidth: "100%" }}>
-      <div style={{ width: "100%", overflow: "hidden", minWidth: 0 }}>
-        <pre
-          className="rounded-md bg-muted p-3 text-label font-mono"
-          style={{
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-all",
-            overflowWrap: "anywhere",
-            width: "100%",
-            minWidth: 0,
-            boxSizing: "border-box",
-            margin: 0,
-          }}
-        >
-          {command || "Generating token…"}
-        </pre>
-      </div>
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={!command}
-        onClick={() => {
-          void navigator.clipboard.writeText(command);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        }}
-      >
-        {copied ? "Copied!" : "Copy commands"}
-      </Button>
-      <p className="text-label text-muted-foreground">Waiting for your computer to check in…</p>
-    </div>
-  );
-}
-
-function CreateAgentStep({ onAdvance }: { onAdvance: () => Promise<void> }) {
-  const [name, setName] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!name.trim()) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await api.post("/admin/agents", {
-        name: name.trim(),
-        type: "autonomous_agent",
-        displayName: name.trim(),
-      });
-      await onAdvance();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create agent");
-    } finally {
-      setBusy(false);
+  // Auto-advance: client just registered while we were waiting.
+  useEffect(() => {
+    if (localStep === "connect" && step === "create_agent" && agentName.trim()) {
+      void finishOnboarding(agentName);
     }
-  };
+  }, [localStep, step, agentName, finishOnboarding]);
+
+  const cliCommand = token
+    ? `npm install -g @agent-team-foundation/first-tree-hub\nfirst-tree-hub connect ${token}`
+    : "Generating token…";
 
   return (
-    <form className="space-y-3" onSubmit={handleSubmit}>
-      {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
-      <Input
-        id="onboarding-agent-name"
-        aria-label="Agent name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="my-first-agent"
-        autoFocus
-      />
-      <Button type="submit" className="w-full" disabled={busy || !name.trim()}>
-        {busy ? "Creating…" : "Create agent"}
-      </Button>
-    </form>
+    <Dialog open={modalOpen} onOpenChange={(next) => !next && closeModal()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{greeting}</DialogTitle>
+          <DialogDescription>
+            {localStep === "name"
+              ? "What should we call your agent?"
+              : localStep === "connect"
+                ? `Connect a computer to run "${agentName.trim()}".`
+                : "Setting things up…"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+
+        {localStep === "name" && (
+          <form className="space-y-3" onSubmit={onSubmitName}>
+            <div className="space-y-2">
+              <Label htmlFor="onboarding-agent-name">Agent name</Label>
+              <Input
+                id="onboarding-agent-name"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder="my-first-agent"
+                autoFocus
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={!agentName.trim()}>
+              Continue
+            </Button>
+          </form>
+        )}
+
+        {localStep === "connect" && (
+          <div className="space-y-3" style={{ minWidth: 0, maxWidth: "100%" }}>
+            <div style={{ width: "100%", overflow: "hidden", minWidth: 0 }}>
+              <pre
+                className="rounded-md bg-muted p-3 text-label font-mono"
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-all",
+                  overflowWrap: "anywhere",
+                  width: "100%",
+                  minWidth: 0,
+                  boxSizing: "border-box",
+                  margin: 0,
+                }}
+              >
+                {cliCommand}
+              </pre>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!token}
+              onClick={() => {
+                if (!token) return;
+                void navigator.clipboard.writeText(cliCommand);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+            >
+              {copied ? "Copied!" : "Copy commands"}
+            </Button>
+            <p className="text-label text-muted-foreground">Waiting for your computer to check in…</p>
+          </div>
+        )}
+
+        {localStep === "creating" && <p className="text-body text-muted-foreground">Creating your agent…</p>}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -36,18 +36,13 @@ export function OnboardingModal() {
   }, [isOpen]);
 
   const currentOrg = orgs.find((o) => o.id === organizationId);
-  // Strip the "'s Personal Team" suffix from auto-provisioned team names
-  // so the user-facing copy doesn't surface that internal label.
-  const friendlyTeamName = (currentOrg?.displayName ?? "").replace(/'s Personal Team$/, "'s team");
+  const teamName = currentOrg?.displayName ?? "";
 
-  const greeting =
-    joinPath === "invite" && friendlyTeamName
-      ? `You've joined ${friendlyTeamName}.`
-      : "Welcome — let's get you set up.";
+  const greeting = joinPath === "invite" && teamName ? `You've joined ${teamName}.` : "Welcome — let's get you set up.";
 
   // Solo (default-team) sign-ins: surface a single explanatory line so the
-  // user knows the auto-provisioned `<login>-personal` slug isn't a system
-  // mistake — they can rename or invite later. Proposal §决策 #16.
+  // user knows the auto-provisioned default team isn't a system mistake —
+  // they can rename or invite teammates later.
   const showDefaultTeamHint = step === "connect" && joinPath !== "invite";
 
   return (

--- a/packages/web/src/hooks/use-onboarding-state.tsx
+++ b/packages/web/src/hooks/use-onboarding-state.tsx
@@ -1,79 +1,80 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useAuth } from "../auth/auth-context.js";
-import { ONBOARDING_AUTO_OPEN_KEY, ONBOARDING_JOIN_PATH_KEY } from "../utils/onboarding-flags.js";
-
-const AUTO_OPEN_KEY = ONBOARDING_AUTO_OPEN_KEY;
-const JOIN_PATH_KEY = ONBOARDING_JOIN_PATH_KEY;
+import { ONBOARDING_BANNER_DISMISSED_KEY, ONBOARDING_JOIN_PATH_KEY } from "../utils/onboarding-flags.js";
 
 type JoinPath = "solo" | "invite";
 type WizardStep = "connect" | "create_agent" | "completed" | null;
 
 type OnboardingContextValue = {
-  isOpen: boolean;
-  open: () => void;
-  close: () => void;
+  /** Modal is open. Only changes via `openModal` / `closeModal` — no auto-open. */
+  modalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+  /** Banner is shown — true iff onboarding incomplete AND user hasn't dismissed. */
+  bannerVisible: boolean;
+  /** Persistently mark the banner as dismissed. */
+  dismissBanner: () => void;
   joinPath: JoinPath | null;
   step: WizardStep;
-  shouldShowResumeCTA: boolean;
 };
 
 const OnboardingContext = createContext<OnboardingContextValue | null>(null);
 
 /**
- * Drives the onboarding modal's open state. Mount the provider once near
- * the top of the auth-required tree so EmptyState's [Resume setup] CTA
- * and the modal share a single state instance.
+ * Onboarding state provider. Two surfaces share this context:
  *
- * Auto-open semantics: opens itself ONCE, immediately after OAuth
- * completion, by consuming a transient sessionStorage flag the
- * OAuth-complete page sets. After dismiss, modal stays closed in this
- * and all subsequent sessions until manually re-opened.
+ *   - <OnboardingBanner /> — top-of-layout dismissible reminder; shown to
+ *     users whose wizard step is not "completed" and who haven't dismissed.
+ *   - <OnboardingModal />  — opened only by explicit user action (banner
+ *     button, EmptyState "Resume setup"). Never auto-pops.
  *
- * Once `wizard.step === "completed"`, the flags are cleaned up so
- * stale state doesn't carry across an unrelated next sign-in.
+ * Auto-popup was retired: it covered the workspace before the user could
+ * see anything, was wrong for invite users (who joined an existing team
+ * and might not need to install a CLI at all), and removed user agency.
+ * The banner is the equivalent gentle entry point.
  */
 export function OnboardingProvider({ children }: { children: ReactNode }) {
   const { wizardStep, isAuthenticated } = useAuth();
-  const [isOpen, setIsOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [bannerDismissed, setBannerDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(ONBOARDING_BANNER_DISMISSED_KEY) === "1";
+  });
   const [joinPath, setJoinPath] = useState<JoinPath | null>(() => {
-    const v = typeof window !== "undefined" ? window.sessionStorage.getItem(JOIN_PATH_KEY) : null;
+    const v = typeof window !== "undefined" ? window.sessionStorage.getItem(ONBOARDING_JOIN_PATH_KEY) : null;
     return v === "solo" || v === "invite" ? v : null;
   });
 
-  // Auto-open once after OAuth completion.
-  useEffect(() => {
-    if (!isAuthenticated) return;
-    if (wizardStep === null || wizardStep === "completed") return;
-    const flag = window.sessionStorage.getItem(AUTO_OPEN_KEY);
-    if (flag === "1") {
-      setIsOpen(true);
-      window.sessionStorage.removeItem(AUTO_OPEN_KEY);
-    }
-  }, [isAuthenticated, wizardStep]);
-
-  // Wizard completed → close modal + clean up flags.
+  // When wizard reaches completed, clean up persistent flags so a future
+  // "incomplete" state (e.g. user deletes their client) gets a fresh banner.
   useEffect(() => {
     if (wizardStep === "completed") {
-      setIsOpen(false);
-      window.sessionStorage.removeItem(AUTO_OPEN_KEY);
-      window.sessionStorage.removeItem(JOIN_PATH_KEY);
+      setModalOpen(false);
+      window.sessionStorage.removeItem(ONBOARDING_JOIN_PATH_KEY);
+      window.localStorage.removeItem(ONBOARDING_BANNER_DISMISSED_KEY);
       setJoinPath(null);
+      setBannerDismissed(false);
     }
   }, [wizardStep]);
 
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
+  const openModal = useCallback(() => setModalOpen(true), []);
+  const closeModal = useCallback(() => setModalOpen(false), []);
+  const dismissBanner = useCallback(() => {
+    window.localStorage.setItem(ONBOARDING_BANNER_DISMISSED_KEY, "1");
+    setBannerDismissed(true);
+  }, []);
 
   const value = useMemo<OnboardingContextValue>(
     () => ({
-      isOpen,
-      open,
-      close,
+      modalOpen,
+      openModal,
+      closeModal,
+      bannerVisible: isAuthenticated && wizardStep !== null && wizardStep !== "completed" && !bannerDismissed,
+      dismissBanner,
       joinPath,
       step: wizardStep,
-      shouldShowResumeCTA: isAuthenticated && wizardStep !== null && wizardStep !== "completed" && !isOpen,
     }),
-    [isOpen, open, close, joinPath, wizardStep, isAuthenticated],
+    [modalOpen, openModal, closeModal, isAuthenticated, wizardStep, bannerDismissed, dismissBanner, joinPath],
   );
 
   return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
@@ -82,15 +83,16 @@ export function OnboardingProvider({ children }: { children: ReactNode }) {
 export function useOnboardingState(): OnboardingContextValue {
   const ctx = useContext(OnboardingContext);
   if (!ctx) {
-    // Not inside a provider — most likely a public route. Return a
-    // permanently-closed default so callers don't have to null-check.
+    // Not inside a provider — most likely a public route. Return permanently-
+    // closed defaults so callers don't have to null-check.
     return {
-      isOpen: false,
-      open: () => {},
-      close: () => {},
+      modalOpen: false,
+      openModal: () => {},
+      closeModal: () => {},
+      bannerVisible: false,
+      dismissBanner: () => {},
       joinPath: null,
       step: null,
-      shouldShowResumeCTA: false,
     };
   }
   return ctx;

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -1,23 +1,25 @@
-import type { InvitationPreview } from "@agent-team-foundation/first-tree-hub-shared";
-import { Github } from "lucide-react";
+import type { InvitationPreview, OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
+import { ArrowLeft, Github, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import { markOnboardingResume } from "../utils/onboarding-flags.js";
 
 /**
  * Public landing for `/invite/:token`. Two cases:
  *
- *   - Visitor not signed in: show the org name + a "Continue with GitHub"
- *     button that round-trips through OAuth and lands them inside the team.
- *   - Visitor already signed in: surface a "Join now" button that POSTs
- *     `/me/organizations/join` and switches their token over.
+ *   - Visitor not signed in: "Continue with GitHub" round-trips through OAuth
+ *     and lands them inside the team.
+ *   - Visitor already signed in: "Join now" POSTs `/me/organizations/join`
+ *     and switches their token over.
  *
- * The preview only exposes org name + display name + role — the public
- * endpoint deliberately does NOT leak member counts, emails, or billing.
+ * The preview omits anything internal (memberCount, member emails, billing).
+ * The page is team-centric on purpose — invite links are shareable URLs that
+ * may reach the recipient via channels we don't track, so identifying "who
+ * invited you" can mislead. The team is the load-bearing identity.
  */
 export function InviteAcceptPage() {
   const { token } = useParams<{ token: string }>();
@@ -26,6 +28,7 @@ export function InviteAcceptPage() {
   const [preview, setPreview] = useState<InvitationPreview | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [currentTeamName, setCurrentTeamName] = useState<string | null>(null);
 
   useEffect(() => {
     if (!token) return;
@@ -33,8 +36,7 @@ export function InviteAcceptPage() {
       try {
         const res = await fetch(`/api/v1/invite/${encodeURIComponent(token)}/preview`);
         if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { error?: string };
-          setError(body.error ?? "This invitation is no longer valid");
+          setError("This invitation is no longer valid");
           return;
         }
         setPreview((await res.json()) as InvitationPreview);
@@ -44,12 +46,29 @@ export function InviteAcceptPage() {
     })();
   }, [token]);
 
-  if (!token) return <Centered>Bad invitation URL</Centered>;
-  if (error) return <Centered>{error}</Centered>;
-  if (!preview) return <Centered>Loading…</Centered>;
+  // For the switch warning we need the current team's displayName, not just
+  // the orgId from the JWT. Fetched lazily — no-op for unauthenticated visitors.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    void (async () => {
+      try {
+        const orgs = await api.get<OrgBrief[]>("/me/organizations");
+        // The /me JWT carries `organizationId`; resolve via the listing so we
+        // get the human-readable display name.
+        const me = await api.get<{ member: { organizationId: string } }>("/me");
+        const current = orgs.find((o) => o.id === me.member.organizationId);
+        setCurrentTeamName(current?.displayName ?? null);
+      } catch {
+        // best-effort — switch warning just stays hidden
+      }
+    })();
+  }, [isAuthenticated]);
+
+  if (!token) return <ErrorScreen message="Bad invitation URL" />;
+  if (error) return <ErrorScreen message="This invitation is no longer valid" />;
+  if (!preview) return <SkeletonScreen />;
 
   const handleJoin = async () => {
-    if (!token) return;
     setBusy(true);
     try {
       const res = await api.post<{
@@ -59,7 +78,6 @@ export function InviteAcceptPage() {
         tokens: { accessToken: string; refreshToken: string };
       }>("/me/organizations/join", { token });
       await adoptTokens(res.tokens);
-      // Land on dashboard; onboarding modal layers on top if wizard incomplete.
       markOnboardingResume("invite");
       navigate("/", { replace: true });
     } catch (err) {
@@ -70,19 +88,32 @@ export function InviteAcceptPage() {
   };
 
   const continueOauthHref = `/api/v1/auth/github/start?next=${encodeURIComponent(`/invite/${token}`)}`;
+  const switchingTeam = isAuthenticated && currentTeamName && currentTeamName !== preview.organizationDisplayName;
+  const expiresHint = formatExpiresHint(preview.expiresAt);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <Card className="w-full max-w-md">
+    <PageShell>
+      <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-title">Join {preview.organizationDisplayName}</CardTitle>
-          <CardDescription>
-            You've been invited as a {preview.role}.
+          <CardTitle className="text-title">
+            You're invited to join
             <br />
-            <span className="text-muted-foreground">team: {preview.organizationName}</span>
-          </CardDescription>
+            {preview.organizationDisplayName}
+          </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {switchingTeam && (
+            <div
+              className="flex items-start gap-2 rounded-md p-3 text-label"
+              style={{ background: "var(--bg-sunken)", color: "var(--fg-2)" }}
+            >
+              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>
+                You'll switch from <span className="font-medium">{currentTeamName}</span> to{" "}
+                <span className="font-medium">{preview.organizationDisplayName}</span>.
+              </span>
+            </div>
+          )}
           {isAuthenticated ? (
             <Button className="w-full" disabled={busy} onClick={handleJoin}>
               {busy ? "Joining…" : `Join ${preview.organizationDisplayName}`}
@@ -95,16 +126,109 @@ export function InviteAcceptPage() {
               </a>
             </Button>
           )}
+          {expiresHint && (
+            <p
+              className="text-center text-label"
+              style={{ color: expiresHint.urgent ? "var(--destructive)" : "var(--fg-3)" }}
+            >
+              {expiresHint.text}
+            </p>
+          )}
+          <p className="text-center text-label text-muted-foreground">
+            By continuing you agree to our{" "}
+            <a href="/terms" className="underline underline-offset-2 transition-colors hover:text-foreground">
+              Terms
+            </a>{" "}
+            ·{" "}
+            <a href="/privacy" className="underline underline-offset-2 transition-colors hover:text-foreground">
+              Privacy
+            </a>
+          </p>
         </CardContent>
       </Card>
+    </PageShell>
+  );
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="px-4 py-3">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to home
+        </Link>
+      </header>
+      <div className="flex flex-1 items-center justify-center px-4 pb-16">{children}</div>
     </div>
   );
 }
 
-function Centered({ children }: { children: React.ReactNode }) {
+function SkeletonScreen() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background text-body text-muted-foreground">
-      {children}
-    </div>
+    <PageShell>
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <div className="mx-auto h-5 w-2/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+          <div className="mx-auto mt-2 h-5 w-1/2 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="h-9 w-full rounded-md" style={{ background: "var(--bg-sunken)" }} />
+          <div className="mx-auto h-3 w-1/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        </CardContent>
+      </Card>
+    </PageShell>
   );
+}
+
+function ErrorScreen({ message }: { message: string }) {
+  return (
+    <PageShell>
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center text-fg-3">
+            <TriangleAlert className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-title">{message}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-center text-body text-muted-foreground">
+            It may have expired or been revoked. Ask the team admin for a fresh link.
+          </p>
+          <Button asChild variant="outline" className="w-full">
+            <Link to="/">
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Back to home
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}
+
+/**
+ * Format the expiry hint shown under the join CTA. Returns null when the link
+ * has more than 7 days left (no urgency, no need to show the user the date).
+ * Marked `urgent` when under 24 hours so the UI can render it in the
+ * destructive color.
+ */
+function formatExpiresHint(expiresAt: string | null): { text: string; urgent: boolean } | null {
+  if (!expiresAt) return null;
+  const target = new Date(expiresAt).getTime();
+  if (!Number.isFinite(target)) return null;
+  const diffMs = target - Date.now();
+  if (diffMs <= 0) return null;
+
+  const minutes = Math.floor(diffMs / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 7) return null;
+  if (days >= 1) return { text: `Expires in ${days} ${days === 1 ? "day" : "days"}`, urgent: false };
+  if (hours >= 1) return { text: `Expires in ${hours} ${hours === 1 ? "hour" : "hours"}`, urgent: true };
+  return { text: `Expires in ${Math.max(1, minutes)} ${minutes === 1 ? "minute" : "minutes"}`, urgent: true };
 }

--- a/packages/web/src/pages/team-identity-panel.tsx
+++ b/packages/web/src/pages/team-identity-panel.tsx
@@ -1,27 +1,20 @@
 import type { Organization } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, X } from "lucide-react";
+import { Check } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
-import { listMembers } from "../api/members.js";
 import { getOrganization, updateOrganization } from "../api/organizations.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Panel, PanelBody, PanelHeader, PanelTitle } from "../components/ui/panel.js";
 
-const RENAME_HINT_DISMISS_PREFIX = "rename-hint:";
-
 /**
  * Admin-only panel for renaming the team (`organizations.display_name` and
- * the URL slug `organizations.name`). Implements proposal §决策 #17 (rename
- * is a v1 feature) and §决策 #19 (one-shot rename hint when a default
- * "<login>-personal" team grows past one member).
+ * the URL slug `organizations.name`). Implements proposal §决策 #17.
  *
- * The hint banner is intentionally derived client-side from facts already
- * on the wire (org slug + members list + localStorage dismissed flag) —
- * no schema changes, no toast system, no event triggers. Trade-off vs
- * proposal: the hint surfaces "next time admin visits Settings" instead
- * of "instantly when the second member joins" — but the rename form is
- * right here, so the timing miss doesn't cost any clicks.
+ * The auto-provisioned default team's name is the user's GitHub login
+ * (slug) and real name (display name) — already a friendly default — so
+ * there's no separate "rename hint" surface; admins who want to customize
+ * just edit the form below.
  */
 export function TeamIdentityPanel() {
   const { organizationId } = useAuth();
@@ -31,11 +24,6 @@ export function TeamIdentityPanel() {
     queryKey: ["organization", organizationId],
     queryFn: () => (organizationId ? getOrganization(organizationId) : Promise.reject(new Error("no org"))),
     enabled: !!organizationId,
-  });
-
-  const membersQuery = useQuery({
-    queryKey: ["members"],
-    queryFn: listMembers,
   });
 
   const [displayName, setDisplayName] = useState("");
@@ -74,26 +62,6 @@ export function TeamIdentityPanel() {
     mutation.mutate();
   };
 
-  // Rename-hint visibility (v1 simplified version of proposal §决策 #19):
-  //   - admin (this panel is only mounted under the admin tab)
-  //   - team slug still ends in "-personal" (auto-provisioned default)
-  //   - >= 2 active members in the team
-  //   - user hasn't dismissed the hint for THIS org before
-  const dismissKey = `${RENAME_HINT_DISMISS_PREFIX}${organizationId ?? "unknown"}:dismissed`;
-  const [hintDismissed, setHintDismissed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(dismissKey) === "1";
-  });
-  const dismissHint = () => {
-    window.localStorage.setItem(dismissKey, "1");
-    setHintDismissed(true);
-  };
-  const showRenameHint =
-    !hintDismissed &&
-    !!orgQuery.data?.name &&
-    orgQuery.data.name.endsWith("-personal") &&
-    (membersQuery.data?.length ?? 0) >= 2;
-
   return (
     <Panel>
       <PanelHeader>
@@ -111,33 +79,6 @@ export function TeamIdentityPanel() {
         </div>
       </PanelHeader>
       <PanelBody>
-        {showRenameHint && (
-          <div
-            className="flex items-start justify-between gap-3"
-            style={{
-              padding: "var(--sp-2_5) var(--sp-3)",
-              marginBottom: "var(--sp-3)",
-              background: "var(--bg-sunken)",
-              border: "var(--hairline) solid var(--border-faint)",
-              borderRadius: "var(--radius-input)",
-            }}
-          >
-            <div className="text-label" style={{ color: "var(--fg-2)" }}>
-              Heads up — this team is still using its auto-generated name (
-              <span className="mono">{orgQuery.data?.name}</span>). Now that you have teammates, you might want to give
-              it a friendlier name in the form below.
-            </div>
-            <button
-              type="button"
-              aria-label="Dismiss rename hint"
-              onClick={dismissHint}
-              className="shrink-0"
-              style={{ color: "var(--fg-3)", padding: 2, background: "transparent", border: "none", cursor: "pointer" }}
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
         {orgQuery.isLoading ? (
           <div className="text-body" style={{ color: "var(--fg-3)" }}>
             Loading…

--- a/packages/web/src/pages/workspace/center/empty-state.tsx
+++ b/packages/web/src/pages/workspace/center/empty-state.tsx
@@ -3,9 +3,10 @@ import { Button } from "../../../components/ui/button.js";
 import { useOnboardingState } from "../../../hooks/use-onboarding-state.js";
 
 export function EmptyState() {
-  const { shouldShowResumeCTA, open, step } = useOnboardingState();
+  const { step, openModal } = useOnboardingState();
+  const onboardingIncomplete = step !== null && step !== "completed";
 
-  if (shouldShowResumeCTA) {
+  if (onboardingIncomplete) {
     const stepLabel =
       step === "connect"
         ? "Connect your computer to create your first agent."
@@ -18,7 +19,7 @@ export function EmptyState() {
           <FirstTreeLogo width={36} height={40} className="mx-auto mb-3 text-primary opacity-60" />
           <div className="text-subtitle mb-1">No agents yet</div>
           <div className="text-body text-muted-foreground mb-4">{stepLabel}</div>
-          <Button onClick={open}>Resume setup</Button>
+          <Button onClick={openModal}>Resume setup</Button>
         </div>
       </div>
     );

--- a/packages/web/src/utils/onboarding-flags.ts
+++ b/packages/web/src/utils/onboarding-flags.ts
@@ -1,25 +1,33 @@
 /**
- * Shared sessionStorage flags consumed by `OnboardingProvider` to decide
- * whether the wizard modal should auto-open after a token-adoption surface
- * (OAuth fragment consumer, invite-accept). Centralising the keys here
- * avoids drift between the two writers and the single reader.
+ * Onboarding-related browser-side flags.
+ *
+ * - `joinPath` (sessionStorage): set by the OAuth-complete page and the
+ *   invite-accept handler. Drives the modal's greeting copy ("You've joined
+ *   {team}." vs "Welcome — let's get you set up."). Cleared once the user's
+ *   wizard reaches `completed`.
+ *
+ * - `bannerDismissed` (localStorage): set when the user clicks ✕ on the
+ *   onboarding banner. localStorage (not sessionStorage) so dismiss persists
+ *   across reloads but resets if the user signs in on a different device.
+ *   Cleared when the user actually completes onboarding so the dismiss flag
+ *   doesn't leak into a future "incomplete" state (e.g. they delete their
+ *   client).
  */
 
-const AUTO_OPEN_KEY = "onboarding:autoOpen";
 const JOIN_PATH_KEY = "onboarding:joinPath";
+const BANNER_DISMISSED_KEY = "onboarding:bannerDismissed";
 
 export type OnboardingJoinPath = "solo" | "invite";
 
 /**
- * Mark "the next time the dashboard mounts, auto-open the onboarding modal
- * (with copy keyed off `joinPath`)." Idempotent — overwriting is fine.
+ * Mark the join path so the next dashboard mount can pick context-aware
+ * copy. Idempotent — overwriting is fine.
  */
 export function markOnboardingResume(joinPath: OnboardingJoinPath): void {
   if (typeof window === "undefined") return;
-  window.sessionStorage.setItem(AUTO_OPEN_KEY, "1");
   window.sessionStorage.setItem(JOIN_PATH_KEY, joinPath);
 }
 
-/** Internal — used by `OnboardingProvider` to consume + clear the flag. */
-export const ONBOARDING_AUTO_OPEN_KEY = AUTO_OPEN_KEY;
+/** Internal — used by `OnboardingProvider` to read/clear the flags. */
 export const ONBOARDING_JOIN_PATH_KEY = JOIN_PATH_KEY;
+export const ONBOARDING_BANNER_DISMISSED_KEY = BANNER_DISMISSED_KEY;


### PR DESCRIPTION
## Summary

Three independent improvements to the new-user onboarding surface, bundled because they share a theme and don't conflict. Reviewer-friendly commit-by-commit:

1. **`feat(onboarding): rename auto-provisioned default team`** — drops the `-personal` slug suffix and `'s Personal Team` display-name suffix on the team minted at first GitHub sign-in. New defaults: `slug = ${login}`, `displayName = ${user.name}` (GitHub real name, fallback to login). Web layer's strip regex on the now-irrelevant suffix removed too. Only changes new-team creation; existing teams keep their current names.

2. **`feat(onboarding): redesign /invite/<token> landing page`** — team-centric layout. Title leads with `You're invited to join {teamDisplayName}`; slug exposure (`team: acme-robotics`) retired. Added: `Expires in N days` hint (red when < 24h), switch warning when signed into a different team, skeleton loading (no layout jump), friendly error page for expired/revoked links. Inviter info deliberately omitted — invite links are shareable URLs whose recipients may receive them via untracked channels, so naming the link's *creator* can mislead. Server change: `invitationPreviewSchema` adds `expiresAt: nullable string`.

3. **`feat(onboarding): replace auto-popup modal with dismissible banner + 2-step stepper`** — auto-popup was wrong for invite users (forced a CLI install on someone who joined an existing team) and removed user agency. Replaced with a top-of-layout dismissible banner. Modal opens only on user action and walks through `name agent → connect computer (if needed) → auto-create + open chat → navigate user into the workspace's chat view`. CLI install becomes motivated (`Connect a computer to run "<agent name>"`). Magic moment is the user's *real* first message in the *real* workspace — no fake pre-filled "Hello!".

## Test plan

- [ ] **Solo new user**: signup via GitHub → lands on `/` → sees banner `Set up your first agent` → click `Get started` → name agent → install CLI → modal auto-progresses to chat view inside new chat with empty input
- [ ] **Returning user with existing client**: open modal manually → name agent → modal skips Step 2 → goes straight to chat view
- [ ] **Banner dismiss**: click ✕ → banner disappears → reload page → still gone (localStorage)
- [ ] **Banner re-appears after wizard regression**: complete onboarding → delete client + agents → next sign-in shows fresh banner
- [ ] **Invite redemption**: open `/invite/<token>` (signed out) → see team-centric layout with `Expires in N days` → continue with GitHub → land on team
- [ ] **Already-signed-in invite**: open invite link while signed into a different team → see switch warning before Join button
- [ ] **Expired/revoked invite**: bad token → see friendly error page with `Back to home` CTA
- [ ] **New team naming**: fresh GitHub signup → check DB: `organizations.name === '<github-login>'` (not `<login>-personal`); `displayName === '<user.name>'` (not `'<user>'s Personal Team'`)

## Quality gates

- ✅ Biome / typecheck all green
- ✅ Server tests: 504 / 504 (incl. updated assertions for new team naming + new `expiresAt` test on invite preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)