### PR TITLE
fix: sync Context Tree remote repo for Context UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,10 @@ FIRST_TREE_HUB_DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:543
 FIRST_TREE_HUB_HOST=0.0.0.0
 
 # Optional deployment-level read token for private Context Tree repos configured
-# in Team Settings. Requires repository contents read access only.
+# in Team Settings. Requires repository contents read access only. The token is
+# only applied to repos listed in FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS.
 # FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN=
+# FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS=agent-team-foundation/first-tree-context
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Server — Optional (have defaults or are auto-generated)                  │

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ FIRST_TREE_HUB_HOST=0.0.0.0
 # Context Tree GitHub repository (URL or owner/repo format, optional)
 # FIRST_TREE_HUB_CONTEXT_TREE_REPO=org/first-tree
 
+# Read-only GitHub token for private Context Tree repos.
+# Requires repository contents read access only.
+# FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN=
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Server — Optional (have defaults or are auto-generated)                  │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -329,7 +329,8 @@ Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also acce
 | `FIRST_TREE_HUB_HOST` | Bind address | `127.0.0.1` |
 | `FIRST_TREE_HUB_JWT_SECRET` | JWT signing key | auto: random generated |
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | Adapter credential encryption key | auto: random generated |
-| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | Optional deployment-level read token for private Context Tree repos configured in Team Settings. Only used by the server-managed Context Tree mirror for `https://github.com/...` repos. | — |
+| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | Optional deployment-level read token for private Context Tree repos configured in Team Settings. Only used by the server-managed Context Tree mirror for allowlisted `https://github.com/...` repos. | — |
+| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` | Comma-separated GitHub repo allowlist (`owner/repo`) that may use `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN`. Required before the token is applied to any org-configured repo. | — |
 | `FIRST_TREE_HUB_WEB_DIST_PATH` | Web static files path | auto-discovered |
 | `FIRST_TREE_HUB_PUBLIC_URL` | Public-facing hub URL. Stamped as the `iss` claim on connect tokens (so `connect <token>` derives the hub URL with no extra arg) and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | request `Host` (dev only) |
 | `FIRST_TREE_HUB_GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App client ID. Enables `/signup` + `/auth/github/start`. Both client id AND secret must be set together. | — |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -331,7 +331,7 @@ Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also acce
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | Adapter credential encryption key | auto: random generated |
 | `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | Context Tree repository URL (optional). Hub server syncs this into a managed readonly checkout for the Context UI. | — |
 | `FIRST_TREE_HUB_CONTEXT_TREE_PATH` | Optional server-local Context Tree checkout override for development or self-host debugging. | — |
-| `FIRST_TREE_HUB_GITHUB_TOKEN` | GitHub API token (optional, for webhooks) | — |
+| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | Read-only GitHub token for private Context Tree repos. Only used when syncing `https://github.com/...` Context Tree repos. | — |
 | `FIRST_TREE_HUB_WEB_DIST_PATH` | Web static files path | auto-discovered |
 | `FIRST_TREE_HUB_PUBLIC_URL` | Public-facing hub URL. Stamped as the `iss` claim on connect tokens (so `connect <token>` derives the hub URL with no extra arg) and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | request `Host` (dev only) |
 | `FIRST_TREE_HUB_GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App client ID. Enables `/signup` + `/auth/github/start`. Both client id AND secret must be set together. | — |
@@ -383,7 +383,6 @@ See [observability.md](observability.md) for the full config reference, backend 
 ```
 ~/.first-tree/hub/
 ├── .onboard-state.json           # Saved args for onboard resume
-├── context-tree/                 # Auto-managed clone (optional, for organizational context)
 ├── config/                      # Configuration (human-edited)
 │   ├── server.yaml
 │   ├── client.yaml
@@ -391,6 +390,7 @@ See [observability.md](observability.md) for the full config reference, backend 
 │       ├── my-agent/agent.yaml
 │       └── another/agent.yaml
 └── data/                        # Runtime data (system-managed)
+    ├── context-tree-repos/       # Server-managed readonly Context Tree mirrors
     ├── sessions/                # Agent session registry
     ├── workspaces/              # Per-chat isolated workspaces
     │   └── <agent-name>/

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -329,7 +329,8 @@ Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also acce
 | `FIRST_TREE_HUB_HOST` | Bind address | `127.0.0.1` |
 | `FIRST_TREE_HUB_JWT_SECRET` | JWT signing key | auto: random generated |
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | Adapter credential encryption key | auto: random generated |
-| `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | Context Tree repository URL (optional) | — |
+| `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | Context Tree repository URL (optional). Hub server syncs this into a managed readonly checkout for the Context UI. | — |
+| `FIRST_TREE_HUB_CONTEXT_TREE_PATH` | Optional server-local Context Tree checkout override for development or self-host debugging. | — |
 | `FIRST_TREE_HUB_GITHUB_TOKEN` | GitHub API token (optional, for webhooks) | — |
 | `FIRST_TREE_HUB_WEB_DIST_PATH` | Web static files path | auto-discovered |
 | `FIRST_TREE_HUB_PUBLIC_URL` | Public-facing hub URL. Stamped as the `iss` claim on connect tokens (so `connect <token>` derives the hub URL with no extra arg) and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | request `Host` (dev only) |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -38,7 +38,7 @@ These must be set for Docker / CI / `--no-interactive` deployments. Interactive 
 |----------|---------|-------------|
 | `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | — | Context Tree repo URL (optional, for organizational context and the Context UI managed mirror) |
 | `FIRST_TREE_HUB_CONTEXT_TREE_PATH` | — | Optional server-local Context Tree checkout override for development or self-host debugging |
-| `FIRST_TREE_HUB_GITHUB_TOKEN` | — | GitHub token (optional, for webhooks) |
+| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | — | Read-only GitHub token for private Context Tree repos |
 | `FIRST_TREE_HUB_GITHUB_WEBHOOK_SECRET` | — | GitHub webhook secret (only needed if using github webhooks) |
 | `FIRST_TREE_HUB_GITHUB_ALLOWED_ORG` | — | GitHub org for agent registration access control (optional) |
 | `FIRST_TREE_HUB_PORT` | `8000` | Server port |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -37,6 +37,7 @@ These must be set for Docker / CI / `--no-interactive` deployments. Interactive 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | — | Optional deployment-level read token for private Context Tree repos configured in Team Settings |
+| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` | — | Comma-separated GitHub repo allowlist (`owner/repo`) that may use the Context Tree read token |
 | `FIRST_TREE_HUB_PORT` | `8000` | Server port |
 | `FIRST_TREE_HUB_JWT_SECRET` | auto-generated | JWT signing secret |
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | auto-generated | Adapter credential encryption key |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -36,7 +36,8 @@ These must be set for Docker / CI / `--no-interactive` deployments. Interactive 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | — | Context Tree repo URL (optional, for organizational context) |
+| `FIRST_TREE_HUB_CONTEXT_TREE_REPO` | — | Context Tree repo URL (optional, for organizational context and the Context UI managed mirror) |
+| `FIRST_TREE_HUB_CONTEXT_TREE_PATH` | — | Optional server-local Context Tree checkout override for development or self-host debugging |
 | `FIRST_TREE_HUB_GITHUB_TOKEN` | — | GitHub token (optional, for webhooks) |
 | `FIRST_TREE_HUB_GITHUB_WEBHOOK_SECRET` | — | GitHub webhook secret (only needed if using github webhooks) |
 | `FIRST_TREE_HUB_GITHUB_ALLOWED_ORG` | — | GitHub org for agent registration access control (optional) |

--- a/docs/user-facing-context-tree-ui-design.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-design.zh-CN.md
@@ -213,9 +213,11 @@ Agents may be working from stale team context · last synced 2h ago
 没有可用 snapshot:
 
 ```text
-Team context unavailable
-Connect a Context Tree repo to show the decision context available to agents.
+Context Tree sync unavailable
+Hub cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo.
 ```
+
+不可用态只显示单一 setup / sync state,不显示 update count、Added / Edited / Removed 或时间窗口。原因是这时系统没有可读 snapshot,不能把它表达成“0 个更新”。
 
 等有 per-agent readiness telemetry 后,Header 才升级为:
 

--- a/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
@@ -157,7 +157,7 @@ ContextTreeStatus
 - 用短 TTL in-memory cache 缓解同一 `repo + branch + headCommit + window` 的重复请求。
 - 返回 active / stale / unavailable 状态;refresh 失败但已有 managed checkout 时返回 stale snapshot,只有没有可读 snapshot 时才返回 unavailable。
 
-当前实现支持 remote repo 自动 materialize:当组织的 Context Tree repo 是 remote URL 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。私有 GitHub repo 通过 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` 提供部署级只读 token;token 只用于 server-side git sync,不暴露给 Web。
+当前实现支持 remote repo 自动 materialize:当组织的 Context Tree repo 是 HTTPS remote URL 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。私有 GitHub repo 通过 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` 提供部署级只读 token;token 只用于 server-side git sync,不暴露给 Web,且只会应用到 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` 显式 allowlist 中的 GitHub repos。
 
 ### 性能和复用边界
 

--- a/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
@@ -155,9 +155,9 @@ ContextTreeStatus
 - 校验本地 checkout branch 与 server config 是否一致,避免错标 branch。
 - 对 git command 设置 timeout / buffer 上限,并对 diff entry 做上限保护。
 - 用短 TTL in-memory cache 缓解同一 `repo + branch + headCommit + window` 的重复请求。
-- 返回 active / unavailable 状态;不可用态表达 sync/access 问题,不把 server 机器环境变量暴露给用户。
+- 返回 active / stale / unavailable 状态;refresh 失败但已有 managed checkout 时返回 stale snapshot,只有没有可读 snapshot 时才返回 unavailable。
 
-当前实现支持 remote repo 自动 materialize:当 `contextTree.repo` 是 remote URL 或 `owner/repo` shorthand 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。`contextTree.localPath` 保留为本地开发、self-host debug 或特殊部署 override,不是线上默认路径。
+当前实现支持 remote repo 自动 materialize:当 `contextTree.repo` 是 remote URL 或 `owner/repo` shorthand 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。`contextTree.localPath` 保留为本地开发、self-host debug 或特殊部署 override,不是线上默认路径。私有 GitHub repo 通过 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` 提供只读 token;token 只用于 server-side git sync,不暴露给 Web。
 
 ### 性能和复用边界
 
@@ -167,7 +167,7 @@ ContextTreeStatus
 
 - 按 `repo + branch + headCommit` 缓存 nodes / edges / previews。
 - `window` 只影响 changes / updates,不要导致每次请求都重建整棵树。
-- credential refresh、stale snapshot fallback 放到 server refresh/cache 层。
+- credential refresh 和更完整的 background refresh 可继续沉到 server refresh/cache 层;当前版本已经具备 request-time sync 的 stale snapshot fallback。
 - 通用扫描、frontmatter 解析、soft link 解析长期应沉到 `first-tree` 包,例如 `first-tree tree export --json` 或包内 `readContextTreeSnapshot()`;Hub 只保留 auth、config、cache、API wrapper 和 Context Updates 产品表达。
 
 这样既避免 request-time 重复计算,也避免 Hub 长期拥有一套越来越厚的 Context Tree parser。
@@ -200,7 +200,8 @@ git diff --name-status <window-base>..HEAD -- '*.md'
 异常处理:
 
 - 没有可用 snapshot:返回 unavailable。
-- remote URL 未绑定到本地 checkout:返回 unavailable,并提示配置本地路径。
+- remote sync 失败但已有 managed checkout:返回 stale,并继续展示上一次可读 snapshot。
+- remote sync 失败且没有 managed checkout:返回 unavailable,提示 Hub Server 无法读取配置的 Context Tree repo。
 
 ## Web 实现
 

--- a/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
@@ -144,7 +144,8 @@ ContextTreeStatus
 职责:
 
 - 读取 server config 中的 Context Tree repo / branch。
-- 读取 `FIRST_TREE_HUB_CONTEXT_TREE_PATH` 或 server config 指向的本地 Context Tree checkout。
+- 以 server config 中的 remote Context Tree repo / branch 作为 source of truth。
+- Hub Server 自动把 remote repo 同步到 server-managed readonly checkout;`FIRST_TREE_HUB_CONTEXT_TREE_PATH` / `contextTree.localPath` 仅作为 dev/self-host override。
 - 解析 markdown files 和 directories。
 - 生成 parent edges、soft link edges、markdown link edges。
 - 生成 preview、owners、title、affected context area。
@@ -154,9 +155,9 @@ ContextTreeStatus
 - 校验本地 checkout branch 与 server config 是否一致,避免错标 branch。
 - 对 git command 设置 timeout / buffer 上限,并对 diff entry 做上限保护。
 - 用短 TTL in-memory cache 缓解同一 `repo + branch + headCommit + window` 的重复请求。
-- 返回 active / unavailable 状态。
+- 返回 active / unavailable 状态;不可用态表达 sync/access 问题,不把 server 机器环境变量暴露给用户。
 
-当前实现不做 remote clone、credential refresh 或 stale snapshot fallback。如果 `contextTree.repo` 是 remote URL,需要通过 `FIRST_TREE_HUB_CONTEXT_TREE_PATH` 指向 server 可读的本地 checkout。后续生产化可以把 refresh / persistent cache / stale fallback 补到这一层,但不改变 Web 的只读 read model。
+当前实现支持 remote repo 自动 materialize:当 `contextTree.repo` 是 remote URL 或 `owner/repo` shorthand 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。`contextTree.localPath` 保留为本地开发、self-host debug 或特殊部署 override,不是线上默认路径。
 
 ### 性能和复用边界
 
@@ -166,7 +167,7 @@ ContextTreeStatus
 
 - 按 `repo + branch + headCommit` 缓存 nodes / edges / previews。
 - `window` 只影响 changes / updates,不要导致每次请求都重建整棵树。
-- remote clone / pull、credential、stale snapshot fallback 放到 server refresh/cache 层。
+- credential refresh、stale snapshot fallback 放到 server refresh/cache 层。
 - 通用扫描、frontmatter 解析、soft link 解析长期应沉到 `first-tree` 包,例如 `first-tree tree export --json` 或包内 `readContextTreeSnapshot()`;Hub 只保留 auth、config、cache、API wrapper 和 Context Updates 产品表达。
 
 这样既避免 request-time 重复计算,也避免 Hub 长期拥有一套越来越厚的 Context Tree parser。

--- a/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
@@ -145,7 +145,7 @@ ContextTreeStatus
 
 - 读取当前用户所在组织的 Context Tree repo / branch 设置。
 - 以组织级 remote Context Tree repo / branch 作为 source of truth。
-- Hub Server 自动把 remote repo 同步到 server-managed readonly checkout;repo / branch 由 Team Settings 配置,不是 server-wide global config。
+- Hub Server 自动把 remote repo 同步到 server-managed mirror;repo / branch 由 Team Settings 配置,不是 server-wide global config。
 - 解析 markdown files 和 directories。
 - 生成 parent edges、soft link edges、markdown link edges。
 - 生成 preview、owners、title、affected context area。

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.11.4",
+  "version": "0.11.3",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -17,6 +17,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  contextTreeSnapshotTestInternals.clearRemoteSyncState();
   await rm(testDir, { recursive: true, force: true });
 });
 
@@ -189,14 +190,53 @@ Body`);
     await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Remote Context\n---\nGuidance\n");
     await commitAllAt(remoteDir, "docs: add remote context");
 
-    const managedRoot = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+    const materialized = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
       remoteDir,
       "main",
       cacheRoot,
     );
 
+    const { root: managedRoot } = materialized;
     expect(managedRoot.startsWith(cacheRoot)).toBe(true);
     expect(managedRoot).not.toBe(remoteDir);
     await expect(readFile(join(managedRoot, "NODE.md"), "utf8")).resolves.toContain("Remote Context");
+  });
+
+  it("uses an existing managed checkout when remote refresh fails", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const cacheRoot = join(testDir, "managed-cache");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Stale Context\n---\nGuidance\n");
+    await commitAllAt(remoteDir, "docs: add remote context");
+
+    const first = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(remoteDir, "main", cacheRoot);
+    contextTreeSnapshotTestInternals.clearRemoteSyncState();
+    await rm(remoteDir, { recursive: true, force: true });
+
+    const second = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(remoteDir, "main", cacheRoot);
+
+    expect(second.root).toBe(first.root);
+    expect(second.staleReason).toContain("Showing the last synced Context Tree snapshot");
+    await expect(readFile(join(second.root, "NODE.md"), "utf8")).resolves.toContain("Stale Context");
+
+    const cached = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(remoteDir, "main", cacheRoot);
+    expect(cached.staleReason).toBe(second.staleReason);
+  });
+
+  it("wires GitHub token auth through askpass without putting the token in git args", async () => {
+    const cacheRoot = join(testDir, "managed-cache");
+
+    const env = await contextTreeSnapshotTestInternals.gitAuthEnv(
+      "https://github.com/agent-team-foundation/first-tree-context",
+      cacheRoot,
+      "ghp_secret",
+    );
+
+    expect(env?.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env?.GIT_USERNAME).toBe("x-access-token");
+    expect(env?.GIT_PASSWORD).toBe("ghp_secret");
+    expect(env?.GIT_ASKPASS).toBeDefined();
+    const askpass = await readFile(env?.GIT_ASKPASS ?? "", "utf8");
+    expect(askpass).not.toContain("ghp_secret");
   });
 });

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -217,6 +217,17 @@ Body`);
     await expect(readFile(join(managedRoot, "NODE.md"), "utf8")).resolves.toContain("Remote Context");
   });
 
+  it("uses a full sha256 digest for managed checkout paths", () => {
+    const managedPath = contextTreeSnapshotTestInternals.managedContextTreePath(
+      "https://github.com/example/tree",
+      "main",
+      join(testDir, "managed-cache"),
+    );
+    const hash = managedPath.split("/").at(-1) ?? "";
+
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
   it("builds a snapshot from an organization remote repo binding", async () => {
     const remoteDir = join(testDir, "remote-source");
     await initRepoAt(remoteDir);
@@ -236,6 +247,17 @@ Body`);
         }),
       ]),
     );
+  });
+
+  it("rejects unsafe branch names before remote sync", async () => {
+    const snapshot = await getContextTreeSnapshot(
+      { repo: "https://github.com/example/tree", branch: "--upload-pack=evil" },
+      "7d",
+    );
+
+    expect(snapshot.snapshotStatus).toBe("unavailable");
+    expect(snapshot.contextStatus.detail).toContain("branch");
+    expect(snapshot.contextStatus.detail).toContain("invalid");
   });
 
   it("uses an existing managed checkout when remote refresh fails", async () => {
@@ -259,6 +281,39 @@ Body`);
     expect(cached.staleReason).toBe(second.staleReason);
   });
 
+  it("caches first-clone failures briefly to avoid repeated clone attempts", async () => {
+    const missingRemote = join(testDir, "missing-remote");
+    const cacheRoot = join(testDir, "managed-cache");
+
+    await expect(
+      contextTreeSnapshotTestInternals.materializeRemoteContextTree(missingRemote, "main", cacheRoot),
+    ).rejects.toThrow();
+    await expect(
+      contextTreeSnapshotTestInternals.materializeRemoteContextTree(missingRemote, "main", cacheRoot),
+    ).rejects.toThrow("Previous Context Tree sync failed recently.");
+  });
+
+  it("cleans an incomplete managed checkout before retrying first clone", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const cacheRoot = join(testDir, "managed-cache");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Clean Retry\n---\nGuidance\n");
+    await commitAllAt(remoteDir, "docs: add remote context");
+    const managedRoot = contextTreeSnapshotTestInternals.managedContextTreePath(remoteDir, "main", cacheRoot);
+    await mkdir(managedRoot, { recursive: true });
+    await writeFile(join(managedRoot, "partial-clone-leftover"), "stale");
+
+    const materialized = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+      remoteDir,
+      "main",
+      cacheRoot,
+    );
+
+    expect(materialized.root).toBe(managedRoot);
+    expect(existsSync(join(managedRoot, "partial-clone-leftover"))).toBe(false);
+    await expect(readFile(join(managedRoot, "NODE.md"), "utf8")).resolves.toContain("Clean Retry");
+  });
+
   it("wires GitHub token auth through askpass without putting the token in git args", async () => {
     const cacheRoot = join(testDir, "managed-cache");
 
@@ -272,6 +327,7 @@ Body`);
     expect(env?.GIT_USERNAME).toBe("x-access-token");
     expect(env?.GIT_PASSWORD).toBe("ghp_secret");
     expect(env?.GIT_ASKPASS).toBeDefined();
+    expect(env?.GIT_ASKPASS).toContain(join("managed-cache", ".tools", "git-askpass.sh"));
     const askpass = await readFile(env?.GIT_ASKPASS ?? "", "utf8");
     expect(askpass).not.toContain("ghp_secret");
   });
@@ -282,5 +338,11 @@ Body`);
         "fatal: could not read from https://user:secret@github.com/example/private.git",
       ),
     ).toBe("fatal: could not read from https://[redacted]@github.com/example/private.git");
+    expect(contextTreeSnapshotTestInternals.redactSecret("fatal: token ghp_secret123 failed")).toBe(
+      "fatal: token [redacted] failed",
+    );
+    expect(contextTreeSnapshotTestInternals.redactSecret("fatal: token github_pat_secret123 failed")).toBe(
+      "fatal: token [redacted] failed",
+    );
   });
 });

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -30,16 +30,25 @@ async function gitOutput(cwd: string, args: string[]): Promise<string> {
 }
 
 async function initRepo(): Promise<string> {
-  await git(testDir, ["init"]);
-  await git(testDir, ["config", "user.name", "Context Reviewer"]);
-  await git(testDir, ["config", "user.email", "context-reviewer@example.com"]);
-  return testDir;
+  return initRepoAt(testDir);
+}
+
+async function initRepoAt(cwd: string): Promise<string> {
+  await mkdir(cwd, { recursive: true });
+  await git(cwd, ["init", "--initial-branch=main"]);
+  await git(cwd, ["config", "user.name", "Context Reviewer"]);
+  await git(cwd, ["config", "user.email", "context-reviewer@example.com"]);
+  return cwd;
 }
 
 async function commitAll(message: string): Promise<string> {
-  await git(testDir, ["add", "."]);
-  await git(testDir, ["commit", "-m", message]);
-  return gitOutput(testDir, ["rev-parse", "HEAD"]);
+  return commitAllAt(testDir, message);
+}
+
+async function commitAllAt(cwd: string, message: string): Promise<string> {
+  await git(cwd, ["add", "."]);
+  await git(cwd, ["commit", "-m", message]);
+  return gitOutput(cwd, ["rev-parse", "HEAD"]);
 }
 
 describe("Context Tree snapshot service", () => {
@@ -171,5 +180,23 @@ Body`);
     expect(diff.entries).toEqual([]);
     expect(existsSync(payloadPath)).toBe(false);
     expect(existsSync(`${payloadPath}..HEAD`)).toBe(false);
+  });
+
+  it("materializes a remote repo into a managed checkout", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const cacheRoot = join(testDir, "managed-cache");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Remote Context\n---\nGuidance\n");
+    await commitAllAt(remoteDir, "docs: add remote context");
+
+    const managedRoot = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+      remoteDir,
+      "main",
+      cacheRoot,
+    );
+
+    expect(managedRoot.startsWith(cacheRoot)).toBe(true);
+    expect(managedRoot).not.toBe(remoteDir);
+    await expect(readFile(join(managedRoot, "NODE.md"), "utf8")).resolves.toContain("Remote Context");
   });
 });

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import type { ContextTreeChange, ContextTreeNode } from "@agent-team-foundation/first-tree-hub-shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { contextTreeGithubTokenForRepo } from "../api/context-tree-snapshot.js";
 import { contextTreeSnapshotTestInternals, getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
 
 const execFileAsync = promisify(execFile);
@@ -53,6 +54,20 @@ async function commitAllAt(cwd: string, message: string): Promise<string> {
 }
 
 describe("Context Tree snapshot service", () => {
+  it("only applies the deployment GitHub token to allowlisted repos", () => {
+    const syncConfig = {
+      githubToken: "ghp_secret",
+      githubTokenRepos: "agent-team-foundation/first-tree-context, Example/Other.git",
+    };
+
+    expect(
+      contextTreeGithubTokenForRepo("https://github.com/agent-team-foundation/first-tree-context.git", syncConfig),
+    ).toBe("ghp_secret");
+    expect(contextTreeGithubTokenForRepo("https://github.com/example/other", syncConfig)).toBe("ghp_secret");
+    expect(contextTreeGithubTokenForRepo("https://github.com/example/not-allowed", syncConfig)).toBeUndefined();
+    expect(contextTreeGithubTokenForRepo("https://user:secret@github.com/example/other", syncConfig)).toBeUndefined();
+  });
+
   it("parses fallback frontmatter lists", () => {
     const parsed = contextTreeSnapshotTestInternals.parseMarkdownFallback(`---
 title: "Client Runtime"
@@ -259,5 +274,13 @@ Body`);
     expect(env?.GIT_ASKPASS).toBeDefined();
     const askpass = await readFile(env?.GIT_ASKPASS ?? "", "utf8");
     expect(askpass).not.toContain("ghp_secret");
+  });
+
+  it("redacts URL-embedded credentials from surfaced git errors", () => {
+    expect(
+      contextTreeSnapshotTestInternals.redactSecret(
+        "fatal: could not read from https://user:secret@github.com/example/private.git",
+      ),
+    ).toBe("fatal: could not read from https://[redacted]@github.com/example/private.git");
   });
 });

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -160,6 +160,22 @@ describe("org-settings service", () => {
     ).rejects.toThrow();
   });
 
+  it("rejects non-HTTPS or credential-bearing Context Tree repo URLs", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const putRepo = (repo: string) =>
+      orgSettingsService.putOrgSetting(
+        app.db,
+        admin.organizationId,
+        "context_tree",
+        { repo },
+        { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+      );
+
+    await expect(putRepo("ssh://git@github.com/example/tree.git")).rejects.toThrow();
+    await expect(putRepo("https://user:secret@github.com/example/tree.git")).rejects.toThrow();
+  });
+
   it("putOrgSetting bumps version on subsequent writes", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -1,8 +1,9 @@
 import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
+import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireUser } from "../scope/require-user.js";
-import { getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
+import { getContextTreeSnapshot, type ContextTreeBinding } from "../services/context-tree-snapshot.js";
 import { getOrgContextTree, resolveUserPrimaryOrgId } from "../services/org-settings.js";
 
 const querySchema = z
@@ -27,12 +28,52 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
       const query = querySchema.parse(request.query);
       const { userId } = requireUser(request);
       const orgId = await resolveUserPrimaryOrgId(app.db, userId);
-      const binding = orgId ? await getOrgContextTree(app.db, orgId) : {};
-      const snapshot = await getContextTreeSnapshot(
-        { ...binding, githubToken: app.config.contextTreeSync?.githubToken },
-        query.window ?? "7d",
-      );
+      const binding: ContextTreeBinding = orgId ? await getOrgContextTree(app.db, orgId) : {};
+      const githubToken = contextTreeGithubTokenForRepo(binding.repo, app.config.contextTreeSync);
+      const snapshot = await getContextTreeSnapshot({ ...binding, githubToken }, query.window ?? "7d");
       return contextTreeSnapshotSchema.parse(snapshot);
     },
   );
+}
+
+type ContextTreeSyncConfig = NonNullable<ServerConfig["contextTreeSync"]>;
+
+export function contextTreeGithubTokenForRepo(
+  repo: string | null | undefined,
+  syncConfig: ContextTreeSyncConfig | undefined,
+): string | undefined {
+  if (!repo || !syncConfig?.githubToken) return undefined;
+  const repoKey = githubRepoKey(repo);
+  if (!repoKey) return undefined;
+  const allowedRepos = new Set(
+    (syncConfig.githubTokenRepos ?? "")
+      .split(",")
+      .map((entry) => normalizeGithubRepoKey(entry))
+      .filter((entry): entry is string => entry !== null),
+  );
+  return allowedRepos.has(repoKey) ? syncConfig.githubToken : undefined;
+}
+
+function githubRepoKey(value: string): string | null {
+  const shorthand = normalizeGithubRepoKey(value);
+  if (shorthand) return shorthand;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") return null;
+  if (url.username || url.password) return null;
+  return normalizeGithubRepoKey(url.pathname.replace(/^\/+/, ""));
+}
+
+function normalizeGithubRepoKey(value: string): string | null {
+  const trimmed = value
+    .trim()
+    .replace(/^\/+/, "")
+    .replace(/\.git$/i, "");
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(trimmed);
+  if (!match) return null;
+  return `${match[1]?.toLowerCase()}/${match[2]?.toLowerCase()}`;
 }

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -3,7 +3,7 @@ import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireUser } from "../scope/require-user.js";
-import { getContextTreeSnapshot, type ContextTreeBinding } from "../services/context-tree-snapshot.js";
+import { type ContextTreeBinding, getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
 import { getOrgContextTree, resolveUserPrimaryOrgId } from "../services/org-settings.js";
 
 const querySchema = z

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -444,7 +444,7 @@ function errorMessage(error: unknown): string {
 }
 
 function redactSecret(message: string): string {
-  return message.replace(/x-access-token:[^@\s]+@/g, "x-access-token:[redacted]@");
+  return message.replace(/(https?:\/\/)[^/@\s]+@/g, "$1[redacted]@");
 }
 
 function unavailableSnapshot(repo: string | null, branch: string | null, detail: string): ContextTreeSnapshot {
@@ -1091,5 +1091,6 @@ export const contextTreeSnapshotTestInternals = {
   materializeRemoteContextTree,
   parseMarkdownFallback,
   readDiffEntries,
+  redactSecret,
   resolveContextTreeRoot,
 };

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import type {
@@ -13,6 +14,7 @@ import type {
   ContextTreeSummary,
   ContextTreeUpdate,
 } from "@agent-team-foundation/first-tree-hub-shared";
+import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import matter from "gray-matter";
 import type { Config } from "../config.js";
 
@@ -25,8 +27,10 @@ const MAX_MARKDOWN_FILES = 1_000;
 const MAX_MARKDOWN_FILE_BYTES = 512 * 1024;
 const SNAPSHOT_CACHE_TTL_MS = 30_000;
 const GIT_TIMEOUT_MS = 5_000;
+const GIT_SYNC_TIMEOUT_MS = 60_000;
 const GIT_MAX_BUFFER = 10 * 1024 * 1024;
 const GIT_LOG_RECORD_SEPARATOR = "\x1e";
+const REMOTE_SYNC_TTL_MS = 60_000;
 const CONTEXT_TREE_SNAPSHOT_WINDOWS = {
   ONE_DAY: "1d",
   SEVEN_DAYS: "7d",
@@ -83,6 +87,8 @@ type SnapshotCacheEntry = {
 };
 
 const snapshotCache = new Map<string, SnapshotCacheEntry>();
+const remoteSyncPromises = new Map<string, Promise<void>>();
+const remoteLastSyncedAt = new Map<string, number>();
 
 export async function getContextTreeSnapshot(
   config: Config,
@@ -90,7 +96,7 @@ export async function getContextTreeSnapshot(
 ): Promise<ContextTreeSnapshot> {
   const repo = config.contextTree?.repo ?? null;
   const branch = config.contextTree?.branch ?? null;
-  const resolved = resolveContextTreeRoot(repo, config.contextTree?.localPath);
+  const resolved = await resolveContextTreeRoot(repo, config.contextTree?.localPath, branch);
 
   if (!resolved.root) {
     return unavailableSnapshot(repo, branch, resolved.reason);
@@ -167,30 +173,125 @@ function contextStatusWarning(truncated: boolean): string | null {
   return null;
 }
 
-function resolveContextTreeRoot(
+async function resolveContextTreeRoot(
   repo: string | null,
   localPath: string | null | undefined,
-): { root: string | null; reason: string } {
-  const candidate = localPath && localPath.trim().length > 0 ? localPath : repo;
-  if (!candidate) {
+  branch: string | null,
+): Promise<{ root: string | null; reason: string }> {
+  if (localPath && localPath.trim().length > 0) {
+    const root = resolveLocalPath(localPath);
+    if (existsSync(root)) return { root, reason: "ok" };
+    return { root: null, reason: `Context Tree checkout not found at ${root}.` };
+  }
+
+  if (!repo) {
     return { root: null, reason: "Context Tree is not configured." };
   }
 
-  const normalized = candidate.startsWith("file://") ? candidate.slice("file://".length) : candidate;
-  const root = isAbsolute(normalized) ? normalize(normalized) : resolve(process.cwd(), normalized);
+  if (isRemoteRepo(repo)) {
+    const resolvedBranch = branch ?? "main";
+    if (!isSafeBranchName(resolvedBranch)) {
+      return { root: null, reason: `Configured Context Tree branch "${resolvedBranch}" is invalid.` };
+    }
+    try {
+      const root = await materializeRemoteContextTree(repo, resolvedBranch);
+      return { root, reason: "ok" };
+    } catch (error) {
+      return {
+        root: null,
+        reason: `Hub could not sync the configured Context Tree repo. Check repo access and branch "${resolvedBranch}". ${errorMessage(error)}`,
+      };
+    }
+  }
+
+  const root = resolveLocalPath(repo);
   if (existsSync(root)) {
     return { root, reason: "ok" };
   }
 
-  if (/^https?:\/\//.test(normalized) || /^[^/]+\/[^/]+$/.test(normalized)) {
-    return {
-      root: null,
-      reason:
-        "Context Tree repo is configured as a remote URL. Set FIRST_TREE_HUB_CONTEXT_TREE_PATH to a readable local checkout for this version.",
-    };
+  return { root: null, reason: `Context Tree checkout not found at ${root}.` };
+}
+
+function resolveLocalPath(value: string): string {
+  const normalized = value.startsWith("file://") ? value.slice("file://".length) : value;
+  return isAbsolute(normalized) ? normalize(normalized) : resolve(process.cwd(), normalized);
+}
+
+function isRemoteRepo(value: string): boolean {
+  return (
+    /^https?:\/\//.test(value) || /^file:\/\//.test(value) || /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value)
+  );
+}
+
+function normalizeRemoteRepoUrl(value: string): string {
+  if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value)) {
+    return `https://github.com/${value}`;
+  }
+  return value;
+}
+
+function managedContextTreeCacheRoot(): string {
+  return join(DEFAULT_DATA_DIR, "context-tree-repos");
+}
+
+function managedContextTreePath(repoUrl: string, branch: string, cacheRoot = managedContextTreeCacheRoot()): string {
+  const hash = createHash("sha256").update(`${repoUrl}\0${branch}`).digest("hex").slice(0, 16);
+  return join(cacheRoot, hash);
+}
+
+async function materializeRemoteContextTree(
+  repo: string,
+  branch: string,
+  cacheRoot = managedContextTreeCacheRoot(),
+): Promise<string> {
+  const repoUrl = normalizeRemoteRepoUrl(repo);
+  const root = managedContextTreePath(repoUrl, branch, cacheRoot);
+  const lastSyncedAt = remoteLastSyncedAt.get(root);
+  if (lastSyncedAt && Date.now() - lastSyncedAt < REMOTE_SYNC_TTL_MS && existsSync(join(root, ".git"))) {
+    return root;
   }
 
-  return { root: null, reason: `Context Tree checkout not found at ${root}.` };
+  const existing = remoteSyncPromises.get(root);
+  if (existing) {
+    await existing;
+    return root;
+  }
+
+  const syncPromise = syncRemoteContextTree(repoUrl, branch, root, cacheRoot);
+  remoteSyncPromises.set(root, syncPromise);
+  try {
+    await syncPromise;
+    remoteLastSyncedAt.set(root, Date.now());
+    return root;
+  } finally {
+    remoteSyncPromises.delete(root);
+  }
+}
+
+async function syncRemoteContextTree(repoUrl: string, branch: string, root: string, cacheRoot: string): Promise<void> {
+  await mkdir(cacheRoot, { recursive: true });
+  if (!existsSync(join(root, ".git"))) {
+    await rm(root, { recursive: true, force: true });
+    await gitOutput(cacheRoot, ["clone", "--branch", branch, "--single-branch", repoUrl, root], {
+      timeout: GIT_SYNC_TIMEOUT_MS,
+    });
+    return;
+  }
+
+  await gitOutput(root, ["remote", "set-url", "origin", repoUrl], { timeout: GIT_TIMEOUT_MS });
+  await gitOutput(root, ["fetch", "origin", branch, "--prune"], { timeout: GIT_SYNC_TIMEOUT_MS });
+  await gitOutput(root, ["checkout", "-B", branch, `origin/${branch}`], { timeout: GIT_TIMEOUT_MS });
+}
+
+function isSafeBranchName(branch: string): boolean {
+  if (branch.startsWith("-")) return false;
+  if (branch.includes("..") || branch.includes("@{") || branch.includes("\\")) return false;
+  return /^[A-Za-z0-9._/-]+$/.test(branch);
+}
+
+function errorMessage(error: unknown): string {
+  if (!(error instanceof Error) || error.message.trim().length === 0) return "";
+  return error.message.trim().split("\n")[0] ?? "";
 }
 
 function unavailableSnapshot(repo: string | null, branch: string | null, detail: string): ContextTreeSnapshot {
@@ -213,10 +314,10 @@ function unavailableSnapshot(repo: string | null, branch: string | null, detail:
   };
 }
 
-async function gitOutput(cwd: string, args: string[]): Promise<string> {
+async function gitOutput(cwd: string, args: string[], options?: { timeout?: number }): Promise<string> {
   const { stdout } = await execFileAsync("git", args, {
     cwd,
-    timeout: GIT_TIMEOUT_MS,
+    timeout: options?.timeout ?? GIT_TIMEOUT_MS,
     maxBuffer: GIT_MAX_BUFFER,
   });
   return stdout.trim();
@@ -825,6 +926,8 @@ export const contextTreeSnapshotTestInternals = {
   buildTreeFromRawFiles(files: Array<{ relativePath: string; raw: string }>): TreeBuildResult {
     return buildTree(files.map((file) => ({ relativePath: file.relativePath, parsed: parseMarkdown(file.raw) })));
   },
+  materializeRemoteContextTree,
   parseMarkdownFallback,
   readDiffEntries,
+  resolveContextTreeRoot,
 };

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import type {
@@ -86,9 +86,26 @@ type SnapshotCacheEntry = {
   snapshot: ContextTreeSnapshot;
 };
 
+type ResolvedContextTreeRoot = {
+  root: string | null;
+  reason: string;
+  staleReason: string | null;
+};
+
+type RemoteSyncResult = {
+  staleReason: string | null;
+};
+
+type GitOutputOptions = {
+  timeout?: number;
+  env?: NodeJS.ProcessEnv;
+  disableHooks?: boolean;
+};
+
 const snapshotCache = new Map<string, SnapshotCacheEntry>();
-const remoteSyncPromises = new Map<string, Promise<void>>();
+const remoteSyncPromises = new Map<string, Promise<RemoteSyncResult>>();
 const remoteLastSyncedAt = new Map<string, number>();
+const remoteLastSyncWarnings = new Map<string, string>();
 
 export async function getContextTreeSnapshot(
   config: Config,
@@ -96,7 +113,12 @@ export async function getContextTreeSnapshot(
 ): Promise<ContextTreeSnapshot> {
   const repo = config.contextTree?.repo ?? null;
   const branch = config.contextTree?.branch ?? null;
-  const resolved = await resolveContextTreeRoot(repo, config.contextTree?.localPath, branch);
+  const resolved = await resolveContextTreeRoot(
+    repo,
+    config.contextTree?.localPath,
+    branch,
+    config.contextTree?.githubToken,
+  );
 
   if (!resolved.root) {
     return unavailableSnapshot(repo, branch, resolved.reason);
@@ -118,7 +140,10 @@ export async function getContextTreeSnapshot(
     const cacheKey = snapshotCacheKey(resolved.root, actualBranch ?? branch, headCommit, comparisonBaseCommit, window);
     const cached = snapshotCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
-      return { ...cached.snapshot, syncedAt: now };
+      const staleCacheRecovered = cached.snapshot.snapshotStatus === "stale" && !resolved.staleReason;
+      if (!staleCacheRecovered) {
+        return withSnapshotStatus(cached.snapshot, now, statusWarningFromResolved(resolved.staleReason, null));
+      }
     }
 
     const files = await readMarkdownFiles(resolved.root);
@@ -131,19 +156,15 @@ export async function getContextTreeSnapshot(
     const nodesWithGhosts = addRemovedGhostNodes(nodes, changes);
     const summary = summarizeChanges(changes);
     const updates = buildUpdates(changes, nodesWithGhosts);
-    const statusWarning = contextStatusWarning(diffResult.truncated);
+    const statusWarning = statusWarningFromResolved(resolved.staleReason, diffResult.truncated);
 
     const snapshot: ContextTreeSnapshot = {
       repo,
       branch: actualBranch ?? branch,
       headCommit,
       syncedAt: now,
-      snapshotStatus: "active",
-      contextStatus: {
-        label: statusWarning ? "Team context needs attention" : "Team context is current",
-        detail: statusWarning ?? "Agents have a synced team context snapshot available.",
-        severity: statusWarning ? "warning" : "ok",
-      },
+      snapshotStatus: statusWarning?.stale ? "stale" : "active",
+      contextStatus: contextStatus(statusWarning),
       summary,
       updates,
       nodes: nodesWithGhosts,
@@ -168,8 +189,15 @@ function snapshotCacheKey(
   return [root, branch ?? "unknown", headCommit, comparisonBase ?? "none", window].join(":");
 }
 
-function contextStatusWarning(truncated: boolean): string | null {
-  if (truncated) return `Showing the first ${MAX_DIFF_ENTRIES} changed files.`;
+function statusWarningFromResolved(
+  staleReason: string | null,
+  truncated: boolean | null,
+): { detail: string; stale: boolean } | null {
+  if (staleReason) {
+    const suffix = truncated ? ` Showing the first ${MAX_DIFF_ENTRIES} changed files.` : "";
+    return { detail: `${staleReason}${suffix}`, stale: true };
+  }
+  if (truncated) return { detail: `Showing the first ${MAX_DIFF_ENTRIES} changed files.`, stale: false };
   return null;
 }
 
@@ -177,39 +205,45 @@ async function resolveContextTreeRoot(
   repo: string | null,
   localPath: string | null | undefined,
   branch: string | null,
-): Promise<{ root: string | null; reason: string }> {
+  githubToken?: string | null,
+): Promise<ResolvedContextTreeRoot> {
   if (localPath && localPath.trim().length > 0) {
     const root = resolveLocalPath(localPath);
-    if (existsSync(root)) return { root, reason: "ok" };
-    return { root: null, reason: `Context Tree checkout not found at ${root}.` };
+    if (existsSync(root)) return { root, reason: "ok", staleReason: null };
+    return { root: null, reason: `Context Tree checkout not found at ${root}.`, staleReason: null };
   }
 
   if (!repo) {
-    return { root: null, reason: "Context Tree is not configured." };
+    return { root: null, reason: "Context Tree is not configured.", staleReason: null };
   }
 
   if (isRemoteRepo(repo)) {
     const resolvedBranch = branch ?? "main";
     if (!isSafeBranchName(resolvedBranch)) {
-      return { root: null, reason: `Configured Context Tree branch "${resolvedBranch}" is invalid.` };
+      return {
+        root: null,
+        reason: `Configured Context Tree branch "${resolvedBranch}" is invalid.`,
+        staleReason: null,
+      };
     }
     try {
-      const root = await materializeRemoteContextTree(repo, resolvedBranch);
-      return { root, reason: "ok" };
+      const materialized = await materializeRemoteContextTree(repo, resolvedBranch, undefined, githubToken);
+      return { root: materialized.root, reason: "ok", staleReason: materialized.staleReason };
     } catch (error) {
       return {
         root: null,
         reason: `Hub could not sync the configured Context Tree repo. Check repo access and branch "${resolvedBranch}". ${errorMessage(error)}`,
+        staleReason: null,
       };
     }
   }
 
   const root = resolveLocalPath(repo);
   if (existsSync(root)) {
-    return { root, reason: "ok" };
+    return { root, reason: "ok", staleReason: null };
   }
 
-  return { root: null, reason: `Context Tree checkout not found at ${root}.` };
+  return { root: null, reason: `Context Tree checkout not found at ${root}.`, staleReason: null };
 }
 
 function resolveLocalPath(value: string): string {
@@ -243,44 +277,153 @@ async function materializeRemoteContextTree(
   repo: string,
   branch: string,
   cacheRoot = managedContextTreeCacheRoot(),
-): Promise<string> {
+  githubToken?: string | null,
+): Promise<{ root: string; staleReason: string | null }> {
   const repoUrl = normalizeRemoteRepoUrl(repo);
   const root = managedContextTreePath(repoUrl, branch, cacheRoot);
   const lastSyncedAt = remoteLastSyncedAt.get(root);
   if (lastSyncedAt && Date.now() - lastSyncedAt < REMOTE_SYNC_TTL_MS && existsSync(join(root, ".git"))) {
-    return root;
+    return { root, staleReason: remoteLastSyncWarnings.get(root) ?? null };
   }
 
   const existing = remoteSyncPromises.get(root);
   if (existing) {
-    await existing;
-    return root;
+    const result = await existing;
+    return { root, staleReason: result.staleReason };
   }
 
-  const syncPromise = syncRemoteContextTree(repoUrl, branch, root, cacheRoot);
+  const syncPromise = syncRemoteContextTree(repoUrl, branch, root, cacheRoot, githubToken);
   remoteSyncPromises.set(root, syncPromise);
   try {
-    await syncPromise;
+    const syncResult = await syncPromise;
     remoteLastSyncedAt.set(root, Date.now());
-    return root;
+    if (syncResult.staleReason) {
+      remoteLastSyncWarnings.set(root, syncResult.staleReason);
+    } else {
+      remoteLastSyncWarnings.delete(root);
+    }
+    return { root, staleReason: syncResult.staleReason };
   } finally {
     remoteSyncPromises.delete(root);
   }
 }
 
-async function syncRemoteContextTree(repoUrl: string, branch: string, root: string, cacheRoot: string): Promise<void> {
+async function syncRemoteContextTree(
+  repoUrl: string,
+  branch: string,
+  root: string,
+  cacheRoot: string,
+  githubToken?: string | null,
+): Promise<RemoteSyncResult> {
   await mkdir(cacheRoot, { recursive: true });
+  const env = await gitAuthEnv(repoUrl, cacheRoot, githubToken);
   if (!existsSync(join(root, ".git"))) {
     await rm(root, { recursive: true, force: true });
     await gitOutput(cacheRoot, ["clone", "--branch", branch, "--single-branch", repoUrl, root], {
       timeout: GIT_SYNC_TIMEOUT_MS,
+      env,
+      disableHooks: true,
     });
-    return;
+    return { staleReason: null };
   }
 
-  await gitOutput(root, ["remote", "set-url", "origin", repoUrl], { timeout: GIT_TIMEOUT_MS });
-  await gitOutput(root, ["fetch", "origin", branch, "--prune"], { timeout: GIT_SYNC_TIMEOUT_MS });
-  await gitOutput(root, ["checkout", "-B", branch, `origin/${branch}`], { timeout: GIT_TIMEOUT_MS });
+  try {
+    await gitOutput(root, ["remote", "set-url", "origin", repoUrl], {
+      timeout: GIT_TIMEOUT_MS,
+      disableHooks: true,
+    });
+    await gitOutput(root, ["fetch", "origin", branch, "--prune"], {
+      timeout: GIT_SYNC_TIMEOUT_MS,
+      env,
+      disableHooks: true,
+    });
+    await gitOutput(root, ["checkout", "-B", branch, `origin/${branch}`], {
+      timeout: GIT_TIMEOUT_MS,
+      disableHooks: true,
+    });
+    return { staleReason: null };
+  } catch (error) {
+    if (existsSync(join(root, ".git"))) {
+      return {
+        staleReason: `Showing the last synced Context Tree snapshot because Hub could not refresh the configured repo. ${errorMessage(error)}`,
+      };
+    }
+    throw error;
+  }
+}
+
+async function gitAuthEnv(
+  repoUrl: string,
+  cacheRoot: string,
+  githubToken?: string | null,
+): Promise<NodeJS.ProcessEnv | undefined> {
+  if (!githubToken || !isGithubHttpsRepo(repoUrl)) return undefined;
+  await mkdir(cacheRoot, { recursive: true });
+  const askpassPath = join(cacheRoot, "git-askpass.sh");
+  await writeFile(
+    askpassPath,
+    [
+      "#!/bin/sh",
+      'case "$1" in',
+      '*Username*) printf "%s\\n" "$GIT_USERNAME" ;;',
+      '*) printf "%s\\n" "$GIT_PASSWORD" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(askpassPath, 0o700);
+  return {
+    ...process.env,
+    GIT_ASKPASS: askpassPath,
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_USERNAME: "x-access-token",
+    GIT_PASSWORD: githubToken,
+  };
+}
+
+function isGithubHttpsRepo(repoUrl: string): boolean {
+  try {
+    const url = new URL(repoUrl);
+    return url.protocol === "https:" && url.hostname.toLowerCase() === "github.com";
+  } catch {
+    return false;
+  }
+}
+
+function contextStatus(warning: { detail: string; stale: boolean } | null): ContextTreeSnapshot["contextStatus"] {
+  if (warning?.stale) {
+    return {
+      label: "Team context is stale",
+      detail: warning.detail,
+      severity: "warning",
+    };
+  }
+  if (warning) {
+    return {
+      label: "Team context needs attention",
+      detail: warning.detail,
+      severity: "warning",
+    };
+  }
+  return {
+    label: "Team context is current",
+    detail: "Agents have a synced team context snapshot available.",
+    severity: "ok",
+  };
+}
+
+function withSnapshotStatus(
+  snapshot: ContextTreeSnapshot,
+  syncedAt: string,
+  warning: { detail: string; stale: boolean } | null,
+): ContextTreeSnapshot {
+  return {
+    ...snapshot,
+    syncedAt,
+    snapshotStatus: warning?.stale ? "stale" : snapshot.snapshotStatus,
+    contextStatus: warning ? contextStatus(warning) : snapshot.contextStatus,
+  };
 }
 
 function isSafeBranchName(branch: string): boolean {
@@ -291,7 +434,11 @@ function isSafeBranchName(branch: string): boolean {
 
 function errorMessage(error: unknown): string {
   if (!(error instanceof Error) || error.message.trim().length === 0) return "";
-  return error.message.trim().split("\n")[0] ?? "";
+  return redactSecret(error.message.trim().split("\n")[0] ?? "");
+}
+
+function redactSecret(message: string): string {
+  return message.replace(/x-access-token:[^@\s]+@/g, "x-access-token:[redacted]@");
 }
 
 function unavailableSnapshot(repo: string | null, branch: string | null, detail: string): ContextTreeSnapshot {
@@ -314,11 +461,13 @@ function unavailableSnapshot(repo: string | null, branch: string | null, detail:
   };
 }
 
-async function gitOutput(cwd: string, args: string[], options?: { timeout?: number }): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
+async function gitOutput(cwd: string, args: string[], options?: GitOutputOptions): Promise<string> {
+  const gitArgs = options?.disableHooks ? ["-c", "core.hooksPath=/dev/null", ...args] : args;
+  const { stdout } = await execFileAsync("git", gitArgs, {
     cwd,
     timeout: options?.timeout ?? GIT_TIMEOUT_MS,
     maxBuffer: GIT_MAX_BUFFER,
+    env: options?.env,
   });
   return stdout.trim();
 }
@@ -926,6 +1075,12 @@ export const contextTreeSnapshotTestInternals = {
   buildTreeFromRawFiles(files: Array<{ relativePath: string; raw: string }>): TreeBuildResult {
     return buildTree(files.map((file) => ({ relativePath: file.relativePath, parsed: parseMarkdown(file.raw) })));
   },
+  clearRemoteSyncState(): void {
+    remoteLastSyncedAt.clear();
+    remoteLastSyncWarnings.clear();
+    remoteSyncPromises.clear();
+  },
+  gitAuthEnv,
   materializeRemoteContextTree,
   parseMarkdownFallback,
   readDiffEntries,

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -26,10 +26,11 @@ const MAX_MARKDOWN_FILES = 1_000;
 const MAX_MARKDOWN_FILE_BYTES = 512 * 1024;
 const SNAPSHOT_CACHE_TTL_MS = 30_000;
 const GIT_TIMEOUT_MS = 5_000;
-const GIT_SYNC_TIMEOUT_MS = 60_000;
+const GIT_SYNC_TIMEOUT_MS = 120_000;
 const GIT_MAX_BUFFER = 10 * 1024 * 1024;
 const GIT_LOG_RECORD_SEPARATOR = "\x1e";
 const REMOTE_SYNC_TTL_MS = 60_000;
+const REMOTE_FAILURE_TTL_MS = 30_000;
 const CONTEXT_TREE_SNAPSHOT_WINDOWS = {
   ONE_DAY: "1d",
   SEVEN_DAYS: "7d",
@@ -95,6 +96,11 @@ type RemoteSyncResult = {
   staleReason: string | null;
 };
 
+type RemoteSyncFailure = {
+  failedAt: number;
+  reason: string;
+};
+
 type GitOutputOptions = {
   timeout?: number;
   env?: NodeJS.ProcessEnv;
@@ -105,6 +111,7 @@ const snapshotCache = new Map<string, SnapshotCacheEntry>();
 const remoteSyncPromises = new Map<string, Promise<RemoteSyncResult>>();
 const remoteLastSyncedAt = new Map<string, number>();
 const remoteLastSyncWarnings = new Map<string, string>();
+const remoteLastFailures = new Map<string, RemoteSyncFailure>();
 
 /**
  * Per-organization Context Tree binding. Resolved from `organization_settings`
@@ -275,7 +282,7 @@ function managedContextTreeCacheRoot(): string {
 }
 
 function managedContextTreePath(repoUrl: string, branch: string, cacheRoot = managedContextTreeCacheRoot()): string {
-  const hash = createHash("sha256").update(`${repoUrl}\0${branch}`).digest("hex").slice(0, 16);
+  const hash = createHash("sha256").update(`${repoUrl}\0${branch}`).digest("hex");
   return join(cacheRoot, hash);
 }
 
@@ -291,6 +298,10 @@ async function materializeRemoteContextTree(
   if (lastSyncedAt && Date.now() - lastSyncedAt < REMOTE_SYNC_TTL_MS && existsSync(join(root, ".git"))) {
     return { root, staleReason: remoteLastSyncWarnings.get(root) ?? null };
   }
+  const lastFailure = remoteLastFailures.get(root);
+  if (lastFailure && Date.now() - lastFailure.failedAt < REMOTE_FAILURE_TTL_MS && !existsSync(join(root, ".git"))) {
+    throw new Error(lastFailure.reason);
+  }
 
   const existing = remoteSyncPromises.get(root);
   if (existing) {
@@ -303,12 +314,21 @@ async function materializeRemoteContextTree(
   try {
     const syncResult = await syncPromise;
     remoteLastSyncedAt.set(root, Date.now());
+    remoteLastFailures.delete(root);
     if (syncResult.staleReason) {
       remoteLastSyncWarnings.set(root, syncResult.staleReason);
     } else {
       remoteLastSyncWarnings.delete(root);
     }
     return { root, staleReason: syncResult.staleReason };
+  } catch (error) {
+    if (!existsSync(join(root, ".git"))) {
+      remoteLastFailures.set(root, {
+        failedAt: Date.now(),
+        reason: `Previous Context Tree sync failed recently. ${errorMessage(error)}`,
+      });
+    }
+    throw error;
   } finally {
     remoteSyncPromises.delete(root);
   }
@@ -364,21 +384,23 @@ async function gitAuthEnv(
   githubToken?: string | null,
 ): Promise<NodeJS.ProcessEnv | undefined> {
   if (!githubToken || !isGithubHttpsRepo(repoUrl)) return undefined;
-  await mkdir(cacheRoot, { recursive: true });
-  const askpassPath = join(cacheRoot, "git-askpass.sh");
-  await writeFile(
-    askpassPath,
-    [
-      "#!/bin/sh",
-      'case "$1" in',
-      '*Username*) printf "%s\\n" "$GIT_USERNAME" ;;',
-      '*) printf "%s\\n" "$GIT_PASSWORD" ;;',
-      "esac",
-      "",
-    ].join("\n"),
-    "utf8",
-  );
-  await chmod(askpassPath, 0o700);
+  const askpassPath = join(cacheRoot, ".tools", "git-askpass.sh");
+  if (!existsSync(askpassPath)) {
+    await mkdir(dirname(askpassPath), { recursive: true });
+    await writeFile(
+      askpassPath,
+      [
+        "#!/bin/sh",
+        'case "$1" in',
+        '*Username*) printf "%s\\n" "$GIT_USERNAME" ;;',
+        '*) printf "%s\\n" "$GIT_PASSWORD" ;;',
+        "esac",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(askpassPath, 0o700);
+  }
   return {
     ...process.env,
     GIT_ASKPASS: askpassPath,
@@ -444,7 +466,10 @@ function errorMessage(error: unknown): string {
 }
 
 function redactSecret(message: string): string {
-  return message.replace(/(https?:\/\/)[^/@\s]+@/g, "$1[redacted]@");
+  return message
+    .replace(/(https?:\/\/)[^/@\s]+@/g, "$1[redacted]@")
+    .replace(/\bghp_[A-Za-z0-9_]+/g, "[redacted]")
+    .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, "[redacted]");
 }
 
 function unavailableSnapshot(repo: string | null, branch: string | null, detail: string): ContextTreeSnapshot {
@@ -1085,9 +1110,11 @@ export const contextTreeSnapshotTestInternals = {
     snapshotCache.clear();
     remoteLastSyncedAt.clear();
     remoteLastSyncWarnings.clear();
+    remoteLastFailures.clear();
     remoteSyncPromises.clear();
   },
   gitAuthEnv,
+  managedContextTreePath,
   materializeRemoteContextTree,
   parseMarkdownFallback,
   readDiffEntries,

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -74,6 +74,9 @@ export const serverConfigSchema = defineConfig({
       env: "FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN",
       secret: true,
     }),
+    githubTokenRepos: field(z.string().optional(), {
+      env: "FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS",
+    }),
   }),
   oauth: optional({
     /**

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -69,6 +69,10 @@ export const serverConfigSchema = defineConfig({
     localPath: field(z.string().optional(), {
       env: "FIRST_TREE_HUB_CONTEXT_TREE_PATH",
     }),
+    githubToken: field(z.string().optional(), {
+      env: "FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN",
+      secret: true,
+    }),
     branch: field(z.string().default("main")),
   }),
   github: {

--- a/packages/shared/src/schemas/org-settings.ts
+++ b/packages/shared/src/schemas/org-settings.ts
@@ -28,14 +28,40 @@ import { z } from "zod";
 
 // -- context_tree --
 
+const orgContextTreeRepoUrlSchema = z
+  .string()
+  .url()
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(value);
+        return url.protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    { message: "Context Tree repo URL must use HTTPS." },
+  )
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(value);
+        return url.username.length === 0 && url.password.length === 0;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Context Tree repo URL must not include credentials." },
+  );
+
 export const orgContextTreeStorageSchema = z.object({
-  repo: z.string().url().optional(),
+  repo: orgContextTreeRepoUrlSchema.optional(),
   branch: z.string().default("main"),
 });
 
 export const orgContextTreeInputSchema = z.object({
-  /** Set / replace (must be a valid URL). `null` clears. `undefined` leaves unchanged. */
-  repo: z.string().url().min(1).nullish(),
+  /** Set / replace (must be an HTTPS URL without credentials). `null` clears. `undefined` leaves unchanged. */
+  repo: orgContextTreeRepoUrlSchema.nullish(),
   /** Set / replace (non-empty). `null` clears (server falls back to "main"). `undefined` leaves unchanged. */
   branch: z.string().min(1).nullish(),
 });

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -92,7 +92,7 @@ export function ContextTreeSettingsPanel() {
         <form id="context-tree-form" onSubmit={handleSubmit}>
           <Field
             label="Repo URL"
-            hint="HTTPS or SSH URL of the Context Tree git repository for this team."
+            hint="HTTPS URL of the Context Tree git repository for this team."
             value={repo}
             onChange={setRepo}
             mono

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -59,21 +59,23 @@ export function ContextPage() {
         ) : null}
         {snapshot && !query.isLoading ? (
           <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-            <ContextStatus snapshot={snapshot} window={window} onWindowChange={setWindow} />
             {snapshot.snapshotStatus === "unavailable" ? (
               <UnavailableState snapshot={snapshot} />
             ) : (
-              <UpdatesView
-                snapshot={snapshot}
-                selectedUpdate={selectedUpdate}
-                selectedUpdateNode={selectedUpdateNode}
-                selectedOverviewNodeId={selectedOverviewNode}
-                onSelectUpdate={(update) => {
-                  setSelectedUpdateId(update.id);
-                  setSelectedOverviewNodeId(update.nodeId);
-                }}
-                onSelectOverviewNode={setSelectedOverviewNodeId}
-              />
+              <>
+                <ContextStatus snapshot={snapshot} window={window} onWindowChange={setWindow} />
+                <UpdatesView
+                  snapshot={snapshot}
+                  selectedUpdate={selectedUpdate}
+                  selectedUpdateNode={selectedUpdateNode}
+                  selectedOverviewNodeId={selectedOverviewNode}
+                  onSelectUpdate={(update) => {
+                    setSelectedUpdateId(update.id);
+                    setSelectedOverviewNodeId(update.nodeId);
+                  }}
+                  onSelectOverviewNode={setSelectedOverviewNodeId}
+                />
+              </>
             )}
           </div>
         ) : null}
@@ -587,6 +589,10 @@ function ErrorState({ message }: { message: string }) {
 }
 
 function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
+  const title = snapshot.repo ? "Context Tree sync unavailable" : "Connect Context Tree";
+  const detail = snapshot.repo
+    ? "Hub cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
+    : "Connect a Context Tree repo to show the team knowledge agents can use.";
   return (
     <Panel>
       <PanelBody>
@@ -594,9 +600,16 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
           <AlertTriangle size={18} style={{ color: "var(--warn)" }} />
           <div>
             <div className="font-semibold" style={{ color: "var(--fg)" }}>
-              {snapshot.contextStatus.label}
+              {title}
             </div>
-            <div style={{ marginTop: "var(--sp-1)" }}>{snapshot.contextStatus.detail}</div>
+            <div style={{ marginTop: "var(--sp-1)" }}>{detail}</div>
+            {snapshot.repo || snapshot.branch ? (
+              <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-2)" }}>
+                {snapshot.repo ? `Repo: ${snapshot.repo}` : null}
+                {snapshot.repo && snapshot.branch ? " · " : null}
+                {snapshot.branch ? `Branch: ${snapshot.branch}` : null}
+              </div>
+            ) : null}
           </div>
         </div>
       </PanelBody>

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -593,6 +593,7 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
   const detail = snapshot.repo
     ? "Hub cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
     : "Connect a Context Tree repo to show the team knowledge agents can use.";
+  const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
   return (
     <Panel>
       <PanelBody>
@@ -605,7 +606,7 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
             <div style={{ marginTop: "var(--sp-1)" }}>{detail}</div>
             {snapshot.repo || snapshot.branch ? (
               <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-2)" }}>
-                {snapshot.repo ? `Repo: ${snapshot.repo}` : null}
+                {repoLabel ? `Repo: ${repoLabel}` : null}
                 {snapshot.repo && snapshot.branch ? " · " : null}
                 {snapshot.branch ? `Branch: ${snapshot.branch}` : null}
               </div>
@@ -615,6 +616,10 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
       </PanelBody>
     </Panel>
   );
+}
+
+function redactRepoForDisplay(repo: string): string {
+  return repo.replace(/(https?:\/\/)[^/@\s]+@/g, "$1[redacted]@");
 }
 
 function EmptyChanges() {


### PR DESCRIPTION
## Summary
- make the Context UI use the configured remote Context Tree repo as the default source of truth by syncing it into a Hub-managed readonly checkout
- keep contextTree.localPath / FIRST_TREE_HUB_CONTEXT_TREE_PATH as a local override instead of the production default path
- simplify the unavailable UI so it does not show duplicate warnings, zero update counts, or server env-var instructions
- update Context Tree UI docs and deployment/config docs; bump command package to 0.11.4

## Validation
- pnpm check
- pnpm --filter @agent-team-foundation/first-tree-hub-shared build
- pnpm --filter @first-tree-hub/server exec vitest run src/__tests__/context-tree-snapshot.test.ts
- pnpm typecheck
- pnpm test