### PR TITLE
fix(server,cli): apply RDS SSL skip-verify to migrate and notifier paths

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/core/migrate.ts
+++ b/packages/command/src/core/migrate.ts
@@ -5,6 +5,20 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
+// Mirror of packages/server/src/db/connection.ts — kept local to avoid pulling
+// the server package into the command CLI bundle. RDS/Aurora enforces
+// rds.force_ssl=1 with a cert outside Node's default CA bundle.
+function sslOptions(url: string) {
+  try {
+    if (new URL(url).hostname.endsWith(".rds.amazonaws.com")) {
+      return { ssl: { rejectUnauthorized: false } };
+    }
+  } catch {
+    // Not a parseable URL — let postgres-js report the error.
+  }
+  return {};
+}
+
 /**
  * Resolve the drizzle migrations directory.
  * 1. npm install: embedded at dist/drizzle/ (relative to the built CLI)
@@ -59,7 +73,9 @@ export async function runMigrations(databaseUrl: string): Promise<number> {
   // Fail fast if journal timestamps are out of order
   validateJournalOrder(migrationsFolder);
 
-  const client = postgres(databaseUrl, { max: 1 });
+  const ssl = sslOptions(databaseUrl);
+
+  const client = postgres(databaseUrl, { max: 1, ...ssl });
   const db = drizzle(client);
 
   try {
@@ -69,7 +85,7 @@ export async function runMigrations(databaseUrl: string): Promise<number> {
   }
 
   // Count tables as a rough indicator of migration state
-  const countClient = postgres(databaseUrl, { max: 1 });
+  const countClient = postgres(databaseUrl, { max: 1, ...ssl });
   try {
     const result = await countClient`
       SELECT count(*)::int AS count

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -58,7 +58,7 @@ import { taskRoutes } from "./api/tasks.js";
 // Public agent discovery removed — visibility is now handled via agent.visibility field
 import { githubWebhookRoutes } from "./api/webhooks/github.js";
 import type { Config } from "./config.js";
-import { connectDatabase } from "./db/connection.js";
+import { connectDatabase, sslOptions } from "./db/connection.js";
 import { AppError } from "./errors.js";
 import { agentSelectorHook } from "./middleware/agent-selector.js";
 import { userAuthHook } from "./middleware/user-auth.js";
@@ -276,7 +276,7 @@ export async function buildApp(config: Config) {
   app.log.info({ commandVersion }, "Hub server advertising command version");
 
   // Notifier: dedicated PG connection for LISTEN/NOTIFY
-  const listenClient = postgres(config.database.url, { max: 1 });
+  const listenClient = postgres(config.database.url, { max: 1, ...sslOptions(config.database.url) });
   const notifier = createNotifier(listenClient);
 
   // WebSocket plugin. `maxPayload` caps a single inbound frame so a hostile

--- a/packages/server/src/db/connection.ts
+++ b/packages/server/src/db/connection.ts
@@ -11,7 +11,7 @@ export function connectDatabase(url: string) {
 // AWS RDS / Aurora enforces rds.force_ssl=1 and serves a cert that isn't in
 // Node's default CA bundle — skip verification for RDS hosts only. Everything
 // else (testcontainers, local Docker, self-host) stays on the no-SSL default.
-function sslOptions(url: string) {
+export function sslOptions(url: string) {
   try {
     if (new URL(url).hostname.endsWith(".rds.amazonaws.com")) {
       return { ssl: { rejectUnauthorized: false } };


### PR DESCRIPTION
## Summary
PR #259 only patched [packages/server/src/db/connection.ts](packages/server/src/db/connection.ts) — the main db pool. Aurora kept refusing the boot sequence because two other `postgres()` call-sites still went out with no SSL option:

- [packages/command/src/core/migrate.ts](packages/command/src/core/migrate.ts) — `runMigrations()` opens its own short-lived connections, and is invoked from `core/server.ts` *before* `connectDatabase()`, so the earlier `sslOptions` was never reached on the migration path.
- [packages/server/src/app.ts:279](packages/server/src/app.ts#L279) — the LISTEN/NOTIFY notifier opens a dedicated connection.

Both now share the same `.rds.amazonaws.com` heuristic. Local Docker, testcontainers, and self-host postgres remain unaffected.

### Implementation note
`sslOptions` is exported from [db/connection.ts](packages/server/src/db/connection.ts) for `app.ts`, and **duplicated** in `command/migrate.ts` — pulling the server package into the CLI bundle for a 7-line helper is the wrong trade-off. Flagged for a future shared-package extraction.

### Versioning
Bumped `@agent-team-foundation/first-tree-hub` 0.11.3 → 0.11.4 (patch) — change touches `packages/command`.

## Test plan
- [x] `pnpm check && pnpm typecheck` clean
- [x] Server testcontainers suite — 96 files / 659 tests pass
- [ ] Verify Aurora boot path (migrations + notifier) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)