### PR TITLE
refactor(web): redesign watching-mode chat view, drop redundant @handle

### DIFF
--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -314,11 +314,6 @@ export function MentionAutocompletePopover({
             }}
           >
             <span className="font-medium">{c.displayName ?? (c.name ? `@${c.name}` : "—")}</span>
-            {c.name && c.displayName && (
-              <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
-                @{c.name}
-              </span>
-            )}
           </button>
         );
       })}

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef } from "react";
 import { getChat } from "../../../api/chats.js";
 import { joinMeChat, listMeChats, markMeChatRead } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
-import { Button } from "../../../components/ui/button.js";
 import { ChatView } from "./chat-view.js";
 
 /**
@@ -134,66 +133,14 @@ export function ChatByIdView({ chatId }: { chatId: string }) {
 
   if (isWatching) {
     return (
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <div
-          className="shrink-0"
-          style={{
-            padding: "var(--sp-2_5) var(--sp-3_5)",
-            borderBottom: "var(--hairline) solid var(--border)",
-          }}
-        >
-          <div className="flex items-center" style={{ gap: 8 }}>
-            <span className="text-subtitle" style={{ color: "var(--fg)" }}>
-              {meRow?.title ?? "Chat"}
-            </span>
-            <span
-              className="mono uppercase text-eyebrow"
-              style={{
-                padding: "var(--hairline) var(--sp-1_25)",
-                borderRadius: 2,
-                color: "var(--fg-3)",
-                background: "var(--bg-sunken)",
-              }}
-            >
-              watching
-            </span>
-          </div>
-          <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: 4 }}>
-            You can read this chat. Join to reply.
-          </div>
-        </div>
-        <div className="flex-1 overflow-hidden">
-          {/* Read-only timeline — render the same ChatView; the composer
-              state is hidden by the `Join to reply` overlay below. */}
-          <ChatView agentId={primaryAgent} chatId={chatId} />
-        </div>
-        <div
-          className="shrink-0"
-          style={{
-            padding: "var(--sp-2_5) var(--sp-3_5)",
-            borderTop: "var(--hairline) solid var(--border)",
-            background: "var(--bg-raised)",
-          }}
-        >
-          <div style={{ maxWidth: 640, margin: "0 auto" }}>
-            <Button
-              type="button"
-              onClick={() => joinMut.mutate()}
-              disabled={joinMut.isPending}
-              style={{
-                width: "100%",
-              }}
-            >
-              {joinMut.isPending ? "Joining…" : "Join to reply"}
-            </Button>
-            {joinMut.isError && (
-              <p className="mono text-label" style={{ color: "var(--state-error)", marginTop: 6 }}>
-                {joinMut.error instanceof Error ? joinMut.error.message : "Failed to join"}
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
+      <ChatView
+        agentId={primaryAgent}
+        chatId={chatId}
+        readOnly
+        onJoin={() => joinMut.mutate()}
+        joining={joinMut.isPending}
+        joinError={joinMut.isError ? (joinMut.error instanceof Error ? joinMut.error.message : "Failed to join") : null}
+      />
     );
   }
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,6 +1,6 @@
 import { extractMentions, type MentionParticipant } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, AtSign, Check, MessageSquare, Paperclip, Plus, X } from "lucide-react";
+import { ArrowUp, AtSign, Check, Eye, MessageSquare, Paperclip, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getActivityOverview } from "../../../api/activity.js";
 import {
@@ -450,7 +450,23 @@ type TimelineItem =
   | { kind: "message"; at: string; key: string; data: MessageWithDelivery }
   | { kind: "event"; at: string; key: string; data: SessionEventRow };
 
-export function ChatView({ agentId, chatId }: { agentId: string; chatId: string }) {
+export function ChatView({
+  agentId,
+  chatId,
+  readOnly = false,
+  onJoin,
+  joining = false,
+  joinError = null,
+}: {
+  agentId: string;
+  chatId: string;
+  /** When true, render watching mode: timeline only, no rename, no [+] participant,
+   *  composer slot replaced with a Join panel. */
+  readOnly?: boolean;
+  onJoin?: () => void;
+  joining?: boolean;
+  joinError?: string | null;
+}) {
   const queryClient = useQueryClient();
   const agentName = useAgentNameMap();
   const agentIdentity = useAgentIdentityMap();
@@ -823,7 +839,24 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
               concept that belongs on each chip avatar (D-4), not on
               the chat header. */}
           <div className="flex items-center min-w-0" style={{ gap: 8, flex: 1 }}>
-            {renaming ? (
+            {readOnly ? (
+              <>
+                <span className="truncate text-subtitle min-w-0" style={{ color: "var(--fg)" }}>
+                  {chatDetail?.title ?? "…"}
+                </span>
+                <span
+                  className="mono uppercase text-eyebrow shrink-0"
+                  style={{
+                    padding: "var(--hairline) var(--sp-1_25)",
+                    borderRadius: 2,
+                    color: "var(--fg-3)",
+                    background: "var(--bg-sunken)",
+                  }}
+                >
+                  watching
+                </span>
+              </>
+            ) : renaming ? (
               <>
                 <input
                   ref={renameInputRef}
@@ -934,6 +967,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
             candidates={mentionCandidates}
             agentIdentity={agentIdentity}
             onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
+            readOnly={readOnly}
           />
         </div>
       </div>
@@ -946,7 +980,7 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
           narrow viewports. */}
       <div className="flex-1 overflow-y-auto relative" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>
         <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
-          {itemCount === 0 && (
+          {itemCount === 0 && !readOnly && (
             <div
               className="flex flex-col items-center text-body"
               style={{ color: "var(--fg-3)", padding: "var(--sp-8) 0", gap: 6 }}
@@ -993,269 +1027,315 @@ export function ChatView({ agentId, chatId }: { agentId: string; chatId: string 
         }}
       >
         <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
-          <div
-            style={{
-              position: "relative",
-              border: "var(--hairline) solid var(--border)",
-              borderRadius: 6,
-              background: "var(--bg-sunken)",
-            }}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => {
-              e.preventDefault();
-              addImages(Array.from(e.dataTransfer.files));
-            }}
-          >
-            {/* Image preview area — above textarea */}
-            {pendingImages.length > 0 && (
+          {readOnly ? (
+            <div
+              className="flex items-center"
+              style={{
+                gap: "var(--sp-3)",
+                padding: "var(--sp-2) var(--sp-3)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: 6,
+                background: "var(--bg-sunken)",
+              }}
+            >
+              <Eye className="h-4 w-4 shrink-0" style={{ color: "var(--fg-3)" }} />
+              <div className="flex-1 min-w-0">
+                <div className="text-body" style={{ color: "var(--fg-2)" }}>
+                  You're watching this chat — read-only.
+                </div>
+                {joinError && (
+                  <div className="mono text-label" style={{ color: "var(--state-error)", marginTop: 2 }}>
+                    {joinError}
+                  </div>
+                )}
+              </div>
+              {onJoin && (
+                <button
+                  type="button"
+                  onClick={onJoin}
+                  disabled={joining}
+                  className="shrink-0 text-body"
+                  style={{
+                    padding: "var(--sp-1) var(--sp-2_5)",
+                    borderRadius: "var(--radius-input)",
+                    border: "var(--hairline) solid var(--border)",
+                    background: "var(--bg-raised)",
+                    color: "var(--fg)",
+                    cursor: joining ? "default" : "pointer",
+                    opacity: joining ? 0.6 : 1,
+                  }}
+                >
+                  {joining ? "Joining…" : "Join to reply"}
+                </button>
+              )}
+            </div>
+          ) : (
+            <>
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
               <div
-                className="flex items-center"
-                style={{ gap: 6, padding: "var(--sp-1_5) var(--sp-2_5) 0", overflowX: "auto" }}
+                style={{
+                  position: "relative",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: 6,
+                  background: "var(--bg-sunken)",
+                }}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  addImages(Array.from(e.dataTransfer.files));
+                }}
               >
-                {pendingImages.map((img) => (
+                {/* Image preview area — above textarea */}
+                {pendingImages.length > 0 && (
                   <div
-                    key={img.id}
-                    style={{
-                      position: "relative",
-                      flexShrink: 0,
-                      borderRadius: 4,
-                      border: "var(--hairline) solid var(--border)",
-                      overflow: "hidden",
-                    }}
+                    className="flex items-center"
+                    style={{ gap: 6, padding: "var(--sp-1_5) var(--sp-2_5) 0", overflowX: "auto" }}
                   >
-                    <img
-                      src={img.previewUrl}
-                      alt={img.file.name}
-                      style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
-                    />
+                    {pendingImages.map((img) => (
+                      <div
+                        key={img.id}
+                        style={{
+                          position: "relative",
+                          flexShrink: 0,
+                          borderRadius: 4,
+                          border: "var(--hairline) solid var(--border)",
+                          overflow: "hidden",
+                        }}
+                      >
+                        <img
+                          src={img.previewUrl}
+                          alt={img.file.name}
+                          style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeImage(img.id)}
+                          style={{
+                            position: "absolute",
+                            top: 1,
+                            right: 1,
+                            width: 14,
+                            height: 14,
+                            borderRadius: "50%",
+                            background: "var(--color-overlay-scrim)",
+                            border: "none",
+                            color: "var(--bg-raised)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            cursor: "pointer",
+                            padding: 0,
+                          }}
+                        >
+                          <X className="h-2 w-2" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div style={{ position: "relative" }}>
+                  <MentionAutocompletePopover
+                    trigger={mention.trigger}
+                    results={mention.results}
+                    highlightIndex={mention.highlightIndex}
+                    anchorRef={textareaRef}
+                    onPick={mention.pick}
+                  />
+                  <textarea
+                    ref={textareaRef}
+                    value={draft}
+                    onChange={(e) => {
+                      setDraft(e.target.value);
+                      setCursor(e.target.selectionStart ?? e.target.value.length);
+                    }}
+                    onSelect={(e) => {
+                      setCursor(e.currentTarget.selectionStart ?? draft.length);
+                    }}
+                    onFocus={() => {
+                      // Group / about-to-be-group chats: prime the input with `@`
+                      // on focus so the autocomplete pops the recipient list right
+                      // away — matches the proposal §2 "must choose a receiver
+                      // before typing" UX. Once-per-chat (focusPrimedRef): we
+                      // don't want to re-stamp `@` after the user has cleared
+                      // their draft and tabbed away/back; that would constantly
+                      // fight the user when they're trying to write a fresh
+                      // empty message without addressing anyone (e.g. paste over).
+                      if (!requiresMention) return;
+                      if (focusPrimedRef.current) return;
+                      if (draft.length > 0 || mentionCandidates.length === 0) return;
+                      focusPrimedRef.current = true;
+                      setDraft("@");
+                      setCursor(1);
+                      requestAnimationFrame(() => {
+                        const el = textareaRef.current;
+                        if (!el) return;
+                        el.setSelectionRange(1, 1);
+                      });
+                    }}
+                    onPaste={(e) => {
+                      const files = Array.from(e.clipboardData.files);
+                      if (files.length > 0) {
+                        e.preventDefault();
+                        addImages(files);
+                      }
+                    }}
+                    placeholder={
+                      requiresMention
+                        ? "Type @ to pick a recipient, then your message"
+                        : `Message @${displayName}  ·  / for commands  ·  @ to mention`
+                    }
+                    rows={2}
+                    onKeyDown={(e) => {
+                      // Mention autocomplete gets first crack at navigation keys so
+                      // ArrowUp/Down/Enter/Tab/Escape cycle candidates instead of
+                      // sending or moving the cursor.
+                      if (mention.handleKey(e)) return;
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleSend();
+                      }
+                    }}
+                    disabled={sendMut.isPending || uploading}
+                    className="w-full outline-none text-subtitle font-normal"
+                    style={{
+                      padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
+                      background: "transparent",
+                      border: "none",
+                      resize: "none",
+                      color: "var(--fg)",
+                    }}
+                  />
+                </div>
+                <div
+                  className="flex items-center justify-between text-caption"
+                  style={{
+                    position: "absolute",
+                    bottom: 6,
+                    left: 10,
+                    right: 10,
+                    color: "var(--fg-4)",
+                  }}
+                >
+                  <span className="mono flex items-center" style={{ gap: 10 }}>
                     <button
                       type="button"
-                      onClick={() => removeImage(img.id)}
+                      onClick={() => {
+                        // Insert `@` at the cursor (or replace the current selection)
+                        // and re-focus. The mention autocomplete will pick it up
+                        // from the resulting `value`/`cursor` state — same path as
+                        // typing `@` directly. Mirrors the Feishu / Slack
+                        // explicit-button affordance for users who don't know the
+                        // keyboard trick.
+                        const el = textareaRef.current;
+                        if (!el) return;
+                        const start = el.selectionStart ?? draft.length;
+                        const end = el.selectionEnd ?? start;
+                        const next = `${draft.slice(0, start)}@${draft.slice(end)}`;
+                        setDraft(next);
+                        setCursor(start + 1);
+                        requestAnimationFrame(() => {
+                          el.focus();
+                          el.setSelectionRange(start + 1, start + 1);
+                        });
+                      }}
+                      title="Mention an agent (or type @)"
                       style={{
-                        position: "absolute",
-                        top: 1,
-                        right: 1,
-                        width: 14,
-                        height: 14,
-                        borderRadius: "50%",
-                        background: "var(--color-overlay-scrim)",
+                        background: "none",
                         border: "none",
-                        color: "var(--bg-raised)",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
                         cursor: "pointer",
+                        color: "var(--fg-3)",
                         padding: 0,
+                        display: "inline-flex",
+                        alignItems: "center",
                       }}
                     >
-                      <X className="h-2 w-2" />
+                      <AtSign className="h-3.5 w-3.5" />
                     </button>
-                  </div>
-                ))}
-              </div>
-            )}
-            <div style={{ position: "relative" }}>
-              <MentionAutocompletePopover
-                trigger={mention.trigger}
-                results={mention.results}
-                highlightIndex={mention.highlightIndex}
-                anchorRef={textareaRef}
-                onPick={mention.pick}
-              />
-              <textarea
-                ref={textareaRef}
-                value={draft}
-                onChange={(e) => {
-                  setDraft(e.target.value);
-                  setCursor(e.target.selectionStart ?? e.target.value.length);
-                }}
-                onSelect={(e) => {
-                  setCursor(e.currentTarget.selectionStart ?? draft.length);
-                }}
-                onFocus={() => {
-                  // Group / about-to-be-group chats: prime the input with `@`
-                  // on focus so the autocomplete pops the recipient list right
-                  // away — matches the proposal §2 "must choose a receiver
-                  // before typing" UX. Once-per-chat (focusPrimedRef): we
-                  // don't want to re-stamp `@` after the user has cleared
-                  // their draft and tabbed away/back; that would constantly
-                  // fight the user when they're trying to write a fresh
-                  // empty message without addressing anyone (e.g. paste over).
-                  if (!requiresMention) return;
-                  if (focusPrimedRef.current) return;
-                  if (draft.length > 0 || mentionCandidates.length === 0) return;
-                  focusPrimedRef.current = true;
-                  setDraft("@");
-                  setCursor(1);
-                  requestAnimationFrame(() => {
-                    const el = textareaRef.current;
-                    if (!el) return;
-                    el.setSelectionRange(1, 1);
-                  });
-                }}
-                onPaste={(e) => {
-                  const files = Array.from(e.clipboardData.files);
-                  if (files.length > 0) {
-                    e.preventDefault();
-                    addImages(files);
-                  }
-                }}
-                placeholder={
-                  requiresMention
-                    ? "Type @ to pick a recipient, then your message"
-                    : `Message @${displayName}  ·  / for commands  ·  @ to mention`
-                }
-                rows={2}
-                onKeyDown={(e) => {
-                  // Mention autocomplete gets first crack at navigation keys so
-                  // ArrowUp/Down/Enter/Tab/Escape cycle candidates instead of
-                  // sending or moving the cursor.
-                  if (mention.handleKey(e)) return;
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault();
-                    handleSend();
-                  }
-                }}
-                disabled={sendMut.isPending || uploading}
-                className="w-full outline-none text-subtitle font-normal"
-                style={{
-                  padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
-                  background: "transparent",
-                  border: "none",
-                  resize: "none",
-                  color: "var(--fg)",
-                }}
-              />
-            </div>
-            <div
-              className="flex items-center justify-between text-caption"
-              style={{
-                position: "absolute",
-                bottom: 6,
-                left: 10,
-                right: 10,
-                color: "var(--fg-4)",
-              }}
-            >
-              <span className="mono flex items-center" style={{ gap: 10 }}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    // Insert `@` at the cursor (or replace the current selection)
-                    // and re-focus. The mention autocomplete will pick it up
-                    // from the resulting `value`/`cursor` state — same path as
-                    // typing `@` directly. Mirrors the Feishu / Slack
-                    // explicit-button affordance for users who don't know the
-                    // keyboard trick.
-                    const el = textareaRef.current;
-                    if (!el) return;
-                    const start = el.selectionStart ?? draft.length;
-                    const end = el.selectionEnd ?? start;
-                    const next = `${draft.slice(0, start)}@${draft.slice(end)}`;
-                    setDraft(next);
-                    setCursor(start + 1);
-                    requestAnimationFrame(() => {
-                      el.focus();
-                      el.setSelectionRange(start + 1, start + 1);
-                    });
-                  }}
-                  title="Mention an agent (or type @)"
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                    color: "var(--fg-3)",
-                    padding: 0,
-                    display: "inline-flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <AtSign className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  title="Attach image"
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                    color: "var(--fg-3)",
-                    padding: 0,
-                    display: "inline-flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <Paperclip className="h-3.5 w-3.5" />
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  style={{ display: "none" }}
-                  onChange={(e) => {
-                    if (e.target.files) {
-                      addImages(Array.from(e.target.files));
-                      e.target.value = "";
-                    }
-                  }}
-                />
-              </span>
-              <span className="flex items-center" style={{ gap: 8 }}>
-                {uploading && (
-                  <span className="mono text-caption" style={{ color: "var(--accent)" }}>
-                    uploading…
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      title="Attach image"
+                      style={{
+                        background: "none",
+                        border: "none",
+                        cursor: "pointer",
+                        color: "var(--fg-3)",
+                        padding: 0,
+                        display: "inline-flex",
+                        alignItems: "center",
+                      }}
+                    >
+                      <Paperclip className="h-3.5 w-3.5" />
+                    </button>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      style={{ display: "none" }}
+                      onChange={(e) => {
+                        if (e.target.files) {
+                          addImages(Array.from(e.target.files));
+                          e.target.value = "";
+                        }
+                      }}
+                    />
                   </span>
-                )}
-                <button
-                  type="button"
-                  onClick={handleSend}
-                  disabled={
-                    sendMut.isPending ||
-                    uploading ||
-                    (!draft.trim() && pendingImages.length === 0) ||
-                    (requiresMention && draftMentions.length === 0)
-                  }
-                  title={
-                    requiresMention && draftMentions.length === 0
-                      ? "Pick at least one recipient with @ before sending in a group chat"
-                      : "Send (Enter)"
-                  }
-                  aria-label="Send"
-                  className={cn(
-                    "inline-flex items-center justify-center transition-opacity",
-                    (sendMut.isPending ||
-                      uploading ||
-                      (!draft.trim() && pendingImages.length === 0) ||
-                      (requiresMention && draftMentions.length === 0)) &&
-                      "opacity-40 cursor-not-allowed",
-                  )}
+                  <span className="flex items-center" style={{ gap: 8 }}>
+                    {uploading && (
+                      <span className="mono text-caption" style={{ color: "var(--accent)" }}>
+                        uploading…
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={handleSend}
+                      disabled={
+                        sendMut.isPending ||
+                        uploading ||
+                        (!draft.trim() && pendingImages.length === 0) ||
+                        (requiresMention && draftMentions.length === 0)
+                      }
+                      title={
+                        requiresMention && draftMentions.length === 0
+                          ? "Pick at least one recipient with @ before sending in a group chat"
+                          : "Send (Enter)"
+                      }
+                      aria-label="Send"
+                      className={cn(
+                        "inline-flex items-center justify-center transition-opacity",
+                        (sendMut.isPending ||
+                          uploading ||
+                          (!draft.trim() && pendingImages.length === 0) ||
+                          (requiresMention && draftMentions.length === 0)) &&
+                          "opacity-40 cursor-not-allowed",
+                      )}
+                      style={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: "var(--radius-input)",
+                        background: "var(--fg)",
+                        color: "var(--bg-raised)",
+                        border: "none",
+                      }}
+                    >
+                      <ArrowUp className="h-3.5 w-3.5" strokeWidth={2.5} />
+                    </button>
+                  </span>
+                </div>
+              </div>
+              {(sendMut.isError || uploadError) && (
+                <p
+                  className="mono text-label"
                   style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: "var(--radius-input)",
-                    background: "var(--fg)",
-                    color: "var(--bg-raised)",
-                    border: "none",
+                    color: "var(--state-error)",
+                    padding: "var(--sp-1_5) var(--sp-0_5) 0",
                   }}
                 >
-                  <ArrowUp className="h-3.5 w-3.5" strokeWidth={2.5} />
-                </button>
-              </span>
-            </div>
-          </div>
-          {(sendMut.isError || uploadError) && (
-            <p
-              className="mono text-label"
-              style={{
-                color: "var(--state-error)",
-                padding: "var(--sp-1_5) var(--sp-0_5) 0",
-              }}
-            >
-              {uploadError ?? (sendMut.error instanceof Error ? sendMut.error.message : "Failed to send")}
-            </p>
+                  {uploadError ?? (sendMut.error instanceof Error ? sendMut.error.message : "Failed to send")}
+                </p>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -1279,6 +1359,7 @@ function ParticipantsHeader({
   candidates,
   agentIdentity,
   onAdded,
+  readOnly = false,
 }: {
   chatId: string;
   participantIds: string[];
@@ -1288,6 +1369,7 @@ function ParticipantsHeader({
    *  self correctly instead of falling back to a UUID prefix. */
   agentIdentity: (uuid: string | null | undefined) => { name: string | null; displayName: string } | null;
   onAdded: () => void;
+  readOnly?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -1340,70 +1422,67 @@ function ParticipantsHeader({
           </span>
         );
       })}
-      <div ref={containerRef} style={{ position: "relative" }}>
-        <button
-          type="button"
-          onClick={() => setOpen(!open)}
-          disabled={outsideCandidates.length === 0 || addMut.isPending}
-          title={outsideCandidates.length === 0 ? "All available agents are already in this chat" : "Add participant"}
-          aria-label="Add participant"
-          className="inline-flex items-center transition-colors hover:bg-[var(--bg-sunken)]"
-          style={{
-            padding: "var(--sp-0_5) var(--sp-1)",
-            borderRadius: "var(--radius-chip)",
-            border: "var(--hairline) solid var(--border)",
-            background: "transparent",
-            color: outsideCandidates.length === 0 ? "var(--fg-4)" : "var(--fg-3)",
-            cursor: outsideCandidates.length === 0 ? "not-allowed" : "pointer",
-          }}
-        >
-          <Plus className="h-3 w-3" />
-        </button>
-        {open && outsideCandidates.length > 0 && (
-          <div
-            role="listbox"
+      {!readOnly && (
+        <div ref={containerRef} style={{ position: "relative" }}>
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            disabled={outsideCandidates.length === 0 || addMut.isPending}
+            title={outsideCandidates.length === 0 ? "All available agents are already in this chat" : "Add participant"}
             aria-label="Add participant"
-            className="absolute z-20 max-h-56 overflow-auto rounded-md border shadow-lg"
-            // Right-anchored so the dropdown grows leftward from the
-            // [+] button instead of rightward — chip rows tend to push
-            // [+] near the panel edge, where left-anchoring would cause
-            // the dropdown to overflow off-screen.
+            className="inline-flex items-center transition-colors hover:bg-[var(--bg-sunken)]"
             style={{
-              top: "calc(100% + var(--sp-1))",
-              right: 0,
-              minWidth: 280,
-              background: "var(--bg-raised)",
-              borderColor: "var(--border)",
+              padding: "var(--sp-0_5) var(--sp-1)",
+              borderRadius: "var(--radius-chip)",
+              border: "var(--hairline) solid var(--border)",
+              background: "transparent",
+              color: outsideCandidates.length === 0 ? "var(--fg-4)" : "var(--fg-3)",
+              cursor: outsideCandidates.length === 0 ? "not-allowed" : "pointer",
             }}
           >
-            {outsideCandidates.map((c) => (
-              <button
-                key={c.agentId}
-                type="button"
-                role="option"
-                aria-selected="false"
-                onClick={() => addMut.mutate(c.agentId)}
-                disabled={addMut.isPending}
-                className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
-                style={{
-                  background: "transparent",
-                  color: "var(--fg)",
-                  border: "none",
-                  cursor: "pointer",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                <span className="font-medium">{c.displayName ?? (c.name ? `@${c.name}` : "—")}</span>
-                {c.name && c.displayName && (
-                  <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
-                    @{c.name}
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+            <Plus className="h-3 w-3" />
+          </button>
+          {open && outsideCandidates.length > 0 && (
+            <div
+              role="listbox"
+              aria-label="Add participant"
+              className="absolute z-20 max-h-56 overflow-auto rounded-md border shadow-lg"
+              // Right-anchored so the dropdown grows leftward from the
+              // [+] button instead of rightward — chip rows tend to push
+              // [+] near the panel edge, where left-anchoring would cause
+              // the dropdown to overflow off-screen.
+              style={{
+                top: "calc(100% + var(--sp-1))",
+                right: 0,
+                minWidth: 280,
+                background: "var(--bg-raised)",
+                borderColor: "var(--border)",
+              }}
+            >
+              {outsideCandidates.map((c) => (
+                <button
+                  key={c.agentId}
+                  type="button"
+                  role="option"
+                  aria-selected="false"
+                  onClick={() => addMut.mutate(c.agentId)}
+                  disabled={addMut.isPending}
+                  className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+                  style={{
+                    background: "transparent",
+                    color: "var(--fg)",
+                    border: "none",
+                    cursor: "pointer",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  <span className="font-medium">{c.displayName ?? (c.name ? `@${c.name}` : "—")}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -445,11 +445,6 @@ function ParticipantChips({
                 }}
               >
                 <span className="font-medium">{c.displayName ?? (c.name ? `@${c.name}` : "—")}</span>
-                {c.name && c.displayName && (
-                  <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
-                    @{c.name}
-                  </span>
-                )}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary

- **Watching mode redesign.** Push \`readOnly\` into \`ChatView\` so wrapper header/footer can be removed. WATCHING badge moves inline with the title; rename click and \`[+]\` add-participant hide in read-only. Disabled composer is replaced by a single-row Join panel (Eye icon + status text + non-full-width primary button) with error/loading inline.
- **Drop redundant @handle from mention dropdowns.** Display name alone is enough since the dropdown inserts the @handle on pick — keeping both was pure noise when display name and handle were identical (which they were for 4/5 agents in practice).

### Before / after (watching mode)

Before: two stacked headers (title shown twice), \`[+]\` and click-to-rename leaking into read-only, disabled composer with wrong "Send a message to start the conversation" empty state, full-width green Join CTA competing with composer.

After: one header, no rename / no \`[+]\` in read-only, no misleading empty state, composer slot replaced by a single Join panel.

## Test plan

- [ ] Open a chat where you're a member → header has rename + \`[+]\` + composer (unchanged).
- [ ] Open a chat where you're a watcher → single header with WATCHING badge, no rename, no \`[+]\`, Join panel in composer slot.
- [ ] Click \`Join to reply\` → joins, composer activates, header switches to full mode.
- [ ] Trigger a join error (e.g. revoke membership server-side) → error renders inline below the panel text.
- [ ] In any composer with mentions, type \`@\` → dropdown lists candidates with display name only (no \`@handle\` line).
- [ ] Pick a candidate → \`@handle\` is inserted into the textarea (insertion contract unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)