### PR TITLE
test: PR-B2 — Phase B follow-up coverage gaps (#7, #13)

### DIFF
--- a/packages/command/src/__tests__/org-bind-tree.test.ts
+++ b/packages/command/src/__tests__/org-bind-tree.test.ts
@@ -1,0 +1,319 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Coverage for `first-tree-hub org bind-tree` (Phase B handoff #7). The
+ * command is wired to Step 3 onboarding agents that just created a fresh
+ * context-tree repo and need the Hub to record the binding under
+ * `orgs/:orgId/settings/context_tree`. We assert:
+ *
+ *   1. URL validation rejects malformed input with `INVALID_URL` and exits 2.
+ *   2. `--org <id>` short-circuits the `/me` lookup and uses the explicit id.
+ *   3. Without `--org`, a single-membership user auto-picks; multi-membership
+ *      without a default org refuses with `AMBIGUOUS_ORG` rather than guessing.
+ */
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+class ProcessExit extends Error {
+  constructor(public exitCode: number) {
+    super(`__process_exit__:${exitCode}`);
+    this.name = "ProcessExit";
+  }
+}
+
+describe("org bind-tree CLI", () => {
+  let testHome: string;
+  let originalHome: string | undefined;
+  let originalServerUrl: string | undefined;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let exitCalls: number[];
+  let originalExit: typeof process.exit;
+  let stderr: string;
+  let stdout: string;
+  let originalStderrWrite: typeof process.stderr.write;
+  let originalStdoutWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    testHome = join(tmpdir(), `ft-hub-bind-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(testHome, "config"), { recursive: true });
+    writeFileSync(
+      join(testHome, "config", "credentials.json"),
+      JSON.stringify({
+        // exp ~30 minutes in the future so ensureFreshAccessToken returns
+        // it without firing /auth/refresh.
+        accessToken: makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 }),
+        refreshToken: "refresh-xyz",
+        serverUrl: "http://hub.test",
+      }),
+    );
+    writeFileSync(join(testHome, "config", "client.yaml"), "server:\n  url: http://hub.test\n");
+
+    originalHome = process.env.FIRST_TREE_HUB_HOME;
+    originalServerUrl = process.env.FIRST_TREE_HUB_SERVER_URL;
+    process.env.FIRST_TREE_HUB_HOME = testHome;
+    delete process.env.FIRST_TREE_HUB_SERVER_URL;
+
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Convert process.exit into a thrown sentinel so the action can be
+    // awaited. Commander surfaces action errors via the returned promise.
+    exitCalls = [];
+    originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCalls.push(code ?? 0);
+      throw new ProcessExit(code ?? 0);
+    }) as typeof process.exit;
+
+    stderr = "";
+    stdout = "";
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      stderr += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+      return true;
+    }) as typeof process.stderr.write;
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      stdout += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+      return true;
+    }) as typeof process.stdout.write;
+
+    // Force module-level constants (DEFAULT_HOME_DIR / DEFAULT_CONFIG_DIR)
+    // to re-evaluate against the new env in each dynamic import.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HUB_HOME;
+    else process.env.FIRST_TREE_HUB_HOME = originalHome;
+
+    if (originalServerUrl === undefined) delete process.env.FIRST_TREE_HUB_SERVER_URL;
+    else process.env.FIRST_TREE_HUB_SERVER_URL = originalServerUrl;
+
+    rmSync(testHome, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+    process.exit = originalExit;
+    process.stderr.write = originalStderrWrite;
+    process.stdout.write = originalStdoutWrite;
+  });
+
+  async function buildProgram(): Promise<Command> {
+    const program = new Command();
+    program.exitOverride();
+    const { registerOrgCommands } = await import("../commands/org.js");
+    registerOrgCommands(program);
+    return program;
+  }
+
+  function firstErrorEnvelope(): { ok: false; error: { code: string; message: string } } | null {
+    // print.fail writes a JSON envelope per line on stderr. The action wraps
+    // its body in a generic try/catch that turns any caught throw into a
+    // second `UNEXPECTED` envelope; in production `process.exit` aborts
+    // before that catch fires, but here `process.exit` is mocked to throw
+    // so the catch runs. Read the FIRST envelope so assertions reflect the
+    // original failure code, not the catch-all repackaging.
+    for (const line of stderr.split("\n")) {
+      if (line.length === 0) continue;
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed && typeof parsed === "object" && parsed.ok === false) return parsed;
+      } catch {
+        // Not a JSON line, keep scanning.
+      }
+    }
+    return null;
+  }
+
+  function firstExitCode(): number | undefined {
+    return exitCalls[0];
+  }
+
+  it("rejects a malformed URL with INVALID_URL and exits 2", async () => {
+    const program = await buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(["node", "first-tree-hub", "org", "bind-tree", "not-a-url"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstExitCode()).toBe(2);
+
+    const envelope = firstErrorEnvelope();
+    expect(envelope?.error.code).toBe("INVALID_URL");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty URL with INVALID_URL and exits 2", async () => {
+    const program = await buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(["node", "first-tree-hub", "org", "bind-tree", "   "]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstExitCode()).toBe(2);
+    expect(firstErrorEnvelope()?.error.code).toBe("INVALID_URL");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("with --org, PUTs to /orgs/:orgId/settings/context_tree without consulting /me", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const program = await buildProgram();
+    await program.parseAsync([
+      "node",
+      "first-tree-hub",
+      "org",
+      "bind-tree",
+      "https://github.com/acme/tree",
+      "--org",
+      "org-explicit",
+    ]);
+
+    // Single fetch — no /me round-trip when --org is provided.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe("http://hub.test/api/v1/orgs/org-explicit/settings/context_tree");
+    expect((init as RequestInit).method).toBe("PUT");
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({ repo: "https://github.com/acme/tree" });
+
+    const envelope = JSON.parse(stdout.trim().split("\n").pop() ?? "{}") as {
+      ok: boolean;
+      data: { orgId: string; repo: string };
+    };
+    expect(envelope.ok).toBe(true);
+    expect(envelope.data).toEqual({ orgId: "org-explicit", repo: "https://github.com/acme/tree" });
+  });
+
+  it("URL-encodes the org id in the PUT path", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const program = await buildProgram();
+    await program.parseAsync([
+      "node",
+      "first-tree-hub",
+      "org",
+      "bind-tree",
+      "https://github.com/acme/tree",
+      "--org",
+      "org with space",
+    ]);
+
+    const [url] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toBe("http://hub.test/api/v1/orgs/org%20with%20space/settings/context_tree");
+  });
+
+  it("without --org, single-membership user auto-picks the org", async () => {
+    fetchMock.mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/me")) {
+        return new Response(
+          JSON.stringify({
+            memberships: [{ organizationId: "only-one", role: "admin" }],
+            defaultOrganizationId: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    const program = await buildProgram();
+    await program.parseAsync(["node", "first-tree-hub", "org", "bind-tree", "https://github.com/acme/tree"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const putUrl = String(fetchMock.mock.calls[1]?.[0] ?? "");
+    expect(putUrl).toBe("http://hub.test/api/v1/orgs/only-one/settings/context_tree");
+  });
+
+  it("without --org and multiple orgs without a default, fails AMBIGUOUS_ORG and does not PUT", async () => {
+    fetchMock.mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/me")) {
+        return new Response(
+          JSON.stringify({
+            memberships: [
+              { organizationId: "org-a", role: "admin" },
+              { organizationId: "org-b", role: "admin" },
+            ],
+            defaultOrganizationId: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    });
+
+    const program = await buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(["node", "first-tree-hub", "org", "bind-tree", "https://github.com/acme/tree"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstErrorEnvelope()?.error.code).toBe("AMBIGUOUS_ORG");
+    // /me only — no PUT attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("without --org but with defaultOrganizationId, picks the default", async () => {
+    fetchMock.mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/me")) {
+        return new Response(
+          JSON.stringify({
+            memberships: [
+              { organizationId: "org-a", role: "admin" },
+              { organizationId: "org-default", role: "admin" },
+            ],
+            defaultOrganizationId: "org-default",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    const program = await buildProgram();
+    await program.parseAsync(["node", "first-tree-hub", "org", "bind-tree", "https://github.com/acme/tree"]);
+
+    const putUrl = String(fetchMock.mock.calls[1]?.[0] ?? "");
+    expect(putUrl).toBe("http://hub.test/api/v1/orgs/org-default/settings/context_tree");
+  });
+
+  it("surfaces server errors as PUT_FAILED with the response body", async () => {
+    fetchMock.mockResolvedValue(new Response("forbidden: not an admin", { status: 403 }));
+
+    const program = await buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync([
+        "node",
+        "first-tree-hub",
+        "org",
+        "bind-tree",
+        "https://github.com/acme/tree",
+        "--org",
+        "org-x",
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    const envelope = firstErrorEnvelope();
+    expect(envelope?.error.code).toBe("PUT_FAILED");
+    expect(envelope?.error.message).toContain("403");
+    expect(envelope?.error.message).toContain("forbidden");
+  });
+});

--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -207,6 +207,82 @@ describe("GET /me/github/repos", () => {
   });
 });
 
+describe("POST /me/onboarding/events", () => {
+  const getApp = useTestApp();
+
+  it("rejects forged event/userId smuggled in attrs (#248 codex review)", async () => {
+    // Pre-fix the spread order was `{ event, userId, ...attrs }`, so a
+    // hostile authenticated tab could POST
+    //   attrs: { event: "fake.event", userId: "victim-uid" }
+    // and have those values overwrite the JWT-derived `userId` and the
+    // Zod-validated event in the structured log line, corrupting funnel
+    // attribution.
+    //
+    // The fix flips the order to `{ ...attrs, event, userId }` so the
+    // server-controlled fields always win. This test pins that behavior
+    // by capturing the actual log payload via a vi spy on app.log.info.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const captured: Array<Record<string, unknown>> = [];
+    const infoSpy = vi.spyOn(app.log, "info").mockImplementation(((...args: unknown[]) => {
+      const obj = args[0];
+      if (obj && typeof obj === "object") captured.push(obj as Record<string, unknown>);
+      return app.log;
+    }) as typeof app.log.info);
+
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/me/onboarding/events",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: {
+          event: "agent_created",
+          attrs: {
+            event: "onboarding.fake_forged_event",
+            userId: "attacker-controlled-user-id",
+            extra: "legit-attr-keeps-working",
+          },
+        },
+      });
+      expect(res.statusCode).toBe(204);
+    } finally {
+      infoSpy.mockRestore();
+    }
+
+    // Find the funnel line and confirm server-controlled fields stand.
+    const funnelEntry = captured.find((c) => typeof c.event === "string" && String(c.event).startsWith("onboarding."));
+    expect(funnelEntry).toBeDefined();
+    expect(funnelEntry?.event).toBe("onboarding.agent_created");
+    expect(funnelEntry?.userId).toBe(admin.userId);
+    // Non-conflicting attrs keys must still flow through — the schema lets
+    // callers attach arbitrary primitives for funnel context.
+    expect(funnelEntry?.extra).toBe("legit-attr-keeps-working");
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    const app = getApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/onboarding/events",
+      payload: { event: "agent_created" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects unknown event names with 400 (Zod enum)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/onboarding/events",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { event: "totally_made_up_event" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
 describe("/me onboarding payload", () => {
   const getApp = useTestApp();
 


### PR DESCRIPTION
## Summary

PR-B2 from the Phase B follow-up sequence. Two independent test-only commits, both pinning behavior already on main:

- **`test(cli): org bind-tree command coverage`** (handoff #7) — exercises URL validation, explicit `--org` short-circuit, single-membership auto-pick, multi-org `AMBIGUOUS_ORG`, default-org honoring, and `PUT_FAILED` mapping. The CLI's action-level catch repackages thrown errors as `UNEXPECTED`; in production `process.exit` aborts before that catch fires, so the test reads the FIRST stderr envelope and exit code to assert on the original failure.
- **`test(server): /me/onboarding/events resists attrs forgery`** (handoff #13) — pins the spread-order fix from `a05bd2d`. Posts malicious `attrs: { event, userId }`, captures `app.log.info` payloads, asserts the JWT-derived `userId` and Zod-validated `event` win and non-conflicting attrs keys still flow through. Also adds 401 unauth and 400 unknown-event cases.

No production code changes.

## Test plan

- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` — 96 passed (was 88, +8 new)
- [x] `pnpm --filter @first-tree-hub/server test` — 682 passed
- [x] `pnpm check` — clean
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub typecheck` + `pnpm --filter @first-tree-hub/server typecheck` — clean

## Notes

Base = `main` so this is mergeable independent of #258. Companion PR-B1 (invitee Step 3 + onboarding-view refactor) waits for #258 to land per the Phase B handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)