### PR TITLE
feat(hub): per-org settings (Context Tree + GitHub integration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,8 @@ External projects (e.g. context-tree) import core via `import { startServer, che
 
 ### Versioning
 
-- **Bump `packages/command`** on every PR that touches `command` / `client` / `server` / `web` / `shared` — this is the consumer-facing tarball.
+- **Bump `packages/command`** on every PR that touches `command` or `client`, **or** parts of `shared` that `command` / `client` actually import. This is the consumer-facing tarball — only changes that flow through `npm install` need a new version.
+- **Do not bump** for changes confined to `server` / `web`, or to `shared` modules consumed only by `server` / `web` (e.g. admin-API contract schemas, server-only Zod schemas, web-only types). Those ship via the docker image and SaaS cloud deploy, not npm.
 - **Never bump** `private: true` packages (`shared` / `client` / `server` / `web`) — `tsdown` inlines them into the `command` tarball; their `version` is inert.
 
 Full policy (how to pick the next version, anti-patterns, bash recipes): [docs/versioning-and-publishing.md](docs/versioning-and-publishing.md).

--- a/docs/versioning-and-publishing.md
+++ b/docs/versioning-and-publishing.md
@@ -16,11 +16,21 @@ effect on what downstream consumers receive.
 
 | Package | Path | Published | Bump rule |
 |---|---|---|---|
-| `@agent-team-foundation/first-tree-hub` | `packages/command` | Yes (`publishConfig.access: public`) | **Bump on every PR that changes any source file in `command`, `client`, or `shared`.** This tarball is the unified CLI consumers install; without a new version the bundled change cannot reach `npm ci`. |
-| `@agent-team-foundation/first-tree-hub-shared` | `packages/shared` | Yes | **Bump when the externally-importable surface of `shared` changes** — exported Zod schemas, types, or constants that another npm package could consume. Internal-only edits to `shared` still require the `command` bump above; they do not require a `shared` bump. |
+| `@agent-team-foundation/first-tree-hub` | `packages/command` | Yes (`publishConfig.access: public`) | **Bump on every PR that changes `command` or `client` source, or `shared` modules actually imported by `command` / `client`.** This tarball is the unified CLI consumers install — only changes that flow through it need a new version. |
+| `@agent-team-foundation/first-tree-hub-shared` | `packages/shared` | Yes | **Bump when the externally-importable surface of `shared` changes** — exported Zod schemas, types, or constants that another npm package could consume. Internal-only edits to `shared` may still require the `command` bump above (if `command` / `client` import them); they do not require a `shared` bump. |
 | `@first-tree-hub/client` | `packages/client` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
-| `@first-tree-hub/server` | `packages/server` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
-| `@first-tree-hub/web` | `packages/web` | No (`private: true`) | Do not bump — version is inert. Bump `command` instead. |
+| `@first-tree-hub/server` | `packages/server` | No (`private: true`) | Do not bump — version is inert. Server reaches users via the docker image and SaaS cloud deploy, **not via the npm tarball**. Server-only changes (and `shared` modules consumed only by server) therefore do not require a `command` bump. |
+| `@first-tree-hub/web` | `packages/web` | No (`private: true`) | Do not bump — version is inert. Web reaches users via docker / cloud deploy, not npm; same rule as `server`. |
+
+### When does a `shared` change require a `command` bump?
+
+`shared` is a single package but its modules split into two consumer
+camps:
+
+- **`command` / `client` consumers** — types and Zod schemas imported by the CLI or the agent runtime (e.g. agent runtime config, websocket frames, organization schemas surfaced through `/me`). Changes here **must** bump `command`.
+- **`server` / `web` consumers only** — admin-API contract schemas, server-config Zod, server-internal types, web-only output shapes. Changes here ship via docker / cloud and **do not** need a `command` bump.
+
+When unsure, grep `packages/command/src` and `packages/client/src` for the export name. No hits → server/web-only → no bump.
 
 ## Choosing the next version
 

--- a/packages/command/scripts/e2e-auto-agent-add.ts
+++ b/packages/command/scripts/e2e-auto-agent-add.ts
@@ -132,7 +132,6 @@ async function main(): Promise<void> {
       jwtSecret,
       encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     },
-    github: { webhookSecret: "e2e", allowedOrg: "e2e" },
     rateLimit: { max: 10000, loginMax: 10000, webhookMax: 10000 },
     instanceId: "e2e-instance",
     logger: false,

--- a/packages/server/drizzle/0032_organization_settings.sql
+++ b/packages/server/drizzle/0032_organization_settings.sql
@@ -1,0 +1,36 @@
+-- Per-organization settings, keyed by (organization_id, namespace).
+--
+-- Each row holds an entire group of related config as a JSONB blob; the
+-- schema for each namespace lives in @agent-team-foundation/first-tree-hub-shared
+-- (ORG_SETTINGS_NAMESPACES) and is enforced by the service layer on every
+-- read/write. Adding a new config group means registering a new namespace +
+-- Zod schema in shared — the DB does not change.
+--
+-- `version` is reserved for future optimistic locking (PUT with If-Match).
+-- We keep the column from day one so tightening to compare-and-swap later
+-- is a code-only change with no migration.
+--
+-- Sensitive fields inside `value` (e.g. github_integration.webhookSecret)
+-- are AES-256-GCM-encrypted at the service layer using crypto.ts's
+-- encryptValue / decryptValue — same pattern as adapter_configs.
+--
+-- ON DELETE CASCADE on organization_id: settings have no independent
+-- lifecycle, deleting an org must drop them. updated_by is SET NULL so a
+-- user deletion does not cascade-clobber unrelated config rows.
+
+CREATE TABLE IF NOT EXISTS "organization_settings" (
+  "organization_id" text NOT NULL,
+  "namespace"       text NOT NULL,
+  "value"           jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "version"         integer NOT NULL DEFAULT 0,
+  "updated_by"      text,
+  "updated_at"      timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "organization_settings_pkey" PRIMARY KEY ("organization_id", "namespace"),
+  CONSTRAINT "organization_settings_organization_id_organizations_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE,
+  CONSTRAINT "organization_settings_updated_by_users_id_fk"
+    FOREIGN KEY ("updated_by") REFERENCES "users"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_org_settings_namespace"
+  ON "organization_settings" ("namespace");

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1777939200000,
       "tag": "0031_drop_system_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0032_organization_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -25,7 +25,6 @@ const baseConfig: Config = {
     encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   },
   auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
-  github: { webhookSecret: undefined, allowedOrg: undefined },
   trustProxy: false,
   observability: { logging: { level: "error", format: "json", bridgeToSpanLevel: "off" } },
   runtime: {

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -86,10 +86,6 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       refreshTokenExpiry: "30d",
       connectTokenExpiry: "10m",
     },
-    github: {
-      webhookSecret: "test-webhook-secret",
-      allowedOrg: "test-org",
-    },
     oauth: {
       github: {
         clientId: "test-github-client",

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -1,0 +1,464 @@
+import { createHmac } from "node:crypto";
+import bcrypt from "bcrypt";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { users } from "../db/schema/users.js";
+import { createAgent } from "../services/agent.js";
+import { signTokensForUser } from "../services/auth.js";
+import { isEncryptedValue } from "../services/crypto.js";
+import * as orgSettingsService from "../services/org-settings.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, INVALID_BCRYPT_PLACEHOLDER, useTestApp } from "./helpers.js";
+
+const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
+// 32 bytes hex — matches the crypto.parseKey contract.
+const TEST_ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("org-settings service", () => {
+  const getApp = useTestApp();
+
+  it("getOrgSetting returns namespace defaults when no row exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const ct = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree");
+    expect(ct).toEqual({ branch: "main" });
+
+    const gh = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "github_integration");
+    // webhookUrl is left as "" by the service; the route layer enriches it with publicUrl.
+    expect(gh).toEqual({ webhookSecretConfigured: false, webhookUrl: "" });
+  });
+
+  it("putOrgSetting stores context_tree and round-trips via getOrgSetting", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const out = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/tree", branch: "main" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    expect(out).toMatchObject({ repo: "https://github.com/example/tree", branch: "main" });
+
+    const re = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree");
+    expect(re).toEqual(out);
+  });
+
+  it("putOrgSetting input semantics: undefined unchanged, null clears, value sets", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/tree", branch: "v2" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    // undefined `repo` leaves it intact; null `branch` clears (server falls back to "main").
+    const after = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { branch: null },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    expect(after).toEqual({ repo: "https://github.com/example/tree", branch: "main" });
+  });
+
+  it("putOrgSetting encrypts webhook secret at rest; getOrgSetting masks it", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const out = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: "super-secret-123" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    expect(out).toEqual({ webhookSecretConfigured: true, webhookUrl: "" });
+
+    // Stored value never contains plaintext.
+    const [row] = await app.db
+      .select()
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "github_integration"),
+        ),
+      );
+    expect(row).toBeDefined();
+    const stored = row?.value as { webhookSecretCipher?: string };
+    expect(stored.webhookSecretCipher).toBeDefined();
+    expect(isEncryptedValue(stored.webhookSecretCipher ?? "")).toBe(true);
+    expect(stored.webhookSecretCipher).not.toContain("super-secret");
+
+    // Internal helper decrypts back to plaintext.
+    const decrypted = await orgSettingsService.getDecryptedGithubWebhookSecret(
+      app.db,
+      admin.organizationId,
+      TEST_ENCRYPTION_KEY,
+    );
+    expect(decrypted).toBe("super-secret-123");
+  });
+
+  it("putOrgSetting null webhookSecret clears the cipher", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: "first" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    const cleared = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: null },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    expect(cleared.webhookSecretConfigured).toBe(false);
+  });
+
+  it("rejects empty-string webhookSecret at the schema layer (#3)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await expect(
+      orgSettingsService.putOrgSetting(
+        app.db,
+        admin.organizationId,
+        "github_integration",
+        { webhookSecret: "" },
+        { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects empty-string repo at the schema layer (#3)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await expect(
+      orgSettingsService.putOrgSetting(
+        app.db,
+        admin.organizationId,
+        "context_tree",
+        { repo: "" },
+        { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("putOrgSetting bumps version on subsequent writes", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/a" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    const [v1] = await app.db
+      .select({ version: organizationSettings.version })
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree"),
+        ),
+      );
+    expect(v1?.version).toBe(1);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/b" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    const [v2] = await app.db
+      .select({ version: organizationSettings.version })
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree"),
+        ),
+      );
+    expect(v2?.version).toBe(2);
+  });
+
+  it("deleteOrgSetting drops the row; subsequent get returns defaults", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/example/x" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    await orgSettingsService.deleteOrgSetting(app.db, admin.organizationId, "context_tree");
+
+    const after = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree");
+    expect(after).toEqual({ branch: "main" });
+  });
+
+  it("rejects unknown namespace with BadRequestError", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await expect(orgSettingsService.getOrgSetting(app.db, admin.organizationId, "nope" as never)).rejects.toThrow(
+      /Unknown organization-settings namespace/,
+    );
+  });
+
+  it("rejects PUT against unknown org with NotFoundError", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await expect(
+      orgSettingsService.putOrgSetting(
+        app.db,
+        "00000000-0000-0000-0000-000000000000",
+        "context_tree",
+        { repo: "https://github.com/example/x" },
+        { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+      ),
+    ).rejects.toThrow(/Organization .* not found/);
+  });
+});
+
+describe("org-settings API (admin gating + masking)", () => {
+  const getApp = useTestApp();
+
+  async function adminAndMember(app: Awaited<ReturnType<typeof getApp>>) {
+    const admin = await createTestAdmin(app);
+
+    // Seed a second user joined to the same org with role "member".
+    const memberUserId = uuidv7();
+    const memberMemberId = uuidv7();
+    const username = `member-${memberUserId.slice(0, 8)}`;
+    const passwordHash = await bcrypt.hash("placeholder", 1).catch(() => INVALID_BCRYPT_PLACEHOLDER);
+    await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({ id: memberUserId, username, passwordHash, displayName: "Member" });
+      const humanAgent = await createAgent(tx as unknown as typeof app.db, {
+        name: `member-human-${memberUserId.slice(0, 8)}`,
+        type: "human",
+        displayName: "Member",
+        managerId: memberMemberId,
+        organizationId: admin.organizationId,
+      });
+      await tx.insert(members).values({
+        id: memberMemberId,
+        userId: memberUserId,
+        organizationId: admin.organizationId,
+        agentId: humanAgent.uuid,
+        role: "member",
+      });
+    });
+    const memberTokens = await signTokensForUser(TEST_JWT_SECRET, memberUserId, {
+      accessTokenExpiry: "30m",
+      refreshTokenExpiry: "30d",
+    });
+    return { admin, member: { ...memberTokens, userId: memberUserId } };
+  }
+
+  it("admin can GET, PUT, DELETE the namespace", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const url = `/api/v1/orgs/${admin.organizationId}/settings/context_tree`;
+
+    const get1 = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(get1.statusCode).toBe(200);
+    expect(get1.json()).toEqual({ branch: "main" });
+
+    const put = await app.inject({
+      method: "PUT",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { repo: "https://github.com/example/api", branch: "api" },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toMatchObject({ repo: "https://github.com/example/api", branch: "api" });
+
+    const del = await app.inject({
+      method: "DELETE",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(del.statusCode).toBe(204);
+
+    const get2 = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(get2.json()).toEqual({ branch: "main" });
+  });
+
+  it("non-admin member is forbidden from GET / PUT / DELETE", async () => {
+    const app = getApp();
+    const { admin, member } = await adminAndMember(app);
+    const url = `/api/v1/orgs/${admin.organizationId}/settings/context_tree`;
+
+    for (const method of ["GET", "PUT", "DELETE"] as const) {
+      const res = await app.inject({
+        method,
+        url,
+        headers: { authorization: `Bearer ${member.accessToken}` },
+        ...(method === "PUT" ? { payload: { branch: "x" } } : {}),
+      });
+      expect(res.statusCode, `${method} should be 403 for non-admin`).toBe(403);
+    }
+  });
+
+  it("unknown namespace returns 400", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/settings/nope`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("PUT webhookSecret then GET returns masked output (no plaintext)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const url = `/api/v1/orgs/${admin.organizationId}/settings/github_integration`;
+
+    const put = await app.inject({
+      method: "PUT",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { webhookSecret: "do-not-leak-me" },
+    });
+    expect(put.statusCode).toBe(200);
+    // webhookUrl is "" in tests because helpers.ts leaves server.publicUrl undefined.
+    expect(put.json()).toEqual({ webhookSecretConfigured: true, webhookUrl: "" });
+    expect(put.body).not.toContain("do-not-leak-me");
+
+    const get = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(get.json()).toEqual({ webhookSecretConfigured: true, webhookUrl: "" });
+    expect(get.body).not.toContain("do-not-leak-me");
+  });
+
+  it("PUT empty-string webhookSecret returns 400 (#3)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/v1/orgs/${admin.organizationId}/settings/github_integration`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { webhookSecret: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("github webhook end-to-end (per-org URL + signature)", () => {
+  const getApp = useTestApp();
+
+  it("POST /webhooks/github/:orgId with valid signature reaches the handler", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    // Configure a webhook secret for this org through the service layer.
+    const SECRET = "e2e-webhook-secret";
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: SECRET },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    // Send a `ping` event — minimal payload that the handler short-circuits on.
+    const body = JSON.stringify({ zen: "Practicality beats purity." });
+    const signature = `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": signature,
+        "x-github-event": "ping",
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, event: "ping" });
+  });
+
+  it("POST /webhooks/github/:orgId with bad signature returns 401", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: "real-secret" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    const body = JSON.stringify({ zen: "x" });
+    const wrongSignature = `sha256=${createHmac("sha256", "wrong-secret").update(body).digest("hex")}`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": wrongSignature,
+        "x-github-event": "ping",
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("POST /webhooks/github/:orgId returns 501 when secret never configured", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    // No webhookSecret put for this org — should fall through to 501.
+
+    const body = JSON.stringify({ zen: "x" });
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": `sha256=${createHmac("sha256", "anything").update(body).digest("hex")}`,
+        "x-github-event": "ping",
+      },
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(501);
+  });
+});

--- a/packages/server/src/api/bootstrap/config.ts
+++ b/packages/server/src/api/bootstrap/config.ts
@@ -1,10 +1,16 @@
 import type { FastifyInstance } from "fastify";
 
-export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void> {
-  /** Public endpoint — returns bootstrap prerequisites for CLI auto-discovery. */
-  app.get("/config", async () => {
-    return {
-      allowedOrg: app.config.github.allowedOrg ?? null,
-    };
+export async function bootstrapConfigRoutes(_app: FastifyInstance): Promise<void> {
+  /**
+   * Public endpoint — returns bootstrap prerequisites for CLI auto-discovery.
+   *
+   * `allowedOrg` used to surface here from the global `github.allowedOrg`
+   * config; it is now a per-org setting (see issue #255). A public bootstrap
+   * endpoint can't resolve an org without a caller, so the field is
+   * surfaced as `null` and consumers should fetch the per-org value via
+   * `/api/v1/orgs/:orgId/settings/github_integration` after auth.
+   */
+  _app.get("/config", async () => {
+    return { allowedOrg: null as string | null };
   });
 }

--- a/packages/server/src/api/context-tree-info.ts
+++ b/packages/server/src/api/context-tree-info.ts
@@ -1,10 +1,21 @@
 import type { FastifyInstance } from "fastify";
+import { requireUser } from "../scope/require-user.js";
+import { getOrgContextTree, resolveUserPrimaryOrgId } from "../services/org-settings.js";
 
 export async function contextTreeInfoRoutes(app: FastifyInstance): Promise<void> {
-  /** Public endpoint — returns Context Tree repo metadata for CLI auto-discovery. */
-  app.get("/info", async () => {
-    const repo = app.config.contextTree?.repo ?? null;
-    const branch = app.config.contextTree?.branch ?? null;
-    return { repo, branch };
+  /**
+   * Class A — `/api/v1/context-tree/info`. Returns the caller's
+   * organization-scoped Context Tree binding for CLI auto-discovery.
+   * Responds with `{ repo: null, branch: null }` when the user is not in
+   * any org or the org hasn't configured a tree yet.
+   */
+  app.get("/info", async (request) => {
+    const { userId } = requireUser(request);
+    const orgId = await resolveUserPrimaryOrgId(app.db, userId);
+    if (!orgId) {
+      return { repo: null, branch: null };
+    }
+    const tree = await getOrgContextTree(app.db, orgId);
+    return { repo: tree.repo ?? null, branch: tree.branch ?? null };
   });
 }

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -1,7 +1,9 @@
 import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
+import { requireUser } from "../scope/require-user.js";
 import { getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
+import { getOrgContextTree, resolveUserPrimaryOrgId } from "../services/org-settings.js";
 
 const querySchema = z
   .object({
@@ -23,7 +25,10 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
     },
     async (request) => {
       const query = querySchema.parse(request.query);
-      const snapshot = await getContextTreeSnapshot(app.config, query.window ?? "7d");
+      const { userId } = requireUser(request);
+      const orgId = await resolveUserPrimaryOrgId(app.db, userId);
+      const binding = orgId ? await getOrgContextTree(app.db, orgId) : {};
+      const snapshot = await getContextTreeSnapshot(binding, query.window ?? "7d");
       return contextTreeSnapshotSchema.parse(snapshot);
     },
   );

--- a/packages/server/src/api/orgs/settings.ts
+++ b/packages/server/src/api/orgs/settings.ts
@@ -1,0 +1,82 @@
+import {
+  isOrgSettingNamespace,
+  type OrgSettingNamespace,
+  type OrgSettingOutput,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import type { FastifyInstance } from "fastify";
+import { BadRequestError } from "../../errors.js";
+import { requireOrgAdmin } from "../../scope/require-org.js";
+import * as orgSettingsService from "../../services/org-settings.js";
+
+/**
+ * Class B — `/api/v1/orgs/:orgId/settings/:namespace`.
+ *
+ * Generic per-org settings surface. The `:namespace` URL parameter is
+ * dispatched against `ORG_SETTINGS_NAMESPACES` (in the shared package);
+ * adding a new config group only requires registering it there — no new
+ * route file.
+ *
+ * All three verbs are admin-only. Even GET, because the masked output
+ * still leaks "configured / not-configured" booleans for secret fields,
+ * which we don't want to expose to non-admin members.
+ */
+export async function orgSettingsRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Params: { orgId: string; namespace: string } }>("/:namespace", async (request) => {
+    const scope = await requireOrgAdmin(request, app.db);
+    const namespace = parseNamespace(request.params.namespace);
+    const out = await orgSettingsService.getOrgSetting(app.db, scope.organizationId, namespace);
+    return enrichOutput(namespace, out, scope.organizationId, app.config.server.publicUrl);
+  });
+
+  app.put<{ Params: { orgId: string; namespace: string } }>(
+    "/:namespace",
+    { config: { otelRecordBody: true } },
+    async (request) => {
+      const scope = await requireOrgAdmin(request, app.db);
+      const namespace = parseNamespace(request.params.namespace);
+      const out = await orgSettingsService.putOrgSetting(app.db, scope.organizationId, namespace, request.body, {
+        updatedBy: scope.userId,
+        encryptionKey: app.config.secrets.encryptionKey,
+      });
+      return enrichOutput(namespace, out, scope.organizationId, app.config.server.publicUrl);
+    },
+  );
+
+  app.delete<{ Params: { orgId: string; namespace: string } }>("/:namespace", async (request, reply) => {
+    const scope = await requireOrgAdmin(request, app.db);
+    const namespace = parseNamespace(request.params.namespace);
+    await orgSettingsService.deleteOrgSetting(app.db, scope.organizationId, namespace);
+    reply.status(204).send();
+  });
+}
+
+function parseNamespace(raw: string): OrgSettingNamespace {
+  if (!isOrgSettingNamespace(raw)) {
+    throw new BadRequestError(`Unknown organization-settings namespace: "${raw}"`);
+  }
+  return raw;
+}
+
+/**
+ * Resolve namespace-specific server-config-derived fields. The service
+ * layer stays config-agnostic — namespace knowledge that needs `app.config`
+ * lives here. Currently only `github_integration.webhookUrl` qualifies.
+ *
+ * If `server.publicUrl` is unset on the Hub, `webhookUrl` is left as `""`
+ * so the UI can render a "contact your site administrator" notice rather
+ * than fall back to `window.location.origin` (which is wrong behind a
+ * reverse proxy). (#12)
+ */
+function enrichOutput<K extends OrgSettingNamespace>(
+  namespace: K,
+  out: OrgSettingOutput<K>,
+  orgId: string,
+  publicUrl: string | undefined,
+): OrgSettingOutput<K> {
+  if (namespace === "github_integration") {
+    const o = out as OrgSettingOutput<"github_integration">;
+    const webhookUrl = publicUrl ? `${publicUrl.replace(/\/+$/, "")}/api/v1/webhooks/github/${orgId}` : "";
+    return { ...o, webhookUrl } as OrgSettingOutput<K>;
+  }
+  return out;
+}

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -9,7 +9,7 @@ import { createAgent } from "../../services/agent.js";
 import { findOrCreateDirectChat } from "../../services/chat.js";
 import { sendMessage } from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
-import { resolveDefaultOrgId } from "../../services/organization.js";
+import { getDecryptedGithubWebhookSecret } from "../../services/org-settings.js";
 
 const log = createLogger("GithubWebhook");
 
@@ -67,12 +67,11 @@ function verifySignature(secret: string, rawBody: Buffer, signatureHeader: strin
   }
 }
 
-async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
-  const defaultOrgId = await resolveDefaultOrgId(db);
+async function ensureGitHubAdapterAgent(db: Database, organizationId: string): Promise<string> {
   const [existing] = await db
     .select({ uuid: agents.uuid })
     .from(agents)
-    .where(and(eq(agents.organizationId, defaultOrgId), eq(agents.name, GITHUB_ADAPTER_ID)))
+    .where(and(eq(agents.organizationId, organizationId), eq(agents.name, GITHUB_ADAPTER_ID)))
     .limit(1);
 
   if (existing) {
@@ -84,7 +83,7 @@ async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
       name: GITHUB_ADAPTER_ID,
       type: "autonomous_agent",
       displayName: "GitHub Adapter",
-      organizationId: defaultOrgId,
+      organizationId,
       metadata: { source: "github", managed: true },
     });
     return agent.uuid;
@@ -94,7 +93,7 @@ async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
       const [created] = await db
         .select({ uuid: agents.uuid })
         .from(agents)
-        .where(and(eq(agents.organizationId, defaultOrgId), eq(agents.name, GITHUB_ADAPTER_ID)))
+        .where(and(eq(agents.organizationId, organizationId), eq(agents.name, GITHUB_ADAPTER_ID)))
         .limit(1);
       if (created) return created.uuid;
     }
@@ -102,12 +101,12 @@ async function ensureGitHubAdapterAgent(db: Database): Promise<string> {
   }
 }
 
-async function findTargetAgent(db: Database, repoFullName: string): Promise<string | null> {
+async function findTargetAgent(db: Database, organizationId: string, repoFullName: string): Promise<string | null> {
   // First: look for an agent whose metadata has github.repos containing the repo full_name
   const allAgents = await db
     .select({ id: agents.uuid, name: agents.name, metadata: agents.metadata, type: agents.type })
     .from(agents)
-    .where(eq(agents.status, "active"));
+    .where(and(eq(agents.organizationId, organizationId), eq(agents.status, "active")));
 
   for (const agent of allAgents) {
     if (agent.name === GITHUB_ADAPTER_ID) continue;
@@ -161,6 +160,7 @@ type MentionContext = {
  */
 async function routeMentionDelegations(
   app: FastifyInstance,
+  organizationId: string,
   mentionedNames: string[],
   ctx: MentionContext,
 ): Promise<number> {
@@ -175,7 +175,13 @@ async function routeMentionDelegations(
       status: agents.status,
     })
     .from(agents)
-    .where(and(inArray(agents.name, mentionedNames), isNotNull(agents.delegateMention)));
+    .where(
+      and(
+        eq(agents.organizationId, organizationId),
+        inArray(agents.name, mentionedNames),
+        isNotNull(agents.delegateMention),
+      ),
+    );
 
   let routed = 0;
   for (const agent of delegates) {
@@ -290,18 +296,24 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
     done(null, body);
   });
 
-  const webhookSecret = app.config.github.webhookSecret;
   const webhookMax = app.config.rateLimit?.webhookMax ?? 60;
 
-  app.post(
-    "/github",
+  app.post<{ Params: { orgId: string } }>(
+    "/github/:orgId",
     { config: { rateLimit: { max: webhookMax, timeWindow: "1 minute" } } },
     async (request, reply) => {
-      // Webhook secret not configured — reject requests
+      const { orgId } = request.params;
+
+      // Resolve the per-org webhook secret. Missing org and "secret not
+      // configured" both fall through to the same 501 — the orgId is in
+      // the URL already and timing differentiation here wouldn't buy real
+      // defense (UUID v7 is not enumerable). (#5)
+      const webhookSecret = await getDecryptedGithubWebhookSecret(app.db, orgId, app.config.secrets.encryptionKey);
       if (!webhookSecret) {
-        return reply
-          .status(501)
-          .send({ error: "GitHub webhook is not configured. Set FIRST_TREE_HUB_GITHUB_WEBHOOK_SECRET to enable." });
+        return reply.status(501).send({
+          error:
+            "GitHub webhook is not configured for this organization. An admin must set the webhook secret in Team settings.",
+        });
       }
 
       const rawBody = request.body;
@@ -336,11 +348,11 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
 
       // --- Event-specific handlers (mention delegation runs inside, after action gating) ---
       if (eventType === "issues") {
-        return handleIssuesEvent(app, eventType, payload, reply);
+        return handleIssuesEvent(app, orgId, eventType, payload, reply);
       }
 
       if (eventType === "issue_comment") {
-        return handleIssueCommentEvent(app, eventType, payload, reply);
+        return handleIssueCommentEvent(app, orgId, eventType, payload, reply);
       }
 
       // Other event types with @mention support (PRs, discussions, reviews, etc.)
@@ -349,7 +361,7 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
       const allowedActions = MENTION_ACTIONS[eventType];
       const action = isRecord(payload) && typeof payload.action === "string" ? payload.action : undefined;
       if (allowedActions && action && allowedActions.includes(action)) {
-        mentionsRouted = await handleMentionDelegation(app, eventType, payload);
+        mentionsRouted = await handleMentionDelegation(app, orgId, eventType, payload);
       }
       return reply.status(200).send({ ok: true, event: eventType, handled: mentionsRouted > 0, mentionsRouted });
     },
@@ -508,12 +520,17 @@ function extractEventContext(eventType: string, payload: unknown): MentionContex
  * Run mention delegation for a given event type and payload.
  * Only called after action gating confirms this is a "new content" event.
  */
-async function handleMentionDelegation(app: FastifyInstance, eventType: string, payload: unknown): Promise<number> {
+async function handleMentionDelegation(
+  app: FastifyInstance,
+  organizationId: string,
+  eventType: string,
+  payload: unknown,
+): Promise<number> {
   const mentionText = extractEventText(eventType, payload);
   const mentions = extractMentions(mentionText);
   const mentionCtx = extractEventContext(eventType, payload);
   if (mentions.length > 0 && mentionCtx) {
-    return routeMentionDelegations(app, mentions, mentionCtx);
+    return routeMentionDelegations(app, organizationId, mentions, mentionCtx);
   }
   return 0;
 }
@@ -532,6 +549,7 @@ const MENTION_ACTIONS: Record<string, string[]> = {
 
 async function handleIssuesEvent(
   app: FastifyInstance,
+  organizationId: string,
   eventType: string,
   payload: unknown,
   reply: FastifyReply,
@@ -540,7 +558,7 @@ async function handleIssuesEvent(
 
   // Mention delegation — only on new/changed content
   if (MENTION_ACTIONS.issues?.includes(data.action)) {
-    await handleMentionDelegation(app, eventType, payload);
+    await handleMentionDelegation(app, organizationId, eventType, payload);
   }
 
   // Only handle specific actions for repo-targeted routing
@@ -550,8 +568,8 @@ async function handleIssuesEvent(
   }
 
   const [senderId, targetAgentId] = await Promise.all([
-    ensureGitHubAdapterAgent(app.db),
-    findTargetAgent(app.db, data.repository.full_name),
+    ensureGitHubAdapterAgent(app.db, organizationId),
+    findTargetAgent(app.db, organizationId, data.repository.full_name),
   ]);
 
   if (!targetAgentId) {
@@ -594,6 +612,7 @@ async function handleIssuesEvent(
 
 async function handleIssueCommentEvent(
   app: FastifyInstance,
+  organizationId: string,
   eventType: string,
   payload: unknown,
   reply: FastifyReply,
@@ -602,7 +621,7 @@ async function handleIssueCommentEvent(
 
   // Mention delegation — only on new comments
   if (MENTION_ACTIONS.issue_comment?.includes(data.action)) {
-    await handleMentionDelegation(app, eventType, payload);
+    await handleMentionDelegation(app, organizationId, eventType, payload);
   }
 
   // Only handle "created" action for repo-targeted routing
@@ -611,8 +630,8 @@ async function handleIssueCommentEvent(
   }
 
   const [senderId, targetAgentId] = await Promise.all([
-    ensureGitHubAdapterAgent(app.db),
-    findTargetAgent(app.db, data.repository.full_name),
+    ensureGitHubAdapterAgent(app.db, organizationId),
+    findTargetAgent(app.db, organizationId, data.repository.full_name),
   ]);
 
   if (!targetAgentId) {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -50,6 +50,7 @@ import { orgMemberRoutes } from "./api/orgs/members.js";
 import { orgNotificationRoutes } from "./api/orgs/notifications.js";
 import { orgOverviewRoutes } from "./api/orgs/overview.js";
 import { orgSessionRoutes } from "./api/orgs/sessions.js";
+import { orgSettingsRoutes } from "./api/orgs/settings.js";
 import { orgTaskRoutes } from "./api/orgs/tasks.js";
 import { orgWsRoutes } from "./api/orgs/ws.js";
 import { sessionRoutes } from "./api/sessions.js";
@@ -416,12 +417,12 @@ export async function buildApp(config: Config) {
       await api.register(authRoutes, { prefix: "/auth" });
       await api.register(githubOauthRoutes, { prefix: "/auth/github" });
       await api.register(publicInvitationRoutes, { prefix: "/invitations" });
-      await api.register(contextTreeInfoRoutes, { prefix: "/context-tree" });
       await api.register(bootstrapConfigRoutes, { prefix: "/bootstrap" });
 
       // ── Class A — `/me`, `/auth` (user-scoped) ──────────────────────────
       await api.register(
         userScope("contextTreeScope", async (scope) => {
+          await scope.register(contextTreeInfoRoutes);
           await scope.register(contextTreeSnapshotRoutes);
         }),
         { prefix: "/context-tree" },
@@ -451,6 +452,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgClientRoutes, { prefix: "/clients" });
           await scope.register(orgInvitationRoutes, { prefix: "/invitations" });
           await scope.register(orgMemberRoutes, { prefix: "/members" });
+          await scope.register(orgSettingsRoutes, { prefix: "/settings" });
         }),
         { prefix: "/orgs/:orgId" },
       );

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -14,6 +14,7 @@ export { invitationRedemptions, invitations } from "./invitations.js";
 export { members } from "./members.js";
 export { messages } from "./messages.js";
 export { notifications } from "./notifications.js";
+export { organizationSettings } from "./organization-settings.js";
 export { organizations } from "./organizations.js";
 export { serverInstances } from "./server-instances.js";
 export { sessionEvents } from "./session-events.js";

--- a/packages/server/src/db/schema/organization-settings.ts
+++ b/packages/server/src/db/schema/organization-settings.ts
@@ -1,0 +1,42 @@
+import { index, integer, jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations.js";
+import { users } from "./users.js";
+
+/**
+ * Per-organization settings, keyed by `(organization_id, namespace)`.
+ *
+ * One row holds an entire group of related config as a JSONB blob — schema
+ * for each namespace lives in `@agent-team-foundation/first-tree-hub-shared`
+ * (`ORG_SETTINGS_NAMESPACES`) and is enforced by the service layer on every
+ * read/write. Adding a new config group means registering a new namespace +
+ * Zod schema in shared; the DB does not change.
+ *
+ * `version` is reserved for future optimistic locking (PUT with If-Match)
+ * and is currently set unconditionally. We keep it on the table from day
+ * one so tightening to compare-and-swap later is a code-only change.
+ *
+ * Sensitive fields inside `value` (e.g. `github_integration.webhookSecret`)
+ * are AES-256-GCM-encrypted at the service layer using `crypto.ts`'s
+ * `encryptValue` / `decryptValue` — same pattern as `adapter_configs`.
+ */
+export const organizationSettings = pgTable(
+  "organization_settings",
+  {
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    /** e.g. "context_tree" | "github_integration"; validated by shared registry. */
+    namespace: text("namespace").notNull(),
+    /** Whole-group config JSON; schema-validated by namespace at the service layer. */
+    value: jsonb("value").$type<Record<string, unknown>>().notNull().default({}),
+    /** Reserved for optimistic locking; not enforced yet. */
+    version: integer("version").notNull().default(0),
+    /** User id of last writer; null if seeded by the migration helper. */
+    updatedBy: text("updated_by").references(() => users.id, { onDelete: "set null" }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.organizationId, table.namespace] }),
+    index("idx_org_settings_namespace").on(table.namespace),
+  ],
+);

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -14,7 +14,6 @@ import type {
   ContextTreeUpdate,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import matter from "gray-matter";
-import type { Config } from "../config.js";
 
 const execFileAsync = promisify(execFile);
 const ROOT_NODE_ID = "root";
@@ -84,13 +83,24 @@ type SnapshotCacheEntry = {
 
 const snapshotCache = new Map<string, SnapshotCacheEntry>();
 
+/**
+ * Per-organization Context Tree binding. Resolved from `organization_settings`
+ * by the calling route — this service stays decoupled from any single-tenant
+ * global config so each org gets its own tree.
+ */
+export type ContextTreeBinding = {
+  repo?: string;
+  branch?: string;
+  localPath?: string;
+};
+
 export async function getContextTreeSnapshot(
-  config: Config,
+  binding: ContextTreeBinding,
   window: ContextTreeSnapshotWindow = CONTEXT_TREE_SNAPSHOT_WINDOWS.SEVEN_DAYS,
 ): Promise<ContextTreeSnapshot> {
-  const repo = config.contextTree?.repo ?? null;
-  const branch = config.contextTree?.branch ?? null;
-  const resolved = resolveContextTreeRoot(repo, config.contextTree?.localPath);
+  const repo = binding.repo ?? null;
+  const branch = binding.branch ?? null;
+  const resolved = resolveContextTreeRoot(repo, binding.localPath);
 
   if (!resolved.root) {
     return unavailableSnapshot(repo, branch, resolved.reason);

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -1,0 +1,266 @@
+import {
+  isOrgSettingNamespace,
+  ORG_SETTINGS_NAMESPACES,
+  type OrgContextTreeStorage,
+  type OrgSettingInput,
+  type OrgSettingNamespace,
+  type OrgSettingOutput,
+  type OrgSettingStorage,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { and, asc, eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { organizations } from "../db/schema/organizations.js";
+import { BadRequestError, NotFoundError } from "../errors.js";
+import { decryptValue, encryptValue, isEncryptedValue } from "./crypto.js";
+
+/**
+ * Per-organization settings, keyed by `(organizationId, namespace)`. The
+ * registry of valid namespaces and their storage / input / output schemas
+ * lives in `@agent-team-foundation/first-tree-hub-shared`.
+ *
+ * Read path:  storage row → decrypt secrets → output (mask)
+ * Write path: input → validate → encrypt secrets → merge with current storage → upsert (in tx)
+ *
+ * The generic getter returns the masked output. Callers needing plaintext
+ * for a specific secret use a purpose-built helper (e.g.
+ * `getDecryptedGithubWebhookSecret`) rather than the generic storage shape
+ * — this avoids a `…Cipher` field name silently holding plaintext at
+ * call-sites and limits secret exposure to one explicit code path per
+ * secret. (#4)
+ */
+
+function assertNamespace(ns: string): asserts ns is OrgSettingNamespace {
+  if (!isOrgSettingNamespace(ns)) {
+    throw new BadRequestError(`Unknown organization-settings namespace: "${ns}"`);
+  }
+}
+
+async function fetchStorageRow<K extends OrgSettingNamespace>(
+  db: Database,
+  orgId: string,
+  namespace: K,
+): Promise<OrgSettingStorage<K> | null> {
+  const [row] = await db
+    .select({ value: organizationSettings.value })
+    .from(organizationSettings)
+    .where(and(eq(organizationSettings.organizationId, orgId), eq(organizationSettings.namespace, namespace)))
+    .limit(1);
+  if (!row) return null;
+  const schema = ORG_SETTINGS_NAMESPACES[namespace].storage;
+  return schema.parse(row.value) as OrgSettingStorage<K>;
+}
+
+function emptyStorage<K extends OrgSettingNamespace>(namespace: K): OrgSettingStorage<K> {
+  // The storage schema's `.parse({})` fills in any defaults (e.g. context_tree.branch="main").
+  const schema = ORG_SETTINGS_NAMESPACES[namespace].storage;
+  return schema.parse({}) as OrgSettingStorage<K>;
+}
+
+function ensureEncrypted(value: string, encryptionKey: string): string {
+  return isEncryptedValue(value) ? value : encryptValue(value, encryptionKey);
+}
+
+/**
+ * Merge a validated input into the current storage row for a namespace.
+ * Secret fields are encrypted here.
+ *
+ * Input semantics per nullish field:
+ *   `undefined` → unchanged
+ *   `null`      → cleared
+ *   value       → set / replace (already validated as non-empty by the input schema)
+ */
+function applyInputDelta<K extends OrgSettingNamespace>(
+  namespace: K,
+  current: OrgSettingStorage<K>,
+  input: OrgSettingInput<K>,
+  encryptionKey: string,
+): OrgSettingStorage<K> {
+  if (namespace === "context_tree") {
+    const cur = current as OrgSettingStorage<"context_tree">;
+    const inp = input as OrgSettingInput<"context_tree">;
+    const next: OrgSettingStorage<"context_tree"> = {
+      repo: inp.repo === undefined ? cur.repo : (inp.repo ?? undefined),
+      branch: inp.branch === undefined ? cur.branch : (inp.branch ?? "main"),
+    };
+    return next as OrgSettingStorage<K>;
+  }
+  if (namespace === "github_integration") {
+    const cur = current as OrgSettingStorage<"github_integration">;
+    const inp = input as OrgSettingInput<"github_integration">;
+    const next: OrgSettingStorage<"github_integration"> = {
+      webhookSecretCipher:
+        inp.webhookSecret === undefined
+          ? cur.webhookSecretCipher
+          : inp.webhookSecret === null
+            ? undefined
+            : ensureEncrypted(inp.webhookSecret, encryptionKey),
+    };
+    return next as OrgSettingStorage<K>;
+  }
+  // Exhaustiveness — adding a new namespace forces a compile error here.
+  const _exhaustive: never = namespace;
+  return _exhaustive;
+}
+
+/**
+ * Project the storage row into the API output for a namespace, masking
+ * any secret fields. `webhookUrl` for `github_integration` is left as an
+ * empty string here — the route layer enriches it with the resolved
+ * `server.publicUrl` (the service stays config-agnostic).
+ */
+function toOutput<K extends OrgSettingNamespace>(namespace: K, storage: OrgSettingStorage<K>): OrgSettingOutput<K> {
+  if (namespace === "context_tree") {
+    const s = storage as OrgSettingStorage<"context_tree">;
+    const out: OrgSettingOutput<"context_tree"> = {
+      repo: s.repo,
+      branch: s.branch,
+    };
+    return out as OrgSettingOutput<K>;
+  }
+  if (namespace === "github_integration") {
+    const s = storage as OrgSettingStorage<"github_integration">;
+    const out: OrgSettingOutput<"github_integration"> = {
+      webhookSecretConfigured: typeof s.webhookSecretCipher === "string" && s.webhookSecretCipher.length > 0,
+      webhookUrl: "",
+    };
+    return out as OrgSettingOutput<K>;
+  }
+  const _exhaustive: never = namespace;
+  return _exhaustive;
+}
+
+/**
+ * Read a setting masked for the API. Missing rows → namespace defaults
+ * (parse `{}` against the storage schema).
+ */
+export async function getOrgSetting<K extends OrgSettingNamespace>(
+  db: Database,
+  orgId: string,
+  namespace: K,
+): Promise<OrgSettingOutput<K>> {
+  assertNamespace(namespace);
+  const storage = (await fetchStorageRow(db, orgId, namespace)) ?? emptyStorage(namespace);
+  return toOutput(namespace, storage);
+}
+
+/**
+ * Read the per-org Context Tree binding for server-internal consumers
+ * (`/context-tree/info`, snapshot service). No secrets in this namespace,
+ * so the storage shape is safe to expose directly. Missing row → defaults.
+ */
+export async function getOrgContextTree(db: Database, orgId: string): Promise<OrgContextTreeStorage> {
+  return (await fetchStorageRow(db, orgId, "context_tree")) ?? emptyStorage("context_tree");
+}
+
+/**
+ * Decrypt and return the plaintext GitHub webhook secret for an org.
+ * Returns `null` when the org has not configured one. The only intended
+ * caller is the webhook route's signature verifier — the result must
+ * never leak through HTTP responses or logs. (#4)
+ */
+export async function getDecryptedGithubWebhookSecret(
+  db: Database,
+  orgId: string,
+  encryptionKey: string,
+): Promise<string | null> {
+  const storage = await fetchStorageRow(db, orgId, "github_integration");
+  const cipher = storage?.webhookSecretCipher;
+  if (!cipher) return null;
+  return isEncryptedValue(cipher) ? decryptValue(cipher, encryptionKey) : cipher;
+}
+
+/**
+ * Upsert a setting. Returns the masked output of the resulting row.
+ *
+ * The fetch + merge + upsert sequence runs inside a single transaction so
+ * two concurrent admin writes can't both base their delta on the same
+ * pre-image and silently lose each other's fields. Optimistic locking
+ * (the `version` column) remains reserved for a future If-Match flip.
+ * (#6)
+ */
+export async function putOrgSetting<K extends OrgSettingNamespace>(
+  db: Database,
+  orgId: string,
+  namespace: K,
+  rawInput: unknown,
+  options: { updatedBy: string; encryptionKey: string },
+): Promise<OrgSettingOutput<K>> {
+  assertNamespace(namespace);
+
+  const inputSchema = ORG_SETTINGS_NAMESPACES[namespace].input;
+  const input = inputSchema.parse(rawInput) as OrgSettingInput<K>;
+
+  return db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
+    const [org] = await txDb
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+    if (!org) {
+      throw new NotFoundError(`Organization "${orgId}" not found`);
+    }
+
+    const current = (await fetchStorageRow(txDb, orgId, namespace)) ?? emptyStorage(namespace);
+    const merged = applyInputDelta(namespace, current, input, options.encryptionKey);
+
+    // Final shape check (defensive — should always pass after applyInputDelta).
+    const storageSchema = ORG_SETTINGS_NAMESPACES[namespace].storage;
+    const validated = storageSchema.parse(merged) as OrgSettingStorage<K>;
+
+    await tx
+      .insert(organizationSettings)
+      .values({
+        organizationId: orgId,
+        namespace,
+        value: validated as Record<string, unknown>,
+        version: 1,
+        updatedBy: options.updatedBy,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [organizationSettings.organizationId, organizationSettings.namespace],
+        set: {
+          value: validated as Record<string, unknown>,
+          version: sql`${organizationSettings.version} + 1`,
+          updatedBy: options.updatedBy,
+          updatedAt: new Date(),
+        },
+      });
+
+    return toOutput(namespace, validated);
+  });
+}
+
+/**
+ * Delete a namespace row; subsequent GETs return defaults.
+ */
+export async function deleteOrgSetting(db: Database, orgId: string, namespace: string): Promise<void> {
+  assertNamespace(namespace);
+  await db
+    .delete(organizationSettings)
+    .where(and(eq(organizationSettings.organizationId, orgId), eq(organizationSettings.namespace, namespace)));
+}
+
+/**
+ * Resolve the caller's "primary org" — the earliest-joined active
+ * membership for the given user. Used by user-scoped routes that
+ * historically didn't take an `:orgId` (e.g. `/context-tree/info`) so
+ * the SDK call shape doesn't have to change while the per-tenant lookup
+ * still happens correctly.
+ *
+ * Returns `null` for users with no active membership. Tightening to
+ * "explicit org selector" is a future change-once-multi-org-clients-arrive
+ * concern. (#7)
+ */
+export async function resolveUserPrimaryOrgId(db: Database, userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ organizationId: members.organizationId })
+    .from(members)
+    .where(and(eq(members.userId, userId), eq(members.status, "active")))
+    .orderBy(asc(members.createdAt))
+    .limit(1);
+  return row?.organizationId ?? null;
+}

--- a/packages/shared/src/config/__tests__/resolver.test.ts
+++ b/packages/shared/src/config/__tests__/resolver.test.ts
@@ -15,7 +15,6 @@ import {
   setConfigValue,
 } from "../resolver.js";
 import { defineConfig, field, optional } from "../schema.js";
-import { serverConfigSchema } from "../server-config.js";
 import { getConfig, resetConfig } from "../singleton.js";
 
 let testDir: string;
@@ -248,23 +247,6 @@ describe("optional groups", () => {
 
     expect(config.extra?.repo).toBe("org/repo");
     expect(config.extra?.branch).toBe("main");
-  });
-});
-
-describe("server contextTree config", () => {
-  it("activates contextTree from FIRST_TREE_HUB_CONTEXT_TREE_PATH without requiring repo", async () => {
-    vi.stubEnv("FIRST_TREE_HUB_DATABASE_URL", "postgresql://user:pass@localhost:5432/hub");
-    vi.stubEnv("FIRST_TREE_HUB_CONTEXT_TREE_PATH", "/tmp/first-tree-context");
-
-    const config = await initConfig({
-      schema: serverConfigSchema,
-      role: "server",
-      configDir: testDir,
-    });
-
-    expect(config.contextTree?.localPath).toBe("/tmp/first-tree-context");
-    expect(config.contextTree?.repo).toBeUndefined();
-    expect(config.contextTree?.branch).toBe("main");
   });
 });
 

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -61,25 +61,10 @@ export const serverConfigSchema = defineConfig({
     refreshTokenExpiry: field(z.string().default("30d"), { env: "FIRST_TREE_HUB_AUTH_REFRESH_TOKEN_EXPIRY" }),
     connectTokenExpiry: field(z.string().default("10m"), { env: "FIRST_TREE_HUB_AUTH_CONNECT_TOKEN_EXPIRY" }),
   },
-  contextTree: optional({
-    repo: field(z.string().optional(), {
-      env: "FIRST_TREE_HUB_CONTEXT_TREE_REPO",
-      prompt: { message: "Context Tree repo URL (e.g. https://github.com/org/first-tree):" },
-    }),
-    localPath: field(z.string().optional(), {
-      env: "FIRST_TREE_HUB_CONTEXT_TREE_PATH",
-    }),
-    branch: field(z.string().default("main")),
-  }),
-  github: {
-    webhookSecret: field(z.string().optional(), {
-      env: "FIRST_TREE_HUB_GITHUB_WEBHOOK_SECRET",
-      secret: true,
-    }),
-    allowedOrg: field(z.string().optional(), {
-      env: "FIRST_TREE_HUB_GITHUB_ALLOWED_ORG",
-    }),
-  },
+  // Context Tree (repo / branch / localPath) and GitHub integration
+  // (webhook secret / allowed org) used to live here as global config.
+  // They are now per-org settings in the `organization_settings` table —
+  // admins configure them through Team Settings. See issue #255.
   oauth: optional({
     /**
      * GitHub OAuth App credentials for SaaS sign-in. The "half configured"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -327,6 +327,28 @@ export {
   githubStartQuerySchema,
 } from "./schemas/oauth.js";
 export {
+  isOrgSettingNamespace,
+  ORG_SETTINGS_NAMESPACE_KEYS,
+  ORG_SETTINGS_NAMESPACES,
+  type OrgContextTreeInput,
+  type OrgContextTreeOutput,
+  type OrgContextTreeStorage,
+  type OrgGithubIntegrationInput,
+  type OrgGithubIntegrationOutput,
+  type OrgGithubIntegrationStorage,
+  type OrgSettingInput,
+  type OrgSettingNamespace,
+  type OrgSettingOutput,
+  type OrgSettingStorage,
+  orgContextTreeInputSchema,
+  orgContextTreeOutputSchema,
+  orgContextTreeStorageSchema,
+  orgGithubIntegrationInputSchema,
+  orgGithubIntegrationOutputSchema,
+  orgGithubIntegrationStorageSchema,
+  orgSettingNamespaceSchema,
+} from "./schemas/org-settings.js";
+export {
   type CreateOrganization,
   type CreateOrganizationInput,
   createOrganizationSchema,

--- a/packages/shared/src/schemas/org-settings.ts
+++ b/packages/shared/src/schemas/org-settings.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+/**
+ * Per-organization settings — schemas, namespaces, and the registry that
+ * dispatches `(orgId, namespace)` lookups to the right validator.
+ *
+ * Each namespace has three schemas:
+ *   - `storage` — what is persisted in `organization_settings.value`. For
+ *     namespaces with secrets, the storage schema names the *cipher* field
+ *     (e.g. `webhookSecretCipher`); plaintext never touches the row.
+ *   - `input`   — what the admin API accepts in PUT bodies. For namespaces
+ *     with secrets, `webhookSecret` is plaintext; the service layer
+ *     encrypts it before merging into storage.
+ *   - `output`  — what GET returns. Secrets are replaced by a boolean
+ *     `…Configured` flag — plaintext is never echoed.
+ *
+ * Adding a new per-org config group:
+ *   1. Define three schemas (storage / input / output).
+ *   2. Add a key to `ORG_SETTINGS_NAMESPACES`.
+ *   3. Done. No DB migration, no new API route.
+ */
+
+// Empty / whitespace-only strings on the input layer mean "no change is
+// being requested" rather than "set this field to an empty value" — the
+// service layer coerces them to `null` (which means *clear*) only on the
+// explicit `null` form. Users who want to clear a field send `null`,
+// users who pass `""` get a validation error from `min(1)` below.
+
+// -- context_tree --
+
+export const orgContextTreeStorageSchema = z.object({
+  repo: z.string().url().optional(),
+  branch: z.string().default("main"),
+});
+
+export const orgContextTreeInputSchema = z.object({
+  /** Set / replace (must be a valid URL). `null` clears. `undefined` leaves unchanged. */
+  repo: z.string().url().min(1).nullish(),
+  /** Set / replace (non-empty). `null` clears (server falls back to "main"). `undefined` leaves unchanged. */
+  branch: z.string().min(1).nullish(),
+});
+
+export const orgContextTreeOutputSchema = z.object({
+  repo: z.string().optional(),
+  branch: z.string().optional(),
+});
+
+// -- github_integration --
+
+export const orgGithubIntegrationStorageSchema = z.object({
+  /** AES-256-GCM ciphertext via crypto.ts.encryptValue. Plaintext is never persisted. */
+  webhookSecretCipher: z.string().optional(),
+});
+
+export const orgGithubIntegrationInputSchema = z.object({
+  /**
+   * Plaintext webhook secret.
+   *   non-empty string — set / replace
+   *   `null`           — clear
+   *   `undefined`      — leave unchanged
+   * Empty strings are rejected so the panel can't accidentally lock the
+   * webhook into a "configured but never-validates" state (#3).
+   */
+  webhookSecret: z.string().min(1).nullish(),
+});
+
+export const orgGithubIntegrationOutputSchema = z.object({
+  webhookSecretConfigured: z.boolean(),
+  /**
+   * Hub-resolved webhook URL surfaced to the admin UI. Empty string when
+   * `server.publicUrl` is unset on the Hub — UI must show a "contact your
+   * site administrator" notice in that case rather than fall back to
+   * `window.location.origin` (which fails behind reverse proxies).
+   */
+  webhookUrl: z.string(),
+});
+
+// -- registry --
+
+export const ORG_SETTINGS_NAMESPACES = {
+  context_tree: {
+    storage: orgContextTreeStorageSchema,
+    input: orgContextTreeInputSchema,
+    output: orgContextTreeOutputSchema,
+  },
+  github_integration: {
+    storage: orgGithubIntegrationStorageSchema,
+    input: orgGithubIntegrationInputSchema,
+    output: orgGithubIntegrationOutputSchema,
+  },
+} as const;
+
+export const ORG_SETTINGS_NAMESPACE_KEYS = Object.keys(ORG_SETTINGS_NAMESPACES) as ReadonlyArray<
+  keyof typeof ORG_SETTINGS_NAMESPACES
+>;
+
+export type OrgSettingNamespace = keyof typeof ORG_SETTINGS_NAMESPACES;
+
+export type OrgSettingStorage<K extends OrgSettingNamespace> = z.infer<(typeof ORG_SETTINGS_NAMESPACES)[K]["storage"]>;
+export type OrgSettingInput<K extends OrgSettingNamespace> = z.infer<(typeof ORG_SETTINGS_NAMESPACES)[K]["input"]>;
+export type OrgSettingOutput<K extends OrgSettingNamespace> = z.infer<(typeof ORG_SETTINGS_NAMESPACES)[K]["output"]>;
+
+export type OrgContextTreeStorage = OrgSettingStorage<"context_tree">;
+export type OrgContextTreeInput = OrgSettingInput<"context_tree">;
+export type OrgContextTreeOutput = OrgSettingOutput<"context_tree">;
+
+export type OrgGithubIntegrationStorage = OrgSettingStorage<"github_integration">;
+export type OrgGithubIntegrationInput = OrgSettingInput<"github_integration">;
+export type OrgGithubIntegrationOutput = OrgSettingOutput<"github_integration">;
+
+export const orgSettingNamespaceSchema = z.enum(
+  ORG_SETTINGS_NAMESPACE_KEYS as [OrgSettingNamespace, ...OrgSettingNamespace[]],
+);
+
+export function isOrgSettingNamespace(value: unknown): value is OrgSettingNamespace {
+  return typeof value === "string" && (ORG_SETTINGS_NAMESPACE_KEYS as ReadonlyArray<string>).includes(value);
+}

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -206,5 +206,6 @@ export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body?: unknown) => request<T>(path, { method: "POST", body }),
   patch: <T>(path: string, body?: unknown) => request<T>(path, { method: "PATCH", body }),
+  put: <T>(path: string, body?: unknown) => request<T>(path, { method: "PUT", body }),
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
 };

--- a/packages/web/src/api/org-settings.ts
+++ b/packages/web/src/api/org-settings.ts
@@ -1,0 +1,38 @@
+import type {
+  OrgContextTreeInput,
+  OrgContextTreeOutput,
+  OrgGithubIntegrationInput,
+  OrgGithubIntegrationOutput,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { api } from "./client.js";
+
+function path(orgId: string, namespace: string): string {
+  return `/orgs/${encodeURIComponent(orgId)}/settings/${encodeURIComponent(namespace)}`;
+}
+
+export function getContextTreeSetting(orgId: string): Promise<OrgContextTreeOutput> {
+  return api.get<OrgContextTreeOutput>(path(orgId, "context_tree"));
+}
+
+export function putContextTreeSetting(orgId: string, body: OrgContextTreeInput): Promise<OrgContextTreeOutput> {
+  return api.put<OrgContextTreeOutput>(path(orgId, "context_tree"), body);
+}
+
+export function deleteContextTreeSetting(orgId: string): Promise<void> {
+  return api.delete<void>(path(orgId, "context_tree"));
+}
+
+export function getGithubIntegrationSetting(orgId: string): Promise<OrgGithubIntegrationOutput> {
+  return api.get<OrgGithubIntegrationOutput>(path(orgId, "github_integration"));
+}
+
+export function putGithubIntegrationSetting(
+  orgId: string,
+  body: OrgGithubIntegrationInput,
+): Promise<OrgGithubIntegrationOutput> {
+  return api.put<OrgGithubIntegrationOutput>(path(orgId, "github_integration"), body);
+}
+
+export function deleteGithubIntegrationSetting(orgId: string): Promise<void> {
+  return api.delete<void>(path(orgId, "github_integration"));
+}

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -1,51 +1,50 @@
-import type { Organization } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
-import { getOrganization, updateOrganization } from "../api/organizations.js";
+import { getContextTreeSetting, putContextTreeSetting } from "../api/org-settings.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { FlatSectionHeader } from "../components/ui/flat-section-header.js";
 
 /**
- * Admin-only panel for renaming the team (`organizations.display_name` and
- * the URL slug `organizations.name`). Implements proposal §决策 #17.
+ * Admin-only panel for the per-org Context Tree binding (repo / branch /
+ * localPath). Replaces the legacy global FIRST_TREE_HUB_CONTEXT_TREE_*
+ * env vars; each org now points at its own tree.
  *
- * The auto-provisioned default team's name is the user's GitHub login
- * (slug) and real name (display name) — already a friendly default — so
- * there's no separate "rename hint" surface; admins who want to customize
- * just edit the form below.
+ * Changes apply to *new* agent sessions: client agents fetch the latest
+ * binding at startup, existing sessions keep the value they were spun up
+ * with. Admins should advise members to restart agents after editing.
  */
-export function TeamIdentityPanel() {
+export function ContextTreeSettingsPanel() {
   const { organizationId } = useAuth();
   const queryClient = useQueryClient();
 
-  const orgQuery = useQuery({
-    queryKey: ["organization", organizationId],
-    queryFn: () => (organizationId ? getOrganization(organizationId) : Promise.reject(new Error("no org"))),
+  const settingQuery = useQuery({
+    queryKey: ["org-setting", organizationId, "context_tree"],
+    queryFn: () => (organizationId ? getContextTreeSetting(organizationId) : Promise.reject(new Error("no org"))),
     enabled: !!organizationId,
   });
 
-  const [displayName, setDisplayName] = useState("");
+  const [repo, setRepo] = useState("");
+  const [branch, setBranch] = useState("");
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    if (!orgQuery.data) return;
-    setDisplayName(orgQuery.data.displayName);
-  }, [orgQuery.data]);
+    if (!settingQuery.data) return;
+    setRepo(settingQuery.data.repo ?? "");
+    setBranch(settingQuery.data.branch ?? "main");
+  }, [settingQuery.data]);
 
   const mutation = useMutation({
     mutationFn: () => {
-      if (!organizationId || !orgQuery.data) throw new Error("organization not loaded");
-      const trimmedDisplay = displayName.trim();
-      if (!trimmedDisplay || trimmedDisplay === orgQuery.data.displayName) return Promise.resolve(orgQuery.data);
-      return updateOrganization(organizationId, { displayName: trimmedDisplay });
+      if (!organizationId) throw new Error("organization not loaded");
+      return putContextTreeSetting(organizationId, {
+        repo: repo.trim() ? repo.trim() : null,
+        branch: branch.trim() ? branch.trim() : null,
+      });
     },
-    onSuccess: (next: Organization) => {
-      queryClient.setQueryData(["organization", organizationId], next);
-      // /me/organizations cached in UserMenu — bust so the dropdown
-      // displayName updates without a reload.
-      queryClient.invalidateQueries({ queryKey: ["me-organizations"] });
+    onSuccess: (next) => {
+      queryClient.setQueryData(["org-setting", organizationId, "context_tree"], next);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     },
@@ -68,10 +67,10 @@ export function TeamIdentityPanel() {
             )}
             <Button
               type="submit"
-              form="team-identity-form"
+              form="context-tree-form"
               size="xs"
               variant="outline"
-              disabled={mutation.isPending || !orgQuery.data}
+              disabled={mutation.isPending || !settingQuery.data}
             >
               <Check className="h-3 w-3" />
               {mutation.isPending ? "Saving…" : "Save"}
@@ -79,24 +78,37 @@ export function TeamIdentityPanel() {
           </div>
         }
       >
-        Team identity
+        Context Tree
       </FlatSectionHeader>
-      {orgQuery.isLoading ? (
+      {settingQuery.isLoading ? (
         <div className="text-body" style={{ color: "var(--fg-3)", padding: "var(--sp-3) var(--sp-1)" }}>
           Loading…
         </div>
-      ) : orgQuery.error ? (
+      ) : settingQuery.error ? (
         <div className="text-body" style={{ color: "var(--state-error)", padding: "var(--sp-3) var(--sp-1)" }}>
-          {orgQuery.error instanceof Error ? orgQuery.error.message : "Failed to load team"}
+          {settingQuery.error instanceof Error ? settingQuery.error.message : "Failed to load setting"}
         </div>
       ) : (
-        <form id="team-identity-form" onSubmit={handleSubmit}>
+        <form id="context-tree-form" onSubmit={handleSubmit}>
           <Field
-            label="Team name"
-            hint="Shown in the team switcher and dashboard header."
-            value={displayName}
-            onChange={setDisplayName}
+            label="Repo URL"
+            hint="HTTPS or SSH URL of the Context Tree git repository for this team."
+            value={repo}
+            onChange={setRepo}
+            mono
+            placeholder="https://github.com/your-org/first-tree-context"
           />
+          <Field
+            label="Branch"
+            hint="Branch checked out by client agents on startup."
+            value={branch}
+            onChange={setBranch}
+            mono
+            placeholder="main"
+          />
+          <div className="text-label" style={{ color: "var(--fg-3)", padding: "var(--sp-2) var(--sp-1) 0" }}>
+            Changes apply to new agent sessions. Members should restart agents to pick up updated tree contents.
+          </div>
           {mutation.error instanceof Error && (
             <div className="text-body" style={{ color: "var(--state-error)", marginTop: "var(--sp-2)" }}>
               {mutation.error.message}
@@ -114,14 +126,14 @@ function Field({
   value,
   onChange,
   mono,
-  pattern,
+  placeholder,
 }: {
   label: string;
   hint: string;
   value: string;
   onChange: (next: string) => void;
   mono?: boolean;
-  pattern?: string;
+  placeholder?: string;
 }) {
   return (
     <div
@@ -143,7 +155,7 @@ function Field({
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        pattern={pattern}
+        placeholder={placeholder}
         className={`w-full outline-none text-body ${mono ? "mono" : ""}`}
         style={{
           padding: "var(--sp-1_25) var(--sp-2_5)",

--- a/packages/web/src/pages/github-integration-panel.tsx
+++ b/packages/web/src/pages/github-integration-panel.tsx
@@ -1,0 +1,321 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Check, Copy } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+import { getGithubIntegrationSetting, putGithubIntegrationSetting } from "../api/org-settings.js";
+import { useAuth } from "../auth/auth-context.js";
+import { Button } from "../components/ui/button.js";
+import { FlatSectionHeader } from "../components/ui/flat-section-header.js";
+
+/**
+ * Admin-only panel for the per-org GitHub integration: just the webhook
+ * secret used to verify GitHub-signed requests for this team.
+ *
+ * The webhook URL is computed server-side from `server.publicUrl` — when
+ * the Hub does not have its public URL configured, the UI shows a
+ * "contact your site administrator" notice rather than fall back to
+ * `window.location.origin` (which is wrong behind a reverse proxy).
+ *
+ * The plaintext secret is never echoed back; once configured, the panel
+ * only shows a "configured" status with a "Replace" affordance.
+ */
+export function GithubIntegrationPanel() {
+  const { organizationId } = useAuth();
+  const queryClient = useQueryClient();
+
+  const settingQuery = useQuery({
+    queryKey: ["org-setting", organizationId, "github_integration"],
+    queryFn: () => (organizationId ? getGithubIntegrationSetting(organizationId) : Promise.reject(new Error("no org"))),
+    enabled: !!organizationId,
+  });
+
+  const [secretInput, setSecretInput] = useState("");
+  const [replacing, setReplacing] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!settingQuery.data) return;
+    // Don't clear secret input mid-edit — only sync on first load.
+  }, [settingQuery.data]);
+
+  const webhookUrl = settingQuery.data?.webhookUrl ?? "";
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!organizationId) throw new Error("organization not loaded");
+      const trimmedSecret = secretInput.trim();
+      // Only send `webhookSecret` when the admin actually typed something
+      // (or explicitly cleared after pressing Replace). Otherwise leave
+      // the cipher untouched.
+      if (trimmedSecret.length === 0 && !replacing) {
+        return Promise.resolve(settingQuery.data);
+      }
+      return putGithubIntegrationSetting(organizationId, {
+        webhookSecret: trimmedSecret.length > 0 ? trimmedSecret : null,
+      });
+    },
+    onSuccess: (next) => {
+      if (!next) return;
+      queryClient.setQueryData(["org-setting", organizationId, "github_integration"], next);
+      setSecretInput("");
+      setReplacing(false);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    mutation.mutate();
+  };
+
+  const copyWebhookUrl = async () => {
+    if (!webhookUrl) return;
+    await navigator.clipboard.writeText(webhookUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const secretConfigured = settingQuery.data?.webhookSecretConfigured ?? false;
+
+  return (
+    <section>
+      <FlatSectionHeader
+        right={
+          <div className="flex items-center gap-1.5">
+            {saved && (
+              <span className="mono text-caption" style={{ color: "var(--accent-dim)" }}>
+                saved
+              </span>
+            )}
+            <Button
+              type="submit"
+              form="github-integration-form"
+              size="xs"
+              variant="outline"
+              disabled={mutation.isPending || !settingQuery.data}
+            >
+              <Check className="h-3 w-3" />
+              {mutation.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        }
+      >
+        GitHub integration
+      </FlatSectionHeader>
+      {settingQuery.isLoading ? (
+        <div className="text-body" style={{ color: "var(--fg-3)", padding: "var(--sp-3) var(--sp-1)" }}>
+          Loading…
+        </div>
+      ) : settingQuery.error ? (
+        <div className="text-body" style={{ color: "var(--state-error)", padding: "var(--sp-3) var(--sp-1)" }}>
+          {settingQuery.error instanceof Error ? settingQuery.error.message : "Failed to load setting"}
+        </div>
+      ) : (
+        <form id="github-integration-form" onSubmit={handleSubmit}>
+          {webhookUrl ? (
+            <ReadOnlyField
+              label="Webhook URL"
+              hint="Configure this URL in GitHub repo / org Settings → Webhooks. Never changes."
+              value={webhookUrl}
+              rightSlot={
+                <Button type="button" size="xs" variant="ghost" onClick={copyWebhookUrl}>
+                  <Copy className="h-3 w-3" />
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              }
+            />
+          ) : (
+            <NoticeRow
+              label="Webhook URL"
+              message="The Hub's public URL is not configured. Please contact your site administrator to enable the GitHub webhook."
+            />
+          )}
+          {secretConfigured && !replacing ? (
+            <SecretStatusRow
+              onReplace={() => {
+                setReplacing(true);
+                setSecretInput("");
+              }}
+            />
+          ) : (
+            <Field
+              label="Webhook secret"
+              hint="Paste the value you used when configuring the GitHub webhook. Stored encrypted; never echoed back."
+              value={secretInput}
+              onChange={setSecretInput}
+              mono
+              placeholder={replacing ? "Enter new secret" : "(none)"}
+              type="password"
+            />
+          )}
+          {mutation.error instanceof Error && (
+            <div className="text-body" style={{ color: "var(--state-error)", marginTop: "var(--sp-2)" }}>
+              {mutation.error.message}
+            </div>
+          )}
+        </form>
+      )}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  mono,
+  placeholder,
+  type,
+}: {
+  label: string;
+  hint: string;
+  value: string;
+  onChange: (next: string) => void;
+  mono?: boolean;
+  placeholder?: string;
+  type?: string;
+}) {
+  return (
+    <div
+      className="grid items-start gap-5"
+      style={{
+        gridTemplateColumns: "var(--sp-45) 1fr",
+        padding: "var(--sp-3_5) var(--sp-1)",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div>
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          {label}
+        </div>
+        <div className="text-label" style={{ color: "var(--fg-3)", marginTop: 2 }}>
+          {hint}
+        </div>
+      </div>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        type={type ?? "text"}
+        placeholder={placeholder}
+        className={`w-full outline-none text-body ${mono ? "mono" : ""}`}
+        style={{
+          padding: "var(--sp-1_25) var(--sp-2_5)",
+          background: "var(--bg-sunken)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg)",
+        }}
+      />
+    </div>
+  );
+}
+
+function ReadOnlyField({
+  label,
+  hint,
+  value,
+  rightSlot,
+}: {
+  label: string;
+  hint: string;
+  value: string;
+  rightSlot?: React.ReactNode;
+}) {
+  return (
+    <div
+      className="grid items-start gap-5"
+      style={{
+        gridTemplateColumns: "var(--sp-45) 1fr",
+        padding: "var(--sp-3_5) var(--sp-1)",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div>
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          {label}
+        </div>
+        <div className="text-label" style={{ color: "var(--fg-3)", marginTop: 2 }}>
+          {hint}
+        </div>
+      </div>
+      <div
+        className="mono text-body flex items-center justify-between gap-2"
+        style={{
+          padding: "var(--sp-1_25) var(--sp-2_5)",
+          background: "var(--bg-sunken)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg-3)",
+          overflow: "hidden",
+        }}
+      >
+        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{value}</span>
+        {rightSlot}
+      </div>
+    </div>
+  );
+}
+
+function NoticeRow({ label, message }: { label: string; message: string }) {
+  return (
+    <div
+      className="grid items-start gap-5"
+      style={{
+        gridTemplateColumns: "var(--sp-45) 1fr",
+        padding: "var(--sp-3_5) var(--sp-1)",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div>
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          {label}
+        </div>
+      </div>
+      <div
+        className="flex items-start gap-2 text-body"
+        style={{
+          padding: "var(--sp-1_25) var(--sp-2_5)",
+          background: "var(--bg-sunken)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--state-warning, var(--fg-3))",
+        }}
+      >
+        <AlertTriangle className="h-4 w-4 shrink-0" style={{ marginTop: 2 }} />
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+}
+
+function SecretStatusRow({ onReplace }: { onReplace: () => void }) {
+  return (
+    <div
+      className="grid items-center gap-5"
+      style={{
+        gridTemplateColumns: "var(--sp-45) 1fr",
+        padding: "var(--sp-3_5) var(--sp-1)",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div>
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          Webhook secret
+        </div>
+        <div className="text-label" style={{ color: "var(--fg-3)", marginTop: 2 }}>
+          Configured. Replace to rotate; webhook signature verification will fail until GitHub is also updated.
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="mono text-body" style={{ color: "var(--accent-dim)" }}>
+          ••••••••
+        </span>
+        <Button type="button" size="xs" variant="ghost" onClick={onReplace}>
+          Replace
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/org-settings.tsx
+++ b/packages/web/src/pages/org-settings.tsx
@@ -1,16 +1,26 @@
+import { ContextTreeSettingsPanel } from "./context-tree-settings-panel.js";
+import { GithubIntegrationPanel } from "./github-integration-panel.js";
 import { TeamIdentityPanel } from "./team-identity-panel.js";
 
 /**
- * Per-org settings page. The former "System configuration" panel
- * (inbox_timeout / max_retry / polling_interval / presence_cleanup) was
- * removed when those four knobs were promoted to deployment-level env vars
- * (FIRST_TREE_HUB_INBOX_TIMEOUT_SECONDS, etc.). Operators tune them via
- * the deploy manifest now — the API surface is gone, so the UI is too.
+ * Per-org settings page (Team → Team Settings).
+ *
+ * Three admin-only panels:
+ *   1. TeamIdentityPanel — display name + short identifier
+ *   2. ContextTreeSettingsPanel — per-org Context Tree binding
+ *   3. GithubIntegrationPanel — per-org GitHub webhook URL + secret
+ *
+ * Earlier versions of this page also exposed the global "System
+ * configuration" panel (inbox_timeout / max_retry / polling_interval /
+ * presence_cleanup); those moved to deployment-level env vars and the
+ * UI / API surface was removed.
  */
 export function OrgSettingsPage() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}>
       <TeamIdentityPanel />
+      <ContextTreeSettingsPanel />
+      <GithubIntegrationPanel />
     </div>
   );
 }

--- a/packages/web/src/pages/team/settings.tsx
+++ b/packages/web/src/pages/team/settings.tsx
@@ -19,7 +19,7 @@ export function TeamSettingsPage() {
 
   return (
     <>
-      <PageHeader title="Team settings" subtitle="Organization name, slug, and metadata" />
+      <PageHeader title="Team settings" subtitle="Identity, Context Tree, GitHub integration" />
       <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
         <OrgSettingsPage />
       </div>


### PR DESCRIPTION
## Summary

- Introduces a generic `organization_settings(org_id, namespace, value JSONB)` table. Two initial namespaces ship with three Zod schemas each (storage / input / output); adding a new per-org config group is a one-file change in shared, no DB migration, no new route.
- Migrates **Context Tree** (`repo` / `branch`) and **GitHub integration** (`webhookSecret`) off the global `serverConfigSchema` and onto per-org rows. Server-config schema, env vars, and the `/admin/system/config` surface are all gone.
- GitHub webhook URL becomes `/api/v1/webhooks/github/<orgId>` using the immutable `organizations.id` (UUID v7), so admins never have to re-configure GitHub when a team is renamed. The webhook handler runs scoped agent lookups; per-org `webhookSecret` is decrypted on demand only by the verifier.
- Web admin UI: Team → Team Settings now has two admin-only cards (Context Tree, GitHub integration). Webhook URL is computed server-side from `server.publicUrl`; if that's unset the panel shows a "contact your site administrator" notice rather than fall back to `window.location.origin` (which is wrong behind a reverse proxy).

Closes #255.

## Migration notes

- **No data migration shipped.** The user runs a single org and prefers configuring through the web UI; SaaS deploys upgrade by visiting Team Settings.
- `FIRST_TREE_HUB_CONTEXT_TREE_REPO` / `_PATH` / `FIRST_TREE_HUB_GITHUB_WEBHOOK_SECRET` / `_ALLOWED_ORG` env vars are no longer read.
- Self-hosted users with existing GitHub webhooks: re-configure GitHub Settings → Webhooks with the new per-team URL surfaced in Team Settings (the new URL contains the org's UUID and never changes after that).
- `/api/v1/bootstrap/config` now always returns `{ allowedOrg: null }` — the field is deprecated and unused; per-org integration values are read post-auth via `/api/v1/orgs/:orgId/settings/github_integration`. CLI grep confirmed no consumers depend on the old value.
- Web Team Settings panel renames "URL slug" to "Team name" / removes — the field is unused for routing today (webhook URL uses orgId UUID). DB column kept for future invite-link / subdomain work.

## Versioning

`packages/command` version unchanged. Per the refined rule (also in this PR's `AGENTS.md` / `docs/versioning-and-publishing.md` updates), `command` only bumps when its npm-installed surface changes. This PR touches `server` / `web` and only the parts of `shared` that those two consume — server reaches users via docker / cloud, not npm.

## Out of scope (follow-ups)

- Drizzle `meta/` snapshot chain is broken (predates this PR; 0019..0031 were also hand-written without snapshot updates) — should be repaired in a dedicated cleanup PR, after which `AGENTS.md`'s "Never hand-edit Drizzle migrations" rule can become enforceable again.
- `allowedOrg` enforcement on inbound webhooks (the field is currently dropped from the schema; bring it back together with the actual gating logic when there's a use case).
- Server-side `syncContextTree` auto-clone (currently the snapshot service requires a pre-mounted local checkout; client-side `syncContextTree` already auto-clones).
- `/api/v1/server-info` for web-side `publicUrl` discovery (current panel falls back to a notice when unset; stricter than `window.location.origin`).
- Optimistic locking on concurrent admin edits (`version` column is reserved; PR description in #255 has the design).

## Test plan

- [x] `pnpm check && pnpm typecheck` clean
- [x] `pnpm test` — 96 files, 659 cases (was 653 before; +6 net: empty-secret rejection at service + API layer, end-to-end webhook POST 200/401/501)
- [ ] Smoke-test the web admin flow: as org admin, set Context Tree repo + GitHub webhook secret, verify `webhookSecretConfigured: true` is masked correctly and webhook URL renders (or shows the notice if `FIRST_TREE_HUB_PUBLIC_URL` is unset)
- [ ] Smoke-test against a real GitHub webhook: configure repo → verify ping is acknowledged 200, an issue event routes to the org's `github-adapter` agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)