### PR TITLE
fix(server): resolveUserPrimaryOrgId mirrors /me's defaultOrganizationId selection

### DIFF
--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -1,9 +1,10 @@
-import { createHmac } from "node:crypto";
+import crypto, { createHmac } from "node:crypto";
 import bcrypt from "bcrypt";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
+import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import { signTokensForUser } from "../services/auth.js";
@@ -375,6 +376,94 @@ describe("org-settings service", () => {
         { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
       ),
     ).rejects.toThrow(/Organization .* not found/);
+  });
+});
+
+describe("resolveUserPrimaryOrgId", () => {
+  const getApp = useTestApp();
+
+  /**
+   * Add an extra membership for an existing user. `createdAt` is exposed so
+   * tests can deterministically control which membership is "most recent".
+   */
+  async function addMembership(
+    app: Awaited<ReturnType<typeof getApp>>,
+    userId: string,
+    role: "admin" | "member",
+    createdAt?: Date,
+    status: "active" | "left" = "active",
+  ): Promise<{ orgId: string; memberId: string }> {
+    const orgId = `org-rup-${crypto.randomUUID().slice(0, 8)}`;
+    const memberId = uuidv7();
+    await app.db.transaction(async (tx) => {
+      await tx.insert(organizations).values({ id: orgId, name: orgId.slice(0, 30), displayName: "Side org" });
+      const human = await createAgent(tx as unknown as typeof app.db, {
+        name: `rup-h-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: "RUP Human",
+        managerId: memberId,
+        organizationId: orgId,
+      });
+      await tx.insert(members).values({
+        id: memberId,
+        userId,
+        organizationId: orgId,
+        agentId: human.uuid,
+        role,
+        status,
+        ...(createdAt ? { createdAt } : {}),
+      });
+    });
+    return { orgId, memberId };
+  }
+
+  it("returns the only active membership when user has one org", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const got = await orgSettingsService.resolveUserPrimaryOrgId(app.db, admin.userId);
+    expect(got).toBe(admin.organizationId);
+  });
+
+  it("returns most-recent active membership for multi-org users (matches /me's defaultOrganizationId)", async () => {
+    const app = getApp();
+    // First org via createTestAdmin. Force its membership createdAt to a known
+    // earlier moment so we can deterministically assert "most recent wins"
+    // regardless of how fast the test runs.
+    const admin = await createTestAdmin(app);
+    const earlier = new Date(Date.now() - 60_000);
+    await app.db.update(members).set({ createdAt: earlier }).where(eq(members.id, admin.memberId));
+
+    // Second org — created "now", which is more recent than `earlier`.
+    const later = await addMembership(app, admin.userId, "admin", new Date());
+
+    const got = await orgSettingsService.resolveUserPrimaryOrgId(app.db, admin.userId);
+    expect(got).toBe(later.orgId);
+    expect(got).not.toBe(admin.organizationId);
+  });
+
+  it("ignores 'left' memberships even when their createdAt is more recent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    // A more-recent membership the user has since left.
+    await addMembership(app, admin.userId, "admin", new Date(Date.now() + 60_000), "left");
+
+    const got = await orgSettingsService.resolveUserPrimaryOrgId(app.db, admin.userId);
+    expect(got).toBe(admin.organizationId);
+  });
+
+  it("returns null when user has no active memberships", async () => {
+    const app = getApp();
+    const userId = uuidv7();
+    const passwordHash = await bcrypt.hash(crypto.randomUUID(), 4);
+    await app.db.insert(users).values({
+      id: userId,
+      username: `nomembers-${crypto.randomUUID().slice(0, 8)}`,
+      passwordHash,
+      displayName: "No Memberships",
+    });
+
+    const got = await orgSettingsService.resolveUserPrimaryOrgId(app.db, userId);
+    expect(got).toBeNull();
   });
 });
 

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -7,12 +7,13 @@ import {
   type OrgSettingOutput,
   type OrgSettingStorage,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
 import { organizations } from "../db/schema/organizations.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
+import { pickDefaultMembership } from "./auth.js";
 import { decryptValue, encryptValue, isEncryptedValue } from "./crypto.js";
 
 /**
@@ -260,22 +261,28 @@ export async function deleteOrgSetting(db: Database, orgId: string, namespace: s
 }
 
 /**
- * Resolve the caller's "primary org" — the earliest-joined active
- * membership for the given user. Used by user-scoped routes that
- * historically didn't take an `:orgId` (e.g. `/context-tree/info`) so
- * the SDK call shape doesn't have to change while the per-tenant lookup
- * still happens correctly.
+ * Resolve the caller's "primary org" for user-scoped routes that
+ * historically didn't take an `:orgId` (e.g. `/context-tree/info`,
+ * `/context-tree/snapshot`).
  *
- * Returns `null` for users with no active membership. Tightening to
- * "explicit org selector" is a future change-once-multi-org-clients-arrive
- * concern. (#7)
+ * Uses the same `pickDefaultMembership` helper that `/me` uses to compute
+ * `defaultOrganizationId` (most-recently-active membership, id desc tie-break).
+ * That guarantees the org `/me` reports as the default is the same org these
+ * server-internal lookups read from — earlier the two sides used opposite
+ * orderings (`/me` desc, this fn asc), so multi-org users saw `/info`
+ * resolve to a different (often unconfigured) org than the one Team Settings
+ * was edited for.
+ *
+ * Returns `null` for users with no active membership.
  */
 export async function resolveUserPrimaryOrgId(db: Database, userId: string): Promise<string | null> {
-  const [row] = await db
-    .select({ organizationId: members.organizationId })
+  const rows = await db
+    .select({
+      id: members.id,
+      organizationId: members.organizationId,
+      createdAt: members.createdAt,
+    })
     .from(members)
-    .where(and(eq(members.userId, userId), eq(members.status, "active")))
-    .orderBy(asc(members.createdAt))
-    .limit(1);
-  return row?.organizationId ?? null;
+    .where(and(eq(members.userId, userId), eq(members.status, "active")));
+  return pickDefaultMembership(rows)?.organizationId ?? null;
 }


### PR DESCRIPTION
## Summary

`/api/v1/context-tree/info` and `/api/v1/context-tree/snapshot` both call `resolveUserPrimaryOrgId` to translate a user-scoped JWT into an org for the per-org Team Settings lookup. The function ordered active memberships by `createdAt ASC` and took the first — i.e. the user's earliest-joined active org.

But `/me`'s `defaultOrganizationId` is computed by `pickDefaultMembership` over the same rows with the **opposite** ordering: most-recently-active first, id desc as tie-break.

Multi-org users therefore saw `/me` advertise one default org while the two context-tree endpoints silently resolved a different one — typically an older personal org with no Context Tree configured at all.

## Concrete failure mode

An admin in `agent-team-foundation` who also owns a personal org (joined first) configures Context Tree in Team Settings for `agent-team-foundation`.

```bash
$ curl -H "Authorization: Bearer $TOK" https://dev.cloud.first-tree.ai/api/v1/context-tree/info
{"repo":null,"branch":"main"}    # ← expected agent-team-foundation tree URL
```

`syncContextTree` on Hub Client returns null → `installFirstTreeIntegration` silently no-ops in `runBootstrap` → skills never land in any chat workspace.

## Fix

Delegate the membership pick to the existing `pickDefaultMembership` helper from `services/auth.ts`. Both code paths now read from the same source of truth, so `/me`'s reported default org and the org these server-internal lookups read from can no longer drift apart. Updated docstring records the invariant.

```ts
// before
.orderBy(asc(members.createdAt))
.limit(1);

// after
const rows = await db
  .select({ id: members.id, organizationId: members.organizationId, createdAt: members.createdAt })
  .from(members)
  .where(and(eq(members.userId, userId), eq(members.status, "active")));
return pickDefaultMembership(rows)?.organizationId ?? null;
```

## Test cases (new in `packages/server/src/__tests__/org-settings.test.ts`)

- [x] Single membership → returns that org
- [x] Multi-org with controlled `createdAt` → returns most-recently-created (matches `/me`'s `defaultOrganizationId`)
- [x] `status: "left"` membership with newer `createdAt` → ignored, falls back to active membership
- [x] User with no active memberships → null

All 697 monorepo tests pass; new file count: org-settings.test.ts grew 30 → 34 tests.

## Blast radius

`resolveUserPrimaryOrgId` callers (verified by `git grep`):

- `packages/server/src/api/context-tree-info.ts`
- `packages/server/src/api/context-tree-snapshot.ts`

Both behaviors converge on the org `/me` already advertises — no other surface affected.

## Versioning

Per the updated policy in CLAUDE.md (server-only changes ship via docker / SaaS, not npm), `packages/command` is **not** bumped here. Will piggyback on the next CLI-visible change.

## Closes

- Closes #278

## Test plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm typecheck` — 9/9 successful
- [x] `pnpm test` — 697 / 697 passed
- [ ] After merge + staging deploy: `curl /api/v1/context-tree/info` with a multi-org user account returns the org configured in Team Settings (verifying #278 reproducer is fixed end-to-end).
- [ ] Restart Hub Client daemon connected to staging → start a new chat → confirm `<chat-cwd>/.agents/skills/` and `<chat-cwd>/.claude/skills/` are populated by `installFirstTreeIntegration`.

## Related

- #278 — main bug this fixes
- #279 — companion cleanup: dead `FIRST_TREE_HUB_CONTEXT_TREE_REPO` env var lingering on deploys post PR #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)