### PR TITLE
fix(multi-org): wizardStep is user-level — count agents across all memberships

### DIFF
--- a/packages/server/src/__tests__/me.test.ts
+++ b/packages/server/src/__tests__/me.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createTestAdmin, useTestApp } from "./helpers.js";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("GET /api/v1/me", () => {
   const getApp = useTestApp();
@@ -35,5 +39,94 @@ describe("GET /api/v1/me", () => {
       url: "/api/v1/me",
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  /**
+   * `wizardStep` is user-level: once the operator has connected any client
+   * AND created any non-human agent in any of their memberships, the
+   * wizard is `completed` everywhere. Earlier code keyed the agent check
+   * off `m.memberId` (JWT default org), which froze multi-org users in
+   * `create_agent` whenever their work happened in a non-default team —
+   * the workspace then re-popped OnboardingView in every team they
+   * switched into, even ones with existing agents.
+   */
+  describe("wizardStep is user-level (multi-org)", () => {
+    it("returns `completed` when the user's only managed agent lives in a non-default org", async () => {
+      const app = getApp();
+      const alice = await createAdminContext(app);
+
+      // Stand up a second org Alice is admin of, and seed her managed
+      // agent there. Her JWT default org keeps zero non-human agents.
+      const orgBId = `org-wizard-${crypto.randomUUID().slice(0, 8)}`;
+      const orgBMemberId = uuidv7();
+      await app.db.transaction(async (tx) => {
+        await tx
+          .insert(organizations)
+          .values({ id: orgBId, name: `wizard-${crypto.randomUUID().slice(0, 6)}`, displayName: "Wizard Side" });
+        const human = await createAgent(tx as unknown as typeof app.db, {
+          name: `wizard-h-${crypto.randomUUID().slice(0, 6)}`,
+          type: "human",
+          displayName: "Wizard Human",
+          managerId: orgBMemberId,
+          organizationId: orgBId,
+        });
+        await tx.insert(members).values({
+          id: orgBMemberId,
+          userId: alice.userId,
+          organizationId: orgBId,
+          agentId: human.uuid,
+          role: "admin",
+        });
+      });
+
+      // Non-human agent ONLY in org B; managerId points at Alice's org-B
+      // member, not her JWT-default member.
+      await createAgent(app.db, {
+        name: `wizard-target-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: "Wizard Target",
+        managerId: orgBMemberId,
+        clientId: alice.clientId,
+        organizationId: orgBId,
+      });
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me",
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ wizard: { step: string } }>();
+      expect(body.wizard.step).toBe("completed");
+    });
+
+    it("still returns `create_agent` when the user has a client but no managed agents anywhere", async () => {
+      const app = getApp();
+      const alice = await createAdminContext(app);
+      // createAdminContext seeds a client but no non-human agent — the
+      // legacy "create_agent" branch should still fire.
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me",
+        headers: { authorization: `Bearer ${alice.accessToken}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ wizard: { step: string } }>();
+      expect(body.wizard.step).toBe("create_agent");
+    });
+
+    it("still returns `connect` when the user has no clients", async () => {
+      const app = getApp();
+      // createTestAdmin (vs createAdminContext) does NOT seed a client.
+      const admin = await createTestAdmin(app);
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{ wizard: { step: string } }>();
+      expect(body.wizard.step).toBe("connect");
+    });
   });
 });

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -293,18 +293,32 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
  * Infer the wizard step from observable runtime state. Refer to
  * proposal §"Onboarding 状态推断" for the rationale.
  *
- * Note: we deliberately do NOT filter by `clients.status='connected'`
- * here. The original "fact-is-state" reading would have flapped between
- * `completed` and `connect` every time the user's client briefly went
- * offline — UX disaster (the onboarding modal would re-pop). "Ever
- * connected" (= a clients row exists at all for this user/org) is still
- * fact-derived: deleting the row really does rewind the wizard, and
- * that's the explicit reset path.
+ * Both checks here are deliberately user-level — `wizardStep` represents
+ * the operator's product onboarding ("did they learn the tool yet?"),
+ * not the state of any individual team. Once a user has connected ANY
+ * machine and created ANY non-human agent in ANY of their memberships,
+ * they're done with onboarding everywhere.
+ *
+ * Earlier code keyed the agent check off `m.memberId`, which is the JWT
+ * default-org membership — effectively the membership that happened to
+ * be current the moment the access token was minted (no JWT swap on
+ * `/auth/switch-org`, decouple-client-from-identity §4.6). That made
+ * `wizardStep` flap based on which org the user signed in under, and
+ * pinned multi-org users in `create_agent` forever when their primary
+ * work happens in a non-default team — workspace then re-popped
+ * OnboardingView in every team they switched into, including ones with
+ * existing agents. Joining `members` on `userId` removes that coupling.
+ *
+ * The client check stays a simple `eq(clients.userId, …)` because
+ * `clients` already carries `user_id` directly (one client serves all of
+ * a user's orgs in the unified-token model). We deliberately do NOT
+ * filter by `clients.status='connected'`: the original "fact-is-state"
+ * reading would flap between `completed` and `connect` every time the
+ * user's client briefly went offline. "Ever connected" (= a clients row
+ * exists at all for this user) is still fact-derived: deleting the row
+ * really does rewind the wizard, and that's the explicit reset path.
  */
-async function inferWizardStep(
-  app: FastifyInstance,
-  m: { userId: string; memberId: string; organizationId: string },
-): Promise<WizardStep> {
+async function inferWizardStep(app: FastifyInstance, m: { userId: string }): Promise<WizardStep> {
   const [hasClient] = await app.db
     .select({ id: clients.id })
     .from(clients)
@@ -315,7 +329,15 @@ async function inferWizardStep(
   const [hasAgent] = await app.db
     .select({ uuid: agents.uuid })
     .from(agents)
-    .where(and(eq(agents.managerId, m.memberId), ne(agents.type, "human"), eq(agents.status, "active")))
+    .innerJoin(members, eq(members.id, agents.managerId))
+    .where(
+      and(
+        eq(members.userId, m.userId),
+        eq(members.status, "active"),
+        ne(agents.type, "human"),
+        eq(agents.status, "active"),
+      ),
+    )
     .limit(1);
   if (!hasAgent) return "create_agent";
   return "completed";


### PR DESCRIPTION
## Symptom (live on staging)

Multi-org user (admin in their personal team, member of `agent-team-foundation`) sees "Let's create your first agent." in workspace whenever they switch to ATF — even though ATF has agents bound to their connected computer (visible under Settings → Computers → Bound Agents).

The user's screenshot, transcribed:

- Team dropdown shows ATF selected (✓ checkmark, MEMBER role)
- Center panel: "Welcome to First Tree Hub · Let's create your first agent." with steps `01` and `02`
- Settings page on the same account shows ATF agents `gandy-assistant` and `coder` both IDLE / bound

## Root cause

[`inferWizardStep`](https://github.com/agent-team-foundation/first-tree-hub/blob/main/packages/server/src/api/me.ts) keyed the agent check off `m.memberId`:

```ts
const [hasAgent] = await app.db
  .select({ uuid: agents.uuid })
  .from(agents)
  .where(and(eq(agents.managerId, m.memberId), …))
```

`m.memberId` comes from `requireMember(request)` — it's the membership row id baked into the JWT. The decouple-client-from-identity rework left `/auth/switch-org` returning 204 (no JWT swap), so the JWT's `memberId`/`organizationId` claims are effectively a fossil — they reflect whichever team was current the moment the access token was minted, not what the user is currently looking at in the dropdown.

For multi-org users whose primary work happens in a non-default team, this query returns 0 agents → wizardStep stays `create_agent` permanently → the chat-first workspace's `CenterPanel` re-pops OnboardingView in every team they switch into.

## Fix

Join `members` on `userId` so the agent check spans every active membership the user holds, not just the JWT default one. The client check is already user-level (`clients.user_id` is keyed off the user, not the org).

```ts
const [hasAgent] = await app.db
  .select({ uuid: agents.uuid })
  .from(agents)
  .innerJoin(members, eq(members.id, agents.managerId))
  .where(and(
    eq(members.userId, m.userId),
    eq(members.status, "active"),
    ne(agents.type, "human"),
    eq(agents.status, "active"),
  ))
  .limit(1);
```

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Brand-new user, no agents anywhere | `create_agent` | `create_agent` ✓ |
| Agent only in JWT default org | `completed` | `completed` ✓ |
| Agent only in a non-default org | `create_agent` | **`completed`** (the regression) |
| Member of an empty team but has agents elsewhere | `create_agent` (when JWT defaulted to empty team) | **`completed`** |
| No client at all | `connect` | `connect` ✓ |

## Tests

Three new cases in `me.test.ts` covering the matrix above. All five tests in the file pass; full server suite green.

## Why user-level (not per-team)

Once we accepted that the JWT's `organizationId` is a fossil (decouple-client-from-identity §4.6), gating wizardStep on it stopped reflecting any product semantic — it was effectively "which membership existed when you signed in." The remaining defensible options were:

1. **User-level** — has the operator learned the product yet? Once is enough.
2. **Current-team-level** — does the team the dropdown is showing have agents?

User-level wins on principle: re-popping "Let's create your first agent" for a member who just joined a new (but non-empty) team is condescending and confusing — they're not a new user, they're a new member of an existing org. Empty-team affordances (a "this team has no agents yet, create one →" CTA distinct from first-time onboarding) are a separate UX concern and intentionally out of scope here.

## Test plan

- [x] `pnpm --filter @first-tree-hub/server test` (5/5 in `me.test.ts`, full suite green)
- [x] `pnpm check && pnpm typecheck`
- [ ] Verify on staging once redeployed: multi-org user (gandy + ATF) switches to ATF → workspace shows ATF chats / NoChatView, no longer pops OnboardingView

🤖 Generated with [Claude Code](https://claude.com/claude-code)