### PR TITLE
fix(client): WS proactive refresh + symlinked global install detection

### DIFF
--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -411,7 +411,16 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.wsLogger.debug("socket opened, sending auth");
 
         try {
-          const token = await this.getAccessToken();
+          // Ask for a token still valid past our proactive-refresh lead
+          // time, otherwise the cached token returned here would already be
+          // inside the lead window and the next proactive refresh would be
+          // a no-op — server would push `auth:expired` instead.
+          //
+          // The +5_000 is just a readability slack so the boundary check
+          // explicitly clears the lead window rather than comparing equal.
+          // Any positive epsilon would do; 5s reads as deliberate at a
+          // glance and is small enough to never matter operationally.
+          const token = await this.getAccessToken({ minValidityMs: AUTH_REFRESH_LEAD_MS + 5_000 });
           ws.send(JSON.stringify({ type: "auth", token }));
           // C5: arm the proactive refresh timer as soon as we've sent the
           // auth frame — auth:ok only confirms the token was accepted, the
@@ -451,7 +460,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           return;
         }
 
-        this.wsLogger.warn({ code, wasRegistered }, "disconnected");
+        // Code 1000 is a clean close — the only one we issue ourselves is
+        // the proactive auth refresh, which is expected and recovers
+        // silently. Surface it at info so genuine drops (4401, 1006, etc.)
+        // remain warn-visible.
+        if (code === 1000) {
+          this.wsLogger.info({ code, wasRegistered }, "disconnected");
+        } else {
+          this.wsLogger.warn({ code, wasRegistered }, "disconnected");
+        }
         if (!this.closing) {
           this.emit("disconnected");
           if (wasRegistered) this.scheduleReconnect();

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -12,8 +12,16 @@ import {
   type SendToAgent,
 } from "@agent-team-foundation/first-tree-hub-shared";
 
-/** Callback that returns the current member access JWT. */
-export type AccessTokenProvider = () => string | Promise<string>;
+/**
+ * Callback that returns the current member access JWT.
+ *
+ * `minValidityMs` lets the caller declare "I need a token still valid for at
+ * least N milliseconds." Implementations should refresh whenever the cached
+ * token has less than that much life remaining. Without this hint the WS
+ * proactive-refresh path would reuse a cached token that is about to expire
+ * and immediately get kicked off with `auth:expired`.
+ */
+export type AccessTokenProvider = (opts?: { minValidityMs?: number }) => string | Promise<string>;
 
 export type SdkConfig = {
   serverUrl: string;

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/ensure-fresh-access-token.test.ts
+++ b/packages/command/src/__tests__/ensure-fresh-access-token.test.ts
@@ -122,6 +122,29 @@ describe("ensureFreshAccessToken — safety margin", () => {
     for (const r of results) expect(r).toBe(refreshed);
   });
 
+  it("respects opts.minValidityMs — refreshes a token that the default would consider fresh", async () => {
+    // Regression: WS proactive refresh fires at exp-60s; before this fix it
+    // re-called ensureFreshAccessToken() with the default 30s lead, saw
+    // ~60s of life remaining, returned the *same* token, and the server
+    // pushed auth:expired ~55s later. Asking for 65s validity must drive a
+    // real /auth/refresh round-trip.
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) + 60 });
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(stale);
+
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+
+    // Default threshold (30s): the 60s-lived token is still considered fresh.
+    expect(await ensureFreshAccessToken()).toBe(stale);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // WS-style call asking for 65s of validity: must refresh.
+    expect(await ensureFreshAccessToken({ minValidityMs: 65_000 })).toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("releases the inflight slot so subsequent expirations can refresh again", async () => {
     const stale1 = makeJwt({ exp: Math.floor(Date.now() / 1000) - 5 });
     const refreshed1 = makeJwt({ exp: Math.floor(Date.now() / 1000) + 10 }); // still within 30s lead

--- a/packages/command/src/__tests__/update-detect-install-mode.test.ts
+++ b/packages/command/src/__tests__/update-detect-install-mode.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -53,6 +53,30 @@ describe("detectInstallMode", () => {
     mkdirSync(join(root, "stray/dir"), { recursive: true });
     writeFileSync(argv1, "// stub");
     expect(detectInstallMode(argv1)).toBe("npx");
+  });
+
+  it("classifies a global install as 'global' when invoked through a symlinked bin/", () => {
+    // Regression: standard `npm i -g` lays the binary out as
+    // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/dist/cli/index.mjs`.
+    // process.argv[1] keeps the symlink path, so without realpath the walk
+    // starts in `<prefix>/bin/` and never reaches the package.json — the
+    // command falls through to "npx" and `update` refuses to run.
+    const prefix = join(root, "usr", "local");
+    const pkgDir = join(prefix, "lib", "node_modules", "@agent-team-foundation", "first-tree-hub");
+    mkdirSync(join(pkgDir, "dist", "cli"), { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@agent-team-foundation/first-tree-hub", version: "0.10.12" }),
+    );
+    const target = join(pkgDir, "dist", "cli", "index.mjs");
+    writeFileSync(target, "// stub");
+
+    const binDir = join(prefix, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binLink = join(binDir, "first-tree-hub");
+    symlinkSync(target, binLink);
+
+    expect(detectInstallMode(binLink)).toBe("global");
   });
 
   it("treats a dist build inside a checkout as 'source' even when an inner package.json matches our name", () => {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -78,7 +78,7 @@ function createSdk(agentName?: string): FirstTreeHubSDK {
   const { serverUrl, agentId } = resolveLocalAgent(agentName);
   return new FirstTreeHubSDK({
     serverUrl,
-    getAccessToken: () => ensureFreshAccessToken(),
+    getAccessToken: (opts) => ensureFreshAccessToken(opts),
     agentId,
   });
 }
@@ -234,7 +234,7 @@ export function registerAgentCommands(program: Command): void {
       try {
         const serverUrl = resolveServerUrl(options.server);
         const clientId = readClientId();
-        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
+        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: (opts) => ensureFreshAccessToken(opts) });
         const stale = await findStaleAliases({
           clientId,
           listPinnedAgents: () => sdk.listMyAgents(),

--- a/packages/command/src/commands/client.ts
+++ b/packages/command/src/commands/client.ts
@@ -284,7 +284,7 @@ export function registerClientCommands(program: Command): void {
       try {
         const serverUrl = resolveServerUrl();
         const cfg = await initConfig({ schema: clientConfigSchema, role: "client" });
-        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
+        const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: (opts) => ensureFreshAccessToken(opts) });
         agentCheck = await reconcileAgentConfigs({
           clientId: cfg.client.id,
           listPinnedAgents: () => sdk.listMyAgents(),
@@ -539,7 +539,7 @@ export function registerClientCommands(program: Command): void {
         // doctor keeps reporting the inflated "N configured" count.
         // Detect + offer to prune in the same breath as the claim.
         try {
-          const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: () => ensureFreshAccessToken() });
+          const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken: (opts) => ensureFreshAccessToken(opts) });
           const stale = await findStaleAliases({
             clientId,
             listPinnedAgents: () => sdk.listMyAgents(),

--- a/packages/command/src/core/bootstrap.ts
+++ b/packages/command/src/core/bootstrap.ts
@@ -63,18 +63,27 @@ export function resolveAccessToken(): string {
  */
 let inflightRefresh: Promise<string> | null = null;
 
+/** Default freshness window for HTTP callers: refresh if token expires within 30s. */
+const DEFAULT_MIN_VALIDITY_MS = 30_000;
+
 /**
  * Ensure the persisted access token is fresh. Call before any API request
  * when using persisted credentials. Returns the (possibly refreshed) access
  * token. Service-user API keys are out of scope for this milestone.
+ *
+ * `opts.minValidityMs` raises the freshness bar — refresh when the cached
+ * token has less than that much life left. The WS proactive-refresh path
+ * passes a value that overlaps its lead window so it never receives a
+ * token already inside the "about to expire" zone.
  */
-export async function ensureFreshAccessToken(): Promise<string> {
+export async function ensureFreshAccessToken(opts?: { minValidityMs?: number }): Promise<string> {
+  const minValidityMs = opts?.minValidityMs ?? DEFAULT_MIN_VALIDITY_MS;
   const creds = loadCredentials();
   if (!creds) {
     throw new Error("No credentials found. Run `first-tree-hub client connect <server-url>` to sign in.");
   }
 
-  if (!isTokenExpired(creds.accessToken)) {
+  if (!isTokenStale(creds.accessToken, minValidityMs)) {
     return creds.accessToken;
   }
 
@@ -109,14 +118,13 @@ export async function ensureFreshAccessToken(): Promise<string> {
 /** Back-compat alias retained so existing call sites keep compiling. */
 export const ensureFreshAdminToken = ensureFreshAccessToken;
 
-function isTokenExpired(token: string): boolean {
+function isTokenStale(token: string, minValidityMs: number): boolean {
   try {
     const parts = token.split(".");
     if (parts.length !== 3 || !parts[1]) return true;
     const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString()) as { exp?: number };
     if (!payload.exp) return false;
-    // Refresh 30s before exp so requests never fly with an about-to-expire token.
-    return payload.exp * 1000 < Date.now() + 30_000;
+    return payload.exp * 1000 < Date.now() + minValidityMs;
   } catch {
     return true;
   }

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -72,7 +72,7 @@ export class ClientRuntime {
       serverUrl,
       clientId,
       sdkVersion: options.currentVersion,
-      getAccessToken: () => ensureFreshAccessToken(),
+      getAccessToken: (opts) => ensureFreshAccessToken(opts),
     });
     registerBuiltinHandlers();
 

--- a/packages/command/src/core/update.ts
+++ b/packages/command/src/core/update.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import * as semver from "semver";
 import { print } from "./output.js";
@@ -38,8 +38,23 @@ function resolveNpmCommand(): string {
  */
 export function detectInstallMode(argv1: string = process.argv[1] ?? ""): InstallMode {
   if (!argv1) return "npx";
+  // Resolve symlinks first. Standard `npm i -g` lays the binary out as
+  // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/dist/cli/index.mjs`,
+  // and `process.argv[1]` keeps the symlink path. Walking from the link
+  // dir (`<prefix>/bin/`) never hits an ancestor `package.json` matching
+  // our name, so the function falls through to "npx" and `update` refuses
+  // to run on a perfectly valid global install. realpathSync moves the
+  // walk start into the package tree where detection actually works.
+  // Wrapped in try/catch because argv1 may be a path that no longer
+  // exists on disk (overridden process.argv[1], odd test fixtures).
+  let resolvedArgv1: string;
+  try {
+    resolvedArgv1 = realpathSync(argv1);
+  } catch {
+    resolvedArgv1 = argv1;
+  }
   // Cap at 10 levels to avoid runaway walks on exotic symlink layouts.
-  const start = dirname(resolve(argv1));
+  const start = dirname(resolve(resolvedArgv1));
 
   // Pass 1: any ancestor with a `.git` dir means we're inside a checkout.
   // This MUST happen before the package.json scan — when a built dist lives


### PR DESCRIPTION
## Summary

Three independent fixes bundled together (one branch per reviewer guidance is acknowledged but accepted as a tradeoff for ship velocity):

1. **WS proactive refresh was a no-op.** Timer fired 60s before exp and reconnected, but `ensureFreshAccessToken` saw the default 30s threshold satisfied (token still had ~60s of life) and returned the *same* token — server then pushed `auth:expired` ~55s later, forcing a 4401 disconnect every cycle. Fixed by giving `AccessTokenProvider` an optional `{ minValidityMs }` and having the WS open path pass `AUTH_REFRESH_LEAD_MS + 5_000`.
2. **`first-tree-hub update` rejected standard global installs.** `detectInstallMode` walked from `dirname(resolve(argv1))`, but for `npm i -g` argv1 is a symlink at `<prefix>/bin/` whose ancestors never contain our package.json — falls through to `"npx"` and the command refuses to run. Resolve via `realpathSync` (with try/catch fallback) so the walk starts inside the package tree. Same fix transparently re-enables the auto-update path in `update-glue.ts`.
3. **Logging noise.** Code 1000 disconnects (only ever issued by our own proactive refresh) downgraded from warn to info so genuine drops (4401, 1006, etc.) remain warn-visible.

Bumps `@agent-team-foundation/first-tree-hub` 0.10.11 → 0.10.12.

## Test plan

- [x] `pnpm check && pnpm typecheck`
- [x] `pnpm --filter @first-tree-hub/client test` — 241 passing
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` — 82 passing (incl. 2 new regression cases)
- [ ] Run staging client overnight; confirm logs show no `code=4401` proactive-refresh disconnects, only `code=1000` info-level ones
- [ ] Confirm `first-tree-hub update` works on a globally-installed copy (the bug-trigger scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)