### PR TITLE
fix(web): scope context tab to selected org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ COPY --from=build /app/packages/command/dist packages/command/dist/
 COPY --from=build /app/packages/server/drizzle packages/server/drizzle/
 COPY --from=build /app/packages/web/dist packages/web/dist/
 
-RUN apk add --no-cache wget
+# git is required by the server-managed Context Tree mirror used by
+# /api/v1/context-tree/snapshot. wget is used by the container healthcheck.
+RUN apk add --no-cache git wget
 
 ENV NODE_ENV=production
 EXPOSE 8000

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -1,4 +1,4 @@
-import crypto, { createHmac } from "node:crypto";
+import crypto, { createHmac, randomUUID } from "node:crypto";
 import bcrypt from "bcrypt";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
@@ -502,6 +502,33 @@ describe("org-settings API (admin gating + masking)", () => {
     return { admin, member: { ...memberTokens, userId: memberUserId } };
   }
 
+  async function attachOrg(app: Awaited<ReturnType<typeof getApp>>, userId: string) {
+    const orgId = `org-ct-${randomUUID().slice(0, 8)}`;
+    const memberId = uuidv7();
+    await app.db.transaction(async (tx) => {
+      await tx.insert(organizations).values({
+        id: orgId,
+        name: `ct-${randomUUID().slice(0, 8)}`,
+        displayName: "Context Tree Side Org",
+      });
+      const humanAgent = await createAgent(tx as unknown as typeof app.db, {
+        name: `ct-human-${randomUUID().slice(0, 8)}`,
+        type: "human",
+        displayName: "Context Tree Human",
+        managerId: memberId,
+        organizationId: orgId,
+      });
+      await tx.insert(members).values({
+        id: memberId,
+        userId,
+        organizationId: orgId,
+        agentId: humanAgent.uuid,
+        role: "admin",
+      });
+    });
+    return orgId;
+  }
+
   it("admin can GET, PUT, DELETE the namespace", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -537,6 +564,42 @@ describe("org-settings API (admin gating + masking)", () => {
       headers: { authorization: `Bearer ${admin.accessToken}` },
     });
     expect(get2.json()).toEqual({ branch: "main" });
+  });
+
+  it("context tree snapshot uses the org id from the route, not the caller's primary org", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const sideOrgId = await attachOrg(app, admin.userId);
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      sideOrgId,
+      "context_tree",
+      { repo: "https://github.com/example/current-team-context", branch: "--bad" },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    const sideSnapshot = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${sideOrgId}/context-tree/snapshot?window=7d`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(sideSnapshot.statusCode).toBe(200);
+    expect(sideSnapshot.json()).toMatchObject({
+      repo: "https://github.com/example/current-team-context",
+      branch: "--bad",
+      snapshotStatus: "unavailable",
+    });
+
+    const defaultSnapshot = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/snapshot?window=7d`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(defaultSnapshot.statusCode).toBe(200);
+    expect(defaultSnapshot.json()).toMatchObject({
+      repo: null,
+      snapshotStatus: "unavailable",
+    });
   });
 
   it("non-admin member is forbidden from PUT / DELETE on context_tree (write is admin-only)", async () => {

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -1,0 +1,50 @@
+import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
+import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { requireOrgMembership } from "../../scope/require-org.js";
+import { type ContextTreeBinding, getContextTreeSnapshot } from "../../services/context-tree-snapshot.js";
+import { getOrgContextTree } from "../../services/org-settings.js";
+import { contextTreeGithubTokenForRepo } from "../context-tree-snapshot.js";
+
+const querySchema = z
+  .object({
+    window: z.enum(["1d", "7d", "30d"]).optional(),
+  })
+  .strict();
+
+type ContextTreeSyncConfig = NonNullable<ServerConfig["contextTreeSync"]>;
+
+export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Params: { orgId: string } }>(
+    "/snapshot",
+    {
+      config: {
+        rateLimit: {
+          max: app.config.rateLimit?.contextTreeSnapshotMax ?? 6,
+          timeWindow: "1 minute",
+          keyGenerator: (request: FastifyRequest): string =>
+            `${request.user?.userId ?? request.ip}:${orgIdParam(request.params) ?? "unknown-org"}`,
+        },
+      },
+    },
+    async (request) => {
+      const query = querySchema.parse(request.query);
+      const scope = await requireOrgMembership(request, app.db);
+      const binding: ContextTreeBinding = await getOrgContextTree(app.db, scope.organizationId);
+      const githubToken = contextTreeGithubTokenForRepo(
+        binding.repo,
+        app.config.contextTreeSync as ContextTreeSyncConfig | undefined,
+      );
+      const snapshot = await getContextTreeSnapshot({ ...binding, githubToken }, query.window ?? "7d");
+      return contextTreeSnapshotSchema.parse(snapshot);
+    },
+  );
+}
+
+function orgIdParam(params: unknown): string | null {
+  if (!params || typeof params !== "object") return null;
+  if (!("orgId" in params)) return null;
+  const orgId = params.orgId;
+  return typeof orgId === "string" ? orgId : null;
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -44,6 +44,7 @@ import { orgAdapterRoutes } from "./api/orgs/adapters.js";
 import { orgAgentRoutes } from "./api/orgs/agents.js";
 import { orgChatRoutes } from "./api/orgs/chats.js";
 import { orgClientRoutes } from "./api/orgs/clients.js";
+import { orgContextTreeSnapshotRoutes } from "./api/orgs/context-tree-snapshot.js";
 import { orgIdentityRoutes } from "./api/orgs/identity.js";
 import { orgInvitationRoutes } from "./api/orgs/invitations.js";
 import { orgMemberRoutes } from "./api/orgs/members.js";
@@ -453,6 +454,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgInvitationRoutes, { prefix: "/invitations" });
           await scope.register(orgMemberRoutes, { prefix: "/members" });
           await scope.register(orgSettingsRoutes, { prefix: "/settings" });
+          await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
         }),
         { prefix: "/orgs/:orgId" },
       );

--- a/packages/web/src/api/context-tree.ts
+++ b/packages/web/src/api/context-tree.ts
@@ -1,9 +1,12 @@
 import type { ContextTreeSnapshot } from "@agent-team-foundation/first-tree-hub-shared";
-import { api } from "./client.js";
+import { api, withOrgAt } from "./client.js";
 
 export type ContextTreeWindow = "1d" | "7d" | "30d";
 
-export function getContextTreeSnapshot(window: ContextTreeWindow): Promise<ContextTreeSnapshot> {
+export function getContextTreeSnapshot(
+  organizationId: string,
+  window: ContextTreeWindow,
+): Promise<ContextTreeSnapshot> {
   const query = `?window=${encodeURIComponent(window)}`;
-  return api.get<ContextTreeSnapshot>(`/context-tree/snapshot${query}`);
+  return api.get<ContextTreeSnapshot>(withOrgAt(organizationId, `/context-tree/snapshot${query}`));
 }

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -9,6 +9,7 @@ import { stratify, tree } from "d3-hierarchy";
 import { AlertTriangle, CheckCircle2, Copy, FolderTree, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { type ContextTreeWindow, getContextTreeSnapshot } from "../api/context-tree.js";
+import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Markdown } from "../components/ui/markdown.js";
 import { PageHeader } from "../components/ui/page-header.js";
@@ -21,13 +22,18 @@ const CONTEXT_WINDOWS: Array<{ value: ContextTreeWindow; label: string; summary:
 ];
 
 export function ContextPage() {
+  const { organizationId } = useAuth();
   const [window, setWindow] = useState<ContextTreeWindow>("7d");
   const [selectedUpdateId, setSelectedUpdateId] = useState<string | null>(null);
   const [selectedOverviewNodeId, setSelectedOverviewNodeId] = useState<string | null>(null);
 
   const query = useQuery({
-    queryKey: ["context-tree-snapshot", window],
-    queryFn: () => getContextTreeSnapshot(window),
+    queryKey: ["context-tree-snapshot", organizationId, window],
+    queryFn: () => {
+      if (!organizationId) throw new Error("No organization selected");
+      return getContextTreeSnapshot(organizationId, window);
+    },
+    enabled: !!organizationId,
   });
 
   const snapshot = query.data;
@@ -593,6 +599,7 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
   const detail = snapshot.repo
     ? "Hub cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
     : "Connect a Context Tree repo to show the team knowledge agents can use.";
+  const syncDetail = snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
   return (
     <Panel>
@@ -604,6 +611,11 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
               {title}
             </div>
             <div style={{ marginTop: "var(--sp-1)" }}>{detail}</div>
+            {syncDetail ? (
+              <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-2)" }}>
+                {syncDetail}
+              </div>
+            ) : null}
             {snapshot.repo || snapshot.branch ? (
               <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-2)" }}>
                 {repoLabel ? `Repo: ${repoLabel}` : null}


### PR DESCRIPTION
## Summary

- add an org-scoped Context Tree snapshot endpoint at `/api/v1/orgs/:orgId/context-tree/snapshot`
- switch the Web Context tab to request snapshots for the currently selected team instead of the legacy user-scoped fallback
- surface server-provided Context Tree sync failure detail in the unavailable state
- install `git` in the production Docker runtime so server-managed Context Tree mirrors can clone/fetch repos

## Why

The Web app already tracks the currently selected team through `AuthContext`, but the Context tab still called `/api/v1/context-tree/snapshot`. That legacy user-scoped endpoint can only infer a fallback org, so multi-team users may see context for a different team than the one selected in the user menu.

Separately, the cloud runtime returned `spawn git ENOENT` while trying to sync the configured Context Tree repo because the server Docker image did not include `git`.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree-hub/server exec vitest run src/__tests__/org-settings.test.ts`
- independent code review session reported no blocking findings
