### PR TITLE
fix(messaging): break agent↔agent direct-chat reply loops via mention_only

### DIFF
--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -82,7 +82,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     expect(body).toMatchObject({ format: "text", content: "final answer", inReplyTo: "m1" });
   });
 
-  it("omits mentions metadata in a 2-person direct chat (peer is always full-mode)", async () => {
+  it("omits mentions metadata in a 2-person direct chat when peer is full-mode (human↔agent)", async () => {
     const { sink, sendMessage } = buildSink({
       trigger: { messageId: "m1", senderId: "agent-peer" },
       participants: [mkParticipant(ME, "me"), mkParticipant("agent-peer", "peer")],
@@ -92,6 +92,28 @@ describe("createResultSink — forwardResult enrichment", () => {
 
     const body = sendMessage.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(body.metadata).toBeUndefined();
+  });
+
+  it("emits default trigger mention in a 2-person direct chat when peer is mention_only (agent↔agent)", async () => {
+    // Migration 0029 + findOrCreateDirectChat seed both participants as
+    // `mention_only` in agent↔agent direct chats so courtesy replies don't
+    // wake the peer and produce A↔B reply loops. The sink has to
+    // explicitly @-mention the trigger sender to route the genuine reply
+    // back to them; without this branch, B's answer to A's question would
+    // land silently and A would never see it.
+    const peer = mkParticipant("agent-peer", "peer");
+    peer.mode = "mention_only";
+    const me = mkParticipant(ME, "me");
+    me.mode = "mention_only";
+    const { sink, sendMessage } = buildSink({
+      trigger: { messageId: "m1", senderId: "agent-peer" },
+      participants: [me, peer],
+    });
+
+    await sink("final answer");
+
+    const body = sendMessage.mock.calls[0]?.[1] as { metadata?: { mentions?: string[] } };
+    expect(body.metadata?.mentions).toEqual(["agent-peer"]);
   });
 
   it("defaults mentions to [trigger.senderId] in a group chat (Mention-default)", async () => {

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -11,9 +11,13 @@ import type { AgentIdentity } from "./handler.js";
  * - `inReplyTo` is pulled from the current trigger (the message that kicked
  *   off this turn), so peers that threaded via reply routing see the answer
  *   in their waiting chat — see proposals/hub-agent-messaging-reply-and-mentions §3.4.
- * - In `mention_only` group chats the trigger sender is added to the outbound
+ * - For `mention_only` peers the trigger sender is added to the outbound
  *   mention list so the server's fan-out filter routes the reply back to them
- *   even if the handler didn't explicitly `@` them.
+ *   even if the handler didn't explicitly `@` them. This applies in groups
+ *   AND in agent↔agent direct chats (both participants are `mention_only`
+ *   under migration 0029 to break A↔B reply loops); we skip it in
+ *   human↔agent direct chats where the human stays `full` and the prefix
+ *   would just be UI noise.
  *
  * Content-level `@<name>` resolution (extracting tokens and cross-validating
  * against the participant list) is the server's job — see
@@ -49,17 +53,19 @@ export type ResultSink = (text: string) => Promise<void>;
 
 export function createResultSink(deps: ResultSinkDeps): ResultSink {
   async function buildMetadata(trigger: Trigger | null): Promise<Record<string, unknown> | undefined> {
-    // Direct chats (2 participants) never need a default mention — the peer
-    // sits in `full` mode so fan-out reaches them regardless. We key on
-    // participant count (not chat type) because the upgrade rule in
-    // services/chat.ts is one-directional: direct → group on the third
-    // join, and groups never shrink back to 2. If that ever changes (e.g.
-    // `removeParticipant` starts down-grading) this branch must switch to
-    // reading chat.type, or groups that transiently shrink will miss the
-    // default @trigger.sender mention.
+    // Default-mention the trigger sender so the server's fan-out wakes them
+    // regardless of whether the handler text contains an explicit `@`. Skip
+    // when the peer is `full` AND we're 1:1: the message reaches them
+    // anyway, so the prefix would just be UI noise (typically a human in a
+    // human↔agent direct chat). In groups we always emit the @ — it's the
+    // visual cue that says "this reply is for X" and the routing guarantee
+    // for any `mention_only` participant who happens to be the trigger.
     if (!trigger || trigger.senderId === deps.agent.agentId) return undefined;
     const participants = await deps.participants.get();
-    if (participants.length <= 2) return undefined;
+    if (participants.length <= 2) {
+      const peer = participants.find((p) => p.agentId === trigger.senderId);
+      if (peer && peer.mode !== "mention_only") return undefined;
+    }
     return { mentions: [trigger.senderId] };
   }
 

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/drizzle/0029_direct_agent_only_mention_only.sql
+++ b/packages/server/drizzle/0029_direct_agent_only_mention_only.sql
@@ -1,0 +1,28 @@
+-- Backfill: in any direct chat with no human participant, flip both agents to
+-- `mention_only`. New direct chats created by `findOrCreateDirectChat` and
+-- `createChat` already encode this rule at insert time; this migration patches
+-- chats created before the rule existed.
+--
+-- Why: `full` mode in agent↔agent direct chats causes a reply loop. Every
+-- message wakes the other party unconditionally, so a courtesy "thanks" or
+-- a duplicated "已回复" tool echo gets treated as a fresh prompt and the two
+-- agents chat forever. `mention_only` makes engagement opt-in via `@` so
+-- conversations naturally end. Human↔agent direct stays `full` because in a
+-- 1:1 with a person the agent must respond on every turn — the human
+-- participant is what flips the rule off.
+--
+-- Group chats are intentionally untouched. Existing rule
+-- (`maybeUpgradeDirectToGroup`) already enforces mention_only for non-human
+-- participants there.
+
+UPDATE "chat_participants"
+SET "mode" = 'mention_only'
+WHERE "chat_id" IN (
+	SELECT c."id" FROM "chats" c
+	WHERE c."type" = 'direct'
+	  AND NOT EXISTS (
+	    SELECT 1 FROM "chat_participants" cp
+	    INNER JOIN "agents" a ON a."uuid" = cp."agent_id"
+	    WHERE cp."chat_id" = c."id" AND a."type" = 'human'
+	  )
+);

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1777680000000,
       "tag": "0028_auth_identity_user_github_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1777766400000,
+      "tag": "0029_direct_agent_only_mention_only",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -91,8 +91,8 @@ describe("Agent Chats API", () => {
     expect(byId.get(a1.agent.uuid)?.name).toBe(`parts-a1-${uid}`);
     expect(byId.get(a2.uuid)?.displayName).toBe("Bob");
     for (const r of rows) {
-      // Direct chat → both start in full mode.
-      expect(r.mode).toBe("full");
+      // Agent↔agent direct → both start in mention_only (migration 0029).
+      expect(r.mode).toBe("mention_only");
       expect(r.type).toBe("autonomous_agent");
     }
   });

--- a/packages/server/src/__tests__/agent-inbox.test.ts
+++ b/packages/server/src/__tests__/agent-inbox.test.ts
@@ -15,9 +15,11 @@ describe("Agent Inbox API", () => {
     });
     const chatId = chatRes.json().id;
 
+    // Agent↔agent direct seeds both as mention_only (migration 0029); add
+    // the @ so the recipient is woken rather than silently parked.
     await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "Inbox test",
+      content: `@${a2.agent.name} Inbox test`,
     });
 
     const pollRes = await a2.request("GET", "/api/v1/agent/inbox");

--- a/packages/server/src/__tests__/agent-messages.test.ts
+++ b/packages/server/src/__tests__/agent-messages.test.ts
@@ -53,16 +53,20 @@ describe("Agent Messages API", () => {
     const app = getApp();
     const { a1, a2, chatId } = await setupChat(app);
 
+    // Agent↔agent direct chat is mention_only on both ends (migration 0029)
+    // so this fan-out test must include an explicit @ to wake the recipient
+    // — without it, the entry would be a silent context row and `pollInbox`
+    // would skip it.
     await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "Fan-out test",
+      content: `@${a2.agent.name} Fan-out test`,
     });
 
     const pollRes = await a2.request("GET", "/api/v1/agent/inbox");
     expect(pollRes.statusCode).toBe(200);
     const entries = pollRes.json();
     expect(entries.length).toBeGreaterThanOrEqual(1);
-    expect(entries[0].message.content).toBe("Fan-out test");
+    expect(entries[0].message.content).toContain("Fan-out test");
   });
 
   it("rejects message from non-participant", async () => {

--- a/packages/server/src/__tests__/chat-upgrade.test.ts
+++ b/packages/server/src/__tests__/chat-upgrade.test.ts
@@ -40,9 +40,12 @@ describe("chat upgrade — direct to group", () => {
       participantIds: [a2.uuid],
     });
 
-    // Both agents start in full mode (default).
-    expect((await loadParticipant(chat.id, a1.agent.uuid))?.mode).toBe("full");
-    expect((await loadParticipant(chat.id, a2.uuid))?.mode).toBe("full");
+    // Both agents start as `mention_only` because no human is in the chat —
+    // see migration 0029 / `createChat`'s direct-agent-only branch. The
+    // upgrade rule is therefore a no-op for the existing two on this path,
+    // but we still want to assert it doesn't downgrade them or break.
+    expect((await loadParticipant(chat.id, a1.agent.uuid))?.mode).toBe("mention_only");
+    expect((await loadParticipant(chat.id, a2.uuid))?.mode).toBe("mention_only");
 
     // Third autonomous agent joins.
     await addParticipant(app.db, chat.id, a1.agent.uuid, { agentId: a3.uuid, mode: "full" });

--- a/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
+++ b/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
@@ -1,0 +1,197 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants } from "../db/schema/chats.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { createChat, findOrCreateDirectChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Pins migration 0029's "agent-only direct chat → mention_only" rule.
+ *
+ * Background: in agent↔agent direct chats both participants used to default
+ * to `full`, which made every reply wake the peer unconditionally and the
+ * two agents looped on courtesy turns ("ok thanks" / "received") forever.
+ * Migration 0029 (and the matching seed in `findOrCreateDirectChat` /
+ * `createChat`) flips both ends to `mention_only` so engagement requires an
+ * explicit `@`. Human↔agent direct keeps `full` because in a 1:1 with a
+ * person every message is implicitly addressed to the agent.
+ */
+describe("direct chat default mode (migration 0029)", () => {
+  const getApp = useTestApp();
+
+  async function loadModes(chatId: string) {
+    const app = getApp();
+    return app.db
+      .select({ agentId: chatParticipants.agentId, mode: chatParticipants.mode })
+      .from(chatParticipants)
+      .where(eq(chatParticipants.chatId, chatId));
+  }
+
+  async function notifyEntries(chatId: string, agentUuid: string) {
+    const app = getApp();
+    const [row] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, agentUuid))
+      .limit(1);
+    if (!row) return [];
+    return app.db
+      .select({ messageId: inboxEntries.messageId })
+      .from(inboxEntries)
+      .where(
+        and(eq(inboxEntries.inboxId, row.inboxId), eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)),
+      );
+  }
+
+  describe("findOrCreateDirectChat seeds the right modes", () => {
+    it("agent↔agent → both `mention_only`", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `dc-aa1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `dc-aa2-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, a1.agent.uuid, a2.uuid);
+      const modes = await loadModes(chat.id);
+      expect(modes.map((m) => m.mode).sort()).toEqual(["mention_only", "mention_only"]);
+    });
+
+    it("human↔agent → both `full`", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const human = await createTestAgent(app, { name: `dc-hu-${uid}`, type: "human" });
+      const { agent } = await createTestAgent(app, { name: `dc-ag-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, human.agent.uuid, agent.uuid);
+      const modes = await loadModes(chat.id);
+      expect(modes.map((m) => m.mode).sort()).toEqual(["full", "full"]);
+    });
+  });
+
+  describe("createChat seeds the right modes", () => {
+    it("type='direct' with two agents → both `mention_only`", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `cc-aa1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `cc-aa2-${uid}` });
+
+      const chat = await createChat(app.db, a1.agent.uuid, {
+        type: "direct",
+        participantIds: [a2.uuid],
+      });
+      const modes = await loadModes(chat.id);
+      expect(modes.map((m) => m.mode).sort()).toEqual(["mention_only", "mention_only"]);
+    });
+
+    it("type='direct' with a human → both `full`", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const human = await createTestAgent(app, { name: `cc-h-${uid}`, type: "human" });
+      const { agent } = await createTestAgent(app, { name: `cc-a-${uid}` });
+
+      const chat = await createChat(app.db, human.agent.uuid, {
+        type: "direct",
+        participantIds: [agent.uuid],
+      });
+      const modes = await loadModes(chat.id);
+      expect(modes.map((m) => m.mode).sort()).toEqual(["full", "full"]);
+    });
+
+    it("type='group' is unaffected by the rule (kept as `full` default)", async () => {
+      // The group-chat upgrade rule lives in `maybeUpgradeDirectToGroup` and
+      // only fires on the direct→group transition. A born-as-group chat
+      // intentionally starts everyone in `full` — group-noise control is
+      // applied by upgrade-time flips, not at creation.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `cc-g1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `cc-g2-${uid}` });
+      const { agent: a3 } = await createTestAgent(app, { name: `cc-g3-${uid}` });
+
+      const chat = await createChat(app.db, a1.agent.uuid, {
+        type: "group",
+        participantIds: [a2.uuid, a3.uuid],
+      });
+      const modes = await loadModes(chat.id);
+      expect(modes.every((m) => m.mode === "full")).toBe(true);
+    });
+  });
+
+  describe("fan-out semantics under the new mode defaults", () => {
+    it("agent→agent direct without `@` produces a SILENT row, not an active wake", async () => {
+      // The exact bug we're fixing: A's "ok thanks" used to wake B, who
+      // then replied "received", which woke A, … forever. Under 0029 the
+      // courtesy turn lands as a silent context row instead of a notify=true
+      // entry, so the loop dies after the explicit-mention round-trip is over.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `fo-aa1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `fo-aa2-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, a1.agent.uuid, a2.uuid);
+      await sendMessage(app.db, chat.id, a1.agent.uuid, {
+        format: "text",
+        content: "ok thanks",
+      });
+
+      const active = await notifyEntries(chat.id, a2.uuid);
+      expect(active).toHaveLength(0);
+    });
+
+    it("agent→agent direct WITH `@<peer>` wakes the peer", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `fo-mn1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `fo-mn2-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, a1.agent.uuid, a2.uuid);
+      await sendMessage(app.db, chat.id, a1.agent.uuid, {
+        format: "text",
+        content: "ping",
+        metadata: { mentions: [a2.uuid] },
+      });
+
+      const active = await notifyEntries(chat.id, a2.uuid);
+      expect(active).toHaveLength(1);
+    });
+
+    it("human→agent direct without `@` STILL wakes the agent", async () => {
+      // The DX guarantee: a human writing in their own DM never has to type
+      // `@<assistant>`. Falls out naturally because the agent stays in
+      // `full` mode whenever a human is in the chat.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const human = await createTestAgent(app, { name: `fo-h-${uid}`, type: "human" });
+      const { agent } = await createTestAgent(app, { name: `fo-ha-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, human.agent.uuid, agent.uuid);
+      await sendMessage(app.db, chat.id, human.agent.uuid, {
+        format: "text",
+        content: "what's the date?",
+      });
+
+      const active = await notifyEntries(chat.id, agent.uuid);
+      expect(active).toHaveLength(1);
+    });
+
+    it("agent→human direct without `@` STILL wakes the human (symmetric DX)", async () => {
+      // Mirror of the case above — agents replying to humans in a DM
+      // shouldn't have to add a `@<human>` prefix to be heard. The human
+      // is `full` so they're always notified.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const human = await createTestAgent(app, { name: `fo-h2-${uid}`, type: "human" });
+      const { agent } = await createTestAgent(app, { name: `fo-ha2-${uid}` });
+
+      const chat = await findOrCreateDirectChat(app.db, human.agent.uuid, agent.uuid);
+      await sendMessage(app.db, chat.id, agent.uuid, {
+        format: "text",
+        content: "today is 2026-04-29",
+      });
+
+      const active = await notifyEntries(chat.id, human.agent.uuid);
+      expect(active).toHaveLength(1);
+    });
+  });
+});

--- a/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
+++ b/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
@@ -67,6 +67,21 @@ describe("direct chat default mode (migration 0029)", () => {
       const modes = await loadModes(chat.id);
       expect(modes.map((m) => m.mode).sort()).toEqual(["full", "full"]);
     });
+
+    it("autonomous_agent↔personal_assistant → both `mention_only` (rule keys on `type !== 'human'`, not a whitelist)", async () => {
+      // Pin the rule against the kind of refactor that would replace
+      // `type !== 'human'` with a positive whitelist like
+      // `type === 'autonomous_agent'`. `personal_assistant` is also a
+      // non-human agent and must follow the same loop-prevention default.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const auto = await createTestAgent(app, { name: `dc-au-${uid}`, type: "autonomous_agent" });
+      const { agent: pa } = await createTestAgent(app, { name: `dc-pa-${uid}`, type: "personal_assistant" });
+
+      const chat = await findOrCreateDirectChat(app.db, auto.agent.uuid, pa.uuid);
+      const modes = await loadModes(chat.id);
+      expect(modes.map((m) => m.mode).sort()).toEqual(["mention_only", "mention_only"]);
+    });
   });
 
   describe("createChat seeds the right modes", () => {

--- a/packages/server/src/__tests__/inbox-renew.test.ts
+++ b/packages/server/src/__tests__/inbox-renew.test.ts
@@ -16,9 +16,10 @@ describe("Inbox Renew & Timeout API", () => {
     });
     const chatId = chatRes.json().id;
 
+    // mention_only direct (migration 0029) — @a2 to wake the recipient.
     await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "Renew test",
+      content: `@${a2.agent.name} Renew test`,
     });
 
     const pollRes = await a2.request("GET", "/api/v1/agent/inbox");

--- a/packages/server/src/__tests__/inbox-timeout.test.ts
+++ b/packages/server/src/__tests__/inbox-timeout.test.ts
@@ -17,9 +17,10 @@ describe("Inbox Timeout Reset", () => {
     });
     const chatId = chatRes.json().id;
 
+    // mention_only direct (migration 0029) — @a2 to land an active entry.
     await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "Timeout test",
+      content: `@${a2.agent.name} Timeout test`,
     });
 
     const pollRes = await a2.request("GET", "/api/v1/agent/inbox");
@@ -51,9 +52,10 @@ describe("Inbox Timeout Reset", () => {
     });
     const chatId = chatRes.json().id;
 
+    // mention_only direct (migration 0029) — @a2 to land an active entry.
     await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "Fail test",
+      content: `@${a2.agent.name} Fail test`,
     });
 
     const pollRes = await a2.request("GET", "/api/v1/agent/inbox");

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -28,9 +28,12 @@ describe("inbox WS data-plane claim helpers", () => {
       participantIds: [a2.agent.uuid],
     });
     const chatId = chatRes.json().id;
+    // Agent↔agent direct seeds both as mention_only (migration 0029); the
+    // claim helpers operate on `pending` rows with `notify=true`, so the
+    // seed message must @-mention a2 to land an active row.
     const msgRes = await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
       format: "text",
-      content: "WS push test",
+      content: `@${a2.agent.name} WS push test`,
     });
     return { a2, messageId: msgRes.json().id, chatId };
   }
@@ -99,11 +102,15 @@ describe("inbox WS data-plane claim helpers", () => {
     const chatA = await createChat(app.db, sender.uuid, { type: "direct", participantIds: [peer.uuid] });
     const chatB = await createChat(app.db, sender.uuid, { type: "group", participantIds: [] });
 
+    // chatA is mention_only on both ends (migration 0029), so explicit
+    // mentions on each leg keep the fan-out + replyTo rows both notify=true
+    // — this test is about the WS claim shape, not mode semantics.
     const original = await sendMessage(app.db, chatA.id, sender.uuid, {
       format: "text",
       content: "any progress?",
       replyToInbox: sender.inboxId,
       replyToChat: chatB.id,
+      metadata: { mentions: [peer.uuid] },
     });
     // Drain peer's inbox so it doesn't muddy the assertions below.
     await inboxService.pollInbox(app.db, peer.inboxId, 10);
@@ -114,6 +121,7 @@ describe("inbox WS data-plane claim helpers", () => {
       format: "text",
       content: "yes, almost done",
       inReplyTo: original.message.id,
+      metadata: { mentions: [sender.uuid] },
     });
 
     // Sanity check the seed: two pending rows exist before we claim.
@@ -220,10 +228,12 @@ describe("inbox WS data-plane claim helpers", () => {
     });
     const chatId = chatRes.json().id;
 
+    // mention_only direct (migration 0029): each backlog message must @ a2
+    // to land as a notify=true pending row that the backlog claim drains.
     for (let i = 0; i < 3; i++) {
       await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
         format: "text",
-        content: `msg ${i}`,
+        content: `@${a2.agent.name} msg ${i}`,
       });
     }
 

--- a/packages/server/src/__tests__/message-dispatcher.test.ts
+++ b/packages/server/src/__tests__/message-dispatcher.test.ts
@@ -164,7 +164,7 @@ describe("buildClientMessagePayload — recipientMode + inReplyToSnapshot", () =
     expect(built.recipientMode).toBe("mention_only");
   });
 
-  it("returns 'full' for a direct-chat participant (baseline)", async () => {
+  it("returns 'mention_only' for an agent↔agent direct chat (migration 0029)", async () => {
     const a1 = await createAgent(app.db, {
       name: `rmode-dir1-${Date.now()}`,
       type: "autonomous_agent",
@@ -181,6 +181,28 @@ describe("buildClientMessagePayload — recipientMode + inReplyToSnapshot", () =
     const built = await buildClientMessagePayload(
       app.db,
       { kind: "agentId", agentId: a2.uuid },
+      { ...RAW, chatId: chat.id },
+      chat.id,
+    );
+    expect(built.recipientMode).toBe("mention_only");
+  });
+
+  it("returns 'full' for a human↔agent direct chat", async () => {
+    const human = await createAgent(app.db, {
+      name: `rmode-hum-${Date.now()}`,
+      type: "human",
+      managerId: ctx.memberId,
+    });
+    const agent = await createAgent(app.db, {
+      name: `rmode-agt-${Date.now()}`,
+      type: "autonomous_agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+    const chat = await createChat(app.db, human.uuid, { type: "direct", participantIds: [agent.uuid] });
+    const built = await buildClientMessagePayload(
+      app.db,
+      { kind: "agentId", agentId: agent.uuid },
       { ...RAW, chatId: chat.id },
       chat.id,
     );

--- a/packages/server/src/__tests__/message-recipients.test.ts
+++ b/packages/server/src/__tests__/message-recipients.test.ts
@@ -18,9 +18,13 @@ describe("sendMessage returns recipients", () => {
       participantIds: [a2.uuid],
     });
 
+    // Agent↔agent direct seeds both as mention_only (migration 0029) so the
+    // recipient is only included when explicitly @-mentioned. Pass the
+    // mention so this stays a recipient-shape test rather than a mode test.
     const result = await sendMessage(app.db, chat.id, a1.uuid, {
       format: "text",
       content: "hello",
+      metadata: { mentions: [a2.uuid] },
     });
 
     expect(result.message).toBeDefined();

--- a/packages/server/src/__tests__/message-session-creation-failure.test.ts
+++ b/packages/server/src/__tests__/message-session-creation-failure.test.ts
@@ -49,7 +49,13 @@ describe("sendMessage — N4-B: predictive activation failure does not block the
     // 1:1 chat fan-out produces exactly one upsertSessionState call.
     mockedUpsert.mockRejectedValueOnce(new Error("simulated upsert failure"));
 
-    const result = await sendMessage(app.db, chat.id, a1.uuid, { format: "text", content: "should still arrive" });
+    // mention_only direct (migration 0029): @ to keep notify=true so the
+    // upsert call site is reached (otherwise the silent fan-out skips it).
+    const result = await sendMessage(app.db, chat.id, a1.uuid, {
+      format: "text",
+      content: "should still arrive",
+      metadata: { mentions: [a2.uuid] },
+    });
 
     expect(result.message).toBeDefined();
     expect(result.message.content).toBe("should still arrive");

--- a/packages/server/src/__tests__/message-session-creation.test.ts
+++ b/packages/server/src/__tests__/message-session-creation.test.ts
@@ -22,7 +22,14 @@ describe("sendMessage — predictive session activation (M plan Step 1b)", () =>
     await seedPresence(app, a2.uuid, oldDate);
 
     const chat = await createChat(app.db, a1.uuid, { type: "direct", participantIds: [a2.uuid] });
-    await sendMessage(app.db, chat.id, a1.uuid, { format: "text", content: "hi" });
+    // Agent↔agent direct seeds both as mention_only (migration 0029). The
+    // predictive activation only fires for notify=true rows, so the message
+    // must @ the recipient to count as an active fan-out target.
+    await sendMessage(app.db, chat.id, a1.uuid, {
+      format: "text",
+      content: "hi",
+      metadata: { mentions: [a2.uuid] },
+    });
 
     expect(await readSessionState(app, a2.uuid, chat.id)).toBe("active");
     const presence = await readPresence(app, a2.uuid);
@@ -38,7 +45,12 @@ describe("sendMessage — predictive session activation (M plan Step 1b)", () =>
     const chat = await createChat(app.db, a1.uuid, { type: "direct", participantIds: [a2.uuid] });
     await app.db.insert(agentChatSessions).values({ agentId: a2.uuid, chatId: chat.id, state: "evicted" });
 
-    await sendMessage(app.db, chat.id, a1.uuid, { format: "text", content: "ping" });
+    // mention_only direct (migration 0029): @ to wake + revive.
+    await sendMessage(app.db, chat.id, a1.uuid, {
+      format: "text",
+      content: "ping",
+      metadata: { mentions: [a2.uuid] },
+    });
 
     expect(await readSessionState(app, a2.uuid, chat.id)).toBe("active");
   });

--- a/packages/server/src/__tests__/messaging-e2e.test.ts
+++ b/packages/server/src/__tests__/messaging-e2e.test.ts
@@ -110,31 +110,30 @@ describe("messaging E2E — proposal §六 scenarios", () => {
     });
     await ackAll(app, b2Pulled, b2.inboxId);
 
-    // Simulate b1's runtime polling again — should see BOTH the fan-out entry
-    // (chatId=c2) AND the replyTo-routed entry (chatId=c1).
+    // Simulate b1's runtime polling again. Under migration 0029, c2
+    // (b1↔b2 agent-only direct) is `mention_only` on both ends, so b2's
+    // reply lands as a SILENT context row in c2 (not delivered to b1's
+    // active poll) — the no-echo invariant is now enforced at the inbox
+    // layer instead of by the runtime's suppression filter. The c1 entry
+    // survives because replyTo routing always inserts notify=true.
     const b1Pulled2 = await pollInbox(app.db, b1.inboxId, 10);
-    expect(b1Pulled2).toHaveLength(2);
+    expect(b1Pulled2).toHaveLength(1);
 
     const byChat = new Map<string, InboxEntryWithMessage>(
       b1Pulled2.map((e) => [e.chatId ?? e.message.chatId, e as InboxEntryWithMessage]),
     );
     const c1Entry = byChat.get(c1.id);
-    const c2Entry = byChat.get(c2Id);
-    if (!c1Entry || !c2Entry) throw new Error("expected both c1 and c2 entries");
+    if (!c1Entry) throw new Error("expected c1 entry from replyTo routing");
+    expect(byChat.has(c2Id)).toBe(false);
 
-    // Both entries carry the same snapshot (original M1 from b1 in c2).
-    for (const e of [c1Entry, c2Entry]) {
-      expect(e.message.inReplyToSnapshot).toEqual({
-        senderId: b1.uuid,
-        chatId: c2Id,
-        replyToChat: c1.id,
-      });
-    }
+    // The surviving entry carries the same snapshot (original M1 from b1 in c2).
+    expect(c1Entry.message.inReplyToSnapshot).toEqual({
+      senderId: b1.uuid,
+      chatId: c2Id,
+      replyToChat: c1.id,
+    });
 
-    // Suppression verdict:
-    // - c2 entry: me + same chat + replyTo elsewhere → SUPPRESS (echo blocker)
-    // - c1 entry: snapshot.chatId (c2) ≠ entryChatId (c1) → keep, wake c1 session
-    expect(suppressEcho(c2Entry, b1.uuid)).toBe(true);
+    // c1 entry: snapshot.chatId (c2) ≠ entryChatId (c1) → keep, wake c1 session.
     expect(suppressEcho(c1Entry, b1.uuid)).toBe(false);
 
     // No-echo invariant: c2 has exactly M1 (b1→b2) + M2 (b2→b1), stays at 2
@@ -165,21 +164,24 @@ describe("messaging E2E — proposal §六 scenarios", () => {
 
     const c2 = await findOrCreateDirectChat(app.db, b1.uuid, b2.uuid);
 
-    // b1 writes in c2 with replyTo = c2 itself.
+    // b1 writes in c2 with replyTo = c2 itself. Both ends are mention_only
+    // (migration 0029) so b1 must @-mention b2 explicitly to wake the peer.
     const m1 = await sendMessage(app.db, c2.id, b1.uuid, {
       format: "text",
       content: "hi",
       replyToInbox: b1.inboxId,
       replyToChat: c2.id,
+      metadata: { mentions: [b2.uuid] },
     });
 
-    // b2 auto-forwards.
+    // b2 auto-forwards. Same rule applies — b2's reply must mention b1.
     const b2Pulled = await pollInbox(app.db, b2.inboxId, 10);
     expect(b2Pulled).toHaveLength(1);
     await sendMessage(app.db, c2.id, b2.uuid, {
       format: "text",
       content: "reply",
       inReplyTo: m1.message.id,
+      metadata: { mentions: [b1.uuid] },
     });
     await ackAll(app, b2Pulled, b2.inboxId);
 
@@ -353,12 +355,15 @@ describe("messaging E2E — proposal §六 scenarios", () => {
     });
     const c1 = await findOrCreateDirectChat(app.db, b1.uuid, b2.uuid);
 
-    // Send M1 from b1 with a replyTo envelope.
+    // Send M1 from b1 with a replyTo envelope. Mention b2 explicitly:
+    // c1 is a mention_only direct (migration 0029) so the active fan-out
+    // entry only lands when the recipient is in the mention set.
     const m1 = await sendMessage(app.db, c1.id, b1.uuid, {
       format: "text",
       content: "first cut",
       replyToInbox: b1.inboxId,
       replyToChat: c1.id,
+      metadata: { mentions: [b2.uuid] },
     });
 
     // b2 drains so we observe the PRE-edit fan-out count (1 entry).

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -197,13 +197,18 @@ export async function findOrCreateChatForChannel(
       metadata: { source: data.platform, externalChannelId: data.externalChannelId },
     });
 
-    // Add bot agent and sender as participants
+    // Add bot agent and sender as participants. External IM users
+    // (Feishu/Slack) always map to a `human` agent on the sender side, so
+    // these chats are inherently human↔agent and should stay `full` —
+    // pin the mode explicitly so a future schema-default change (or a new
+    // adapter that pairs two bots) can't silently drift into the agent↔agent
+    // `mention_only` rule from migration 0029 without an audit.
     const participants =
       data.botAgentId === data.senderAgentId
-        ? [{ chatId, agentId: data.botAgentId, role: "member" as const }]
+        ? [{ chatId, agentId: data.botAgentId, role: "member" as const, mode: "full" as const }]
         : [
-            { chatId, agentId: data.botAgentId, role: "member" as const },
-            { chatId, agentId: data.senderAgentId, role: "member" as const },
+            { chatId, agentId: data.botAgentId, role: "member" as const, mode: "full" as const },
+            { chatId, agentId: data.senderAgentId, role: "member" as const, mode: "full" as const },
           ];
     await tx.insert(chatParticipants).values(participants);
 

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -545,8 +545,8 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
   const agentB = ends.find((a) => a.uuid === agentBId);
   if (!agentB) throw new NotFoundError(`Agent "${agentBId}" not found`);
 
-  const isAgentOnly = agentA.type !== "human" && agentB.type !== "human";
-  const mode = isAgentOnly ? "mention_only" : "full";
+  const isDirectAgentOnly = agentA.type !== "human" && agentB.type !== "human";
+  const mode = isDirectAgentOnly ? "mention_only" : "full";
 
   const chatId = randomUUID();
   return db.transaction(async (tx) => {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -53,7 +53,7 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
 
   // Verify all participants exist and belong to the same organization
   const existingAgents = await db
-    .select({ id: agents.uuid, organizationId: agents.organizationId })
+    .select({ id: agents.uuid, organizationId: agents.organizationId, type: agents.type })
     .from(agents)
     .where(inArray(agents.uuid, [...allParticipantIds]));
 
@@ -72,6 +72,13 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
   }
 
+  // Direct chat with no human participant: every message is implicitly
+  // addressed to the only other party, so `full` mode causes A↔B reply loops
+  // (each agent's reply wakes the other forever). Flip both to `mention_only`
+  // so engagement requires an explicit `@` — see also `findOrCreateDirectChat`
+  // and migration 0029.
+  const isDirectAgentOnly = data.type === "direct" && existingAgents.every((a) => a.type !== "human");
+
   return db.transaction(async (tx) => {
     const [chat] = await tx
       .insert(chats)
@@ -88,6 +95,7 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
       chatId,
       agentId,
       role: agentId === creatorId ? "owner" : "member",
+      ...(isDirectAgentOnly ? { mode: "mention_only" as const } : {}),
     }));
 
     await tx.insert(chatParticipants).values(participantRows);
@@ -523,14 +531,22 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
     }
   }
 
-  // Create new direct chat
-  const [agentA] = await db
-    .select({ organizationId: agents.organizationId })
+  // Create new direct chat. Fetch both agents' types so we can apply the
+  // "agent-only direct → mention_only" rule (see also `createChat` and
+  // migration 0029): without it, A↔B replies loop forever because every
+  // message in a `full` direct chat wakes the other party unconditionally.
+  const ends = await db
+    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
     .from(agents)
-    .where(eq(agents.uuid, agentAId))
-    .limit(1);
+    .where(inArray(agents.uuid, [agentAId, agentBId]));
 
+  const agentA = ends.find((a) => a.uuid === agentAId);
   if (!agentA) throw new NotFoundError(`Agent "${agentAId}" not found`);
+  const agentB = ends.find((a) => a.uuid === agentBId);
+  if (!agentB) throw new NotFoundError(`Agent "${agentBId}" not found`);
+
+  const isAgentOnly = agentA.type !== "human" && agentB.type !== "human";
+  const mode = isAgentOnly ? "mention_only" : "full";
 
   const chatId = randomUUID();
   return db.transaction(async (tx) => {
@@ -544,8 +560,8 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
       .returning();
 
     await tx.insert(chatParticipants).values([
-      { chatId, agentId: agentAId, role: "member" },
-      { chatId, agentId: agentBId, role: "member" },
+      { chatId, agentId: agentAId, role: "member", mode },
+      { chatId, agentId: agentBId, role: "member", mode },
     ]);
 
     if (!chat) throw new Error("Unexpected: INSERT RETURNING produced no row");

--- a/packages/server/src/services/task.ts
+++ b/packages/server/src/services/task.ts
@@ -270,10 +270,13 @@ async function dispatchTaskSystemMessage(
     ...(fromStatus ? { fromStatus } : {}),
     originRef: task.originRef,
   };
+  // Mention the assignee explicitly: agent↔agent direct chats default to
+  // `mention_only` (migration 0029), so without this the task notification
+  // would be parked silently and the assignee never woken.
   return sendMessage(db, chat.id, systemAgentId, {
     format: "task",
     content,
-    metadata: { taskId: task.id, event },
+    metadata: { taskId: task.id, event, mentions: [task.assigneeAgentId] },
   });
 }
 


### PR DESCRIPTION
## Summary

- Agent↔agent direct chats default to `full` mode on both ends, so every reply wakes the peer unconditionally. Courtesy turns ("ok thanks" / "received") get treated as fresh prompts and the two agents loop forever — the visible bug from the screenshots.
- Encode the rule in the data model: in `direct` chats with **no human participant**, seed both ends as `mention_only` so engagement requires an explicit `@`. Human↔agent direct keeps `full` because in a 1:1 with a person every message is implicitly addressed to the agent — falls out automatically without a "human bypass" exception that would leak into group semantics.
- Migration 0029 backfills the same rule for existing agent-only direct chats so deployed servers stop looping immediately on upgrade.

## Mode matrix (after this change)

| Scenario | agent.mode | source |
|---|---|---|
| human↔agent **direct** | `full` | new rule (has human → full) |
| agent↔agent **direct** | `mention_only` | new rule (all non-human → mention_only) |
| group with human | `mention_only` for non-humans | existing `maybeUpgradeDirectToGroup` |
| group all-agents | `mention_only` for non-humans | existing rule |

## Implementation

- `findOrCreateDirectChat` / `createChat`: pick the seed mode based on whether all participants are non-human.
- Migration `0029_direct_agent_only_mention_only.sql`: one-shot SQL that flips existing agent-only direct chats from `full` → `mention_only`.
- `result-sink`: when the trigger sender is `mention_only` (now true for agent↔agent direct), default-mention them so genuine replies still route back. Human↔agent direct keeps the no-prefix UX.
- `task.ts`: explicitly mention the assignee on task assignment notifications so the system-tasks→assignee direct delivery wakes the recipient under the new defaults.
- `adapter-mapping.ts`: pin `mode: 'full'` when creating Feishu/Slack chats. External IM users map to `human` agents today so this is behaviour-equivalent, but the explicit annotation guards against a future bot-to-bot adapter silently inheriting the `mention_only` rule.
- Dispatcher fan-out (`message.ts:200-208`): unchanged — policy lives entirely in `chat_participants.mode`.

## How the loop is broken (and what each layer does)

The data layer alone breaks the **active-send** loop: agent A replying without `@B` no longer wakes B, so courtesy turns die at the inbox. But the **echo** path (B's substantive reply needing to reach A) is preserved by the `result-sink` change — without that, B's answer to A's question would silently fail. And on the rare cross-chat replyTo case, the runtime's existing `suppressEcho` gate is the last line of defence (verified live: log line at 19:25:42 shows it dropping the spurious "已回复" before it can fire a new turn). Each layer addresses a distinct failure mode rather than redundantly stacking on the same one.

## Known leftover (out of scope, separate issue)

The "已回复" spurious self-narration message from the receiving agent still appears in the UI — it's an LLM/handler-side echo, not server-injected (no `已回复` string in the repo). Under the new defaults the runtime echo-suppress correctly drops it before it triggers a new turn, so it's UI noise rather than a behavior bug. Will track and fix separately.

## Test plan

- [x] `pnpm check && pnpm typecheck` — clean
- [x] `pnpm test` — all suites pass (server 535, client 240, shared 150, web 46, command 67)
- [x] New file [`direct-chat-mention-mode.test.ts`](packages/server/src/__tests__/direct-chat-mention-mode.test.ts) pins B' invariants:
  - agent↔agent direct → both `mention_only` (via `findOrCreateDirectChat` and `createChat`)
  - human↔agent direct → both `full`
  - autonomous_agent ↔ personal_assistant → both `mention_only` (rule keys on `type !== 'human'`, not a whitelist — pins against a future positive-whitelist refactor)
  - `type='group'` unaffected
  - fan-out: agent→agent without `@` → silent row, with `@` → wakes peer
  - human→agent without `@` → still wakes (DX guarantee), agent→human without `@` → still wakes (symmetric)
- [x] [`message-dispatcher.test.ts`](packages/server/src/__tests__/message-dispatcher.test.ts) splits the old "direct = full" baseline into mode-aware cases.
- [x] [`messaging-e2e.test.ts`](packages/server/src/__tests__/messaging-e2e.test.ts) Case A rewrites the no-echo invariant assertion to match the new "loop dies at the inbox layer" semantics (one entry instead of two + suppression).
- [x] WS data-plane (#197) and predictive-activation tests on main pre-existed; their direct-chat seeds now include explicit mentions to keep `notify=true` rows.
- [x] Local CLI run reproduces the bug, confirms the loop closes within 4 messages (see logs in PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)