### PR TITLE
feat(server): rate-limit phase 0 (immediate set)

### DIFF
--- a/packages/server/src/__tests__/agent-messages-rate-limit.test.ts
+++ b/packages/server/src/__tests__/agent-messages-rate-limit.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Regression tests for the per-agent rate limit on outbound message writes.
+ *
+ * The first test asserts the basic ceiling. The second asserts the bucket key
+ * is `agent:${uuid}` and not `ip:${req.ip}` — if a future hook-order
+ * regression makes `req.agent` undefined inside the keyGenerator, the
+ * fallback path keys by IP, which under `fastify.inject` collapses every
+ * caller to loopback and would silently degrade the limiter to a global cap.
+ * This is exactly the failure mode flagged in
+ * `proposals/hub-rate-limit-design.20260506.md` §2.5.
+ */
+describe("Agent Messages — per-agent rate limit", () => {
+  const getApp = useTestApp({ rateLimit: { agentMessageMax: 2 } });
+
+  it("returns 429 once a single agent exceeds agentMessageMax/min", async () => {
+    const app = getApp();
+    const sender = await createTestAgent(app, { name: `rl-${crypto.randomUUID().slice(0, 6)}-s` });
+    const target = await createTestAgent(app, { name: `rl-${crypto.randomUUID().slice(0, 6)}-t` });
+
+    const chat = (
+      await sender.request("POST", "/api/v1/agent/chats", {
+        type: "direct",
+        participantIds: [target.agent.uuid],
+      })
+    ).json();
+
+    const send = (i: number) =>
+      sender.request("POST", `/api/v1/agent/chats/${chat.id}/messages`, {
+        format: "text",
+        content: `@${target.agent.name} msg ${i}`,
+      });
+
+    expect((await send(1)).statusCode).toBe(201);
+    expect((await send(2)).statusCode).toBe(201);
+    expect((await send(3)).statusCode).toBe(429);
+  });
+
+  it("buckets are per-agent, not per-IP / global", async () => {
+    const app = getApp();
+    const a1 = await createTestAgent(app, { name: `iso-${crypto.randomUUID().slice(0, 6)}-a1` });
+    const a3 = await createTestAgent(app, { name: `iso-${crypto.randomUUID().slice(0, 6)}-a3` });
+    const target = await createTestAgent(app, { name: `iso-${crypto.randomUUID().slice(0, 6)}-t` });
+
+    const chat1 = (
+      await a1.request("POST", "/api/v1/agent/chats", {
+        type: "direct",
+        participantIds: [target.agent.uuid],
+      })
+    ).json();
+    const chat3 = (
+      await a3.request("POST", "/api/v1/agent/chats", {
+        type: "direct",
+        participantIds: [target.agent.uuid],
+      })
+    ).json();
+
+    // a1 burns through its 2-msg quota.
+    expect(
+      (
+        await a1.request("POST", `/api/v1/agent/chats/${chat1.id}/messages`, {
+          format: "text",
+          content: `@${target.agent.name} 1`,
+        })
+      ).statusCode,
+    ).toBe(201);
+    expect(
+      (
+        await a1.request("POST", `/api/v1/agent/chats/${chat1.id}/messages`, {
+          format: "text",
+          content: `@${target.agent.name} 2`,
+        })
+      ).statusCode,
+    ).toBe(201);
+    expect(
+      (
+        await a1.request("POST", `/api/v1/agent/chats/${chat1.id}/messages`, {
+          format: "text",
+          content: `@${target.agent.name} 3`,
+        })
+      ).statusCode,
+    ).toBe(429);
+
+    // a3 still has full quota — proves the bucket key is agent.uuid, not ip.
+    // Inside fastify.inject every request shares loopback as req.ip; if the
+    // keyGenerator silently fell back to ip, this assertion would flip to 429.
+    expect(
+      (
+        await a3.request("POST", `/api/v1/agent/chats/${chat3.id}/messages`, {
+          format: "text",
+          content: `@${target.agent.name} 1`,
+        })
+      ).statusCode,
+    ).toBe(201);
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -24,7 +24,19 @@ type AgentRequestFn = (
   extraHeaders?: Record<string, string>,
 ) => Promise<InjectResponse>;
 
-export async function createTestApp(): Promise<FastifyInstance> {
+/**
+ * Optional overrides for `createTestApp` / `useTestApp`. Today only the
+ * rate-limit caps are tunable — the default config sets all caps to 10000 so
+ * existing tests never trip them; tests that specifically exercise limiter
+ * behavior (e.g. `agent-messages-rate-limit.test.ts`) override the relevant
+ * field down to a small number to keep the test loop tight.
+ */
+export type CreateTestAppOptions = {
+  rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
+};
+
+export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<FastifyInstance> {
+  const baseRateLimit = { max: 10000, loginMax: 10000, webhookMax: 10000, agentMessageMax: 10000 };
   const config: Config = {
     database: {
       url: process.env.DATABASE_URL ?? "",
@@ -50,7 +62,7 @@ export async function createTestApp(): Promise<FastifyInstance> {
       },
     },
     trustProxy: false,
-    rateLimit: { max: 10000, loginMax: 10000, webhookMax: 10000, agentMessageMax: 10000 },
+    rateLimit: { ...baseRateLimit, ...opts.rateLimit },
     observability: {
       logging: { level: "error", format: "json", bridgeToSpanLevel: "off" },
     },
@@ -62,10 +74,10 @@ export async function createTestApp(): Promise<FastifyInstance> {
 }
 
 /** Lazy test app lifecycle — creates in beforeAll, closes in afterAll. */
-export function useTestApp() {
+export function useTestApp(opts: CreateTestAppOptions = {}) {
   let app: FastifyInstance;
   beforeAll(async () => {
-    app = await createTestApp();
+    app = await createTestApp(opts);
   });
   afterAll(async () => {
     await app?.close();

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -49,7 +49,8 @@ export async function createTestApp(): Promise<FastifyInstance> {
         clientSecret: "test-github-secret",
       },
     },
-    rateLimit: { max: 10000, loginMax: 10000, webhookMax: 10000 },
+    trustProxy: false,
+    rateLimit: { max: 10000, loginMax: 10000, webhookMax: 10000, agentMessageMax: 10000 },
     observability: {
       logging: { level: "error", format: "json", bridgeToSpanLevel: "off" },
     },

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -25,9 +25,15 @@ const editMessageSchema = z.object({
  * the global limiter — registered with `hook: "preHandler"` — fires).
  *
  * Rationale: agent ↔ agent reply loops are the documented failure mode
- * (`mention_only` is the semantic guard; this is the hard ceiling). Falls
- * back to IP keying for the unauthenticated edge case so the limiter never
- * silently disables itself.
+ * (`mention_only` is the semantic guard; this is the hard ceiling).
+ *
+ * The IP fallback is **defensive scaffolding, not a real code path**. These
+ * routes mount under `/agent` which forces `memberAuth + agentSelector`
+ * onRequest hooks (see app.ts) — a missing `req.agent` would have already
+ * 403'd before this preHandler runs. The fallback exists so that if a future
+ * refactor reorders hooks (or detaches one of these routes from the agent
+ * scope), the limiter degrades to per-IP keying with a logged warning rather
+ * than silently keying everyone to the same `undefined` bucket.
  */
 function agentMessageWriteRateLimit(max: number) {
   return {
@@ -36,7 +42,12 @@ function agentMessageWriteRateLimit(max: number) {
       timeWindow: "1 minute",
       keyGenerator: (req: FastifyRequest): string => {
         const agentId = req.agent?.uuid;
-        return agentId ? `agent:${agentId}` : `ip:${req.ip}`;
+        if (agentId) return `agent:${agentId}`;
+        log.warn(
+          { ip: req.ip, route: req.routeOptions?.url ?? req.url },
+          "rate-limit keyGenerator fell back to IP — req.agent missing on a route under /agent (hook order regression?)",
+        );
+        return `ip:${req.ip}`;
       },
     },
   };

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -3,7 +3,7 @@ import {
   sendMessageSchema,
   sendToAgentSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
@@ -19,8 +19,33 @@ const editMessageSchema = z.object({
   content: z.unknown(),
 });
 
+/**
+ * Per-agent rate limit on outbound message writes. Keyed by `agent.uuid`
+ * (populated by `agentSelectorHook`, which runs as an onRequest hook before
+ * the global limiter — registered with `hook: "preHandler"` — fires).
+ *
+ * Rationale: agent ↔ agent reply loops are the documented failure mode
+ * (`mention_only` is the semantic guard; this is the hard ceiling). Falls
+ * back to IP keying for the unauthenticated edge case so the limiter never
+ * silently disables itself.
+ */
+function agentMessageWriteRateLimit(max: number) {
+  return {
+    rateLimit: {
+      max,
+      timeWindow: "1 minute",
+      keyGenerator: (req: FastifyRequest): string => {
+        const agentId = req.agent?.uuid;
+        return agentId ? `agent:${agentId}` : `ip:${req.ip}`;
+      },
+    },
+  };
+}
+
 export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
-  app.post<{ Params: { chatId: string } }>("/:chatId/messages", async (request, reply) => {
+  const writeRateLimit = agentMessageWriteRateLimit(app.config.rateLimit?.agentMessageMax ?? 30);
+
+  app.post<{ Params: { chatId: string } }>("/:chatId/messages", { config: writeRateLimit }, async (request, reply) => {
     const identity = requireAgent(request);
     await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
     const body = sendMessageSchema.parse(request.body);
@@ -79,7 +104,9 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
 }
 
 export async function agentSendToAgentRoutes(app: FastifyInstance): Promise<void> {
-  app.post<{ Params: { name: string } }>("/:name/messages", async (request, reply) => {
+  const writeRateLimit = agentMessageWriteRateLimit(app.config.rateLimit?.agentMessageMax ?? 30);
+
+  app.post<{ Params: { name: string } }>("/:name/messages", { config: writeRateLimit }, async (request, reply) => {
     const identity = requireAgent(request);
     const body = sendToAgentSchema.parse(request.body);
     const { message: msg, recipients } = await messageService.sendToAgent(

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -108,7 +108,14 @@ export async function buildApp(config: Config) {
   // Cast widens pino.Logger<never, boolean> → FastifyBaseLogger so the
   // returned FastifyInstance has the default generic and remains assignable
   // in tests / callers that reference FastifyInstance without type args.
-  const app = Fastify({ loggerInstance: rootLogger as unknown as FastifyBaseLogger });
+  const app = Fastify({
+    loggerInstance: rootLogger as unknown as FastifyBaseLogger,
+    // When deployed behind Cloudflare / reverse proxy, `req.ip` must reflect
+    // the real client IP rather than the proxy — otherwise every IP-keyed
+    // rate-limit key collapses. Operators set FIRST_TREE_HUB_TRUST_PROXY=true
+    // when they control the upstream proxy chain.
+    trustProxy: config.trustProxy,
+  });
 
   // Register @fastify/otel before any route — it wraps each request handler
   // in an HTTP span that becomes the parent for business spans.
@@ -135,8 +142,12 @@ export async function buildApp(config: Config) {
   const listenClient = postgres(config.database.url, { max: 1 });
   const notifier = createNotifier(listenClient);
 
-  // WebSocket plugin
-  await app.register(websocket);
+  // WebSocket plugin. `maxPayload` caps a single inbound frame so a hostile
+  // or buggy client cannot OOM the server with one giant message. Frames in
+  // this codebase are JSON envelopes; image content travels via HTTP.
+  await app.register(websocket, {
+    options: { maxPayload: config.ws?.maxPayload ?? 65_536 },
+  });
 
   // CORS — explicit origins if configured; allow all in dev; same-origin in production
   const corsOrigin = config.cors?.origin;
@@ -146,10 +157,14 @@ export async function buildApp(config: Config) {
     credentials: true,
   });
 
-  // Rate limiting — global default; overridden per-route where needed
+  // Rate limiting — global default; overridden per-route where needed.
+  // `hook: "preHandler"` runs the limiter after route-level onRequest hooks
+  // (memberAuth, agentSelector) so per-route keyGenerators can read
+  // `req.member` / `req.agent` populated by those hooks.
   await app.register(rateLimit, {
     max: config.rateLimit?.max ?? 100,
     timeWindow: "1 minute",
+    hook: "preHandler",
   });
 
   // Auth hooks

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -117,6 +117,20 @@ export async function buildApp(config: Config) {
     trustProxy: config.trustProxy,
   });
 
+  // Loud security reminder: trustProxy=true makes Fastify trust ANY upstream's
+  // x-forwarded-for header. Safe iff the Hub container only receives traffic
+  // through a vetted proxy (Cloudflare → CapRover). If the container is ever
+  // exposed to the public internet directly, attackers can spoof XFF and
+  // bypass every IP-keyed rate limit / audit log. Surface this on every boot
+  // so a misconfiguration is loud rather than silent.
+  if (config.trustProxy) {
+    app.log.warn(
+      "trustProxy=true — Fastify trusts ANY upstream's x-forwarded-for. " +
+        "Ensure Cloudflare / CapRover is the only ingress; do NOT expose this " +
+        "container's port to the public internet directly.",
+    );
+  }
+
   // Register @fastify/otel before any route — it wraps each request handler
   // in an HTTP span that becomes the parent for business spans.
   const otelPlugin = getFastifyOtelPlugin();
@@ -182,6 +196,20 @@ export async function buildApp(config: Config) {
     }
     if (error instanceof ZodError) {
       return reply.status(400).send({ error: "Validation error", details: error.issues, ...traceField });
+    }
+    // Fastify plugins (e.g. @fastify/rate-limit's 429, @fastify/jwt's 401)
+    // throw errors with `statusCode` in the 4xx range. Surface them with
+    // their intended status + message rather than collapsing to 500. 5xx
+    // statuses still fall through to the generic handler below to avoid
+    // leaking server-internal messages.
+    if (
+      error instanceof Error &&
+      "statusCode" in error &&
+      typeof error.statusCode === "number" &&
+      error.statusCode >= 400 &&
+      error.statusCode < 500
+    ) {
+      return reply.status(error.statusCode).send({ error: error.message, ...traceField });
     }
     request.log.error({ err: error }, "unhandled request error");
     return reply.status(500).send({ error: "Internal server error", ...traceField });

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -106,11 +106,16 @@ export const serverConfigSchema = defineConfig({
     /**
      * Maximum payload size (bytes) for a single WebSocket frame on the
      * client/admin sockets. Protects the server against single-frame OOM via a
-     * malicious or buggy client. Default 64 KiB — frames in this codebase are
-     * JSON envelopes (`auth`, `inbox:ack`, `session:event`, …) that fit
-     * comfortably within this bound. Image content travels via HTTP, not WS.
+     * malicious or buggy client. Default 256 KiB — large enough to fit
+     * legitimate `session:event` frames whose `tool_call.payload.args` may
+     * carry full file contents (Claude Code's Write/Edit `new_string`, Bash
+     * heredoc payloads, MCP tools forwarding diffs/AST), while still bounding
+     * worst-case memory per frame. Image content travels via HTTP, not WS.
+     * Real OOM attackers send MB+, not KiB — this is a guardrail, not a DoS
+     * shield. Tighten or loosen via `FIRST_TREE_HUB_WS_MAX_PAYLOAD` once we
+     * have production P99 frame-size data.
      */
-    maxPayload: field(z.number().int().min(1024).default(65536), { env: "FIRST_TREE_HUB_WS_MAX_PAYLOAD" }),
+    maxPayload: field(z.number().int().min(1024).default(262_144), { env: "FIRST_TREE_HUB_WS_MAX_PAYLOAD" }),
   }),
   inbox: optional({
     /**

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -81,10 +81,36 @@ export const serverConfigSchema = defineConfig({
   cors: optional({
     origin: field(z.string(), { env: "FIRST_TREE_HUB_CORS_ORIGIN" }),
   }),
+  /**
+   * Trust upstream proxy headers (e.g. `x-forwarded-for`) for `req.ip`. Required
+   * in production where Hub sits behind Cloudflare / a reverse proxy — otherwise
+   * `req.ip` resolves to the proxy and every IP-keyed rate-limit key collapses
+   * to the same value. Default false; safe for local development.
+   */
+  trustProxy: field(z.boolean().default(false), { env: "FIRST_TREE_HUB_TRUST_PROXY" }),
   rateLimit: optional({
+    /** Default cap applied to all routes that don't override; overridden per-route below. */
     max: field(z.number().default(100), { env: "FIRST_TREE_HUB_RATE_LIMIT_MAX" }),
+    /** Cap on `/auth/login`, `/auth/connect-token`, and other token-issuing paths. */
     loginMax: field(z.number().default(5), { env: "FIRST_TREE_HUB_RATE_LIMIT_LOGIN_MAX" }),
+    /** Cap on `/webhooks/github`. */
     webhookMax: field(z.number().default(60), { env: "FIRST_TREE_HUB_RATE_LIMIT_WEBHOOK_MAX" }),
+    /**
+     * Per-agent cap on outbound message writes (`POST /agent/chats/:chatId/messages`
+     * and `POST /agent/agents/:name/messages`). Tighter than the global default
+     * because automated agents are the common loop-failure mode.
+     */
+    agentMessageMax: field(z.number().default(30), { env: "FIRST_TREE_HUB_RATE_LIMIT_AGENT_MESSAGE_MAX" }),
+  }),
+  ws: optional({
+    /**
+     * Maximum payload size (bytes) for a single WebSocket frame on the
+     * client/admin sockets. Protects the server against single-frame OOM via a
+     * malicious or buggy client. Default 64 KiB — frames in this codebase are
+     * JSON envelopes (`auth`, `inbox:ack`, `session:event`, …) that fit
+     * comfortably within this bound. Image content travels via HTTP, not WS.
+     */
+    maxPayload: field(z.number().int().min(1024).default(65536), { env: "FIRST_TREE_HUB_WS_MAX_PAYLOAD" }),
   }),
   inbox: optional({
     /**


### PR DESCRIPTION
## Summary

Implements the **immediate** subset of the rate-limit Phase 0 plan from the [`hub-rate-limit-design.20260506.md`](https://github.com/agent-team-foundation/first-tree-context/blob/main/proposals/hub-rate-limit-design.20260506.md) proposal in `first-tree-context`. Observation-driven items deferred per YAGNI (see proposal §6.2).

## ⚠️ Scope: what this PR does NOT include (intentional)

These are explicitly out-of-scope per the YAGNI Phase 0 split. They will be added when production signals warrant — see the proposal's §6.2 trigger conditions.

| Deferred item | Trigger to add |
|---|---|
| keyGenerator → userId on authenticated routes | 429 misfires on real users (shared NAT/office IP) |
| `/login` username-keyed limiter | Account brute-force visible in logs (rotated-IP attacker on a fixed username) |
| Global default 100 → 200 req/min | 100/min frequently triggered by legit web/WS traffic |
| `onExceeded` OTel attribute on Logfire | Need to slice 429 by user/agent/route in Logfire (today `status_code = 429` already gives counts) |

## Operations side (separate from this PR; please confirm)

The application-layer change assumes Cloudflare proxied mode + production env var. Without this, `trustProxy: true` is unsafe.

- [ ] Cloudflare DNS-only → orange cloud (proxied) for production domain
- [ ] Cloudflare DNS-only → orange cloud for staging subdomain (recommended over direct CapRover URL)
- [ ] Cloudflare add 2 free rate-limit rules: `/login` 10/min per IP; global 5000/5min per IP
- [ ] Set `FIRST_TREE_HUB_TRUST_PROXY=true` on production + staging environments

## Application-layer changes (this PR)

### User-visible features
- ✅ Fastify `trustProxy` (env `FIRST_TREE_HUB_TRUST_PROXY`) — required before launch so `req.ip` reflects the real client behind Cloudflare / CapRover. Without it, early IP data in Logfire collapses to the proxy and cannot be backfilled.
- ✅ WebSocket `maxPayload` cap (env `FIRST_TREE_HUB_WS_MAX_PAYLOAD`, default **256 KiB**) — single-frame OOM defense, large enough to fit `session:event` frames carrying file contents (Claude Code Write/Edit `new_string`, Bash heredoc, MCP tool diffs).
- ✅ Per-agentId rate limit (env `FIRST_TREE_HUB_RATE_LIMIT_AGENT_MESSAGE_MAX`, default 30/min) on `POST /agent/chats/:chatId/messages` and `POST /agent/agents/:name/messages` — hard ceiling against agent reply loops on top of the existing `mention_only` semantic guard (cf. 7f400b5).

### Supporting changes
- Switch `@fastify/rate-limit` to `hook: "preHandler"` so route-level keyGenerators run after `agentSelectorHook` and can read `req.agent`. **Behavioral note**: 4xx-throttled responses now arrive after onRequest hooks finish (vs. before), a tiny cost paid uniformly across all routes — visible to no client but worth flagging.
- Configuration schema extension for the env vars above.
- Loud warn-log when `trustProxy=true` so operators are reminded the deployment must keep Cloudflare/CapRover as the only ingress.

### Bug fix (latent, surfaced by review)
- `app.setErrorHandler` was collapsing fastify-plugin-thrown 4xx errors (rate-limit's 429, jwt's 401, …) to `500 Internal server error`, preventing clients from distinguishing throttling from real failures. Now surfaces 4xx with intended status + message; 5xx still goes through the generic handler.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` (biome) passes
- [x] `pnpm test` passes (556/556 — includes 2 new rate-limit cases)
- [ ] Smoke-test on staging: `req.ip` shows real client IP after deploy
- [ ] Smoke-test: simulate agent sending >30 messages/min → 31st returns **429** (not 500)
- [ ] Smoke-test: WS frame >256 KiB → connection closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)