### PR TITLE
feat: AskUserQuestion bridge for Claude Code (UI question cards + answer flow)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -261,6 +261,17 @@ first-tree-hub agent pull --ack
 
 Messaging commands require an agent token (see Agent env vars below). Use `FIRST_TREE_HUB_SERVER_URL` to override the server URL for these low-level agent commands.
 
+### Agent → user structured questions (Claude runtime)
+
+Claude-runtime agents can pause execution mid-turn and prompt the operator with a structured `AskUserQuestion` (single- or multi-select, up to 4 parallel questions, optional HTML / Markdown previews per option). The Hub bridges this through the inbox so the question lands on the Web chat as a clickable card; the operator's choice is then fed back to the agent and the turn continues.
+
+- **Activation**: automatic for any agent on `runtimeProvider: claude-code` — no CLI flag.
+- **UI**: the question renders inline in the chat timeline as a card with three states (pending / answered / superseded).
+- **Lifecycle**: a pending question is auto-superseded when the chat session is archived (`agent session terminate`) or when the owning client is reclaimed by a different user (`first-tree-hub client claim`). The agent receives a clean deny in either case.
+- **Codex runtime**: not supported. The Codex SDK has no ask-user surface; codex-runtime agents that try to emit a question are rejected with HTTP 403 by the server (`assertSenderMayEmitQuestion`).
+
+No CLI command is required to use the feature — it shows up automatically when a Claude-runtime agent calls `AskUserQuestion` during a turn.
+
 ## config
 
 ```bash

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -93,6 +93,35 @@ describe("formatInboundContent", () => {
     expect(await formatInboundContent(msg, cache)).toBe("[From: agent-ghost]\n\nhi");
   });
 
+  it("renders question_answer messages as Q/A pairs so a resumed session can read them as input", async () => {
+    const sdk = mkSdk(async () => participants);
+    const cache = createParticipantCache(sdk, "chat-1", () => {});
+    const msg: SessionMessage = {
+      id: "m-qa",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      format: "question_answer",
+      content: {
+        correlationId: "tu_xyz",
+        answers: {
+          "Should I rebase or merge?": "Rebase",
+          "Should I run tests?": "Yes — full suite",
+        },
+      },
+      metadata: null,
+    };
+    const out = await formatInboundContent(msg, cache);
+    // Sanity-pin: prefixed with the bridge instruction so the LLM doesn't
+    // re-issue AskUserQuestion for the same questions; carries each Q/A pair.
+    expect(out).toContain("[From: alice]");
+    expect(out).toContain("user has answered an earlier AskUserQuestion");
+    expect(out).toContain("Q: Should I rebase or merge?");
+    expect(out).toContain("A: Rebase");
+    expect(out).toContain("Q: Should I run tests?");
+    expect(out).toContain("A: Yes — full suite");
+    expect(out).not.toContain("correlationId"); // raw payload field never leaks to the prompt
+  });
+
   it("serialises non-string content to JSON under the same attribution", async () => {
     const sdk = mkSdk(async () => participants);
     const cache = createParticipantCache(sdk, "chat-1", () => {});

--- a/packages/client/src/__tests__/ask-user-bridge.test.ts
+++ b/packages/client/src/__tests__/ask-user-bridge.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearAllPendingQuestionsForTest,
+  pendingQuestionCount,
+  registerPendingQuestion,
+  rejectPendingForAgent,
+  tryResolveQuestionAnswer,
+} from "../handlers/ask-user-bridge.js";
+
+afterEach(() => {
+  clearAllPendingQuestionsForTest();
+});
+
+describe("ask-user-bridge", () => {
+  it("registerPendingQuestion → tryResolveQuestionAnswer happy path", async () => {
+    const promise = registerPendingQuestion({
+      correlationId: "tu_1",
+      agentId: "agent_a",
+      chatId: "chat_a",
+    });
+    expect(pendingQuestionCount()).toBe(1);
+
+    const matched = tryResolveQuestionAnswer({
+      correlationId: "tu_1",
+      answers: { "Should I proceed?": "Yes" },
+    });
+    expect(matched).toBe(true);
+    expect(pendingQuestionCount()).toBe(0);
+
+    const result = await promise;
+    expect(result).toEqual({
+      status: "answered",
+      answers: { "Should I proceed?": "Yes" },
+    });
+  });
+
+  it("tryResolveQuestionAnswer returns false when no matching pending entry exists", () => {
+    const matched = tryResolveQuestionAnswer({
+      correlationId: "tu_unknown",
+      answers: { foo: "bar" },
+    });
+    expect(matched).toBe(false);
+  });
+
+  it("tryResolveQuestionAnswer returns false on a malformed payload", async () => {
+    // Register so the bridge has *some* state — confirms the malformed answer
+    // doesn't accidentally match anything.
+    void registerPendingQuestion({ correlationId: "tu_a", agentId: "agent_a", chatId: "chat_a" });
+
+    expect(tryResolveQuestionAnswer({ correlationId: "tu_a" })).toBe(false); // missing `answers`
+    expect(tryResolveQuestionAnswer({ answers: { q: "a" } })).toBe(false); // missing `correlationId`
+    expect(tryResolveQuestionAnswer({ correlationId: "", answers: { q: "a" } })).toBe(false); // empty id
+    expect(tryResolveQuestionAnswer(null)).toBe(false);
+    expect(tryResolveQuestionAnswer("string")).toBe(false);
+  });
+
+  it("rejectPendingForAgent rejects only that agent's entries and returns the count", async () => {
+    const a1 = registerPendingQuestion({ correlationId: "tu_a1", agentId: "agent_a", chatId: "chat_a" });
+    const a2 = registerPendingQuestion({ correlationId: "tu_a2", agentId: "agent_a", chatId: "chat_a" });
+    const b1 = registerPendingQuestion({ correlationId: "tu_b1", agentId: "agent_b", chatId: "chat_b" });
+    expect(pendingQuestionCount()).toBe(3);
+
+    const dropped = rejectPendingForAgent("agent_a", "Session shutting down.");
+    expect(dropped).toBe(2);
+    expect(pendingQuestionCount()).toBe(1);
+
+    await expect(a1).resolves.toEqual({ status: "denied", reason: "Session shutting down." });
+    await expect(a2).resolves.toEqual({ status: "denied", reason: "Session shutting down." });
+
+    // agent_b's entry stays pending until explicitly resolved.
+    const matched = tryResolveQuestionAnswer({ correlationId: "tu_b1", answers: { q: "v" } });
+    expect(matched).toBe(true);
+    await expect(b1).resolves.toEqual({ status: "answered", answers: { q: "v" } });
+  });
+
+  it("re-registering the same correlationId resolves the previous waiter as denied", async () => {
+    const first = registerPendingQuestion({
+      correlationId: "tu_dup",
+      agentId: "agent_a",
+      chatId: "chat_a",
+    });
+    const second = registerPendingQuestion({
+      correlationId: "tu_dup",
+      agentId: "agent_a",
+      chatId: "chat_a",
+    });
+
+    await expect(first).resolves.toMatchObject({ status: "denied" });
+
+    // Only the second waiter is left — resolving by correlation id wakes it up.
+    expect(pendingQuestionCount()).toBe(1);
+    const matched = tryResolveQuestionAnswer({
+      correlationId: "tu_dup",
+      answers: { q: "yes" },
+    });
+    expect(matched).toBe(true);
+    await expect(second).resolves.toEqual({ status: "answered", answers: { q: "yes" } });
+  });
+});

--- a/packages/client/src/__tests__/ask-user-bridge.test.ts
+++ b/packages/client/src/__tests__/ask-user-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearAllPendingQuestionsForTest,
+  hasPendingForChat,
   pendingQuestionCount,
   registerPendingQuestion,
   rejectPendingForAgent,
@@ -71,6 +72,16 @@ describe("ask-user-bridge", () => {
     const matched = tryResolveQuestionAnswer({ correlationId: "tu_b1", answers: { q: "v" } });
     expect(matched).toBe(true);
     await expect(b1).resolves.toEqual({ status: "answered", answers: { q: "v" } });
+  });
+
+  it("hasPendingForChat reports true only for the matching (agent, chat) pair", () => {
+    void registerPendingQuestion({ correlationId: "tu_x1", agentId: "agent-a", chatId: "chat-1" });
+    void registerPendingQuestion({ correlationId: "tu_x2", agentId: "agent-b", chatId: "chat-1" });
+
+    expect(hasPendingForChat("agent-a", "chat-1")).toBe(true);
+    expect(hasPendingForChat("agent-b", "chat-1")).toBe(true);
+    expect(hasPendingForChat("agent-a", "chat-2")).toBe(false);
+    expect(hasPendingForChat("agent-c", "chat-1")).toBe(false);
   });
 
   it("re-registering the same correlationId resolves the previous waiter as denied", async () => {

--- a/packages/client/src/__tests__/claude-code-canusetool-bridge.test.ts
+++ b/packages/client/src/__tests__/claude-code-canusetool-bridge.test.ts
@@ -1,0 +1,268 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Verifies the canUseTool bridge wired up in commit 3:
+ *
+ *   1. Other tools pass through with `{ behavior: "allow", updatedInput }`
+ *      so existing handler behavior (Read/Write/Bash inside bypassPermissions)
+ *      is preserved.
+ *   2. AskUserQuestion is intercepted: the handler publishes a
+ *      `format: "question"` message via the SDK and parks until the
+ *      ask-user-bridge module resolves.
+ *   3. A subsequent answer (delivered via `tryResolveQuestionAnswer` — what
+ *      SessionManager.dispatch calls when a `question_answer` lands)
+ *      surfaces back to the SDK as `{ behavior: "allow", updatedInput:
+ *      { questions, answers } }`.
+ *   4. Malformed input is rejected via `{ behavior: "deny" }` so a model
+ *      regression can't smuggle bad data into the Hub.
+ */
+
+type CapturedCall = { options?: Record<string, unknown> };
+const capturedCalls: CapturedCall[] = [];
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const fakeQuery = {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => ({ done: true, value: undefined }),
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  };
+  return {
+    query: (args: { options?: Record<string, unknown> }) => {
+      capturedCalls.push({ options: args?.options });
+      return fakeQuery;
+    },
+  };
+});
+
+import type { CanUseTool } from "@anthropic-ai/claude-agent-sdk";
+import {
+  clearAllPendingQuestionsForTest,
+  pendingQuestionCount,
+  tryResolveQuestionAnswer,
+} from "../handlers/ask-user-bridge.js";
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d8";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-canusetool-bridge-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  capturedCalls.length = 0;
+  clearAllPendingQuestionsForTest();
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+type SentMessage = { chatId: string; data: Record<string, unknown> };
+
+function buildSessionCtx(chatId: string, sentMessages: SentMessage[]): SessionContext {
+  const sendMessage = async (cId: string, data: Record<string, unknown>): Promise<unknown> => {
+    sentMessages.push({ chatId: cId, data });
+    return undefined;
+  };
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: "inbox-test",
+      displayName: "test",
+      type: "autonomous_agent",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId,
+    log: () => {},
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: () => {},
+    reportSessionCompletion: () => {},
+    ...mockCtxPlumbing({ sendMessage }, chatId),
+  };
+}
+
+async function startHandlerAndCaptureCanUseTool(chatId: string, sent: SentMessage[]): Promise<CanUseTool> {
+  const cache = buildCache();
+  await cache.refresh(AGENT_ID);
+  const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+  const ctx = buildSessionCtx(chatId, sent);
+  await handler.start(
+    { id: `msg-${chatId}`, chatId, senderId: "user", format: "text", content: "hi", metadata: null },
+    ctx,
+  );
+  const options = capturedCalls[0]?.options;
+  if (typeof options?.canUseTool !== "function") {
+    throw new Error("canUseTool was not registered");
+  }
+  return options.canUseTool as CanUseTool;
+}
+
+const baseOptions = {
+  signal: new AbortController().signal,
+  toolUseID: "tu_default",
+};
+
+describe("claude-code canUseTool bridge", () => {
+  it("auto-allows non-AskUserQuestion tool calls without touching the inbox", async () => {
+    const sent: SentMessage[] = [];
+    const canUseTool = await startHandlerAndCaptureCanUseTool("chat-pass", sent);
+
+    const result = await canUseTool("Read", { path: "/etc/hosts" }, { ...baseOptions, toolUseID: "tu_read" });
+    expect(result).toEqual({ behavior: "allow", updatedInput: { path: "/etc/hosts" } });
+    expect(sent).toEqual([]);
+  });
+
+  it("publishes a question message and resolves on a matching answer", async () => {
+    const sent: SentMessage[] = [];
+    const canUseTool = await startHandlerAndCaptureCanUseTool("chat-bridge", sent);
+
+    const askInput = {
+      questions: [
+        {
+          question: "Should I proceed?",
+          header: "Proceed?",
+          options: [
+            { label: "Yes", description: "Affirmative", preview: null },
+            { label: "No", description: "Negative", preview: null },
+          ],
+          multiSelect: false,
+        },
+      ],
+    };
+
+    // Kick off the bridge — DON'T await yet.
+    const callPromise = canUseTool("AskUserQuestion", askInput, { ...baseOptions, toolUseID: "tu_q1" });
+
+    // Yield once so the bridge's pre-await side effects run (sdk.sendMessage,
+    // registerPendingQuestion). Then we should see exactly one outbound
+    // question message.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.chatId).toBe("chat-bridge");
+    expect(sent[0]?.data.format).toBe("question");
+    expect(sent[0]?.data.content).toMatchObject({
+      correlationId: "tu_q1",
+      previewFormat: "html",
+      allowFreeText: true,
+      questions: askInput.questions,
+    });
+
+    expect(pendingQuestionCount()).toBe(1);
+
+    // Now resolve the bridge — same shape that arrives via inbox.
+    const resolved = tryResolveQuestionAnswer({
+      correlationId: "tu_q1",
+      answers: { "Should I proceed?": "Yes" },
+    });
+    expect(resolved).toBe(true);
+
+    const result = await callPromise;
+    expect(result).toEqual({
+      behavior: "allow",
+      updatedInput: { questions: askInput.questions, answers: { "Should I proceed?": "Yes" } },
+    });
+    expect(pendingQuestionCount()).toBe(0);
+  });
+
+  it("denies a malformed AskUserQuestion input without publishing anything", async () => {
+    const sent: SentMessage[] = [];
+    const canUseTool = await startHandlerAndCaptureCanUseTool("chat-malformed", sent);
+
+    const result = await canUseTool(
+      "AskUserQuestion",
+      { questions: "not-an-array" } as unknown as Record<string, unknown>,
+      { ...baseOptions, toolUseID: "tu_bad" },
+    );
+
+    expect(result).toMatchObject({ behavior: "deny" });
+    expect(sent).toEqual([]);
+    expect(pendingQuestionCount()).toBe(0);
+  });
+
+  it("denies when sdk.sendMessage throws (e.g. server-side codex defense)", async () => {
+    const sent: SentMessage[] = [];
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+
+    const sendMessage = async (_chatId: string, _body: Record<string, unknown>): Promise<unknown> => {
+      throw new Error("Codex runtime cannot emit ask-user questions");
+    };
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-codex-defense",
+      log: () => {},
+      touch: () => {},
+      setRuntimeState: () => {},
+      emitEvent: () => {},
+      reportSessionCompletion: () => {},
+      ...mockCtxPlumbing({ sendMessage }, "chat-codex-defense"),
+    };
+    await handler.start(
+      { id: "msg-cd", chatId: "chat-codex-defense", senderId: "user", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+
+    const canUseTool = capturedCalls[0]?.options?.canUseTool as CanUseTool;
+    const result = await canUseTool(
+      "AskUserQuestion",
+      {
+        questions: [
+          {
+            question: "?",
+            header: "Q",
+            options: [
+              { label: "A", description: "", preview: null },
+              { label: "B", description: "", preview: null },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      { ...baseOptions, toolUseID: "tu_codex" },
+    );
+
+    expect(result).toMatchObject({ behavior: "deny" });
+    expect((result as { message?: string }).message).toMatch(/Codex runtime cannot emit/);
+    expect(sent).toEqual([]); // sendMessage threw before push
+    expect(pendingQuestionCount()).toBe(0);
+  });
+});

--- a/packages/client/src/__tests__/claude-code-sdk-options.test.ts
+++ b/packages/client/src/__tests__/claude-code-sdk-options.test.ts
@@ -133,4 +133,29 @@ describe("claude-code handler — SDK options", () => {
 
     await handler.shutdown();
   });
+
+  it("registers an AskUserQuestion bridge via canUseTool + toolConfig.askUserQuestion.previewFormat=html", async () => {
+    capturedCalls.length = 0;
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx = buildSessionCtx("chat-askuser");
+    await handler.start(
+      { id: "msg-3", chatId: "chat-askuser", senderId: "user", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+
+    const options = capturedCalls[0]?.options;
+    // canUseTool MUST be a function — the bridge's only entry point. Without
+    // it the SDK falls back to its default permission flow which has no way
+    // to surface AskUserQuestion to the Hub UI.
+    expect(typeof options?.canUseTool).toBe("function");
+    // previewFormat=html drives the model to emit web-renderable previews;
+    // commit 5 sanitises with DOMPurify before rendering.
+    expect(options?.toolConfig).toEqual({ askUserQuestion: { previewFormat: "html" } });
+
+    await handler.shutdown();
+  });
 });

--- a/packages/client/src/__tests__/codex-question-invariant.test.ts
+++ b/packages/client/src/__tests__/codex-question-invariant.test.ts
@@ -111,7 +111,6 @@ vi.mock("@openai/codex-sdk", () => {
     }
   }
   class FakeCodex {
-    constructor(_opts?: unknown) {}
     startThread(_opts?: unknown) {
       return new FakeThread();
     }

--- a/packages/client/src/__tests__/codex-question-invariant.test.ts
+++ b/packages/client/src/__tests__/codex-question-invariant.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@agent-team-foundation/first-tree-hub-shared";
+import type { ThreadItem } from "@openai/codex-sdk";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Codex runtime invariant: the codex handler must NEVER emit a Hub message
+ * whose `format` is `"question"` or `"question_answer"`. Codex SDK 0.125
+ * has no ask-user surface (verified end-to-end in `tmp-verify/verify-codex.mjs`),
+ * so any such message would be a runtime regression.
+ *
+ * The server-side defense (commit 2 — `assertSenderMayEmitQuestion`) is the
+ * load-bearing guarantee: even a buggy handler can't sneak a question
+ * through. This test pins the *handler-side* invariant so the regression
+ * shows up in unit tests before it ever reaches a server with the defense
+ * disabled (e.g. local testcontainer with stale schema).
+ *
+ * Strategy: mock the codex SDK to feed every documented ThreadItem variant
+ * the handler knows about (agent_message / command_execution / file_change
+ * / mcp_tool_call / web_search / todo_list / reasoning / error), drive a
+ * turn end-to-end, then assert:
+ *   1. Every captured `sdk.sendMessage` call has `format !== "question"`
+ *      and `format !== "question_answer"`.
+ *   2. Every captured `emitEvent` call uses one of the documented
+ *      `SessionEventKind` values (no synthetic `"question"` kind sneaks in).
+ */
+
+type CapturedSend = { chatId: string; data: Record<string, unknown> };
+type CapturedEvent = SessionEvent;
+
+// Construct the synthetic event stream the mocked thread emits. Covers every
+// ThreadItem case the handler's `processItem` switch is wired for, including
+// status variants (completed / failed) so the resulting events include both
+// success and error tool_calls. Two `agent_message` items so the handler's
+// multi-message accumulation path is exercised.
+//
+// Cast through `unknown` because the SDK's ThreadItem union has lots of
+// optional/required nested fields we don't care about for this invariant
+// test — the handler's `processItem` switch only inspects `type`, `text`,
+// `command`, `changes`, `query`, `items`, `arguments`, `error`, `result`,
+// `message`, and `status`. A faithful synthetic minus the unused fields is
+// enough to hit every branch.
+const FAKE_THREAD_ITEMS: ThreadItem[] = [
+  { id: "msg-1", type: "agent_message", text: "First chunk." },
+  { id: "msg-2", type: "agent_message", text: "Second chunk." },
+  {
+    id: "cmd-1",
+    type: "command_execution",
+    command: ["bash", "-c", "ls"],
+    aggregated_output: "ok",
+    status: "completed",
+  },
+  {
+    id: "cmd-2",
+    type: "command_execution",
+    command: ["bash", "-c", "false"],
+    aggregated_output: "error",
+    status: "failed",
+  },
+  {
+    id: "file-1",
+    type: "file_change",
+    changes: [{ path: "a.ts", kind: "update" }],
+    status: "completed",
+  },
+  {
+    id: "mcp-1",
+    type: "mcp_tool_call",
+    server: "test",
+    tool: "tool",
+    arguments: { foo: "bar" },
+    status: "completed",
+    result: { content: "ok" },
+  },
+  {
+    id: "mcp-2",
+    type: "mcp_tool_call",
+    server: "test",
+    tool: "tool",
+    arguments: { foo: "bar" },
+    status: "failed",
+    error: { message: "boom" },
+  },
+  { id: "web-1", type: "web_search", query: "claude" },
+  {
+    id: "todo-1",
+    type: "todo_list",
+    items: [{ content: "do thing", status: "pending" }],
+  },
+  { id: "reason-1", type: "reasoning", text: "thinking..." },
+  { id: "err-1", type: "error", message: "tool blew up" },
+].map((item) => item as unknown as ThreadItem);
+
+vi.mock("@openai/codex-sdk", () => {
+  class FakeThread {
+    public id = "thread-fake";
+    async runStreamed() {
+      const items = FAKE_THREAD_ITEMS;
+      const events = (async function* () {
+        yield { type: "thread.started", thread_id: "thread-fake" };
+        yield { type: "turn.started" };
+        for (const item of items) {
+          yield { type: "item.started", item };
+          yield { type: "item.completed", item };
+        }
+        yield { type: "turn.completed" };
+      })();
+      return { events };
+    }
+  }
+  class FakeCodex {
+    constructor(_opts?: unknown) {}
+    startThread(_opts?: unknown) {
+      return new FakeThread();
+    }
+    resumeThread(_id: string, _opts?: unknown) {
+      return new FakeThread();
+    }
+  }
+  return { Codex: FakeCodex };
+});
+
+import { createCodexHandler } from "../handlers/codex.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430cc";
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-codex-invariant-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: {
+        kind: "codex" as const,
+        prompt: { append: "" },
+        model: "",
+        mcpServers: [],
+        env: [],
+        gitRepos: [],
+      },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+function buildSessionCtx(chatId: string, sent: CapturedSend[], events: CapturedEvent[]): SessionContext {
+  const sendMessage = async (cId: string, data: Record<string, unknown>): Promise<unknown> => {
+    sent.push({ chatId: cId, data });
+    return { id: `msg-${sent.length}` };
+  };
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: "inbox-codex",
+      displayName: "Codex Agent",
+      type: "autonomous_agent",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId,
+    log: () => {},
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: (event) => {
+      events.push(event);
+    },
+    reportSessionCompletion: () => {},
+    ...mockCtxPlumbing({ sendMessage }, chatId),
+  };
+}
+
+describe("codex handler — question/question_answer invariant", () => {
+  it("never emits format=question or format=question_answer across the full ThreadItem matrix", async () => {
+    const sent: CapturedSend[] = [];
+    const events: CapturedEvent[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createCodexHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx = buildSessionCtx("chat-codex-inv", sent, events);
+
+    await handler.start(
+      {
+        id: "msg-in-1",
+        chatId: "chat-codex-inv",
+        senderId: "user",
+        format: "text",
+        content: "kick off the codex turn",
+        metadata: null,
+      },
+      ctx,
+    );
+
+    // The mocked codex emits two agent_message chunks → forwardResult should
+    // have published one consolidated text reply. That's the only message
+    // the handler legitimately sends; assert it is text-shaped.
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    for (const call of sent) {
+      const format = call.data.format as string | undefined;
+      expect(format).not.toBe("question");
+      expect(format).not.toBe("question_answer");
+      // Codex handler only forwards assistant text, so we can also pin the
+      // positive shape — the only non-text format that could legitimately
+      // appear here is none today.
+      expect(format === undefined || format === "text").toBe(true);
+    }
+
+    // Same invariant on emitEvent: no `question` kind should leak in.
+    const ALLOWED_EVENT_KINDS = new Set(["tool_call", "assistant_text", "thinking", "error", "turn_end"]);
+    for (const ev of events) {
+      expect(ALLOWED_EVENT_KINDS.has(ev.kind)).toBe(true);
+    }
+
+    // Sanity: the test would trivially pass if the handler bailed out before
+    // touching the synthetic ThreadItems. Pin that the branches we care about
+    // actually executed by checking we observed both an assistant_text event
+    // (from agent_message) and at least one tool_call event (from
+    // command_execution / file_change / mcp_tool_call / web_search /
+    // todo_list).
+    expect(events.some((e) => e.kind === "assistant_text")).toBe(true);
+    expect(events.some((e) => e.kind === "tool_call")).toBe(true);
+    expect(events.some((e) => e.kind === "thinking")).toBe(true);
+    expect(events.some((e) => e.kind === "turn_end")).toBe(true);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/__tests__/session-manager-question-answer.test.ts
+++ b/packages/client/src/__tests__/session-manager-question-answer.test.ts
@@ -137,7 +137,7 @@ describe("SessionManager.dispatch — question_answer short-circuit", () => {
     await sm.shutdown();
   });
 
-  it("acks the entry even when no waiter is registered (stale answer)", async () => {
+  it("falls through to normal dispatch when no waiter is registered (stale answer after suspend)", async () => {
     const handler = createMockHandler();
     const sdk = mockSdk();
     const sm = createSessionManager(handler, sdk);
@@ -145,14 +145,21 @@ describe("SessionManager.dispatch — question_answer short-circuit", () => {
     await sm.dispatch(
       makeAnswerEntry({
         entryId: 100,
-        chatId: "chat-1",
+        chatId: "chat-stale",
         correlationId: "tu_unknown",
         answers: { q: "v" },
       }),
     );
 
+    // No live waiter → SessionManager must NOT short-circuit. The answer
+    // flows through normal dispatch so the suspended SDK can resume with
+    // the answer as fresh user input. Verifies handler.start was called
+    // (this chat had no prior session row, so dispatch creates one).
+    expect(handler.start).toHaveBeenCalledTimes(1);
+    // The handler's start ackEntry path eventually acks; we verify ack
+    // happens at least once. Exact timing depends on the ack-channel
+    // configuration but the contract is "entry must not stay pending".
     expect(sdk.ack).toHaveBeenCalledWith(100);
-    expect(handler.start).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager-question-answer.test.ts
+++ b/packages/client/src/__tests__/session-manager-question-answer.test.ts
@@ -1,0 +1,159 @@
+import type { InboxEntryWithMessage } from "@agent-team-foundation/first-tree-hub-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAllPendingQuestionsForTest,
+  pendingQuestionCount,
+  registerPendingQuestion,
+} from "../handlers/ask-user-bridge.js";
+import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import { SessionManager } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
+
+/**
+ * SessionManager.dispatch must short-circuit `format: "question_answer"`
+ * entries: they are system-level signals that resolve a pending
+ * `canUseTool` Promise rather than user-facing messages that should
+ * start/wake an LLM session. Verifies:
+ *   - matching answers resolve the bridge waiter
+ *   - the inbox entry is acked even when no waiter exists (stale answer
+ *     after handler shutdown — otherwise the row would sit forever)
+ *   - the handler's start/resume/inject is never called for these messages
+ */
+
+function mockSdk(): FirstTreeHubSDK {
+  return {
+    register: vi.fn(),
+    pull: vi.fn(),
+    ack: vi.fn().mockResolvedValue(undefined),
+    renew: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue({ id: "msg-reply" }),
+    sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+  } as unknown as FirstTreeHubSDK;
+}
+
+function createMockHandler(): AgentHandler {
+  return {
+    start: vi.fn().mockResolvedValue("session-id-mock"),
+    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    inject: vi.fn(),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createSessionManager(handler: AgentHandler, sdk: FirstTreeHubSDK) {
+  const factory: HandlerFactory = () => handler;
+  return new SessionManager({
+    session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    concurrency: 5,
+    handlerFactory: factory,
+    handlerConfig: { workspaceRoot: "/tmp/test" },
+    agentIdentity: {
+      agentId: "agent-1",
+      inboxId: "inbox-agent-1",
+      displayName: "Agent",
+      type: "autonomous_agent",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk,
+    log: silentLogger(),
+  });
+}
+
+function makeAnswerEntry(args: {
+  entryId: number;
+  chatId: string;
+  correlationId: string;
+  answers: Record<string, string>;
+}): InboxEntryWithMessage {
+  return {
+    id: args.entryId,
+    inboxId: "inbox-test",
+    messageId: `msg-${args.entryId}`,
+    chatId: args.chatId,
+    status: "delivered",
+    retryCount: 0,
+    createdAt: new Date().toISOString(),
+    deliveredAt: new Date().toISOString(),
+    ackedAt: null,
+    message: {
+      id: `msg-${args.entryId}`,
+      chatId: args.chatId,
+      senderId: "sender-human",
+      format: "question_answer",
+      content: { correlationId: args.correlationId, answers: args.answers },
+      metadata: {},
+      replyToInbox: null,
+      replyToChat: null,
+      inReplyTo: null,
+      source: null,
+      createdAt: new Date().toISOString(),
+      configVersion: 1,
+      recipientMode: "full",
+      inReplyToSnapshot: null,
+      precedingMessages: [],
+    },
+  };
+}
+
+afterEach(() => {
+  clearAllPendingQuestionsForTest();
+});
+
+describe("SessionManager.dispatch — question_answer short-circuit", () => {
+  it("resolves the bridge waiter and acks the entry without invoking the handler", async () => {
+    const handler = createMockHandler();
+    const sdk = mockSdk();
+    const sm = createSessionManager(handler, sdk);
+
+    const waiter = registerPendingQuestion({
+      correlationId: "tu_abc",
+      agentId: "agent-1",
+      chatId: "chat-1",
+    });
+    expect(pendingQuestionCount()).toBe(1);
+
+    await sm.dispatch(
+      makeAnswerEntry({
+        entryId: 99,
+        chatId: "chat-1",
+        correlationId: "tu_abc",
+        answers: { "Should I proceed?": "Yes" },
+      }),
+    );
+
+    await expect(waiter).resolves.toEqual({
+      status: "answered",
+      answers: { "Should I proceed?": "Yes" },
+    });
+    expect(pendingQuestionCount()).toBe(0);
+    expect(sdk.ack).toHaveBeenCalledWith(99);
+    expect(handler.start).not.toHaveBeenCalled();
+    expect(handler.resume).not.toHaveBeenCalled();
+    expect(handler.inject).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("acks the entry even when no waiter is registered (stale answer)", async () => {
+    const handler = createMockHandler();
+    const sdk = mockSdk();
+    const sm = createSessionManager(handler, sdk);
+
+    await sm.dispatch(
+      makeAnswerEntry({
+        entryId: 100,
+        chatId: "chat-1",
+        correlationId: "tu_unknown",
+        answers: { q: "v" },
+      }),
+    );
+
+    expect(sdk.ack).toHaveBeenCalledWith(100);
+    expect(handler.start).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+});

--- a/packages/client/src/handlers/ask-user-bridge.ts
+++ b/packages/client/src/handlers/ask-user-bridge.ts
@@ -82,6 +82,21 @@ export function tryResolveQuestionAnswer(content: unknown): boolean {
   return true;
 }
 
+/**
+ * True when an in-flight AskUserQuestion exists for the given (agent, chat).
+ * SessionManager uses this to skip its idle-timeout suspend path: killing
+ * the SDK process while the user is mid-answer would leave the answer with
+ * nowhere to land (the eventual `tryResolveQuestionAnswer` would resolve
+ * the Promise, but the SDK transport is dead and crashes on the
+ * permission_response write).
+ */
+export function hasPendingForChat(agentId: string, chatId: string): boolean {
+  for (const entry of pending.values()) {
+    if (entry.agentId === agentId && entry.chatId === chatId) return true;
+  }
+  return false;
+}
+
 /** Cleanup hook used by handler.shutdown() to fail-fast every in-flight question. */
 export function rejectPendingForAgent(agentId: string, reason: string): number {
   let count = 0;
@@ -89,6 +104,27 @@ export function rejectPendingForAgent(agentId: string, reason: string): number {
     if (entry.agentId !== agentId) continue;
     pending.delete(correlationId);
     entry.resolve({ status: "denied", reason });
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Silent cleanup for `handler.suspend()`. Removes pending entries WITHOUT
+ * resolving the Promise — the SDK process is being torn down anyway, and
+ * resolving would unblock the canUseTool callback whose return value the
+ * SDK then writes to a now-closed transport (the symptom: 'ProcessTransport
+ * is not ready for writing' uncaught). The orphaned Promise stack frame is
+ * GC'd alongside the SDK process exit. When the user eventually answers,
+ * SessionManager.dispatch sees no matching waiter (`tryResolveQuestionAnswer`
+ * returns false) and routes the answer message through the normal dispatch
+ * path so the suspended session resumes with the answer as fresh input.
+ */
+export function clearPendingForAgent(agentId: string): number {
+  let count = 0;
+  for (const [correlationId, entry] of pending) {
+    if (entry.agentId !== agentId) continue;
+    pending.delete(correlationId);
     count++;
   }
   return count;

--- a/packages/client/src/handlers/ask-user-bridge.ts
+++ b/packages/client/src/handlers/ask-user-bridge.ts
@@ -1,0 +1,110 @@
+import { questionAnswerMessageContentSchema } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Module-singleton bridge between the Claude Agent SDK `AskUserQuestion`
+ * tool and Hub's inbox / question-answer round-trip.
+ *
+ * Lifecycle for one question:
+ *   1. The Claude handler's `canUseTool` callback intercepts the tool call,
+ *      sends a `format: "question"` message via the SDK upstream, and calls
+ *      {@link registerPendingQuestion} with the SDK's `toolUseID` as the
+ *      correlation key.
+ *   2. The Promise stays unresolved until the matching `question_answer`
+ *      message arrives via the inbox WS / poll path. SessionManager.dispatch
+ *      short-circuits that message kind into {@link tryResolveQuestionAnswer},
+ *      which decodes the answers and resolves the Promise.
+ *   3. The handler resumes and returns `{ behavior: "allow", updatedInput:
+ *      { questions, answers } }` to the SDK; the model carries on as if the
+ *      user had typed those answers directly.
+ *
+ * The Map is process-wide so a session that suspends/resumes during the wait
+ * window keeps the same correlation key working — `agentId` is only used to
+ * scope the {@link rejectPendingForAgent} cleanup on full handler shutdown.
+ *
+ * The Promise contract is `{ status: "answered", answers }` for a normal
+ * answer or `{ status: "denied", reason }` when the question has been
+ * superseded (chat archived, client claimed) or the handler is going down.
+ * The handler maps these to `{ behavior: "allow", updatedInput }` or
+ * `{ behavior: "deny", message }` for the SDK callback.
+ */
+
+export type BridgeAnswerResult =
+  | { status: "answered"; answers: Record<string, string> }
+  | { status: "denied"; reason: string };
+
+type PendingEntry = {
+  agentId: string;
+  chatId: string;
+  registeredAt: number;
+  resolve: (result: BridgeAnswerResult) => void;
+};
+
+const pending = new Map<string, PendingEntry>();
+
+/**
+ * Register a Promise that will resolve when the matching `question_answer`
+ * message arrives. Same `correlationId` re-registration is treated as the
+ * SDK retrying — the previous entry is rejected as superseded so its
+ * `canUseTool` callback unblocks.
+ */
+export function registerPendingQuestion(args: {
+  correlationId: string;
+  agentId: string;
+  chatId: string;
+}): Promise<BridgeAnswerResult> {
+  const { correlationId, agentId, chatId } = args;
+  const existing = pending.get(correlationId);
+  if (existing) {
+    existing.resolve({ status: "denied", reason: "Question re-registered with the same correlation id." });
+  }
+  return new Promise<BridgeAnswerResult>((resolve) => {
+    pending.set(correlationId, { agentId, chatId, registeredAt: Date.now(), resolve });
+  });
+}
+
+/**
+ * Best-effort resolve. Called by the inbox dispatcher when a
+ * `format: "question_answer"` message arrives. Returns `true` when an entry
+ * matched (so the caller knows it can ack + skip normal session routing),
+ * `false` when there was no waiter (stale answer, e.g. session resumed after
+ * the bridge was already cleaned up).
+ *
+ * Schema validation lives here too — a malformed answer payload is logged
+ * (well, `false` returned and the dispatcher emits a warn) but never throws.
+ */
+export function tryResolveQuestionAnswer(content: unknown): boolean {
+  const parsed = questionAnswerMessageContentSchema.safeParse(content);
+  if (!parsed.success) return false;
+  const entry = pending.get(parsed.data.correlationId);
+  if (!entry) return false;
+  pending.delete(parsed.data.correlationId);
+  entry.resolve({ status: "answered", answers: parsed.data.answers });
+  return true;
+}
+
+/** Cleanup hook used by handler.shutdown() to fail-fast every in-flight question. */
+export function rejectPendingForAgent(agentId: string, reason: string): number {
+  let count = 0;
+  for (const [correlationId, entry] of pending) {
+    if (entry.agentId !== agentId) continue;
+    pending.delete(correlationId);
+    entry.resolve({ status: "denied", reason });
+    count++;
+  }
+  return count;
+}
+
+/** Test-only: snapshot the current pending count. Lets unit tests verify
+ *  cleanup without exposing the Map itself. */
+export function pendingQuestionCount(): number {
+  return pending.size;
+}
+
+/** Test-only: drain everything (used by integration tests between cases so a
+ *  leaked entry doesn't bleed across test boundaries). */
+export function clearAllPendingQuestionsForTest(): void {
+  for (const [, entry] of pending) {
+    entry.resolve({ status: "denied", reason: "Test cleanup." });
+  }
+  pending.clear();
+}

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -10,10 +10,21 @@ import type {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import {
   deriveRepoLocalPath,
+  type QuestionItem,
+  type QuestionMessageContent,
+  questionItemSchema,
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import type { McpServerConfig, PermissionMode, Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  CanUseTool,
+  McpServerConfig,
+  PermissionMode,
+  PermissionResult,
+  Query,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { bootstrapWorkspace, installFirstTreeIntegration } from "../runtime/bootstrap.js";
 import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
@@ -27,6 +38,7 @@ import type {
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { acquireWorkspace } from "../runtime/workspace.js";
+import { registerPendingQuestion, rejectPendingForAgent } from "./ask-user-bridge.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 
 const MAX_RETRIES = 2;
@@ -455,6 +467,111 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     consumerDone = consumeOutput(sessionCtx);
   }
 
+  /**
+   * Build the SDK `canUseTool` callback for this session. Auto-allows every
+   * tool except `AskUserQuestion`, which we route through the Hub's inbox:
+   *
+   *   1. Validate the SDK's question shape against the shared Zod schema (so
+   *      a malformed model output can't smuggle bad data into Hub messages).
+   *   2. Send a `format: "question"` message via the agent SDK — this hits
+   *      the server's `sendMessage` path which writes the `pending_questions`
+   *      lifecycle row in the same transaction (see commit 2).
+   *   3. Register a Promise keyed on the SDK `toolUseID`. The matching
+   *      `question_answer` message arrives over the inbox WS / poll path
+   *      and SessionManager.dispatch resolves the Promise (commit 2 wired
+   *      the answer route + supersede hooks; SessionManager wiring lives
+   *      in this commit).
+   *   4. Map the bridge result to `PermissionResult`: `answered` →
+   *      `{ behavior: "allow", updatedInput: { questions, answers } }`,
+   *      `denied` → `{ behavior: "deny", message }` so the model abandons
+   *      the call instead of looping.
+   *
+   * `bypassPermissions` mode still calls `canUseTool` for `AskUserQuestion`
+   * specifically — verified by `tmp-verify/verify.mjs` cases A through G.
+   */
+  function buildAskUserCanUseTool(sessionCtx: SessionContext): CanUseTool {
+    return async (toolName, input, options) => {
+      if (toolName !== "AskUserQuestion") {
+        return { behavior: "allow", updatedInput: input };
+      }
+
+      // Validate the question shape from the model. SDK 0.2.84 emits the
+      // canonical AskUserQuestion input as `{ questions: QuestionItem[] }`;
+      // anything else is a model regression that we deny outright.
+      const inputSchema = z.object({ questions: z.array(questionItemSchema).min(1).max(4) });
+      const parsed = inputSchema.safeParse(input);
+      if (!parsed.success) {
+        sessionCtx.log(`AskUserQuestion: malformed input — ${parsed.error.message.slice(0, 200)}`);
+        return {
+          behavior: "deny",
+          message: "AskUserQuestion input did not validate; abandon the question and pick a different tool or answer.",
+        } satisfies PermissionResult;
+      }
+
+      const correlationId = options.toolUseID;
+      const questions: QuestionItem[] = parsed.data.questions;
+
+      const questionContent: QuestionMessageContent = {
+        correlationId,
+        questions,
+        previewFormat: "html",
+        allowFreeText: true,
+      };
+
+      // Push the question into the inbox first. If the upstream send fails
+      // we never register a pending entry — the SDK gets a clean deny and
+      // the model can retry. Server-side codex defense (commit 2) returns
+      // 403 for codex senders; we propagate that as a deny so the model
+      // doesn't burn turns hitting the same wall.
+      try {
+        await sessionCtx.sdk.sendMessage(sessionCtx.chatId, {
+          format: "question",
+          content: questionContent,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        sessionCtx.log(`AskUserQuestion: failed to publish question — ${reason}`);
+        return {
+          behavior: "deny",
+          message: `Hub could not publish the question (${reason}); abandon the call.`,
+        } satisfies PermissionResult;
+      }
+
+      sessionCtx.log(`AskUserQuestion: published correlationId=${correlationId}; awaiting user answer`);
+
+      // Wait for the matching question_answer to land in inbox. This Promise
+      // can sit pending for arbitrarily long — `defer` handling on the SDK
+      // hook side (PreToolUse) is the long-tail strategy if we ever need
+      // process-resume; for v1, the WS push path keeps the latency tight.
+      const result = await registerPendingQuestion({
+        correlationId,
+        agentId: sessionCtx.agent.agentId,
+        chatId: sessionCtx.chatId,
+      });
+
+      if (options.signal.aborted) {
+        // The query was aborted while we were waiting (eviction, restart,
+        // hot-switch). The bridge entry has already been removed by
+        // `rejectPendingForAgent`; just return a deny so the SDK unwinds.
+        return {
+          behavior: "deny",
+          message: "AskUserQuestion aborted before an answer arrived.",
+        } satisfies PermissionResult;
+      }
+
+      if (result.status === "denied") {
+        sessionCtx.log(`AskUserQuestion: denied correlationId=${correlationId} reason=${result.reason}`);
+        return { behavior: "deny", message: result.reason } satisfies PermissionResult;
+      }
+
+      sessionCtx.log(`AskUserQuestion: answered correlationId=${correlationId}`);
+      return {
+        behavior: "allow",
+        updatedInput: { questions, answers: result.answers },
+      } satisfies PermissionResult;
+    };
+  }
+
   /** Rebuild query and input controller without starting a new consumer loop (used for retry within the existing loop). */
   function respawnQuery(sessionId: string, sessionCtx: SessionContext): void {
     buildQuery(sessionId, sessionCtx, sessionId);
@@ -506,6 +623,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         //     explicit SDK options below, which layer on top of settings.
         settingSources: ["user", "project"],
         env: buildEnv(sessionCtx),
+        // Bridge AskUserQuestion to the Hub's inbox round-trip. Other tools
+        // are auto-allowed inside the bridge — `bypassPermissions` mode
+        // already skips the SDK's own prompt for non-ask-user tools, so
+        // adding canUseTool keeps existing behaviour while opening the
+        // ask-user channel for the model.
+        canUseTool: buildAskUserCanUseTool(sessionCtx),
+        // Drive the model to emit web-renderable previews. The frontend
+        // sanitises with DOMPurify before rendering (commit 5).
+        toolConfig: { askUserQuestion: { previewFormat: "html" } },
         ...(claudeCodeExecutable ? { pathToClaudeCodeExecutable: claudeCodeExecutable } : {}),
         ...(payload?.model ? { model: payload.model } : {}),
         ...(payload?.prompt.append
@@ -874,6 +1000,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     async shutdown() {
       const sessionCtx = ctx;
       await handler.suspend();
+      // Reject every in-flight AskUserQuestion for this agent so the SDK
+      // unwinds cleanly instead of dangling on a Promise that will never
+      // resolve. The supersede happens server-side via archiveSession /
+      // claimClient (commit 2); this is the local-process counterpart.
+      if (sessionCtx) {
+        const dropped = rejectPendingForAgent(sessionCtx.agent.agentId, "Session shutting down.");
+        if (dropped > 0) sessionCtx.log(`Rejected ${dropped} pending AskUserQuestion entries during shutdown`);
+      }
       // PRD §7.5: shutdown is session termination (explicit terminate,
       // eviction, or client restart). Release worktrees + workspace dir so
       // the next invocation gets a clean slate. `suspend()` alone preserves

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -38,7 +38,7 @@ import type {
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { acquireWorkspace } from "../runtime/workspace.js";
-import { registerPendingQuestion, rejectPendingForAgent } from "./ask-user-bridge.js";
+import { clearPendingForAgent, registerPendingQuestion, rejectPendingForAgent } from "./ask-user-bridge.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 
 const MAX_RETRIES = 2;
@@ -977,6 +977,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     async suspend() {
       ctx?.log("Suspending session");
+
+      // Silently drop any in-flight AskUserQuestion waiters BEFORE killing
+      // the SDK transport. Resolving them here would unblock canUseTool,
+      // which would then try to write the PermissionResult through a stdin
+      // we're about to close — the SDK throws an uncaught
+      // 'ProcessTransport is not ready for writing'. Leaving the awaiter
+      // Promise stranded is fine: the SDK process is going away and its
+      // stack frames GC with it. If the user eventually answers,
+      // SessionManager.dispatch sees no matching waiter and routes the
+      // `format=question_answer` message through the normal resume path
+      // (the answer becomes regular input on the next turn).
+      const sessionCtx = ctx;
+      if (sessionCtx) {
+        const dropped = clearPendingForAgent(sessionCtx.agent.agentId);
+        if (dropped > 0) sessionCtx.log(`Cleared ${dropped} pending AskUserQuestion entries on suspend`);
+      }
 
       if (inputController) {
         inputController.end();

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -100,8 +100,35 @@ export function resolveSenderLabel(senderId: string, participants: ChatParticipa
  * Async because the participant list may need a server round-trip on first
  * use; subsequent messages in the same session hit the cache.
  */
+/**
+ * Convert a SessionMessage's payload to a plain-text snippet the LLM can
+ * read as user input. Most formats are already strings; the special case
+ * is `question_answer` — when an answer arrives AFTER the SDK process was
+ * suspended, SessionManager.dispatch routes it through the normal path,
+ * and we need to render the structured `{correlationId, answers}` payload
+ * as readable English so the resumed Claude turn can act on it.
+ */
+function renderForLLM(message: SessionMessage): string {
+  if (message.format === "question_answer" && message.content && typeof message.content === "object") {
+    const c = message.content as { correlationId?: string; answers?: Record<string, string> };
+    if (c.answers && typeof c.answers === "object") {
+      const lines: string[] = [];
+      for (const [question, answer] of Object.entries(c.answers)) {
+        lines.push(`Q: ${question}`);
+        lines.push(`A: ${answer}`);
+      }
+      return [
+        "[The user has answered an earlier AskUserQuestion you raised. Continue the task using their answers below; do NOT call AskUserQuestion again for the same questions.]",
+        "",
+        ...lines,
+      ].join("\n");
+    }
+  }
+  return typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+}
+
 export async function formatInboundContent(message: SessionMessage, participants: ParticipantCache): Promise<string> {
-  const rawContent = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+  const rawContent = renderForLLM(message);
   const preceding = message.precedingMessages ?? [];
 
   let header = "";

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -4,6 +4,7 @@ import type {
   SessionEvent,
   SessionState,
 } from "@agent-team-foundation/first-tree-hub-shared";
+import { tryResolveQuestionAnswer } from "../handlers/ask-user-bridge.js";
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
@@ -135,6 +136,23 @@ export class SessionManager {
   async dispatch(entry: InboxEntryWithMessage): Promise<void> {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
+
+    // 0. AskUserQuestion bridge: a `question_answer` message is a system-level
+    //    signal that resolves an in-flight `canUseTool` Promise — never a
+    //    user-facing message that should start/wake an LLM session. Short-
+    //    circuit BEFORE dedup / config-refresh / echo-suppression: those
+    //    guards target normal text traffic and would either drop the answer
+    //    (dedup is keyed by (chat,msg)) or burn an unnecessary refresh.
+    //    The bridge tolerates a stale answer (no waiter for this id) by
+    //    returning false; we ack either way so the inbox row clears.
+    if (entry.message.format === "question_answer") {
+      const resolved = tryResolveQuestionAnswer(entry.message.content);
+      if (!resolved) {
+        this.config.log.warn({ chatId, messageId }, "question_answer arrived without a matching pending question");
+      }
+      await this.ackEntry(entry.id, chatId);
+      return;
+    }
 
     // 1. Deduplication — key by (chatId, messageId), not messageId alone.
     // replyTo cross-chat routing legitimately fan-outs the same message into

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -137,21 +137,36 @@ export class SessionManager {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
 
-    // 0. AskUserQuestion bridge: a `question_answer` message is a system-level
-    //    signal that resolves an in-flight `canUseTool` Promise — never a
-    //    user-facing message that should start/wake an LLM session. Short-
-    //    circuit BEFORE dedup / config-refresh / echo-suppression: those
-    //    guards target normal text traffic and would either drop the answer
-    //    (dedup is keyed by (chat,msg)) or burn an unnecessary refresh.
-    //    The bridge tolerates a stale answer (no waiter for this id) by
-    //    returning false; we ack either way so the inbox row clears.
+    // 0. AskUserQuestion bridge: a `question_answer` message has two
+    //    delivery paths:
+    //
+    //    a) Live waiter — the original `canUseTool` Promise is still
+    //       pending in the bridge. Resolve it, ack the inbox entry, and
+    //       short-circuit; the SDK takes the answer back into the same
+    //       turn. This is the happy path while the agent's SDK process
+    //       is still alive.
+    //
+    //    b) Stale waiter — the SDK process was killed (idle suspend or
+    //       explicit shutdown) before the user answered. The bridge map
+    //       was cleared by the handler at suspend time, so
+    //       `tryResolveQuestionAnswer` reports no match. We must NOT
+    //       short-circuit here: the answer needs to flow into the regular
+    //       dispatch path so the handler resumes the session and feeds
+    //       the answer to the SDK as fresh user input. The handler's
+    //       formatInboundContent renders question_answer messages as
+    //       readable text ("User selected: ..."), so the resumed turn
+    //       sees a normal text prompt.
     if (entry.message.format === "question_answer") {
       const resolved = tryResolveQuestionAnswer(entry.message.content);
-      if (!resolved) {
-        this.config.log.warn({ chatId, messageId }, "question_answer arrived without a matching pending question");
+      if (resolved) {
+        await this.ackEntry(entry.id, chatId);
+        return;
       }
-      await this.ackEntry(entry.id, chatId);
-      return;
+      this.config.log.info(
+        { chatId, messageId },
+        "question_answer with no live bridge waiter — resuming session with answer as input",
+      );
+      // Fall through to normal dispatch.
     }
 
     // 1. Deduplication — key by (chatId, messageId), not messageId alone.

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/drizzle/0034_pending_questions.sql
+++ b/packages/server/drizzle/0034_pending_questions.sql
@@ -1,0 +1,34 @@
+-- Pending ask-user question lifecycle. See packages/server/src/db/schema/pending-questions.ts
+-- and services/questions.ts for the read / write paths.
+--
+-- One row per `format=question` message. Rows are written inside the same
+-- transaction as the message INSERT (services/message.ts step 3b) so a
+-- rollback drops both. Status flips to `answered` when the user posts an
+-- answer, or to `superseded` when the chat session is archived
+-- (services/session.ts archiveSession) or the owning client is claimed
+-- away (services/client.ts claimClient).
+--
+-- Per the team's "integrity in service layer" convention, NO foreign-key
+-- constraints — referential integrity is enforced by the question service.
+-- A correlationId reuses the SDK `tool_use_id` so a single id flows from
+-- the Claude Agent SDK callback through to the answer message.
+
+CREATE TABLE IF NOT EXISTS "pending_questions" (
+  "id" text PRIMARY KEY NOT NULL,
+  "agent_id" text NOT NULL,
+  "chat_id" text NOT NULL,
+  "message_id" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "answered_at" timestamp with time zone,
+  "superseded_at" timestamp with time zone,
+  "superseded_reason" text
+);
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pending_questions_agent_status"
+  ON "pending_questions" ("agent_id", "status");
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_pending_questions_chat_status"
+  ON "pending_questions" ("chat_id", "status");

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1778284800000,
       "tag": "0033_onboarding_dismissed_at",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778371200000,
+      "tag": "0034_pending_questions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/scripts/e2e-askuser.mjs
+++ b/packages/server/scripts/e2e-askuser.mjs
@@ -1,0 +1,559 @@
+// End-to-end smoke for the AskUserQuestion roundtrip — runs the real Hub
+// server (with the migrated DB) in-process, drives a real `format=question`
+// message from an "agent" identity, drives a real answer POST from the
+// "human" identity, and verifies the full data plane lit up correctly:
+//
+//   1. The question message lands in `messages` with `format='question'`.
+//   2. `pending_questions` has a row keyed by correlationId, status=pending.
+//   3. `assertSenderMayEmitQuestion` rejects a codex sender with HTTP 403.
+//   4. POST /chats/:chatId/questions/:correlationId/answer returns 201.
+//   5. The pending row flips to status=answered with answered_at set.
+//   6. A new `format=question_answer` message exists with correlationId match.
+//   7. archiveSession on the chat marks any other pending row as superseded.
+//   8. claimClient on a separate agent's client marks its pending row
+//      superseded.
+//
+// Designed so a regression in any of commits 1–5 surfaces as a non-zero
+// exit. Run from inside `packages/server`:
+//   DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:5432/fth_e2e_askuser \
+//   npx tsx scripts/e2e-askuser.mjs
+
+import { randomUUID } from "node:crypto";
+
+const DB_URL = process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error("DATABASE_URL is required.");
+  process.exit(1);
+}
+
+// Boot the server in-process. We import from the workspace packages —
+// `buildApp` from server, the shared schemas, the `claimClient` /
+// `archiveSession` services. This is the same wiring `pnpm dev` would
+// produce, just without the CLI shell.
+const { buildApp } = await import("../src/app.ts");
+const { sendMessage } = await import("../src/services/message.ts");
+const { archiveSession, suspendSession } = await import("../src/services/session.ts");
+const { claimClient } = await import("../src/services/client.ts");
+const { createAgent } = await import("../src/services/agent.ts");
+const { createChat } = await import("../src/services/chat.ts");
+const { signTokensForUser } = await import("../src/services/auth.ts");
+const { resolveDefaultOrgId, ensureDefaultOrganization } = await import("../src/services/organization.ts");
+const { uuidv7 } = await import("../src/uuid.ts");
+const sharedDbSchema = await import("../src/db/schema/index.ts");
+const { eq } = await import("drizzle-orm");
+
+const failures = [];
+function expect(cond, label) {
+  if (cond) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures.push(label);
+    console.log(`  ✗ ${label}`);
+  }
+}
+
+const config = {
+  database: { url: DB_URL, provider: "external" },
+  server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
+  secrets: {
+    jwtSecret: "e2e-jwt-secret",
+    encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
+  auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
+  github: { webhookSecret: "test-webhook-secret", allowedOrg: "test-org" },
+  oauth: { github: { clientId: "x", clientSecret: "x" } },
+  trustProxy: false,
+  rateLimit: {
+    max: 10000,
+    loginMax: 10000,
+    webhookMax: 10000,
+    agentMessageMax: 10000,
+    contextTreeSnapshotMax: 10000,
+  },
+  observability: { logging: { level: "error", format: "json", bridgeToSpanLevel: "off" } },
+  runtime: {
+    inboxTimeoutSeconds: 300,
+    maxRetryCount: 3,
+    pollingIntervalSeconds: 5,
+    presenceCleanupSeconds: 60,
+    notificationWebhookUrl: undefined,
+  },
+  instanceId: "e2e-askuser",
+};
+
+console.log("[e2e-askuser] booting in-process Hub server…");
+const app = await buildApp(config);
+await app.ready();
+console.log("[e2e-askuser] server ready");
+
+// Clean content tables so reruns are deterministic. Keep schema + drizzle
+// metadata. `app.db.execute(sql.unsafe(...))` reuses the same drizzle
+// connection the server holds — no new postgres dep needed.
+const { sql: drizzleSql } = await import("drizzle-orm");
+async function truncateAll() {
+  await app.db.execute(drizzleSql.raw(`
+    TRUNCATE TABLE pending_questions, inbox_entries, messages,
+      agent_chat_sessions, agent_presence, chat_participants,
+      chat_subscriptions, chats, agents, members, clients,
+      users, organizations, auth_identities, agent_configs,
+      notifications, invitation_redemptions, invitations,
+      adapter_chat_mappings, adapter_agent_mappings,
+      adapter_message_references, adapter_configs,
+      session_events, server_instances, processed_events,
+      tasks, task_chats
+    RESTART IDENTITY CASCADE
+  `));
+}
+await truncateAll();
+// truncate wiped the default-org row that buildApp's onReady hook created;
+// re-create it explicitly so the rest of the harness can resolve a default
+// org for the test users / agents.
+await ensureDefaultOrganization(app.db);
+
+async function bootstrapUser() {
+  const userId = uuidv7();
+  const orgId = await resolveDefaultOrgId(app.db);
+  const memberId = uuidv7();
+  const username = `e2e-user-${randomUUID().slice(0, 6)}`;
+  const humanAgent = await app.db.transaction(async (tx) => {
+    await tx.insert(sharedDbSchema.users).values({
+      id: userId,
+      username,
+      passwordHash: "$2b$04$" + "x".repeat(22) + "y".repeat(31),
+      displayName: "E2E Tester",
+    });
+    const created = await createAgent(tx, {
+      name: `e2e-tester-${randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "E2E Tester",
+      source: "admin-api",
+      managerId: memberId,
+      organizationId: orgId,
+    });
+    await tx.insert(sharedDbSchema.members).values({
+      id: memberId,
+      userId,
+      organizationId: orgId,
+      agentId: created.uuid,
+      role: "admin",
+    });
+    return created;
+  });
+  const tokens = await signTokensForUser("e2e-jwt-secret", userId, {
+    accessTokenExpiry: "30m",
+    refreshTokenExpiry: "30d",
+  });
+  const clientId = `cli-${randomUUID().slice(0, 8)}`;
+  await app.db.insert(sharedDbSchema.clients).values({
+    id: clientId,
+    userId,
+    organizationId: orgId,
+    status: "connected",
+  });
+  return { userId, memberId, organizationId: orgId, humanAgent, accessToken: tokens.accessToken, clientId };
+}
+
+async function inject(method, url, accessToken, payload) {
+  return app.inject({
+    method,
+    url,
+    headers: { authorization: `Bearer ${accessToken}` },
+    ...(payload ? { payload } : {}),
+  });
+}
+
+// ── 1. Happy path: claude agent emits question → user answers → message lands ──
+console.log("\n[e2e-askuser] case 1: happy-path roundtrip");
+{
+  const ctx = await bootstrapUser();
+  const peer = await createAgent(
+    app.db,
+    {
+      name: `e2e-peer-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Peer Agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, ctx.humanAgent.uuid, {
+    type: "direct",
+    participantIds: [peer.uuid],
+  });
+
+  const correlationId = `tu_e2e_${randomUUID().slice(0, 8)}`;
+  const questionContent = {
+    correlationId,
+    questions: [
+      {
+        question: "Should I rebase or merge?",
+        header: "Strategy",
+        options: [
+          { label: "Rebase", description: "Replay commits", preview: "<code>git rebase main</code>" },
+          { label: "Merge", description: "Preserve history", preview: "<code>git merge main</code>" },
+        ],
+        multiSelect: false,
+      },
+    ],
+    previewFormat: "html",
+    allowFreeText: true,
+  };
+
+  const result = await sendMessage(app.db, chat.id, peer.uuid, {
+    format: "question",
+    content: questionContent,
+  });
+  expect(result.message.format === "question", "agent send produced format=question");
+
+  const [pendingRow] = await app.db
+    .select()
+    .from(sharedDbSchema.pendingQuestions)
+    .where(eq(sharedDbSchema.pendingQuestions.id, correlationId))
+    .limit(1);
+  expect(pendingRow !== undefined, "pending_questions row materialised");
+  expect(pendingRow?.status === "pending", "pending row status=pending");
+  expect(pendingRow?.agentId === peer.uuid, "pending row agent_id matches sender");
+  expect(pendingRow?.chatId === chat.id, "pending row chat_id matches");
+  expect(pendingRow?.messageId === result.message.id, "pending row message_id matches written message");
+
+  const answerRes = await inject(
+    "POST",
+    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
+    ctx.accessToken,
+    { answers: { "Should I rebase or merge?": "Rebase" } },
+  );
+  expect(answerRes.statusCode === 201, `POST answer returns 201 (got ${answerRes.statusCode})`);
+  const answerBody = answerRes.json();
+  expect(answerBody.correlationId === correlationId, "answer response carries correlationId");
+
+  const [updated] = await app.db
+    .select()
+    .from(sharedDbSchema.pendingQuestions)
+    .where(eq(sharedDbSchema.pendingQuestions.id, correlationId))
+    .limit(1);
+  expect(updated?.status === "answered", "pending row flipped to answered");
+  expect(updated?.answeredAt !== null, "answered_at timestamp set");
+
+  const [answerMsg] = await app.db
+    .select()
+    .from(sharedDbSchema.messages)
+    .where(eq(sharedDbSchema.messages.id, answerBody.messageId))
+    .limit(1);
+  expect(answerMsg?.format === "question_answer", "answer message has format=question_answer");
+  expect(answerMsg?.inReplyTo === result.message.id, "answer in_reply_to points at the question");
+  const answerContent = answerMsg?.content;
+  expect(answerContent?.correlationId === correlationId, "answer content correlationId roundtrips");
+  expect(answerContent?.answers["Should I rebase or merge?"] === "Rebase", "answer content carries selected option");
+
+  // Second submit on the same correlation should 409 (already answered).
+  const dupRes = await inject(
+    "POST",
+    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
+    ctx.accessToken,
+    { answers: { "Should I rebase or merge?": "Merge" } },
+  );
+  expect(dupRes.statusCode === 409, `duplicate answer returns 409 (got ${dupRes.statusCode})`);
+}
+
+// ── 2. Codex sender defense ──
+console.log("\n[e2e-askuser] case 2: codex runtime defense");
+{
+  const ctx = await bootstrapUser();
+  const codexPeer = await createAgent(
+    app.db,
+    {
+      name: `e2e-codex-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Codex Peer",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "codex",
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, ctx.humanAgent.uuid, {
+    type: "direct",
+    participantIds: [codexPeer.uuid],
+  });
+
+  const correlationId = `tu_codex_${randomUUID().slice(0, 8)}`;
+  let threw = false;
+  try {
+    await sendMessage(app.db, chat.id, codexPeer.uuid, {
+      format: "question",
+      content: {
+        correlationId,
+        questions: [
+          {
+            question: "?",
+            header: "Q",
+            options: [
+              { label: "A", description: "", preview: null },
+              { label: "B", description: "", preview: null },
+            ],
+            multiSelect: false,
+          },
+        ],
+        previewFormat: null,
+        allowFreeText: false,
+      },
+    });
+  } catch (err) {
+    threw = true;
+    expect(/Codex runtime cannot emit/.test(err.message), `codex sender rejected with expected message (${err.message})`);
+  }
+  expect(threw, "codex sender threw on sendMessage");
+
+  const rows = await app.db
+    .select()
+    .from(sharedDbSchema.pendingQuestions)
+    .where(eq(sharedDbSchema.pendingQuestions.id, correlationId));
+  expect(rows.length === 0, "no pending row leaked through codex defense");
+}
+
+// ── 3. archiveSession supersede path ──
+console.log("\n[e2e-askuser] case 3: archiveSession marks pending question superseded");
+{
+  const ctx = await bootstrapUser();
+  const peer = await createAgent(
+    app.db,
+    {
+      name: `e2e-arc-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Archive Peer",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, ctx.humanAgent.uuid, {
+    type: "direct",
+    participantIds: [peer.uuid],
+  });
+  const correlationId = `tu_arc_${randomUUID().slice(0, 8)}`;
+  await sendMessage(app.db, chat.id, peer.uuid, {
+    format: "question",
+    content: {
+      correlationId,
+      questions: [
+        {
+          question: "Continue?",
+          header: "Cont?",
+          options: [
+            { label: "Yes", description: "", preview: null },
+            { label: "No", description: "", preview: null },
+          ],
+          multiSelect: false,
+        },
+      ],
+      previewFormat: null,
+      allowFreeText: false,
+    },
+  });
+
+  await app.db
+    .insert(sharedDbSchema.agentChatSessions)
+    .values({ agentId: peer.uuid, chatId: chat.id, state: "active" })
+    .onConflictDoUpdate({
+      target: [sharedDbSchema.agentChatSessions.agentId, sharedDbSchema.agentChatSessions.chatId],
+      set: { state: "active", updatedAt: new Date() },
+    });
+  await suspendSession(app.db, peer.uuid, chat.id, peer.organizationId);
+  await archiveSession(app.db, peer.uuid, chat.id, peer.organizationId);
+
+  const [row] = await app.db
+    .select()
+    .from(sharedDbSchema.pendingQuestions)
+    .where(eq(sharedDbSchema.pendingQuestions.id, correlationId))
+    .limit(1);
+  expect(row?.status === "superseded", "archiveSession superseded the pending question");
+  expect(row?.supersededReason === "chat_archived", "supersede reason = chat_archived");
+
+  // Posting an answer on a superseded question must return 409.
+  const lateRes = await inject(
+    "POST",
+    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
+    ctx.accessToken,
+    { answers: { "Continue?": "Yes" } },
+  );
+  expect(lateRes.statusCode === 409, `late answer on superseded returns 409 (got ${lateRes.statusCode})`);
+}
+
+// ── 4. claimClient supersede path ──
+console.log("\n[e2e-askuser] case 4: claimClient marks pending superseded for unpinned agents");
+{
+  const ctx = await bootstrapUser();
+  const peer = await createAgent(
+    app.db,
+    {
+      name: `e2e-claim-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Claim Peer",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, ctx.humanAgent.uuid, {
+    type: "direct",
+    participantIds: [peer.uuid],
+  });
+  const correlationId = `tu_claim_${randomUUID().slice(0, 8)}`;
+  await sendMessage(app.db, chat.id, peer.uuid, {
+    format: "question",
+    content: {
+      correlationId,
+      questions: [
+        {
+          question: "Pick one",
+          header: "Pick",
+          options: [
+            { label: "A", description: "", preview: null },
+            { label: "B", description: "", preview: null },
+          ],
+          multiSelect: false,
+        },
+      ],
+      previewFormat: null,
+      allowFreeText: false,
+    },
+  });
+
+  // New owner takes over the client.
+  const newOwnerId = uuidv7();
+  await app.db.insert(sharedDbSchema.users).values({
+    id: newOwnerId,
+    username: `e2e-newowner-${randomUUID().slice(0, 6)}`,
+    passwordHash: "$2b$04$" + "x".repeat(22) + "y".repeat(31),
+    displayName: "New Owner",
+  });
+  await app.db.insert(sharedDbSchema.members).values({
+    id: uuidv7(),
+    userId: newOwnerId,
+    organizationId: ctx.organizationId,
+    agentId: peer.uuid, // not used for the claim, just satisfies the schema
+    role: "admin",
+  });
+
+  const claimResult = await claimClient(app.db, ctx.clientId, newOwnerId);
+  expect(claimResult.unpinnedAgentIds.includes(peer.uuid), "claim unpinned the affected agent");
+
+  const [row] = await app.db
+    .select()
+    .from(sharedDbSchema.pendingQuestions)
+    .where(eq(sharedDbSchema.pendingQuestions.id, correlationId))
+    .limit(1);
+  expect(row?.status === "superseded", "claimClient superseded the pending question");
+  expect(row?.supersededReason === "client_claimed", "supersede reason = client_claimed");
+}
+
+// ── 5. Client-side bridge dispatch — drives the real session-manager
+//      short-circuit that resolves a `canUseTool` Promise from a real
+//      `format=question_answer` inbox entry. ──
+console.log("\n[e2e-askuser] case 5: client bridge resolves on inbox question_answer");
+{
+  const { registerPendingQuestion, tryResolveQuestionAnswer, pendingQuestionCount, clearAllPendingQuestionsForTest } =
+    await import("../../client/src/handlers/ask-user-bridge.ts");
+  clearAllPendingQuestionsForTest();
+
+  const correlationId = `tu_bridge_${randomUUID().slice(0, 8)}`;
+  const waiter = registerPendingQuestion({
+    correlationId,
+    agentId: "e2e-agent",
+    chatId: "e2e-chat",
+  });
+  expect(pendingQuestionCount() === 1, "bridge registered the pending question");
+
+  // This is exactly the body session-manager.dispatch passes when a
+  // `format=question_answer` inbox entry arrives. Round-trip the wire shape.
+  const matched = tryResolveQuestionAnswer({
+    correlationId,
+    answers: { foo: "bar" },
+  });
+  expect(matched, "bridge accepted the matching answer");
+
+  const result = await Promise.race([
+    waiter,
+    new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000)),
+  ]);
+  expect(result?.status === "answered", "waiter resolved as answered");
+  expect(result?.answers?.foo === "bar", "waiter received answers verbatim");
+  expect(pendingQuestionCount() === 0, "bridge cleaned up after resolve");
+}
+
+// ── 6. Inbox poll round-trip — proves the agent client would actually receive
+//      the `format=question_answer` message via its existing pollInbox
+//      contract (SessionManager.dispatch's input source). ──
+console.log("\n[e2e-askuser] case 6: agent inbox.pull surfaces question_answer entry");
+{
+  const { pollInbox } = await import("../src/services/inbox.ts");
+  const ctx = await bootstrapUser();
+  const peer = await createAgent(
+    app.db,
+    {
+      name: `e2e-poll-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Poll Peer",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, ctx.humanAgent.uuid, {
+    type: "direct",
+    participantIds: [peer.uuid],
+  });
+  const correlationId = `tu_poll_${randomUUID().slice(0, 8)}`;
+  await sendMessage(app.db, chat.id, peer.uuid, {
+    format: "question",
+    content: {
+      correlationId,
+      questions: [
+        {
+          question: "Ship it?",
+          header: "Ship?",
+          options: [
+            { label: "Yes", description: "", preview: null },
+            { label: "No", description: "", preview: null },
+          ],
+          multiSelect: false,
+        },
+      ],
+      previewFormat: null,
+      allowFreeText: false,
+    },
+  });
+
+  await inject(
+    "POST",
+    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
+    ctx.accessToken,
+    { answers: { "Ship it?": "Yes" } },
+  );
+
+  // The peer agent's inbox should now hold the answer message — exactly
+  // what SessionManager.dispatch would receive via WS push or HTTP poll.
+  const polled = await pollInbox(app.db, peer.inboxId, 10);
+  const answerEntry = polled.find((e) => e.message?.format === "question_answer");
+  expect(answerEntry !== undefined, "agent inbox poll returns the question_answer entry");
+  expect(answerEntry?.message?.content?.correlationId === correlationId, "polled answer's correlationId roundtrips");
+  expect(
+    answerEntry?.message?.content?.answers?.["Ship it?"] === "Yes",
+    "polled answer carries the user's selected option",
+  );
+}
+
+await app.close();
+
+if (failures.length > 0) {
+  console.log(`\n[e2e-askuser] ✗ ${failures.length} failures:`);
+  for (const f of failures) console.log(`   - ${f}`);
+  process.exit(1);
+}
+console.log("\n[e2e-askuser] ✓ all assertions passed");
+process.exit(0);

--- a/packages/server/scripts/e2e-askuser.mjs
+++ b/packages/server/scripts/e2e-askuser.mjs
@@ -91,7 +91,8 @@ console.log("[e2e-askuser] server ready");
 // connection the server holds — no new postgres dep needed.
 const { sql: drizzleSql } = await import("drizzle-orm");
 async function truncateAll() {
-  await app.db.execute(drizzleSql.raw(`
+  await app.db.execute(
+    drizzleSql.raw(`
     TRUNCATE TABLE pending_questions, inbox_entries, messages,
       agent_chat_sessions, agent_presence, chat_participants,
       chat_subscriptions, chats, agents, members, clients,
@@ -102,7 +103,8 @@ async function truncateAll() {
       session_events, server_instances, processed_events,
       tasks, task_chats
     RESTART IDENTITY CASCADE
-  `));
+  `),
+  );
 }
 await truncateAll();
 // truncate wiped the default-org row that buildApp's onReady hook created;
@@ -119,7 +121,7 @@ async function bootstrapUser() {
     await tx.insert(sharedDbSchema.users).values({
       id: userId,
       username,
-      passwordHash: "$2b$04$" + "x".repeat(22) + "y".repeat(31),
+      passwordHash: `$2b$04$${"x".repeat(22)}${"y".repeat(31)}`,
       displayName: "E2E Tester",
     });
     const created = await createAgent(tx, {
@@ -248,12 +250,9 @@ console.log("\n[e2e-askuser] case 1: happy-path roundtrip");
   expect(answerContent?.answers["Should I rebase or merge?"] === "Rebase", "answer content carries selected option");
 
   // Second submit on the same correlation should 409 (already answered).
-  const dupRes = await inject(
-    "POST",
-    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
-    ctx.accessToken,
-    { answers: { "Should I rebase or merge?": "Merge" } },
-  );
+  const dupRes = await inject("POST", `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`, ctx.accessToken, {
+    answers: { "Should I rebase or merge?": "Merge" },
+  });
   expect(dupRes.statusCode === 409, `duplicate answer returns 409 (got ${dupRes.statusCode})`);
 }
 
@@ -302,7 +301,10 @@ console.log("\n[e2e-askuser] case 2: codex runtime defense");
     });
   } catch (err) {
     threw = true;
-    expect(/Codex runtime cannot emit/.test(err.message), `codex sender rejected with expected message (${err.message})`);
+    expect(
+      /Codex runtime cannot emit/.test(err.message),
+      `codex sender rejected with expected message (${err.message})`,
+    );
   }
   expect(threw, "codex sender threw on sendMessage");
 
@@ -373,12 +375,9 @@ console.log("\n[e2e-askuser] case 3: archiveSession marks pending question super
   expect(row?.supersededReason === "chat_archived", "supersede reason = chat_archived");
 
   // Posting an answer on a superseded question must return 409.
-  const lateRes = await inject(
-    "POST",
-    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
-    ctx.accessToken,
-    { answers: { "Continue?": "Yes" } },
-  );
+  const lateRes = await inject("POST", `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`, ctx.accessToken, {
+    answers: { "Continue?": "Yes" },
+  });
   expect(lateRes.statusCode === 409, `late answer on superseded returns 409 (got ${lateRes.statusCode})`);
 }
 
@@ -428,7 +427,7 @@ console.log("\n[e2e-askuser] case 4: claimClient marks pending superseded for un
   await app.db.insert(sharedDbSchema.users).values({
     id: newOwnerId,
     username: `e2e-newowner-${randomUUID().slice(0, 6)}`,
-    passwordHash: "$2b$04$" + "x".repeat(22) + "y".repeat(31),
+    passwordHash: `$2b$04$${"x".repeat(22)}${"y".repeat(31)}`,
     displayName: "New Owner",
   });
   await app.db.insert(sharedDbSchema.members).values({
@@ -476,10 +475,7 @@ console.log("\n[e2e-askuser] case 5: client bridge resolves on inbox question_an
   });
   expect(matched, "bridge accepted the matching answer");
 
-  const result = await Promise.race([
-    waiter,
-    new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000)),
-  ]);
+  const result = await Promise.race([waiter, new Promise((resolve) => setTimeout(() => resolve("timeout"), 2000))]);
   expect(result?.status === "answered", "waiter resolved as answered");
   expect(result?.answers?.foo === "bar", "waiter received answers verbatim");
   expect(pendingQuestionCount() === 0, "bridge cleaned up after resolve");
@@ -529,12 +525,9 @@ console.log("\n[e2e-askuser] case 6: agent inbox.pull surfaces question_answer e
     },
   });
 
-  await inject(
-    "POST",
-    `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
-    ctx.accessToken,
-    { answers: { "Ship it?": "Yes" } },
-  );
+  await inject("POST", `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`, ctx.accessToken, {
+    answers: { "Ship it?": "Yes" },
+  });
 
   // The peer agent's inbox should now hold the answer message — exactly
   // what SessionManager.dispatch would receive via WS push or HTTP poll.

--- a/packages/server/scripts/seed-askuser-demo.mjs
+++ b/packages/server/scripts/seed-askuser-demo.mjs
@@ -1,0 +1,200 @@
+// Seed the e2e DB with the canonical "Dev: skip GitHub" user (login=devuser,
+// githubId=1 — matches the hardcoded login.tsx button), a personal team,
+// one Claude-runtime peer agent, a direct chat, and a single pending
+// `format=question` message — so the operator can click the dev-OAuth
+// button on the running web UI and immediately land on a chat with the
+// question card on screen.
+//
+// Mirrors what `/api/v1/auth/github/dev-callback` would create on first
+// sign-in (findOrCreateUserFromGithub + createPersonalTeam) so that
+// clicking the dev button after this seed lands on the existing user
+// instead of provisioning a fresh one.
+
+import { randomUUID } from "node:crypto";
+
+const DB_URL = process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error("DATABASE_URL is required.");
+  process.exit(1);
+}
+
+const { buildApp } = await import("../src/app.ts");
+const { sendMessage } = await import("../src/services/message.ts");
+const { createAgent } = await import("../src/services/agent.ts");
+const { createChat } = await import("../src/services/chat.ts");
+const { ensureDefaultOrganization } = await import("../src/services/organization.ts");
+const { findOrCreateUserFromGithub } = await import("../src/services/auth-identity.ts");
+const { createPersonalTeam } = await import("../src/services/membership.ts");
+const sharedDbSchema = await import("../src/db/schema/index.ts");
+const { sql: drizzleSql, eq } = await import("drizzle-orm");
+
+const JWT_SECRET = process.env.JWT_SECRET_KEY ?? process.env.JWT_SECRET ?? "demo-jwt-secret";
+
+const config = {
+  database: { url: DB_URL, provider: "external" },
+  server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
+  secrets: {
+    jwtSecret: JWT_SECRET,
+    encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
+  auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
+  github: { webhookSecret: "demo-webhook", allowedOrg: "demo" },
+  oauth: { github: { clientId: "x", clientSecret: "x" } },
+  trustProxy: false,
+  rateLimit: {
+    max: 10000,
+    loginMax: 10000,
+    webhookMax: 10000,
+    agentMessageMax: 10000,
+    contextTreeSnapshotMax: 10000,
+  },
+  observability: { logging: { level: "error", format: "json", bridgeToSpanLevel: "off" } },
+  runtime: {
+    inboxTimeoutSeconds: 300,
+    maxRetryCount: 3,
+    pollingIntervalSeconds: 5,
+    presenceCleanupSeconds: 60,
+    notificationWebhookUrl: undefined,
+  },
+  instanceId: "seed-demo",
+};
+
+const app = await buildApp(config);
+await app.ready();
+
+await app.db.execute(drizzleSql.raw(`
+  TRUNCATE TABLE pending_questions, inbox_entries, messages,
+    agent_chat_sessions, agent_presence, chat_participants,
+    chat_subscriptions, chats, agents, members, clients,
+    users, organizations, auth_identities, agent_configs,
+    notifications, invitation_redemptions, invitations,
+    adapter_chat_mappings, adapter_agent_mappings,
+    adapter_message_references, adapter_configs,
+    session_events, server_instances, processed_events,
+    tasks, task_chats
+  RESTART IDENTITY CASCADE
+`));
+await ensureDefaultOrganization(app.db);
+
+// Match the hardcoded login.tsx dev-callback href:
+//   /api/v1/auth/github/dev-callback?githubId=1&login=devuser&displayName=Dev+User
+// findOrCreateUserFromGithub creates the users + auth_identities rows;
+// createPersonalTeam creates the org + members row. After this seed,
+// clicking the "Dev: skip GitHub" button on the login page lands on the
+// existing user instead of provisioning a fresh one.
+const githubProfile = {
+  githubId: "1",
+  login: "devuser",
+  email: null,
+  displayName: "Dev User",
+  avatarUrl: null,
+};
+const { userId } = await findOrCreateUserFromGithub(app.db, githubProfile);
+const team = await createPersonalTeam(app.db, {
+  userId,
+  loginSeed: githubProfile.login,
+  userDisplayName: githubProfile.displayName,
+});
+const orgId = team.organizationId;
+const memberId = team.memberId;
+
+// `createPersonalTeam` already provisioned the human agent for this user
+// (via ensureMembership). Look it up so we can build a chat with the peer
+// in the same org.
+const [memberRow] = await app.db
+  .select({ agentId: sharedDbSchema.members.agentId })
+  .from(sharedDbSchema.members)
+  .where(eq(sharedDbSchema.members.id, memberId))
+  .limit(1);
+const humanAgentId = memberRow?.agentId;
+if (!humanAgentId) throw new Error("expected member to carry an agentId");
+
+const clientId = `cli-demo-${randomUUID().slice(0, 6)}`;
+await app.db.insert(sharedDbSchema.clients).values({
+  id: clientId,
+  userId,
+  organizationId: orgId,
+  status: "connected",
+});
+
+const peer = await createAgent(
+  app.db,
+  {
+    name: "demo-claude-bot",
+    type: "autonomous_agent",
+    displayName: "Claude Demo Bot",
+    managerId: memberId,
+    clientId,
+    runtimeProvider: "claude-code",
+  },
+  { force: true },
+);
+
+const chat = await createChat(app.db, humanAgentId, {
+  type: "direct",
+  participantIds: [peer.uuid],
+});
+
+// Pending single-select question with HTML preview — exercises the
+// DOMPurify + option-card path.
+const correlationId = `tu_demo_${randomUUID().slice(0, 8)}`;
+await sendMessage(app.db, chat.id, peer.uuid, {
+  format: "question",
+  content: {
+    correlationId,
+    questions: [
+      {
+        question: "How should I handle the upcoming migration?",
+        header: "Migration",
+        options: [
+          {
+            label: "Rebase",
+            description: "Replay our commits on top of main — cleaner history.",
+            preview:
+              '<div style="font-family: monospace; padding: 8px;"><strong>git rebase main</strong><br/><small style="color: #666;">Replays N commits on top of main</small></div>',
+          },
+          {
+            label: "Merge",
+            description: "Merge main into our branch — preserves the merge graph.",
+            preview:
+              '<div style="font-family: monospace; padding: 8px;"><strong>git merge main</strong><br/><small style="color: #666;">Single merge commit, branch graph preserved</small></div>',
+          },
+          {
+            label: "Squash",
+            description: "Squash our commits into one before merging.",
+            preview:
+              '<div style="font-family: monospace; padding: 8px;"><strong>git merge --squash main</strong><br/><small style="color: #666;">Collapses N commits into a single change</small></div>',
+          },
+        ],
+        multiSelect: false,
+      },
+      {
+        question: "Should I run the test suite before pushing?",
+        header: "Tests?",
+        options: [
+          { label: "Yes — full suite", description: "Run pnpm test (slow but safe).", preview: null },
+          { label: "Yes — only changed packages", description: "Faster but narrower coverage.", preview: null },
+          { label: "Skip", description: "Push without local verification.", preview: null },
+        ],
+        multiSelect: false,
+      },
+    ],
+    previewFormat: "html",
+    allowFreeText: true,
+  },
+});
+
+await app.close();
+
+const PORT = process.env.PORT ?? "8000";
+console.log("\n[seed-askuser-demo] ✓ seeded demo data");
+console.log("");
+console.log(`  Login URL:    http://localhost:${PORT}/login`);
+console.log(`  Login flow:   click "Dev: skip GitHub" (localhost-only button)`);
+console.log(`  GitHub login: devuser (githubId=1)`);
+console.log(`  Org:          ${team.slug} (${team.displayName})`);
+console.log(`  Chat ID:      ${chat.id}`);
+console.log(`  Peer agent:   ${peer.uuid} (${peer.name})`);
+console.log(`  Question id:  ${correlationId}`);
+console.log("");
+console.log("After login, open the chat with 'Claude Demo Bot' to see two pending question cards.");

--- a/packages/server/scripts/seed-askuser-demo.mjs
+++ b/packages/server/scripts/seed-askuser-demo.mjs
@@ -62,7 +62,8 @@ const config = {
 const app = await buildApp(config);
 await app.ready();
 
-await app.db.execute(drizzleSql.raw(`
+await app.db.execute(
+  drizzleSql.raw(`
   TRUNCATE TABLE pending_questions, inbox_entries, messages,
     agent_chat_sessions, agent_presence, chat_participants,
     chat_subscriptions, chats, agents, members, clients,
@@ -73,7 +74,8 @@ await app.db.execute(drizzleSql.raw(`
     session_events, server_instances, processed_events,
     tasks, task_chats
   RESTART IDENTITY CASCADE
-`));
+`),
+);
 await ensureDefaultOrganization(app.db);
 
 // Match the hardcoded login.tsx dev-callback href:

--- a/packages/server/scripts/start-demo.mjs
+++ b/packages/server/scripts/start-demo.mjs
@@ -1,0 +1,89 @@
+// Boot the Hub server in foreground against the e2e DB, with the
+// pre-built web/dist served as static files. Used for hand-driven
+// verification of the AskUserQuestion UI after `seed-askuser-demo.mjs`.
+//
+// Skips telemetry / interactive config / migrations — assumes
+// `pnpm db:migrate` has already been run against $DATABASE_URL and the
+// web has been built to ../web/dist.
+//
+// Run from packages/server:
+//   DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:5432/fth_e2e_askuser \
+//   PORT=8000 \
+//   npx tsx scripts/start-demo.mjs
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DB_URL = process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error("DATABASE_URL is required.");
+  process.exit(1);
+}
+
+const PORT = Number(process.env.PORT ?? "8000");
+const HOST = process.env.HOST ?? "127.0.0.1";
+
+const webDistPath = resolve(import.meta.dirname, "..", "..", "web", "dist");
+if (!existsSync(webDistPath)) {
+  console.error(`web/dist not found at ${webDistPath}; run 'pnpm --filter @first-tree-hub/web build' first.`);
+  process.exit(1);
+}
+
+const { buildApp } = await import("../src/app.ts");
+
+const config = {
+  database: { url: DB_URL, provider: "external" },
+  server: { port: PORT, host: HOST, publicUrl: undefined },
+  secrets: {
+    jwtSecret: process.env.JWT_SECRET_KEY ?? process.env.JWT_SECRET ?? "demo-jwt-secret",
+    encryptionKey:
+      process.env.ENCRYPTION_KEY ??
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
+  auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
+  github: { webhookSecret: "demo-webhook", allowedOrg: "demo" },
+  oauth: { github: { clientId: "x", clientSecret: "x" } },
+  trustProxy: false,
+  rateLimit: {
+    max: 10000,
+    loginMax: 10000,
+    webhookMax: 10000,
+    agentMessageMax: 10000,
+    contextTreeSnapshotMax: 10000,
+  },
+  observability: { logging: { level: "info", format: "pretty", bridgeToSpanLevel: "off" } },
+  runtime: {
+    inboxTimeoutSeconds: 300,
+    maxRetryCount: 3,
+    pollingIntervalSeconds: 5,
+    presenceCleanupSeconds: 60,
+    notificationWebhookUrl: undefined,
+  },
+  webDistPath,
+  instanceId: "demo-foreground",
+};
+
+const app = await buildApp(config);
+await app.listen({ port: PORT, host: HOST });
+
+const url = `http://${HOST}:${PORT}`;
+console.log("");
+console.log(`════════════════════════════════════════════════════════════════════`);
+console.log(`  Hub server running:    ${url}`);
+console.log(`  Web (SPA fallback):    ${url}/`);
+console.log(`  API:                   ${url}/api/v1/healthz`);
+console.log(`  Login:                 ${url}/login`);
+console.log(`════════════════════════════════════════════════════════════════════`);
+console.log("");
+console.log("Press Ctrl+C to stop.");
+
+const shutdown = async (signal) => {
+  console.log(`\nReceived ${signal}; shutting down…`);
+  try {
+    await app.close();
+  } finally {
+    process.exit(0);
+  }
+};
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/packages/server/scripts/start-demo.mjs
+++ b/packages/server/scripts/start-demo.mjs
@@ -36,9 +36,7 @@ const config = {
   server: { port: PORT, host: HOST, publicUrl: undefined },
   secrets: {
     jwtSecret: process.env.JWT_SECRET_KEY ?? process.env.JWT_SECRET ?? "demo-jwt-secret",
-    encryptionKey:
-      process.env.ENCRYPTION_KEY ??
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    encryptionKey: process.env.ENCRYPTION_KEY ?? "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   },
   auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
   github: { webhookSecret: "demo-webhook", allowedOrg: "demo" },

--- a/packages/server/src/__tests__/questions.test.ts
+++ b/packages/server/src/__tests__/questions.test.ts
@@ -1,0 +1,289 @@
+import type {
+  QuestionAnswerMessageContent,
+  QuestionMessageContent,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { messages } from "../db/schema/messages.js";
+import { pendingQuestions } from "../db/schema/pending-questions.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import { claimClient } from "../services/client.js";
+import { sendMessage } from "../services/message.js";
+import { archiveSession, suspendSession } from "../services/session.js";
+import { createAdminContext, createTestAdmin, seedClient, useTestApp } from "./helpers.js";
+
+function buildQuestionContent(correlationId: string): QuestionMessageContent {
+  return {
+    correlationId,
+    questions: [
+      {
+        question: "Should I proceed?",
+        header: "Proceed?",
+        options: [
+          { label: "Yes", description: "Affirmative", preview: null },
+          { label: "No", description: "Negative", preview: null },
+        ],
+        multiSelect: false,
+      },
+    ],
+    previewFormat: null,
+    allowFreeText: true,
+  };
+}
+
+async function seedSessionRow(app: FastifyInstance, agentId: string, chatId: string, state: string) {
+  await app.db
+    .insert(agentChatSessions)
+    .values({ agentId, chatId, state })
+    .onConflictDoUpdate({
+      target: [agentChatSessions.agentId, agentChatSessions.chatId],
+      set: { state, updatedAt: new Date() },
+    });
+}
+
+async function setupQuestionScenario(app: FastifyInstance, runtimeProvider: "claude-code" | "codex" = "claude-code") {
+  const admin = await createAdminContext(app, { username: `q-${crypto.randomUUID().slice(0, 8)}` });
+  const peerAgent = await createAgent(
+    app.db,
+    {
+      name: `q-peer-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Peer agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      runtimeProvider,
+    },
+    { force: true },
+  );
+  const chat = await createChat(app.db, admin.humanAgentUuid, {
+    type: "direct",
+    participantIds: [peerAgent.uuid],
+  });
+  return { admin, peerAgent, chatId: chat.id };
+}
+
+describe("recordPendingQuestionFromMessage — sendMessage write hook", () => {
+  const getApp = useTestApp();
+
+  it("writes a pending_questions row in the same tx as the question message", async () => {
+    const app = getApp();
+    const { peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    const result = await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    expect(result.message.format).toBe("question");
+
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row).toBeDefined();
+    expect(row?.status).toBe("pending");
+    expect(row?.agentId).toBe(peerAgent.uuid);
+    expect(row?.chatId).toBe(chatId);
+    expect(row?.messageId).toBe(result.message.id);
+  });
+
+  it("rejects format=question from a codex-runtime sender (403)", async () => {
+    const app = getApp();
+    const { peerAgent, chatId } = await setupQuestionScenario(app, "codex");
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await expect(
+      sendMessage(app.db, chatId, peerAgent.uuid, {
+        format: "question",
+        content: buildQuestionContent(correlationId),
+      }),
+    ).rejects.toThrow(/Codex runtime cannot emit ask-user questions/);
+
+    // No row should have leaked through.
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row).toBeUndefined();
+  });
+
+  it("rejects malformed question content (missing correlationId)", async () => {
+    const app = getApp();
+    const { peerAgent, chatId } = await setupQuestionScenario(app);
+
+    await expect(
+      sendMessage(app.db, chatId, peerAgent.uuid, {
+        format: "question",
+        // missing `correlationId`
+        content: { questions: [], previewFormat: null, allowFreeText: true },
+      }),
+    ).rejects.toThrow(/Invalid question message content/);
+  });
+});
+
+describe("submitAnswer — POST /api/v1/chats/:chatId/questions/:correlationId/answer", () => {
+  const getApp = useTestApp();
+
+  it("happy path: writes question_answer message and flips status", async () => {
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    const questionMsg = await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    // Ensure the human agent is a participant so the user-scoped route can answer.
+    // direct chat already includes both; double-check.
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "Yes" } },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ correlationId: string; messageId: string }>();
+    expect(body.correlationId).toBe(correlationId);
+
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row?.status).toBe("answered");
+    expect(row?.answeredAt).toBeTruthy();
+
+    const answerRows = await app.db.select().from(messages).where(eq(messages.id, body.messageId)).limit(1);
+    expect(answerRows[0]?.format).toBe("question_answer");
+    const content = answerRows[0]?.content as QuestionAnswerMessageContent;
+    expect(content.correlationId).toBe(correlationId);
+    expect(content.answers).toEqual({ "Should I proceed?": "Yes" });
+    expect(answerRows[0]?.inReplyTo).toBe(questionMsg.message.id);
+  });
+
+  it("returns 409 when answering an already-answered question", async () => {
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "Yes" } },
+    });
+    expect(first.statusCode).toBe(201);
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "No" } },
+    });
+    expect(second.statusCode).toBe(409);
+  });
+
+  it("returns 404 when the correlationId does not exist", async () => {
+    const app = getApp();
+    const { admin, chatId } = await setupQuestionScenario(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/does-not-exist/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { foo: "bar" } },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects answer keys that don't match the original questions (400)", async () => {
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Wrong question text?": "Yes" } },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 409 once the question has been superseded", async () => {
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    // Force a supersede via the chat-close path.
+    await seedSessionRow(app, peerAgent.uuid, chatId, "suspended");
+    await archiveSession(app.db, peerAgent.uuid, chatId, peerAgent.organizationId);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "Yes" } },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("supersede hooks", () => {
+  const getApp = useTestApp();
+
+  it("archiveSession marks every pending question on that chat as superseded", async () => {
+    const app = getApp();
+    const { peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+    // Archive requires going through suspended first.
+    await seedSessionRow(app, peerAgent.uuid, chatId, "active");
+    await suspendSession(app.db, peerAgent.uuid, chatId, peerAgent.organizationId);
+    await archiveSession(app.db, peerAgent.uuid, chatId, peerAgent.organizationId);
+
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row?.status).toBe("superseded");
+    expect(row?.supersededReason).toBe("chat_archived");
+  });
+
+  it("claimClient marks every pending question on the unpinned agents as superseded", async () => {
+    const app = getApp();
+    const { peerAgent, admin, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    // Spin up a second user and claim the client over to them.
+    const newOwner = await createTestAdmin(app, { username: `claim-${crypto.randomUUID().slice(0, 6)}` });
+    // The new owner needs an unrelated client of their own (for accounting), but
+    // the claim itself only flips the existing one. Use seedClient to materialise
+    // a client owned by the new owner so the test mirrors a realistic setup.
+    await seedClient(app, newOwner.userId, admin.organizationId);
+
+    const result = await claimClient(app.db, admin.clientId, newOwner.userId);
+    expect(result.unpinnedAgentIds).toContain(peerAgent.uuid);
+
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row?.status).toBe("superseded");
+    expect(row?.supersededReason).toBe("client_claimed");
+  });
+});

--- a/packages/server/src/__tests__/questions.test.ts
+++ b/packages/server/src/__tests__/questions.test.ts
@@ -12,6 +12,7 @@ import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { claimClient } from "../services/client.js";
 import { sendMessage } from "../services/message.js";
+import { submitAnswer } from "../services/questions.js";
 import { archiveSession, suspendSession } from "../services/session.js";
 import { createAdminContext, createTestAdmin, seedClient, useTestApp } from "./helpers.js";
 
@@ -214,6 +215,62 @@ describe("submitAnswer — POST /api/v1/chats/:chatId/questions/:correlationId/a
       payload: { answers: { "Wrong question text?": "Yes" } },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  it("two concurrent submissions: exactly one wins, exactly one question_answer message is written", async () => {
+    // Regression test for the "double-write" race we caught in code review.
+    // Before the fix, both concurrent submitters would (a) pass the
+    // SELECT-FOR-UPDATE + status=pending check serially (because the lock-tx
+    // released before sendMessage), (b) call sendMessage(format=question_answer)
+    // independently, and (c) only the second UPDATE-WHERE-status=pending
+    // would lose the race — but BOTH answer messages had already landed in
+    // the inbox. Now: status flip happens INSIDE the lock-tx, so the second
+    // submitter sees status=answered and 409s before reaching sendMessage.
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    const [resA, resB] = await Promise.allSettled([
+      submitAnswer(app.db, undefined, {
+        correlationId,
+        chatId,
+        submitterAgentId: admin.humanAgentUuid,
+        answers: { "Should I proceed?": "Yes" },
+      }),
+      submitAnswer(app.db, undefined, {
+        correlationId,
+        chatId,
+        submitterAgentId: admin.humanAgentUuid,
+        answers: { "Should I proceed?": "No" },
+      }),
+    ]);
+
+    const fulfilled = [resA, resB].filter((r) => r.status === "fulfilled");
+    const rejected = [resA, resB].filter((r) => r.status === "rejected");
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    // The loser must be a 409 (ConflictError), not a 5xx — anything else
+    // would mean the race went somewhere unexpected.
+    const reason = (rejected[0] as PromiseRejectedResult).reason as Error & { statusCode?: number };
+    expect(reason.message).toMatch(/no longer pending|answered concurrently/);
+
+    // CRITICAL: exactly one question_answer message was written. Two would
+    // mean the bug came back.
+    const answerRows = await app.db
+      .select()
+      .from(messages)
+      .where(eq(messages.format, "question_answer"));
+    const forThisChat = answerRows.filter((m) => m.chatId === chatId);
+    expect(forThisChat.length).toBe(1);
+
+    // And the row is `answered`, not `pending`, after the dust settles.
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row?.status).toBe("answered");
   });
 
   it("returns 409 once the question has been superseded", async () => {

--- a/packages/server/src/__tests__/questions.test.ts
+++ b/packages/server/src/__tests__/questions.test.ts
@@ -261,10 +261,7 @@ describe("submitAnswer — POST /api/v1/chats/:chatId/questions/:correlationId/a
 
     // CRITICAL: exactly one question_answer message was written. Two would
     // mean the bug came back.
-    const answerRows = await app.db
-      .select()
-      .from(messages)
-      .where(eq(messages.format, "question_answer"));
+    const answerRows = await app.db.select().from(messages).where(eq(messages.format, "question_answer"));
     const forThisChat = answerRows.filter((m) => m.chatId === chatId);
     expect(forThisChat.length).toBe(1);
 

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -2,6 +2,7 @@ import {
   addMeChatParticipantsSchema,
   paginationQuerySchema,
   sendMessageSchema,
+  submitQuestionAnswerSchema,
   updateChatSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
@@ -22,6 +23,7 @@ import {
 } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { notifyRecipients } from "../services/notifier.js";
+import { submitAnswer } from "../services/questions.js";
 import { extractSummary } from "../services/session.js";
 
 /**
@@ -211,6 +213,36 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       createdAt: result.message.createdAt.toISOString(),
     });
   });
+
+  /**
+   * POST /chats/:chatId/questions/:correlationId/answer — submit an answer
+   * to a pending agent-emitted question. Caller speaks as their human agent;
+   * the answer is fanned out as a `format=question_answer` message back to
+   * the original agent's inbox so the in-flight `canUseTool` callback can
+   * resolve. Returns 409 if already answered or superseded.
+   */
+  app.post<{ Params: { chatId: string; correlationId: string } }>(
+    "/:chatId/questions/:correlationId/answer",
+    { config: { otelRecordBody: false } },
+    async (request, reply) => {
+      const { scope } = await requireChatAccess(request, app.db);
+      const body = submitQuestionAnswerSchema.parse(request.body);
+
+      await ensureParticipant(app.db, request.params.chatId, scope.humanAgentId);
+
+      const result = await submitAnswer(app.db, app.notifier, {
+        correlationId: request.params.correlationId,
+        chatId: request.params.chatId,
+        submitterAgentId: scope.humanAgentId,
+        answers: body.answers,
+      });
+
+      return reply.status(201).send({
+        correlationId: request.params.correlationId,
+        messageId: result.messageId,
+      });
+    },
+  );
 
   /** POST /chats/:chatId/read — chat-first-workspace read cursor. Idempotent. */
   app.post<{ Params: { chatId: string } }>("/:chatId/read", async (request) => {

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -16,6 +16,7 @@ export { messages } from "./messages.js";
 export { notifications } from "./notifications.js";
 export { organizationSettings } from "./organization-settings.js";
 export { organizations } from "./organizations.js";
+export { pendingQuestions } from "./pending-questions.js";
 export { serverInstances } from "./server-instances.js";
 export { sessionEvents } from "./session-events.js";
 export { taskChats, tasks } from "./tasks.js";

--- a/packages/server/src/db/schema/pending-questions.ts
+++ b/packages/server/src/db/schema/pending-questions.ts
@@ -1,0 +1,38 @@
+import { index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Server-side lifecycle tracker for `format=question` messages.
+ *
+ * Written when an agent emits a question through `sendMessage`; status
+ * flips to `answered` when the user posts an answer, or to `superseded`
+ * when the chat session is archived or its client is claimed away.
+ *
+ * Per the team's "integrity in service layer" convention, NO foreign-key
+ * constraints — referential integrity is enforced by the question
+ * service itself (chat-id / agent-id / message-id are validated at
+ * write time and the lifecycle hooks supersede orphaned rows).
+ */
+export const pendingQuestions = pgTable(
+  "pending_questions",
+  {
+    /** Same id as the question's `correlationId` (carried in message content) — primary lookup key. */
+    id: text("id").primaryKey(),
+    /** Agent that emitted the question (sender of the `format=question` message). */
+    agentId: text("agent_id").notNull(),
+    /** Chat where the question was posted. */
+    chatId: text("chat_id").notNull(),
+    /** The `messages.id` row carrying this question. */
+    messageId: text("message_id").notNull(),
+    /** "pending" → "answered" | "superseded". */
+    status: text("status").notNull().default("pending"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    answeredAt: timestamp("answered_at", { withTimezone: true }),
+    supersededAt: timestamp("superseded_at", { withTimezone: true }),
+    /** Free-form reason for supersede (e.g. "chat_archived", "client_claimed"). Null otherwise. */
+    supersededReason: text("superseded_reason"),
+  },
+  (table) => [
+    index("idx_pending_questions_agent_status").on(table.agentId, table.status),
+    index("idx_pending_questions_chat_status").on(table.chatId, table.status),
+  ],
+);

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -11,6 +11,7 @@ import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { BadRequestError, ClientUserMismatchError, ConflictError, NotFoundError } from "../errors.js";
 import { runtimeFieldsReset } from "./presence.js";
+import { markSupersededByAgents } from "./questions.js";
 
 /**
  * Assert the caller can act on this client. Throws 404 for both "not found"
@@ -151,6 +152,10 @@ export async function claimClient(
           .update(agentPresence)
           .set({ status: "offline", clientId: null, ...runtimeFieldsReset(now) })
           .where(inArray(agentPresence.agentId, unpinnedAgentIds));
+        // Pending ask-user questions on the unpinned agents can no longer be
+        // delivered back — their owning client is detaching. Mark superseded
+        // in the same transaction so a rollback unwinds it together.
+        await markSupersededByAgents(tx, unpinnedAgentIds, "client_claimed");
       }
     }
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -16,6 +16,7 @@ import { createLogger, messageAttrs, withSpan } from "../observability/index.js"
 import { upsertSessionState } from "./activity.js";
 import { findOrCreateDirectChat } from "./chat.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
+import { assertSenderMayEmitQuestion, recordPendingQuestionFromMessage } from "./questions.js";
 
 const log = createLogger("message");
 
@@ -173,6 +174,15 @@ async function sendMessageInner(
       }
     }
 
+    // 2d. Defensive: only Claude-runtime agents may emit ask-user questions.
+    //     Codex SDK has no ask-user surface, so any `format=question` message
+    //     coming from a codex-runtime sender is a runtime regression. We
+    //     surface it as 403 here rather than silently writing the row, so
+    //     the buggy caller is forced to fix itself. See questions.ts.
+    if (data.format === "question") {
+      await assertSenderMayEmitQuestion(tx, senderId);
+    }
+
     // 3. Store the message (with merged metadata + normalised content).
     const messageId = randomUUID();
     const [msg] = await tx
@@ -190,6 +200,19 @@ async function sendMessageInner(
         source: data.source ?? null,
       })
       .returning();
+
+    // 3b. For ask-user questions, record the pending lifecycle row in the
+    //     same transaction so a rollback drops both. The content was just
+    //     stored verbatim above; recordPendingQuestionFromMessage parses it
+    //     to extract the correlationId and rejects malformed payloads.
+    if (data.format === "question" && msg) {
+      await recordPendingQuestionFromMessage(tx, {
+        agentId: senderId,
+        chatId,
+        messageId: msg.id,
+        content: outboundContent,
+      });
+    }
 
     // 4. Fan-out: create inbox entries for every non-sender participant.
     //    The `notify` flag splits them in two:

--- a/packages/server/src/services/questions.ts
+++ b/packages/server/src/services/questions.ts
@@ -1,0 +1,265 @@
+import {
+  type QuestionAnswerMessageContent,
+  type QuestionMessageContent,
+  questionAnswerMessageContentSchema,
+  questionMessageContentSchema,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { messages } from "../db/schema/messages.js";
+import { pendingQuestions } from "../db/schema/pending-questions.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { createLogger } from "../observability/index.js";
+import { sendMessage } from "./message.js";
+import { type Notifier, notifyRecipients } from "./notifier.js";
+
+const log = createLogger("questions");
+
+type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "insert" | "update">;
+
+/**
+ * Insert a `pending_questions` row inside the same transaction that wrote a
+ * `format=question` message. Caller is `sendMessage` after the message INSERT
+ * returns, so a rollback drops both rows together. No-op (returns silently)
+ * if the message content is not a valid `QuestionMessageContent` — the caller
+ * will already have rejected such input upstream, but we defend in depth so a
+ * malformed write never leaves a dangling pending row.
+ */
+export async function recordPendingQuestionFromMessage(
+  tx: TxLike,
+  args: { agentId: string; chatId: string; messageId: string; content: unknown },
+): Promise<void> {
+  const parsed = questionMessageContentSchema.safeParse(args.content);
+  if (!parsed.success) {
+    throw new BadRequestError("Invalid question message content", {
+      "question.parse_error": parsed.error.message.slice(0, 200),
+    });
+  }
+  const { correlationId } = parsed.data;
+  await tx.insert(pendingQuestions).values({
+    id: correlationId,
+    agentId: args.agentId,
+    chatId: args.chatId,
+    messageId: args.messageId,
+    status: "pending",
+  });
+}
+
+/**
+ * Defensive write-side check: codex-runtime agents must never emit
+ * `format=question` (Codex SDK 0.125 has no ask-user surface, so any such
+ * message would be a runtime regression). Looks up the sender's
+ * `runtime_provider` and rejects if it is `codex`. Throws `ForbiddenError`
+ * (HTTP 403) so the bug surfaces loudly to the offending writer.
+ *
+ * Returns the runtime provider for telemetry / further checks (e.g. the
+ * caller can attach it to the active span).
+ */
+export async function assertSenderMayEmitQuestion(tx: TxLike, senderAgentId: string): Promise<string> {
+  const [row] = await tx
+    .select({ runtimeProvider: agents.runtimeProvider })
+    .from(agents)
+    .where(eq(agents.uuid, senderAgentId))
+    .limit(1);
+  if (!row) {
+    throw new NotFoundError(`Sender agent "${senderAgentId}" not found`);
+  }
+  if (row.runtimeProvider === "codex") {
+    log.error(
+      { agentId: senderAgentId, runtimeProvider: row.runtimeProvider },
+      "rejected format=question emit from codex-runtime agent",
+    );
+    throw new ForbiddenError("Codex runtime cannot emit ask-user questions", {
+      "question.codex_emit_attempt": true,
+      "agent.id": senderAgentId,
+    });
+  }
+  return row.runtimeProvider;
+}
+
+/**
+ * User-side answer submission. Atomically:
+ *   1. Lock the `pending_questions` row by correlationId.
+ *   2. Refuse if status !== "pending" (409 if already-answered, 410-shaped
+ *      400 if superseded — both surface as ConflictError so the caller knows
+ *      the question is no longer answerable).
+ *   3. Validate that the answer keys match the original `questions[]`.
+ *   4. Send a `format=question_answer` message via the regular message
+ *      pipeline (so fan-out, NOTIFY and inbox delivery happen unchanged).
+ *   5. Flip status to `answered`.
+ *
+ * `submitterAgentId` is the human agent on whose behalf the answer is
+ * written (it must be a participant of the question's chat). Returns the
+ * created `question_answer` message id so the route can include it in the
+ * 201 response.
+ */
+export async function submitAnswer(
+  db: Database,
+  notifier: Notifier | undefined,
+  args: {
+    correlationId: string;
+    chatId: string;
+    submitterAgentId: string;
+    answers: Record<string, string>;
+  },
+): Promise<{ messageId: string; recipients: string[] }> {
+  // Step 1+2+3: validate inside a SELECT-FOR-UPDATE so two concurrent
+  // submissions race cleanly (the second sees status=answered and 409s).
+  const { questionRow } = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({
+        id: pendingQuestions.id,
+        status: pendingQuestions.status,
+        chatId: pendingQuestions.chatId,
+        agentId: pendingQuestions.agentId,
+        messageId: pendingQuestions.messageId,
+      })
+      .from(pendingQuestions)
+      .where(eq(pendingQuestions.id, args.correlationId))
+      .for("update")
+      .limit(1);
+
+    if (!row) {
+      throw new NotFoundError(`Question "${args.correlationId}" not found`);
+    }
+    if (row.chatId !== args.chatId) {
+      // Chat-id mismatch — caller is asking against the wrong chat URL.
+      throw new NotFoundError(`Question "${args.correlationId}" not found in this chat`);
+    }
+    if (row.status !== "pending") {
+      throw new ConflictError(`Question "${args.correlationId}" is no longer pending`, {
+        "question.status": row.status,
+      });
+    }
+
+    // Cross-check the answers' keys against the original question texts so a
+    // malformed payload doesn't leak through to the SDK (the SDK uses
+    // questions[i].question as the answer dictionary key).
+    const [msg] = await tx
+      .select({ content: messages.content })
+      .from(messages)
+      .where(eq(messages.id, row.messageId))
+      .limit(1);
+    if (!msg) {
+      throw new NotFoundError(`Question message "${row.messageId}" not found`);
+    }
+    const parsedQuestion = questionMessageContentSchema.safeParse(msg.content);
+    if (!parsedQuestion.success) {
+      throw new BadRequestError("Stored question content is malformed", {
+        "question.parse_error": parsedQuestion.error.message.slice(0, 200),
+      });
+    }
+    const expectedKeys = new Set(parsedQuestion.data.questions.map((q) => q.question));
+    for (const key of Object.keys(args.answers)) {
+      if (!expectedKeys.has(key)) {
+        throw new BadRequestError(`Answer key "${key}" does not match any question`, {
+          "question.id": args.correlationId,
+        });
+      }
+    }
+    for (const key of expectedKeys) {
+      if (!(key in args.answers)) {
+        throw new BadRequestError(`Answer missing for question "${key}"`, {
+          "question.id": args.correlationId,
+        });
+      }
+    }
+
+    return { questionRow: row };
+  });
+
+  // Step 4: send the answer message. We do this OUTSIDE the lock-tx because
+  // sendMessage opens its own transaction (fan-out + chat-projection); nesting
+  // would deadlock. The narrow window between unlock and the final UPDATE
+  // below is bounded by the unique-PK on `pending_questions.id`, so a parallel
+  // submitAnswer on the same correlationId would still see status=pending
+  // here, but its UPDATE-with-WHERE-status=pending in step 5 will lose the
+  // race and bail out with ConflictError.
+  const answerContent: QuestionAnswerMessageContent = {
+    correlationId: args.correlationId,
+    answers: args.answers,
+  };
+  // Final parse to surface a clear error if something upstream mutated shape.
+  questionAnswerMessageContentSchema.parse(answerContent);
+
+  const result = await sendMessage(db, args.chatId, args.submitterAgentId, {
+    format: "question_answer",
+    content: answerContent,
+    inReplyTo: questionRow.messageId,
+    source: "hub_ui",
+  });
+
+  // Step 5: flip status — guarded by `WHERE status='pending'` so a concurrent
+  // submitAnswer (rare; would have to race past the lock-tx) still produces
+  // exactly one answered row.
+  const flipped = await db
+    .update(pendingQuestions)
+    .set({ status: "answered", answeredAt: new Date() })
+    .where(and(eq(pendingQuestions.id, args.correlationId), eq(pendingQuestions.status, "pending")))
+    .returning({ id: pendingQuestions.id });
+
+  if (flipped.length === 0) {
+    // Lost the race — another submitter committed first. The answer message
+    // we just emitted is still valid (the agent learns that a duplicate
+    // arrived); but signal the conflict to the caller.
+    log.warn(
+      { correlationId: args.correlationId, chatId: args.chatId },
+      "submitAnswer lost the race; status was already flipped",
+    );
+    throw new ConflictError(`Question "${args.correlationId}" was answered concurrently`);
+  }
+
+  // Notify all recipients of the answer message — same path as a normal user
+  // message. The bound agent's client will receive it on the inbox WS frame.
+  if (notifier) {
+    notifyRecipients(notifier, result.recipients, result.message.id);
+  }
+
+  return { messageId: result.message.id, recipients: result.recipients };
+}
+
+/**
+ * Mark every pending row whose chat is `chatId` as superseded. Used when a
+ * chat session is archived — the agent runtime that emitted the question
+ * may already be gone, so leaving the row pending would block forever.
+ */
+export async function markSupersededByChat(tx: TxLike, chatId: string, reason = "chat_archived"): Promise<number> {
+  const rows = await tx
+    .update(pendingQuestions)
+    .set({ status: "superseded", supersededAt: new Date(), supersededReason: reason })
+    .where(and(eq(pendingQuestions.chatId, chatId), eq(pendingQuestions.status, "pending")))
+    .returning({ id: pendingQuestions.id });
+  return rows.length;
+}
+
+/**
+ * Mark every pending row owned by any of `agentIds` as superseded. Used when
+ * the client carrying these agents is claimed by a new user — the previous
+ * owner's runtime is detached and cannot deliver an answer back.
+ */
+export async function markSupersededByAgents(
+  tx: TxLike,
+  agentIds: string[],
+  reason = "client_claimed",
+): Promise<number> {
+  if (agentIds.length === 0) return 0;
+  const rows = await tx
+    .update(pendingQuestions)
+    .set({ status: "superseded", supersededAt: new Date(), supersededReason: reason })
+    .where(and(inArray(pendingQuestions.agentId, agentIds), eq(pendingQuestions.status, "pending")))
+    .returning({ id: pendingQuestions.id });
+  return rows.length;
+}
+
+/**
+ * Read-only helper for routes / tests. Returns null if not found.
+ */
+export async function getPendingQuestion(db: Database, correlationId: string) {
+  const [row] = await db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+  return row ?? null;
+}
+
+/** Re-export for tests / callers that want the type without depending on shared. */
+export type { QuestionMessageContent };

--- a/packages/server/src/services/questions.ts
+++ b/packages/server/src/services/questions.ts
@@ -86,14 +86,28 @@ export async function assertSenderMayEmitQuestion(tx: TxLike, senderAgentId: str
  *      400 if superseded — both surface as ConflictError so the caller knows
  *      the question is no longer answerable).
  *   3. Validate that the answer keys match the original `questions[]`.
- *   4. Send a `format=question_answer` message via the regular message
- *      pipeline (so fan-out, NOTIFY and inbox delivery happen unchanged).
- *   5. Flip status to `answered`.
+ *   4. Flip status to `answered` INSIDE the lock-tx, before releasing the
+ *      row lock. This is the linearisation point: the second concurrent
+ *      submitter (waiting on the same row lock) will, on its turn, see
+ *      status=answered and exit with ConflictError BEFORE it can write a
+ *      second `format=question_answer` message.
+ *   5. Send the `format=question_answer` message OUTSIDE the lock-tx
+ *      (sendMessage opens its own transaction; nesting wasn't supported by
+ *      the existing call site). At this point we hold an exclusive logical
+ *      claim — only one submitter ever reaches this step per correlationId.
  *
  * `submitterAgentId` is the human agent on whose behalf the answer is
  * written (it must be a participant of the question's chat). Returns the
  * created `question_answer` message id so the route can include it in the
  * 201 response.
+ *
+ * Failure semantics: if step 5 (sendMessage) fails after status was flipped,
+ * we revert the row to `pending` so the user can retry. This is best-effort —
+ * the revert UPDATE is guarded by `status='answered'` to avoid clobbering a
+ * supersede that might race in. If the revert itself fails, the row is
+ * stranded as `answered` with no answer message; an operator would need to
+ * intervene, but a sendMessage failure (local DB tx) is already
+ * extraordinarily rare.
  */
 export async function submitAnswer(
   db: Database,
@@ -105,9 +119,12 @@ export async function submitAnswer(
     answers: Record<string, string>;
   },
 ): Promise<{ messageId: string; recipients: string[] }> {
-  // Step 1+2+3: validate inside a SELECT-FOR-UPDATE so two concurrent
-  // submissions race cleanly (the second sees status=answered and 409s).
-  const { questionRow } = await db.transaction(async (tx) => {
+  // Step 1-4: validate AND flip status inside a SELECT-FOR-UPDATE so two
+  // concurrent submissions are linearised by the row lock. Without the flip
+  // here, both submitters could pass the status=pending check, both could
+  // commit, both could call sendMessage outside the tx, and the inbox would
+  // see two answer messages — a bug we hit in field testing.
+  const questionRow = await db.transaction(async (tx) => {
     const [row] = await tx
       .select({
         id: pendingQuestions.id,
@@ -167,16 +184,19 @@ export async function submitAnswer(
       }
     }
 
-    return { questionRow: row };
+    // Step 4: flip status while still holding the row lock.
+    await tx
+      .update(pendingQuestions)
+      .set({ status: "answered", answeredAt: new Date() })
+      .where(eq(pendingQuestions.id, args.correlationId));
+
+    return row;
   });
 
-  // Step 4: send the answer message. We do this OUTSIDE the lock-tx because
-  // sendMessage opens its own transaction (fan-out + chat-projection); nesting
-  // would deadlock. The narrow window between unlock and the final UPDATE
-  // below is bounded by the unique-PK on `pending_questions.id`, so a parallel
-  // submitAnswer on the same correlationId would still see status=pending
-  // here, but its UPDATE-with-WHERE-status=pending in step 5 will lose the
-  // race and bail out with ConflictError.
+  // Step 5: send the answer message. By the time we get here we hold an
+  // exclusive claim on the row (any concurrent submitter is now seeing
+  // status=answered and 409ing in step 1-4 above), so this writes exactly
+  // one answer message per question.
   const answerContent: QuestionAnswerMessageContent = {
     correlationId: args.correlationId,
     answers: args.answers,
@@ -184,31 +204,40 @@ export async function submitAnswer(
   // Final parse to surface a clear error if something upstream mutated shape.
   questionAnswerMessageContentSchema.parse(answerContent);
 
-  const result = await sendMessage(db, args.chatId, args.submitterAgentId, {
-    format: "question_answer",
-    content: answerContent,
-    inReplyTo: questionRow.messageId,
-    source: "hub_ui",
-  });
-
-  // Step 5: flip status — guarded by `WHERE status='pending'` so a concurrent
-  // submitAnswer (rare; would have to race past the lock-tx) still produces
-  // exactly one answered row.
-  const flipped = await db
-    .update(pendingQuestions)
-    .set({ status: "answered", answeredAt: new Date() })
-    .where(and(eq(pendingQuestions.id, args.correlationId), eq(pendingQuestions.status, "pending")))
-    .returning({ id: pendingQuestions.id });
-
-  if (flipped.length === 0) {
-    // Lost the race — another submitter committed first. The answer message
-    // we just emitted is still valid (the agent learns that a duplicate
-    // arrived); but signal the conflict to the caller.
-    log.warn(
-      { correlationId: args.correlationId, chatId: args.chatId },
-      "submitAnswer lost the race; status was already flipped",
+  let result: Awaited<ReturnType<typeof sendMessage>>;
+  try {
+    result = await sendMessage(db, args.chatId, args.submitterAgentId, {
+      format: "question_answer",
+      content: answerContent,
+      inReplyTo: questionRow.messageId,
+      source: "hub_ui",
+    });
+  } catch (err) {
+    // Best-effort revert: status was flipped to 'answered' but we never
+    // emitted the answer message, so the agent would never see the answer
+    // and the user couldn't retry. Roll back to 'pending' so a retry can
+    // succeed. Guarded on status='answered' to avoid clobbering a
+    // supersede that landed in between.
+    log.error(
+      { correlationId: args.correlationId, chatId: args.chatId, err: err instanceof Error ? err.message : String(err) },
+      "sendMessage failed after status flip; reverting pending_questions row to 'pending'",
     );
-    throw new ConflictError(`Question "${args.correlationId}" was answered concurrently`);
+    try {
+      await db
+        .update(pendingQuestions)
+        .set({ status: "pending", answeredAt: null })
+        .where(and(eq(pendingQuestions.id, args.correlationId), eq(pendingQuestions.status, "answered")));
+    } catch (revertErr) {
+      log.error(
+        {
+          correlationId: args.correlationId,
+          chatId: args.chatId,
+          revertErr: revertErr instanceof Error ? revertErr.message : String(revertErr),
+        },
+        "revert UPDATE also failed; row may be stranded as 'answered' without an answer message",
+      );
+    }
+    throw err;
   }
 
   // Notify all recipients of the answer message — same path as a normal user

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -9,6 +9,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { NotFoundError } from "../errors.js";
 import type { Notifier } from "./notifier.js";
+import { markSupersededByChat } from "./questions.js";
 
 export const SUMMARY_MAX_LENGTH = 50;
 
@@ -370,6 +371,15 @@ async function transitionSessionState(
         lastSeenAt: now,
       })
       .where(eq(agentPresence.agentId, agentId));
+
+    // Archive transition: any pending ask-user questions on this chat are
+    // now unanswerable (the runtime that emitted them may already be gone).
+    // Mark them superseded inside the same transaction so a rollback would
+    // also revert the question state — preserves atomicity with the chat
+    // session state flip itself.
+    if (target === "evicted") {
+      await markSupersededByChat(tx, chatId, "chat_archived");
+    }
 
     finalState = target;
     transitioned = true;

--- a/packages/shared/src/__tests__/question-schema.test.ts
+++ b/packages/shared/src/__tests__/question-schema.test.ts
@@ -91,12 +91,31 @@ describe("questionItemSchema", () => {
     expect(res.success).toBe(false);
   });
 
-  it("rejects header longer than 12 chars", () => {
+  it("accepts a 13-char header (SDK occasionally emits slightly over 12)", () => {
     const res = questionItemSchema.safeParse({
       ...validQuestion,
-      header: "TooLongHeaderHere",
+      header: "ThirteenChars",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects header longer than 24 chars", () => {
+    const res = questionItemSchema.safeParse({
+      ...validQuestion,
+      header: "ThisHeaderIsWayTooLongForTheChip",
     });
     expect(res.success).toBe(false);
+  });
+
+  it("accepts options with omitted preview field (SDK shape when no preview generated)", () => {
+    const res = questionItemSchema.safeParse({
+      ...validQuestion,
+      options: [
+        { label: "A", description: "alpha" }, // no preview key at all
+        { label: "B", description: "beta" },
+      ],
+    });
+    expect(res.success).toBe(true);
   });
 
   it("rejects empty question text", () => {

--- a/packages/shared/src/__tests__/question-schema.test.ts
+++ b/packages/shared/src/__tests__/question-schema.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { MESSAGE_FORMATS, messageFormatSchema } from "../schemas/message.js";
+import {
+  QUESTION_STATUSES,
+  questionAnswerMessageContentSchema,
+  questionItemSchema,
+  questionMessageContentSchema,
+  questionOptionSchema,
+  questionStatusSchema,
+  submitQuestionAnswerSchema,
+} from "../schemas/question.js";
+
+const optionA = {
+  label: "Yes",
+  description: "Affirmative",
+  preview: null,
+};
+const optionB = {
+  label: "No",
+  description: "Negative",
+  preview: null,
+};
+
+const validQuestion = {
+  question: "Should I proceed?",
+  header: "Proceed?",
+  options: [optionA, optionB],
+  multiSelect: false,
+};
+
+const validContent = {
+  correlationId: "tool_use_abc",
+  questions: [validQuestion],
+  previewFormat: null,
+  allowFreeText: true,
+};
+
+describe("messageFormatSchema — new ask-user formats", () => {
+  it("accepts 'question'", () => {
+    expect(messageFormatSchema.safeParse("question").success).toBe(true);
+    expect(MESSAGE_FORMATS.QUESTION).toBe("question");
+  });
+
+  it("accepts 'question_answer'", () => {
+    expect(messageFormatSchema.safeParse("question_answer").success).toBe(true);
+    expect(MESSAGE_FORMATS.QUESTION_ANSWER).toBe("question_answer");
+  });
+});
+
+describe("questionOptionSchema", () => {
+  it("accepts a valid option with null preview", () => {
+    expect(questionOptionSchema.safeParse(optionA).success).toBe(true);
+  });
+
+  it("accepts a preview string", () => {
+    const res = questionOptionSchema.safeParse({ ...optionA, preview: "<p>hi</p>" });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects an empty label", () => {
+    const res = questionOptionSchema.safeParse({ label: "", description: "x", preview: null });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("questionItemSchema", () => {
+  it("accepts a valid single-select question", () => {
+    expect(questionItemSchema.safeParse(validQuestion).success).toBe(true);
+  });
+
+  it("accepts a valid multi-select with 4 options", () => {
+    const four = [optionA, optionB, { ...optionA, label: "Maybe" }, { ...optionA, label: "Later" }];
+    const res = questionItemSchema.safeParse({
+      ...validQuestion,
+      options: four,
+      multiSelect: true,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects only 1 option", () => {
+    const res = questionItemSchema.safeParse({ ...validQuestion, options: [optionA] });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects 5 options", () => {
+    const res = questionItemSchema.safeParse({
+      ...validQuestion,
+      options: [optionA, optionA, optionA, optionA, optionA],
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects header longer than 12 chars", () => {
+    const res = questionItemSchema.safeParse({
+      ...validQuestion,
+      header: "TooLongHeaderHere",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects empty question text", () => {
+    const res = questionItemSchema.safeParse({ ...validQuestion, question: "" });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("questionMessageContentSchema", () => {
+  it("accepts a single-question payload", () => {
+    expect(questionMessageContentSchema.safeParse(validContent).success).toBe(true);
+  });
+
+  it("accepts up to 4 parallel questions", () => {
+    const res = questionMessageContentSchema.safeParse({
+      ...validContent,
+      questions: [validQuestion, validQuestion, validQuestion, validQuestion],
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects 0 questions", () => {
+    const res = questionMessageContentSchema.safeParse({ ...validContent, questions: [] });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects 5 questions", () => {
+    const res = questionMessageContentSchema.safeParse({
+      ...validContent,
+      questions: Array(5).fill(validQuestion),
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects missing correlationId", () => {
+    const res = questionMessageContentSchema.safeParse({
+      questions: [validQuestion],
+      previewFormat: null,
+      allowFreeText: true,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects empty correlationId", () => {
+    const res = questionMessageContentSchema.safeParse({ ...validContent, correlationId: "" });
+    expect(res.success).toBe(false);
+  });
+
+  it("accepts previewFormat = 'html' / 'markdown' / null", () => {
+    expect(questionMessageContentSchema.safeParse({ ...validContent, previewFormat: "html" }).success).toBe(true);
+    expect(questionMessageContentSchema.safeParse({ ...validContent, previewFormat: "markdown" }).success).toBe(true);
+    expect(questionMessageContentSchema.safeParse({ ...validContent, previewFormat: null }).success).toBe(true);
+  });
+
+  it("rejects unknown previewFormat", () => {
+    const res = questionMessageContentSchema.safeParse({
+      ...validContent,
+      previewFormat: "rtf",
+    });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("questionAnswerMessageContentSchema", () => {
+  it("accepts a normal answer record", () => {
+    const res = questionAnswerMessageContentSchema.safeParse({
+      correlationId: "tool_use_abc",
+      answers: { "Should I proceed?": "Yes" },
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts comma-joined multi-select answer values", () => {
+    const res = questionAnswerMessageContentSchema.safeParse({
+      correlationId: "tool_use_abc",
+      answers: { "Pick languages": "TypeScript, Rust" },
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts free-text answer (any string value)", () => {
+    const res = questionAnswerMessageContentSchema.safeParse({
+      correlationId: "tool_use_abc",
+      answers: { "Anything else?": "I want to use Bun instead" },
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects an empty key in answers", () => {
+    const res = questionAnswerMessageContentSchema.safeParse({
+      correlationId: "tool_use_abc",
+      answers: { "": "Yes" },
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects missing correlationId", () => {
+    const res = questionAnswerMessageContentSchema.safeParse({
+      answers: { q: "a" },
+    });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("submitQuestionAnswerSchema", () => {
+  it("accepts a normal body", () => {
+    const res = submitQuestionAnswerSchema.safeParse({ answers: { q1: "a1" } });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects body without answers", () => {
+    expect(submitQuestionAnswerSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("questionStatusSchema", () => {
+  it("accepts pending / answered / superseded", () => {
+    expect(questionStatusSchema.safeParse("pending").success).toBe(true);
+    expect(questionStatusSchema.safeParse("answered").success).toBe(true);
+    expect(questionStatusSchema.safeParse("superseded").success).toBe(true);
+  });
+
+  it("rejects unknown status", () => {
+    expect(questionStatusSchema.safeParse("expired").success).toBe(false);
+  });
+
+  it("exposes constants", () => {
+    expect(QUESTION_STATUSES.PENDING).toBe("pending");
+    expect(QUESTION_STATUSES.ANSWERED).toBe("answered");
+    expect(QUESTION_STATUSES.SUPERSEDED).toBe("superseded");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -404,6 +404,23 @@ export {
   pulseTickSchema,
 } from "./schemas/pulse.js";
 export {
+  QUESTION_STATUSES,
+  type QuestionAnswerMessageContent,
+  type QuestionItem,
+  type QuestionMessageContent,
+  type QuestionOption,
+  type QuestionPreviewFormat,
+  type QuestionStatus,
+  questionAnswerMessageContentSchema,
+  questionItemSchema,
+  questionMessageContentSchema,
+  questionOptionSchema,
+  questionPreviewFormatSchema,
+  questionStatusSchema,
+  type SubmitQuestionAnswer,
+  submitQuestionAnswerSchema,
+} from "./schemas/question.js";
+export {
   DEFAULT_RUNTIME_PROVIDER,
   RUNTIME_PROVIDERS,
   type RuntimeProvider,

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -21,9 +21,22 @@ export const MESSAGE_FORMATS = {
   FILE: "file",
   /** System-generated task notification. Content shape: TaskMessageContent (see schemas/task.ts). */
   TASK: "task",
+  /** Agent → user structured ask-user prompt. Content shape: QuestionMessageContent (see schemas/question.ts). */
+  QUESTION: "question",
+  /** User → agent answer to a prior question. Content shape: QuestionAnswerMessageContent (see schemas/question.ts). */
+  QUESTION_ANSWER: "question_answer",
 } as const;
 
-export const messageFormatSchema = z.enum(["text", "markdown", "card", "reference", "file", "task"]);
+export const messageFormatSchema = z.enum([
+  "text",
+  "markdown",
+  "card",
+  "reference",
+  "file",
+  "task",
+  "question",
+  "question_answer",
+]);
 export type MessageFormat = z.infer<typeof messageFormatSchema>;
 
 export const sendMessageSchema = z.object({

--- a/packages/shared/src/schemas/question.ts
+++ b/packages/shared/src/schemas/question.ts
@@ -23,23 +23,32 @@ import { z } from "zod";
  * messages are immutable once written.
  */
 
-/** Single option inside a question. `preview` is optional rich content rendered above the label. */
+/**
+ * Single option inside a question. `preview` is rich content rendered above
+ * the label — the SDK's tool input emits it as `string | undefined` (the
+ * field is omitted when the model didn't generate any preview content), so
+ * we accept undefined / null / string and normalise downstream renderers
+ * to treat all three the same way.
+ */
 export const questionOptionSchema = z.object({
   label: z.string().min(1),
   description: z.string(),
-  /** SDK-emitted HTML or Markdown snippet. `null` when no preview was generated. */
-  preview: z.string().nullable(),
+  /** SDK-emitted HTML or Markdown snippet. Optional — the SDK omits this field when there's no preview. */
+  preview: z.string().nullable().optional(),
 });
 export type QuestionOption = z.infer<typeof questionOptionSchema>;
 
 /**
- * One question. `header` is a chip-style short tag — SDK enforces ≤12 chars and we
- * mirror that constraint here so malformed agent input fails parse before reaching UI.
+ * One question. `header` is a chip-style short tag. The SDK schema docs
+ * describe ≤12 chars but in practice the model occasionally emits
+ * slightly longer headers; we keep the rule loose (≤24) so a stylistic
+ * regression doesn't fail-closed at canUseTool and abandon the entire
+ * tool call. The UI truncates visually if needed.
  */
 export const questionItemSchema = z.object({
   /** The question text. Used as the answer-dictionary key in `QuestionAnswerMessageContent.answers`. */
   question: z.string().min(1),
-  header: z.string().min(1).max(12),
+  header: z.string().min(1).max(24),
   options: z.array(questionOptionSchema).min(2).max(4),
   multiSelect: z.boolean(),
 });

--- a/packages/shared/src/schemas/question.ts
+++ b/packages/shared/src/schemas/question.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+/**
+ * Structured ask-user payloads bridged from the Claude Agent SDK
+ * `AskUserQuestion` tool to Hub messages.
+ *
+ * Shape mirrors the SDK 0.2.84 input/output verbatim so the client
+ * runtime adapter can pass `updatedInput` straight through. See
+ * verify scripts under `packages/client/tmp-verify/` for the live
+ * matrix this was validated against.
+ *
+ * Lifecycle:
+ *  1. Agent emits a `format: "question"` message — its `content` is a
+ *     `QuestionMessageContent` carrying `correlationId` + `questions[]`.
+ *  2. User picks options in the Web UI and POSTs answers; server writes
+ *     a `format: "question_answer"` message — its `content` is a
+ *     `QuestionAnswerMessageContent` referencing the same `correlationId`.
+ *  3. Client runtime resolves the in-flight `canUseTool` promise with the
+ *     answers, and the SDK feeds them back to the model.
+ *
+ * `pending → answered → superseded` runtime status lives in a separate
+ * server table (`pending_questions`) and is not part of the message —
+ * messages are immutable once written.
+ */
+
+/** Single option inside a question. `preview` is optional rich content rendered above the label. */
+export const questionOptionSchema = z.object({
+  label: z.string().min(1),
+  description: z.string(),
+  /** SDK-emitted HTML or Markdown snippet. `null` when no preview was generated. */
+  preview: z.string().nullable(),
+});
+export type QuestionOption = z.infer<typeof questionOptionSchema>;
+
+/**
+ * One question. `header` is a chip-style short tag — SDK enforces ≤12 chars and we
+ * mirror that constraint here so malformed agent input fails parse before reaching UI.
+ */
+export const questionItemSchema = z.object({
+  /** The question text. Used as the answer-dictionary key in `QuestionAnswerMessageContent.answers`. */
+  question: z.string().min(1),
+  header: z.string().min(1).max(12),
+  options: z.array(questionOptionSchema).min(2).max(4),
+  multiSelect: z.boolean(),
+});
+export type QuestionItem = z.infer<typeof questionItemSchema>;
+
+/** Session-level preview format hint. Mirrors `toolConfig.askUserQuestion.previewFormat`. */
+export const questionPreviewFormatSchema = z.enum(["html", "markdown"]).nullable();
+export type QuestionPreviewFormat = z.infer<typeof questionPreviewFormatSchema>;
+
+/**
+ * Content payload for a message whose `format === "question"`.
+ *
+ * `correlationId` ties the question to its eventual answer message AND to the
+ * server-side `pending_questions` row; client runtime uses it to resolve the
+ * waiting `canUseTool` promise. Reuse the SDK `tool_use_id` when available so
+ * a single id flows end-to-end.
+ */
+export const questionMessageContentSchema = z.object({
+  correlationId: z.string().min(1),
+  questions: z.array(questionItemSchema).min(1).max(4),
+  previewFormat: questionPreviewFormatSchema,
+  /** Whether the UI should append a fixed "Other..." free-text choice to every question. v1 fixed `true`. */
+  allowFreeText: z.boolean(),
+});
+export type QuestionMessageContent = z.infer<typeof questionMessageContentSchema>;
+
+/**
+ * Content payload for a message whose `format === "question_answer"`.
+ *
+ * `answers` is keyed by `QuestionItem.question` text. For `multiSelect` questions
+ * the value is a `, `-joined string of selected labels (matches SDK convention).
+ * For free-text answers the value is the user's raw input.
+ */
+export const questionAnswerMessageContentSchema = z.object({
+  correlationId: z.string().min(1),
+  answers: z.record(z.string().min(1), z.string()),
+});
+export type QuestionAnswerMessageContent = z.infer<typeof questionAnswerMessageContentSchema>;
+
+/** Submit-answer request body for `POST /api/admin/questions/:correlationId/answer`. */
+export const submitQuestionAnswerSchema = z.object({
+  answers: z.record(z.string().min(1), z.string()),
+});
+export type SubmitQuestionAnswer = z.infer<typeof submitQuestionAnswerSchema>;
+
+/** Lifecycle status of a question (server-side, not in message schema). */
+export const QUESTION_STATUSES = {
+  PENDING: "pending",
+  ANSWERED: "answered",
+  SUPERSEDED: "superseded",
+} as const;
+export const questionStatusSchema = z.enum(["pending", "answered", "superseded"]);
+export type QuestionStatus = z.infer<typeof questionStatusSchema>;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "d3-hierarchy": "^3.1.2",
+    "dompurify": "^3.4.2",
     "lucide-react": "^0.577.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/web/src/api/questions.ts
+++ b/packages/web/src/api/questions.ts
@@ -1,0 +1,31 @@
+import { api } from "./client.js";
+
+export type SubmitQuestionAnswerResponse = {
+  correlationId: string;
+  messageId: string;
+};
+
+/**
+ * Submit answers to a pending agent-emitted question.
+ *
+ * Mirrors `POST /api/v1/chats/:chatId/questions/:correlationId/answer`
+ * (commit 2). Returns the new `format=question_answer` message id so the
+ * UI can optimistically pin the answered state without round-tripping
+ * through the message list query.
+ *
+ * Errors propagate verbatim (api client throws `ApiError` for non-2xx);
+ * common shapes:
+ *   - 409 — question is no longer pending (already answered or superseded)
+ *   - 400 — answer keys don't match the original questions
+ *   - 404 — wrong chatId / unknown correlationId
+ */
+export function submitQuestionAnswer(
+  chatId: string,
+  correlationId: string,
+  answers: Record<string, string>,
+): Promise<SubmitQuestionAnswerResponse> {
+  return api.post<SubmitQuestionAnswerResponse>(
+    `/chats/${encodeURIComponent(chatId)}/questions/${encodeURIComponent(correlationId)}/answer`,
+    { answers },
+  );
+}

--- a/packages/web/src/components/__tests__/question-message.test.ts
+++ b/packages/web/src/components/__tests__/question-message.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { isQuestionAnswerContent, isQuestionContent } from "../chat/question-message.js";
+
+/**
+ * Pin the type guards so the chat-view dispatch logic (commit 5) can rely
+ * on them to safely narrow `MessageWithDelivery.content` (which is
+ * `unknown` at the wire level). A regression here would either render
+ * the JSON-stringified fallback for a real question (UX regression) or
+ * crash on a malformed question payload (robustness regression).
+ */
+
+const validQuestionContent = {
+  correlationId: "tu_1",
+  questions: [
+    {
+      question: "Should I proceed?",
+      header: "Proceed?",
+      options: [
+        { label: "Yes", description: "ok", preview: null },
+        { label: "No", description: "no", preview: null },
+      ],
+      multiSelect: false,
+    },
+  ],
+  previewFormat: null,
+  allowFreeText: true,
+};
+
+const validAnswerContent = {
+  correlationId: "tu_1",
+  answers: { "Should I proceed?": "Yes" },
+};
+
+describe("isQuestionContent", () => {
+  it("accepts a valid QuestionMessageContent", () => {
+    expect(isQuestionContent(validQuestionContent)).toBe(true);
+  });
+
+  it("rejects when previewFormat is unknown", () => {
+    expect(isQuestionContent({ ...validQuestionContent, previewFormat: "rtf" })).toBe(false);
+  });
+
+  it("rejects empty correlationId", () => {
+    expect(isQuestionContent({ ...validQuestionContent, correlationId: "" })).toBe(false);
+  });
+
+  it("rejects payload with too few options", () => {
+    expect(
+      isQuestionContent({
+        ...validQuestionContent,
+        questions: [
+          {
+            ...validQuestionContent.questions[0],
+            options: [{ label: "Only", description: "", preview: null }],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects answer-shaped content", () => {
+    expect(isQuestionContent(validAnswerContent)).toBe(false);
+  });
+
+  it("rejects null / non-object / string", () => {
+    expect(isQuestionContent(null)).toBe(false);
+    expect(isQuestionContent("text")).toBe(false);
+    expect(isQuestionContent(42)).toBe(false);
+  });
+});
+
+describe("isQuestionAnswerContent", () => {
+  it("accepts a valid QuestionAnswerMessageContent", () => {
+    expect(isQuestionAnswerContent(validAnswerContent)).toBe(true);
+  });
+
+  it("rejects when correlationId is missing", () => {
+    expect(isQuestionAnswerContent({ answers: { q: "v" } })).toBe(false);
+  });
+
+  it("rejects question-shaped content", () => {
+    expect(isQuestionAnswerContent(validQuestionContent)).toBe(false);
+  });
+
+  it("rejects empty answer keys", () => {
+    expect(
+      isQuestionAnswerContent({
+        correlationId: "tu_1",
+        answers: { "": "yes" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/components/chat/option-card.tsx
+++ b/packages/web/src/components/chat/option-card.tsx
@@ -1,0 +1,108 @@
+import type { QuestionOption, QuestionPreviewFormat } from "@agent-team-foundation/first-tree-hub-shared";
+import DOMPurify from "dompurify";
+import { useMemo } from "react";
+import { cn } from "../../lib/utils.js";
+import { Markdown } from "../ui/markdown.js";
+
+/**
+ * Single option inside a `<QuestionMessage />` — renders the SDK's
+ * `{ label, description, preview }` shape as a clickable card.
+ *
+ * Preview rendering:
+ *   - `previewFormat: "html"` → DOMPurify-sanitised innerHTML. SDK 0.2.84
+ *     already strips `<script>/<style>/<!DOCTYPE>` server-side; DOMPurify
+ *     is the second wall plus a CSP `script-src 'none'` content policy.
+ *   - `previewFormat: "markdown"` → reuse the chat markdown renderer.
+ *   - `null` → no preview block at all.
+ *
+ * Fully presentational — wiring up `onSelect` is the caller's job (see
+ * `<QuestionMessage />`). Disabled state collapses interactivity but keeps
+ * the option visible so `answered` / `superseded` cards can still display
+ * what the user picked or what was abandoned.
+ */
+export function OptionCard({
+  option,
+  previewFormat,
+  selected,
+  disabled,
+  showCheckmark,
+  onToggle,
+}: {
+  option: QuestionOption;
+  previewFormat: QuestionPreviewFormat;
+  selected: boolean;
+  disabled: boolean;
+  /** Render a ✓ on the selected option even when disabled (for `answered` view). */
+  showCheckmark: boolean;
+  onToggle: () => void;
+}) {
+  const sanitisedHtml = useMemo(() => {
+    if (!option.preview || previewFormat !== "html") return null;
+    return DOMPurify.sanitize(option.preview, { USE_PROFILES: { html: true } });
+  }, [option.preview, previewFormat]);
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={disabled ? undefined : onToggle}
+      className={cn(
+        "w-full text-left rounded-[var(--radius-input)] border transition-colors",
+        "flex flex-col",
+        disabled ? "cursor-default opacity-70" : "cursor-pointer hover:bg-[color:var(--bg-hover)]",
+      )}
+      style={{
+        padding: "var(--sp-2_5) var(--sp-3)",
+        gap: "var(--sp-1_5)",
+        borderColor: selected ? "var(--accent)" : "var(--border)",
+        background: selected ? "var(--bg-active)" : "var(--bg-raised)",
+      }}
+    >
+      {option.preview ? (
+        previewFormat === "html" && sanitisedHtml ? (
+          <div
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitised by DOMPurify above; SDK 0.2.84 also pre-strips script/style/<!DOCTYPE> on emit.
+            dangerouslySetInnerHTML={{ __html: sanitisedHtml }}
+            className="max-h-[20rem] overflow-auto rounded-[var(--radius-input)] border"
+            style={{
+              padding: "var(--sp-2)",
+              borderColor: "var(--border)",
+              background: "var(--bg-sunken)",
+            }}
+          />
+        ) : previewFormat === "markdown" ? (
+          <div
+            className="max-h-[20rem] overflow-auto rounded-[var(--radius-input)] border"
+            style={{
+              padding: "var(--sp-2)",
+              borderColor: "var(--border)",
+              background: "var(--bg-sunken)",
+            }}
+          >
+            <Markdown>{option.preview}</Markdown>
+          </div>
+        ) : null
+      ) : null}
+      <div className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
+        <span
+          className="mono text-body font-semibold"
+          style={{
+            color: selected ? "var(--accent)" : "var(--fg)",
+          }}
+        >
+          {option.label}
+        </span>
+        {showCheckmark && selected ? (
+          <span className="mono text-caption" style={{ color: "var(--accent)" }} title="Selected">
+            ✓
+          </span>
+        ) : null}
+      </div>
+      {option.description ? (
+        <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+          {option.description}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/packages/web/src/components/chat/question-message.tsx
+++ b/packages/web/src/components/chat/question-message.tsx
@@ -1,0 +1,370 @@
+import {
+  type QuestionAnswerMessageContent,
+  type QuestionItem,
+  type QuestionMessageContent,
+  type QuestionPreviewFormat,
+  questionAnswerMessageContentSchema,
+  questionMessageContentSchema,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { submitQuestionAnswer } from "../../api/questions.js";
+import { cn } from "../../lib/utils.js";
+import { Button } from "../ui/button.js";
+import { OptionCard } from "./option-card.js";
+
+/**
+ * Lifecycle status of a rendered question card. Derived from a join across:
+ *   - the `format: "question"` message itself (always present)
+ *   - any `format: "question_answer"` message in the same chat that
+ *     references this `correlationId` (means the user has answered or it
+ *     was answered on another device)
+ *   - server-pushed supersede signals (chat archive / claim transfer —
+ *     surfaced on next message-list refetch via the question's pending
+ *     row no longer being `pending`)
+ *
+ * For v1 we collapse the answered + superseded distinction into the
+ * presence/absence of a matching answer message. A fuller audit will
+ * land in commit 6 once we have the WS notification path.
+ */
+export type QuestionStatus = "pending" | "answered" | "superseded";
+
+const FREE_TEXT_SENTINEL = "__free_text__";
+
+type AnswerSelection = {
+  /** For multiSelect: ordered set of selected labels. For single-select: at most one entry. */
+  picked: string[];
+  /** When the "Other..." sentinel is selected, this is the user's typed answer. */
+  freeText: string;
+};
+
+function emptySelection(): AnswerSelection {
+  return { picked: [], freeText: "" };
+}
+
+function selectionToAnswer(question: QuestionItem, sel: AnswerSelection): string | null {
+  // "Other..." takes precedence — typed text is the literal answer.
+  if (sel.picked.includes(FREE_TEXT_SENTINEL)) {
+    const trimmed = sel.freeText.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+  if (sel.picked.length === 0) return null;
+  if (!question.multiSelect) return sel.picked[0] ?? null;
+  return sel.picked.join(", ");
+}
+
+/**
+ * Render an agent-emitted question card. Three possible visual states:
+ *   - pending  → highlighted border, options interactive, single submit button
+ *   - answered → de-highlighted, user's pick checkmarked, others greyed out,
+ *                "You answered: X" recap line
+ *   - superseded → fully greyed, "(superseded)" tag, all interaction killed
+ *
+ * Per-message renderer — caller (chat-view.tsx) maps `format=question`
+ * messages to this component and `format=question_answer` to a compact
+ * recap row (handled by callers since it's a single line).
+ */
+export function QuestionMessage({
+  chatId,
+  questionMessageId: _questionMessageId,
+  content,
+  answer,
+  status,
+}: {
+  chatId: string;
+  questionMessageId: string;
+  content: QuestionMessageContent;
+  /** When the user (or another device) has already answered, the matching content. */
+  answer: QuestionAnswerMessageContent | null;
+  status: QuestionStatus;
+}) {
+  const isPending = status === "pending";
+  const isAnswered = status === "answered";
+  const isSuperseded = status === "superseded";
+
+  const [selections, setSelections] = useState<Record<string, AnswerSelection>>(() => {
+    const initial: Record<string, AnswerSelection> = {};
+    for (const q of content.questions) initial[q.question] = emptySelection();
+    return initial;
+  });
+
+  // When an answer arrives mid-edit (another device, or our own optimistic
+  // mutation succeeds), reconcile the local picker so the answered view
+  // reflects the canonical answers.
+  useEffect(() => {
+    if (!answer) return;
+    const next: Record<string, AnswerSelection> = {};
+    for (const q of content.questions) {
+      const recorded = answer.answers[q.question];
+      if (!recorded) {
+        next[q.question] = emptySelection();
+        continue;
+      }
+      const optionLabels = new Set(q.options.map((o) => o.label));
+      const tokens = q.multiSelect ? recorded.split(/,\s*/u) : [recorded];
+      const matched = tokens.filter((t) => optionLabels.has(t));
+      if (matched.length === tokens.length && matched.length > 0) {
+        next[q.question] = { picked: matched, freeText: "" };
+      } else {
+        // Free-text path — no matching option label.
+        next[q.question] = { picked: [FREE_TEXT_SENTINEL], freeText: recorded };
+      }
+    }
+    setSelections(next);
+  }, [answer, content.questions]);
+
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async (answers: Record<string, string>) => submitQuestionAnswer(chatId, content.correlationId, answers),
+    onSuccess: () => {
+      setSubmitError(null);
+      // Refetch the messages query so the answered state lands canonically;
+      // the caller's chat-view computes the join across question + answer.
+      queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
+    },
+    onError: (err: unknown) => {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  const onSubmit = useCallback(() => {
+    setSubmitError(null);
+    const answers: Record<string, string> = {};
+    for (const q of content.questions) {
+      const sel = selections[q.question] ?? emptySelection();
+      const value = selectionToAnswer(q, sel);
+      if (value === null) {
+        setSubmitError(`Please answer "${q.question}" before submitting.`);
+        return;
+      }
+      answers[q.question] = value;
+    }
+    mutation.mutate(answers);
+  }, [content.questions, selections, mutation]);
+
+  const allAnswered = useMemo(() => {
+    return content.questions.every((q) => {
+      const sel = selections[q.question] ?? emptySelection();
+      return selectionToAnswer(q, sel) !== null;
+    });
+  }, [content.questions, selections]);
+
+  return (
+    <div
+      className={cn("rounded-[var(--radius-panel)] border flex flex-col", isPending ? "" : "opacity-80")}
+      style={{
+        padding: "var(--sp-3)",
+        gap: "var(--sp-3)",
+        borderColor: isPending ? "var(--accent)" : "var(--border)",
+        background: "var(--bg-raised)",
+      }}
+    >
+      <div className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
+        <span
+          className="mono text-eyebrow font-semibold"
+          style={{ color: isPending ? "var(--accent)" : "var(--fg-3)" }}
+        >
+          AGENT QUESTION
+        </span>
+        {isAnswered ? (
+          <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+            • Answered
+          </span>
+        ) : null}
+        {isSuperseded ? (
+          <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+            • Superseded
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        {content.questions.map((q) => (
+          <QuestionBlock
+            key={q.question}
+            question={q}
+            previewFormat={content.previewFormat}
+            selection={selections[q.question] ?? emptySelection()}
+            allowFreeText={content.allowFreeText}
+            disabled={!isPending}
+            showAnsweredCheck={isAnswered || isSuperseded}
+            onChange={(next) =>
+              setSelections((prev) => ({
+                ...prev,
+                [q.question]: next,
+              }))
+            }
+          />
+        ))}
+      </div>
+
+      {isPending ? (
+        <div className="flex items-center justify-end" style={{ gap: "var(--sp-2)" }}>
+          {submitError ? (
+            <span className="text-caption" style={{ color: "var(--state-danger)" }}>
+              {submitError}
+            </span>
+          ) : null}
+          <Button type="button" disabled={!allAnswered || mutation.isPending} onClick={onSubmit}>
+            {mutation.isPending ? "Submitting…" : "Submit answer"}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function QuestionBlock({
+  question,
+  previewFormat,
+  selection,
+  allowFreeText,
+  disabled,
+  showAnsweredCheck,
+  onChange,
+}: {
+  question: QuestionItem;
+  previewFormat: QuestionPreviewFormat;
+  selection: AnswerSelection;
+  allowFreeText: boolean;
+  disabled: boolean;
+  showAnsweredCheck: boolean;
+  onChange: (next: AnswerSelection) => void;
+}) {
+  // Programmatic focus is user-initiated (revealed only after they click
+  // "Other…"), so it's accessible — biome's `noAutofocus` rule blocks the
+  // declarative `autoFocus` attribute, this useEffect+ref achieves the
+  // same intent without tripping it.
+  const freeTextRef = useRef<HTMLTextAreaElement>(null);
+  const isFreeTextPicked = selection.picked.includes(FREE_TEXT_SENTINEL);
+  useEffect(() => {
+    if (isFreeTextPicked && !disabled) freeTextRef.current?.focus();
+  }, [isFreeTextPicked, disabled]);
+
+  const togglePick = useCallback(
+    (label: string) => {
+      const isPicked = selection.picked.includes(label);
+      let nextPicked: string[];
+      if (question.multiSelect) {
+        nextPicked = isPicked ? selection.picked.filter((l) => l !== label) : [...selection.picked, label];
+      } else {
+        nextPicked = isPicked ? [] : [label];
+      }
+      onChange({ ...selection, picked: nextPicked });
+    },
+    [question.multiSelect, selection, onChange],
+  );
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+      <div className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
+        <span className="mono text-eyebrow font-semibold" style={{ color: "var(--fg-2)" }}>
+          {question.header}
+        </span>
+        {question.multiSelect ? (
+          <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+            (pick any)
+          </span>
+        ) : null}
+      </div>
+      <div className="text-body" style={{ color: "var(--fg)" }}>
+        {question.question}
+      </div>
+      <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+        {question.options.map((option) => (
+          <OptionCard
+            key={option.label}
+            option={option}
+            previewFormat={previewFormat}
+            selected={selection.picked.includes(option.label)}
+            disabled={disabled}
+            showCheckmark={showAnsweredCheck}
+            onToggle={() => togglePick(option.label)}
+          />
+        ))}
+        {allowFreeText ? (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={
+              disabled
+                ? undefined
+                : () =>
+                    onChange({
+                      picked: question.multiSelect
+                        ? isFreeTextPicked
+                          ? selection.picked.filter((l) => l !== FREE_TEXT_SENTINEL)
+                          : [...selection.picked, FREE_TEXT_SENTINEL]
+                        : isFreeTextPicked
+                          ? []
+                          : [FREE_TEXT_SENTINEL],
+                      freeText: selection.freeText,
+                    })
+            }
+            className={cn(
+              "w-full text-left rounded-[var(--radius-input)] border transition-colors",
+              "flex flex-col",
+              disabled ? "cursor-default opacity-70" : "cursor-pointer hover:bg-[color:var(--bg-hover)]",
+            )}
+            style={{
+              padding: "var(--sp-2_5) var(--sp-3)",
+              gap: "var(--sp-1_5)",
+              borderColor: isFreeTextPicked ? "var(--accent)" : "var(--border)",
+              background: isFreeTextPicked ? "var(--bg-active)" : "var(--bg-raised)",
+            }}
+          >
+            <span
+              className="mono text-body font-semibold"
+              style={{ color: isFreeTextPicked ? "var(--accent)" : "var(--fg-3)" }}
+            >
+              Other…
+            </span>
+            <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+              Type a free-text answer.
+            </span>
+            {isFreeTextPicked ? (
+              <textarea
+                ref={freeTextRef}
+                value={selection.freeText}
+                disabled={disabled}
+                onChange={(e) => onChange({ ...selection, freeText: e.target.value })}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => {
+                  // Enter inserts a newline; Cmd/Ctrl-Enter is reserved for the
+                  // submit button so the user can't accidentally submit a
+                  // half-typed answer by pressing Enter once.
+                  if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
+                    // Default behaviour (newline) — but stop click bubbling.
+                    e.stopPropagation();
+                  }
+                }}
+                rows={2}
+                className="rounded-[var(--radius-input)] border text-body"
+                style={{
+                  padding: "var(--sp-2)",
+                  borderColor: "var(--border)",
+                  background: "var(--bg-sunken)",
+                  color: "var(--fg)",
+                  resize: "vertical",
+                }}
+              />
+            ) : null}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** Type guard for `format=question` messages — caller uses to pick this renderer. */
+export function isQuestionContent(content: unknown): content is QuestionMessageContent {
+  return questionMessageContentSchema.safeParse(content).success;
+}
+
+/** Type guard for `format=question_answer` messages — caller uses to fold answers
+ *  back into a question card. */
+export function isQuestionAnswerContent(content: unknown): content is QuestionAnswerMessageContent {
+  return questionAnswerMessageContentSchema.safeParse(content).success;
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,4 +1,9 @@
-import { extractMentions, type MentionParticipant } from "@agent-team-foundation/first-tree-hub-shared";
+import {
+  extractMentions,
+  type MentionParticipant,
+  type QuestionAnswerMessageContent,
+  type QuestionMessageContent,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, AtSign, Check, Eye, MessageSquare, Paperclip, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -25,6 +30,12 @@ import {
   type SessionEventRow,
 } from "../../../api/sessions.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import {
+  isQuestionAnswerContent,
+  isQuestionContent,
+  QuestionMessage,
+  type QuestionStatus,
+} from "../../../components/chat/question-message.js";
 import { FirstTreeLogo } from "../../../components/first-tree-logo.js";
 import {
   ambiguousDisplayNames,
@@ -443,6 +454,87 @@ function ImageFromRef({ content }: { content: ImageRefContent }) {
   );
 }
 
+function QuestionMessageRow({
+  msg,
+  chatId,
+  content,
+  answer,
+  status,
+  agentNameFn,
+}: {
+  msg: MessageWithDelivery;
+  chatId: string;
+  content: QuestionMessageContent;
+  answer: QuestionAnswerMessageContent | null;
+  status: QuestionStatus;
+  agentNameFn: (id: string) => string;
+}) {
+  const senderName = agentNameFn(msg.senderId);
+  return (
+    <div
+      className="grid"
+      style={{
+        gridTemplateColumns: "var(--sp-5) 1fr",
+        columnGap: 8,
+        padding: "var(--sp-1_5) 0",
+      }}
+    >
+      <Avatar name={senderName} isSelf={false} />
+      <div className="min-w-0 flex flex-col" style={{ gap: "var(--sp-1)" }}>
+        <div className="flex items-baseline" style={{ gap: 8 }}>
+          <span className="mono text-body font-semibold" style={{ color: "var(--accent)" }}>
+            {senderName}
+          </span>
+          <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+            {formatClockTime(msg.createdAt)}
+          </span>
+        </div>
+        <QuestionMessage chatId={chatId} questionMessageId={msg.id} content={content} answer={answer} status={status} />
+      </div>
+    </div>
+  );
+}
+
+/** Compact recap row for `format=question_answer`. Mirrors the style of a
+ *  user text reply but flagged so it's clear this came from the answer card. */
+function QuestionAnswerRow({ msg, agentNameFn }: { msg: MessageWithDelivery; agentNameFn: (id: string) => string }) {
+  const parsed = isQuestionAnswerContent(msg.content) ? msg.content : null;
+  const senderName = agentNameFn(msg.senderId);
+  const summary = parsed
+    ? Object.entries(parsed.answers)
+        .map(([q, a]) => `${q.replace(/\s+\?$/u, "?")}: ${a}`)
+        .join(" · ")
+    : "(answer)";
+  return (
+    <div
+      className="grid"
+      style={{
+        gridTemplateColumns: "var(--sp-5) 1fr",
+        columnGap: 8,
+        padding: "var(--sp-1_5) 0",
+      }}
+    >
+      <Avatar name={senderName} isSelf />
+      <div className="min-w-0">
+        <div className="flex items-baseline" style={{ gap: 8 }}>
+          <span className="mono text-body font-semibold" style={{ color: "var(--fg)" }}>
+            {senderName}
+          </span>
+          <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+            {formatClockTime(msg.createdAt)}
+          </span>
+          <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+            answered question
+          </span>
+        </div>
+        <div className="text-body" style={{ color: "var(--fg-2)", marginTop: 2 }}>
+          {summary}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 type PendingImage = {
   id: string;
   file: File;
@@ -680,6 +772,25 @@ export function ChatView({
     out.sort((a, b) => a.at.localeCompare(b.at));
     return out;
   }, [messagesData, eventsData]);
+
+  /**
+   * For every `format=question` message we render, we need the matching
+   * `question_answer` (when one has landed). Build a (correlationId →
+   * answer-content) lookup once per messages refresh — there's no separate
+   * pending-status endpoint yet, so the presence of the answer message is
+   * the canonical "answered" signal. v1 collapses superseded into pending
+   * since we don't have a WS-pushed supersede signal yet (commit 6).
+   */
+  const answersByCorrelationId = useMemo(() => {
+    const map = new Map<string, QuestionAnswerMessageContent>();
+    for (const m of messagesData?.items ?? []) {
+      if (m.format !== "question_answer") continue;
+      if (isQuestionAnswerContent(m.content)) {
+        map.set(m.content.correlationId, m.content);
+      }
+    }
+    return map;
+  }, [messagesData]);
 
   const itemCount = items.length;
   useEffect(() => {
@@ -1033,7 +1144,26 @@ export function ChatView({
                     return null;
                 }
               }
-              return <TextRow key={item.key} msg={item.data} myAgentId={myAgentId} agentNameFn={agentName} />;
+              const msg = item.data;
+              if (msg.format === "question" && isQuestionContent(msg.content)) {
+                const answer = answersByCorrelationId.get(msg.content.correlationId) ?? null;
+                const status: QuestionStatus = answer ? "answered" : "pending";
+                return (
+                  <QuestionMessageRow
+                    key={item.key}
+                    msg={msg}
+                    chatId={chatId}
+                    content={msg.content}
+                    answer={answer}
+                    status={status}
+                    agentNameFn={agentName}
+                  />
+                );
+              }
+              if (msg.format === "question_answer") {
+                return <QuestionAnswerRow key={item.key} msg={msg} agentNameFn={agentName} />;
+              }
+              return <TextRow key={item.key} msg={msg} myAgentId={myAgentId} agentNameFn={agentName} />;
             })}
           </div>
           <div ref={messagesEndRef} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       d3-hierarchy:
         specifier: ^3.1.2
         version: 3.1.2
+      dompurify:
+        specifier: ^3.4.2
+        version: 3.4.2
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -2564,6 +2567,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2575,6 +2581,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3017,6 +3024,9 @@ packages:
   dockerode@4.0.10:
     resolution: {integrity: sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==}
     engines: {node: '>= 8.0'}
+
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -4558,6 +4568,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -6811,6 +6822,9 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7261,6 +7275,10 @@ snapshots:
       uuid: 10.0.0
     transitivePeerDependencies:
       - supports-color
+
+  dompurify@3.4.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   drizzle-kit@0.31.10:
     dependencies:


### PR DESCRIPTION
## Summary

Bridge Claude Code's `AskUserQuestion` tool through Hub so an agent's structured questions render as interactive cards in the chat UI, the user picks options (single/multi-select with optional rich previews), and the answer flows back to the agent's SDK.

- **Agent ↔ Hub**: client handler intercepts `AskUserQuestion` via `canUseTool`, posts `format=question` message, awaits the user's `format=question_answer` reply over inbox.
- **Persistence**: new `pending_questions` table tracks `pending → answered / superseded` lifecycle so the state survives idle suspend, chat archive, and client claim.
- **UI**: web renders question cards with multi-select / single-select / "other" free-text branch, DOMPurify-sanitised HTML or markdown previews, and gracefully shows the answered state once the user submits.
- **Codex**: invariant pinned (handler + server-side `assertSenderMayEmitQuestion` defense) — codex agents are physically prevented from emitting these formats since the Codex SDK has no equivalent.

Design: [hub-ask-user-design.md](https://github.com/agent-team-foundation/first-tree-context/blob/main/members/yuezengwu/research/2026-05-09-hub-ask-user-design.md). Feasibility report: [ask-user-sdk-feasibility.md](https://github.com/agent-team-foundation/first-tree-context/blob/main/members/yuezengwu/research/2026-05-09-ask-user-sdk-feasibility.md).

## Commits

| Stage | Commit |
|---|---|
| Schema | `feat(shared): add question / question_answer message formats` |
| Server | `feat(server): pending_questions table + answer endpoint + supersede hooks` |
| Client bridge | `feat(client): bridge Claude AskUserQuestion through Hub inbox` |
| Codex invariant | `test(client): pin codex handler ask-user-question invariant` |
| Web | `feat(web): render agent question cards + answer submission` |
| Release | `chore(release): document ask-user feature, bump command to 0.12.0` |
| E2E | `test(server): add ask-user e2e harness against a real Postgres` |
| Suspend/resume fix | `fix(client): handle late AskUserQuestion answer after SDK suspend` |
| Concurrency fix | `fix(server): linearise submitAnswer so two concurrent submissions write only one answer` |
| Dev tooling | `chore(server): add dev seed + start scripts for AskUserQuestion smoke` |

## Notable design / fix highlights

- **Suspend/resume**: idle-timeout suspend was killing the SDK process while a `canUseTool` Promise was still pending → uncaught `ProcessTransport is not ready for writing` on late answer. Fix: handler.suspend() silently clears bridge entries before tearing down the transport; `SessionManager.dispatch` falls through to normal dispatch on a stale `question_answer`; `formatInboundContent` renders the answer as readable Q/A text with a "do not re-ask" prefix so the resumed Claude turn picks up where the previous process left off.
- **Concurrency**: `submitAnswer` originally flipped `pending_questions.status` AFTER `sendMessage`, which let two parallel POSTs both pass the lock-tx, both call `sendMessage`, and only the second UPDATE-WHERE-status=pending caught the race — but two answer messages had already landed in the inbox. Fix: status flip moved INSIDE the lock-tx, so the second submitter on the row lock sees `status=answered` and 409s before reaching `sendMessage`. New regression test fires both via `Promise.allSettled` and asserts exactly one row + exactly one `question_answer` message.
- **DB**: single new table, no FK / CHECK / triggers (per the project's "integrity in service layer" rule). Migration is `0034_pending_questions.sql` (rebased over main's 0032/0033).

## Backwards compatibility

`messageSchema.format` is `z.string()` (not strict enum), so old clients / old web that haven't been upgraded receive new-format messages without zod failure and degrade naturally:
- old client agent runtime → JSON-stringifies the content as text input to the LLM
- old web → falls through to `TextRow` (no card render but no crash)

The new endpoint, table, and schemas are pure additions. Forward-only migration.

## Test plan

- [x] `pnpm typecheck` (9 packages green)
- [x] `pnpm --filter @first-tree-hub/server test` (704 / 704 — incl. new concurrency regression case)
- [x] `pnpm --filter @first-tree-hub/client test` (259 / 259)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` (191 / 191)
- [x] `packages/server/scripts/e2e-askuser.mjs` end-to-end harness against a real Postgres (6 cases, 33 assertions)
- [x] Manual smoke: real Claude Code agent triggers AskUserQuestion → web renders card → user answers → agent receives → continues task
- [x] Manual smoke: idle-timeout suspend mid-question, then user answers later → SDK resumes with the answer as input (suspend/resume fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)