### PR TITLE
fix(server): deterministic GitHub webhook routing + delivery dedup (#283)

### DIFF
--- a/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
+++ b/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
@@ -210,3 +210,47 @@ describe("direct chat default mode (migration 0029)", () => {
     });
   });
 });
+
+/**
+ * Pins the fix for issue #283: when a (human, delegate) pair has multiple
+ * direct chats — which the product explicitly allows — `findOrCreateDirectChat`
+ * MUST return the same chat across calls. Previously the lookup had no
+ * `ORDER BY`, so the row returned was effectively arbitrary, and GitHub
+ * webhook fan-out landed in non-deterministic chats / split across them on
+ * near-simultaneous retries.
+ */
+describe("findOrCreateDirectChat deterministic selection (issue #283)", () => {
+  const getApp = useTestApp();
+
+  it("returns the earliest-created direct chat every call when multiple exist for the same pair", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { name: `det-h-${uid}`, type: "human" });
+    const { agent } = await createTestAgent(app, { name: `det-a-${uid}` });
+
+    // Create two direct chats for the same pair. Product allows this — users
+    // can "New chat" from the workspace whenever they like.
+    const first = await createChat(app.db, human.agent.uuid, {
+      type: "direct",
+      participantIds: [agent.uuid],
+    });
+    // Force a distinct created_at so the ordering is unambiguous regardless
+    // of clock resolution on the test runner.
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await createChat(app.db, human.agent.uuid, {
+      type: "direct",
+      participantIds: [agent.uuid],
+    });
+
+    expect(first.id).not.toBe(second.id);
+
+    // Repeated lookup must always land on the earliest chat.
+    const a = await findOrCreateDirectChat(app.db, human.agent.uuid, agent.uuid);
+    const b = await findOrCreateDirectChat(app.db, human.agent.uuid, agent.uuid);
+    const c = await findOrCreateDirectChat(app.db, agent.uuid, human.agent.uuid);
+
+    expect(a.id).toBe(first.id);
+    expect(b.id).toBe(first.id);
+    expect(c.id).toBe(first.id);
+  });
+});

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -831,4 +831,143 @@ describe("github webhook end-to-end (per-org URL + signature)", () => {
 
     expect(res.statusCode).toBe(501);
   });
+
+  // Pins issue #283 — without idempotency, GitHub retries (and near-simultaneous
+  // duplicate fires) produced duplicate fan-out into the routed chat.
+  it("dedupes repeated x-github-delivery on side-effecting events", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const SECRET = "dedup-secret";
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: SECRET },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    // `push` is not in MENTION_ACTIONS, so the handler returns 200 without
+    // fan-out — perfect for exercising the dedup gate in isolation.
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const signature = `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+    const deliveryId = randomUUID();
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": signature,
+        "x-github-event": "push",
+        "x-github-delivery": deliveryId,
+      },
+      payload: body,
+    });
+    expect(first.statusCode).toBe(200);
+    expect(first.json()).toMatchObject({ ok: true, event: "push" });
+    expect(first.json()).not.toHaveProperty("deduped");
+
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": signature,
+        "x-github-event": "push",
+        "x-github-delivery": deliveryId,
+      },
+      payload: body,
+    });
+    expect(second.statusCode).toBe(200);
+    expect(second.json()).toEqual({ ok: true, event: "push", deduped: true });
+  });
+
+  // Regression guard: if someone deletes the `unclaimEvent` call in the
+  // route handler's catch block, GitHub's retry of a failed delivery would
+  // be permanently swallowed by the dedup gate (claim succeeds on attempt 1,
+  // handler throws, claim stays held, retry returns `deduped: true` even
+  // though the work was never done). This test pins the contract that an
+  // erroring handler must release the slot.
+  it("releases the dedup slot when the handler throws so GitHub retry can re-process", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const SECRET = "unclaim-secret";
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: SECRET },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    // Malformed `issues` payload — missing the `issue` / `repository` / `sender`
+    // fields makes `parseIssuesPayload` throw `BadRequestError` deep inside
+    // `handleIssuesEvent`, which exercises the catch-and-unclaim branch.
+    const body = JSON.stringify({ action: "opened" });
+    const signature = `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+    const deliveryId = randomUUID();
+    const headers = {
+      "content-type": "application/json",
+      "x-hub-signature-256": signature,
+      "x-github-event": "issues",
+      "x-github-delivery": deliveryId,
+    };
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers,
+      payload: body,
+    });
+    expect(first.statusCode).toBe(400);
+
+    const retry = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers,
+      payload: body,
+    });
+    // If unclaim had not run, retry would be 200 with `{ deduped: true }`.
+    expect(retry.statusCode).toBe(400);
+    expect(retry.json()).not.toMatchObject({ deduped: true });
+  });
+
+  it("ping events bypass the idempotency table", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const SECRET = "ping-secret";
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "github_integration",
+      { webhookSecret: SECRET },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+
+    const body = JSON.stringify({ zen: "x" });
+    const signature = `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+    const deliveryId = randomUUID();
+    const headers = {
+      "content-type": "application/json",
+      "x-hub-signature-256": signature,
+      "x-github-event": "ping",
+      "x-github-delivery": deliveryId,
+    };
+
+    const first = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers,
+      payload: body,
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/github/${admin.organizationId}`,
+      headers,
+      payload: body,
+    });
+
+    expect(first.json()).toEqual({ ok: true, event: "ping" });
+    expect(second.json()).toEqual({ ok: true, event: "ping" });
+  });
 });

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -5,6 +5,7 @@ import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
 import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
 import { createLogger } from "../../observability/index.js";
+import { claimEvent, unclaimEvent } from "../../services/adapter-mapping.js";
 import { createAgent } from "../../services/agent.js";
 import { findOrCreateDirectChat } from "../../services/chat.js";
 import { sendMessage } from "../../services/message.js";
@@ -341,29 +342,60 @@ export async function githubWebhookRoutes(app: FastifyInstance): Promise<void> {
         throw new BadRequestError("Missing x-github-event header");
       }
 
-      // Handle ping event (GitHub sends this when webhook is first configured)
+      // Handle ping event (GitHub sends this when webhook is first configured).
+      // Skipped from idempotency tracking: pings have no side effects and
+      // shouldn't consume rows in `processed_events`.
       if (eventType === "ping") {
         return reply.status(200).send({ ok: true, event: "ping" });
       }
 
-      // --- Event-specific handlers (mention delegation runs inside, after action gating) ---
-      if (eventType === "issues") {
-        return handleIssuesEvent(app, orgId, eventType, payload, reply);
+      // Idempotency: GitHub retries failed deliveries (and occasionally
+      // double-fires near-simultaneous events) with the same
+      // `x-github-delivery` UUID. Without this gate, retries produce
+      // duplicate fan-out messages. See issue #283. Reuses the
+      // `processed_events` table that the Feishu adapter already uses
+      // via `claimEvent` / `unclaimEvent`.
+      const deliveryHeader = request.headers["x-github-delivery"];
+      const deliveryId = typeof deliveryHeader === "string" && deliveryHeader.length > 0 ? deliveryHeader : null;
+
+      if (deliveryId) {
+        const claimed = await claimEvent(app.db, deliveryId, "github");
+        if (!claimed) {
+          log.info({ deliveryId, eventType }, "duplicate GitHub delivery, skipping");
+          return reply.status(200).send({ ok: true, event: eventType, deduped: true });
+        }
       }
 
-      if (eventType === "issue_comment") {
-        return handleIssueCommentEvent(app, orgId, eventType, payload, reply);
-      }
+      try {
+        // --- Event-specific handlers (mention delegation runs inside, after action gating) ---
+        if (eventType === "issues") {
+          return await handleIssuesEvent(app, orgId, eventType, payload, reply);
+        }
 
-      // Other event types with @mention support (PRs, discussions, reviews, etc.)
-      // Only run delegation if the action represents new/changed content
-      let mentionsRouted = 0;
-      const allowedActions = MENTION_ACTIONS[eventType];
-      const action = isRecord(payload) && typeof payload.action === "string" ? payload.action : undefined;
-      if (allowedActions && action && allowedActions.includes(action)) {
-        mentionsRouted = await handleMentionDelegation(app, orgId, eventType, payload);
+        if (eventType === "issue_comment") {
+          return await handleIssueCommentEvent(app, orgId, eventType, payload, reply);
+        }
+
+        // Other event types with @mention support (PRs, discussions, reviews, etc.)
+        // Only run delegation if the action represents new/changed content
+        let mentionsRouted = 0;
+        const allowedActions = MENTION_ACTIONS[eventType];
+        const action = isRecord(payload) && typeof payload.action === "string" ? payload.action : undefined;
+        if (allowedActions && action && allowedActions.includes(action)) {
+          mentionsRouted = await handleMentionDelegation(app, orgId, eventType, payload);
+        }
+        return reply.status(200).send({ ok: true, event: eventType, handled: mentionsRouted > 0, mentionsRouted });
+      } catch (err) {
+        // Release the claim so GitHub's retry can re-process. On permanent
+        // 4xx failures GitHub does not retry, so the freed row is harmless;
+        // on transient 5xx the retry needs the slot back to succeed.
+        if (deliveryId) {
+          await unclaimEvent(app.db, deliveryId, "github").catch((unclaimErr) => {
+            log.error({ err: unclaimErr, deliveryId }, "failed to unclaim GitHub delivery after handler error");
+          });
+        }
+        throw err;
       }
-      return reply.status(200).send({ ok: true, event: eventType, handled: mentionsRouted > 0, mentionsRouted });
     },
   );
 }

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -570,11 +570,17 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
   const commonChatIds = aChats.map((r) => r.chatId).filter((id) => bChatIds.has(id));
 
   if (commonChatIds.length > 0) {
-    // Check if any common chat is a direct chat
+    // Check if any common chat is a direct chat. Order by `created_at` so the
+    // selection is deterministic across calls: webhook re-deliveries / retries
+    // (see issue #283) and any other caller that re-enters this helper for
+    // the same pair must always land on the same chat, regardless of how
+    // many direct chats the pair has accumulated.
     const directChats = await db
       .select()
       .from(chats)
-      .where(and(inArray(chats.id, commonChatIds), eq(chats.type, "direct")));
+      .where(and(inArray(chats.id, commonChatIds), eq(chats.type, "direct")))
+      .orderBy(chats.createdAt, chats.id)
+      .limit(1);
 
     if (directChats.length > 0 && directChats[0]) {
       return directChats[0];


### PR DESCRIPTION
Closes #283.

## Summary

- `findOrCreateDirectChat` now orders common direct chats by `(created_at, id)` and `LIMIT 1`, so a `(human, delegate)` pair with multiple direct chats always resolves to the same chat across calls — webhook fan-out can no longer pick an arbitrary one.
- The GitHub webhook entry claims each `x-github-delivery` against the existing `processed_events` table (already used by the Feishu adapter). Duplicate deliveries return `{ deduped: true }` instead of producing duplicate fan-out messages. `ping` bypasses the gate; handler errors release the slot via `unclaimEvent` so GitHub retries can re-process.
- Short-term fix only — the mid-term plan (dedicated `metadata.source = 'github'` chat per pair) is out of scope and tracked separately.

## Code pointers

- `packages/server/src/services/chat.ts:573-587` — deterministic `ORDER BY` in `findOrCreateDirectChat`.
- `packages/server/src/api/webhooks/github.ts:345-398` — dedup gate + try/catch with unclaim on error.

## Test plan

- [x] `pnpm check`
- [x] `pnpm --filter @first-tree-hub/server typecheck`
- [x] `pnpm --filter @first-tree-hub/server test` — 712/712 pass, including 4 new tests:
  - `findOrCreateDirectChat deterministic selection (issue #283)` — three lookups across two existing direct chats all land on the earliest, both agent orderings.
  - `dedupes repeated x-github-delivery on side-effecting events` — same delivery id twice → second returns `{ deduped: true }`.
  - `ping events bypass the idempotency table` — `ping` does not consume a row.
  - `releases the dedup slot when the handler throws so GitHub retry can re-process` — pins the `unclaimEvent` contract in the catch branch.

## Notes for reviewers

- `pnpm typecheck` reports a pre-existing `dompurify` module-resolution error in `packages/web/src/components/chat/option-card.tsx`. Reproduces on `main` after `git stash` of this PR's changes — unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)