### PR TITLE
feat(onboarding): single-card flow that waits for runtime ready

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -21,6 +21,14 @@ type ConnectCommandPanelProps = {
   errorContent?: ReactNode;
   /** Caption under the command block. Default: `Single-use · regenerates the previous one.`. */
   caption?: ReactNode;
+  /**
+   * Where to place the Copy button relative to the command block.
+   * `"right"` (default) is compact and matches the `/clients` New Connection
+   * surface. `"bottom"` puts the button on its own row below the command —
+   * better when the host modal is narrow and the inline button squeezes
+   * the command text.
+   */
+  copyButtonPlacement?: "right" | "bottom";
 };
 
 const COPY_FEEDBACK_MS = 1_500;
@@ -49,6 +57,7 @@ export function ConnectCommandPanel({
   successContent,
   errorContent,
   caption = "Single-use · regenerates the previous one.",
+  copyButtonPlacement = "right",
 }: ConnectCommandPanelProps) {
   const [copied, setCopied] = useState(false);
 
@@ -61,46 +70,62 @@ export function ConnectCommandPanel({
 
   const expiryMinutes = expiresInSeconds !== undefined ? Math.max(1, Math.round(expiresInSeconds / 60)) : null;
 
+  const commandBlock = (
+    <pre
+      className="mono text-label"
+      style={{
+        margin: 0,
+        padding: "var(--sp-2_5) var(--sp-3)",
+        background: "var(--bg-sunken)",
+        border: "var(--hairline) solid var(--border-faint)",
+        borderRadius: "var(--radius-input)",
+        color: "var(--fg-2)",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+        overflowWrap: "anywhere",
+        minWidth: 0,
+        flex: copyButtonPlacement === "right" ? 1 : undefined,
+      }}
+      title={command ?? ""}
+    >
+      {command ? (
+        <>
+          {command}
+          {expiryMinutes !== null && <span style={{ color: "var(--fg-4)" }}> # expires in {expiryMinutes}m</span>}
+        </>
+      ) : (
+        "Generating token…"
+      )}
+    </pre>
+  );
+
+  const copyButton = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleCopy}
+      disabled={!command}
+      style={{ alignSelf: "flex-start" }}
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? copyLabel.done : copyLabel.idle}
+    </Button>
+  );
+
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-      <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
-        <pre
-          className="mono text-label flex-1"
-          style={{
-            margin: 0,
-            padding: "var(--sp-2_5) var(--sp-3)",
-            background: "var(--bg-sunken)",
-            border: "var(--hairline) solid var(--border-faint)",
-            borderRadius: "var(--radius-input)",
-            color: "var(--fg-2)",
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-all",
-            overflowWrap: "anywhere",
-            minWidth: 0,
-          }}
-          title={command ?? ""}
-        >
-          {command ? (
-            <>
-              {command}
-              {expiryMinutes !== null && <span style={{ color: "var(--fg-4)" }}> # expires in {expiryMinutes}m</span>}
-            </>
-          ) : (
-            "Generating token…"
-          )}
-        </pre>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={handleCopy}
-          disabled={!command}
-          style={{ alignSelf: "flex-start" }}
-        >
-          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          {copied ? copyLabel.done : copyLabel.idle}
-        </Button>
-      </div>
+      {copyButtonPlacement === "right" ? (
+        <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+          {commandBlock}
+          {copyButton}
+        </div>
+      ) : (
+        <>
+          {commandBlock}
+          {copyButton}
+        </>
+      )}
 
       {caption && (
         <p className="text-label" style={{ color: "var(--fg-4)", margin: 0 }}>

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -10,6 +10,8 @@ import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { type HubClient, listClients } from "../api/activity.js";
 import { type AgentNameAvailability, checkAgentNameAvailability, createAgent } from "../api/agents.js";
 import { ApiError, type ValidationIssue } from "../api/client.js";
+import { useAuth } from "../auth/auth-context.js";
+import { slugify } from "../utils/agent-naming.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
 import { Input } from "./ui/input.js";
@@ -58,22 +60,6 @@ function issuesToFieldErrors(issues: ValidationIssue[] | undefined): FieldErrors
 // dialog picks them up automatically.
 
 /**
- * Full slugification — lowercase, ASCII-only, strip leading/trailing
- * separators, clamp length. Used when deriving the agent name from the
- * display name (auto-follow path) where we always want a clean final
- * slug. NOT used for interactive typing, because trimming trailing
- * separators mid-edit would eat every `-` / `_` the moment the user
- * typed it ("alice-" → "alice" → next char lands against "alice").
- */
-function slugify(raw: string): string {
-  return raw
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/^[-_]+|[-_]+$/g, "")
-    .slice(0, AGENT_NAME_MAX_LENGTH);
-}
-
-/**
  * Lightweight normalizer applied to every keystroke in the agent-name
  * input: downcase + fold illegal runs to `-`, but keep trailing `-` /
  * `_` so users can type `alice-bot` one character at a time. Leading
@@ -115,6 +101,7 @@ type AvailabilityState =
 
 export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const queryClient = useQueryClient();
+  const { refreshMe } = useAuth();
   const [displayName, setDisplayName] = useState("");
   const [name, setName] = useState("");
   const [nameDirty, setNameDirty] = useState(false);
@@ -208,6 +195,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
     onSuccess: (agent) => {
       queryClient.invalidateQueries({ queryKey: ["agents"] });
       queryClient.invalidateQueries({ queryKey: ["activity"] });
+      // Refresh /me so wizardStep flips to "completed" — otherwise the
+      // onboarding banner sticks around even though the user just
+      // created an agent through this non-onboarding path.
+      void refreshMe();
       onCreated(agent, runtime);
     },
   });

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -1,10 +1,12 @@
-import type { OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
-import { useCallback, useEffect, useState } from "react";
+import type { ClientCapabilities, OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
+import { getClientCapabilities, type HubClient, listClients } from "../api/activity.js";
 import { createAgentChat } from "../api/chats.js";
 import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { useOnboardingState } from "../hooks/use-onboarding-state.js";
+import { slugify } from "../utils/agent-naming.js";
 import { ConnectCommandPanel } from "./connect-command-panel.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog.js";
@@ -12,53 +14,69 @@ import { Input } from "./ui/input.js";
 import { Label } from "./ui/label.js";
 
 /**
- * Onboarding stepper modal — opened only by user action (banner button or
- * EmptyState "Resume setup"). Two surfaces, one outcome:
- *
- *   Step 1 "Name" — single input. Captures the agent name BEFORE asking
- *                   the user to install anything. The CLI install becomes
- *                   *motivated* ("Connect a computer to run …") instead of
- *                   the modal's first impression being a shell command.
- *
- *   Step 2 "Connect" — only shown when no client is registered yet. Once
- *                      the wizard advances (server detects a checked-in
- *                      client), the modal proceeds automatically: it POSTs
- *                      the agent (with the name from Step 1), opens a chat
- *                      with that agent, and navigates the user into the
- *                      workspace's chat view. Modal closes; the user lands
- *                      in front of an empty input box and types whatever
- *                      they actually want to ask their agent.
- *
- * If the user already has a client (returning user with deleted agent,
- * second sign-in, etc.), Step 2 is skipped — Step 1 leads straight into
- * agent creation + chat + navigate.
- *
- * Magic moment is deliberately NOT a pre-filled "Hello!" message — that's
- * a fake demo. The user types their own first message into the real
- * workspace, exactly as they will every day after.
+ * Single-card onboarding: name + connect + runtime + Create button, all
+ * visible at once. "Create" succeeds only when the agent's runtime actually
+ * comes online on the bound client (poll `/admin/agents/:uuid/client-status`
+ * until `online`), so the user lands on a chat where the agent can already
+ * answer.
  */
+
+const RUNTIME_READY_TIMEOUT_MS = 30_000;
+const RUNTIME_READY_POLL_MS = 1_000;
+const CLIENT_DETECT_POLL_MS = 3_000;
+const RUNTIME_READY_TIMEOUT_S = RUNTIME_READY_TIMEOUT_MS / 1000;
+
+type CreatingPhase = "creating-agent" | "starting-runtime" | "timeout" | null;
+
+/** Polished label for known runtime providers; falls back to the raw id. */
+function prettyRuntimeLabel(provider: string): string {
+  if (provider === "claude-code") return "Claude Code";
+  if (provider === "codex") return "Codex";
+  return provider;
+}
+
 export function OnboardingModal() {
-  const { modalOpen, closeModal, joinPath, step } = useOnboardingState();
+  const { modalOpen, closeModal, joinPath } = useOnboardingState();
   const { refreshMe, organizationId } = useAuth();
   const navigate = useNavigate();
-  const [orgs, setOrgs] = useState<OrgBrief[]>([]);
 
-  const [agentName, setAgentName] = useState("");
-  const [localStep, setLocalStep] = useState<"name" | "connect" | "creating">("name");
-  const [token, setToken] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [selectedRuntime, setSelectedRuntime] = useState<string | null>(null);
+  const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
+  const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
+  const [connectToken, setConnectToken] = useState<string | null>(null);
+  const [orgs, setOrgs] = useState<OrgBrief[]>([]);
+  const [creatingPhase, setCreatingPhase] = useState<CreatingPhase>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset local state on open. Server-driven `step` may already be
-  // `create_agent` (returning user with a connected client) — we still
-  // start at "name" so the user always picks the agent name first.
+  // Persisted across timeout retries so Try again does not recreate (and
+  // collide on the unique name).
+  const createdAgentRef = useRef<string | null>(null);
+  // Cancellation token for the active poll loop. Flipping `cancelled` makes
+  // every awaited step in pollUntilReady return early, so closing the modal
+  // mid-poll does not race state updates or fire a stale navigate().
+  const pollCancelRef = useRef<{ cancelled: boolean } | null>(null);
+
+  // Reset on open. wizardStep may already be "create_agent" (returning user
+  // with a connected client) — the card just renders Section 2 as already
+  // satisfied in that case. On close, cancel the active poll loop.
   useEffect(() => {
-    if (!modalOpen) return;
-    setAgentName("");
-    setLocalStep("name");
-    setToken(null);
+    if (!modalOpen) {
+      if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+      return;
+    }
+    setDisplayName("");
+    setSelectedRuntime(null);
+    setConnectedClient(null);
+    setCapabilities(null);
+    setConnectToken(null);
+    setCreatingPhase(null);
     setError(null);
+    createdAgentRef.current = null;
+    pollCancelRef.current = null;
   }, [modalOpen]);
 
+  // Greeting source: org name (only used in invite path).
   useEffect(() => {
     if (!modalOpen) return;
     void (async () => {
@@ -71,64 +89,54 @@ export function OnboardingModal() {
     })();
   }, [modalOpen]);
 
-  const teamName = orgs.find((o) => o.id === organizationId)?.displayName ?? "";
-  const greeting = joinPath === "invite" && teamName ? `You've joined ${teamName}.` : "Set up your first agent";
-
-  // Memoized so the auto-advance effect's dep list stays stable —
-  // recreating the function each render would refire the effect spuriously.
-  const finishOnboarding = useCallback(
-    async (name: string): Promise<void> => {
-      setLocalStep("creating");
-      setError(null);
-      try {
-        const trimmed = name.trim();
-        const agent = await api.post<{ uuid: string }>("/admin/agents", {
-          name: trimmed,
-          type: "autonomous_agent",
-          displayName: trimmed,
-        });
-        const chat = await createAgentChat(agent.uuid);
-        await refreshMe();
-        closeModal();
-        // Land the user inside the freshly-created chat with an empty input —
-        // the natural place to send a real first message.
-        navigate(`/?a=${encodeURIComponent(agent.uuid)}&c=${encodeURIComponent(chat.id)}`, { replace: true });
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to create agent");
-        // Always fall back to the name step so the user sees the error and
-        // chooses whether to retry. NOT the connect step — `finishOnboarding`
-        // is only ever entered when `step === "create_agent"` (i.e. a client
-        // is registered), so a "connect" fallback would put the user back in
-        // a now-pointless install screen AND would let the auto-advance
-        // effect immediately re-fire `finishOnboarding`, looping on
-        // persistent errors (name collision, server 500, quota).
-        setLocalStep("name");
-      }
-    },
-    [refreshMe, closeModal, navigate],
-  );
-
-  // When user submits the name input.
-  const onSubmitName = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault();
-    if (!agentName.trim()) return;
-    if (step === "connect") {
-      // Need a client first. Surface Step 2.
-      setLocalStep("connect");
-    } else {
-      // Already has a client — go straight to creation.
-      await finishOnboarding(agentName);
-    }
-  };
-
-  // Lazy-load a connect token once we know we'll show Step 2.
+  // Detect the user's most recently active connected client + its runtime
+  // capabilities. Polls every 3s while the modal is open and the user hasn't
+  // started creating yet. Re-fetching capabilities on every tick is the
+  // intentional fix for capability staleness — if the user installs a runtime
+  // mid-onboarding, the radio list updates without a modal reopen.
   useEffect(() => {
-    if (localStep !== "connect" || token) return;
+    if (!modalOpen || creatingPhase) return;
+    let cancelled = false;
+    const detect = async (): Promise<void> => {
+      try {
+        const clients = await listClients();
+        if (cancelled) return;
+        const connected = clients
+          .filter((c) => c.status === "connected")
+          .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
+        const latest = connected[0] ?? null;
+        setConnectedClient((prev) => (prev?.id === latest?.id ? prev : latest));
+        if (latest) {
+          try {
+            const withCaps = await getClientCapabilities(latest.id);
+            if (cancelled) return;
+            setCapabilities(withCaps.capabilities);
+          } catch {
+            // transient — keep last capabilities; next tick retries
+          }
+        } else {
+          setCapabilities(null);
+        }
+      } catch {
+        // best-effort
+      }
+    };
+    void detect();
+    const handle = setInterval(detect, CLIENT_DETECT_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [modalOpen, creatingPhase]);
+
+  // Lazy-load a connect token when no client is bound yet.
+  useEffect(() => {
+    if (!modalOpen || connectedClient || connectToken) return;
     let cancelled = false;
     void (async () => {
       try {
         const r = await api.post<{ token: string; expiresIn: number }>("/connect-tokens", {});
-        if (!cancelled) setToken(r.token);
+        if (!cancelled) setConnectToken(r.token);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to generate connect token");
       }
@@ -136,84 +144,244 @@ export function OnboardingModal() {
     return () => {
       cancelled = true;
     };
-  }, [localStep, token]);
+  }, [modalOpen, connectedClient, connectToken]);
 
-  // While in Step 2, poll /me every 3s. When the wizard advances to
-  // `create_agent` (server saw a client), kick off agent + chat creation
-  // automatically.
+  // Compute the runtime options visible to the user (only state="ok" — the
+  // ones we can actually pin without sending the user to fix auth/install).
+  // Default-select the first one. If the active selection becomes invalid
+  // (client switched, runtime removed), drop back to the first ok option.
+  const okRuntimes = capabilities
+    ? Object.entries(capabilities)
+        .filter(([, entry]) => entry.state === "ok")
+        .map(([provider]) => provider)
+    : [];
+  // Functional setter avoids reading `selectedRuntime` from closure, so the
+  // dependency list legitimately stays at [capabilities] without lint suppression.
   useEffect(() => {
-    if (localStep !== "connect") return;
-    let stopped = false;
-    const tick = async () => {
-      if (stopped) return;
-      await refreshMe();
-    };
-    const handle = setInterval(tick, 3000);
-    return () => {
-      stopped = true;
-      clearInterval(handle);
-    };
-  }, [localStep, refreshMe]);
+    setSelectedRuntime((prev) => {
+      if (!capabilities) return null;
+      const ok = Object.entries(capabilities)
+        .filter(([, entry]) => entry.state === "ok")
+        .map(([provider]) => provider);
+      if (prev && ok.includes(prev)) return prev;
+      return ok[0] ?? null;
+    });
+  }, [capabilities]);
 
-  // Auto-advance: client just registered while we were waiting.
-  useEffect(() => {
-    if (localStep === "connect" && step === "create_agent" && agentName.trim()) {
-      void finishOnboarding(agentName);
-    }
-  }, [localStep, step, agentName, finishOnboarding]);
+  const teamName = orgs.find((o) => o.id === organizationId)?.displayName ?? "";
+  const greeting = joinPath === "invite" && teamName ? `You've joined ${teamName}.` : "Set up your first agent";
 
-  const cliCommand = token
-    ? `npm install -g @agent-team-foundation/first-tree-hub\nfirst-tree-hub connect ${token}`
+  const cliCommand = connectToken
+    ? `npm install -g @agent-team-foundation/first-tree-hub\nfirst-tree-hub connect ${connectToken}`
     : null;
 
+  // Poll `/admin/agents/:uuid/client-status` until `online: true` or the
+  // 30s timeout. Cancellable via `pollCancelRef`: on modal close every
+  // awaited boundary returns early without touching state.
+  const pollUntilReady = useCallback(
+    async (agentUuid: string): Promise<void> => {
+      // Cancel any prior loop so two retries can't coexist.
+      if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+      const token: { cancelled: boolean } = { cancelled: false };
+      pollCancelRef.current = token;
+
+      const startedAt = Date.now();
+      while (!token.cancelled) {
+        let online = false;
+        try {
+          const status = await api.get<{ online: boolean; clientId: string | null }>(
+            `/admin/agents/${encodeURIComponent(agentUuid)}/client-status`,
+          );
+          if (token.cancelled) return;
+          online = status.online === true;
+        } catch {
+          if (token.cancelled) return;
+          // transient — keep polling
+        }
+        if (online) {
+          try {
+            const chat = await createAgentChat(agentUuid);
+            if (token.cancelled) return;
+            await refreshMe();
+            if (token.cancelled) return;
+            closeModal();
+            navigate(`/?a=${encodeURIComponent(agentUuid)}&c=${encodeURIComponent(chat.id)}`, { replace: true });
+          } catch (err) {
+            if (token.cancelled) return;
+            // Reuse the timeout UI: agent + runtime are fine, only the chat
+            // creation failed. "Try again" will re-enter the loop, find
+            // online=true again, and retry createAgentChat.
+            setError(err instanceof Error ? err.message : "Failed to open chat");
+            setCreatingPhase("timeout");
+          }
+          return;
+        }
+        if (Date.now() - startedAt > RUNTIME_READY_TIMEOUT_MS) {
+          if (!token.cancelled) setCreatingPhase("timeout");
+          return;
+        }
+        await new Promise((r) => setTimeout(r, RUNTIME_READY_POLL_MS));
+      }
+    },
+    [refreshMe, closeModal, navigate],
+  );
+
+  const canCreate = !!(
+    displayName.trim() &&
+    connectedClient &&
+    selectedRuntime &&
+    okRuntimes.includes(selectedRuntime) &&
+    !creatingPhase
+  );
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = displayName.trim();
+    if (!connectedClient || !selectedRuntime || !trimmed) return;
+    setError(null);
+    setCreatingPhase("creating-agent");
+    // Derive the @handle slug from the display name. Empty (e.g. all CJK)
+    // → omit `name` so the server stores NULL; the user can set a handle
+    // later in Settings if they need one for @mention.
+    const slug = slugify(trimmed);
+    let agentUuid: string;
+    try {
+      const res = await api.post<{ uuid: string }>("/admin/agents", {
+        type: "personal_assistant",
+        displayName: trimmed,
+        ...(slug ? { name: slug } : {}),
+        clientId: connectedClient.id,
+        runtimeProvider: selectedRuntime,
+      });
+      agentUuid = res.uuid;
+      createdAgentRef.current = agentUuid;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create agent");
+      setCreatingPhase(null);
+      return;
+    }
+    setCreatingPhase("starting-runtime");
+    await pollUntilReady(agentUuid);
+  }, [displayName, connectedClient, selectedRuntime, pollUntilReady]);
+
+  const handleRetry = useCallback(async () => {
+    const agentUuid = createdAgentRef.current;
+    if (!agentUuid) return;
+    setError(null);
+    setCreatingPhase("starting-runtime");
+    await pollUntilReady(agentUuid);
+  }, [pollUntilReady]);
+
+  // Block dismissal only while a network call is in flight; allow dismissal
+  // during the timeout state (the user explicitly wants out).
+  const dismissBlocked = creatingPhase === "creating-agent" || creatingPhase === "starting-runtime";
+
   return (
-    <Dialog open={modalOpen} onOpenChange={(next) => !next && closeModal()}>
+    <Dialog open={modalOpen} onOpenChange={(next) => !next && !dismissBlocked && closeModal()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{greeting}</DialogTitle>
-          <DialogDescription>
-            {localStep === "name"
-              ? "What should we call your agent?"
-              : localStep === "connect"
-                ? `Connect a computer to run "${agentName.trim()}".`
-                : "Setting things up…"}
-          </DialogDescription>
+          <DialogDescription>Three quick steps and you're chatting with your agent.</DialogDescription>
         </DialogHeader>
 
-        {error && localStep !== "connect" && (
-          <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>
-        )}
+        {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
 
-        {localStep === "name" && (
-          <form className="space-y-3" onSubmit={onSubmitName}>
-            <div className="space-y-2">
-              <Label htmlFor="onboarding-agent-name">Agent name</Label>
-              <Input
-                id="onboarding-agent-name"
-                value={agentName}
-                onChange={(e) => setAgentName(e.target.value)}
-                placeholder="my-first-agent"
-                autoFocus
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={!agentName.trim()}>
-              Continue
-            </Button>
-          </form>
-        )}
-
-        {localStep === "connect" && (
-          <ConnectCommandPanel
-            command={cliCommand}
-            phase={error ? "error" : "waiting"}
-            copyLabel={{ idle: "Copy commands", done: "Copied" }}
-            waitingText="Waiting for your computer to check in…"
-            errorContent={error}
-            caption={null}
+        <div className="space-y-2">
+          <Label htmlFor="onboarding-agent-name">
+            <span className="font-semibold">1. Agent name</span>
+          </Label>
+          <Input
+            id="onboarding-agent-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="My assistant"
+            maxLength={200}
+            autoFocus
+            disabled={!!creatingPhase}
           />
-        )}
+        </div>
 
-        {localStep === "creating" && <p className="text-body text-muted-foreground">Creating your agent…</p>}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">2. Connect a computer</span>
+            {connectedClient && (
+              <span className="text-label" style={{ color: "var(--color-success)" }}>
+                ✓ Connected
+              </span>
+            )}
+          </div>
+          {connectedClient ? (
+            <p className="text-label text-muted-foreground">{connectedClient.id}</p>
+          ) : (
+            <ConnectCommandPanel
+              command={cliCommand}
+              phase="waiting"
+              copyLabel={{ idle: "Copy commands", done: "Copied" }}
+              waitingText="Waiting for your computer to check in…"
+            />
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2" id="onboarding-runtime-label">
+            <span className="font-semibold">3. Where it runs</span>
+            {!connectedClient && <span className="text-label text-muted-foreground">(available after connecting)</span>}
+          </div>
+          {connectedClient && okRuntimes.length === 0 && (
+            <p className="text-label text-destructive">
+              No runtime is ready on this computer. Install Claude Code or Codex, then check back.
+            </p>
+          )}
+          {okRuntimes.length > 0 && (
+            <div role="radiogroup" aria-labelledby="onboarding-runtime-label" className="space-y-1">
+              {okRuntimes.map((provider) => (
+                <label key={provider} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="onboarding-runtime"
+                    value={provider}
+                    checked={selectedRuntime === provider}
+                    onChange={() => setSelectedRuntime(provider)}
+                    disabled={!!creatingPhase}
+                  />
+                  <span>{prettyRuntimeLabel(provider)}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {creatingPhase === "creating-agent" && <p className="text-body text-muted-foreground">⟳ Creating agent…</p>}
+        {creatingPhase === "starting-runtime" && (
+          <div className="space-y-1">
+            <p className="text-body text-muted-foreground">✓ Agent created</p>
+            <p className="text-body text-muted-foreground">⟳ Starting runtime on your computer…</p>
+          </div>
+        )}
+        {creatingPhase === "timeout" && (
+          <div className="space-y-2">
+            <p className="text-body text-destructive">
+              ⚠️ The runtime didn't start within {RUNTIME_READY_TIMEOUT_S} seconds.
+            </p>
+            <p className="text-label text-muted-foreground">
+              Common causes: missing API key, network issue, expired credentials. Your agent has been created — fix the
+              issue on your computer and click Try again. If you close instead, reusing the same name will require
+              deleting the existing agent in Settings first.
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleRetry}>
+                Try again
+              </Button>
+              <Button variant="outline" onClick={closeModal}>
+                Close
+              </Button>
+            </div>
+          </div>
+        )}
+        {!creatingPhase && (
+          <Button className="w-full" disabled={!canCreate} onClick={handleCreate}>
+            Create
+          </Button>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -317,6 +317,8 @@ export function OnboardingModal() {
               phase="waiting"
               copyLabel={{ idle: "Copy commands", done: "Copied" }}
               waitingText="Waiting for your computer to check in…"
+              caption={null}
+              copyButtonPlacement="bottom"
             />
           )}
         </div>

--- a/packages/web/src/components/onboarding-modal.tsx
+++ b/packages/web/src/components/onboarding-modal.tsx
@@ -283,7 +283,12 @@ export function OnboardingModal() {
           <DialogDescription>Three quick steps and you're chatting with your agent.</DialogDescription>
         </DialogHeader>
 
-        {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+        {/* Top-level error banner. Hidden in the timeout phase so the
+            phase-specific timeout block can frame the error in context
+            (runtime timeout vs createAgentChat failure). */}
+        {error && creatingPhase !== "timeout" && (
+          <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+        )}
 
         <div className="space-y-2">
           <Label htmlFor="onboarding-agent-name">
@@ -361,14 +366,26 @@ export function OnboardingModal() {
         )}
         {creatingPhase === "timeout" && (
           <div className="space-y-2">
-            <p className="text-body text-destructive">
-              ⚠️ The runtime didn't start within {RUNTIME_READY_TIMEOUT_S} seconds.
-            </p>
-            <p className="text-label text-muted-foreground">
-              Common causes: missing API key, network issue, expired credentials. Your agent has been created — fix the
-              issue on your computer and click Try again. If you close instead, reusing the same name will require
-              deleting the existing agent in Settings first.
-            </p>
+            {error ? (
+              <>
+                <p className="text-body text-destructive">⚠️ {error}</p>
+                <p className="text-label text-muted-foreground">
+                  Your agent is set up but we couldn't open the chat. Click Try again, or Close to abandon this attempt
+                  — reusing the same name will require deleting the existing agent in Settings first.
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="text-body text-destructive">
+                  ⚠️ The runtime didn't start within {RUNTIME_READY_TIMEOUT_S} seconds.
+                </p>
+                <p className="text-label text-muted-foreground">
+                  Common causes: missing API key, network issue, expired credentials. Your agent has been created — fix
+                  the issue on your computer and click Try again. If you close instead, reusing the same name will
+                  require deleting the existing agent in Settings first.
+                </p>
+              </>
+            )}
             <div className="flex gap-2">
               <Button variant="outline" onClick={handleRetry}>
                 Try again

--- a/packages/web/src/utils/agent-naming.ts
+++ b/packages/web/src/utils/agent-naming.ts
@@ -1,0 +1,19 @@
+import { AGENT_NAME_MAX_LENGTH } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Lowercase, ASCII-only slug from arbitrary unicode display names. Strips
+ * leading/trailing separators and clamps to the agent-name length cap.
+ * NFKD-normalized first so latin-1 accents collapse to their base letter
+ * (`café` → `cafe`) instead of being lost. Returns an empty string for input
+ * that has no representable ASCII (e.g. all CJK or emoji) — callers should
+ * treat empty as "let the server leave name NULL" rather than as a valid slug.
+ */
+export function slugify(raw: string): string {
+  return raw
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
+    .slice(0, AGENT_NAME_MAX_LENGTH);
+}


### PR DESCRIPTION
## Summary

- Replace the multi-step onboarding wizard with a **single card** showing all three sections at once (name, connect, runtime). Create succeeds only when the agent's runtime is actually online on the bound client (poll `/admin/agents/:uuid/client-status` with a 30s timeout, cancellable on modal close), so the user lands on a chat that can answer immediately.
- `POST /admin/agents` now passes `clientId` (latest active connected client) + `runtimeProvider` (user's pick from the client's `state="ok"` capabilities). Both fields were missing previously, so onboarding agents were created as orphans without a runtime.
- Drop the auto-sent seed first message — chat is empty for the user's own first question.
- `new-agent-dialog` now refreshes `/me` on `onSuccess` so the onboarding banner clears immediately after a non-onboarding agent creation (banner visibility hangs on `wizardStep` from `/me`, which previously wasn't being invalidated).
- Reuse `ConnectCommandPanel` from #201; adds a new `copyButtonPlacement: "right" | "bottom"` prop (default `"right"` preserves the `/clients` New Connection layout) so onboarding can place the Copy button below the long CLI command instead of squeezing it on the right.
- Display-name-driven input: store user input as `displayName` (unicode) and derive `name` (the @-handle slug) via `slugify` (NFKD-normalized so `"café"` → `"cafe"`); empty slug omits `name` so server stores NULL.
- Extract `slugify` to `packages/web/src/utils/agent-naming.ts`; both onboarding and `new-agent-dialog` now share it.
- Pretty runtime labels (`"Claude Code"`, `"Codex"`) instead of raw provider ids.
- A11y: radio group via `role="radiogroup"` + `aria-labelledby`.

Bumps `packages/command` 0.10.5 → 0.10.6.

## Test plan

- [ ] Reset dev user (no clients, no active personal_assistant agents) → banner appears at top
- [ ] Click "Get started" → modal opens with three sections, Create button disabled
- [ ] Fill name (try unicode like "我的助手", "Café Bot") → ① shows ✓
- [ ] Copy CLI command from ② → run on a fresh `FIRST_TREE_HUB_HOME` → ② flips to "✓ Connected" within ~3s
- [ ] ③ runtime list populates from client capabilities; only `state="ok"` providers shown; first auto-selected; labels are pretty ("Claude Code")
- [ ] Click Create → "Creating agent…" → "Agent created ✓ / Starting runtime…" → land on empty chat (input ready for typing)
- [ ] **Timeout path**: kill CLI right after Create → 30s later see runtime-timeout copy + [Try again] / [Close]
- [ ] **Chat-failure path** (harder to reproduce manually): if `createAgentChat` fails after runtime ready, timeout block shows the error message + chat-specific hint (not the runtime-cold-start copy)
- [ ] Close modal mid-poll → no stale `navigate` fires after closure (cancellation token works)
- [ ] Try again after timeout reuses the same agent (no 409 collision)
- [ ] In `new-agent-dialog`: create an agent → banner disappears immediately (verifies `refreshMe`)
- [ ] `/clients` New Connection modal still shows Copy button on the right (default `copyButtonPlacement` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)