### PR TITLE
fix(server): prevent cross-org direct chat pollution

### DIFF
--- a/packages/server/src/__tests__/cross-org-chat-pollution.test.ts
+++ b/packages/server/src/__tests__/cross-org-chat-pollution.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatParticipants, chats } from "../db/schema/chats.js";
+import { organizations } from "../db/schema/organizations.js";
+import { BadRequestError } from "../errors.js";
+import { createAgent } from "../services/agent.js";
+import { findOrCreateDirectChat } from "../services/chat.js";
+import { listMeChats } from "../services/me-chat.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Regression coverage for cross-org direct-chat pollution.
+ *
+ * Each test sets up a user in org-A and a separate org-B with its own agents.
+ * The bugs we are pinning down:
+ *
+ *   - A. `findOrCreateDirectChat` used to accept cross-org pairs and even
+ *        reuse a dirty cross-org chat whose participants happened to include
+ *        both ends — producing chats with `organization_id` disagreeing with
+ *        a participant's `organization_id`.
+ *   - C. `listMeChats` looked up membership purely by `chat_participants.agent_id`
+ *        with no org filter, so any historical cross-org dirty chat that
+ *        still listed the caller's human agent leaked into the org-A workspace
+ *        list (and 404'd on click via `requireChatAccess`).
+ */
+describe("cross-org direct chat pollution — guard rails", () => {
+  const getApp = useTestApp();
+
+  /**
+   * Create a foreign organization with a single agent in it.
+   *
+   * We use a raw INSERT instead of `createAgent` here because the service
+   * insists on a manager member of the target org — and a full
+   * admin/user/member bootstrap inside a side org isn't worth the boilerplate
+   * for this regression suite. `manager_id` is NOT NULL, so we point it at
+   * the caller's admin member: the FK is unconstrained across orgs in the
+   * schema, and the cross-org weirdness is exactly the legacy data shape this
+   * test is policing.
+   */
+  async function makeForeignOrgAgent(
+    app: ReturnType<typeof getApp>,
+    label: string,
+    fallbackManagerId: string,
+  ): Promise<{ orgId: string; agentUuid: string }> {
+    const orgId = `org-${label}-${randomUUID().slice(0, 6)}`;
+    await app.db.insert(organizations).values({
+      id: orgId,
+      name: orgId.slice(0, 30),
+      displayName: `Org ${label}`,
+    });
+    const agentUuid = randomUUID();
+    await app.db.insert(agents).values({
+      uuid: agentUuid,
+      name: `bot-${label}-${randomUUID().slice(0, 6)}`,
+      organizationId: orgId,
+      type: "autonomous_agent",
+      displayName: `Bot ${label}`,
+      inboxId: `inbox_${agentUuid}`,
+      managerId: fallbackManagerId,
+    });
+    return { orgId, agentUuid };
+  }
+
+  it("A: findOrCreateDirectChat rejects cross-org agent pairs", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const other = await makeForeignOrgAgent(app, "b", admin.memberId);
+
+    await expect(findOrCreateDirectChat(app.db, admin.humanAgentUuid, other.agentUuid)).rejects.toBeInstanceOf(
+      BadRequestError,
+    );
+  });
+
+  it("A: does not reuse a historical cross-org chat that lists both ends as participants", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    // Two same-org agents in admin's org; both will (in a moment) appear as
+    // participants of a dirty chat owned by a different org.
+    const peerA = await createAgent(app.db, {
+      name: `same-org-a-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Peer A",
+      organizationId: admin.organizationId,
+    });
+    const peerB = await createAgent(app.db, {
+      name: `same-org-b-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Peer B",
+      organizationId: admin.organizationId,
+    });
+
+    // Simulate the legacy dirty state: a direct chat in a DIFFERENT org whose
+    // chat_participants table contains both same-org agents (this is exactly
+    // the pollution shape observed in production).
+    const otherOrg = await makeForeignOrgAgent(app, "other", admin.memberId);
+    const dirtyChatId = randomUUID();
+    await app.db.insert(chats).values({
+      id: dirtyChatId,
+      organizationId: otherOrg.orgId,
+      type: "direct",
+    });
+    await app.db.insert(chatParticipants).values([
+      { chatId: dirtyChatId, agentId: peerA.uuid, role: "member" },
+      { chatId: dirtyChatId, agentId: peerB.uuid, role: "member" },
+    ]);
+
+    // Pre-fix behavior: returns the dirty chat. Post-fix: filters by
+    // chats.organizationId and creates a fresh chat in admin's org.
+    const chat = await findOrCreateDirectChat(app.db, peerA.uuid, peerB.uuid);
+    expect(chat.id).not.toBe(dirtyChatId);
+    expect(chat.organizationId).toBe(admin.organizationId);
+  });
+
+  it("C: listMeChats does not surface chats whose organization differs from the caller's", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    // Mint a foreign-org chat and splice the caller's human agent into its
+    // participants table by raw INSERT — this mirrors the dirty data observed
+    // in production (a path no current code can produce, but historical rows
+    // still exist).
+    const foreign = await makeForeignOrgAgent(app, "foreign", admin.memberId);
+    const dirtyChatId = randomUUID();
+    await app.db.insert(chats).values({
+      id: dirtyChatId,
+      organizationId: foreign.orgId,
+      type: "direct",
+    });
+    await app.db.insert(chatParticipants).values([
+      { chatId: dirtyChatId, agentId: foreign.agentUuid, role: "member" },
+      { chatId: dirtyChatId, agentId: admin.humanAgentUuid, role: "member" },
+    ]);
+
+    // Sanity check that the dirty row really would have leaked without the
+    // org filter: the caller IS a participant.
+    const [participantRow] = await app.db
+      .select({ chatId: chatParticipants.chatId })
+      .from(chatParticipants)
+      .where(eq(chatParticipants.agentId, admin.humanAgentUuid));
+    expect(participantRow?.chatId).toBe(dirtyChatId);
+
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+      limit: 50,
+      filter: "all",
+    });
+    expect(res.rows.find((r) => r.chatId === dirtyChatId)).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -45,7 +45,7 @@ describe("chat-first workspace service layer", () => {
   it("listMeChats: empty when user has no participations", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const res = await listMeChats(app.db, admin.humanAgentUuid, { limit: 50, filter: "all" });
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 50, filter: "all" });
     expect(res.rows).toEqual([]);
     expect(res.nextCursor).toBeNull();
   });
@@ -87,7 +87,7 @@ describe("chat-first workspace service layer", () => {
     });
 
     // admin (manager of `managed`) should now see this chat as a watcher
-    const list = await listMeChats(app.db, admin.humanAgentUuid, { limit: 50, filter: "all" });
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 50, filter: "all" });
     const row = list.rows.find((r) => r.chatId === result.chatId);
     expect(row).toBeDefined();
     expect(row?.membershipKind).toBe("watching");
@@ -163,7 +163,7 @@ describe("chat-first workspace service layer", () => {
     expect(projRow?.last_message_preview).toContain("Please review");
 
     // watcher counter incremented for admin (manager of `managed`)
-    const list = await listMeChats(app.db, admin.humanAgentUuid, { limit: 10, filter: "all" });
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 10, filter: "all" });
     const row = list.rows.find((r) => r.chatId === chatId);
     expect(row?.unreadMentionCount).toBeGreaterThanOrEqual(1);
     void applyAfterFanOut;
@@ -260,7 +260,7 @@ describe("chat-first workspace service layer", () => {
     const result = await leaveMeChat(app.db, chatId, admin.humanAgentUuid);
     expect(result.membershipKind).toBe("watching");
 
-    const list = await listMeChats(app.db, admin.humanAgentUuid, { limit: 50, filter: "all" });
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 50, filter: "all" });
     const row = list.rows.find((r) => r.chatId === chatId);
     expect(row?.membershipKind).toBe("watching");
   });
@@ -416,12 +416,12 @@ describe("chat-first workspace service layer", () => {
 
     // Page size 2: first page is [c1, one of c2/c3]; second page returns
     // exactly the missing one.
-    const page1 = await listMeChats(app.db, admin.humanAgentUuid, { limit: 2, filter: "all" });
+    const page1 = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 2, filter: "all" });
     expect(page1.rows).toHaveLength(2);
     expect(page1.nextCursor).not.toBeNull();
     expect(page1.rows[0]?.chatId).toBe(c1.chatId); // most-recent message wins
 
-    const page2 = await listMeChats(app.db, admin.humanAgentUuid, {
+    const page2 = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
       limit: 2,
       filter: "all",
       cursor: page1.nextCursor ?? undefined,
@@ -452,7 +452,7 @@ describe("chat-first workspace service layer", () => {
       VALUES ('thread-x', ${admin.humanAgentUuid}, 'member')
     `);
 
-    const list = await listMeChats(app.db, admin.humanAgentUuid, { limit: 50, filter: "all" });
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, { limit: 50, filter: "all" });
     const ids = list.rows.map((r) => r.chatId);
     expect(ids).toContain(chatId);
     expect(ids).not.toContain("thread-x");

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -131,7 +131,7 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
 
   app.post<{ Params: { uuid: string } }>("/:uuid/test", async (request, reply) => {
     const { uuid } = request.params;
-    await requireAgentAccess(request, app.db, "manage");
+    const { agent: targetAgent } = await requireAgentAccess(request, app.db, "manage");
 
     const presence = await presenceService.getPresence(app.db, uuid);
     const wsConnected = hasActiveConnection(uuid);
@@ -189,10 +189,21 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
       });
     }
 
+    // Sender must live in the target's org. Without this scope, the owner
+    // lookup (delegate_mention → uuid) or the fallback ("any other active
+    // agent") can pick up an agent from an unrelated org — `findOrCreateDirectChat`
+    // would then refuse the pair, and historically (before that guard) it
+    // produced cross-org chats unreachable by their nominal owner.
     const [owner] = await app.db
       .select({ uuid: agents.uuid })
       .from(agents)
-      .where(and(eq(agents.delegateMention, uuid), eq(agents.status, "active")))
+      .where(
+        and(
+          eq(agents.delegateMention, uuid),
+          eq(agents.status, "active"),
+          eq(agents.organizationId, targetAgent.organizationId),
+        ),
+      )
       .limit(1);
 
     let senderId = owner?.uuid ?? null;
@@ -200,7 +211,13 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
       const [other] = await app.db
         .select({ uuid: agents.uuid })
         .from(agents)
-        .where(and(ne(agents.uuid, uuid), eq(agents.status, "active")))
+        .where(
+          and(
+            ne(agents.uuid, uuid),
+            eq(agents.status, "active"),
+            eq(agents.organizationId, targetAgent.organizationId),
+          ),
+        )
         .limit(1);
       senderId = other?.uuid ?? null;
     }
@@ -208,7 +225,7 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
     if (!senderId) {
       return reply.status(200).send({
         status: "error",
-        message: "No suitable sender found. Need at least one other active agent.",
+        message: "No suitable sender found. Need at least one other active agent in the same organization.",
         connection,
       });
     }

--- a/packages/server/src/api/orgs/chats.ts
+++ b/packages/server/src/api/orgs/chats.ts
@@ -90,7 +90,7 @@ export async function orgChatRoutes(app: FastifyInstance): Promise<void> {
 
     // Default: workspace conversation list for the caller's HUMAN agent.
     const query = listMeChatsQuerySchema.parse(request.query);
-    return listMeChats(app.db, scope.humanAgentId, query);
+    return listMeChats(app.db, scope.humanAgentId, scope.organizationId, query);
   });
 
   /**

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -555,6 +555,32 @@ export async function leaveChat(db: Database, chatId: string, humanAgentId: stri
 }
 
 export async function findOrCreateDirectChat(db: Database, agentAId: string, agentBId: string) {
+  // Resolve both endpoints up front. Two reasons:
+  //   1. Reject cross-org pairs. A direct chat whose `chats.organization_id`
+  //      disagrees with one of its participants is unreachable by the chat
+  //      owner (org membership fails `requireChatAccess` → 404) yet still
+  //      leaks into the other side's chat list — exactly the breakage
+  //      observed when a caller (e.g. agent connection test, follow-up to
+  //      #288) handed us a cross-org pair.
+  //   2. Carry `organizationId` into the existing-chat lookup below so we
+  //      cannot reuse a historical dirty row whose participants happen to
+  //      include both ends but whose chat lives in another org.
+  const ends = await db
+    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
+    .from(agents)
+    .where(inArray(agents.uuid, [agentAId, agentBId]));
+
+  const agentA = ends.find((a) => a.uuid === agentAId);
+  if (!agentA) throw new NotFoundError(`Agent "${agentAId}" not found`);
+  const agentB = ends.find((a) => a.uuid === agentBId);
+  if (!agentB) throw new NotFoundError(`Agent "${agentBId}" not found`);
+  if (agentA.organizationId !== agentB.organizationId) {
+    throw new BadRequestError(
+      `Cannot create direct chat across organizations: agent "${agentAId}" (org "${agentA.organizationId}") vs agent "${agentBId}" (org "${agentB.organizationId}")`,
+    );
+  }
+  const orgId = agentA.organizationId;
+
   // Find existing direct chat between the two agents
   const aChats = await db
     .select({ chatId: chatParticipants.chatId })
@@ -570,15 +596,15 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
   const commonChatIds = aChats.map((r) => r.chatId).filter((id) => bChatIds.has(id));
 
   if (commonChatIds.length > 0) {
-    // Check if any common chat is a direct chat. Order by `created_at` so the
-    // selection is deterministic across calls: webhook re-deliveries / retries
-    // (see issue #283) and any other caller that re-enters this helper for
-    // the same pair must always land on the same chat, regardless of how
-    // many direct chats the pair has accumulated.
+    // Order by `created_at` for determinism across webhook re-deliveries
+    // and any other caller re-entering for the same pair (see #283).
+    // The `organizationId` predicate is what prevents reuse of historical
+    // cross-org dirty rows — without it, two new-org agents could resolve
+    // to an old-org chat just because both names sit in its participants.
     const directChats = await db
       .select()
       .from(chats)
-      .where(and(inArray(chats.id, commonChatIds), eq(chats.type, "direct")))
+      .where(and(inArray(chats.id, commonChatIds), eq(chats.type, "direct"), eq(chats.organizationId, orgId)))
       .orderBy(chats.createdAt, chats.id)
       .limit(1);
 
@@ -587,20 +613,9 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
     }
   }
 
-  // Create new direct chat. Fetch both agents' types so we can apply the
-  // "agent-only direct → mention_only" rule (see also `createChat` and
-  // migration 0029): without it, A↔B replies loop forever because every
-  // message in a `full` direct chat wakes the other party unconditionally.
-  const ends = await db
-    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
-    .from(agents)
-    .where(inArray(agents.uuid, [agentAId, agentBId]));
-
-  const agentA = ends.find((a) => a.uuid === agentAId);
-  if (!agentA) throw new NotFoundError(`Agent "${agentAId}" not found`);
-  const agentB = ends.find((a) => a.uuid === agentBId);
-  if (!agentB) throw new NotFoundError(`Agent "${agentBId}" not found`);
-
+  // Create new direct chat. The "agent-only direct → mention_only" rule
+  // (see also `createChat` and migration 0029) prevents A↔B reply loops in
+  // `full` mode where every message wakes the other party unconditionally.
   const isDirectAgentOnly = agentA.type !== "human" && agentB.type !== "human";
   const mode = isDirectAgentOnly ? "mention_only" : "full";
 
@@ -610,7 +625,7 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
       .insert(chats)
       .values({
         id: chatId,
-        organizationId: agentA.organizationId,
+        organizationId: orgId,
         type: "direct",
       })
       .returning();

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -89,6 +89,7 @@ export function decodeCursor(cursor: string): { lastMessageAt: Date | null; chat
 export async function listMeChats(
   db: Database,
   humanAgentId: string,
+  organizationId: string,
   query: ListMeChatsQuery,
 ): Promise<ListMeChatsResponse> {
   const limit = query.limit;
@@ -168,6 +169,11 @@ export async function listMeChats(
       FROM chats c
       JOIN deduped d ON d.chat_id = c.id
      WHERE c.parent_chat_id IS NULL
+       /* Scope to the caller's org. Without this, cross-org dirty chats
+          whose chat_participants still reference the caller's human agent
+          (historical pollution — see fix/cross-org-direct-chat-pollution)
+          would leak into the list and 404 on click via requireChatAccess. */
+       AND c.organization_id = ${organizationId}
        /* Filter: unread / watching */
        AND (${!filterUnreadOnly}::bool OR d.unread_mention_count > 0)
        AND (${!filterWatchingOnly}::bool OR d.membership_kind = 'watching')


### PR DESCRIPTION
## Summary

Three independent paths could splice an agent from org X into a direct chat owned by org Y, producing rows that `listMeChats` happily surfaced to the participant's org-Y workspace but `requireChatAccess` promptly 404'd on click. This PR closes all three.

- **`findOrCreateDirectChat`** — resolve both endpoints up front, reject cross-org pairs with `BadRequestError`, and scope the existing-chat lookup by `chats.organization_id`. The org filter is the actual fix for *historical* dirty rows: even if both ends are listed as participants of a foreign-org chat, that row is now silently skipped and a clean same-org chat is created instead.
- **`POST /agents/:uuid/test`** — the owner lookup (`delegate_mention`) and the "any other active agent" fallback now require `agents.organization_id = targetAgent.organizationId`. Pre-fix, the fallback would happily pick an agent from an unrelated org, then hand the pair to `findOrCreateDirectChat`, which produced the cross-org chats we observed in prod.
- **`listMeChats`** — thread `organizationId` through from the route handler (`api/orgs/chats.ts`) and filter `c.organization_id = $orgId`. Without this, any legacy dirty row referencing the caller's human agent would leak into the workspace list and 404 on click.

Companion one-off cleanup SQL exists under `scripts/` locally and is intentionally **not** part of this PR (per-deploy data work, run manually after this rolls out).

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — turbo all packages clean
- [x] `pnpm test` — full server suite passes (99 files / 717 tests)
- [x] New regression suite `cross-org-chat-pollution.test.ts`:
  - `findOrCreateDirectChat` rejects a cross-org pair
  - Existing dirty cross-org row is **not** reused when two same-org agents call `findOrCreateDirectChat`
  - `listMeChats` does not surface a foreign-org chat even when the caller's human agent is spuriously listed as a participant
- [ ] Reviewer: after merge, run the local cleanup SQL against the affected DB to drop the residual cross-org `chat_participants` rows (script keeps backups + has a roll-back recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)