### PR TITLE
feat(multi-org): pin createAgent to selected org + cross-org name map

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -1,7 +1,10 @@
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("Admin Agents API", () => {
   const getApp = useTestApp();
@@ -150,5 +153,124 @@ describe("Admin Agents API", () => {
     const app = getApp();
     const res = await app.inject({ method: "GET", url: "/api/v1/admin/agents" });
     expect(res.statusCode).toBe(401);
+  });
+
+  /**
+   * PR #220 — `POST /admin/agents` resolves the target organization with
+   * precedence `body > query > JWT default`. The query-string fallback exists
+   * because the api-client `decoratePath` (in `packages/web/src/api/client.ts`)
+   * injects `?organizationId=<selectedOrgId>` into every `/admin/*` URL; the
+   * pre-#220 handler ignored that on writes, silently creating agents in the
+   * JWT default org regardless of what the user's dropdown showed.
+   */
+  describe("org precedence on create", () => {
+    /** Attach `userId` to a fresh org with the requested role. Mirrors the
+     * helper in admin-realtime-role.test.ts. */
+    async function attachOrg(
+      app: FastifyInstance,
+      userId: string,
+      role: "admin" | "member",
+    ): Promise<{ orgId: string; memberId: string }> {
+      const orgId = `org-prec-${crypto.randomUUID().slice(0, 8)}`;
+      const memberId = uuidv7();
+      await app.db.transaction(async (tx) => {
+        await tx
+          .insert(organizations)
+          .values({ id: orgId, name: `prec-${crypto.randomUUID().slice(0, 6)}`, displayName: "Precedence Side" });
+        const human = await createAgent(tx as unknown as typeof app.db, {
+          name: `prec-h-${crypto.randomUUID().slice(0, 6)}`,
+          type: "human",
+          displayName: "Prec Human",
+          managerId: memberId,
+          organizationId: orgId,
+        });
+        await tx.insert(members).values({ id: memberId, userId, organizationId: orgId, agentId: human.uuid, role });
+      });
+      return { orgId, memberId };
+    }
+
+    it("body.organizationId wins over JWT default", async () => {
+      const app = getApp();
+      const alice = await createTestAdmin(app);
+      const orgB = await attachOrg(app, alice.userId, "admin");
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/admin/agents",
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+        payload: {
+          name: `body-wins-${crypto.randomUUID().slice(0, 6)}`,
+          type: "autonomous_agent",
+          displayName: "Body Wins",
+          organizationId: orgB.orgId,
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json<{ organizationId: string }>().organizationId).toBe(orgB.orgId);
+    });
+
+    it("?organizationId= wins over JWT default when body omits it (decoratePath fallback)", async () => {
+      const app = getApp();
+      const alice = await createTestAdmin(app);
+      const orgB = await attachOrg(app, alice.userId, "admin");
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/admin/agents?organizationId=${encodeURIComponent(orgB.orgId)}`,
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+        payload: {
+          name: `query-wins-${crypto.randomUUID().slice(0, 6)}`,
+          type: "autonomous_agent",
+          displayName: "Query Wins",
+          // intentionally no organizationId in body — mirrors what the web
+          // sends when the developer forgets to thread the selected org
+          // through the mutation
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json<{ organizationId: string }>().organizationId).toBe(orgB.orgId);
+    });
+
+    it("body.organizationId wins over ?organizationId= when both are set", async () => {
+      const app = getApp();
+      const alice = await createTestAdmin(app);
+      const orgB = await attachOrg(app, alice.userId, "admin");
+      const orgC = await attachOrg(app, alice.userId, "admin");
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/admin/agents?organizationId=${encodeURIComponent(orgC.orgId)}`,
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+        payload: {
+          name: `body-over-query-${crypto.randomUUID().slice(0, 6)}`,
+          type: "autonomous_agent",
+          displayName: "Body Over Query",
+          organizationId: orgB.orgId,
+        },
+      });
+      expect(res.statusCode).toBe(201);
+      // Body's orgB wins over query's orgC.
+      expect(res.json<{ organizationId: string }>().organizationId).toBe(orgB.orgId);
+    });
+
+    it("rejects ?organizationId= for an org the caller has no membership in (403 via requireMemberInOrg)", async () => {
+      const app = getApp();
+      const alice = await createTestAdmin(app);
+      // brand-new org Alice never joined
+      const orgC = `org-prec-c-${crypto.randomUUID().slice(0, 8)}`;
+      await app.db.insert(organizations).values({ id: orgC, name: orgC.slice(0, 30), displayName: "Outside" });
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/admin/agents?organizationId=${encodeURIComponent(orgC)}`,
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+        payload: {
+          name: `cross-org-no-${crypto.randomUUID().slice(0, 6)}`,
+          type: "autonomous_agent",
+          displayName: "Cross-Org Forbidden",
+        },
+      });
+      expect(res.statusCode).toBe(403);
+    });
   });
 });

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -32,6 +32,46 @@ describe("Admin Auth", () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    // Regression: services/auth.ts::login picks the most-recently-joined active
+    // membership as the JWT default org. Without `ORDER BY created_at DESC, id
+    // DESC` the multi-org user gets a non-deterministic default each login,
+    // and `POST /admin/agents` falls back to that default when the body omits
+    // `organizationId` — which silently lands new agents in the wrong tenant.
+    it("picks the most-recently-joined active membership as the JWT default org", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+
+      const create = await app.inject({
+        method: "POST",
+        url: "/api/v1/me/organizations",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: {
+          name: `t-${crypto.randomUUID().slice(0, 8)}`,
+          displayName: "Second Org",
+        },
+      });
+      expect(create.statusCode).toBe(201);
+      const secondOrgId = create.json<{ organization: { id: string } }>().organization.id;
+      expect(secondOrgId).not.toBe(admin.organizationId);
+
+      // Password login → JWT default member should be the most recent join (second org).
+      const re = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/login",
+        payload: { username: admin.username, password: admin.password },
+      });
+      expect(re.statusCode).toBe(200);
+      const tokens = re.json<{ accessToken: string }>();
+
+      const me = await app.inject({
+        method: "GET",
+        url: "/api/v1/me",
+        headers: { authorization: `Bearer ${tokens.accessToken}` },
+      });
+      expect(me.statusCode).toBe(200);
+      expect(me.json<{ member: { organizationId: string } }>().member.organizationId).toBe(secondOrgId);
+    });
   });
 
   describe("POST /api/v1/auth/refresh", () => {

--- a/packages/server/src/api/admin/agents.ts
+++ b/packages/server/src/api/admin/agents.ts
@@ -158,11 +158,19 @@ export async function adminAgentRoutes(app: FastifyInstance): Promise<void> {
   app.post("/", async (request, reply) => {
     const scope = memberScope(request);
     const body = createAgentSchema.parse(request.body);
+    const { organizationId: queryOrganizationId } = listAgentsFilterSchema.parse(request.query);
     // Realtime role probe — JWT `role` claim is a hint for the default org
     // only. An admin in org A cannot exercise admin powers when creating
     // an agent in org B by passing `body.organizationId = orgB`
     // (decouple-client-from-identity §4.5).
-    const targetOrgId = body.organizationId ?? scope.organizationId;
+    //
+    // Org resolution precedence: body > query > JWT default. The query-string
+    // fallback exists so the api-client `decoratePath` injection
+    // (`?organizationId=<selectedOrgId>`) is honored even if the web caller
+    // forgets to set `body.organizationId` — without this, a multi-org user
+    // creates agents in the JWT default org regardless of what their dropdown
+    // shows ("agent landed in the wrong team").
+    const targetOrgId = body.organizationId ?? queryOrganizationId ?? scope.organizationId;
     const probe = await requireMemberInOrg(app.db, request, targetOrgId);
     // member role: managerId forced to caller's member in target org;
     // admin role: may specify any managerId in that org.

--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import bcrypt from "bcrypt";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { jwtVerify, SignJWT } from "jose";
 import type { Database } from "../db/connection.js";
 import { members } from "../db/schema/members.js";
@@ -71,11 +71,25 @@ export async function login(db: Database, username: string, password: string, jw
 
   // Password login: pick the most recently joined ACTIVE membership. Soft-
   // deleted ("left") rows are ignored so a member who left their last team
-  // can't password-login back in without re-joining.
+  // can't password-login back in without re-joining. Note: `createdAt` is
+  // the original insert timestamp; `ensureMembership` reactivates a left
+  // member without touching it, so a leave-and-rejoin reads as "first
+  // joined" — acceptable because the reactivation path is rare and the
+  // determinism is what we actually need.
+  //
+  // The ORDER BY is load-bearing: without it, Postgres returns memberships
+  // in implementation-defined order and a multi-org user gets a non-
+  // deterministic JWT default org across logins. That non-determinism is
+  // the upstream cause of "I created an agent in team A but it shows up in
+  // team B" — `POST /admin/agents` falls back to JWT default when the body
+  // omits `organizationId`. The `desc(id)` tiebreak guards the (rare) case
+  // of two memberships with identical `created_at`; `members.id` is
+  // uuidv7 so its lexicographic order matches insert order.
   const [member] = await db
     .select()
     .from(members)
     .where(and(eq(members.userId, user.id), eq(members.status, "active")))
+    .orderBy(desc(members.createdAt), desc(members.id))
     .limit(1);
 
   if (!member) {

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -93,7 +93,7 @@ export const createAgentSchema = z.object({
    */
   displayName: z.string().min(1).max(200).optional(),
   delegateMention: z.string().max(100).optional(),
-  organizationId: z.string().max(100).optional(),
+  organizationId: z.string().min(1).max(100).optional(),
   /** How this agent was created */
   source: agentSourceSchema.optional(),
   /** Agent visibility: "private" (manager only) or "organization" (all members) */

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -16,6 +16,33 @@ export function listAgents(params?: { limit?: number; cursor?: string; type?: st
 }
 
 /**
+ * Cross-org list of every agent the caller manages — the web mirror of the
+ * CLI `agent list --remote` view. Backed by `GET /me/managed-agents`, which
+ * is org-free (joins `agents → members.user_id`) so it returns agents in
+ * non-default orgs too.
+ *
+ * The Computers panel uses this as a name-resolution source for `BOUND
+ * AGENTS` rows: a client is user-scoped and may host agents from multiple
+ * orgs, so the org-scoped `/admin/agents` query alone falls back to the raw
+ * UUID for any agent outside the currently-selected org.
+ */
+export type ManagedAgent = {
+  uuid: string;
+  name: string | null;
+  displayName: string;
+  type: string;
+  organizationId: string;
+  inboxId: string;
+  visibility: string;
+  runtimeProvider: string;
+  clientId: string | null;
+};
+
+export function listManagedAgents(): Promise<ManagedAgent[]> {
+  return api.get<ManagedAgent[]>("/me/managed-agents");
+}
+
+/**
  * Admin-only: every agent in the caller's org, ignoring visibility. Used by
  * the Admin → All Agents tab; the server 403s for non-admin callers.
  */

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -101,7 +101,7 @@ type AvailabilityState =
 
 export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const queryClient = useQueryClient();
-  const { refreshMe } = useAuth();
+  const { refreshMe, organizationId } = useAuth();
   const [displayName, setDisplayName] = useState("");
   const [name, setName] = useState("");
   const [nameDirty, setNameDirty] = useState(false);
@@ -190,6 +190,11 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
         displayName: effectiveDisplay,
         clientId: opts.clientId,
         runtimeProvider: runtime,
+        // Pin the agent to the org the user is currently viewing in the
+        // dropdown — the JWT default org is non-deterministic across logins
+        // (auth.ts member pick) and creating into "wherever the JWT lands"
+        // is the source of "I created it in atf, why is it in gandy02?".
+        ...(organizationId ? { organizationId } : {}),
       });
     },
     onSuccess: (agent) => {

--- a/packages/web/src/lib/use-agent-name-map.ts
+++ b/packages/web/src/lib/use-agent-name-map.ts
@@ -1,13 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { listAgents } from "../api/agents.js";
+import { listAgents, listManagedAgents } from "../api/agents.js";
 
 /**
  * Shared hook that builds a UUID → name lookup map from the agents list.
  * Used by pages that display agent UUIDs (delegate mentions, participants, senders, bindings).
  *
- * Note: limited to 100 agents (API max). For deployments with more agents,
- * this should be replaced with a paginated fetch or a dedicated lookup endpoint.
+ * Two sources merged:
+ *   1. `/admin/agents` — org-scoped (current selected org). Covers same-org
+ *      teammates and any agent visible via the org roster.
+ *   2. `/me/managed-agents` — user-scoped, cross-org. Covers agents the
+ *      caller manages in non-default orgs, so a client that hosts agents
+ *      from multiple orgs (e.g. the `BOUND AGENTS` panel on the Computers
+ *      tab) can resolve every UUID to a real name instead of falling back
+ *      to the raw UUID. The org-scoped source wins on collision since it
+ *      is the more authoritative view for the currently-selected tenant.
+ *
+ * Note: limited to 100 agents (API max) for the org-scoped page. For
+ * deployments with more agents, this should be replaced with a paginated
+ * fetch or a dedicated lookup endpoint.
  */
 export function useAgentNameMap(): (uuid: string | null | undefined) => string {
   const { data } = useQuery({
@@ -15,25 +26,37 @@ export function useAgentNameMap(): (uuid: string | null | undefined) => string {
     queryFn: () => listAgents({ limit: 100 }),
     staleTime: 30_000,
   });
+  const { data: managed } = useQuery({
+    queryKey: ["managed-agents", "name-map"],
+    queryFn: listManagedAgents,
+    staleTime: 30_000,
+  });
 
   // Post-Phase 2 of the agent-naming refactor, `displayName` is guaranteed
   // non-null by the DB (migration 0024) and the service-level default.
-  // The old `a.displayName ?? a.name ?? a.uuid` fallback chain is gone \u2014
+  // The old `a.displayName ?? a.name ?? a.uuid` fallback chain is gone —
   // any missing label now means the UUID isn't in the cached page (e.g.
   // soft-deleted, org changed mid-session), which we surface as the raw
   // uuid so the caller can at least render something stable.
   return useMemo(() => {
     const map = new Map<string, string>();
+    // Cross-org managed agents first — the org-scoped source overwrites
+    // them so the more authoritative roster view wins on collision.
+    if (managed) {
+      for (const a of managed) {
+        map.set(a.uuid, a.displayName);
+      }
+    }
     if (data?.items) {
       for (const a of data.items) {
         map.set(a.uuid, a.displayName);
       }
     }
     return (uuid: string | null | undefined) => {
-      if (!uuid) return "\u2014";
+      if (!uuid) return "—";
       return map.get(uuid) ?? uuid;
     };
-  }, [data]);
+  }, [data, managed]);
 }
 
 /**
@@ -50,9 +73,9 @@ export type AgentIdentity = {
 /**
  * Variant of `useAgentNameMap` that returns the full `{ name, displayName }`
  * pair for a UUID, so callers can feed `<AgentChip>` without re-querying
- * the agents list. Returns `null` when the UUID is missing from the cached
- * list (soft-deleted, filtered out, or org changed mid-session) \u2014 callers
- * render their own fallback.
+ * the agents list. Returns `null` when the UUID is missing from both the
+ * org-scoped and cross-org caches (soft-deleted, filtered out, or never
+ * loaded) — callers render their own fallback.
  */
 export function useAgentIdentityMap(): (uuid: string | null | undefined) => AgentIdentity | null {
   const { data } = useQuery({
@@ -60,9 +83,19 @@ export function useAgentIdentityMap(): (uuid: string | null | undefined) => Agen
     queryFn: () => listAgents({ limit: 100 }),
     staleTime: 30_000,
   });
+  const { data: managed } = useQuery({
+    queryKey: ["managed-agents", "name-map"],
+    queryFn: listManagedAgents,
+    staleTime: 30_000,
+  });
 
   return useMemo(() => {
     const map = new Map<string, AgentIdentity>();
+    if (managed) {
+      for (const a of managed) {
+        map.set(a.uuid, { name: a.name, displayName: a.displayName });
+      }
+    }
     if (data?.items) {
       for (const a of data.items) {
         map.set(a.uuid, { name: a.name, displayName: a.displayName });
@@ -72,5 +105,5 @@ export function useAgentIdentityMap(): (uuid: string | null | undefined) => Agen
       if (!uuid) return null;
       return map.get(uuid) ?? null;
     };
-  }, [data]);
+  }, [data, managed]);
 }

--- a/packages/web/src/pages/workspace/center/onboarding-view.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding-view.tsx
@@ -274,6 +274,11 @@ export function OnboardingView() {
         ...(slug ? { name: slug } : {}),
         clientId: connectedClient.id,
         runtimeProvider: selectedRuntime,
+        // Pin the agent to the org the user has selected in the dropdown.
+        // Without this the server falls back to JWT default org, which is
+        // non-deterministic across logins (auth.ts password-login member pick)
+        // and silently lands the agent in the wrong tenant.
+        ...(organizationId ? { organizationId } : {}),
       });
       agentUuid = res.uuid;
       createdAgentRef.current = agentUuid;
@@ -283,7 +288,7 @@ export function OnboardingView() {
       return;
     }
     await pollUntilReady(agentUuid);
-  }, [trimmedName, connectedClient, selectedRuntime, pollUntilReady]);
+  }, [trimmedName, connectedClient, selectedRuntime, pollUntilReady, organizationId]);
 
   const handleRetry = useCallback(async () => {
     const agentUuid = createdAgentRef.current;


### PR DESCRIPTION
## Summary

Follow-up to [#214](https://github.com/agent-team-foundation/first-tree-hub/pull/214) (decouple-client-from-identity). Closes the gap where the web could not actually direct a write to the org the user had selected, and where the Computers tab dropped to raw UUIDs for any agent outside the currently selected tenant.

Four interlocking fixes (all six files were uncovered while debugging a single user-reported "I created agents in atf but they showed up in gandy02's team" thread):

- **web:** `NewAgentDialog` + workspace inline onboarding now include `currentMembership.organizationId` in the `POST /admin/agents` body. Without it the server fell back to the JWT default org, which was non-deterministic across logins.
- **server (`POST /admin/agents`):** accept `?organizationId=` as a fallback. Precedence is now `body > query > JWT default`. The api-client `decoratePath` injection added in #214 had no effect on writes until now. `requireMemberInOrg` still re-checks the live membership against the DB, so this does not weaken the auth boundary — an admin in org A passing `?organizationId=B` still 403s.
- **server (`auth.login`):** password-login member pick gets `ORDER BY created_at DESC, id DESC`. The previous `LIMIT 1` had no ORDER BY, so a multi-org user got an implementation-defined default org each login. `members.id` is uuidv7 (sortable) and serves as the tiebreak.
- **web (`useAgentNameMap` / `useAgentIdentityMap`):** layer `/me/managed-agents` (cross-org, user-scoped) on top of `/admin/agents` (org-scoped) so the Computers `BOUND AGENTS` panel resolves UUIDs that belong to the user's other-org agents — a single client is allowed to host agents from multiple orgs post-#214, but the name resolver had not caught up.
- **shared (`createAgentSchema`):** `organizationId` gains `.min(1)` so an empty string cannot shadow the query/JWT fallback chain (caught in independent review pass).
- **command:** bumped to `0.10.10` per the repo's "any PR touching server/web/shared bumps the published CLI" rule.

Re-opened from #219 with a convention-conforming branch name (`feat/...`).

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm typecheck` clean across all 9 packages
- [x] `@agent-team-foundation/first-tree-hub-shared` 150/150 unit tests pass
- [x] `@first-tree-hub/web` 53/53 unit tests pass
- [ ] Server integration suite (testcontainers + PG) — not run locally; CI to cover. Tests not added in this PR; the changes affect existing `auth.login` member pick + `POST /admin/agents` org resolution paths and a follow-up should pin the new precedence + ORDER BY behavior with regression tests
- [ ] Manual web verification post-deploy: create one agent in each of three orgs, confirm each lands in the right tenant; confirm `BOUND AGENTS` panel shows real names rather than UUIDs after a multi-org bind

🤖 Generated with [Claude Code](https://claude.com/claude-code)