### PR TITLE
feat(web): topbar disconnect chip + new-connection modal

### DIFF
--- a/docs/design/computer-disconnect-preview.html
+++ b/docs/design/computer-disconnect-preview.html
@@ -1,0 +1,1031 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Computer Disconnect — UI Preview</title>
+    <style>
+      :root {
+        --font-sans:
+          "Inter", "Inter Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
+          "Microsoft YaHei", system-ui, ui-sans-serif, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+        --accent: oklch(0.72 0.17 150);
+        --accent-bg: oklch(0.72 0.17 150 / 0.12);
+
+        --state-idle: oklch(0.72 0.17 150);
+        --state-blocked: oklch(0.82 0.18 75);
+        --state-error: oklch(0.68 0.22 25);
+        --state-offline: oklch(0.5 0 0);
+
+        --bg: oklch(0.985 0.005 150);
+        --bg-raised: oklch(1 0 0);
+        --bg-sunken: oklch(0.965 0.006 150);
+        --bg-hover: oklch(0.95 0.008 150);
+
+        --fg: oklch(0.18 0.01 150);
+        --fg-2: oklch(0.36 0.01 150);
+        --fg-3: oklch(0.52 0.008 150);
+        --fg-4: oklch(0.68 0.005 150);
+
+        --border: oklch(0.9 0.006 150);
+        --border-strong: oklch(0.82 0.008 150);
+        --border-faint: oklch(0.94 0.005 150);
+
+        --overlay-scrim: oklch(0 0 0 / 0.55);
+        --shadow-md: 0 4px 12px oklch(0 0 0 / 0.08);
+
+        --radius-input: 6px;
+        --radius-chip: 5px;
+        --radius-panel: 8px;
+
+        --hairline: 1px;
+      }
+
+      /* Mirrors packages/web/src/index.css `ring-pulse` keyframe used by StateDot.working. */
+      @keyframes ring-pulse {
+        0% {
+          transform: scale(1);
+          opacity: 0.6;
+        }
+        100% {
+          transform: scale(2.6);
+          opacity: 0;
+        }
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: var(--font-sans);
+        background: oklch(0.93 0.008 150);
+        color: var(--fg);
+        font-size: 14px;
+        line-height: 1.45;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .doc {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 28px 24px 80px;
+      }
+
+      .doc h1 {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: -0.2px;
+        margin: 0 0 4px;
+      }
+      .doc .subtitle {
+        font-size: 13px;
+        color: var(--fg-3);
+        margin: 0 0 28px;
+      }
+
+      .doc h2 {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--fg-3);
+        margin: 32px 0 10px;
+      }
+      .doc .note {
+        font-size: 12px;
+        color: var(--fg-3);
+        margin: 4px 0 12px;
+        line-height: 1.5;
+      }
+
+      /* ----- Frame: simulates a browser window ----- */
+      .frame {
+        background: var(--bg);
+        border: var(--hairline) solid var(--border);
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 1px 2px oklch(0 0 0 / 0.04);
+      }
+
+      /* =================== TOP BAR ===================
+         Three-column grid: 1fr auto 1fr.
+         Tabs sit in the centre (auto) column → guaranteed to be at the
+         page's horizontal centre regardless of how many elements exist on
+         either side. Future left/right additions never shift the tabs. */
+      .topbar {
+        height: 48px;
+        background: var(--bg-raised);
+        border-bottom: var(--hairline) solid var(--border);
+        padding: 0 12px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .brand-cluster {
+        display: inline-flex;
+        align-items: center;
+        gap: 14px;
+        min-width: 0;
+        justify-self: start;
+      }
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        flex-shrink: 0;
+      }
+      .brand .logo {
+        width: 16px;
+        height: 18px;
+        color: var(--fg);
+        display: inline-block;
+      }
+      .brand .name {
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: -0.2px;
+      }
+      .brand .name .light {
+        font-weight: 400;
+        color: var(--fg-3);
+      }
+
+      /* The disconnect chip — brand-anchored, immediately right of "First Tree Hub".
+         No icon. Hostname truncates to keep total chip width sane. */
+      .disconnect-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        height: 26px;
+        padding: 0 10px 0 9px;
+        border: 0;
+        border-radius: 999px;
+        font-size: 12.5px;
+        font-weight: 500;
+        letter-spacing: -0.1px;
+        cursor: pointer;
+        background: color-mix(in oklch, var(--state-error) 14%, transparent);
+        color: color-mix(in oklch, var(--state-error) 80%, var(--fg));
+        outline: var(--hairline) solid color-mix(in oklch, var(--state-error) 38%, transparent);
+        outline-offset: -1px;
+        transition:
+          background 0.12s,
+          outline-color 0.12s;
+        max-width: 100%;
+        min-width: 0;
+      }
+      .disconnect-chip:hover {
+        background: color-mix(in oklch, var(--state-error) 22%, transparent);
+        outline-color: color-mix(in oklch, var(--state-error) 50%, transparent);
+      }
+
+      /* Pulse follows project StateDot.working pattern: solid dot + expanding ring.
+         We swap the colour token to --state-error. */
+      .pulse-dot {
+        position: relative;
+        width: 8px;
+        height: 8px;
+        flex-shrink: 0;
+        display: inline-block;
+      }
+      .pulse-dot::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background: var(--state-error);
+      }
+      .pulse-dot::after {
+        content: "";
+        position: absolute;
+        inset: -3px;
+        border-radius: 50%;
+        border: var(--hairline) solid var(--state-error);
+        animation: ring-pulse 1.8s infinite;
+        opacity: 0.6;
+      }
+
+      .chip-text {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        min-width: 0;
+        max-width: 280px;
+      }
+      .chip-host {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 500;
+        max-width: 160px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: color-mix(in oklch, var(--state-error) 60%, var(--fg));
+      }
+      .chip-suffix {
+        flex-shrink: 0;
+      }
+      .chip-count {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+      }
+
+      /* Tabs (centre column — always page-centred) */
+      .tabs {
+        display: flex;
+        gap: 2px;
+        justify-self: center;
+      }
+      .tab {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--fg-3);
+        padding: 6px 12px;
+        border-radius: 5px;
+        cursor: pointer;
+      }
+      .tab.active {
+        color: var(--fg);
+        background: var(--bg-hover);
+      }
+      .tab .kbd {
+        margin-left: 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-4);
+        border: var(--hairline) solid var(--border);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
+
+      /* Right controls */
+      .controls {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        justify-self: end;
+      }
+      .jumpbtn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 8px;
+        color: var(--fg-3);
+        border: var(--hairline) solid var(--border);
+        border-radius: var(--radius-input);
+        background: var(--bg-sunken);
+        font-size: 13px;
+      }
+      .jumpbtn .kbd {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--fg-4);
+      }
+      .icon-btn {
+        width: 28px;
+        height: 28px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--radius-input);
+        color: var(--fg-3);
+        cursor: pointer;
+      }
+      .icon-btn:hover {
+        background: var(--bg-hover);
+      }
+      .divider {
+        width: 1px;
+        height: 18px;
+        background: var(--border);
+        margin: 0 4px;
+      }
+      .avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        background: linear-gradient(135deg, var(--accent), var(--state-idle));
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      /* =================== Page body =================== */
+      .page {
+        padding: 14px 20px 40px;
+      }
+      .pageheader {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 12px 0 18px;
+        border-bottom: var(--hairline) solid var(--border-faint);
+        margin-bottom: 14px;
+      }
+      .pageheader h1 {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: -0.3px;
+        margin: 0;
+      }
+      .pageheader .stats {
+        font-size: 12.5px;
+        color: var(--fg-3);
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 14px;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 32px;
+        padding: 0 12px;
+        border-radius: var(--radius-input);
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        border: var(--hairline) solid transparent;
+        background: var(--bg-raised);
+        color: var(--fg);
+      }
+      .btn.primary {
+        background: var(--fg);
+        color: var(--bg-raised);
+        border-color: var(--fg);
+      }
+      .btn.primary:hover {
+        opacity: 0.92;
+      }
+      .btn.outline {
+        background: var(--bg-raised);
+        border-color: var(--border-strong);
+        color: var(--fg);
+      }
+      .btn.outline:hover {
+        background: var(--bg-hover);
+      }
+      .btn.ghost {
+        background: transparent;
+        color: var(--fg-3);
+      }
+      .btn.ghost:hover {
+        color: var(--fg);
+      }
+      .btn svg {
+        width: 14px;
+        height: 14px;
+      }
+
+      .panel {
+        background: var(--bg-raised);
+        border: var(--hairline) solid var(--border);
+        border-radius: var(--radius-panel);
+        overflow: hidden;
+      }
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 16px;
+        border-bottom: var(--hairline) solid var(--border-faint);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--fg-3);
+      }
+      .section-head .right {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 400;
+        letter-spacing: 0;
+        text-transform: none;
+        color: var(--fg-3);
+      }
+
+      table.dense {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      table.dense th,
+      table.dense td {
+        padding: 7px 12px;
+        text-align: left;
+        font-size: 13px;
+        border-bottom: var(--hairline) solid var(--border-faint);
+      }
+      table.dense th {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--fg-3);
+        background: var(--bg-sunken);
+        letter-spacing: 0.04em;
+      }
+      table.dense tr:last-child td {
+        border-bottom: none;
+      }
+      table.dense td.mono {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--fg-3);
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        height: 20px;
+        padding: 0 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 500;
+      }
+      .chip .dot {
+        width: 5px;
+        height: 5px;
+        border-radius: 999px;
+      }
+      .chip.idle {
+        background: color-mix(in oklch, var(--state-idle) 15%, transparent);
+        color: color-mix(in oklch, var(--state-idle) 70%, var(--fg));
+      }
+      .chip.idle .dot {
+        background: var(--state-idle);
+      }
+      .chip.offline {
+        background: color-mix(in oklch, var(--state-offline) 15%, transparent);
+        color: var(--fg-3);
+      }
+      .chip.offline .dot {
+        background: var(--state-offline);
+      }
+
+      /* =================== Modal =================== */
+      .modal-stage {
+        position: relative;
+        background: var(--bg-sunken);
+        padding: 24px;
+        border-top: var(--hairline) solid var(--border);
+      }
+      .modal-stage::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: var(--overlay-scrim);
+        pointer-events: none;
+      }
+      .modal {
+        position: relative;
+        max-width: 480px;
+        margin: 0 auto;
+        background: var(--bg-raised);
+        border: var(--hairline) solid var(--border);
+        border-radius: var(--radius-panel);
+        box-shadow: var(--shadow-md);
+        padding: 22px 24px 22px;
+      }
+      .modal h3 {
+        margin: 0 0 4px;
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: -0.1px;
+      }
+      .modal p.desc {
+        margin: 0 0 16px;
+        font-size: 13px;
+        color: var(--fg-3);
+      }
+      .modal .cmd-row {
+        display: flex;
+        gap: 8px;
+        align-items: stretch;
+        margin-bottom: 6px;
+      }
+      .modal .cmd {
+        flex: 1;
+        background: var(--bg-sunken);
+        border: var(--hairline) solid var(--border-faint);
+        border-radius: var(--radius-input);
+        padding: 10px 12px;
+        font-family: var(--font-mono);
+        font-size: 12.5px;
+        color: var(--fg-2);
+        word-break: break-all;
+        line-height: 1.5;
+      }
+      .modal .cmd .expiry {
+        color: var(--fg-4);
+      }
+      .modal .copy-btn {
+        align-self: flex-start;
+      }
+      .modal .meta {
+        font-size: 11.5px;
+        color: var(--fg-4);
+        margin: 0 0 14px;
+      }
+
+      /* Waiting — yellow (state-blocked / warn) */
+      .waiting {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        background: color-mix(in oklch, var(--state-blocked) 14%, transparent);
+        border: var(--hairline) solid color-mix(in oklch, var(--state-blocked) 35%, transparent);
+        border-radius: var(--radius-input);
+        font-size: 12.5px;
+        color: color-mix(in oklch, var(--state-blocked) 35%, var(--fg));
+      }
+      .waiting .spinner {
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+        border: 1.5px solid color-mix(in oklch, var(--state-blocked) 30%, transparent);
+        border-top-color: var(--state-blocked);
+        animation: spin 0.85s linear infinite;
+      }
+
+      /* Success — green (state-idle) */
+      .success {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        background: color-mix(in oklch, var(--state-idle) 14%, transparent);
+        border: var(--hairline) solid color-mix(in oklch, var(--state-idle) 35%, transparent);
+        border-radius: var(--radius-input);
+        font-size: 12.5px;
+        color: color-mix(in oklch, var(--state-idle) 45%, var(--fg));
+      }
+      .success svg {
+        width: 14px;
+        height: 14px;
+      }
+
+      .modal .footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 16px;
+      }
+
+      .legend {
+        margin-top: 18px;
+        padding: 14px 16px;
+        background: var(--bg-raised);
+        border: var(--hairline) dashed var(--border);
+        border-radius: var(--radius-panel);
+        font-size: 12.5px;
+        color: var(--fg-3);
+        line-height: 1.6;
+      }
+      .legend strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+
+      /* Centre-line guide for the demo so reviewers can verify tab centring. */
+      .frame.show-center-guide {
+        position: relative;
+      }
+      .frame.show-center-guide::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        width: 1px;
+        background: color-mix(in oklch, var(--accent) 60%, transparent);
+        opacity: 0.5;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="doc">
+      <h1>Computer Disconnect — UI Preview · v2</h1>
+      <p class="subtitle">
+        Iteration on review: chip uses project's <code>ring-pulse</code> on red, no icon, copy is
+        <code>"&lt;host&gt; disconnected"</code> / <code>"&lt;n&gt; computers disconnected"</code>, hostname truncates
+        at 160px, tabs use <code>1fr&nbsp;auto&nbsp;1fr</code> grid (locked centre), waiting state is yellow, success is
+        green. The vertical green guide line marks the page centre so you can verify the tabs stay put.
+      </p>
+
+      <!-- =================== State A: 1 disconnected =================== -->
+      <h2>A · Topbar — single disconnected computer</h2>
+      <p class="note">
+        Copy: <code>&lt;hostname&gt; disconnected</code>. Pulse follows
+        <code>StateDot.working</code> pattern (solid dot + expanding ring), recoloured with
+        <code>--state-error</code>. No warning icon. Hostname truncates with ellipsis past 160px.
+      </p>
+      <div class="frame show-center-guide">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+
+            <button class="disconnect-chip" type="button" title="Click to manage your computers">
+              <span class="pulse-dot" aria-hidden="true"></span>
+              <span class="chip-text">
+                <span class="chip-host">yue-mbp-16</span>
+                <span class="chip-suffix">disconnected</span>
+              </span>
+            </button>
+          </div>
+
+          <nav class="tabs">
+            <span class="tab">Workspace</span>
+            <span class="tab">Agents</span>
+            <span class="tab active">Computers <span class="kbd">⌘3</span></span>
+            <span class="tab">Settings</span>
+          </nav>
+
+          <div class="controls">
+            <span class="jumpbtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+              Jump to…<span class="kbd">⌘K</span>
+            </span>
+            <span class="divider"></span>
+            <span class="icon-btn">🔔</span>
+            <span class="icon-btn">☀</span>
+            <span class="divider"></span>
+            <span class="avatar">YZ</span>
+          </div>
+        </header>
+      </div>
+
+      <!-- =================== State A2: very long hostname (truncation) =================== -->
+      <h2>A2 · Topbar — hostname truncation</h2>
+      <p class="note">
+        Long hostname overflows past <code>max-width: 160px</code> and ellipsises. Hover/title shows the full name.
+      </p>
+      <div class="frame show-center-guide">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+
+            <button
+              class="disconnect-chip"
+              type="button"
+              title="yue-engineering-mbp-16-2024-prod-replica.local"
+            >
+              <span class="pulse-dot" aria-hidden="true"></span>
+              <span class="chip-text">
+                <span class="chip-host">yue-engineering-mbp-16-2024-prod-replica.local</span>
+                <span class="chip-suffix">disconnected</span>
+              </span>
+            </button>
+          </div>
+
+          <nav class="tabs">
+            <span class="tab active">Workspace <span class="kbd">⌘1</span></span>
+            <span class="tab">Agents</span>
+            <span class="tab">Computers</span>
+            <span class="tab">Settings</span>
+          </nav>
+
+          <div class="controls">
+            <span class="jumpbtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+              Jump to…<span class="kbd">⌘K</span>
+            </span>
+            <span class="divider"></span>
+            <span class="icon-btn">🔔</span>
+            <span class="icon-btn">☀</span>
+            <span class="divider"></span>
+            <span class="avatar">YZ</span>
+          </div>
+        </header>
+      </div>
+
+      <!-- =================== State B: 2+ disconnected =================== -->
+      <h2>B · Topbar — multiple disconnected</h2>
+      <p class="note">Copy: <code>&lt;n&gt; computers disconnected</code>. Number is bold tabular-num.</p>
+      <div class="frame show-center-guide">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+
+            <button class="disconnect-chip" type="button">
+              <span class="pulse-dot" aria-hidden="true"></span>
+              <span class="chip-text">
+                <span class="chip-suffix"><span class="chip-count">2</span>&nbsp;computers disconnected</span>
+              </span>
+            </button>
+          </div>
+          <nav class="tabs">
+            <span class="tab active">Workspace <span class="kbd">⌘1</span></span>
+            <span class="tab">Agents</span>
+            <span class="tab">Computers</span>
+            <span class="tab">Settings</span>
+          </nav>
+          <div class="controls">
+            <span class="jumpbtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+              Jump to…<span class="kbd">⌘K</span>
+            </span>
+            <span class="divider"></span>
+            <span class="icon-btn">🔔</span>
+            <span class="icon-btn">☀</span>
+            <span class="divider"></span>
+            <span class="avatar">YZ</span>
+          </div>
+        </header>
+      </div>
+
+      <!-- =================== State C: all good =================== -->
+      <h2>C · Topbar — healthy (no chip)</h2>
+      <p class="note">No chip. Tabs sit at the same centre line as the previous frames.</p>
+      <div class="frame show-center-guide">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+          </div>
+          <nav class="tabs">
+            <span class="tab active">Workspace <span class="kbd">⌘1</span></span>
+            <span class="tab">Agents</span>
+            <span class="tab">Computers</span>
+            <span class="tab">Settings</span>
+          </nav>
+          <div class="controls">
+            <span class="jumpbtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+              Jump to…<span class="kbd">⌘K</span>
+            </span>
+            <span class="divider"></span>
+            <span class="icon-btn">🔔</span>
+            <span class="icon-btn">☀</span>
+            <span class="divider"></span>
+            <span class="avatar">YZ</span>
+          </div>
+        </header>
+      </div>
+
+      <!-- =================== State D: Computers page =================== -->
+      <h2>D · Computers page — "New Connection +" replaces ConnectStrip</h2>
+      <p class="note">
+        ConnectStrip removed. Right-aligned <strong>New Connection</strong> primary CTA above the registered table.
+        Stats and table unchanged.
+      </p>
+      <div class="frame show-center-guide">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+            <button class="disconnect-chip" type="button">
+              <span class="pulse-dot" aria-hidden="true"></span>
+              <span class="chip-text">
+                <span class="chip-host">yue-mbp-16</span>
+                <span class="chip-suffix">disconnected</span>
+              </span>
+            </button>
+          </div>
+          <nav class="tabs">
+            <span class="tab">Workspace</span><span class="tab">Agents</span>
+            <span class="tab active">Computers <span class="kbd">⌘3</span></span><span class="tab">Settings</span>
+          </nav>
+          <div class="controls">
+            <span class="jumpbtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>
+              Jump to…<span class="kbd">⌘K</span>
+            </span>
+            <span class="divider"></span>
+            <span class="icon-btn">🔔</span>
+            <span class="icon-btn">☀</span>
+            <span class="divider"></span>
+            <span class="avatar">YZ</span>
+          </div>
+        </header>
+
+        <main class="page">
+          <div class="pageheader">
+            <h1>Computers</h1>
+            <span class="stats">2 total · 1 connected · 4 agents bound</span>
+          </div>
+
+          <div class="toolbar">
+            <button class="btn primary" type="button">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+              New Connection
+            </button>
+          </div>
+
+          <div class="panel">
+            <div class="section-head">
+              <span>Registered · 2</span>
+              <span class="right">click a row to expand</span>
+            </div>
+            <table class="dense">
+              <thead>
+                <tr>
+                  <th style="width:16px"></th>
+                  <th>Hostname</th>
+                  <th>OS</th>
+                  <th>SDK</th>
+                  <th>Agents</th>
+                  <th>Connected</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>›</td>
+                  <td style="font-weight:500;">yue-mbp-16</td>
+                  <td style="color:var(--fg-3);">macOS</td>
+                  <td class="mono">v1.4.2</td>
+                  <td class="mono">3</td>
+                  <td class="mono" style="color:var(--fg-4); font-size:11.5px;">2026-04-29 09:14</td>
+                  <td><span class="chip offline"><span class="dot"></span>offline</span></td>
+                  <td style="text-align:right; color:var(--fg-3); font-size:12px;">Disconnect · Retire</td>
+                </tr>
+                <tr>
+                  <td>›</td>
+                  <td style="font-weight:500;">yue-studio-mac</td>
+                  <td style="color:var(--fg-3);">macOS</td>
+                  <td class="mono">v1.4.2</td>
+                  <td class="mono">1</td>
+                  <td class="mono" style="color:var(--fg-4); font-size:11.5px;">2026-04-28 22:01</td>
+                  <td><span class="chip idle"><span class="dot"></span>idle</span></td>
+                  <td style="text-align:right; color:var(--fg-3); font-size:12px;">Disconnect · Retire</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </main>
+      </div>
+
+      <!-- =================== State E: New Connection modal — waiting (yellow) =================== -->
+      <h2>E · New Connection modal — waiting (yellow)</h2>
+      <p class="note">
+        Waiting state uses <code>--state-blocked</code> (yellow) — same warn pair the rest of the app uses for
+        "blocked / waiting on something external". Spinner is yellow-tinted.
+      </p>
+      <div class="frame">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+          </div>
+          <nav class="tabs">
+            <span class="tab">Workspace</span><span class="tab">Agents</span>
+            <span class="tab active">Computers <span class="kbd">⌘3</span></span><span class="tab">Settings</span>
+          </nav>
+          <div class="controls"><span class="avatar">YZ</span></div>
+        </header>
+
+        <div class="modal-stage">
+          <div class="modal">
+            <h3>Connect a new computer</h3>
+            <p class="desc">Run this command on the machine you want to pair with this Hub.</p>
+            <div class="cmd-row">
+              <code class="cmd"
+                >first-tree-hub connect <span style="color:var(--fg);">eyJhbGciOi…iY4WX</span>
+                <span class="expiry"># expires in 10m</span></code
+              >
+              <button class="btn outline copy-btn" type="button">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                Copy
+              </button>
+            </div>
+            <p class="meta">Single-use · regenerates the previous one.</p>
+
+            <div class="waiting">
+              <span class="spinner"></span>
+              Waiting for your computer to connect…
+            </div>
+
+            <div class="footer">
+              <button class="btn ghost" type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- =================== State F: success (green) =================== -->
+      <h2>F · New Connection modal — success (green)</h2>
+      <p class="note">
+        On detecting a new client, swap waiting → success (green, <code>--state-idle</code>), brief hold (~1.2s), then
+        auto-close + refresh table.
+      </p>
+      <div class="frame">
+        <header class="topbar">
+          <div class="brand-cluster">
+            <span class="brand">
+              <svg class="logo" viewBox="0 0 9 10" fill="currentColor" shape-rendering="crispEdges" aria-hidden="true">
+                <rect x="4" y="0" width="1" height="1" /><rect x="3" y="1" width="3" height="1" /><rect x="2" y="2" width="5" height="1" /><rect x="3" y="3" width="3" height="1" /><rect x="2" y="4" width="5" height="1" /><rect x="1" y="5" width="7" height="1" /><rect x="2" y="6" width="5" height="1" /><rect x="1" y="7" width="7" height="1" /><rect x="0" y="8" width="9" height="1" /><rect x="3" y="9" width="3" height="1" />
+              </svg>
+              <span class="name">First Tree <span class="light">Hub</span></span>
+            </span>
+          </div>
+          <nav class="tabs">
+            <span class="tab">Workspace</span><span class="tab">Agents</span>
+            <span class="tab active">Computers <span class="kbd">⌘3</span></span><span class="tab">Settings</span>
+          </nav>
+          <div class="controls"><span class="avatar">YZ</span></div>
+        </header>
+
+        <div class="modal-stage">
+          <div class="modal">
+            <h3>Connect a new computer</h3>
+            <p class="desc">Run this command on the machine you want to pair with this Hub.</p>
+            <div class="cmd-row">
+              <code class="cmd"
+                >first-tree-hub connect <span style="color:var(--fg);">eyJhbGciOi…iY4WX</span>
+                <span class="expiry"># expires in 10m</span></code
+              >
+              <button class="btn outline copy-btn" type="button">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                Copied
+              </button>
+            </div>
+            <p class="meta">Single-use · regenerates the previous one.</p>
+
+            <div class="success">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>
+              <span><strong style="font-weight:600;">yue-mbp-16</strong>&nbsp;connected. Closing…</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- =================== Behavioural notes =================== -->
+      <div class="legend">
+        <strong>Decisions reflected in this iteration</strong>
+        <ul style="margin: 8px 0 0 0; padding-left: 18px;">
+          <li>
+            <strong>Pulsing dot</strong> — exact same DOM pattern as <code>StateDot.working</code>: solid circle +
+            absolute ring with <code>animation: ring-pulse 1.8s infinite</code>. Only the colour token changes
+            (<code>--state-error</code>).
+          </li>
+          <li><strong>No icon</strong> — chip is dot + text only.</li>
+          <li>
+            <strong>Copy</strong> — single: <code>"&lt;host&gt; disconnected"</code>; multi:
+            <code>"&lt;n&gt; computers disconnected"</code>.
+          </li>
+          <li>
+            <strong>Hostname max-width</strong> — 160px, <code>text-overflow: ellipsis</code>; full hostname surfaces in
+            the chip's <code>title</code> tooltip.
+          </li>
+          <li>
+            <strong>Tab centring</strong> — topbar grid changed from <code>auto&nbsp;1fr&nbsp;auto</code> to
+            <code>1fr&nbsp;auto&nbsp;1fr</code>. Tabs always sit at the page centre regardless of how the brand cluster
+            grows. The dashed green guide line in each frame proves this.
+          </li>
+          <li>
+            <strong>Waiting / success colours</strong> — yellow <code>--state-blocked</code> (warn) for waiting,
+            green <code>--state-idle</code> (ok) for success. Both via <code>color-mix</code> so they sit on the same
+            soft-pastel scale as other inline states.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/computer-disconnect-spec.md
+++ b/docs/design/computer-disconnect-spec.md
@@ -1,0 +1,420 @@
+# Computer Disconnect Awareness — Technical Spec
+
+**Status:** ready for implementation
+**UI preview:** `docs/design/computer-disconnect-preview.html`
+**Owner:** YueZengwu
+**Date:** 2026-04-29
+
+---
+
+## 1. Problem
+
+When the local computer (a First Tree Hub Client process) loses its WebSocket connection, every agent pinned to that computer goes offline. The product surface gives no prominent signal — the user only finds out when an agent fails to respond. The Computers page (`/clients`) is the place to recover, but the user has no reason to visit it until they already notice things are broken.
+
+## 2. Goals
+
+| # | Goal |
+|---|---|
+| G1 | A persistent, **prominent** topbar warning whenever the **caller's own** Client process is disconnected and still has agents bound to it. |
+| G2 | One-click jump from the warning to the Computers page so the user can fix the connection. |
+| G3 | Replace the embedded "Connect a computer" strip with an explicit `New Connection +` button that opens a modal mirroring the OnboardingModal flow (token + waiting state + auto-detect). |
+
+## 3. Non-goals
+
+- No new WebSocket events, no realtime push. The existing 10s polling on `["clients"]` is the freshness budget.
+- No backend schema change, no new API endpoints.
+- The `OnboardingModal` first-run wizard is **not touched** — it continues to greet brand-new accounts. The new dialog is a separate surface for the steady state.
+- Cross-member visibility is out of scope: even an admin only sees their own disconnected machines in the topbar chip.
+
+## 4. UX summary
+
+Reflected in detail by `computer-disconnect-preview.html`. Headlines:
+
+- **Topbar chip** — sits inside the brand cluster (right of `First Tree Hub`). Pulsing red dot + text. No icon. Hostname truncates at 160px with ellipsis; full name in the `title` tooltip.
+- **Copy** — single: `<host> disconnected`; multi: `<n> computers disconnected`.
+- **Trigger** — one or more clients owned by the current user with `status="disconnected"` AND `agentCount > 0`.
+- **Click target** — `navigate("/clients")`.
+- **Tab centring** — topbar grid changes from `auto 1fr auto` to `1fr auto 1fr`. Tabs sit in the centre `auto` column; left and right `1fr` columns absorb growth so tabs stay anchored to the page midpoint regardless of chip presence or future additions.
+- **`New Connection +` button** — primary CTA, right-aligned above the registered table, replacing the entire `ConnectStrip` row.
+- **Dialog** — title + description, generated command in mono code block, `Copy` button, `Cancel` ghost button. Initially shows yellow `Waiting for your computer to connect…` row. On detection, swaps to green success row, briefly holds (~1.2s), auto-closes, refetches the table.
+
+## 5. Architecture
+
+### 5.1 Data sources (existing, unchanged)
+
+| Endpoint | Purpose | Existing polling |
+|---|---|---|
+| `GET /api/v1/clients` | List of `HubClient` rows visible to the caller, including `status`, `agentCount`, `userId` | 10s `refetchInterval` from `pages/clients.tsx` |
+| `POST /api/v1/connect-tokens` | Mints a single-use connect token + ready-made command string | n/a |
+
+The topbar chip and the new dialog **both** consume the same `["clients"]` query. We enable that query from `Layout` via the React Query hook so it refetches once (10s cadence) for the whole app, regardless of which page is active.
+
+### 5.2 Trigger logic (frontend-only)
+
+```
+disconnected = clients.filter(c =>
+   c.userId === currentUser.id &&    // strictly caller's own — admin role does not widen this
+   c.status === "disconnected" &&
+   c.agentCount > 0
+)
+
+show chip          ← disconnected.length >= 1
+copy single        ← `${disconnected[0].hostname ?? "computer"} disconnected`
+copy multi (n>=2)  ← `${disconnected.length} computers disconnected`
+```
+
+`currentUser.id` comes from `useAuth()` → `user.id`. If `user` is null (auth context still warming up) the chip stays hidden.
+
+### 5.3 Failure mode
+
+Up to 10s lag between the WS close and the chip appearing — acceptable for "your computer is gone, please reconnect." If we ever want sub-second feedback, the follow-up is a `client:state` payload broadcast through the existing `broadcastToAdmins` seam (out of scope here).
+
+---
+
+## 6. Frontend change set
+
+### 6.1 New: `packages/web/src/hooks/use-disconnected-computers.ts`
+
+A small hook wrapping the existing `["clients"]` query so both the Layout and the Computers page consume the same cache entry. Returns the filtered list and prefetches it from `Layout` even when the user is not on `/clients`.
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import { listClients, type HubClient } from "../api/activity.js";
+import { useAuth } from "../auth/auth-context.js";
+
+export function useDisconnectedComputers(): { rows: HubClient[]; firstHostname: string | null } {
+  const { user } = useAuth();
+  const { data } = useQuery({
+    queryKey: ["clients"],
+    queryFn: listClients,
+    refetchInterval: 10_000,
+    enabled: !!user,
+  });
+  if (!data || !user) return { rows: [], firstHostname: null };
+  const rows = data.filter((c) => c.userId === user.id && c.status === "disconnected" && c.agentCount > 0);
+  return { rows, firstHostname: rows[0]?.hostname ?? null };
+}
+```
+
+The hook is thin on purpose — it is only the chip's read path and a place to keep the filter rule in one spot. The dialog and the Computers page already use the same query directly, so they automatically share the cache.
+
+### 6.2 New: `packages/web/src/components/disconnect-chip.tsx`
+
+The chip itself. ~50 lines. Uses the shared `StateDot` styling pattern (solid circle + ring-pulse) but inlined — `StateDot.error` is a triangle, not a pulsing dot, so we don't reuse it directly. The pulse keyframe (`ring-pulse`) is already defined in `index.css` and used by `StateDot.working`; we reuse the keyframe and just swap the colour.
+
+```tsx
+import { useNavigate } from "react-router";
+import { useDisconnectedComputers } from "../hooks/use-disconnected-computers.js";
+
+const HOSTNAME_MAX_PX = 160;
+
+export function DisconnectChip() {
+  const navigate = useNavigate();
+  const { rows, firstHostname } = useDisconnectedComputers();
+  if (rows.length === 0) return null;
+
+  const fullTitle =
+    rows.length === 1
+      ? `${firstHostname ?? "Your computer"} is disconnected. Click to manage.`
+      : `${rows.length} computers disconnected. Click to manage.`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate("/clients")}
+      title={fullTitle}
+      className="inline-flex items-center cursor-pointer"
+      style={{
+        gap: 8,
+        height: 26,
+        padding: "0 10px 0 9px",
+        borderRadius: 999,
+        fontSize: 12.5,
+        fontWeight: 500,
+        letterSpacing: "-0.1px",
+        border: 0,
+        outline: "var(--hairline) solid color-mix(in oklch, var(--state-error) 38%, transparent)",
+        outlineOffset: -1,
+        background: "color-mix(in oklch, var(--state-error) 14%, transparent)",
+        color: "color-mix(in oklch, var(--state-error) 80%, var(--fg))",
+      }}
+    >
+      <PulseDot />
+      {rows.length === 1 ? (
+        <span className="inline-flex items-center" style={{ gap: 5, minWidth: 0 }}>
+          <span
+            className="mono"
+            style={{
+              fontSize: 12,
+              fontWeight: 500,
+              maxWidth: HOSTNAME_MAX_PX,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "color-mix(in oklch, var(--state-error) 60%, var(--fg))",
+            }}
+          >
+            {firstHostname ?? "computer"}
+          </span>
+          <span style={{ flexShrink: 0 }}>disconnected</span>
+        </span>
+      ) : (
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          <strong style={{ fontWeight: 600 }}>{rows.length}</strong> computers disconnected
+        </span>
+      )}
+    </button>
+  );
+}
+
+function PulseDot() {
+  return (
+    <span aria-hidden="true" style={{ position: "relative", width: 8, height: 8, flexShrink: 0, display: "inline-block" }}>
+      <span style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--state-error)" }} />
+      <span
+        style={{
+          position: "absolute",
+          inset: -3,
+          borderRadius: "50%",
+          border: "var(--hairline) solid var(--state-error)",
+          animation: "ring-pulse 1.8s infinite",
+          opacity: 0.6,
+        }}
+      />
+    </span>
+  );
+}
+```
+
+### 6.3 Edit: `packages/web/src/components/layout.tsx`
+
+Two changes:
+
+1. **Grid columns** `auto 1fr auto` → `1fr auto 1fr`. Brand cluster is `justify-self: start`; tabs `justify-self: center`; right controls `justify-self: end`. This locks tab centring to the page midpoint.
+2. **Wrap brand + chip in a flex cluster.** Add the new `DisconnectChip` immediately right of the brand `<span>`.
+
+Diff against `layout.tsx:46-66`:
+
+```diff
+       <header
+         className="relative shrink-0 grid items-center"
+         style={{
+           height: 48,
+-          gridTemplateColumns: "auto 1fr auto",
++          gridTemplateColumns: "1fr auto 1fr",
++          gap: 12,
+           padding: "0 var(--sp-3)",
+           borderBottom: "var(--hairline) solid var(--border)",
+           background: "var(--bg-raised)",
+         }}
+       >
+-        {/* Brand */}
+-        <div className="flex items-center" style={{ gap: 10 }}>
+-          <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
+-          <span className="text-title" style={{ color: "var(--fg)" }}>
+-            First Tree{" "}
+-            <span className="font-normal" style={{ color: "var(--fg-3)" }}>
+-              Hub
+-            </span>
+-          </span>
+-        </div>
++        {/* Brand cluster */}
++        <div className="flex items-center" style={{ gap: 14, justifySelf: "start", minWidth: 0 }}>
++          <span className="flex items-center" style={{ gap: 10, flexShrink: 0 }}>
++            <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
++            <span className="text-title" style={{ color: "var(--fg)" }}>
++              First Tree{" "}
++              <span className="font-normal" style={{ color: "var(--fg-3)" }}>
++                Hub
++              </span>
++            </span>
++          </span>
++          <DisconnectChip />
++        </div>
+```
+
+The existing `pointerEvents: "none"` trick on the tabs `<nav>` (line 69) stays; tabs add `style={{ justifySelf: "center" }}` and the right-controls block adds `justifySelf: "end"` so the grid columns settle predictably.
+
+### 6.4 New: `packages/web/src/pages/clients/new-connection-dialog.tsx`
+
+Co-located under a new `pages/clients/` folder so `clients.tsx` shrinks. The dialog wraps the existing Radix `Dialog` primitive (`components/ui/dialog.tsx`).
+
+Behaviour outline:
+
+```tsx
+type Phase = "loading" | "waiting" | "success";
+
+const POLL_MS = 3_000;
+const SUCCESS_HOLD_MS = 1_200;
+
+export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (next: boolean) => void }) {
+  const queryClient = useQueryClient();
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [token, setToken] = useState<ConnectTokenResponse | null>(null);
+  const [newHostname, setNewHostname] = useState<string | null>(null);
+  const baselineRef = useRef<Set<string>>(new Set());
+
+  // 1. On open: snapshot current clientIds, mint a token.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setPhase("loading");
+    setToken(null);
+    setNewHostname(null);
+
+    (async () => {
+      const existing = (queryClient.getQueryData<HubClient[]>(["clients"]) ?? []).map((c) => c.id);
+      baselineRef.current = new Set(existing);
+      try {
+        const t = await generateConnectToken();
+        if (!cancelled) {
+          setToken(t);
+          setPhase("waiting");
+        }
+      } catch {
+        // surface inline; user can cancel + retry
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [open, queryClient]);
+
+  // 2. While waiting: poll /clients every 3s, watch for a new id with status=connected.
+  useEffect(() => {
+    if (!open || phase !== "waiting") return;
+    const tick = async () => {
+      const fresh = await queryClient.fetchQuery({ queryKey: ["clients"], queryFn: listClients });
+      const baseline = baselineRef.current;
+      const arrived = fresh.find((c) => !baseline.has(c.id) && c.status === "connected");
+      if (arrived) {
+        setNewHostname(arrived.hostname ?? null);
+        setPhase("success");
+      }
+    };
+    const handle = setInterval(tick, POLL_MS);
+    return () => clearInterval(handle);
+  }, [open, phase, queryClient]);
+
+  // 3. On success: brief hold, then close.
+  useEffect(() => {
+    if (phase !== "success") return;
+    const handle = setTimeout(() => onOpenChange(false), SUCCESS_HOLD_MS);
+    return () => clearTimeout(handle);
+  }, [phase, onOpenChange]);
+
+  // … render: title/desc, mono command + Copy button, waiting/success row, Cancel.
+}
+```
+
+Notes:
+- The dialog **does not** consume the running `["clients"]` query from `useQuery` — it calls `queryClient.fetchQuery` on its own 3s tick to keep its faster cadence isolated. The shared 10s `refetchInterval` continues independently; both routes write into the same cache so the table refresh is free.
+- `baselineRef` snapshots **all** client ids (regardless of status), so a previously-known computer that reconnects does **not** falsely close the dialog. Only a brand-new id with `status="connected"` triggers success.
+- If the user closes the dialog before a new client appears, the unused token simply expires server-side (TTL is the existing `connect-tokens` setting; nothing to clean up).
+
+### 6.5 Edit: `packages/web/src/pages/clients.tsx`
+
+1. **Delete** the entire `ConnectStrip` function and its render call (`clients.tsx:41-104, 182`).
+2. **Add** a `New Connection +` button in its place, right-aligned above the table:
+
+```tsx
+<div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "var(--sp-3_5)" }}>
+  <Button onClick={() => setNewConnectionOpen(true)}>
+    <Plus className="h-3.5 w-3.5" /> New Connection
+  </Button>
+</div>
+
+<NewConnectionDialog open={newConnectionOpen} onOpenChange={setNewConnectionOpen} />
+```
+
+3. **Drop** the `Terminal`, `Copy`, `Check` imports from `lucide-react` if no longer used elsewhere in this file. Add `Plus`.
+4. **Drop** the unused `generateConnectToken` and `ConnectTokenResponse` imports from `../api/activity.js` (now used only inside the dialog).
+5. The table's empty-state copy `No computers. Use the button above to generate a connect command.` stays — it points at the new button.
+
+---
+
+## 7. Backend
+
+**No changes.** All four touch-points already exist:
+
+- `GET /api/v1/clients` (`packages/server/src/api/admin/clients.ts:18-36`)
+- `POST /api/v1/connect-tokens` (`packages/server/src/api/me.ts:97-112`)
+- `clients.status` flips to `"disconnected"` in the WS close handler (`packages/server/src/api/agent/ws-client.ts:594-601`)
+- The existing 10s React Query poll is the freshness mechanism
+
+If we later move to push-based updates, the seam is `broadcastToAdmins({ type: "client:state", clientId, status, organizationId })` from `clients.ts`'s register/disconnect paths — but that is explicitly out of scope.
+
+---
+
+## 8. Edge cases
+
+| Case | Behaviour |
+|---|---|
+| User has 0 clients | Chip hidden. New Connection button reachable from the (now empty) Computers page. |
+| User has only `agentCount === 0` clients, all disconnected | Chip hidden. Computers page table still shows them with `offline` status — they can disconnect/retire from there. |
+| Multiple disconnected (single user) | Multi copy: `2 computers disconnected`. Click → `/clients`. |
+| Admin viewing teammate's offline computer | No chip — filter is strictly `userId === user.id`. Admin still sees the row in the table because `listClients` returns org-scoped data for admin role. |
+| `user` is null (auth warming up) | Hook returns `rows: []`, chip hidden. |
+| Hostname is null | Chip falls back to `"computer disconnected"` (drop the leading mono span). |
+| Hostname is 80 chars | Truncates at `max-width: 160px` with ellipsis; full name in `title` tooltip. |
+| Dialog closed before reconnect | Token sits unused, expires on its existing TTL. No client-side state to clean up. |
+| Dialog open while a *different* computer reconnects | New computer satisfies the `!baseline.has(id) && status==="connected"` test → success closes. This is the intended behaviour: the user wanted *a* computer connected; they got one. |
+| User cancels while polling | `setInterval` cleared via the cleanup return in the effect — no leaking timer. |
+| Network error on `POST /connect-tokens` | Phase stays at `loading`. Inline error row to be added; Cancel still closes the dialog. |
+
+---
+
+## 9. Test plan
+
+### 9.1 Type + lint
+- `pnpm check && pnpm typecheck` after every edit.
+
+### 9.2 Manual verification (against an isolated `FIRST_TREE_HUB_HOME` per CLAUDE.md)
+
+1. Start the hub + web server. Connect one client. Confirm topbar shows no chip.
+2. Pin an agent to that client. Kill the client process (`pkill -f first-tree-hub`).
+3. Within ~10s, the topbar chip appears with `<host> disconnected`. Verify pulsing dot animates.
+4. Click the chip — should land on `/clients`. Verify the row's `Status` cell reads `offline`.
+5. Reconnect the client. Within ~10s the chip disappears.
+6. Pin a second agent on a second machine; disconnect both. Confirm chip reads `2 computers disconnected`.
+7. Click `New Connection +` on `/clients`. The modal opens with the command inline + yellow `Waiting…` row. Run the command on a fresh machine. The modal flips to green, says `<host> connected. Closing…`, auto-closes within ~1.2s, and the table refreshes to show the new row.
+8. Repeat (7) but cancel before the client connects — modal closes cleanly, no errors in console.
+
+### 9.3 Visual regression
+Cross-check against `docs/design/computer-disconnect-preview.html`:
+- A: single chip + tabs centred (against guide line)
+- A2: long hostname truncates with ellipsis
+- B: multi-count chip + tabs still centred
+- C: no chip + tabs in identical centre position
+- D: ConnectStrip absent, New Connection button present
+- E/F: dialog yellow→green transition
+
+### 9.4 Unit tests (additive, not blocking)
+- `use-disconnected-computers.test.tsx` — filter rule: respects `userId === current`, status === disconnected, agentCount > 0; returns empty when user is null.
+- `disconnect-chip.test.tsx` — copy switches at n=1 vs n>=2; click invokes `navigate("/clients")`; truncation applies via `title` attr.
+
+The existing `clients.test.tsx` (if any) needs updating to drop ConnectStrip assertions and add `New Connection` button + dialog mount checks.
+
+---
+
+## 10. Out of scope / follow-ups
+
+- **Realtime push** of client connect/disconnect via `broadcastToAdmins`. The current 10s lag is acceptable; we can add this when it becomes a clear pain point.
+- **Cross-member visibility** for admins (e.g. "3 of your team's computers are offline"). Possible future feature but explicitly excluded here per decision F.
+- **Highlighting the offending row** when arriving at `/clients` from the chip (e.g. `?focus=<id>` query param). Listed as a nice-to-have in the preview doc; deferred so this PR stays scoped.
+- **Auth-method-specific reconnect hints** (e.g. SDK missing → install hint inline in the chip popover). The expanded row's CapabilityMatrix already covers this once the user is on `/clients`.
+
+---
+
+## 11. File-by-file change summary
+
+| File | Action | Notes |
+|---|---|---|
+| `packages/web/src/hooks/use-disconnected-computers.ts` | **new** | shared filter rule + cache-friendly read |
+| `packages/web/src/components/disconnect-chip.tsx` | **new** | the topbar chip |
+| `packages/web/src/components/layout.tsx` | edit | grid `auto 1fr auto` → `1fr auto 1fr`; mount `<DisconnectChip />` next to brand |
+| `packages/web/src/pages/clients/new-connection-dialog.tsx` | **new** | the modal flow |
+| `packages/web/src/pages/clients.tsx` | edit | remove `ConnectStrip`; add `New Connection +` button + `<NewConnectionDialog />` |
+| `docs/design/computer-disconnect-preview.html` | **new (already landed)** | design preview, referenced from the PR description |
+| `docs/design/computer-disconnect-spec.md` | **new (this file)** | the technical spec |
+
+Total: 4 edits, 4 new files (2 of which are docs). No backend, no shared schema, no DB migration.

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -1,0 +1,178 @@
+import { Check, Copy } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { Button } from "./ui/button.js";
+
+export type ConnectPhase = "loading" | "waiting" | "success" | "error";
+
+type ConnectCommandPanelProps = {
+  /** Full command to display + copy. `null` shows the "Generating token…" placeholder. */
+  command: string | null;
+  /** Optional expiry hint shown after the command (e.g. `# expires in 10m`). */
+  expiresInSeconds?: number;
+  /** Drives the inline status row below the command. */
+  phase: ConnectPhase;
+  /** Override the copy button labels. Default: `Copy` / `Copied`. */
+  copyLabel?: { idle: string; done: string };
+  /** Override the waiting copy. Default: `Waiting for your computer to connect…`. */
+  waitingText?: ReactNode;
+  /** Content of the green success row. Omit to skip the green row entirely (e.g. when the host transitions to a different step on success). */
+  successContent?: ReactNode;
+  /** Content of the red error row. Omit to skip. */
+  errorContent?: ReactNode;
+  /** Caption under the command block. Default: `Single-use · regenerates the previous one.`. */
+  caption?: ReactNode;
+};
+
+const COPY_FEEDBACK_MS = 1_500;
+
+/**
+ * Shared panel for "run this CLI command on the machine you want to pair"
+ * surfaces. Used by the onboarding wizard's connect step and the
+ * `New Connection +` modal on /clients — both render the same code block,
+ * Copy button, and yellow→green status rows so the visual vocabulary stays
+ * unified across the app.
+ *
+ * Polling and end-state semantics are intentionally NOT in this component:
+ *   - Onboarding polls `/me` for the wizard to advance, then transitions
+ *     to a different step (no green row needed).
+ *   - The `/clients` modal polls `/clients` for a new id and shows the
+ *     green row briefly before auto-closing.
+ *
+ * The host owns the phase machine; this panel just renders it.
+ */
+export function ConnectCommandPanel({
+  command,
+  expiresInSeconds,
+  phase,
+  copyLabel = { idle: "Copy", done: "Copied" },
+  waitingText = "Waiting for your computer to connect…",
+  successContent,
+  errorContent,
+  caption = "Single-use · regenerates the previous one.",
+}: ConnectCommandPanelProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (): Promise<void> => {
+    if (!command) return;
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  };
+
+  const expiryMinutes = expiresInSeconds !== undefined ? Math.max(1, Math.round(expiresInSeconds / 60)) : null;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+      <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+        <pre
+          className="mono text-label flex-1"
+          style={{
+            margin: 0,
+            padding: "var(--sp-2_5) var(--sp-3)",
+            background: "var(--bg-sunken)",
+            border: "var(--hairline) solid var(--border-faint)",
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg-2)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+            overflowWrap: "anywhere",
+            minWidth: 0,
+          }}
+          title={command ?? ""}
+        >
+          {command ? (
+            <>
+              {command}
+              {expiryMinutes !== null && <span style={{ color: "var(--fg-4)" }}> # expires in {expiryMinutes}m</span>}
+            </>
+          ) : (
+            "Generating token…"
+          )}
+        </pre>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleCopy}
+          disabled={!command}
+          style={{ alignSelf: "flex-start" }}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? copyLabel.done : copyLabel.idle}
+        </Button>
+      </div>
+
+      {caption && (
+        <p className="text-label" style={{ color: "var(--fg-4)", margin: 0 }}>
+          {caption}
+        </p>
+      )}
+
+      {phase === "waiting" && (
+        <div
+          className="flex items-center text-body"
+          style={{
+            gap: "var(--sp-2_5)",
+            padding: "var(--sp-2_5) var(--sp-3)",
+            background: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",
+            border: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 35%, transparent)",
+            borderRadius: "var(--radius-input)",
+            color: "color-mix(in oklch, var(--state-blocked) 35%, var(--fg))",
+          }}
+        >
+          <WaitingSpinner />
+          {waitingText}
+        </div>
+      )}
+
+      {phase === "success" && successContent && (
+        <div
+          className="flex items-center text-body"
+          style={{
+            gap: "var(--sp-2_5)",
+            padding: "var(--sp-2_5) var(--sp-3)",
+            background: "color-mix(in oklch, var(--state-idle) 14%, transparent)",
+            border: "var(--hairline) solid color-mix(in oklch, var(--state-idle) 35%, transparent)",
+            borderRadius: "var(--radius-input)",
+            color: "color-mix(in oklch, var(--state-idle) 45%, var(--fg))",
+          }}
+        >
+          <Check className="h-3.5 w-3.5" style={{ flexShrink: 0 }} />
+          <span style={{ minWidth: 0 }}>{successContent}</span>
+        </div>
+      )}
+
+      {phase === "error" && errorContent && (
+        <div
+          className="text-body"
+          style={{
+            padding: "var(--sp-2_5) var(--sp-3)",
+            background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+            border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
+            borderRadius: "var(--radius-input)",
+            color: "var(--state-error)",
+          }}
+        >
+          {errorContent}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WaitingSpinner() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 12,
+        height: 12,
+        flexShrink: 0,
+        borderRadius: "50%",
+        border: "var(--hairline-bold) solid color-mix(in oklch, var(--state-blocked) 30%, transparent)",
+        borderTopColor: "var(--state-blocked)",
+        animation: "spin 0.85s linear infinite",
+      }}
+    />
+  );
+}

--- a/packages/web/src/components/disconnect-chip.tsx
+++ b/packages/web/src/components/disconnect-chip.tsx
@@ -1,0 +1,98 @@
+import { useNavigate } from "react-router";
+import { useDisconnectedComputers } from "../hooks/use-disconnected-computers.js";
+
+const HOSTNAME_MAX_PX = 160;
+
+/**
+ * Topbar warning chip — surfaces in `Layout` whenever any of the caller's
+ * own computers is disconnected and still has agents bound. Click jumps to
+ * `/clients`. Renders nothing in the healthy case so the topbar stays clean.
+ */
+export function DisconnectChip() {
+  const navigate = useNavigate();
+  const { rows, firstHostname } = useDisconnectedComputers();
+  if (rows.length === 0) return null;
+
+  const isMulti = rows.length > 1;
+  const tooltip = isMulti
+    ? `${rows.length} computers disconnected. Click to manage.`
+    : `${firstHostname ?? "Your computer"} is disconnected. Click to manage.`;
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate("/clients")}
+      title={tooltip}
+      aria-label={tooltip}
+      className="inline-flex items-center cursor-pointer text-body font-medium"
+      style={{
+        gap: 8,
+        height: 26,
+        padding: "0 var(--sp-2_5) 0 var(--sp-2_25)",
+        borderRadius: 999,
+        border: 0,
+        outline: "var(--hairline) solid color-mix(in oklch, var(--state-error) 38%, transparent)",
+        outlineOffset: -1,
+        background: "color-mix(in oklch, var(--state-error) 14%, transparent)",
+        color: "color-mix(in oklch, var(--state-error) 80%, var(--fg))",
+        minWidth: 0,
+      }}
+    >
+      <PulseDot />
+      {isMulti ? (
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          <span className="font-semibold">{rows.length}</span> computers disconnected
+        </span>
+      ) : (
+        <span className="inline-flex items-center" style={{ gap: 5, minWidth: 0 }}>
+          <span
+            className="mono text-label font-medium"
+            style={{
+              maxWidth: HOSTNAME_MAX_PX,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "color-mix(in oklch, var(--state-error) 60%, var(--fg))",
+            }}
+          >
+            {firstHostname ?? "computer"}
+          </span>
+          <span style={{ flexShrink: 0 }}>disconnected</span>
+        </span>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Mirrors `StateDot.working`'s DOM (solid dot + absolutely-positioned
+ * expanding ring sharing the `ring-pulse` keyframe in index.css). Only the
+ * colour token differs — we want the same visual vocabulary, not a new one.
+ */
+function PulseDot() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{ position: "relative", width: 8, height: 8, flexShrink: 0, display: "inline-block" }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          background: "var(--state-error)",
+        }}
+      />
+      <span
+        style={{
+          position: "absolute",
+          inset: -3,
+          borderRadius: "50%",
+          border: "var(--hairline) solid var(--state-error)",
+          animation: "ring-pulse 1.8s infinite",
+          opacity: 0.6,
+        }}
+      />
+    </span>
+  );
+}

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -4,6 +4,7 @@ import { NavLink, Outlet, useLocation } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
+import { DisconnectChip } from "./disconnect-chip.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { NotificationBell } from "./notification-bell.js";
 import { OnboardingBanner } from "./onboarding-banner.js";
@@ -48,26 +49,33 @@ export function Layout() {
         className="relative shrink-0 grid items-center"
         style={{
           height: 48,
-          gridTemplateColumns: "auto 1fr auto",
+          // 1fr auto 1fr keeps the centre column (tabs) anchored to the
+          // page midpoint regardless of how the brand cluster grows. The
+          // disconnect chip can appear/disappear without shifting tabs.
+          gridTemplateColumns: "1fr auto 1fr",
+          gap: "var(--sp-3)",
           padding: "0 var(--sp-3)",
           borderBottom: "var(--hairline) solid var(--border)",
           background: "var(--bg-raised)",
         }}
       >
-        {/* Brand */}
-        <div className="flex items-center" style={{ gap: 10 }}>
-          <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
-          {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
-          <span className="text-title" style={{ color: "var(--fg)" }}>
-            First Tree{" "}
-            <span className="font-normal" style={{ color: "var(--fg-3)" }}>
-              Hub
+        {/* Brand cluster: logo + name welded together, then the optional chip. */}
+        <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
+          <span className="flex items-center" style={{ gap: 10, flexShrink: 0 }}>
+            <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
+            {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
+            <span className="text-title" style={{ color: "var(--fg)" }}>
+              First Tree{" "}
+              <span className="font-normal" style={{ color: "var(--fg-3)" }}>
+                Hub
+              </span>
             </span>
           </span>
+          <DisconnectChip />
         </div>
 
         {/* Tabs */}
-        <nav className="flex justify-center" style={{ gap: 2, pointerEvents: "none" }}>
+        <nav className="flex" style={{ gap: 2, pointerEvents: "none", justifySelf: "center" }}>
           {tabs.map((tab) => (
             <NavLink
               key={tab.to}
@@ -98,7 +106,7 @@ export function Layout() {
         </nav>
 
         {/* Right controls */}
-        <div className="flex items-center" style={{ gap: 6 }}>
+        <div className="flex items-center" style={{ gap: 6, justifySelf: "end" }}>
           <button
             type="button"
             onClick={() => setPaletteOpen(true)}

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -5,6 +5,7 @@ import { createAgentChat } from "../api/chats.js";
 import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { useOnboardingState } from "../hooks/use-onboarding-state.js";
+import { ConnectCommandPanel } from "./connect-command-panel.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog.js";
 import { Input } from "./ui/input.js";
@@ -46,7 +47,6 @@ export function OnboardingModal() {
   const [localStep, setLocalStep] = useState<"name" | "connect" | "creating">("name");
   const [token, setToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
   // Reset local state on open. Server-driven `step` may already be
   // `create_agent` (returning user with a connected client) — we still
@@ -164,7 +164,7 @@ export function OnboardingModal() {
 
   const cliCommand = token
     ? `npm install -g @agent-team-foundation/first-tree-hub\nfirst-tree-hub connect ${token}`
-    : "Generating token…";
+    : null;
 
   return (
     <Dialog open={modalOpen} onOpenChange={(next) => !next && closeModal()}>
@@ -180,7 +180,9 @@ export function OnboardingModal() {
           </DialogDescription>
         </DialogHeader>
 
-        {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+        {error && localStep !== "connect" && (
+          <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+        )}
 
         {localStep === "name" && (
           <form className="space-y-3" onSubmit={onSubmitName}>
@@ -201,38 +203,14 @@ export function OnboardingModal() {
         )}
 
         {localStep === "connect" && (
-          <div className="space-y-3" style={{ minWidth: 0, maxWidth: "100%" }}>
-            <div style={{ width: "100%", overflow: "hidden", minWidth: 0 }}>
-              <pre
-                className="rounded-md bg-muted p-3 text-label font-mono"
-                style={{
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-all",
-                  overflowWrap: "anywhere",
-                  width: "100%",
-                  minWidth: 0,
-                  boxSizing: "border-box",
-                  margin: 0,
-                }}
-              >
-                {cliCommand}
-              </pre>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={!token}
-              onClick={() => {
-                if (!token) return;
-                void navigator.clipboard.writeText(cliCommand);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1500);
-              }}
-            >
-              {copied ? "Copied!" : "Copy commands"}
-            </Button>
-            <p className="text-label text-muted-foreground">Waiting for your computer to check in…</p>
-          </div>
+          <ConnectCommandPanel
+            command={cliCommand}
+            phase={error ? "error" : "waiting"}
+            copyLabel={{ idle: "Copy commands", done: "Copied" }}
+            waitingText="Waiting for your computer to check in…"
+            errorContent={error}
+            caption={null}
+          />
         )}
 
         {localStep === "creating" && <p className="text-body text-muted-foreground">Creating your agent…</p>}

--- a/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
+++ b/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { HubClient } from "../../api/activity.js";
+import { selectDisconnectedComputers } from "../use-disconnected-computers.js";
+
+/**
+ * Pure-function unit tests for the topbar disconnect-chip filter rule.
+ * The hook itself wires the same helper into React Query — the visual /
+ * behavioural surface is covered by manual e2e (see plan §Verification.B).
+ */
+
+const ME = "user-me";
+const OTHER = "user-other";
+
+function client(overrides: Partial<HubClient>): HubClient {
+  return {
+    id: overrides.id ?? "client-1",
+    userId: ME,
+    status: "disconnected",
+    sdkVersion: "v1.0.0",
+    hostname: "host",
+    os: "macOS",
+    agentCount: 1,
+    connectedAt: null,
+    lastSeenAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("selectDisconnectedComputers", () => {
+  it("returns empty for an empty list", () => {
+    expect(selectDisconnectedComputers([], ME)).toEqual([]);
+  });
+
+  it("returns empty when userId is the empty string (auth not warm)", () => {
+    expect(selectDisconnectedComputers([client({})], "")).toEqual([]);
+  });
+
+  it("includes a row that matches user + status=disconnected + agentCount > 0", () => {
+    const c = client({ id: "match" });
+    expect(selectDisconnectedComputers([c], ME)).toEqual([c]);
+  });
+
+  it("excludes rows owned by another user (admin role does not widen scope)", () => {
+    const mine = client({ id: "mine" });
+    const theirs = client({ id: "theirs", userId: OTHER });
+    expect(selectDisconnectedComputers([mine, theirs], ME)).toEqual([mine]);
+  });
+
+  it("excludes rows whose status is connected", () => {
+    const offline = client({ id: "offline" });
+    const online = client({ id: "online", status: "connected" });
+    expect(selectDisconnectedComputers([offline, online], ME)).toEqual([offline]);
+  });
+
+  it("excludes rows with no bound agents (no-op fleet — not a 'product unusable' case)", () => {
+    const used = client({ id: "used", agentCount: 2 });
+    const unused = client({ id: "unused", agentCount: 0 });
+    expect(selectDisconnectedComputers([used, unused], ME)).toEqual([used]);
+  });
+
+  it("preserves input order across mixed lists", () => {
+    const a = client({ id: "a", hostname: "alpha" });
+    const skip = client({ id: "skip", status: "connected" });
+    const b = client({ id: "b", hostname: "bravo" });
+    expect(selectDisconnectedComputers([a, skip, b], ME).map((c) => c.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/web/src/hooks/use-disconnected-computers.ts
+++ b/packages/web/src/hooks/use-disconnected-computers.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { type HubClient, listClients } from "../api/activity.js";
+import { useAuth } from "../auth/auth-context.js";
+
+export type DisconnectedSummary = {
+  rows: HubClient[];
+  firstHostname: string | null;
+};
+
+/**
+ * Pure filter rule. Exported so the unit test can pin the contract — drift
+ * here changes when the topbar warning shows up. Scope is strictly the
+ * caller's own clients (no admin widening); only computers that were
+ * actively serving agents and are now offline qualify.
+ */
+export function selectDisconnectedComputers(clients: HubClient[], userId: string): HubClient[] {
+  if (!userId) return [];
+  return clients.filter((c) => c.userId === userId && c.status === "disconnected" && c.agentCount > 0);
+}
+
+/**
+ * Topbar-side read of `["clients"]`. Shares the cache with `ClientsPage`
+ * (same query key + queryFn + refetchInterval) so the 10s poll runs once
+ * for the whole app — the chip on every page and the table on `/clients`
+ * see the same snapshot.
+ */
+export function useDisconnectedComputers(): DisconnectedSummary {
+  const { user } = useAuth();
+  const { data } = useQuery({
+    queryKey: ["clients"],
+    queryFn: listClients,
+    refetchInterval: 10_000,
+    enabled: !!user,
+  });
+  if (!data || !user) return { rows: [], firstHostname: null };
+  const rows = selectDisconnectedComputers(data, user.id);
+  return { rows, firstHostname: rows[0]?.hostname ?? null };
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -514,6 +514,11 @@
     transform: rotate(360deg);
   }
 }
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 @keyframes subtle-fade {
   from {
     opacity: 0;

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -5,13 +5,11 @@ import {
   type RuntimeProvider,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, ChevronRight, Copy, Terminal, Trash2, Unplug } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Trash2, Unplug } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
   type ClientWithCapabilities,
-  type ConnectTokenResponse,
   disconnectClient,
-  generateConnectToken,
   getActivityOverview,
   getClientCapabilities,
   type HubClient,
@@ -37,71 +35,7 @@ import { StateChip } from "../components/ui/state-chip.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { useUserNameMap } from "../lib/use-user-name-map.js";
 import { formatDate } from "../lib/utils.js";
-
-function ConnectStrip() {
-  const [connectData, setConnectData] = useState<ConnectTokenResponse | null>(null);
-  const [copied, setCopied] = useState(false);
-
-  const generateMut = useMutation({
-    mutationFn: generateConnectToken,
-    onSuccess: (data) => {
-      setConnectData(data);
-      setCopied(false);
-    },
-  });
-
-  const handleCopy = async () => {
-    if (!connectData) return;
-    await navigator.clipboard.writeText(connectData.command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div
-      className="grid items-center gap-2.5 mb-3.5"
-      style={{
-        gridTemplateColumns: "auto 1fr auto auto",
-        padding: "var(--sp-2) var(--sp-3)",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-      }}
-    >
-      <span className="inline-flex items-center gap-2 text-body" style={{ color: "var(--fg-2)" }}>
-        <Terminal className="h-3.5 w-3.5" />
-        Connect a computer
-      </span>
-      {connectData ? (
-        <code
-          className="mono whitespace-nowrap overflow-hidden text-ellipsis text-label"
-          style={{
-            padding: "var(--sp-1_25) var(--sp-2_5)",
-            background: "var(--bg-sunken)",
-            border: "var(--hairline) solid var(--border-faint)",
-            borderRadius: "var(--radius-input)",
-            color: "var(--fg-2)",
-          }}
-          title={connectData.command}
-        >
-          {connectData.command}{" "}
-          <span style={{ color: "var(--fg-4)" }}># expires in {Math.round(connectData.expiresIn / 60)}m</span>
-        </code>
-      ) : (
-        <span className="mono text-label" style={{ color: "var(--fg-4)" }}>
-          Generate a single-use command to pair a new machine with this Hub.
-        </span>
-      )}
-      <Button variant="outline" size="xs" onClick={handleCopy} disabled={!connectData}>
-        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        {copied ? "Copied" : "Copy"}
-      </Button>
-      <Button variant="outline" size="xs" onClick={() => generateMut.mutate()} disabled={generateMut.isPending}>
-        {generateMut.isPending ? "Generating…" : connectData ? "Regenerate" : "Generate"}
-      </Button>
-    </div>
-  );
-}
+import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
 
 export function ClientsPage() {
   const queryClient = useQueryClient();
@@ -113,6 +47,7 @@ export function ClientsPage() {
   const [confirmDisconnect, setConfirmDisconnect] = useState<HubClient | null>(null);
   const [confirmRetire, setConfirmRetire] = useState<HubClient | null>(null);
   const [retireError, setRetireError] = useState<string | null>(null);
+  const [newConnectionOpen, setNewConnectionOpen] = useState(false);
 
   const { data: clients } = useQuery({
     queryKey: ["clients"],
@@ -176,10 +111,18 @@ export function ClientsPage() {
             </>
           ) : null
         }
+        right={
+          <div className="flex items-center gap-1.5">
+            <Button size="xs" onClick={() => setNewConnectionOpen(true)}>
+              <Plus className="h-3 w-3" />
+              New Connection
+            </Button>
+          </div>
+        }
       />
 
       <div style={{ padding: "var(--sp-3_5) var(--sp-5) var(--sp-7)" }}>
-        <ConnectStrip />
+        <NewConnectionDialog open={newConnectionOpen} onOpenChange={setNewConnectionOpen} />
 
         {confirmRetire && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay-scrim">

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -1,16 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { type ConnectTokenResponse, generateConnectToken, type HubClient, listClients } from "../../api/activity.js";
 import { useAuth } from "../../auth/auth-context.js";
+import { ConnectCommandPanel, type ConnectPhase } from "../../components/connect-command-panel.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 
-type Phase = "loading" | "waiting" | "success" | "error";
-
 const POLL_MS = 3_000;
 const SUCCESS_HOLD_MS = 1_200;
-const COPY_FEEDBACK_MS = 1_500;
 
 /**
  * "Connect a new computer" modal — replaces the always-on ConnectStrip.
@@ -26,11 +23,10 @@ const COPY_FEEDBACK_MS = 1_500;
 export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (next: boolean) => void }) {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const [phase, setPhase] = useState<Phase>("loading");
+  const [phase, setPhase] = useState<ConnectPhase>("loading");
   const [token, setToken] = useState<ConnectTokenResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [arrivedHostname, setArrivedHostname] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
   const baselineRef = useRef<Set<string>>(new Set());
 
   // 1. On open: snapshot, mint, switch to waiting. Reset all state on close.
@@ -40,7 +36,6 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
       setToken(null);
       setErrorMessage(null);
       setArrivedHostname(null);
-      setCopied(false);
       baselineRef.current = new Set();
       return;
     }
@@ -97,13 +92,6 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
     return () => clearTimeout(handle);
   }, [phase, onOpenChange, queryClient]);
 
-  const handleCopy = async () => {
-    if (!token) return;
-    await navigator.clipboard.writeText(token.command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
-  };
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -112,105 +100,17 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
           <DialogDescription>Run this command on the machine you want to pair with this Hub.</DialogDescription>
         </DialogHeader>
 
-        <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
-          <code
-            className="mono text-label flex-1"
-            style={{
-              padding: "var(--sp-2_5) var(--sp-3)",
-              background: "var(--bg-sunken)",
-              border: "var(--hairline) solid var(--border-faint)",
-              borderRadius: "var(--radius-input)",
-              color: "var(--fg-2)",
-              wordBreak: "break-all",
-            }}
-            title={token?.command ?? ""}
-          >
-            {token ? (
-              <>
-                {token.command}{" "}
-                <span style={{ color: "var(--fg-4)" }}># expires in {Math.round(token.expiresIn / 60)}m</span>
-              </>
-            ) : (
-              "Generating token…"
-            )}
-          </code>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleCopy}
-            disabled={!token}
-            style={{ alignSelf: "flex-start" }}
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "Copied" : "Copy"}
-          </Button>
-        </div>
-        <p className="text-label" style={{ color: "var(--fg-4)", margin: 0 }}>
-          Single-use · regenerates the previous one.
-        </p>
-
-        {phase === "waiting" && (
-          <div
-            className="flex items-center text-body"
-            style={{
-              gap: "var(--sp-2_5)",
-              padding: "var(--sp-2_5) var(--sp-3)",
-              background: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",
-              border: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 35%, transparent)",
-              borderRadius: "var(--radius-input)",
-              color: "color-mix(in oklch, var(--state-blocked) 35%, var(--fg))",
-            }}
-          >
-            <span
-              aria-hidden="true"
-              style={{
-                width: 12,
-                height: 12,
-                flexShrink: 0,
-                borderRadius: "50%",
-                border: "var(--hairline-bold) solid color-mix(in oklch, var(--state-blocked) 30%, transparent)",
-                borderTopColor: "var(--state-blocked)",
-                animation: "spin 0.85s linear infinite",
-              }}
-            />
-            Waiting for your computer to connect…
-          </div>
-        )}
-
-        {phase === "success" && (
-          <div
-            className="flex items-center text-body"
-            style={{
-              gap: "var(--sp-2_5)",
-              padding: "var(--sp-2_5) var(--sp-3)",
-              background: "color-mix(in oklch, var(--state-idle) 14%, transparent)",
-              border: "var(--hairline) solid color-mix(in oklch, var(--state-idle) 35%, transparent)",
-              borderRadius: "var(--radius-input)",
-              color: "color-mix(in oklch, var(--state-idle) 45%, var(--fg))",
-            }}
-          >
-            <Check className="h-3.5 w-3.5" style={{ flexShrink: 0 }} />
-            <span>
+        <ConnectCommandPanel
+          command={token?.command ?? null}
+          expiresInSeconds={token?.expiresIn}
+          phase={phase}
+          successContent={
+            <>
               <span className="font-semibold">{arrivedHostname ?? "Computer"}</span> connected. Closing…
-            </span>
-          </div>
-        )}
-
-        {phase === "error" && errorMessage && (
-          <div
-            className="text-body"
-            style={{
-              padding: "var(--sp-2_5) var(--sp-3)",
-              background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
-              border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
-              borderRadius: "var(--radius-input)",
-              color: "var(--state-error)",
-            }}
-          >
-            {errorMessage}
-          </div>
-        )}
+            </>
+          }
+          errorContent={errorMessage}
+        />
 
         <div className="flex justify-end" style={{ gap: "var(--sp-2)" }}>
           <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -1,0 +1,223 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { type ConnectTokenResponse, generateConnectToken, type HubClient, listClients } from "../../api/activity.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+
+type Phase = "loading" | "waiting" | "success" | "error";
+
+const POLL_MS = 3_000;
+const SUCCESS_HOLD_MS = 1_200;
+const COPY_FEEDBACK_MS = 1_500;
+
+/**
+ * "Connect a new computer" modal — replaces the always-on ConnectStrip.
+ *
+ * Lifecycle:
+ *   1. open=true        → snapshot existing client ids → mint a connect token
+ *   2. phase="waiting"  → poll /clients every 3s; first new id with
+ *                         status="connected" AND owned by the caller wins
+ *   3. phase="success"  → brief hold (~1.2s), then close + invalidate
+ *
+ * Cancel / backdrop close: drops the unused token (server expires it on TTL).
+ */
+export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (next: boolean) => void }) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [token, setToken] = useState<ConnectTokenResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [arrivedHostname, setArrivedHostname] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const baselineRef = useRef<Set<string>>(new Set());
+
+  // 1. On open: snapshot, mint, switch to waiting. Reset all state on close.
+  useEffect(() => {
+    if (!open) {
+      setPhase("loading");
+      setToken(null);
+      setErrorMessage(null);
+      setArrivedHostname(null);
+      setCopied(false);
+      baselineRef.current = new Set();
+      return;
+    }
+
+    let cancelled = false;
+    const existing = (queryClient.getQueryData<HubClient[]>(["clients"]) ?? []).map((c) => c.id);
+    baselineRef.current = new Set(existing);
+
+    (async () => {
+      try {
+        const t = await generateConnectToken();
+        if (cancelled) return;
+        setToken(t);
+        setPhase("waiting");
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMessage(err instanceof Error ? err.message : "Failed to generate connect token");
+        setPhase("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, queryClient]);
+
+  // 2. While waiting: poll for the new client. Owner check guards admin role.
+  useEffect(() => {
+    if (!open || phase !== "waiting" || !user) return;
+    const tick = async () => {
+      try {
+        const fresh = await queryClient.fetchQuery({ queryKey: ["clients"], queryFn: listClients });
+        const baseline = baselineRef.current;
+        const arrived = fresh.find((c) => !baseline.has(c.id) && c.status === "connected" && c.userId === user.id);
+        if (arrived) {
+          setArrivedHostname(arrived.hostname ?? null);
+          setPhase("success");
+        }
+      } catch {
+        // transient; next tick will retry
+      }
+    };
+    const handle = setInterval(tick, POLL_MS);
+    return () => clearInterval(handle);
+  }, [open, phase, queryClient, user]);
+
+  // 3. On success: brief hold so the user sees the green confirmation, then close.
+  useEffect(() => {
+    if (phase !== "success") return;
+    const handle = setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ["clients"] });
+      onOpenChange(false);
+    }, SUCCESS_HOLD_MS);
+    return () => clearTimeout(handle);
+  }, [phase, onOpenChange, queryClient]);
+
+  const handleCopy = async () => {
+    if (!token) return;
+    await navigator.clipboard.writeText(token.command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Connect a new computer</DialogTitle>
+          <DialogDescription>Run this command on the machine you want to pair with this Hub.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+          <code
+            className="mono text-label flex-1"
+            style={{
+              padding: "var(--sp-2_5) var(--sp-3)",
+              background: "var(--bg-sunken)",
+              border: "var(--hairline) solid var(--border-faint)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg-2)",
+              wordBreak: "break-all",
+            }}
+            title={token?.command ?? ""}
+          >
+            {token ? (
+              <>
+                {token.command}{" "}
+                <span style={{ color: "var(--fg-4)" }}># expires in {Math.round(token.expiresIn / 60)}m</span>
+              </>
+            ) : (
+              "Generating token…"
+            )}
+          </code>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCopy}
+            disabled={!token}
+            style={{ alignSelf: "flex-start" }}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
+        <p className="text-label" style={{ color: "var(--fg-4)", margin: 0 }}>
+          Single-use · regenerates the previous one.
+        </p>
+
+        {phase === "waiting" && (
+          <div
+            className="flex items-center text-body"
+            style={{
+              gap: "var(--sp-2_5)",
+              padding: "var(--sp-2_5) var(--sp-3)",
+              background: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",
+              border: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 35%, transparent)",
+              borderRadius: "var(--radius-input)",
+              color: "color-mix(in oklch, var(--state-blocked) 35%, var(--fg))",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                width: 12,
+                height: 12,
+                flexShrink: 0,
+                borderRadius: "50%",
+                border: "var(--hairline-bold) solid color-mix(in oklch, var(--state-blocked) 30%, transparent)",
+                borderTopColor: "var(--state-blocked)",
+                animation: "spin 0.85s linear infinite",
+              }}
+            />
+            Waiting for your computer to connect…
+          </div>
+        )}
+
+        {phase === "success" && (
+          <div
+            className="flex items-center text-body"
+            style={{
+              gap: "var(--sp-2_5)",
+              padding: "var(--sp-2_5) var(--sp-3)",
+              background: "color-mix(in oklch, var(--state-idle) 14%, transparent)",
+              border: "var(--hairline) solid color-mix(in oklch, var(--state-idle) 35%, transparent)",
+              borderRadius: "var(--radius-input)",
+              color: "color-mix(in oklch, var(--state-idle) 45%, var(--fg))",
+            }}
+          >
+            <Check className="h-3.5 w-3.5" style={{ flexShrink: 0 }} />
+            <span>
+              <span className="font-semibold">{arrivedHostname ?? "Computer"}</span> connected. Closing…
+            </span>
+          </div>
+        )}
+
+        {phase === "error" && errorMessage && (
+          <div
+            className="text-body"
+            style={{
+              padding: "var(--sp-2_5) var(--sp-3)",
+              background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+              border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--state-error)",
+            }}
+          >
+            {errorMessage}
+          </div>
+        )}
+
+        <div className="flex justify-end" style={{ gap: "var(--sp-2)" }}>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Persistent red chip in the topbar reads `<host> disconnected` (or `N computers disconnected`) whenever a computer owned by the caller is offline **with agents bound to it**. Click → `/clients`. Renders nothing in the healthy case.
- Topbar grid moves from `auto 1fr auto` to `1fr auto 1fr` so tabs stay anchored to the page midpoint regardless of how the brand cluster grows.
- `/clients` drops the always-on `Connect a computer` strip; a `New Connection +` CTA in the page header opens a modal that mints a fresh token, shows the command inline, displays a yellow `Waiting…` row, and auto-closes (~1.2s green hold) the moment the new machine appears.
- Pure-function filter `selectDisconnectedComputers(clients, userId)` exported with 7 unit tests. Reuses existing `["clients"]` 10s React Query — **no new endpoints, no DB schema, no WS push**.

Trigger condition is strict: `client.userId === me.id && status === "disconnected" && agentCount > 0` — admin role does **not** widen scope. The chip is the user's "your own machine is gone" warning, not a fleet-status indicator.

Design preview (6-state HTML mockup): [docs/design/computer-disconnect-preview.html](docs/design/computer-disconnect-preview.html)
Tech spec: [docs/design/computer-disconnect-spec.md](docs/design/computer-disconnect-spec.md)

## Test plan
- [x] `pnpm check && pnpm typecheck && pnpm test` — clean (533 files biome, 9 turbo tasks, 524 server tests + 7 new pure-fn tests)
- [x] `lint:tokens` design-token guardrails clean
- [x] Manual e2e against local hub: kill client → chip appears within 10s; click chip → lands on `/clients`; restart → chip disappears
- [x] Multi-disconnect: chip flips to `2 computers disconnected` (number bold, tabular-nums)
- [x] `New Connection +` → modal yellow Waiting → green Success → auto-close → table refresh
- [x] Long hostname (≥40 chars) ellipsises at 160px, full name in `title` tooltip
- [x] Tabs centred at page midpoint (DOM-verified: tabsCenterX === pageCenterX === 720 in 1440-wide viewport)
- [ ] Reviewer: visual check on dark/light mode parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)