### PR TITLE
chore(server): warn at boot when FIRST_TREE_HUB_CONTEXT_TREE_REPO is set

### DIFF
--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildApp } from "../app.js";
 import type { Config } from "../config.js";
 
@@ -88,6 +88,52 @@ describe("buildApp — token-lifetime config validation", () => {
       await expect(async () => {
         app = await buildApp(cfg);
       }).rejects.toThrow(/access=30m, refresh=bogus, connect=10m/);
+    } finally {
+      await safeClose(app);
+    }
+  });
+});
+
+describe("buildApp — dead env-var watchdog", () => {
+  const ENV_KEY = "FIRST_TREE_HUB_CONTEXT_TREE_REPO";
+  let originalEnvValue: string | undefined;
+
+  beforeEach(() => {
+    originalEnvValue = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalEnvValue;
+    }
+  });
+
+  // We deliberately don't assert the warn message text — pino's level dispatch
+  // plus Fastify's logger wiring make spying on `rootLogger.warn` flaky from a
+  // unit test. The watchdog is one if-block in `buildApp`; a code reviewer can
+  // confirm the message text by reading it. What this test DOES guarantee is
+  // that the watchdog stays on the boot path: the env var being set must not
+  // crash boot, and the env var being unset must remain the normal happy path.
+
+  it("boots cleanly when FIRST_TREE_HUB_CONTEXT_TREE_REPO is set (warn-only, no crash)", async () => {
+    process.env[ENV_KEY] = "https://github.com/example/x";
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp(baseConfig);
+      expect(app).toBeDefined();
+    } finally {
+      await safeClose(app);
+    }
+  });
+
+  it("boots cleanly when FIRST_TREE_HUB_CONTEXT_TREE_REPO is unset", async () => {
+    delete process.env[ENV_KEY];
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp(baseConfig);
+      expect(app).toBeDefined();
     } finally {
       await safeClose(app);
     }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -174,6 +174,21 @@ export async function buildApp(config: Config) {
     );
   }
 
+  // Dead env-var watchdog. PR #256 moved the Context Tree repo URL from a
+  // deployment-level env (FIRST_TREE_HUB_CONTEXT_TREE_REPO) to per-org Team
+  // Settings (organization_settings.context_tree). The env var is no longer
+  // read by any code, so operators who still have it set on a deploy may
+  // assume Context Tree is configured when it isn't. Surface a one-line WARN
+  // at boot so the next operator who inherits the deploy sees it in startup
+  // logs and cleans up. See #279.
+  if (process.env.FIRST_TREE_HUB_CONTEXT_TREE_REPO) {
+    app.log.warn(
+      "FIRST_TREE_HUB_CONTEXT_TREE_REPO is set but no longer read since PR #256. " +
+        "Remove it from your deployment env. Per-org Team Settings is now the " +
+        "source of truth for the Context Tree binding.",
+    );
+  }
+
   // HTTP tracing — `@autotelic/fastify-opentelemetry` opens one span on
   // `onRequest`, ends it on `onResponse`. No per-hook child spans (so we
   // never see `handler - async (app) => …` noise), and the span is exposed


### PR DESCRIPTION
## Summary

PR #256 moved the Context Tree repo URL from a deployment-level env (`FIRST_TREE_HUB_CONTEXT_TREE_REPO`) to per-org Team Settings (`organization_settings.context_tree`). The env var is no longer read by any code (`git grep` returns zero hits in `packages/`), but at least one deployment (staging, discovered while debugging #278) still has it set — leaving operators with a false belief that Context Tree is configured.

This PR adds a one-line WARN at `buildApp` time, in the same spot as the existing `trustProxy=true` boot reminder, so the next operator who inherits the deploy sees the message in startup logs and cleans up the deploy env.

## What this PR does NOT do

- It does **not** delete the env var from any deploy. That's a deploy-platform action (Render / Railway / wherever) outside the scope of this code change.
- It does **not** assert the warn message text in tests — pino's level dispatch + Fastify's logger wiring make spying on the singleton flaky, and the watchdog is one if-block worth visual review. The boot tests verify both paths (env set / env unset) stay crash-free, which is the regression we actually care about.

## Warning message

```
WARN: FIRST_TREE_HUB_CONTEXT_TREE_REPO is set but no longer read since PR #256.
      Remove it from your deployment env. Per-org Team Settings is now the
      source of truth for the Context Tree binding.
```

## Test plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm typecheck` — 9/9 successful
- [x] `pnpm test` — 711/711 passing (server suite picked up 2 new tests in `build-app-validation.test.ts`)
- [ ] After merge + staging deploy: confirm a single startup-log WARN line with the dead env var message.
- [ ] Deploy-side follow-up (operator task): delete `FIRST_TREE_HUB_CONTEXT_TREE_REPO` from staging / dev / prod env. After that, the warning falls silent — the desired end state.

## Versioning

Per the policy in CLAUDE.md, server-only changes ship via docker / SaaS deploy, not npm. **No `packages/command` bump.**

## Closes

- Closes #279

## Related

- #256 — PR that orphaned this env var by moving Context Tree config to per-org Team Settings
- #278 / #280 — sibling work that uncovered this leftover during debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)