### PR TITLE
fix(server): rewrite inbox raw SQL (#194) + skip stale onClose disconnect

### DIFF
--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -250,6 +250,11 @@ describe("inbox WS data-plane claim helpers", () => {
     }
     // Every drained entry must be marked delivered atomically with the claim.
     for (const e of drained) expect(e.status).toBe("delivered");
+    // Pin the bigserial → number conversion on the backlog path too. The WS
+    // push frame schema validates `entryId: z.number()`; if `claimBacklog`
+    // ever regresses to raw SQL, every push frame would be dropped client-
+    // side as malformed. See issue #194.
+    for (const e of drained) expect(typeof e.id).toBe("number");
   });
 
   it("ackEntryByIdForBoundAgents acks only entries in the supplied inbox set", async () => {

--- a/packages/server/src/__tests__/silent-inbox-context.test.ts
+++ b/packages/server/src/__tests__/silent-inbox-context.test.ts
@@ -115,6 +115,14 @@ describe("silent inbox + preceding context", () => {
       "third silent",
     ]);
 
+    // Pin the runtime types of the bigserial / integer columns. The HTTP poll
+    // path historically returned `id` and `retryCount` as JS strings because
+    // the raw-SQL `tx.execute` bypassed Drizzle's column-mode conversion;
+    // anything downstream that strictly validated `z.number()` would reject
+    // the frame. See issue #194.
+    expect(typeof entry.id).toBe("number");
+    expect(typeof entry.retryCount).toBe("number");
+
     // All silent rows should now be acked.
     const remaining = await app.db
       .select({ notify: inboxEntries.notify, status: inboxEntries.status })

--- a/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
+++ b/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
@@ -1,0 +1,161 @@
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { clients } from "../db/schema/clients.js";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+/**
+ * Regression test for the May 7 staging incident: a client reconnects
+ * (typical `systemctl restart` flow), the new socket finishes register
+ * and the row becomes `connected`, but the *old* socket's `socket.on
+ * ("close")` handler — running asynchronously — then awaits
+ * `disconnectClient` and stamps `status='disconnected'`, clobbering the
+ * fresh state. From the operator's perspective everything is healthy
+ * (CLI, doctor, agents bound) but the Web admin shows "offline".
+ *
+ * The fix in ws-client.ts gates the DB write on
+ * `connectionManager.isActiveClientConnection(clientId, socket)` — the
+ * old socket sees `false` (the new socket has already taken over) and
+ * skips the write.
+ *
+ * This test reproduces the race deterministically by opening two
+ * sockets under the same clientId in sequence; the second register
+ * triggers the connection-manager's "ALREADY_CONNECTED" close on the
+ * first socket. We then wait for the first socket's onClose handler to
+ * complete and assert the row remained `connected`.
+ */
+describe("WS client reconnect race — late onClose must not clobber a fresh status", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+  let userId: string;
+  let memberId: string;
+  let orgId: string;
+  let role: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signAccess(): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({
+      sub: userId,
+      memberId,
+      organizationId: orgId,
+      role,
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(secret);
+  }
+
+  /**
+   * Open a WS, send `auth` + `client:register`, resolve once the server
+   * has acknowledged registration (`client:registered` frame). Returns
+   * the open WebSocket so the caller can close it (or wait for the
+   * server to close it).
+   */
+  async function authAndRegister(token: string, clientId: string): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("register timeout")), 5000);
+      ws.on("open", () => ws.send(JSON.stringify({ type: "auth", token })));
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === "auth:ok") {
+          ws.send(JSON.stringify({ type: "client:register", clientId }));
+        } else if (msg.type === "client:registered") {
+          clearTimeout(timer);
+          resolve();
+        } else if (msg.type === "client:register:rejected") {
+          clearTimeout(timer);
+          reject(new Error(`register rejected: ${JSON.stringify(msg)}`));
+        }
+      });
+      ws.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+    return ws;
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+  });
+
+  beforeEach(async () => {
+    const admin = await createTestAdmin(app, { username: `race-${crypto.randomUUID().slice(0, 8)}` });
+    userId = admin.userId;
+    memberId = admin.memberId;
+    const { members } = await import("../db/schema/members.js");
+    const [m] = await app.db.select().from(members).where(eq(members.id, memberId)).limit(1);
+    if (!m) throw new Error("member row missing after setup");
+    orgId = m.organizationId;
+    role = m.role;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("preserves clients.status='connected' when the displaced socket's onClose lands after the new register", async () => {
+    const token = await signAccess();
+    const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
+
+    // First connection — registers and becomes the active socket.
+    const ws1 = await authAndRegister(token, clientId);
+
+    // Track when ws1 actually finishes closing on the server side. The
+    // close is initiated by setClientConnection during ws2's register
+    // (code 4009 ALREADY_CONNECTED), and onClose runs asynchronously
+    // afterwards. We can't directly observe the server's handler, but
+    // the client-side `close` event is a tight upper bound — onClose's
+    // own awaits run within a few ms after the network close.
+    const ws1Closed = new Promise<void>((resolve) => ws1.on("close", () => resolve()));
+
+    // Second connection under the same clientId — server's
+    // setClientConnection forces close on ws1, and ws2's register
+    // writes status='connected'.
+    const ws2 = await authAndRegister(token, clientId);
+
+    // Wait for ws1's close + a small buffer so onClose's awaited DB
+    // write (if any — the fix should suppress it) lands before we
+    // sample.
+    await ws1Closed;
+    await new Promise((r) => setTimeout(r, 100));
+
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+
+    // Without the fix, this would be 'disconnected' — ws1's onClose
+    // would have stamped it after ws2's register. With the fix, ws1's
+    // handler sees `isActiveClientConnection(...)=false` (the slot now
+    // points at ws2) and skips the DB write.
+    expect(row?.status).toBe("connected");
+
+    ws2.close();
+  }, 10_000);
+
+  it("still writes 'disconnected' when the only socket closes (no replacement)", async () => {
+    // Sanity: the fix must not break the normal disconnect path. A
+    // single client opening then closing must end up disconnected in
+    // the DB, otherwise we'd have leaked the entire status signal.
+    const token = await signAccess();
+    const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
+
+    const ws = await authAndRegister(token, clientId);
+    const closed = new Promise<void>((resolve) => ws.on("close", () => resolve()));
+    ws.close();
+    await closed;
+    await new Promise((r) => setTimeout(r, 100));
+
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(row?.status).toBe("disconnected");
+  }, 10_000);
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -884,11 +884,30 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         boundAgents.clear();
 
         if (clientId) {
+          // Reconnect-race guard. A typical `systemctl restart` produces this
+          // sequence:
+          //
+          //   t0  old client process exits → server starts processing this
+          //       onClose handler asynchronously
+          //   t1  new client process connects + registers → setClientConnection
+          //       installs the new socket as the active one for `clientId` and
+          //       writes clients.status='connected'
+          //   t2  the t0 onClose finally awaits to disconnectClient and would
+          //       happily stamp clients.status='disconnected', clobbering t1
+          //
+          // `isActiveClientConnection` returns false at t2 because the in-
+          // memory entry now points at the *new* socket, not us. Skip the DB
+          // write in that case so the new connection's `connected` status
+          // survives. Bug captured live at /clients[0].status='disconnected'
+          // with last_seen_at 13s old + a fully-registered client.log.
+          const stillActive = connectionManager.isActiveClientConnection(clientId, socket);
           connectionManager.removeClientConnection(clientId, socket);
-          try {
-            await clientService.disconnectClient(app.db, clientId);
-          } catch {
-            // best-effort
+          if (stillActive) {
+            try {
+              await clientService.disconnectClient(app.db, clientId);
+            } catch {
+              // best-effort
+            }
           }
         }
       });

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -133,6 +133,24 @@ export function removeClientConnection(clientId: string, ws: WebSocket): string[
   return agentIds;
 }
 
+/**
+ * Was `ws` the socket currently registered as `clientId`'s active connection
+ * at the time of the call? Used by ws-client.ts's `socket.on("close")` to
+ * decide whether to write `clients.status='disconnected'` to the DB — when a
+ * fast reconnect happens, the new socket has already swapped itself in via
+ * `setClientConnection`, so the old socket's late-arriving onClose must NOT
+ * stamp the row back to disconnected.
+ *
+ * The check is "this socket equals the registered ws", not "this socket is
+ * still OPEN" — the close handler runs precisely when the socket is no
+ * longer OPEN, but the in-memory entry might still legitimately point at
+ * us if no new connection has taken over yet.
+ */
+export function isActiveClientConnection(clientId: string, ws: WebSocket): boolean {
+  const entry = clientConnections.get(clientId);
+  return entry?.ws === ws;
+}
+
 /** Send a message to a client's WebSocket. Returns true if delivered. */
 export function sendToClient(clientId: string, message: Record<string, unknown>): boolean {
   const entry = clientConnections.get(clientId);

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,5 +1,5 @@
 import type { InboxEntryWithMessage, PrecedingMessage } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
@@ -8,21 +8,12 @@ import { ForbiddenError, NotFoundError } from "../errors.js";
 import { FIRST_TREE_HUB_ATTR, withSpan } from "../observability/index.js";
 import { buildClientMessagePayloadsForInbox } from "./message-dispatcher.js";
 
-/** Raw `inbox_entries` row shape returned by claim queries below. */
-type ClaimedEntryRow = {
-  id: number;
-  inbox_id: string;
-  message_id: string;
-  chat_id: string | null;
-  status: string;
-  retry_count: number;
-  created_at: string;
-  delivered_at: string | null;
-  acked_at: string | null;
-};
+/** Claimed `inbox_entries` row, typed via Drizzle `$inferSelect` so column-mode
+ *  conversions (bigserial → number, timestamp → Date) flow through. */
+type ClaimedEntry = typeof inboxEntries.$inferSelect;
 
 /** Structurally-typed DB so both `Database` and transaction clients work. */
-type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "execute" | "select">;
+type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete">;
 
 const DEFAULT_INBOX_TIMEOUT_SECONDS = 300;
 const DEFAULT_MAX_RETRY_COUNT = 3;
@@ -47,23 +38,28 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
 }
 
 async function pollInboxInner(db: Database, inboxId: string, limit: number) {
-  // Use raw SQL for SELECT ... FOR UPDATE SKIP LOCKED (not supported by Drizzle query builder)
   return db.transaction(async (tx) => {
-    // 1. Claim pending NOTIFY=true entries (the active triggers). Silent rows
-    //    (notify=false) are intentionally excluded — they piggy-back on the
-    //    next active delivery in their chat as preceding context (proposal §1).
-    const claimed = await tx.execute<ClaimedEntryRow>(sql`
-      UPDATE inbox_entries
-      SET status = 'delivered', delivered_at = NOW()
-      WHERE id IN (
-        SELECT id FROM inbox_entries
-        WHERE inbox_id = ${inboxId} AND status = 'pending' AND notify = true
-        ORDER BY created_at
-        LIMIT ${limit}
-        FOR UPDATE SKIP LOCKED
-      )
-      RETURNING *
-    `);
+    // Claim pending notify=true entries (active triggers). Silent rows
+    // (notify=false) are intentionally excluded — they piggy-back on the
+    // next active delivery in their chat as preceding context (proposal §1).
+    //
+    // The subquery's `FOR UPDATE SKIP LOCKED` is what keeps concurrent
+    // pollers / WS-push handlers from claiming the same row twice. The outer
+    // UPDATE then flips status to 'delivered' on whichever rows the subquery
+    // successfully locked — canonical PG SKIP-LOCKED queue idiom.
+    const targetIds = tx
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "pending"), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.createdAt))
+      .limit(limit)
+      .for("update", { skipLocked: true });
+
+    const claimed = await tx
+      .update(inboxEntries)
+      .set({ status: "delivered", deliveredAt: new Date() })
+      .where(inArray(inboxEntries.id, targetIds))
+      .returning();
 
     return bundleDeliveryWithSilentContext(tx, inboxId, claimed);
   });
@@ -79,7 +75,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
  * hub-inbox-ws-data-plane §3.2 risk #1).
  *
  * Steps:
- *   1. Sort by `created_at` ASC (PG `RETURNING` does not guarantee order).
+ *   1. Sort by `createdAt` ASC (PG `RETURNING` does not guarantee order).
  *   2. For each trigger, collect silent context & bulk-ack stale silent rows.
  *   3. Fetch the trigger messages.
  *   4. Build wire payloads via the single dispatcher.
@@ -89,19 +85,19 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
 export async function bundleDeliveryWithSilentContext(
   tx: TxLike,
   inboxId: string,
-  claimed: ClaimedEntryRow[],
+  claimed: ClaimedEntry[],
 ): Promise<InboxEntryWithMessage[]> {
   if (claimed.length === 0) return [];
 
   // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so we sort
-  // by created_at (ascending) before assembling the response. Downstream
+  // by createdAt (ascending) before assembling the response. Downstream
   // consumers — and silent-context bundling in particular — depend on
   // chronological order to split context windows correctly.
-  claimed.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  claimed.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
   const precedingByEntryId = await collectPrecedingContext(tx, inboxId, claimed);
 
-  const messageIds = claimed.map((e) => e.message_id);
+  const messageIds = claimed.map((e) => e.messageId);
   const msgs = await tx.select().from(messages).where(inArray(messages.id, messageIds));
   const msgMap = new Map(msgs.map((m) => [m.id, m]));
 
@@ -114,10 +110,10 @@ export async function bundleDeliveryWithSilentContext(
     tx,
     inboxId,
     claimed.map((entry) => {
-      const msg = msgMap.get(entry.message_id);
-      if (!msg) throw new Error(`Unexpected: message ${entry.message_id} not found`);
+      const msg = msgMap.get(entry.messageId);
+      if (!msg) throw new Error(`Unexpected: message ${entry.messageId} not found`);
       return {
-        entryChatId: entry.chat_id,
+        entryChatId: entry.chatId,
         precedingMessages: precedingByEntryId.get(entry.id) ?? [],
         message: {
           id: msg.id,
@@ -140,23 +136,15 @@ export async function bundleDeliveryWithSilentContext(
     const payload = payloads[idx];
     if (!payload) throw new Error(`Unexpected: payload for entry ${entry.id} not built`);
     return {
-      // `inbox_entries.id` is bigserial (int8); postgres-js returns int8 as a
-      // JS string by default to preserve precision past 2^53. The raw-SQL
-      // `tx.execute<{ id: number }>` declares a number type but doesn't
-      // coerce — Drizzle only applies the column's `mode: "number"` on
-      // builder queries. The legacy HTTP poll path tolerated the string
-      // because the SDK never validated `id` as a number, but the WS push
-      // path's `inboxDeliverFrameSchema.entryId` is a strict `z.number()`,
-      // so we coerce at this single shared exit point.
-      id: Number(entry.id),
-      inboxId: entry.inbox_id,
-      messageId: entry.message_id,
-      chatId: entry.chat_id,
+      id: entry.id,
+      inboxId: entry.inboxId,
+      messageId: entry.messageId,
+      chatId: entry.chatId,
       status: entry.status,
-      retryCount: entry.retry_count,
-      createdAt: entry.created_at,
-      deliveredAt: entry.delivered_at ?? null,
-      ackedAt: entry.acked_at ?? null,
+      retryCount: entry.retryCount,
+      createdAt: entry.createdAt.toISOString(),
+      deliveredAt: entry.deliveredAt?.toISOString() ?? null,
+      ackedAt: entry.ackedAt?.toISOString() ?? null,
       message: payload,
     };
   });
@@ -195,21 +183,26 @@ export async function claimAndBuildForPush(
 ): Promise<InboxEntryWithMessage[]> {
   return withSpan("inbox.deliver.push", { "inbox.id": inboxId, "message.id": messageId }, () =>
     db.transaction(async (tx) => {
-      const claimed = await tx.execute<ClaimedEntryRow>(sql`
-          UPDATE inbox_entries
-          SET status = 'delivered', delivered_at = NOW()
-          WHERE id IN (
-            SELECT id FROM inbox_entries
-            WHERE inbox_id = ${inboxId}
-              AND message_id = ${messageId}
-              AND status = 'pending'
-              AND notify = true
-            ORDER BY created_at
-            LIMIT ${PUSH_CLAIM_BATCH_LIMIT}
-            FOR UPDATE SKIP LOCKED
-          )
-          RETURNING *
-        `);
+      const targetIds = tx
+        .select({ id: inboxEntries.id })
+        .from(inboxEntries)
+        .where(
+          and(
+            eq(inboxEntries.inboxId, inboxId),
+            eq(inboxEntries.messageId, messageId),
+            eq(inboxEntries.status, "pending"),
+            eq(inboxEntries.notify, true),
+          ),
+        )
+        .orderBy(asc(inboxEntries.createdAt))
+        .limit(PUSH_CLAIM_BATCH_LIMIT)
+        .for("update", { skipLocked: true });
+
+      const claimed = await tx
+        .update(inboxEntries)
+        .set({ status: "delivered", deliveredAt: new Date() })
+        .where(inArray(inboxEntries.id, targetIds))
+        .returning();
 
       return bundleDeliveryWithSilentContext(tx, inboxId, claimed);
     }),
@@ -240,28 +233,28 @@ export async function claimBacklogForPush(
  * `PRECEDING_CONTEXT_WINDOW_SECONDS`. Returned messages are oldest-first.
  *
  * Side effect: bulk-ack ALL silent pending rows in each chat with
- * created_at < latest_trigger.created_at — including ones that fell outside
+ * createdAt < latest_trigger.createdAt — including ones that fell outside
  * the window/cap. Otherwise stale silent rows would accumulate and re-load
  * on every poll.
  */
 async function collectPrecedingContext(
   tx: TxLike,
   inboxId: string,
-  triggers: Array<{ id: number; chat_id: string | null; created_at: string }>,
+  triggers: Array<Pick<ClaimedEntry, "id" | "chatId" | "createdAt">>,
 ): Promise<Map<number, PrecedingMessage[]>> {
   const result = new Map<number, PrecedingMessage[]>();
 
   // Group triggers by chatId so we can split the silent timeline per chat.
-  const byChat = new Map<string, typeof triggers>();
+  const byChat = new Map<string, Array<Pick<ClaimedEntry, "id" | "chatId" | "createdAt">>>();
   for (const t of triggers) {
-    if (t.chat_id === null) continue; // replyTo cross-chat entries with no chat_id can't have context
-    const list = byChat.get(t.chat_id) ?? [];
+    if (t.chatId === null) continue; // replyTo cross-chat entries with no chatId can't have context
+    const list = byChat.get(t.chatId) ?? [];
     list.push(t);
-    byChat.set(t.chat_id, list);
+    byChat.set(t.chatId, list);
   }
 
   for (const [chatId, chatTriggers] of byChat) {
-    chatTriggers.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    chatTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
     // For each trigger, fetch silent context strictly before it (and after
     // the previous trigger in this batch). Window: 24h before the trigger.
@@ -274,51 +267,53 @@ async function collectPrecedingContext(
     // mark them acked anyway, so the agent would silently lose the messages
     // that mattered most.
     //
-    // Concurrency: `FOR UPDATE OF ie SKIP LOCKED` prevents two parallel polls
-    // on the same inbox from bundling the same silent row twice. Without it,
-    // poll A picking trigger T1 and poll B picking T2 (T2 > T1) would both
-    // include silent rows < T1 in their preceding context. With SKIP LOCKED,
-    // the second poll skips the rows the first has reserved.
-    let prevCreatedAt: string | null = null;
+    // Concurrency: `FOR UPDATE OF inboxEntries SKIP LOCKED` prevents two
+    // parallel polls on the same inbox from bundling the same silent row
+    // twice. Without it, poll A picking trigger T1 and poll B picking T2
+    // (T2 > T1) would both include silent rows < T1 in their preceding
+    // context. With SKIP LOCKED, the second poll skips the rows the first
+    // has reserved.
+    let prevCreatedAt: Date | null = null;
     for (const trigger of chatTriggers) {
-      const rows = await tx.execute<{
-        id: number;
-        message_id: string;
-        sender_id: string;
-        format: string;
-        content: unknown;
-        metadata: unknown;
-        created_at: string;
-      }>(sql`
-        SELECT ie.id, m.id AS message_id, m.sender_id, m.format, m.content, m.metadata,
-               m.created_at
-        FROM inbox_entries ie
-        JOIN messages m ON m.id = ie.message_id
-        WHERE ie.inbox_id = ${inboxId}
-          AND ie.chat_id = ${chatId}
-          AND ie.status = 'pending'
-          AND ie.notify = false
-          AND ie.created_at < ${trigger.created_at}
-          ${prevCreatedAt === null ? sql`` : sql`AND ie.created_at > ${prevCreatedAt}`}
-          AND ie.created_at > NOW() - make_interval(secs => ${PRECEDING_CONTEXT_WINDOW_SECONDS})
-        ORDER BY ie.created_at DESC
-        LIMIT ${PRECEDING_CONTEXT_MAX_ENTRIES}
-        FOR UPDATE OF ie SKIP LOCKED
-      `);
+      const rows = await tx
+        .select({
+          messageId: messages.id,
+          senderId: messages.senderId,
+          format: messages.format,
+          content: messages.content,
+          metadata: messages.metadata,
+          createdAt: messages.createdAt,
+        })
+        .from(inboxEntries)
+        .innerJoin(messages, eq(messages.id, inboxEntries.messageId))
+        .where(
+          and(
+            eq(inboxEntries.inboxId, inboxId),
+            eq(inboxEntries.chatId, chatId),
+            eq(inboxEntries.status, "pending"),
+            eq(inboxEntries.notify, false),
+            lt(inboxEntries.createdAt, trigger.createdAt),
+            prevCreatedAt === null ? undefined : gt(inboxEntries.createdAt, prevCreatedAt),
+            sql`${inboxEntries.createdAt} > NOW() - make_interval(secs => ${PRECEDING_CONTEXT_WINDOW_SECONDS})`,
+          ),
+        )
+        .orderBy(desc(inboxEntries.createdAt))
+        .limit(PRECEDING_CONTEXT_MAX_ENTRIES)
+        .for("update", { of: inboxEntries, skipLocked: true });
 
       // Reverse so the prompt-rendered block reads oldest → newest.
       const preceding: PrecedingMessage[] = rows
         .map((r) => ({
-          id: r.message_id,
-          senderId: r.sender_id,
+          id: r.messageId,
+          senderId: r.senderId,
           format: r.format,
           content: r.content,
           metadata: (r.metadata ?? {}) as Record<string, unknown>,
-          createdAt: r.created_at,
+          createdAt: r.createdAt.toISOString(),
         }))
         .reverse();
       result.set(trigger.id, preceding);
-      prevCreatedAt = trigger.created_at;
+      prevCreatedAt = trigger.createdAt;
     }
 
     // Bulk-ack ALL silent pending rows in this chat strictly before the
@@ -327,15 +322,18 @@ async function collectPrecedingContext(
     // the next trigger and grow forever.
     const latestTrigger = chatTriggers[chatTriggers.length - 1];
     if (latestTrigger) {
-      await tx.execute(sql`
-        UPDATE inbox_entries
-        SET status = 'acked', acked_at = NOW()
-        WHERE inbox_id = ${inboxId}
-          AND chat_id = ${chatId}
-          AND status = 'pending'
-          AND notify = false
-          AND created_at < ${latestTrigger.created_at}
-      `);
+      await tx
+        .update(inboxEntries)
+        .set({ status: "acked", ackedAt: new Date() })
+        .where(
+          and(
+            eq(inboxEntries.inboxId, inboxId),
+            eq(inboxEntries.chatId, chatId),
+            eq(inboxEntries.status, "pending"),
+            eq(inboxEntries.notify, false),
+            lt(inboxEntries.createdAt, latestTrigger.createdAt),
+          ),
+        );
     }
   }
 
@@ -415,25 +413,33 @@ export async function resetTimedOutEntries(
   timeoutSeconds = DEFAULT_INBOX_TIMEOUT_SECONDS,
   maxRetries = DEFAULT_MAX_RETRY_COUNT,
 ): Promise<{ reset: number; failed: number }> {
-  // Reset entries that have timed out but haven't exceeded max retries
-  const resetResult = await db.execute<{ id: number }>(sql`
-    UPDATE inbox_entries SET status = 'pending', retry_count = retry_count + 1
-    WHERE status = 'delivered'
-      AND delivered_at < NOW() - make_interval(secs => ${timeoutSeconds})
-      AND retry_count < ${maxRetries}
-    RETURNING id
-  `);
+  // Reset entries that have timed out but haven't exceeded max retries.
+  const reset = await db
+    .update(inboxEntries)
+    .set({ status: "pending", retryCount: sql`${inboxEntries.retryCount} + 1` })
+    .where(
+      and(
+        eq(inboxEntries.status, "delivered"),
+        sql`${inboxEntries.deliveredAt} < NOW() - make_interval(secs => ${timeoutSeconds})`,
+        lt(inboxEntries.retryCount, maxRetries),
+      ),
+    )
+    .returning({ id: inboxEntries.id });
 
-  // Mark entries that have exceeded max retries as failed
-  const failedResult = await db.execute<{ id: number }>(sql`
-    UPDATE inbox_entries SET status = 'failed'
-    WHERE status = 'delivered'
-      AND delivered_at < NOW() - make_interval(secs => ${timeoutSeconds})
-      AND retry_count >= ${maxRetries}
-    RETURNING id
-  `);
+  // Mark entries that have exceeded max retries as failed.
+  const failed = await db
+    .update(inboxEntries)
+    .set({ status: "failed" })
+    .where(
+      and(
+        eq(inboxEntries.status, "delivered"),
+        sql`${inboxEntries.deliveredAt} < NOW() - make_interval(secs => ${timeoutSeconds})`,
+        gte(inboxEntries.retryCount, maxRetries),
+      ),
+    )
+    .returning({ id: inboxEntries.id });
 
-  return { reset: resetResult.length, failed: failedResult.length };
+  return { reset: reset.length, failed: failed.length };
 }
 
 /** Default age (30 days) past which silent rows that no notify-true delivery
@@ -453,7 +459,7 @@ export const SILENT_ROW_GC_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
  *      `(inbox_id, message_id, chat_id)` means leaving them around blocks
  *      legitimate retries with the same key.
  *
- *   2. `notify=false AND status='pending' AND created_at < NOW() - maxAge` —
+ *   2. `notify=false AND status='pending' AND createdAt < NOW() - maxAge` —
  *      stale silent rows that no trigger ever caught up with. After 30
  *      days they're useless as preceding context (the @mention almost
  *      certainly already happened or the chat went dormant).
@@ -465,22 +471,23 @@ export async function pruneStaleSilentEntries(
   db: Database,
   maxAgeSeconds = SILENT_ROW_GC_MAX_AGE_SECONDS,
 ): Promise<{ ackedDeleted: number; stalePendingDeleted: number }> {
-  const ackedResult = await db.execute<{ id: number }>(sql`
-    DELETE FROM inbox_entries
-    WHERE notify = false
-      AND status = 'acked'
-    RETURNING id
-  `);
+  const ackedDeleted = await db
+    .delete(inboxEntries)
+    .where(and(eq(inboxEntries.notify, false), eq(inboxEntries.status, "acked")))
+    .returning({ id: inboxEntries.id });
 
-  const staleResult = await db.execute<{ id: number }>(sql`
-    DELETE FROM inbox_entries
-    WHERE notify = false
-      AND status = 'pending'
-      AND created_at < NOW() - make_interval(secs => ${maxAgeSeconds})
-    RETURNING id
-  `);
+  const stalePendingDeleted = await db
+    .delete(inboxEntries)
+    .where(
+      and(
+        eq(inboxEntries.notify, false),
+        eq(inboxEntries.status, "pending"),
+        sql`${inboxEntries.createdAt} < NOW() - make_interval(secs => ${maxAgeSeconds})`,
+      ),
+    )
+    .returning({ id: inboxEntries.id });
 
-  return { ackedDeleted: ackedResult.length, stalePendingDeleted: staleResult.length };
+  return { ackedDeleted: ackedDeleted.length, stalePendingDeleted: stalePendingDeleted.length };
 }
 
 export async function assertInboxOwner(inboxId: string, agentInboxId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Two independent server-side fixes bundled into one PR.

### #194 — inbox.ts raw SQL bypassed Drizzle column-mode

The 5 `tx.execute(sql\`...\`)` calls in `services/inbox.ts` skipped Drizzle's
column-mode conversion, so `inbox_entries.id` (bigserial) and `retry_count`
(integer) came back as JS strings at runtime despite TS types declaring `number`.
The bug surfaced when `inboxDeliverFrameSchema.entryId: z.number()` rejected the
string and dropped WS push frames; `collectPrecedingContext`'s Map keys were
also structurally fragile (string key + number lookup would silently lose
preceding context).

Rewrite all 5 queries (`pollInboxInner`, `claimAndBuildForPush`,
`collectPrecedingContext` SELECT + bulk-ack, `resetTimedOutEntries`,
`pruneStaleSilentEntries`) to the Drizzle query builder so column-mode flows
through end-to-end. `FOR UPDATE SKIP LOCKED` and `FOR UPDATE OF inboxEntries
SKIP LOCKED` semantics preserved (verified via `toSQL()` inspection during
development).

Add runtime-type pins on the `pollInbox` and `claimBacklogForPush` paths so any
regression to raw SQL fails loud — the `claimAndBuildForPush` path was already
pinned in `inbox-ws-push.test.ts`.

Closes #194.

### Reconnect-race onClose clobber

A typical `systemctl restart` produced a status flap where `clients.status`
landed on `disconnected` even though the new client process was fully
registered:

  - t0: old client process exits, server starts processing onClose
  - t1: new client connects + registers — `setClientConnection` installs the
    new socket, writes `status='connected'`
  - t2: the t0 onClose finally awaits `disconnectClient` and stamps
    `status='disconnected'`, clobbering t1

Add `connectionManager.isActiveClientConnection(clientId, socket)` and gate the
DB write on it. The old socket sees `false` at t2 (the in-memory entry now
points at the new socket) and skips the write so the new connection's status
survives. Includes a deterministic regression test that opens two sockets
under the same `clientId` and asserts the row stays `connected` after the
first socket's onClose drains.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm check` (biome) clean
- [x] `pnpm test` — 599/599 server tests pass, including all inbox-related and the new `ws-client-reconnect-race` regression test
- [x] Generated SQL inspected via `toSQL()` to confirm `FOR UPDATE SKIP LOCKED` lands inside the `WHERE id IN (...)` subquery for the two UPDATE paths and `FOR UPDATE OF \"inbox_entries\" SKIP LOCKED` (NOT messages) on the JOIN path

🤖 Generated with [Claude Code](https://claude.com/claude-code)