### PR TITLE
fix(client): surface stale agent aliases in doctor + add agent prune

### DIFF
--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -59,6 +59,14 @@ export class AgentSlot {
     this.logger = createLogger("slot").child({ agentName: config.name, agentId: config.agentId });
   }
 
+  get name(): string {
+    return this.config.name;
+  }
+
+  get agentId(): string {
+    return this.config.agentId;
+  }
+
   private get clientConnection(): ClientConnection {
     return this.config.clientConnection;
   }

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -135,11 +135,28 @@ export class AgentRuntime {
     const results = await Promise.allSettled(this.slots.map((slot) => slot.start(contextTreePath)));
 
     let failed = 0;
-    for (const result of results) {
+    const failures: Array<{ agentName: string; agentId: string; reason: string }> = [];
+    for (const [i, result] of results.entries()) {
       if (result.status === "rejected") {
-        this.logger.error({ err: result.reason }, "failed to start agent");
+        const slot = this.slots[i];
+        // `slots` and `results` are 1:1 by construction (Promise.allSettled
+        // preserves input order), so this lookup is total.
+        const agentName = slot?.name ?? "<unknown>";
+        const agentId = slot?.agentId ?? "<unknown>";
+        const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        this.logger.error({ err: result.reason, agentName, agentId, reason }, "failed to start agent");
+        failures.push({ agentName, agentId, reason });
         failed++;
       }
+    }
+
+    if (failed > 0) {
+      // One aggregate WARN that operators can grep for from `client doctor` /
+      // log triage without having to scan for every per-slot ERROR line.
+      this.logger.warn(
+        { failedCount: failed, totalCount: this.slots.length, failures },
+        "some agents failed to start — check that each agentId is still pinned to this client",
+      );
     }
 
     if (failed === this.slots.length) {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/agent-prune.test.ts
+++ b/packages/command/src/__tests__/agent-prune.test.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findStaleAliases, type PinnedAgent } from "../core/agent-prune.js";
+
+/**
+ * Pins the four cases that drove the rewrite:
+ *   1. all aliases pinned to me → empty result
+ *   2. agentId present in server response but on another client → "pinned-elsewhere"
+ *   3. agentId not in server response at all → "unowned"
+ *   4. broken / missing yaml → "unreadable" (must not throw — this is the
+ *      junk-dir case that broke the previous loadAgents-based impl)
+ *
+ * The SDK call is injected as `listPinnedAgents`, so these tests don't
+ * need to spin up a Hub or stub fetch.
+ */
+
+const THIS_CLIENT = "client_self";
+const OTHER_CLIENT = "client_other";
+
+function writeAlias(agentsDir: string, name: string, body: string): void {
+  const dir = join(agentsDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "agent.yaml"), body);
+}
+
+let agentsDir: string;
+
+beforeEach(() => {
+  agentsDir = mkdtempSync(join(tmpdir(), "fthub-prune-"));
+});
+
+afterEach(() => {
+  rmSync(agentsDir, { recursive: true, force: true });
+});
+
+describe("findStaleAliases", () => {
+  it("returns empty when every local alias maps to a pinned agent on this client", async () => {
+    writeAlias(agentsDir, "alpha", "agentId: 00000000-0000-0000-0000-00000000aaaa\nruntime: claude-code\n");
+    writeAlias(agentsDir, "beta", "agentId: 00000000-0000-0000-0000-00000000bbbb\nruntime: claude-code\n");
+
+    const remote: PinnedAgent[] = [
+      { agentId: "00000000-0000-0000-0000-00000000aaaa", clientId: THIS_CLIENT },
+      { agentId: "00000000-0000-0000-0000-00000000bbbb", clientId: THIS_CLIENT },
+    ];
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => remote,
+    });
+    expect(stale).toEqual([]);
+  });
+
+  it("classifies an agentId pinned to a different client as pinned-elsewhere", async () => {
+    writeAlias(agentsDir, "shared-name", "agentId: 00000000-0000-0000-0000-00000000cccc\nruntime: claude-code\n");
+
+    const remote: PinnedAgent[] = [{ agentId: "00000000-0000-0000-0000-00000000cccc", clientId: OTHER_CLIENT }];
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => remote,
+    });
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toMatchObject({
+      name: "shared-name",
+      agentId: "00000000-0000-0000-0000-00000000cccc",
+      reason: { kind: "pinned-elsewhere", clientId: OTHER_CLIENT },
+    });
+  });
+
+  it("classifies an unknown agentId as unowned", async () => {
+    writeAlias(agentsDir, "ghost", "agentId: 00000000-0000-0000-0000-00000000dead\nruntime: claude-code\n");
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => [],
+    });
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toMatchObject({
+      name: "ghost",
+      agentId: "00000000-0000-0000-0000-00000000dead",
+      reason: { kind: "unowned" },
+    });
+  });
+
+  it("classifies a malformed yaml as unreadable (does not throw)", async () => {
+    // Real-world junk: dir exists, yaml is empty / has no agentId — used to
+    // crash the entire prune via Zod throwing inside loadAgents.
+    writeAlias(agentsDir, "d", "this: is: not: valid: yaml: at: all\n  - broken");
+    writeAlias(agentsDir, "no-id", "runtime: claude-code\n");
+    // And a dir with no yaml at all.
+    mkdirSync(join(agentsDir, "empty-dir"), { recursive: true });
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => [],
+    });
+    expect(stale).toHaveLength(3);
+    for (const s of stale) {
+      expect(s.agentId).toBeNull();
+      expect(s.reason.kind).toBe("unreadable");
+    }
+    expect(stale.map((s) => s.name).sort()).toEqual(["d", "empty-dir", "no-id"]);
+  });
+
+  it("returns mixed results when good and bad aliases coexist", async () => {
+    writeAlias(agentsDir, "active", "agentId: 00000000-0000-0000-0000-00000000aaaa\nruntime: claude-code\n");
+    writeAlias(agentsDir, "moved", "agentId: 00000000-0000-0000-0000-00000000bbbb\nruntime: claude-code\n");
+    writeAlias(agentsDir, "deleted", "agentId: 00000000-0000-0000-0000-00000000cccc\nruntime: claude-code\n");
+    writeAlias(agentsDir, "junk", "");
+
+    const remote: PinnedAgent[] = [
+      { agentId: "00000000-0000-0000-0000-00000000aaaa", clientId: THIS_CLIENT },
+      { agentId: "00000000-0000-0000-0000-00000000bbbb", clientId: OTHER_CLIENT },
+    ];
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => remote,
+    });
+    const byName = Object.fromEntries(stale.map((s) => [s.name, s.reason]));
+    expect(Object.keys(byName).sort()).toEqual(["deleted", "junk", "moved"]);
+    expect(byName.moved).toEqual({ kind: "pinned-elsewhere", clientId: OTHER_CLIENT });
+    expect(byName.deleted).toEqual({ kind: "unowned" });
+    expect(byName.junk?.kind).toBe("unreadable");
+  });
+
+  it("returns empty when the agents dir does not exist", async () => {
+    const stale = await findStaleAliases({
+      agentsDir: join(agentsDir, "does-not-exist"),
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => [],
+    });
+    expect(stale).toEqual([]);
+  });
+});

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -3,9 +3,11 @@ import { join } from "node:path";
 import type { MessageFormat } from "@agent-team-foundation/first-tree-hub-shared";
 import {
   agentConfigSchema,
+  clientConfigSchema,
   DEFAULT_CONFIG_DIR,
   DEFAULT_DATA_DIR,
   loadAgents,
+  resolveConfigReadonly,
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { cleanWorkspaces, FirstTreeHubSDK, SdkError, SessionRegistry } from "@first-tree-hub/client";
@@ -13,10 +15,9 @@ import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail, success } from "../cli/output.js";
 import { resolveReplyToFromEnv } from "../core/agent-messaging.js";
-import { findStaleAliases, removeLocalAgent } from "../core/agent-prune.js";
 import { ensureFreshAccessToken, resolveServerUrl, saveAgentConfig } from "../core/bootstrap.js";
 import { bindFeishuBot, bindFeishuUser } from "../core/feishu.js";
-import { promptAddAgent } from "../core/index.js";
+import { findStaleAliases, formatStaleReason, promptAddAgent, removeLocalAgent } from "../core/index.js";
 import { print } from "../core/output.js";
 import { registerAgentConfigCommands } from "./agent-config.js";
 
@@ -142,6 +143,24 @@ async function resolveAgent(serverUrl: string, adminToken: string, agentName: st
   return found;
 }
 
+/**
+ * Read the persisted `client.id` from `client.yaml`. Required by `agent
+ * prune` to filter the user-scoped `listMyAgents` response down to "what
+ * actually binds on THIS machine". `fail()` instead of throwing so the
+ * "no client.yaml — run client connect first" path renders as a clean
+ * CLI error rather than a stack trace.
+ */
+function readClientId(): string {
+  const cfg = resolveConfigReadonly({ schema: clientConfigSchema, role: "client" }) as {
+    client?: { id?: unknown };
+  };
+  const id = cfg.client?.id;
+  if (typeof id !== "string" || id.length === 0) {
+    fail("MISSING_CLIENT_ID", "No client.id found in client.yaml. Run `first-tree-hub connect <token>` first.", 2);
+  }
+  return id;
+}
+
 // ── Main registration ─────────────────────────────────────────────────
 
 export function registerAgentCommands(program: Command): void {
@@ -207,16 +226,18 @@ export function registerAgentCommands(program: Command): void {
   // typo `agent add` left a junk dir.
   agent
     .command("prune")
-    .description("Remove local agent aliases that are no longer pinned to this client (or that you don't own)")
+    .description("Remove local agent aliases that won't bind on this client (unowned, pinned elsewhere, or unreadable)")
     .option("--yes", "Skip the interactive confirmation prompt")
     .option("--dry-run", "Only list what would be removed; don't touch the filesystem")
     .option("--server <url>", "Hub server URL")
     .action(async (options: { yes?: boolean; dryRun?: boolean; server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);
+        const clientId = readClientId();
+        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
         const stale = await findStaleAliases({
-          serverUrl,
-          getAccessToken: () => ensureFreshAccessToken(),
+          clientId,
+          listPinnedAgents: () => sdk.listMyAgents(),
         });
 
         if (stale.length === 0) {
@@ -226,7 +247,8 @@ export function registerAgentCommands(program: Command): void {
 
         print.line(`\n  ${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"}:\n\n`);
         for (const s of stale) {
-          print.line(`    - ${s.name.padEnd(30)} (agentId: ${s.agentId})\n`);
+          const id = s.agentId ?? "—";
+          print.line(`    - ${s.name.padEnd(30)} ${id.padEnd(38)} ${formatStaleReason(s.reason)}\n`);
         }
         print.line("\n");
 
@@ -246,11 +268,24 @@ export function registerAgentCommands(program: Command): void {
           }
         }
 
+        // Per-alias try/catch so a single permission/lock error doesn't
+        // skip the rest of the cleanup. Failures are reported inline; the
+        // user can re-run prune to retry the failed entries.
+        let removed = 0;
+        let failed = 0;
         for (const s of stale) {
-          removeLocalAgent(s.name);
-          print.line(`  ✓ removed ${s.name}\n`);
+          try {
+            removeLocalAgent(s.name);
+            print.line(`  ✓ removed ${s.name}\n`);
+            removed++;
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            print.line(`  ✗ ${s.name} (${msg.slice(0, 80)})\n`);
+            failed++;
+          }
         }
-        print.line(`\n  ${stale.length} alias(es) pruned.\n\n`);
+        print.line(`\n  ${removed} pruned${failed > 0 ? `, ${failed} failed (re-run to retry)` : ""}.\n\n`);
+        if (failed > 0) process.exitCode = 1;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("PRUNE_ERROR", msg);

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { MessageFormat } from "@agent-team-foundation/first-tree-hub-shared";
 import {
@@ -9,9 +9,11 @@ import {
   setConfigValue,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { cleanWorkspaces, FirstTreeHubSDK, SdkError, SessionRegistry } from "@first-tree-hub/client";
+import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail, success } from "../cli/output.js";
 import { resolveReplyToFromEnv } from "../core/agent-messaging.js";
+import { findStaleAliases, removeLocalAgent } from "../core/agent-prune.js";
 import { ensureFreshAccessToken, resolveServerUrl, saveAgentConfig } from "../core/bootstrap.js";
 import { bindFeishuBot, bindFeishuUser } from "../core/feishu.js";
 import { promptAddAgent } from "../core/index.js";
@@ -192,11 +194,67 @@ export function registerAgentCommands(program: Command): void {
         print.line(`  Agent "${name}" not found.\n`);
         process.exit(1);
       }
-      rmSync(agentDir, { recursive: true, force: true });
-      rmSync(join(DEFAULT_DATA_DIR, "workspaces", name), { recursive: true, force: true });
-      rmSync(join(DEFAULT_DATA_DIR, "sessions", `${name}.json`), { force: true });
+      removeLocalAgent(name);
 
       print.line(`  Agent "${name}" removed.\n`);
+    });
+
+  // ── prune — drop local aliases the server no longer pins to me ─────
+  // Counterpart to `client doctor`'s "stale aliases" warning. Walks the
+  // local `agents/<name>/` dirs and removes any whose `agentId` is not
+  // returned by `/api/v1/clients/me/agents`. Common after `client claim`,
+  // after the previous owner deleted an agent server-side, or after a
+  // typo `agent add` left a junk dir.
+  agent
+    .command("prune")
+    .description("Remove local agent aliases that are no longer pinned to this client (or that you don't own)")
+    .option("--yes", "Skip the interactive confirmation prompt")
+    .option("--dry-run", "Only list what would be removed; don't touch the filesystem")
+    .option("--server <url>", "Hub server URL")
+    .action(async (options: { yes?: boolean; dryRun?: boolean; server?: string }) => {
+      try {
+        const serverUrl = resolveServerUrl(options.server);
+        const stale = await findStaleAliases({
+          serverUrl,
+          getAccessToken: () => ensureFreshAccessToken(),
+        });
+
+        if (stale.length === 0) {
+          print.line("\n  ✓ No stale agent aliases. Local config matches the server.\n\n");
+          return;
+        }
+
+        print.line(`\n  ${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"}:\n\n`);
+        for (const s of stale) {
+          print.line(`    - ${s.name.padEnd(30)} (agentId: ${s.agentId})\n`);
+        }
+        print.line("\n");
+
+        if (options.dryRun) {
+          print.line("  Dry run — no files removed. Re-run without --dry-run to delete.\n\n");
+          return;
+        }
+
+        if (!options.yes) {
+          const approved = await confirm({
+            message: `Remove the ${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"} above (config + workspace + session state)?`,
+            default: false,
+          }).catch(() => false);
+          if (!approved) {
+            print.line("  Cancelled.\n\n");
+            return;
+          }
+        }
+
+        for (const s of stale) {
+          removeLocalAgent(s.name);
+          print.line(`  ✓ removed ${s.name}\n`);
+        }
+        print.line(`\n  ${stale.length} alias(es) pruned.\n\n`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("PRUNE_ERROR", msg);
+      }
     });
 
   agent

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -15,6 +15,7 @@ import {
   ClientOrgMismatchError,
   ClientUserMismatchError,
   configureClientLoggerForService,
+  FirstTreeHubSDK,
   probeCapabilities,
 } from "@first-tree-hub/client";
 import { confirm } from "@inquirer/prompts";
@@ -34,6 +35,7 @@ import {
   declineUpdate,
   ensureFreshAccessToken,
   findStaleAliases,
+  formatStaleReason,
   handleClientOrgMismatch,
   migrateLocalAgentDirs,
   printResults,
@@ -214,17 +216,26 @@ export function registerClientCommands(program: Command): void {
     .action(async () => {
       print.line("\n  First Tree Hub Client Doctor\n\n");
       // The "Agents" line cross-references local aliases against the
-      // server's pinned-agent set. Without a configured server URL we
-      // can't talk to anything; fall back to the legacy local-only count.
+      // server's pinned-agent set, filtered to THIS client.id (so the
+      // verdict matches what R-RUN will accept). Without a configured
+      // server URL we can't talk to anything; fall back to the legacy
+      // local-only count.
       let agentCheck: Awaited<ReturnType<typeof reconcileAgentConfigs>>;
       try {
         const serverUrl = resolveServerUrl();
+        const cfg = await initConfig({ schema: clientConfigSchema, role: "client" });
+        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
         agentCheck = await reconcileAgentConfigs({
-          serverUrl,
-          getAccessToken: () => ensureFreshAccessToken(),
+          clientId: cfg.client.id,
+          listPinnedAgents: () => sdk.listMyAgents(),
         });
       } catch {
         agentCheck = checkAgentConfigs();
+      } finally {
+        // Doctor is read-only; release the singleton so subsequent
+        // commands re-resolve config cleanly.
+        resetConfig();
+        resetConfigMeta();
       }
       const results = [
         checkNodeVersion(),
@@ -325,7 +336,7 @@ export function registerClientCommands(program: Command): void {
     .description(
       "Transfer ownership of this machine to your account (unpins the previous owner's agents from this machine)",
     )
-    .option("--confirm", "Skip the interactive confirmation prompt")
+    .option("--confirm", "Skip confirmation prompts (claim + auto-prune stale aliases)")
     .option("--server <url>", "Hub server URL")
     .action(async (options: { confirm?: boolean; server?: string }) => {
       try {
@@ -380,25 +391,28 @@ export function registerClientCommands(program: Command): void {
         // doctor keeps reporting the inflated "N configured" count.
         // Detect + offer to prune in the same breath as the claim.
         try {
+          const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
           const stale = await findStaleAliases({
-            serverUrl,
-            getAccessToken: () => ensureFreshAccessToken(),
+            clientId,
+            listPinnedAgents: () => sdk.listMyAgents(),
           });
           if (stale.length === 0) {
             print.line("  No stale local aliases — local config already matches the server.\n");
           } else {
             print.line(
-              `\n  ${stale.length} local ${stale.length === 1 ? "alias" : "aliases"} no longer pinned to this client:\n\n`,
+              `\n  ${stale.length} local ${stale.length === 1 ? "alias" : "aliases"} won't bind on this client:\n\n`,
             );
             for (const s of stale) {
-              print.line(`    - ${s.name.padEnd(30)} (agentId: ${s.agentId})\n`);
+              const id = s.agentId ?? "—";
+              print.line(`    - ${s.name.padEnd(30)} ${id.padEnd(38)} ${formatStaleReason(s.reason)}\n`);
             }
             print.line("\n");
 
             // `--confirm` was the operator pre-acknowledging the claim
             // itself; reusing the flag here keeps `client claim --confirm`
             // a fully non-interactive command (which the docs and the
-            // CLIENT_USER_MISMATCH error message both rely on).
+            // CLIENT_USER_MISMATCH error message both rely on). The flag
+            // description on the command spells this scope out.
             const approved =
               options.confirm === true
                 ? true
@@ -408,11 +422,22 @@ export function registerClientCommands(program: Command): void {
                   }).catch(() => false);
 
             if (approved) {
+              let removed = 0;
+              let failed = 0;
               for (const s of stale) {
-                removeLocalAgent(s.name);
-                print.line(`  ✓ removed ${s.name}\n`);
+                try {
+                  removeLocalAgent(s.name);
+                  print.line(`  ✓ removed ${s.name}\n`);
+                  removed++;
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : String(err);
+                  print.line(`  ✗ ${s.name} (${msg.slice(0, 80)})\n`);
+                  failed++;
+                }
               }
-              print.line(`\n  ${stale.length} alias(es) pruned.\n`);
+              print.line(
+                `\n  ${removed} pruned${failed > 0 ? `, ${failed} failed (re-run \`agent prune\` to retry)` : ""}.\n`,
+              );
             } else {
               print.line("  Skipped. Run `first-tree-hub agent prune` later to clean up.\n");
             }

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -33,12 +33,15 @@ import {
   createExecuteUpdate,
   declineUpdate,
   ensureFreshAccessToken,
+  findStaleAliases,
   handleClientOrgMismatch,
   migrateLocalAgentDirs,
   printResults,
   promptMissingFields,
   promptUpdate,
+  reconcileAgentConfigs,
   reconcileLocalRuntimeProviders,
+  removeLocalAgent,
   resolveServerUrl,
   uploadClientCapabilities,
 } from "../core/index.js";
@@ -210,11 +213,24 @@ export function registerClientCommands(program: Command): void {
     .description("Check client environment readiness")
     .action(async () => {
       print.line("\n  First Tree Hub Client Doctor\n\n");
+      // The "Agents" line cross-references local aliases against the
+      // server's pinned-agent set. Without a configured server URL we
+      // can't talk to anything; fall back to the legacy local-only count.
+      let agentCheck: Awaited<ReturnType<typeof reconcileAgentConfigs>>;
+      try {
+        const serverUrl = resolveServerUrl();
+        agentCheck = await reconcileAgentConfigs({
+          serverUrl,
+          getAccessToken: () => ensureFreshAccessToken(),
+        });
+      } catch {
+        agentCheck = checkAgentConfigs();
+      }
       const results = [
         checkNodeVersion(),
         checkClientConfig(),
         await checkServerReachable(),
-        checkAgentConfigs(),
+        agentCheck,
         await checkWebSocket(),
         checkBackgroundService(),
       ];
@@ -356,7 +372,58 @@ export function registerClientCommands(program: Command): void {
         };
 
         print.line(`  ✓ Ownership transferred. ${result.unpinnedAgentCount} agent(s) unpinned.\n`);
-        print.line("  Run `first-tree-hub client start` to reconnect.\n\n");
+
+        // After claim, the previous owner's pinned agents are unpinned
+        // server-side but their `agents/<name>/agent.yaml` files still
+        // sit on disk. Without cleanup, the next `client start` tries to
+        // bind those orphaned agentIds, R-RUN rejects each one, and
+        // doctor keeps reporting the inflated "N configured" count.
+        // Detect + offer to prune in the same breath as the claim.
+        try {
+          const stale = await findStaleAliases({
+            serverUrl,
+            getAccessToken: () => ensureFreshAccessToken(),
+          });
+          if (stale.length === 0) {
+            print.line("  No stale local aliases — local config already matches the server.\n");
+          } else {
+            print.line(
+              `\n  ${stale.length} local ${stale.length === 1 ? "alias" : "aliases"} no longer pinned to this client:\n\n`,
+            );
+            for (const s of stale) {
+              print.line(`    - ${s.name.padEnd(30)} (agentId: ${s.agentId})\n`);
+            }
+            print.line("\n");
+
+            // `--confirm` was the operator pre-acknowledging the claim
+            // itself; reusing the flag here keeps `client claim --confirm`
+            // a fully non-interactive command (which the docs and the
+            // CLIENT_USER_MISMATCH error message both rely on).
+            const approved =
+              options.confirm === true
+                ? true
+                : await confirm({
+                    message: `Remove the ${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"} above (config + workspace + session state)?`,
+                    default: true,
+                  }).catch(() => false);
+
+            if (approved) {
+              for (const s of stale) {
+                removeLocalAgent(s.name);
+                print.line(`  ✓ removed ${s.name}\n`);
+              }
+              print.line(`\n  ${stale.length} alias(es) pruned.\n`);
+            } else {
+              print.line("  Skipped. Run `first-tree-hub agent prune` later to clean up.\n");
+            }
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.line(`  (Could not check for stale aliases: ${msg.slice(0, 100)})\n`);
+          print.line("  Run `first-tree-hub agent prune` after reconnecting.\n");
+        }
+
+        print.line("\n  Run `first-tree-hub client start` to reconnect.\n\n");
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         fail("CLAIM_ERROR", msg);

--- a/packages/command/src/core/agent-prune.ts
+++ b/packages/command/src/core/agent-prune.ts
@@ -1,55 +1,135 @@
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
-import {
-  agentConfigSchema,
-  DEFAULT_CONFIG_DIR,
-  DEFAULT_DATA_DIR,
-  loadAgents,
-} from "@agent-team-foundation/first-tree-hub-shared/config";
-import { FirstTreeHubSDK } from "@first-tree-hub/client";
+import { DEFAULT_CONFIG_DIR, DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 
 /**
- * A local agent alias whose `agent.yaml::agentId` is no longer in the set
- * the server reports as pinned to this client + owned by the caller.
+ * Why a local alias is no longer usable from this client. Surfaced to
+ * operators in `client doctor`, `agent prune`, and the post-claim cleanup
+ * — knowing *why* a dir is stale changes the next action (delete vs. go
+ * run it on the other machine).
  *
- * Stale aliases are the dominant cause of the "client doctor says N agents,
- * runtime only binds M" mismatch — they accumulate across `client claim`,
- * agent deletion, and bare-typo `agent add` mistakes (e.g. an alias named
- * `d`). Runtime tries to bind them every start, fails the R-RUN check,
- * and only logs a generic `failed to start agent`.
+ * - `unreadable`        — agent.yaml missing, malformed, or has no agentId.
+ * - `unowned`           — server doesn't return this agentId at all under
+ *                         the current user (deleted, or never owned).
+ * - `pinned-elsewhere`  — agentId belongs to the user but is pinned to a
+ *                         *different* client. R-RUN would reject `bind`
+ *                         on this machine; the agent is alive on the other.
  */
+export type StaleAliasReason =
+  | { kind: "unreadable"; error: string }
+  | { kind: "unowned" }
+  | { kind: "pinned-elsewhere"; clientId: string };
+
 export type StaleAlias = {
   name: string;
-  agentId: string;
+  /** Null when the YAML couldn't be parsed enough to extract an agentId. */
+  agentId: string | null;
+  reason: StaleAliasReason;
 };
 
+export type PinnedAgent = { agentId: string; clientId: string };
+
+const minimalAgentYamlSchema = z
+  .object({
+    agentId: z.string().min(1),
+  })
+  .passthrough();
+
 /**
- * Compare local `agents/<name>/agent.yaml::agentId` against the server's
- * `/api/v1/clients/me/agents` (every agent pinned to a client owned by
- * the caller). Returns the set of local alias dirs that don't map to
- * any server-side row — safe to delete.
+ * Cross-reference local `agents/<name>/agent.yaml` files against the
+ * server's pinned-agent set, returning every alias that won't bind on
+ * THIS client.
+ *
+ * Why we don't use `loadAgents`:
+ * `shared/config/loader.loadAgents` is fail-fast — one malformed
+ * agent.yaml throws and the whole scan dies. The dominant prune target
+ * IS the malformed dir (typo `agent add d`, half-written yaml, missing
+ * agentId), so we walk dirs ourselves and degrade per-entry instead.
+ *
+ * Why we filter by clientId, not just userId:
+ * `listPinnedAgents` (`/api/v1/clients/me/agents`) returns every agent
+ * pinned to ANY client this user owns (cross-machine). For prune the
+ * relevant question is "will R-RUN accept it on THIS machine", which
+ * needs `agents.client_id === current client.id`. Anything pinned on
+ * another client is reported with `pinned-elsewhere` so the operator
+ * can either re-pin or delete the local alias deliberately.
  */
 export async function findStaleAliases(opts: {
-  serverUrl: string;
-  getAccessToken: () => Promise<string>;
+  clientId: string;
+  listPinnedAgents: () => Promise<PinnedAgent[]>;
+  /** Override for tests; defaults to `$FIRST_TREE_HUB_HOME/config/agents`. */
+  agentsDir?: string;
 }): Promise<StaleAlias[]> {
-  const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+  const agentsDir = opts.agentsDir ?? join(DEFAULT_CONFIG_DIR, "agents");
   if (!existsSync(agentsDir)) return [];
 
-  const local = loadAgents({ schema: agentConfigSchema, agentsDir });
-  if (local.size === 0) return [];
-
-  const sdk = new FirstTreeHubSDK({ serverUrl: opts.serverUrl, getAccessToken: opts.getAccessToken });
-  const remote = await sdk.listMyAgents();
-  const pinnedAgentIds = new Set(remote.map((a) => a.agentId));
+  const remote = await opts.listPinnedAgents();
+  const pinnedHere = new Set<string>();
+  const pinnedElsewhere = new Map<string, string>();
+  for (const r of remote) {
+    if (r.clientId === opts.clientId) pinnedHere.add(r.agentId);
+    else pinnedElsewhere.set(r.agentId, r.clientId);
+  }
 
   const stale: StaleAlias[] = [];
-  for (const [name, cfg] of local) {
-    if (!pinnedAgentIds.has(cfg.agentId)) {
-      stale.push({ name, agentId: cfg.agentId });
+  for (const entry of readdirSync(agentsDir)) {
+    const agentDir = join(agentsDir, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(agentDir).isDirectory();
+    } catch {
+      // Vanished between readdir and stat; ignore.
+      continue;
+    }
+    if (!isDir) continue;
+
+    const yamlPath = join(agentDir, "agent.yaml");
+    if (!existsSync(yamlPath)) {
+      stale.push({ name: entry, agentId: null, reason: { kind: "unreadable", error: "missing agent.yaml" } });
+      continue;
+    }
+
+    let agentId: string;
+    try {
+      const raw = parseYaml(readFileSync(yamlPath, "utf-8")) as unknown;
+      const parsed = minimalAgentYamlSchema.safeParse(raw);
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0]?.message ?? "schema error";
+        stale.push({ name: entry, agentId: null, reason: { kind: "unreadable", error: issue } });
+        continue;
+      }
+      agentId = parsed.data.agentId;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      stale.push({ name: entry, agentId: null, reason: { kind: "unreadable", error: msg } });
+      continue;
+    }
+
+    if (pinnedHere.has(agentId)) continue;
+
+    const otherClient = pinnedElsewhere.get(agentId);
+    if (otherClient !== undefined) {
+      stale.push({ name: entry, agentId, reason: { kind: "pinned-elsewhere", clientId: otherClient } });
+    } else {
+      stale.push({ name: entry, agentId, reason: { kind: "unowned" } });
     }
   }
+
   return stale;
+}
+
+/** Human-readable suffix for the per-alias listing. */
+export function formatStaleReason(reason: StaleAliasReason): string {
+  switch (reason.kind) {
+    case "unreadable":
+      return `unreadable: ${reason.error}`;
+    case "unowned":
+      return "no longer owned by you (deleted or transferred)";
+    case "pinned-elsewhere":
+      return `pinned to another client: ${reason.clientId}`;
+  }
 }
 
 /**
@@ -57,9 +137,6 @@ export async function findStaleAliases(opts: {
  * tree under `data/workspaces/<name>`, and the session-mapping file under
  * `data/sessions/<name>.json`. Mirrors what `agent remove` does, exposed
  * separately so prune and claim can share it.
- *
- * Best-effort: missing paths are silently ignored (the alias might have
- * been removed manually after a previous failed prune).
  */
 export function removeLocalAgent(name: string): void {
   rmSync(join(DEFAULT_CONFIG_DIR, "agents", name), { recursive: true, force: true });

--- a/packages/command/src/core/agent-prune.ts
+++ b/packages/command/src/core/agent-prune.ts
@@ -1,0 +1,68 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  agentConfigSchema,
+  DEFAULT_CONFIG_DIR,
+  DEFAULT_DATA_DIR,
+  loadAgents,
+} from "@agent-team-foundation/first-tree-hub-shared/config";
+import { FirstTreeHubSDK } from "@first-tree-hub/client";
+
+/**
+ * A local agent alias whose `agent.yaml::agentId` is no longer in the set
+ * the server reports as pinned to this client + owned by the caller.
+ *
+ * Stale aliases are the dominant cause of the "client doctor says N agents,
+ * runtime only binds M" mismatch — they accumulate across `client claim`,
+ * agent deletion, and bare-typo `agent add` mistakes (e.g. an alias named
+ * `d`). Runtime tries to bind them every start, fails the R-RUN check,
+ * and only logs a generic `failed to start agent`.
+ */
+export type StaleAlias = {
+  name: string;
+  agentId: string;
+};
+
+/**
+ * Compare local `agents/<name>/agent.yaml::agentId` against the server's
+ * `/api/v1/clients/me/agents` (every agent pinned to a client owned by
+ * the caller). Returns the set of local alias dirs that don't map to
+ * any server-side row — safe to delete.
+ */
+export async function findStaleAliases(opts: {
+  serverUrl: string;
+  getAccessToken: () => Promise<string>;
+}): Promise<StaleAlias[]> {
+  const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+  if (!existsSync(agentsDir)) return [];
+
+  const local = loadAgents({ schema: agentConfigSchema, agentsDir });
+  if (local.size === 0) return [];
+
+  const sdk = new FirstTreeHubSDK({ serverUrl: opts.serverUrl, getAccessToken: opts.getAccessToken });
+  const remote = await sdk.listMyAgents();
+  const pinnedAgentIds = new Set(remote.map((a) => a.agentId));
+
+  const stale: StaleAlias[] = [];
+  for (const [name, cfg] of local) {
+    if (!pinnedAgentIds.has(cfg.agentId)) {
+      stale.push({ name, agentId: cfg.agentId });
+    }
+  }
+  return stale;
+}
+
+/**
+ * Remove an agent's local footprint: the YAML alias dir, the workspace
+ * tree under `data/workspaces/<name>`, and the session-mapping file under
+ * `data/sessions/<name>.json`. Mirrors what `agent remove` does, exposed
+ * separately so prune and claim can share it.
+ *
+ * Best-effort: missing paths are silently ignored (the alias might have
+ * been removed manually after a previous failed prune).
+ */
+export function removeLocalAgent(name: string): void {
+  rmSync(join(DEFAULT_CONFIG_DIR, "agents", name), { recursive: true, force: true });
+  rmSync(join(DEFAULT_DATA_DIR, "workspaces", name), { recursive: true, force: true });
+  rmSync(join(DEFAULT_DATA_DIR, "sessions", `${name}.json`), { force: true });
+}

--- a/packages/command/src/core/doctor.ts
+++ b/packages/command/src/core/doctor.ts
@@ -9,6 +9,7 @@ import {
   resolveConfigReadonly,
   serverConfigSchema,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
+import { FirstTreeHubSDK } from "@first-tree-hub/client";
 import { blank, print } from "./output.js";
 import { getClientServiceStatus } from "./service-install.js";
 
@@ -173,6 +174,78 @@ export function checkAgentConfigs(): CheckResult {
   } catch {
     return { label: "Agents", ok: false, detail: "error reading agent configs" };
   }
+}
+
+/**
+ * Server-aware agent reconciliation. Reads local `agents/<name>/agent.yaml`
+ * files and cross-references each `agentId` with `/api/v1/clients/me/agents`.
+ * Categorises into:
+ *   - pinned   — agent row is pinned to this client and owned by the caller
+ *   - stale    — local alias whose `agentId` is not in the server list
+ *
+ * This is the check that should be displayed in `client doctor`. The plain
+ * `checkAgentConfigs` (sync, local-only) is retained for back-compat with
+ * external consumers but its "N configured" wording is misleading because
+ * stale aliases never bind at runtime.
+ *
+ * Falls back to the local-only result if the server is unreachable or the
+ * caller is not authenticated — doctor should still print *something* useful
+ * in offline / pre-connect scenarios.
+ */
+export async function reconcileAgentConfigs(opts: {
+  serverUrl: string;
+  getAccessToken: () => Promise<string>;
+}): Promise<CheckResult> {
+  const local = checkAgentConfigs();
+  // Propagate the "no agents configured" / read-error states unchanged.
+  if (!local.ok) return local;
+
+  const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
+  let localAgents: Map<string, { agentId: string }>;
+  try {
+    localAgents = loadAgents({ schema: agentConfigSchema, agentsDir });
+  } catch {
+    return local;
+  }
+
+  let pinnedAgentIds: Set<string>;
+  try {
+    const sdk = new FirstTreeHubSDK({ serverUrl: opts.serverUrl, getAccessToken: opts.getAccessToken });
+    const remote = await sdk.listMyAgents();
+    pinnedAgentIds = new Set(remote.map((a) => a.agentId));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      label: "Agents",
+      ok: true,
+      detail: `${local.detail} — server reconciliation skipped (${msg.slice(0, 60)})`,
+    };
+  }
+
+  const pinned: string[] = [];
+  const stale: string[] = [];
+  for (const [name, cfg] of localAgents) {
+    if (pinnedAgentIds.has(cfg.agentId)) pinned.push(name);
+    else stale.push(name);
+  }
+
+  const total = localAgents.size;
+  if (stale.length === 0) {
+    return {
+      label: "Agents",
+      ok: true,
+      detail: `${total} configured, all pinned to this client (${pinned.join(", ")})`,
+    };
+  }
+
+  return {
+    label: "Agents",
+    ok: false,
+    detail:
+      `${total} configured locally, ${pinned.length} pinned to this client (${pinned.join(", ") || "—"}); ` +
+      `${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"} (${stale.join(", ")}) — ` +
+      "run `first-tree-hub agent prune` to clean up",
+  };
 }
 
 export function checkBackgroundService(): CheckResult {

--- a/packages/command/src/core/doctor.ts
+++ b/packages/command/src/core/doctor.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
   agentConfigSchema,
@@ -9,7 +9,7 @@ import {
   resolveConfigReadonly,
   serverConfigSchema,
 } from "@agent-team-foundation/first-tree-hub-shared/config";
-import { FirstTreeHubSDK } from "@first-tree-hub/client";
+import { findStaleAliases, formatStaleReason, type PinnedAgent, type StaleAlias } from "./agent-prune.js";
 import { blank, print } from "./output.js";
 import { getClientServiceStatus } from "./service-install.js";
 
@@ -177,73 +177,90 @@ export function checkAgentConfigs(): CheckResult {
 }
 
 /**
- * Server-aware agent reconciliation. Reads local `agents/<name>/agent.yaml`
- * files and cross-references each `agentId` with `/api/v1/clients/me/agents`.
- * Categorises into:
- *   - pinned   — agent row is pinned to this client and owned by the caller
- *   - stale    — local alias whose `agentId` is not in the server list
+ * Server-aware agent reconciliation. Walks `agents/<name>/agent.yaml` and
+ * cross-references each `agentId` with `/api/v1/clients/me/agents`,
+ * filtering by `clientId` so the "stale" verdict matches what R-RUN will
+ * actually accept on this machine.
  *
- * This is the check that should be displayed in `client doctor`. The plain
- * `checkAgentConfigs` (sync, local-only) is retained for back-compat with
- * external consumers but its "N configured" wording is misleading because
- * stale aliases never bind at runtime.
+ * Categorises each local alias into:
+ *   - pinned             — bind would succeed on this client.
+ *   - pinned-elsewhere   — owned by you, but pinned to a different client
+ *                          (alias is dead weight here; real agent is alive
+ *                          on the other machine).
+ *   - unowned            — agentId not in the server's response at all.
+ *   - unreadable         — yaml missing/malformed/no agentId.
  *
- * Falls back to the local-only result if the server is unreachable or the
- * caller is not authenticated — doctor should still print *something* useful
- * in offline / pre-connect scenarios.
+ * The plain `checkAgentConfigs` (sync, local-only) is retained for
+ * back-compat with external consumers but its "N configured" wording is
+ * misleading because stale aliases never bind at runtime.
+ *
+ * Skipped reconciliation (server unreachable / unauthenticated) returns
+ * `ok: false` — doctor's other server-touching checks already report
+ * connectivity loss as a failure, and silently passing here would hide
+ * the very issue the operator is running doctor to diagnose.
  */
 export async function reconcileAgentConfigs(opts: {
-  serverUrl: string;
-  getAccessToken: () => Promise<string>;
+  clientId: string;
+  listPinnedAgents: () => Promise<PinnedAgent[]>;
+  /** Override for tests; defaults to `$FIRST_TREE_HUB_HOME/config/agents`. */
+  agentsDir?: string;
 }): Promise<CheckResult> {
-  const local = checkAgentConfigs();
-  // Propagate the "no agents configured" / read-error states unchanged.
-  if (!local.ok) return local;
+  const agentsDir = opts.agentsDir ?? join(DEFAULT_CONFIG_DIR, "agents");
 
-  const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
-  let localAgents: Map<string, { agentId: string }>;
-  try {
-    localAgents = loadAgents({ schema: agentConfigSchema, agentsDir });
-  } catch {
-    return local;
+  // Count local alias dirs ourselves — `loadAgents` is fail-fast on
+  // malformed yaml, and one bad dir would mask the entire alias set.
+  let localCount = 0;
+  if (existsSync(agentsDir)) {
+    for (const entry of readdirSync(agentsDir)) {
+      try {
+        if (statSync(join(agentsDir, entry)).isDirectory()) localCount++;
+      } catch {
+        // Vanished between readdir and stat; treat as absent.
+      }
+    }
+  }
+  if (localCount === 0) {
+    return { label: "Agents", ok: false, detail: "no agents configured" };
   }
 
-  let pinnedAgentIds: Set<string>;
+  let stale: StaleAlias[];
   try {
-    const sdk = new FirstTreeHubSDK({ serverUrl: opts.serverUrl, getAccessToken: opts.getAccessToken });
-    const remote = await sdk.listMyAgents();
-    pinnedAgentIds = new Set(remote.map((a) => a.agentId));
+    stale = await findStaleAliases({
+      clientId: opts.clientId,
+      listPinnedAgents: opts.listPinnedAgents,
+      agentsDir,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {
       label: "Agents",
-      ok: true,
-      detail: `${local.detail} — server reconciliation skipped (${msg.slice(0, 60)})`,
+      ok: false,
+      detail: `${localCount} configured locally — server reconciliation failed (${msg.slice(0, 60)})`,
     };
   }
 
-  const pinned: string[] = [];
-  const stale: string[] = [];
-  for (const [name, cfg] of localAgents) {
-    if (pinnedAgentIds.has(cfg.agentId)) pinned.push(name);
-    else stale.push(name);
-  }
+  const pinnedCount = localCount - stale.length;
 
-  const total = localAgents.size;
   if (stale.length === 0) {
     return {
       label: "Agents",
       ok: true,
-      detail: `${total} configured, all pinned to this client (${pinned.join(", ")})`,
+      detail: `${localCount} configured, all pinned to this client`,
     };
   }
+
+  const staleSummary = stale
+    .map((s) => `${s.name} [${formatStaleReason(s.reason)}]`)
+    .slice(0, 5)
+    .join("; ");
+  const truncated = stale.length > 5 ? `; ...+${stale.length - 5} more` : "";
 
   return {
     label: "Agents",
     ok: false,
     detail:
-      `${total} configured locally, ${pinned.length} pinned to this client (${pinned.join(", ") || "—"}); ` +
-      `${stale.length} stale ${stale.length === 1 ? "alias" : "aliases"} (${stale.join(", ")}) — ` +
+      `${localCount} configured locally, ${pinnedCount} pinned to this client; ` +
+      `${stale.length} stale: ${staleSummary}${truncated} — ` +
       "run `first-tree-hub agent prune` to clean up",
   };
 }

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -4,6 +4,9 @@
 export { createOwner, hasUser } from "./admin.js";
 // Agent messaging helpers
 export { resolveReplyToFromEnv } from "./agent-messaging.js";
+// Local agent alias hygiene (stale alias detection + deletion)
+export type { StaleAlias } from "./agent-prune.js";
+export { findStaleAliases, removeLocalAgent } from "./agent-prune.js";
 // Bootstrap / credentials
 export {
   ensureFreshAccessToken,
@@ -36,6 +39,7 @@ export {
   checkServerReachable,
   checkWebSocket,
   printResults,
+  reconcileAgentConfigs,
 } from "./doctor.js";
 // Feishu
 export { bindFeishuBot, bindFeishuUser } from "./feishu.js";

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -5,8 +5,8 @@ export { createOwner, hasUser } from "./admin.js";
 // Agent messaging helpers
 export { resolveReplyToFromEnv } from "./agent-messaging.js";
 // Local agent alias hygiene (stale alias detection + deletion)
-export type { StaleAlias } from "./agent-prune.js";
-export { findStaleAliases, removeLocalAgent } from "./agent-prune.js";
+export type { PinnedAgent, StaleAlias, StaleAliasReason } from "./agent-prune.js";
+export { findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
 // Bootstrap / credentials
 export {
   ensureFreshAccessToken,


### PR DESCRIPTION
## Summary

- `client doctor` now cross-references local agent aliases with `/api/v1/clients/me/agents` and reports `pinned vs stale` instead of a misleading raw directory count
- New `first-tree-hub agent prune [--yes] [--dry-run]` removes orphaned aliases (config + workspace + session state); `client claim --confirm` runs the same detection at the end and offers cleanup in one step
- Runtime now logs `agentName` / `agentId` / `reason` on each `failed to start agent` instead of a bare error, plus an aggregate WARN when any slot fails — previously the only artifact of a stale alias was a single nameless ERROR line

## Why

On a real machine the local `~/.first-tree/hub/config/agents/` dir was reporting 8 agents in `client doctor`, but only 3 actually bound at runtime. The other 5 were aliases left behind by `client claim`, server-side deletes, and a typo `agent add d`. R-RUN rejected each one silently and doctor kept claiming everything was fine.

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm typecheck` clean (9/9)
- [x] `pnpm --filter @first-tree-hub/client test` 241/241
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` 67/67
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub build` succeeds
- [x] End-to-end smoke against the real `~/.first-tree/hub/` on staging:
  - `client doctor` correctly flags `8 configured locally, 3 pinned to this client; 5 stale aliases (...) — run \`first-tree-hub agent prune\``
  - `agent prune --dry-run` lists exactly the 5 stale aliases with their orphaned `agentId`s
- [x] Local `client connect` → `client claim --confirm` → `client start` round-trip with a different account verifies the new claim → prune offer flow

Bumps the published CLI to 0.10.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)