### PR TITLE
fix(client,shared): SSH support + bidirectional protocol fallback for git mirror

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -5,11 +5,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  canonicalizeRepoUrl,
   createGitMirrorManager,
   deriveSessionBranchName,
+  GitMirrorAuthError,
   GitMirrorError,
   type GitMirrorManager,
   GitMirrorWorktreeConflictError,
+  hashUrl,
+  httpsToSshBaseRewrite,
+  isLikelyHttpsAuthFailure,
+  isLikelySshAuthFailure,
+  sshToHttpsBaseRewrite,
 } from "../runtime/git-mirror-manager.js";
 
 let workRoot: string;
@@ -289,6 +296,260 @@ describe("GitMirrorManager — crash recovery", () => {
     await expect(
       m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "ghosty" }),
     ).rejects.toBeInstanceOf(GitMirrorError);
+  });
+});
+
+describe("GitMirrorManager — HTTPS auth failure heuristic (isLikelyHttpsAuthFailure)", () => {
+  it.each([
+    // The canonical systemd / launchd background-service failure that
+    // motivated this code path — taken verbatim from a production log.
+    "git fetch --prune origin exited with code 128: fatal: could not read Username for 'GitHub · Change is constant.': No such device or address",
+    "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+    "remote: HTTP Basic: Access denied",
+    "fatal: unable to access 'https://example.com/x.git/': The requested URL returned error: 401",
+    "fatal: unable to access 'https://example.com/x.git/': The requested URL returned error: 403",
+    "remote: Invalid username or password.",
+    "fatal: could not read Password for 'https://x@github.com'",
+    "fatal: terminal prompts disabled",
+  ])("matches HTTPS credential-shaped error: %s", (msg) => {
+    expect(isLikelyHttpsAuthFailure(msg)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "fatal: Could not resolve host: github.com",
+    "ssh: connect to host github.com port 22: Connection refused",
+    "fatal: couldn't find remote ref refs/heads/missing",
+    "fatal: repository 'https://example.com/none.git/' not found",
+    "fatal: unable to access 'https://example.com/x.git/': SSL certificate problem: self signed certificate",
+    "fatal: index file corrupt",
+    "error: Could not write config file",
+    // SSH-side failures — should NOT be misclassified as HTTPS.
+    "git@github.com: Permission denied (publickey).",
+    "Host key verification failed.",
+  ])("does NOT match: %s", (msg) => {
+    expect(isLikelyHttpsAuthFailure(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailure)", () => {
+  it.each([
+    "git@github.com: Permission denied (publickey).",
+    "Permission denied, please try again.",
+    "Permission denied (publickey,password,keyboard-interactive).",
+    "fatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
+    "Host key verification failed.\nfatal: Could not read from remote repository.",
+    "Unable to negotiate with 1.2.3.4 port 22: no matching host key type found.",
+    "Unable to negotiate: no mutual signature algorithm",
+  ])("matches SSH credential-shaped error: %s", (msg) => {
+    expect(isLikelySshAuthFailure(msg)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "ssh: connect to host github.com port 22: Connection refused",
+    "ssh: connect to host github.com port 22: Connection timed out",
+    "ssh: Could not resolve hostname github.com: Name or service not known",
+    "fatal: couldn't find remote ref refs/heads/missing",
+    // HTTPS-side failures — should NOT be misclassified as SSH.
+    "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+    "fatal: could not read Username for 'https://github.com'",
+  ])("does NOT match: %s", (msg) => {
+    expect(isLikelySshAuthFailure(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — https→ssh URL rewrite (httpsToSshBaseRewrite)", () => {
+  it("maps the common github.com case to scp-like ssh", () => {
+    expect(httpsToSshBaseRewrite("https://github.com/owner/repo.git")).toEqual({
+      httpsBase: "https://github.com/",
+      sshBase: "git@github.com:",
+    });
+  });
+
+  it("preserves the path-less form (rewrite is on the host base, not the full URL)", () => {
+    expect(httpsToSshBaseRewrite("https://gitlab.com/group/sub/project")).toEqual({
+      httpsBase: "https://gitlab.com/",
+      sshBase: "git@gitlab.com:",
+    });
+  });
+
+  it("returns null when the URL carries a non-default port (no portable HTTPS↔SSH port mapping)", () => {
+    expect(httpsToSshBaseRewrite("https://gitlab.example.com:8443/x/y.git")).toBeNull();
+  });
+
+  it("treats the explicit default port 443 as no-port", () => {
+    expect(httpsToSshBaseRewrite("https://github.com:443/owner/repo.git")).toEqual({
+      httpsBase: "https://github.com/",
+      sshBase: "git@github.com:",
+    });
+  });
+
+  it("ignores non-HTTPS URLs (file://, ssh://, git@, http://)", () => {
+    expect(httpsToSshBaseRewrite("file:///tmp/repo")).toBeNull();
+    expect(httpsToSshBaseRewrite("ssh://git@github.com/foo/bar.git")).toBeNull();
+    expect(httpsToSshBaseRewrite("git@github.com:foo/bar.git")).toBeNull();
+    expect(httpsToSshBaseRewrite("http://github.com/foo/bar.git")).toBeNull();
+  });
+
+  it("refuses URLs with embedded credentials (never silently downgrade auth strength)", () => {
+    expect(httpsToSshBaseRewrite("https://user:token@github.com/foo/bar.git")).toBeNull();
+    expect(httpsToSshBaseRewrite("https://user@github.com/foo/bar.git")).toBeNull();
+  });
+
+  it("returns null on parse failure / empty input", () => {
+    expect(httpsToSshBaseRewrite("")).toBeNull();
+    expect(httpsToSshBaseRewrite("not a url")).toBeNull();
+  });
+});
+
+describe("GitMirrorManager — ssh→https URL rewrite (sshToHttpsBaseRewrite)", () => {
+  it("maps scp-like to https", () => {
+    expect(sshToHttpsBaseRewrite("git@github.com:owner/repo.git")).toEqual({
+      sshBase: "git@github.com:",
+      httpsBase: "https://github.com/",
+    });
+  });
+
+  it("scp-like without user@ still maps", () => {
+    // Edge: `host:path` without explicit user. Not common, but valid ssh.
+    expect(sshToHttpsBaseRewrite("github.com:owner/repo.git")).toEqual({
+      sshBase: "github.com:",
+      httpsBase: "https://github.com/",
+    });
+  });
+
+  it("maps ssh:// URL form to https (default port)", () => {
+    expect(sshToHttpsBaseRewrite("ssh://git@github.com/owner/repo.git")).toEqual({
+      sshBase: "ssh://git@github.com/",
+      httpsBase: "https://github.com/",
+    });
+  });
+
+  it("treats explicit ssh port 22 as default and maps", () => {
+    expect(sshToHttpsBaseRewrite("ssh://git@github.com:22/owner/repo.git")).toEqual({
+      sshBase: "ssh://git@github.com:22/",
+      httpsBase: "https://github.com/",
+    });
+  });
+
+  it("returns null for ssh:// with non-default port (no portable mapping)", () => {
+    expect(sshToHttpsBaseRewrite("ssh://git@gitlab.example.com:2222/x/y.git")).toBeNull();
+  });
+
+  it("rejects scp-like that looks like host:port (ambiguous)", () => {
+    // `host:1234/...` — git would interpret this as ssh://host:1234/...
+    expect(sshToHttpsBaseRewrite("github.com:8080/owner/repo.git")).toBeNull();
+  });
+
+  it("rejects scp-like whose path starts with `/` (matches shared schema rule)", () => {
+    // `git@host:/path` is not legal scp form; the shared schema rejects it on
+    // input. Keep client-side rewrite in lockstep so the two layers can't
+    // disagree on what's "ssh".
+    expect(sshToHttpsBaseRewrite("git@github.com:/owner/repo.git")).toBeNull();
+  });
+
+  it("rejects embedded password in either form", () => {
+    expect(sshToHttpsBaseRewrite("ssh://git:secret@github.com/x.git")).toBeNull();
+    // scp-like has no password field — the regex would reject ":pass@host:path".
+    expect(sshToHttpsBaseRewrite("git:secret@github.com:owner/repo.git")).toBeNull();
+  });
+
+  it("returns null for non-SSH URLs", () => {
+    expect(sshToHttpsBaseRewrite("https://github.com/foo/bar.git")).toBeNull();
+    expect(sshToHttpsBaseRewrite("file:///tmp/repo")).toBeNull();
+    expect(sshToHttpsBaseRewrite("")).toBeNull();
+    expect(sshToHttpsBaseRewrite("not-a-url")).toBeNull();
+  });
+});
+
+describe("GitMirrorManager — canonical URL hashing (canonicalizeRepoUrl + hashUrl)", () => {
+  it("collapses https / ssh / scp-like for the same upstream into one canonical form", () => {
+    const expected = "github.com/owner/repo";
+    expect(canonicalizeRepoUrl("https://github.com/owner/repo.git")).toBe(expected);
+    expect(canonicalizeRepoUrl("https://github.com/owner/repo")).toBe(expected);
+    expect(canonicalizeRepoUrl("git@github.com:owner/repo.git")).toBe(expected);
+    expect(canonicalizeRepoUrl("git@github.com:owner/repo")).toBe(expected);
+    expect(canonicalizeRepoUrl("ssh://git@github.com/owner/repo.git")).toBe(expected);
+    expect(canonicalizeRepoUrl("ssh://git@github.com:22/owner/repo.git")).toBe(expected);
+    expect(canonicalizeRepoUrl("https://github.com:443/owner/repo.git")).toBe(expected);
+    // Mixed-case host normalises down.
+    expect(canonicalizeRepoUrl("https://GitHub.com/owner/repo.git")).toBe(expected);
+  });
+
+  it("ignores trailing slash on path (OAuth pickers occasionally emit it)", () => {
+    const expected = "github.com/owner/repo";
+    expect(canonicalizeRepoUrl("https://github.com/owner/repo/")).toBe(expected);
+    expect(canonicalizeRepoUrl("https://github.com/owner/repo.git/")).toBe(expected);
+    expect(canonicalizeRepoUrl("ssh://git@github.com/owner/repo/")).toBe(expected);
+    // hash collapses too — same mirror dir for slash / no-slash forms.
+    expect(hashUrl("https://github.com/owner/repo/")).toBe(hashUrl("https://github.com/owner/repo"));
+  });
+
+  it("preserves non-default ports (different upstream → different mirror)", () => {
+    expect(canonicalizeRepoUrl("ssh://git@gitlab.example.com:2222/x/y.git")).toBe("gitlab.example.com:2222/x/y");
+    expect(canonicalizeRepoUrl("https://gitlab.example.com:8443/x/y.git")).toBe("gitlab.example.com:8443/x/y");
+  });
+
+  it("hashUrl is identical for all addressing forms of the same repo", () => {
+    const h1 = hashUrl("https://github.com/owner/repo.git");
+    const h2 = hashUrl("git@github.com:owner/repo.git");
+    const h3 = hashUrl("ssh://git@github.com/owner/repo.git");
+    expect(h1).toBe(h2);
+    expect(h2).toBe(h3);
+  });
+
+  it("hashUrl differs for different repos on the same host", () => {
+    expect(hashUrl("https://github.com/a/b.git")).not.toBe(hashUrl("https://github.com/c/d.git"));
+  });
+
+  it("falls back to raw input for un-parseable strings", () => {
+    expect(canonicalizeRepoUrl("garbage")).toBe("garbage");
+  });
+});
+
+describe("GitMirrorManager — ssh fallback", () => {
+  it("does NOT touch ssh path for non-https origins (file://, ssh://) — failure surfaces raw", async () => {
+    // The fixture URL is file:// — even if we point it at a corrupt repo and
+    // fetch fails, the manager must surface the raw `GitMirrorError`, not
+    // `GitMirrorAuthError`. Fallback is HTTPS-only by design; misclassifying
+    // a file:// failure as "try ssh" would mask real bugs and waste a retry.
+    const m = makeManager();
+    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
+    // Corrupt the mirror's origin to an unreachable file:// path.
+    execSync("git remote set-url origin file:///nonexistent/path/that/does/not/exist.git", { cwd: mirrorPath });
+
+    let caught: unknown;
+    try {
+      await m.fetchMirror(fixtureUrl);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(GitMirrorError);
+    expect(caught).not.toBeInstanceOf(GitMirrorAuthError);
+  });
+
+  it("does NOT classify a non-credential https failure as auth — bootstrap against an unreachable https URL throws raw GitMirrorError", async () => {
+    // Drive `ensureMirror` (which goes through the same `fetchOrigin` helper
+    // as `fetchMirror`) against an https URL whose connect() always refuses.
+    // The bootstrap MUST fail with the raw `GitMirrorError` — wrapping a
+    // connect-refused error in `GitMirrorAuthError` would falsely imply that
+    // ssh was tried and also failed for credential reasons.
+    //
+    // Port 1 is reserved & always refuses connections → fast deterministic
+    // failure, no real network egress, safe in any CI sandbox.
+    const m = createGitMirrorManager({
+      dataDir: mkdtempSync(join(tmpdir(), "ftt-mgr-https-")),
+      cloneTimeoutMs: 15_000,
+    });
+    let caught: unknown;
+    try {
+      await m.ensureMirror("https://127.0.0.1:1/nope.git");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(GitMirrorError);
+    expect(caught).not.toBeInstanceOf(GitMirrorAuthError);
   });
 });
 

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -24,8 +24,20 @@ const SESSION_BRANCH_PREFIX = "hub-session";
  *   so two sessions on the same URL get disjoint branch names and cannot
  *   collide on `git worktree add` or on `git fetch` ref locks.
  *
- * Authentication is delegated to the host Git environment — no env vars or
- * credential helpers are injected.
+ * Authentication strategy:
+ * - Credentials are delegated to the host Git environment (credential
+ *   helpers, GCM, ssh agent, on-disk keys). Every spawned `git` has
+ *   `GIT_TERMINAL_PROMPT=0` so missing credentials fail fast instead of
+ *   blocking on a tty that doesn't exist under systemd / launchd.
+ * - When `fetch origin` fails with a credential-shaped error, we
+ *   transparently retry once via the *peer* protocol (HTTPS → SSH or
+ *   SSH → HTTPS, decided by the configured origin URL), using a
+ *   process-scoped `git -c url.<peer-base>.insteadOf=<origin-base>`
+ *   rewrite. No host gitconfig is touched and no on-disk
+ *   `remote.origin.url` is mutated. Mirror dir hashes use the canonical
+ *   form (host + path), so HTTPS and SSH addressing of the same repo
+ *   collapse to one mirror dir on disk regardless of which protocol the
+ *   admin configured.
  */
 export type GitMirrorManagerOptions = {
   dataDir: string;
@@ -47,8 +59,82 @@ export interface GitMirrorManager {
   readonly mirrorsRoot: string;
 }
 
+/**
+ * Hash a repo URL into the mirror directory name.
+ *
+ * The hash is computed over a *canonical* form (host + path, lowercased
+ * host, no `.git` suffix, no leading/trailing slash, no protocol, no
+ * `user@` prefix), so the same upstream repo addressed via any of the
+ * accepted forms (HTTPS, `ssh://`, or scp-like) all land in the same
+ * mirror dir. That matters because:
+ *   - admins may write any of those three forms into `source_repos[].url`
+ *     (the schema accepts all of them)
+ *   - the `fetchOrigin` fallback below transparently swaps protocols when
+ *     credentials are missing — without canonical hashing, the fallback
+ *     would silently maintain a second mirror dir
+ *
+ * Migration cost: pre-existing mirrors created before this change use the
+ * raw-URL hash and will be orphaned after the upgrade. `gcMirrors` removes
+ * them on the next run; the next fetch repopulates the canonical-keyed
+ * mirror. No data loss — mirror is a cache, not state.
+ */
 export function hashUrl(url: string): string {
-  return createHash("sha256").update(url).digest("hex").slice(0, 32);
+  return createHash("sha256").update(canonicalizeRepoUrl(url)).digest("hex").slice(0, 32);
+}
+
+/**
+ * Reduce a repo URL to `<host[:port]>/<path-without-.git>`. Used as the
+ * input to the mirror dir hash and exposed for unit testing.
+ *
+ *   `https://github.com/foo/bar.git`         → `github.com/foo/bar`
+ *   `git@github.com:foo/bar.git`             → `github.com/foo/bar`
+ *   `ssh://git@github.com/foo/bar.git`       → `github.com/foo/bar`
+ *   `ssh://git@gitlab.example.com:2222/x/y`  → `gitlab.example.com:2222/x/y`
+ *
+ * Falls back to the raw input for un-parseable strings — better to keep
+ * a stable mirror than to throw mid-bootstrap.
+ */
+export function canonicalizeRepoUrl(url: string): string {
+  // scp-like: `[user@]host:path` (no `://`, exactly one `:` between host
+  // and path, path doesn't look like a port number, path forbids leading
+  // `/` and any `:`/`@` — same rules as `SCP_LIKE_SSH_RE` in the shared
+  // schema, so what passes input validation is also what we can canonicalise.
+  if (!url.includes("://")) {
+    const m = url.match(/^(?:[A-Za-z0-9_.-]+@)?([A-Za-z0-9.-]+):([^/@:\s][^@:\s]*)$/);
+    const host = m?.[1];
+    const rawPath = m?.[2];
+    if (host && rawPath && !/^\d+(?:\/|$)/.test(rawPath)) {
+      const path = normalizePath(rawPath);
+      return `${host.toLowerCase()}/${path}`;
+    }
+  }
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    // Drop the port when it matches the protocol's default — keeps `https`
+    // and `ssh` (port 22) addressing the same upstream collapse to one dir.
+    const portIsDefault =
+      parsed.port === "" ||
+      (parsed.protocol === "https:" && parsed.port === "443") ||
+      (parsed.protocol === "ssh:" && parsed.port === "22");
+    const hostPort = portIsDefault ? host : `${host}:${parsed.port}`;
+    const path = normalizePath(parsed.pathname);
+    return `${hostPort}/${path}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Strip leading slashes, trailing slashes, and a trailing `.git`. Used by
+ * `canonicalizeRepoUrl` so that `…/foo/bar`, `…/foo/bar/`, and `…/foo/bar.git`
+ * all collapse to the same canonical path (and therefore the same mirror dir).
+ */
+function normalizePath(rawPath: string): string {
+  return rawPath
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\.git$/i, "");
 }
 
 function shortHash(input: string): string {
@@ -103,10 +189,18 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
 
   async function git(args: string[], cwd: string | null, timeoutMs: number, env?: NodeJS.ProcessEnv) {
     const start = Date.now();
+    // Always disable git's tty prompt — under systemd / launchd the tty open
+    // returns ENXIO ("No such device or address") which manifests as a confusing
+    // `could not read Username for '<realm>'` line in stderr; under interactive
+    // shells it would block the request indefinitely instead of failing fast
+    // (defeating the ssh-fallback path below). Callers can still override by
+    // passing an `env` that sets `GIT_TERMINAL_PROMPT` explicitly.
+    const baseEnv = env ?? process.env;
+    const finalEnv = { GIT_TERMINAL_PROMPT: "0", ...baseEnv };
     return await new Promise<{ stdout: string; stderr: string; elapsedMs: number }>((resolveExec, rejectExec) => {
       const proc = spawn("git", args, {
         cwd: cwd ?? undefined,
-        env: env ?? process.env,
+        env: finalEnv,
         stdio: ["ignore", "pipe", "pipe"],
       });
       let stdout = "";
@@ -140,6 +234,70 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
       return true;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * `git fetch --prune origin` with one-shot bidirectional protocol fallback.
+   *
+   * Decides direction from `originUrl`'s protocol:
+   *   - HTTPS origin → on credential-shaped failure, retry as SSH
+   *   - SSH   origin → on credential-shaped failure, retry as HTTPS
+   * The fallback fires only when **all** hold:
+   *   1. The first attempt failed with a credential-shaped error in the
+   *      direction-appropriate sense (`isLikelyHttpsAuthFailure` /
+   *      `isLikelySshAuthFailure`). Network failures, missing-ref errors,
+   *      and TLS/host-key surprises propagate as-is — those won't be cured
+   *      by switching transports and silently retrying would mask real bugs.
+   *   2. The origin URL maps to a usable peer-protocol form
+   *      (see `httpsToSshBaseRewrite` / `sshToHttpsBaseRewrite`). Custom
+   *      ports beyond the protocol default disable the rewrite — there's no
+   *      universal mapping between `https://host:8443` and an SSH peer.
+   *
+   * Implementation: the retry uses `git -c url.<peer-base>.insteadOf=<origin-base>`
+   * — git resolves origin's URL through that rewrite for the duration of
+   * one subprocess and never persists anything to disk. The mirror's
+   * `remote.origin.url` stays as configured, so the next fetch starts back
+   * at the original protocol unless this fallback fires again.
+   */
+  async function fetchOrigin(
+    mirrorPath: string,
+    originUrl: string,
+  ): Promise<{ elapsedMs: number; usedFallback: boolean }> {
+    const direction = pickFallbackDirection(originUrl);
+    try {
+      const { elapsedMs } = await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+      return { elapsedMs, usedFallback: false };
+    } catch (primaryErr) {
+      const primaryMessage = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      if (!direction || !direction.shouldRetry(primaryMessage)) {
+        throw primaryErr;
+      }
+      log?.info(
+        {
+          gitUrl: originUrl,
+          fromProtocol: direction.fromProtocol,
+          toProtocol: direction.toProtocol,
+          peerBase: direction.peerBase,
+        },
+        "fetch failed with credential-shaped error; retrying with peer-protocol insteadOf rewrite",
+      );
+      try {
+        const { elapsedMs } = await git(
+          ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "fetch", "--prune", "origin"],
+          mirrorPath,
+          cloneTimeoutMs,
+        );
+        log?.info({ gitUrl: originUrl, toProtocol: direction.toProtocol }, "protocol-fallback fetch succeeded");
+        return { elapsedMs, usedFallback: true };
+      } catch (peerErr) {
+        const peerMessage = peerErr instanceof Error ? peerErr.message : String(peerErr);
+        throw new GitMirrorAuthError(
+          `Could not fetch ${originUrl} over ${direction.fromProtocol.toUpperCase()} or ${direction.toProtocol.toUpperCase()}. ` +
+            `${direction.fromProtocol.toUpperCase()} attempt failed: ${truncate(primaryMessage)} ` +
+            `${direction.toProtocol.toUpperCase()} retry (${direction.peerBase}) failed: ${truncate(peerMessage)}`,
+        );
+      }
     }
   }
 
@@ -196,7 +354,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     if (migrated) {
       // Populate `refs/remotes/origin/*` and set `origin/HEAD`. Without this,
       // newly-migrated mirrors have no remote-tracking refs to base worktrees on.
-      await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+      await fetchOrigin(mirrorPath, url);
       // Failing `set-head --auto` is non-fatal — callers that pass an explicit
       // `ref` don't need origin/HEAD, and fallbacks below handle its absence.
       await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000);
@@ -217,7 +375,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     await git(["init", "--bare", mirrorPath], null, cloneTimeoutMs);
     await git(["remote", "add", "origin", url], mirrorPath, 10_000);
     await git(["config", "--replace-all", "remote.origin.fetch", FETCH_REFSPEC], mirrorPath, 10_000);
-    await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+    await fetchOrigin(mirrorPath, url);
     await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000);
   }
 
@@ -294,13 +452,20 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           throw new GitMirrorError(`Cannot fetch — no mirror exists for "${url}"`);
         }
         try {
-          const { elapsedMs } = await git(["fetch", "--prune", "origin"], path, cloneTimeoutMs);
+          const { elapsedMs } = await fetchOrigin(path, url);
           return { elapsedMs };
         } catch (err) {
           log?.warn(
             {
               gitUrl: url,
-              errorCode: err instanceof GitMirrorError ? "git-failed" : "unknown",
+              errorCode:
+                err instanceof GitMirrorAuthError
+                  ? "auth-failed"
+                  : err instanceof GitMirrorTimeoutError
+                    ? "timeout"
+                    : err instanceof GitMirrorError
+                      ? "git-failed"
+                      : "unknown",
               stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
             },
             "mirror fetch failed",
@@ -453,4 +618,228 @@ export class GitMirrorWorktreeConflictError extends GitMirrorError {
     super(message);
     this.name = "GitMirrorWorktreeConflictError";
   }
+}
+
+/**
+ * Thrown when both the HTTPS fetch and the SSH fallback fail. The message
+ * carries trimmed stderr from both attempts so the operator can see whether
+ * the host's HTTPS credentials are missing, the SSH key is missing, or both.
+ */
+export class GitMirrorAuthError extends GitMirrorError {
+  constructor(message: string) {
+    super(message);
+    this.name = "GitMirrorAuthError";
+  }
+}
+
+/**
+ * Heuristic for HTTPS-side credential failures. Matches the indicators git
+ * itself emits over libcurl / git-credential helpers, regardless of platform.
+ *
+ * Negative space (intentionally NOT matched): network errors
+ * (`Could not resolve host`, `connection refused`), repo errors
+ * (`Repository not found`, `couldn't find remote ref`), TLS errors
+ * (`SSL certificate problem`). Those won't be cured by switching transports
+ * and silently retrying would mask the real bug.
+ *
+ * Exported for unit testing.
+ */
+export function isLikelyHttpsAuthFailure(message: string): boolean {
+  if (!message) return false;
+  return (
+    /could not read Username/i.test(message) ||
+    /could not read Password/i.test(message) ||
+    /Authentication failed/i.test(message) ||
+    /terminal prompts disabled/i.test(message) ||
+    /HTTP\s*(?:Basic:\s*)?Access denied/i.test(message) ||
+    /\bHTTP[/ ]?(1\.[01]|2|2\.0)?\s*40[13]\b/i.test(message) ||
+    /\bfatal:\s*unable to access\b.*\b(401|403)\b/i.test(message) ||
+    /\bremote: Invalid username or password\b/i.test(message)
+  );
+}
+
+/**
+ * Heuristic for SSH-side credential failures (no key on disk, key not
+ * accepted by remote, agent has nothing usable, host key mismatch).
+ *
+ * Negative space (intentionally NOT matched): SSH-level network errors
+ * (`Could not resolve hostname`, `Connection refused`, `Connection timed out`).
+ * Those are network reachability issues — switching to HTTPS won't help
+ * unless the network policy specifically blocks port 22, which is rare
+ * enough that we'd rather surface the original error than guess.
+ *
+ * Exported for unit testing.
+ */
+export function isLikelySshAuthFailure(message: string): boolean {
+  if (!message) return false;
+  // `Permission denied (<method-list>)` covers publickey-only rejects,
+  // mixed-method rejects (e.g. `publickey,password`), and gssapi-with-mic;
+  // `Permission denied, please try again.` covers the password-prompt
+  // rejection path. We collapse them into one disjunction since both
+  // forms only occur in ssh auth failure context.
+  return (
+    /Permission denied\s*(?:\(|,)/i.test(message) ||
+    /Could not read from remote repository/i.test(message) ||
+    /Host key verification failed/i.test(message) ||
+    /no matching host key type/i.test(message) ||
+    /no mutual signature algorithm/i.test(message)
+  );
+}
+
+/**
+ * Back-compat alias — matches *either* HTTPS or SSH credential failures.
+ * Internal callers prefer the direction-specific predicates so a misfired
+ * fallback doesn't classify an SSH host-key failure as an "HTTPS auth"
+ * problem (or vice versa). This union form is kept for ad-hoc use sites.
+ */
+export function isLikelyAuthFailure(message: string): boolean {
+  return isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message);
+}
+
+/**
+ * Map an HTTPS git URL to the `insteadOf` rewrite needed to make git resolve
+ * it through SSH. Returns *base* strings (suitable for
+ * `git -c url.<sshBase>.insteadOf=<httpsBase>`) — git's `insteadOf` is a
+ * prefix match, so we only need the host segment.
+ *
+ *   `https://github.com/owner/repo.git` → `git@github.com:` / `https://github.com/`
+ *
+ * Returns `null` for inputs that should NOT trigger fallback:
+ *   - non-HTTPS URLs (already SSH, `git://`, `file://`, etc.)
+ *   - URLs with embedded credentials (schema rejects these on input;
+ *     belt-and-braces — never silently downgrade auth strength)
+ *   - HTTPS URLs with a non-default port — there is no portable mapping to
+ *     an SSH port (HTTPS:8443 ↔ SSH:???), so we refuse to guess
+ *   - URLs that fail to parse
+ *
+ * Exported for unit testing.
+ */
+export function httpsToSshBaseRewrite(url: string): { httpsBase: string; sshBase: string } | null {
+  if (!url || !/^https:\/\//i.test(url)) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+  if (parsed.username.length > 0 || parsed.password.length > 0) return null;
+  if (!parsed.hostname) return null;
+  // Reject non-default HTTPS ports — see docstring.
+  if (parsed.port && parsed.port !== "443") return null;
+  return {
+    httpsBase: `https://${parsed.hostname}/`,
+    sshBase: `git@${parsed.hostname}:`,
+  };
+}
+
+/**
+ * Map an SSH git URL (either `ssh://` or scp-like `[user@]host:path`) to the
+ * `insteadOf` rewrite for resolving via HTTPS. Mirror of
+ * `httpsToSshBaseRewrite`.
+ *
+ *   `git@github.com:owner/repo.git`           → `git@github.com:` / `https://github.com/`
+ *   `ssh://git@github.com/owner/repo.git`     → `ssh://git@github.com/` / `https://github.com/`
+ *   `ssh://git@gitlab.example.com:22/x/y.git` → `ssh://git@gitlab.example.com:22/` / `https://gitlab.example.com/`
+ *
+ * Returns `null` when:
+ *   - URL is not SSH-shaped
+ *   - URL has an embedded password (`user:pass@`)
+ *   - SSH URL has a non-default port (≠ 22) — no portable mapping to HTTPS
+ *
+ * Exported for unit testing.
+ */
+export function sshToHttpsBaseRewrite(url: string): { sshBase: string; httpsBase: string } | null {
+  if (!url) return null;
+  // scp-like: `[user@]host:path` (no `://`). Mirrors `SCP_LIKE_SSH_RE` in
+  // the shared schema — path forbids leading `/`, any `:` or `@` (so inputs
+  // like `git:secret@github.com:owner/repo.git`, which superficially fit a
+  // greedy first-colon split, are rejected).
+  if (!url.includes("://")) {
+    const m = url.match(/^((?:[A-Za-z0-9_.-]+@)?)([A-Za-z0-9.-]+):([^/@:\s][^@:\s]*)$/);
+    const userAt = m?.[1];
+    const host = m?.[2];
+    const path = m?.[3];
+    if (userAt === undefined || !host || !path) return null;
+    // Path that is purely digits (optionally followed by `/` or end) means
+    // git would parse it as `host:port` via ssh:// — refuse the ambiguous
+    // case rather than fabricate a base.
+    if (/^\d+(?:\/|$)/.test(path)) return null;
+    return {
+      sshBase: `${userAt}${host}:`,
+      httpsBase: `https://${host}/`,
+    };
+  }
+  // ssh:// form
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "ssh:") return null;
+  if (parsed.password.length > 0) return null;
+  if (!parsed.hostname) return null;
+  if (parsed.port && parsed.port !== "22") return null;
+  const userAt = parsed.username.length > 0 ? `${parsed.username}@` : "";
+  // The on-config origin URL contains either `ssh://user@host/...` or
+  // `ssh://user@host:22/...` — match whichever the input actually used so
+  // git's prefix matcher hits.
+  const sshBase = parsed.port
+    ? `ssh://${userAt}${parsed.hostname}:${parsed.port}/`
+    : `ssh://${userAt}${parsed.hostname}/`;
+  return {
+    sshBase,
+    httpsBase: `https://${parsed.hostname}/`,
+  };
+}
+
+type FallbackDirection = {
+  fromProtocol: "https" | "ssh";
+  toProtocol: "https" | "ssh";
+  /** The base prefix git will see in the on-disk `remote.origin.url`. */
+  originBase: string;
+  /** The base prefix to rewrite to (the peer-protocol form). */
+  peerBase: string;
+  /** Direction-specific failure classifier. */
+  shouldRetry(stderr: string): boolean;
+};
+
+/**
+ * Same shape as `SCP_LIKE_SSH_RE` in the shared schema — kept in sync so
+ * what the schema accepts is exactly what we route through the SSH-side
+ * fallback. Single source of truth would be ideal, but cross-package import
+ * for a regex isn't worth the build coupling.
+ */
+const SCP_LIKE_RE = /^(?:[A-Za-z0-9_.-]+@)?[A-Za-z0-9.-]+:(?!\d+(?:\/|$))[^/:@\s][^:@\s]*$/;
+
+function pickFallbackDirection(originUrl: string): FallbackDirection | null {
+  if (/^https:\/\//i.test(originUrl)) {
+    const r = httpsToSshBaseRewrite(originUrl);
+    if (!r) return null;
+    return {
+      fromProtocol: "https",
+      toProtocol: "ssh",
+      originBase: r.httpsBase,
+      peerBase: r.sshBase,
+      shouldRetry: isLikelyHttpsAuthFailure,
+    };
+  }
+  if (/^ssh:\/\//i.test(originUrl) || SCP_LIKE_RE.test(originUrl)) {
+    const r = sshToHttpsBaseRewrite(originUrl);
+    if (!r) return null;
+    return {
+      fromProtocol: "ssh",
+      toProtocol: "https",
+      originBase: r.sshBase,
+      peerBase: r.httpsBase,
+      shouldRetry: isLikelySshAuthFailure,
+    };
+  }
+  return null;
+}
+
+function truncate(text: string, max = 512): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…[truncated]`;
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -160,7 +160,11 @@ describe("org-settings service", () => {
     ).rejects.toThrow();
   });
 
-  it("rejects non-HTTPS or credential-bearing Context Tree repo URLs", async () => {
+  it("accepts HTTPS, ssh://, and scp-like Context Tree repo URLs (no embedded credentials)", async () => {
+    // Schema accepts both protocols so the client-side fallback layer can
+    // pick whichever the user has credentials for. We still reject embedded
+    // credentials (logs / API responses would leak them) and `http://`
+    // (plaintext, MITM-able).
     const app = getApp();
     const admin = await createTestAdmin(app);
     const putRepo = (repo: string) =>
@@ -172,8 +176,17 @@ describe("org-settings service", () => {
         { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
       );
 
-    await expect(putRepo("ssh://git@github.com/example/tree.git")).rejects.toThrow();
-    await expect(putRepo("https://user:secret@github.com/example/tree.git")).rejects.toThrow();
+    // All three accepted forms.
+    await expect(putRepo("https://github.com/example/tree.git")).resolves.toBeDefined();
+    await expect(putRepo("ssh://git@github.com/example/tree.git")).resolves.toBeDefined();
+    await expect(putRepo("git@github.com:example/tree.git")).resolves.toBeDefined();
+
+    // Embedded credentials always rejected, regardless of protocol.
+    await expect(putRepo("https://user:secret@github.com/example/tree.git")).rejects.toThrow(/credentials/);
+    await expect(putRepo("ssh://git:secret@github.com/example/tree.git")).rejects.toThrow(/credentials/);
+    // Plaintext / unauthenticated protocols still rejected.
+    await expect(putRepo("http://github.com/example/tree")).rejects.toThrow();
+    await expect(putRepo("git://github.com/example/tree")).rejects.toThrow();
   });
 
   it("putOrgSetting bumps version on subsequent writes", async () => {
@@ -327,18 +340,45 @@ describe("org-settings service", () => {
     ).rejects.toThrow();
   });
 
-  it("source_repos rejects http:// URLs (HTTPS-only)", async () => {
+  it("source_repos rejects insecure / unauthenticated protocols (http://, git://)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    await expect(
+    const putUrl = (url: string) =>
       orgSettingsService.putOrgSetting(
         app.db,
         admin.organizationId,
         "source_repos",
-        { repos: [{ url: "http://github.com/example/insecure" }] },
+        { repos: [{ url }] },
         { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
-      ),
-    ).rejects.toThrow(/HTTPS/);
+      );
+
+    await expect(putUrl("http://github.com/example/insecure")).rejects.toThrow(/HTTPS or SSH/);
+    await expect(putUrl("git://github.com/example/insecure")).rejects.toThrow();
+  });
+
+  it("source_repos accepts ssh:// and scp-like SSH URLs alongside HTTPS", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const out = await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "source_repos",
+      {
+        repos: [
+          { url: "https://github.com/example/https-form" },
+          { url: "ssh://git@github.com/example/ssh-url-form.git" },
+          { url: "git@github.com:example/scp-form.git" },
+        ],
+      },
+      { updatedBy: admin.userId, encryptionKey: TEST_ENCRYPTION_KEY },
+    );
+    expect(out.repos).toHaveLength(3);
+    expect(out.repos.map((r) => r.url)).toEqual([
+      "https://github.com/example/https-form",
+      "ssh://git@github.com/example/ssh-url-form.git",
+      "git@github.com:example/scp-form.git",
+    ]);
   });
 
   it("source_repos rejects URLs with embedded credentials", async () => {

--- a/packages/shared/src/schemas/org-settings.ts
+++ b/packages/shared/src/schemas/org-settings.ts
@@ -26,47 +26,101 @@ import { z } from "zod";
 // explicit `null` form. Users who want to clear a field send `null`,
 // users who pass `""` get a validation error from `min(1)` below.
 
-// Shared URL schema for repo URLs persisted in per-org settings — HTTPS-only
-// and free of embedded credentials. Used by both `context_tree.repo` and
-// `source_repos[].url`. Both end up cloned by user agents, so both face the
-// same hazards: `http://` enables MITM-able clones, and credentialed URLs
-// (`https://user:pass@host/...`) leak secrets through logs / API responses.
-const httpsRepoUrlSchema = z
+// Shared URL schema for repo URLs persisted in per-org settings. Accepts
+// three forms — all three end up cloned by user agents, and the client's
+// fallback layer (see `git-mirror-manager.ts`) transparently swaps between
+// HTTPS and SSH when one direction's credentials are missing on a given
+// machine. Used by both `context_tree.repo` and `source_repos[].url`.
+//
+//   1. `https://host[:port]/path[.git]`
+//   2. `ssh://[user@]host[:port]/path[.git]`         (URL form)
+//   3. `[user@]host:path[.git]`                      (scp-like, the form
+//                                                     `git clone` uses by
+//                                                     default for SSH)
+//
+// Hazards we still reject:
+//   - `http://`  — plaintext, MITM-able
+//   - `git://`   — unauthenticated, no integrity
+//   - any URL with embedded credentials (`https://user:pass@host/...` or
+//     `ssh://user:pass@host/...`) — those leak secrets into logs and API
+//     responses; ssh URLs may legitimately carry a username (`git@`) but
+//     never a password.
+
+// scp-like SSH: `[user@]host:path` where:
+//   - host is a non-empty hostname (letters/digits/`.`/`-`/`_`), no `/`, no
+//     port (port can't be expressed in scp form — use ssh:// for that)
+//   - path is non-empty, not all-digits (all-digits means git would
+//     interpret `host:1234` as a port → ambiguous, force ssh:// form),
+//     forbids `:` and `@` (already consumed by the earlier captures), and
+//     can't start with `/` (legal scp paths start with the first repo path
+//     segment, e.g. `owner/repo.git`)
+const SCP_LIKE_SSH_RE = /^(?:[A-Za-z0-9_.-]+@)?[A-Za-z0-9.-]+:(?!\d+(?:\/|$))[^/:@\s][^:@\s]*$/;
+
+function isScpLikeSshUrl(value: string): boolean {
+  // Belt-and-braces guard: anything containing `://` is a URL form, not
+  // scp. Without this, `http://host/path` would superficially fit the regex
+  // (host=`http`, path=`//host/path`) and bypass the protocol checks.
+  if (value.includes("://")) return false;
+  return SCP_LIKE_SSH_RE.test(value);
+}
+
+const repoUrlSchema = z
   .string()
-  .url()
-  .refine(
-    (value) => {
-      try {
-        const url = new URL(value);
-        return url.protocol === "https:";
-      } catch {
-        return false;
-      }
-    },
-    { message: "Repo URL must use HTTPS." },
-  )
-  .refine(
-    (value) => {
-      try {
-        const url = new URL(value);
-        return url.username.length === 0 && url.password.length === 0;
-      } catch {
-        return false;
-      }
-    },
-    { message: "Repo URL must not include credentials." },
-  );
+  .min(1)
+  .superRefine((value, ctx) => {
+    // scp-like form — not a parseable URL; validated by regex above.
+    if (isScpLikeSshUrl(value)) {
+      // No further checks: scp-like form has no place for embedded password
+      // (only `user@host` is allowed before the `:`), and the regex already
+      // anchors host + path shape.
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Repo URL must be HTTPS, SSH (ssh://...), or scp-like (git@host:path).",
+      });
+      return;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "ssh:") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Repo URL must use HTTPS or SSH.",
+      });
+      return;
+    }
+    // Embedded password is always rejected. Embedded username is rejected
+    // for HTTPS (credential leak); for SSH it's expected (`git@host`) so we
+    // only block the password component there.
+    if (url.password.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Repo URL must not include credentials.",
+      });
+      return;
+    }
+    if (url.protocol === "https:" && url.username.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Repo URL must not include credentials.",
+      });
+      return;
+    }
+  });
 
 // -- context_tree --
 
 export const orgContextTreeStorageSchema = z.object({
-  repo: httpsRepoUrlSchema.optional(),
+  repo: repoUrlSchema.optional(),
   branch: z.string().default("main"),
 });
 
 export const orgContextTreeInputSchema = z.object({
-  /** Set / replace (must be an HTTPS URL without credentials). `null` clears. `undefined` leaves unchanged. */
-  repo: httpsRepoUrlSchema.nullish(),
+  /** Set / replace (HTTPS, ssh://, or scp-like — no embedded credentials). `null` clears. `undefined` leaves unchanged. */
+  repo: repoUrlSchema.nullish(),
   /** Set / replace (non-empty). `null` clears (server falls back to "main"). `undefined` leaves unchanged. */
   branch: z.string().min(1).nullish(),
 });
@@ -112,7 +166,7 @@ export const orgSourceReposStorageSchema = z.object({
   repos: z
     .array(
       z.object({
-        url: httpsRepoUrlSchema,
+        url: repoUrlSchema,
         defaultBranch: z.string().optional(),
       }),
     )
@@ -126,15 +180,16 @@ export const orgSourceReposInputSchema = z.object({
    * onboarding writes the whole list each time, and the Team Settings
    * card removes by re-PUTting the surviving entries.
    *
-   * `url` reuses `httpsRepoUrlSchema` — same HTTPS-only / no-credentials
-   * hardening as `context_tree.repo`. `defaultBranch` is `min(1)` here on
+   * `url` reuses `repoUrlSchema` — same protocol allow-list (HTTPS / SSH)
+   * and no-embedded-credentials hardening as `context_tree.repo`.
+   * `defaultBranch` is `min(1)` here on
    * the input boundary — the storage schema is wider so historical /
    * backfilled rows with an empty `defaultBranch` aren't rejected on read.
    */
   repos: z
     .array(
       z.object({
-        url: httpsRepoUrlSchema,
+        url: repoUrlSchema,
         defaultBranch: z.string().min(1).optional(),
       }),
     )


### PR DESCRIPTION
## Summary

- **Problem**: Hub clients running as background services (systemd / launchd) failed to fetch private GitHub repos with `fatal: could not read Username for ...: No such device or address` — git was prompting for HTTPS credentials on a tty that doesn't exist. Common case: admin onboarded the repo via an HTTPS URL, but a teammate's machine only has SSH keys configured.
- **Fix**: Configuration layer now accepts HTTPS / `ssh://` / scp-like (`git@host:path`). On any credential-shaped fetch failure, the client transparently retries via the peer protocol using a process-scoped `git -c url.<peer>.insteadOf=<origin>` rewrite — never touches the user's `~/.gitconfig`, never mutates `remote.origin.url`. Both directions failing throws a dedicated `GitMirrorAuthError` carrying both stderrs.
- **Zero-config**: the affected teammate does nothing on their machine; the fallback fires automatically when HTTPS creds are missing (or vice versa for an SSH-onboarded repo on a machine with only HTTPS creds).

## What changed

### Shared schema (`packages/shared/src/schemas/org-settings.ts`)
- `httpsRepoUrlSchema` → `repoUrlSchema`. Accepts:
  - `https://host[:port]/path[.git]`
  - `ssh://[user@]host[:port]/path[.git]`
  - `[user@]host:path[.git]` (scp-like)
- Still rejects: `http://`, `git://`, any URL with embedded credentials (password unconditionally; HTTPS username also).

### Client (`packages/client/src/runtime/git-mirror-manager.ts`)
- Every spawned `git` gets `GIT_TERMINAL_PROMPT=0` — fail-fast instead of hanging on a missing tty or surfacing the confusing `Username for '<realm>'` line.
- Mirror dir hash now over a **canonical form** (`<host[:port]>/<path>` — lowercased host, no protocol, no `.git`, no leading/trailing slash). HTTPS / SSH / scp-like addressing of the same repo collapse to one mirror on disk.
- `fetchOrigin` orchestrates a **bidirectional one-shot fallback**:
  - HTTPS origin + credential-shaped failure → retry as SSH
  - SSH origin + credential-shaped failure → retry as HTTPS
  - Direction-specific auth heuristics (`isLikelyHttpsAuthFailure` / `isLikelySshAuthFailure`); network errors, TLS, missing refs propagate as-is and do not trigger retries.
  - Non-default ports (HTTPS ≠ 443, SSH ≠ 22) disable rewrite — no portable HTTPS↔SSH port mapping.
- `fetchMirror` log now distinguishes `auth-failed` / `timeout` / `git-failed` / `unknown` for ops visibility.
- scp-like regex in client kept in lockstep with `SCP_LIKE_SSH_RE` in shared schema so what input validation accepts is exactly what the fallback can rewrite.

### Versioning
- `@agent-team-foundation/first-tree-hub` (CLI) bumped `0.12.0` → `0.12.1` per [docs/versioning-and-publishing.md](docs/versioning-and-publishing.md) (client changed).
- Shared schema changes only affect server; not propagated to CLI consumers, no further bump needed.

## Migration cost

Pre-existing mirrors hashed off the raw URL get orphaned once and reaped by `gcMirrors` on the next run; next fetch repopulates the canonical-keyed mirror. No data loss — mirror is a cache, not state.

## Test plan

- [x] `pnpm check` (biome) — clean across 633 files
- [x] `pnpm typecheck` — 9 packages
- [x] `pnpm exec turbo run test --force` (no cache) — **1376 / 1376 tests across 5 packages**
  - `@first-tree-hub/client` 315 (including 72 in `git-mirror-manager.test.ts`)
  - `@first-tree-hub/server` 705 (including 31 in `org-settings.test.ts`)
  - `@agent-team-foundation/first-tree-hub-shared` 191
  - `@agent-team-foundation/first-tree-hub` (CLI) 96
  - `@first-tree-hub/web` 69
- [x] New unit tests cover:
  - HTTPS auth heuristic (positive: production-log `Username for 'GitHub · Change is constant.'` verbatim, plus 7 other forms; negative: network / TLS / missing-ref / SSH-side false positives)
  - SSH auth heuristic (positive: publickey / mixed-method / host-key / negotiation; negative: connect-refused / DNS / HTTPS-side false positives)
  - HTTPS↔SSH URL rewrite both directions (incl. non-default port refused, embedded creds refused, scp ambiguity with `host:port`)
  - Canonical URL hashing (all three forms collapse to one hash; trailing slash collapse; mixed-case host normalized; non-default ports preserved)
  - scp-like path leading-`/` refused (matches shared schema rule)
  - Schema accept ssh:// + scp-like alongside HTTPS, reject `http://` / `git://` / embedded creds for both protocols
- [ ] Manual smoke on the affected teammate's machine (HTTPS origin → SSH fallback succeeds end-to-end)

## Out of scope / follow-ups

- **Spawn-mock test for fallback success path** — current ssh-fallback tests are negative (verifies the fallback does NOT fire on non-credential errors); end-to-end "HTTPS creds missing → SSH succeeds" requires `vi.mock("node:child_process")` or extracting the git runner as DI. Tracked separately.
- Onboarding picker UX for "manually enter SSH URL" (today admins can only get HTTPS from the OAuth picker; SSH must be written via Team Settings UI / API). The schema change unblocks this — UI is a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)