### PR TITLE
fix(multi-org): /me/chats resolves chat org from participants, not JWT default

### DIFF
--- a/packages/server/src/__tests__/me-chats-api.test.ts
+++ b/packages/server/src/__tests__/me-chats-api.test.ts
@@ -1,0 +1,182 @@
+/**
+ * HTTP-level tests for `POST /me/chats` — the chat-first workspace's
+ * member-facing chat-create endpoint.
+ *
+ * Regression target: a multi-org user creating a chat with an agent in a
+ * non-default org used to receive `Cross-organization chat not allowed: …`,
+ * because the handler resolved the chat's org from `memberScope` (JWT
+ * default) instead of the target participant's actual org. Mirrors the
+ * #222 fix shape (which covered the parallel `/admin/agents/:uuid/chats`
+ * surface) for the `/me/chats*` surface introduced in the chat-first
+ * workspace.
+ */
+
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
+import { users } from "../db/schema/users.js";
+import { createAgent } from "../services/agent.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("POST /me/chats — multi-org resolution", () => {
+  const getApp = useTestApp();
+
+  /**
+   * Stand up a second org and attach `userId` to it. Mirrors the helper in
+   * admin-agents.test.ts. Returns the org's id and the caller's human-agent
+   * id within it (so tests can assert it became a participant of the chat).
+   */
+  async function attachOrg(
+    app: FastifyInstance,
+    userId: string,
+    role: "admin" | "member",
+  ): Promise<{ orgId: string; memberId: string; humanAgentId: string }> {
+    const orgId = `org-mechats-${crypto.randomUUID().slice(0, 8)}`;
+    const memberId = uuidv7();
+    let humanAgentId = "";
+    await app.db.transaction(async (tx) => {
+      await tx
+        .insert(organizations)
+        .values({ id: orgId, name: `mechats-${crypto.randomUUID().slice(0, 6)}`, displayName: "MeChats Side" });
+      const human = await createAgent(tx as unknown as typeof app.db, {
+        name: `mechats-h-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: "MeChats Human",
+        managerId: memberId,
+        organizationId: orgId,
+      });
+      humanAgentId = human.uuid;
+      await tx.insert(members).values({ id: memberId, userId, organizationId: orgId, agentId: human.uuid, role });
+    });
+    return { orgId, memberId, humanAgentId };
+  }
+
+  it("creates a direct chat when the target agent lives in a non-default org", async () => {
+    const app = getApp();
+    const alice = await createAdminContext(app);
+    const orgB = await attachOrg(app, alice.userId, "admin");
+
+    // Agent in non-default org B, managed by Alice's org-B member. Alice's
+    // JWT default org is the one `createAdminContext` set up for her.
+    const target = await createAgent(app.db, {
+      name: `target-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Target",
+      managerId: orgB.memberId,
+      clientId: alice.clientId,
+      organizationId: orgB.orgId,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/chats",
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: { participantIds: [target.uuid] },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ chatId: string }>();
+    expect(typeof body.chatId).toBe("string");
+
+    // Verify the chat was created in org B (not Alice's default org) and
+    // that Alice's org-B human agent is a participant — not her default-org
+    // human, which would have been the buggy outcome.
+    const { chats } = await import("../db/schema/chats.js");
+    const { chatParticipants } = await import("../db/schema/chats.js");
+    const { eq } = await import("drizzle-orm");
+    const [chatRow] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    expect(chatRow?.organizationId).toBe(orgB.orgId);
+    const parts = await app.db
+      .select({ agentId: chatParticipants.agentId })
+      .from(chatParticipants)
+      .where(eq(chatParticipants.chatId, body.chatId));
+    const ids = parts.map((p) => p.agentId);
+    expect(ids).toContain(target.uuid);
+    expect(ids).toContain(orgB.humanAgentId);
+  });
+
+  it("400s when the caller has no membership in the target agent's org", async () => {
+    const app = getApp();
+    const alice = await createAdminContext(app);
+
+    // Bob's separate org; Alice is NOT a member.
+    const bobOrgId = `org-mechats-bob-${crypto.randomUUID().slice(0, 8)}`;
+    const bobMemberId = uuidv7();
+    const bobUserId = uuidv7();
+    const targetUuid = await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: bobUserId,
+        username: `bob-${crypto.randomUUID().slice(0, 6)}`,
+        passwordHash: "$2b$04$xxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+        displayName: "Bob",
+      });
+      await tx.insert(organizations).values({ id: bobOrgId, name: bobOrgId.slice(0, 30), displayName: "Bob's Org" });
+      const bobHuman = await createAgent(tx as unknown as typeof app.db, {
+        name: `bob-h-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: "Bob Human",
+        managerId: bobMemberId,
+        organizationId: bobOrgId,
+      });
+      await tx.insert(members).values({
+        id: bobMemberId,
+        userId: bobUserId,
+        organizationId: bobOrgId,
+        agentId: bobHuman.uuid,
+        role: "admin",
+      });
+      const bobAgent = await createAgent(tx as unknown as typeof app.db, {
+        name: `bob-target-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: "Bob's Target",
+        managerId: bobMemberId,
+        organizationId: bobOrgId,
+      });
+      return bobAgent.uuid;
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/chats",
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: { participantIds: [targetUuid] },
+    });
+    // `requireMemberInOrg` raises ForbiddenError → 403.
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("still works when the target agent is in the caller's default org (no regression)", async () => {
+    const app = getApp();
+    const alice = await createAdminContext(app);
+
+    const target = await createAgent(app.db, {
+      name: `default-target-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Default Target",
+      managerId: alice.memberId,
+      clientId: alice.clientId,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/chats",
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: { participantIds: [target.uuid] },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("400s when no non-self participants are supplied", async () => {
+    const app = getApp();
+    const alice = await createAdminContext(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/chats",
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: { participantIds: [alice.humanAgentUuid] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/server/src/api/me-chats.ts
+++ b/packages/server/src/api/me-chats.ts
@@ -3,8 +3,11 @@ import {
   createMeChatSchema,
   listMeChatsQuerySchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { memberScope } from "../services/access-control.js";
+import { agents } from "../db/schema/agents.js";
+import { BadRequestError } from "../errors.js";
+import { memberScope, requireMemberInOrg } from "../services/access-control.js";
 import {
   addMeChatParticipants,
   createMeChat,
@@ -31,11 +34,50 @@ export async function meChatRoutes(app: FastifyInstance): Promise<void> {
     return listMeChats(app.db, scope.humanAgentId, query);
   });
 
-  /** POST /me/chats — always creates a new chat (no dedupe). */
+  /** POST /me/chats — always creates a new chat (no dedupe).
+   *
+   * Multi-org resolution: the chat's org is derived from the participants,
+   * NOT the caller's JWT default org. A user who is a member of multiple
+   * orgs may create a chat with agents in any of them, and `memberScope`
+   * — which reads `organizationId` straight off the JWT — would otherwise
+   * pin the chat to the JWT default and trip `createMeChat`'s same-org
+   * guard ("Cross-organization chat not allowed: …"). Mirrors the same
+   * fix shape as `POST /admin/agents/:uuid/chats` (#222) for the
+   * /me/chats* surface introduced in the chat-first workspace.
+   *
+   * Resolution order:
+   *   1. Look up the first non-self participant → its `organizationId`.
+   *   2. `requireMemberInOrg(targetOrgId)` — verifies the caller is an
+   *      active member there and returns THEIR human agent in that org.
+   *   3. Hand the resolved `(humanAgentId, organizationId)` pair to
+   *      `createMeChat`, which still enforces every other participant
+   *      is in the same org via its existing `crossOrg` check.
+   */
   app.post("/", async (request, reply) => {
     const scope = memberScope(request);
     const body = createMeChatSchema.parse(request.body);
-    const result = await createMeChat(app.db, scope.humanAgentId, scope.organizationId, body);
+
+    const distinct = [...new Set(body.participantIds)].filter((id) => id !== scope.humanAgentId);
+    if (distinct.length === 0) {
+      throw new BadRequestError("At least one non-self participant required");
+    }
+    const firstId = distinct[0];
+    if (!firstId) {
+      // Defensive: distinct.length > 0 implies firstId is defined, but TS
+      // narrows on `string | undefined` from array index access.
+      throw new BadRequestError("At least one non-self participant required");
+    }
+    const [firstAgent] = await app.db
+      .select({ organizationId: agents.organizationId })
+      .from(agents)
+      .where(eq(agents.uuid, firstId))
+      .limit(1);
+    if (!firstAgent) {
+      throw new BadRequestError(`Agent not found: ${firstId}`);
+    }
+    const probe = await requireMemberInOrg(app.db, request, firstAgent.organizationId);
+
+    const result = await createMeChat(app.db, probe.agentId, firstAgent.organizationId, body);
     return reply.status(201).send(result);
   });
 


### PR DESCRIPTION
Stacked fix on top of #228. Targets `feat/chat-first-workspace` so it lands together with the chat-first workspace surface; rebase to main if #228 merges first.

## Symptom

Reproduced live on staging while testing #228:

- Multi-org user (admin in personal team, **member** in `agent-team-foundation`).
- In the workspace, selects an agent owned by ATF (e.g. `gandy-assistant`) in the "What's the task?" composer and types a message.
- Server returns 400: `Cross-organization chat not allowed: 019dfc9f-44be-7c87-b873-5581c915c85f`.

## Root cause

`POST /me/chats` resolved the chat's org from `memberScope(request)`, which reads `organizationId` straight off the JWT — locked to the JWT default org. The web client (`packages/web/src/api/me-chats.ts:createMeChat`) calls `/me/chats` without an `?organizationId=` decoration; only `/admin/*` paths receive that injection via `decoratePath`. So the server had no way to know which org the user meant beyond the JWT default. `createMeChat`'s same-org guard then correctly refused the (default-org human, non-default-org target) pair.

This is the same anti-pattern that #222 fixed for `POST /admin/agents/:uuid/chats`. The chat-first workspace introduced a parallel new endpoint and inherited the bug.

## Fix

Mirrors #222's resolution shape:

1. Look up the first non-self participant → its `organizationId`.
2. `requireMemberInOrg(targetOrgId)` — verifies the caller is an active member there and returns THEIR human agent in that org.
3. Pass the resolved `(humanAgentId, organizationId)` to `createMeChat`. Its existing `crossOrg` guard still rejects mixed-org participant sets, so picking the first agent's org is safe.

## Tests

New file `packages/server/src/__tests__/me-chats-api.test.ts` covering:

- ✓ chat creates correctly when target lives in non-default org (the regression).
- ✓ 403 when caller has no membership in target's org (Bob's agent).
- ✓ default-org target keeps working (no regression).
- ✓ 400 when no non-self participant is supplied.

All 4 pass; full server suite (632 tests) green.

## Out of scope (intentional)

`addMeChatParticipants` (`POST /me/chats/:chatId/participants`) carries the same `scope.organizationId` pattern via `memberScope` and is likely vulnerable to the same multi-org symptom. Same fix shape would apply, but the user-reported failure is the create path so this PR lands that one first. Flag for follow-up.

## Test plan

- [x] `pnpm --filter @first-tree-hub/server test`
- [x] `pnpm check && pnpm typecheck`
- [ ] Verify on staging once redeployed: ATF member can send first message to ATF agent without cross-org error
- [ ] Verify the no-regression case: same user, agent in their default org → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)