### PR TITLE
fix(server): skip SSL cert verify for RDS hosts only

### DIFF
--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -3,7 +3,9 @@ import postgres from "postgres";
 import * as schema from "./schema/index.js";
 
 export function connectDatabase(url: string) {
-  const client = postgres(url);
+  const client = postgres(url, {
+    ssl: { rejectUnauthorized: false },
+  });
   const db = drizzle(client, { schema });
   return Object.assign(db, { end: () => client.end() });
 }

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -3,11 +3,23 @@ import postgres from "postgres";
 import * as schema from "./schema/index.js";
 
 export function connectDatabase(url: string) {
-  const client = postgres(url, {
-    ssl: { rejectUnauthorized: false },
-  });
+  const client = postgres(url, sslOptions(url));
   const db = drizzle(client, { schema });
   return Object.assign(db, { end: () => client.end() });
+}
+
+// AWS RDS / Aurora enforces rds.force_ssl=1 and serves a cert that isn't in
+// Node's default CA bundle — skip verification for RDS hosts only. Everything
+// else (testcontainers, local Docker, self-host) stays on the no-SSL default.
+function sslOptions(url: string) {
+  try {
+    if (new URL(url).hostname.endsWith(".rds.amazonaws.com")) {
+      return { ssl: { rejectUnauthorized: false } };
+    }
+  } catch {
+    // Not a parseable URL — let postgres-js report the error.
+  }
+  return {};
 }
 
 export type Database = ReturnType<typeof connectDatabase>;


### PR DESCRIPTION
## Summary
- AWS RDS / Aurora enforces `rds.force_ssl=1` and rejects unencrypted connections, but its server cert is not in Node's default CA bundle — postgres-js URL query strings (`?ssl=disable`, `?ssl=no-verify`) cannot produce `{ rejectUnauthorized: false }`, only an explicit JS object can.
- Inject `ssl: { rejectUnauthorized: false }` only when the URL hostname ends in `.rds.amazonaws.com`. Testcontainers, local Docker, and self-host postgres stay on the no-SSL default — no config knobs to flip.
- Single touchpoint: [packages/server/src/db/connection.ts](packages/server/src/db/connection.ts). No version bump (server-only change).

## Test plan
- [x] `pnpm check && pnpm typecheck` clean
- [x] Local Docker postgres still connects (verified by user)
- [x] Server testcontainers suite — 96 files / 659 tests pass
- [ ] Verify Aurora connection works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)