### PR TITLE
fix: partial agent-config PATCH no longer wipes untouched fields

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -50,6 +50,50 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(after.json().payload.prompt.append).toBe("你只会一句话");
   });
 
+  it("PATCH with a subset of fields leaves omitted fields untouched", async () => {
+    // Regression: Zod 4's `.partial()` keeps inner `ZodDefault`s, so a
+    // schema with `.default()` per field would silently fill the patch with
+    // defaults for omitted keys — wiping the user's saved prompt / model /
+    // env / git when they edit just one section.
+    const app = getApp();
+    const req = await authedRequest(app);
+    const agent = await (await seedAgentFactory(app))({
+      name: `cfg-partial-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+    });
+
+    // Seed every field with a non-default value so a stray default is visible.
+    const seed = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 1,
+      payload: {
+        prompt: { append: "stay-put-prompt" },
+        model: "claude-sonnet-4-6",
+        env: [{ key: "FOO", value: "bar", sensitive: false }],
+        gitRepos: [{ url: "https://example.com/r.git" }],
+      },
+    });
+    expect(seed.statusCode).toBe(200);
+    await app.configService.flush(agent.uuid);
+
+    // Touch only `mcpServers`. The service must preserve the other 4 fields.
+    const partial = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 2,
+      payload: {
+        mcpServers: [{ name: "demo", transport: "stdio", command: "echo" }],
+      },
+    });
+    expect(partial.statusCode).toBe(200);
+    await app.configService.flush(agent.uuid);
+
+    const after = await req("GET", `/api/v1/agents/${agent.uuid}/config`);
+    const payload = after.json().payload;
+    expect(payload.prompt.append).toBe("stay-put-prompt");
+    expect(payload.model).toBe("claude-sonnet-4-6");
+    expect(payload.env).toEqual([{ key: "FOO", value: "bar", sensitive: false }]);
+    expect(payload.gitRepos).toEqual([{ url: "https://example.com/r.git" }]);
+    expect(payload.mcpServers).toEqual([{ name: "demo", transport: "stdio", command: "echo" }]);
+  });
+
   it("PATCH with stale expectedVersion returns 409", async () => {
     const app = getApp();
     const req = await authedRequest(app);

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -228,6 +228,29 @@ export const agentRuntimeConfigSchema = z.object({
 export type AgentRuntimeConfig = z.infer<typeof agentRuntimeConfigSchema>;
 
 /**
+ * Write-side shape with no `.default()` per field.
+ *
+ * `agentRuntimeConfigPayloadShape` carries `.default()` on every field for the
+ * read path (so legacy DB rows parse cleanly). On the PATCH side those defaults
+ * are actively harmful: Zod 4's `.partial()` makes a field optional but keeps
+ * the inner `ZodDefault`, so a body like `{ mcpServers: [...] }` parses to a
+ * fully-populated patch where the omitted fields are filled with their
+ * defaults — the service layer's `patch.x ?? current.x` then sees a truthy
+ * default and *replaces* the user's saved value with empty. Mirroring the 5
+ * fields here without defaults keeps "field absent" → `undefined` in the
+ * parsed patch, which is what the merge logic expects.
+ */
+const agentRuntimeConfigPatchShape = z
+  .object({
+    prompt: promptConfigSchema,
+    model: z.string(),
+    mcpServers: z.array(mcpServerSchema),
+    env: z.array(envEntrySchema),
+    gitRepos: z.array(gitRepoSchema),
+  })
+  .partial();
+
+/**
  * Patch payload for PATCH /api/v1/admin/agents/:uuid/config.
  *
  * - `expectedVersion` enforces optimistic locking; mismatch → 409.
@@ -235,12 +258,12 @@ export type AgentRuntimeConfig = z.infer<typeof agentRuntimeConfigSchema>;
  */
 export const updateAgentRuntimeConfigSchema = z.object({
   expectedVersion: z.number().int().positive(),
-  payload: agentRuntimeConfigPayloadShape.partial(),
+  payload: agentRuntimeConfigPatchShape,
 });
 export type UpdateAgentRuntimeConfig = z.infer<typeof updateAgentRuntimeConfigSchema>;
 
 export const dryRunAgentRuntimeConfigSchema = z.object({
-  payload: agentRuntimeConfigPayloadShape.partial(),
+  payload: agentRuntimeConfigPatchShape,
 });
 export type DryRunAgentRuntimeConfig = z.infer<typeof dryRunAgentRuntimeConfigSchema>;
 


### PR DESCRIPTION
## Summary

- Web UI's partial save (e.g. user only edits MCP) was silently wiping prompt / model / env / gitRepos. Root cause: Zod 4's `.partial()` keeps inner `ZodDefault` wrappers, so omitted fields parsed to their defaults instead of `undefined`, and the service layer's `patch.x ?? current.x` merge replaced the user's saved values with empty defaults.
- Mirror the 5 PATCH-able fields in a new `agentRuntimeConfigPatchShape` without `.default()` and route both `updateAgentRuntimeConfigSchema` and `dryRunAgentRuntimeConfigSchema` through it. Read-side `agentRuntimeConfigPayloadSchema` is untouched — legacy DB rows still parse cleanly.
- Bump `command` 0.11.4 → 0.11.5 per [docs/versioning-and-publishing.md](docs/versioning-and-publishing.md): the changed `shared` module is imported by `packages/command/src/commands/agent-config.ts`.

## Test plan

- [x] `pnpm check` — clean
- [x] `pnpm typecheck` — 9/9 tasks pass
- [x] `pnpm test` — 680/680 (server suite green; the new regression test in `admin-agent-config.test.ts` is one of them)
- [x] **Bug reproduction:** temporarily reverted the schema change and re-ran the regression test — it failed with `expected '' to be 'stay-put-prompt'`, confirming the test catches the wipe. Re-applied the fix, test passes.
- [ ] Manual web-UI smoke after deploy: open Agent Detail with a non-empty prompt, change only Model, save, reload — prompt should be preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)