### PR TITLE
feat(web): multi-repo onboarding picker + step 2 reframe

### DIFF
--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -19,18 +19,15 @@
 
 export const FIRST_TREE_REFERENCE_URL = "https://github.com/agent-team-foundation/first-tree";
 
-function formatSourceList(sourceUrls: readonly string[]): { label: string; lines: string[] } {
+function formatSourceList(sourceUrls: readonly string[]): string[] {
   if (sourceUrls.length === 1) {
-    return { label: "Source repo", lines: [`Source repo: ${sourceUrls[0]}`] };
+    return [`Source repo: ${sourceUrls[0]}`];
   }
-  return {
-    label: "Source repos",
-    lines: ["Source repos:", ...sourceUrls.map((u) => `- ${u}`)],
-  };
+  return ["Source repos:", ...sourceUrls.map((u) => `- ${u}`)];
 }
 
 export function buildBindBootstrap(sourceUrls: readonly string[], treeUrl: string): string {
-  const sources = formatSourceList(sourceUrls);
+  const sourceLines = formatSourceList(sourceUrls);
   const opener =
     sourceUrls.length === 1
       ? "Bind my source repo to an existing context-tree."
@@ -42,7 +39,7 @@ export function buildBindBootstrap(sourceUrls: readonly string[], treeUrl: strin
   return [
     opener,
     "",
-    ...sources.lines,
+    ...sourceLines,
     `Existing tree: ${treeUrl}`,
     "",
     skillLine,
@@ -52,7 +49,7 @@ export function buildBindBootstrap(sourceUrls: readonly string[], treeUrl: strin
 }
 
 export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
-  const sources = formatSourceList(sourceUrls);
+  const sourceLines = formatSourceList(sourceUrls);
   const opener =
     sourceUrls.length === 1
       ? "Create a brand-new context-tree for my source repo."
@@ -64,7 +61,7 @@ export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
   return [
     opener,
     "",
-    ...sources.lines,
+    ...sourceLines,
     "",
     skillLine,
     "",

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -60,7 +60,7 @@ export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
   const skillLine =
     sourceUrls.length === 1
       ? "Your workspace already has the source repo cloned in a subdirectory; the first-tree skill will locate it. Use the first-tree CLI to install the skill in the source, scaffold a sibling tree directory, and write the binding metadata. Then push that new tree directory up to GitHub as a sibling repo under the same owner as the source, and open a PR back to the source with the skill + binding files."
-      : "Your workspace already has each source repo cloned in its own subdirectory; the first-tree skill will locate them. Scaffold ONE shared tree directory that all the source repos bind to. For every source repo, install the first-tree skill and write the binding metadata pointing at that shared tree. Push the new tree directory up to GitHub as its own repo under the same owner as the first source. Then open a PR back to each source repo with its skill + binding files.";
+      : "Your workspace already has each source repo cloned in its own subdirectory; the first-tree skill will locate them. Scaffold ONE shared tree directory that all the source repos bind to. For every source repo, install the first-tree skill and write the binding metadata pointing at that shared tree. Push the new tree directory up to GitHub as its own repo — if all the source repos share a single GitHub owner, host the tree under that owner; otherwise ask me which owner to use before pushing. Then open a PR back to each source repo with its skill + binding files.";
   return [
     opener,
     "",

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -1,7 +1,7 @@
 /**
  * Two bootstrap-message variants Step 3 IntroBody dispatches based on the
  * user's "do you already have a tree?" choice. Prose, not shell recipes —
- * the agent has the first-tree skill (and the source repo, materialised
+ * the agent has the first-tree skill (and the source repos, materialised
  * via `gitRepos`) ready in its workspace, so the message just describes
  * the goal and references the CLI surfaces by name. The skill knows the
  * concrete commands.
@@ -19,30 +19,58 @@
 
 export const FIRST_TREE_REFERENCE_URL = "https://github.com/agent-team-foundation/first-tree";
 
-export function buildBindBootstrap(sourceUrl: string, treeUrl: string): string {
+function formatSourceList(sourceUrls: readonly string[]): { label: string; lines: string[] } {
+  if (sourceUrls.length === 1) {
+    return { label: "Source repo", lines: [`Source repo: ${sourceUrls[0]}`] };
+  }
+  return {
+    label: "Source repos",
+    lines: ["Source repos:", ...sourceUrls.map((u) => `- ${u}`)],
+  };
+}
+
+export function buildBindBootstrap(sourceUrls: readonly string[], treeUrl: string): string {
+  const sources = formatSourceList(sourceUrls);
+  const opener =
+    sourceUrls.length === 1
+      ? "Bind my source repo to an existing context-tree."
+      : "Bind my source repos to an existing context-tree.";
+  const skillLine =
+    sourceUrls.length === 1
+      ? "Your workspace already has the source repo cloned in a subdirectory; the first-tree skill will locate it. Use the first-tree CLI to install the skill in the source repo and write the binding metadata pointing at the existing tree, then open a PR back to the source with those changes. Walk me through the PR when it's up."
+      : "Your workspace already has each source repo cloned in its own subdirectory; the first-tree skill will locate them. For every source repo, use the first-tree CLI to install the skill and write the binding metadata pointing at the existing tree, then open a PR back to that source repo. Walk me through each PR as it goes up.";
   return [
-    "Bind my source repo to an existing context-tree.",
+    opener,
     "",
-    `Source repo: ${sourceUrl}`,
+    ...sources.lines,
     `Existing tree: ${treeUrl}`,
     "",
-    "Your workspace already has the source repo cloned in a subdirectory; the first-tree skill will locate it. Use the first-tree CLI to install the skill in the source repo and write the binding metadata pointing at the existing tree, then open a PR back to the source with those changes. Walk me through the PR when it's up.",
+    skillLine,
     "",
     `Reference: ${FIRST_TREE_REFERENCE_URL}`,
   ].join("\n");
 }
 
-export function buildCreateBootstrap(sourceUrl: string): string {
+export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
+  const sources = formatSourceList(sourceUrls);
+  const opener =
+    sourceUrls.length === 1
+      ? "Create a brand-new context-tree for my source repo."
+      : "Create a brand-new context-tree for my source repos.";
+  const skillLine =
+    sourceUrls.length === 1
+      ? "Your workspace already has the source repo cloned in a subdirectory; the first-tree skill will locate it. Use the first-tree CLI to install the skill in the source, scaffold a sibling tree directory, and write the binding metadata. Then push that new tree directory up to GitHub as a sibling repo under the same owner as the source, and open a PR back to the source with the skill + binding files."
+      : "Your workspace already has each source repo cloned in its own subdirectory; the first-tree skill will locate them. Scaffold ONE shared tree directory that all the source repos bind to. For every source repo, install the first-tree skill and write the binding metadata pointing at that shared tree. Push the new tree directory up to GitHub as its own repo under the same owner as the first source. Then open a PR back to each source repo with its skill + binding files.";
   return [
-    "Create a brand-new context-tree for my source repo.",
+    opener,
     "",
-    `Source repo: ${sourceUrl}`,
+    ...sources.lines,
     "",
-    "Your workspace already has the source repo cloned in a subdirectory; the first-tree skill will locate it. Use the first-tree CLI to install the skill in the source, scaffold a sibling tree directory, and write the binding metadata. Then push that new tree directory up to GitHub as a sibling repo under the same owner as the source, and open a PR back to the source with the skill + binding files.",
+    skillLine,
     "",
     "Once you know the URL of the new tree repo, use the first-tree-hub CLI's `org bind-tree` command to record it on the Hub so future agents in this team can find it.",
     "",
-    "When everything is up, walk me through what was created — which directory, which repo, which PR.",
+    "When everything is up, walk me through what was created — which directory, which repo, which PRs.",
     "",
     `Reference: ${FIRST_TREE_REFERENCE_URL}`,
   ].join("\n");

--- a/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
@@ -48,11 +48,12 @@ export function Step2Body({
       : null;
   const initialConnectTokenExpiresAt = initialConnectToken ? (initialDraft?.connectTokenExpiresAt ?? null) : null;
 
-  // Default agent name: "Coder" — most onboarding agents are code agents
-  // (per the Step 2 lead). User can rename in the input or via agent
+  // Default agent name: "Assistant" — neutral on capability domain, since
+  // Step 2 just brings a personal agent online (Step 3 is where the team's
+  // context-tree gets built). User can rename in the input or via agent
   // settings later. The draft override wins so we don't clobber a name
   // a returning user already typed.
-  const [displayName, setDisplayName] = useState(() => initialDraft?.displayName ?? "Coder");
+  const [displayName, setDisplayName] = useState(() => initialDraft?.displayName ?? "Assistant");
   const [selectedRuntime, setSelectedRuntime] = useState<string | null>(() => initialDraft?.selectedRuntime ?? null);
   const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
   const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
@@ -397,20 +398,10 @@ function Step2FormBody({
             <span className="font-semibold" style={{ color: "var(--fg-2)" }}>
               {teamName}
             </span>
-            . Set up your first agent — a{" "}
-            <span className="font-semibold" style={{ color: "var(--fg-2)" }}>
-              code agent
-            </span>{" "}
-            that helps with your code.
+            . Set up your first agent — it&apos;ll run on a computer you connect.
           </>
         ) : (
-          <>
-            Set up your first agent — a{" "}
-            <span className="font-semibold" style={{ color: "var(--fg-2)" }}>
-              code agent
-            </span>{" "}
-            that helps with your code.
-          </>
+          <>Set up your first agent — it&apos;ll run on a computer you connect.</>
         )}
       </p>
 
@@ -432,7 +423,7 @@ function Step2FormBody({
               aria-label="Agent display name"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="e.g. Code Reviewer"
+              placeholder="e.g. Buddy, Helper, Code Reviewer"
               maxLength={200}
               className="onboarding-name-input text-body font-medium"
               style={{

--- a/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
@@ -423,7 +423,7 @@ function Step2FormBody({
               aria-label="Agent display name"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="e.g. Buddy, Helper, Code Reviewer"
+              placeholder="e.g. Buddy, Helper"
               maxLength={200}
               className="onboarding-name-input text-body font-medium"
               style={{

--- a/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
@@ -466,8 +466,8 @@ function InviteeWaitingBody() {
         Your team admin hasn&apos;t finished setup yet
       </h2>
       <p className="text-body" style={{ marginTop: "var(--sp-2)", color: "var(--fg-3)" }}>
-        Once they bind a source repo and a context-tree, this view will guide your agent to join. For now, your agent
-        can help with anything that doesn&apos;t depend on your team&apos;s shared knowledge.
+        Once they finish setup, this view will guide your agent to join. For now, your agent can help with anything that
+        doesn&apos;t depend on your team&apos;s shared knowledge.
       </p>
     </div>
   );

--- a/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
@@ -170,6 +170,12 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
   // Picks come from the team-bound list (NOT a GitHub OAuth picker — invitee
   // writing team `source_repos` is the wrong mental model and the API
   // would 403 anyway).
+  //
+  // The useState initializer runs once and relies on InviteeStep3Body not
+  // refetching teamRepos after this body mounts (see the loader in
+  // InviteeStep3Body — single fetch, no live sync). If that invariant ever
+  // changes, add a useEffect that reconciles chosenRepoUrls when teamRepos
+  // identity changes.
   const [chosenRepoUrls, setChosenRepoUrls] = useState<string[]>(() => teamRepos.map((r) => r.url));
   const hasChosen = chosenRepoUrls.length > 0;
 
@@ -460,8 +466,8 @@ function InviteeWaitingBody() {
         Your team admin hasn&apos;t finished setup yet
       </h2>
       <p className="text-body" style={{ marginTop: "var(--sp-2)", color: "var(--fg-3)" }}>
-        Once they bind a source repo and a context-tree, this view will guide you to bind your agent. For now, you can
-        chat with your agent for anything that doesn&apos;t need code context.
+        Once they bind a source repo and a context-tree, this view will guide your agent to join. For now, your agent
+        can help with anything that doesn&apos;t depend on your team&apos;s shared knowledge.
       </p>
     </div>
   );

--- a/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
@@ -264,14 +264,28 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
                 >
                   <input
                     type="checkbox"
-                    name="invitee-source-repo"
                     value={repo.url}
                     checked={active}
                     onChange={() => toggleChosenRepo(repo.url)}
                     className="sr-only"
                   />
-                  <span style={{ width: 14, display: "inline-flex", flexShrink: 0 }}>
-                    {active ? <Check className="h-3.5 w-3.5" /> : null}
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: "var(--sp-3_5)",
+                      height: "var(--sp-3_5)",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      flexShrink: 0,
+                      border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border)",
+                      borderRadius: "var(--radius-chip)",
+                      background: active ? "var(--accent)" : "transparent",
+                      color: "var(--bg)",
+                      transition: "background 120ms ease, border-color 120ms ease",
+                    }}
+                  >
+                    {active ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
                   </span>
                   <span className="mono truncate" style={{ minWidth: 0, flex: 1 }}>
                     {repo.url}

--- a/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
@@ -1,5 +1,5 @@
 import type { OrgContextTreeOutput, OrgSourceReposOutput } from "@agent-team-foundation/first-tree-hub-shared";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { getAgentConfig, updateAgentConfig } from "../../../../api/agent-config.js";
@@ -164,16 +164,21 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
   const { addToast } = useToast();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Single repo: pre-selected so Confirm is one click. Multi-repo: invitee
-  // picks from the team-bound list (NOT a GitHub OAuth picker — invitee
+  // Pre-select everything: the common case is "invitee works on the same
+  // team-bound repos as everyone else." Single repo → Confirm is one click.
+  // Multi-repo → invitee can uncheck any they don't personally work on.
+  // Picks come from the team-bound list (NOT a GitHub OAuth picker — invitee
   // writing team `source_repos` is the wrong mental model and the API
   // would 403 anyway).
-  const [chosenRepoUrl, setChosenRepoUrl] = useState<string | null>(
-    teamRepos.length === 1 ? (teamRepos[0]?.url ?? null) : null,
-  );
+  const [chosenRepoUrls, setChosenRepoUrls] = useState<string[]>(() => teamRepos.map((r) => r.url));
+  const hasChosen = chosenRepoUrls.length > 0;
+
+  const toggleChosenRepo = useCallback((url: string) => {
+    setChosenRepoUrls((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+  }, []);
 
   const handleConfirm = useCallback(async () => {
-    if (!chosenRepoUrl) return;
+    if (chosenRepoUrls.length === 0) return;
     setBusy(true);
     setError(null);
     try {
@@ -181,10 +186,10 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
       const cfg = await getAgentConfig(agent.uuid);
       await updateAgentConfig(agent.uuid, {
         expectedVersion: cfg.version,
-        payload: { gitRepos: [{ url: chosenRepoUrl }] },
+        payload: { gitRepos: chosenRepoUrls.map((url) => ({ url })) },
       });
       const chat = await createAgentChat(agent.uuid);
-      const bootstrap = buildBindBootstrap(chosenRepoUrl, treeUrl);
+      const bootstrap = buildBindBootstrap(chosenRepoUrls, treeUrl);
       try {
         await sendChatMessage(chat.id, bootstrap);
       } catch {
@@ -202,7 +207,7 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
       setError(err instanceof Error ? err.message : "Failed to start the chat");
       setBusy(false);
     }
-  }, [chosenRepoUrl, treeUrl, navigate, dismissOnboarding]);
+  }, [chosenRepoUrls, treeUrl, navigate, dismissOnboarding]);
 
   const handleLater = useCallback(() => {
     void reportOnboardingEvent("tree_intro_dismissed", { joinPath: "invite" });
@@ -228,10 +233,10 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
             style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}
           >
             <legend className="text-label" style={{ color: "var(--fg-3)", padding: 0, marginBottom: "var(--sp-1)" }}>
-              Pick the source repo to bind your agent to
+              Pick the source repos to bind your agent to
             </legend>
             {teamRepos.map((repo) => {
-              const active = chosenRepoUrl === repo.url;
+              const active = chosenRepoUrls.includes(repo.url);
               return (
                 <label
                   key={repo.url}
@@ -252,13 +257,16 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
                   }}
                 >
                   <input
-                    type="radio"
+                    type="checkbox"
                     name="invitee-source-repo"
                     value={repo.url}
                     checked={active}
-                    onChange={() => setChosenRepoUrl(repo.url)}
+                    onChange={() => toggleChosenRepo(repo.url)}
                     className="sr-only"
                   />
+                  <span style={{ width: 14, display: "inline-flex", flexShrink: 0 }}>
+                    {active ? <Check className="h-3.5 w-3.5" /> : null}
+                  </span>
                   <span className="mono truncate" style={{ minWidth: 0, flex: 1 }}>
                     {repo.url}
                   </span>
@@ -271,7 +279,7 @@ function InviteeConfirmBody({ treeUrl, teamRepos }: { treeUrl: string; teamRepos
         {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
         <div className="flex" style={{ gap: "var(--sp-2)" }}>
-          <Button type="button" disabled={!chosenRepoUrl || busy} onClick={() => void handleConfirm()}>
+          <Button type="button" disabled={!hasChosen || busy} onClick={() => void handleConfirm()}>
             {busy ? "Starting…" : "Confirm"}
           </Button>
           <Button type="button" variant="outline" onClick={handleLater} disabled={busy}>
@@ -291,7 +299,12 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
   const [error, setError] = useState<string | null>(null);
   const [repos, setRepos] = useState<GithubRepo[] | null>(null);
   const [reposError, setReposError] = useState<string | null>(null);
-  const [selectedRepoUrl, setSelectedRepoUrl] = useState<string | null>(null);
+  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
+  const hasSelection = selectedRepoUrls.length > 0;
+
+  const toggleSelectedRepo = useCallback((url: string) => {
+    setSelectedRepoUrls((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -310,7 +323,7 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
   }, []);
 
   const handleContinue = useCallback(async () => {
-    if (!selectedRepoUrl) return;
+    if (selectedRepoUrls.length === 0) return;
     setBusy(true);
     setError(null);
     try {
@@ -318,14 +331,14 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
       const cfg = await getAgentConfig(agent.uuid);
       await updateAgentConfig(agent.uuid, {
         expectedVersion: cfg.version,
-        payload: { gitRepos: [{ url: selectedRepoUrl }] },
+        payload: { gitRepos: selectedRepoUrls.map((url) => ({ url })) },
       });
-      // Deliberately NOT writing the invitee's pick back into the team's
+      // Deliberately NOT writing the invitee's picks back into the team's
       // `source_repos` namespace — that's an admin-write surface (server
-      // would 403 too). The invitee's repo is a personal agent binding,
+      // would 403 too). The invitee's repos are a personal agent binding,
       // not a team-wide statement.
       const chat = await createAgentChat(agent.uuid);
-      const bootstrap = buildBindBootstrap(selectedRepoUrl, treeUrl);
+      const bootstrap = buildBindBootstrap(selectedRepoUrls, treeUrl);
       try {
         await sendChatMessage(chat.id, bootstrap);
       } catch {
@@ -343,7 +356,7 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
       setError(err instanceof Error ? err.message : "Failed to start the chat");
       setBusy(false);
     }
-  }, [selectedRepoUrl, treeUrl, navigate, dismissOnboarding]);
+  }, [selectedRepoUrls, treeUrl, navigate, dismissOnboarding]);
 
   const handleLater = useCallback(() => {
     void reportOnboardingEvent("tree_intro_dismissed", { joinPath: "invite" });
@@ -354,7 +367,7 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
   return (
     <>
       <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", maxWidth: 720 }}>
-        Joining your team&apos;s <span style={{ color: "var(--fg-2)" }}>context-tree</span>. Pick the source repo
+        Joining your team&apos;s <span style={{ color: "var(--fg-2)" }}>context-tree</span>. Pick the source repos
         you&apos;ll work with.
       </p>
 
@@ -365,37 +378,38 @@ function InviteePickerBody({ treeUrl }: { treeUrl: string }) {
           <ReadOnlyValueRow label="Tree" value={treeUrl} />
         </StepFrame>
 
-        <StepFrame number="02" state={selectedRepoUrl ? "complete" : "active"}>
+        <StepFrame number="02" state={hasSelection ? "complete" : "active"}>
           <RepoPickerSection
             disabled={busy}
             repos={repos}
             error={reposError}
-            selectedRepoUrl={selectedRepoUrl}
-            onSelect={setSelectedRepoUrl}
+            selectedRepoUrls={selectedRepoUrls}
+            onToggle={toggleSelectedRepo}
           />
         </StepFrame>
 
-        <StepFrame number="03" state={selectedRepoUrl ? "active" : "idle"}>
+        <StepFrame number="03" state={hasSelection ? "active" : "idle"}>
           <h2
             className="text-subtitle font-semibold"
             style={{
               margin: 0,
-              color: selectedRepoUrl ? "var(--fg)" : "var(--fg-4)",
-              fontWeight: selectedRepoUrl ? 600 : 500,
+              color: hasSelection ? "var(--fg)" : "var(--fg-4)",
+              fontWeight: hasSelection ? 600 : 500,
             }}
           >
             Let your agent join the tree
           </h2>
-          {selectedRepoUrl ? (
+          {hasSelection ? (
             <>
               <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-                It&apos;ll install the skill and bind your source repo to the existing team tree.
+                It&apos;ll install the skill and bind{" "}
+                {selectedRepoUrls.length > 1 ? "each source repo" : "your source repo"} to the existing team tree.
               </p>
 
               {error ? <ErrorBanner style={{ marginTop: "var(--sp-3)" }}>{error}</ErrorBanner> : null}
 
               <div className="flex" style={{ marginTop: "var(--sp-3)", gap: "var(--sp-2)" }}>
-                <Button type="button" disabled={!selectedRepoUrl || busy} onClick={() => void handleContinue()}>
+                <Button type="button" disabled={!hasSelection || busy} onClick={() => void handleContinue()}>
                   {busy ? "Starting…" : "Continue"}
                 </Button>
                 <Button type="button" variant="outline" onClick={handleLater} disabled={busy}>
@@ -463,9 +477,13 @@ function AdminBindCreateBody() {
   const [error, setError] = useState<string | null>(null);
   const [treeMode, setTreeMode] = useState<TreeMode | null>(null);
   const [existingTreeUrl, setExistingTreeUrl] = useState("");
-  const [selectedRepoUrl, setSelectedRepoUrl] = useState<string | null>(null);
+  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
   const [repos, setRepos] = useState<GithubRepo[] | null>(null);
   const [reposError, setReposError] = useState<string | null>(null);
+
+  const toggleSelectedRepo = useCallback((url: string) => {
+    setSelectedRepoUrls((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+  }, []);
 
   // Lazy-load the GitHub repo list once when Step 3 mounts. Plan B keeps
   // source picker here (not Step 2) so agent creation in Step 2 stays
@@ -535,7 +553,7 @@ function AdminBindCreateBody() {
   }, [dismissOnboarding, addToast, navigate]);
 
   const handleContinue = useCallback(async () => {
-    if (!selectedRepoUrl) return;
+    if (selectedRepoUrls.length === 0) return;
     if (!treeMode) return;
     if (treeMode === "existing" && !isExistingUrlValid) return;
     setError(null);
@@ -543,25 +561,25 @@ function AdminBindCreateBody() {
     try {
       const agent = await resolveOnboardingAgent();
       const cfg = await getAgentConfig(agent.uuid);
+      const repoEntries = selectedRepoUrls.map((url) => ({ url }));
       await updateAgentConfig(agent.uuid, {
         expectedVersion: cfg.version,
-        payload: { gitRepos: [{ url: selectedRepoUrl }] },
+        payload: { gitRepos: repoEntries },
       });
 
-      // Phase B: mirror the chosen source repo to the team-level
+      // Phase B: mirror the chosen source repos to the team-level
       // `source_repos` namespace so subsequent invitees route through
       // InviteeConfirmBody (one-click join) rather than InviteePickerBody
-      // (re-walk GitHub OAuth). This is the admin's first-time write —
-      // a single-entry list that overwrites whatever was there before.
-      // Admins managing multiple source repos do so via Team Settings;
-      // onboarding doesn't try to merge.
+      // (re-walk GitHub OAuth). The write overwrites whatever was there
+      // before — onboarding is the admin's initial setup; subsequent
+      // additions/removals happen in Team Settings.
       //
       // Non-fatal — agent's own gitRepos already saved above, so a failure
       // here only means the next invitee will see the picker instead of
       // the confirm card.
       if (organizationId) {
         try {
-          await putSourceReposSetting(organizationId, { repos: [{ url: selectedRepoUrl }] });
+          await putSourceReposSetting(organizationId, { repos: repoEntries });
         } catch (err) {
           // eslint-disable-next-line no-console
           console.warn("Step 3: PUT source_repos failed; agent gitRepos already saved", err);
@@ -597,8 +615,8 @@ function AdminBindCreateBody() {
       const chat = await createAgentChat(agent.uuid);
       const bootstrap =
         treeMode === "existing"
-          ? buildBindBootstrap(selectedRepoUrl, trimmedTreeUrl)
-          : buildCreateBootstrap(selectedRepoUrl);
+          ? buildBindBootstrap(selectedRepoUrls, trimmedTreeUrl)
+          : buildCreateBootstrap(selectedRepoUrls);
       try {
         await sendChatMessage(chat.id, bootstrap);
       } catch {
@@ -618,7 +636,7 @@ function AdminBindCreateBody() {
       setBusy(false);
     }
   }, [
-    selectedRepoUrl,
+    selectedRepoUrls,
     treeMode,
     isExistingUrlValid,
     trimmedTreeUrl,
@@ -628,7 +646,8 @@ function AdminBindCreateBody() {
     addToast,
   ]);
 
-  const canContinue = !!selectedRepoUrl && treeMode !== null && !busy && (treeMode === "new" || isExistingUrlValid);
+  const hasSelection = selectedRepoUrls.length > 0;
+  const canContinue = hasSelection && treeMode !== null && !busy && (treeMode === "new" || isExistingUrlValid);
   const treeModeChosen = !!treeMode && (treeMode === "new" || isExistingUrlValid);
 
   return (
@@ -641,28 +660,28 @@ function AdminBindCreateBody() {
       <div style={{ marginTop: "var(--sp-5)", position: "relative" }}>
         <StepRailLine />
 
-        <StepFrame number="01" state={selectedRepoUrl ? "complete" : "active"}>
+        <StepFrame number="01" state={hasSelection ? "complete" : "active"}>
           <RepoPickerSection
             disabled={busy}
             repos={repos}
             error={reposError}
-            selectedRepoUrl={selectedRepoUrl}
-            onSelect={setSelectedRepoUrl}
+            selectedRepoUrls={selectedRepoUrls}
+            onToggle={toggleSelectedRepo}
           />
         </StepFrame>
 
-        <StepFrame number="02" state={treeModeChosen ? "complete" : selectedRepoUrl ? "active" : "idle"}>
+        <StepFrame number="02" state={treeModeChosen ? "complete" : hasSelection ? "active" : "idle"}>
           <h2
             className="text-subtitle font-semibold"
             style={{
               margin: 0,
-              color: selectedRepoUrl ? "var(--fg)" : "var(--fg-4)",
-              fontWeight: selectedRepoUrl ? 600 : 500,
+              color: hasSelection ? "var(--fg)" : "var(--fg-4)",
+              fontWeight: hasSelection ? 600 : 500,
             }}
           >
             Bind or create the tree
           </h2>
-          {selectedRepoUrl ? (
+          {hasSelection ? (
             <div style={{ marginTop: "var(--sp-3)", display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
               {/* Segmented toggle — two-option choice as a single inline
                 control instead of stacked radio cards. Real <input
@@ -750,7 +769,8 @@ function AdminBindCreateBody() {
 
               {treeMode === "new" ? (
                 <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
-                  Your agent will scaffold a new GitHub repo for the tree and bind it to your source repo.
+                  Your agent will scaffold a new GitHub repo for the tree and bind{" "}
+                  {selectedRepoUrls.length > 1 ? "each selected source repo" : "the source repo"} to it.
                 </p>
               ) : null}
             </div>
@@ -771,7 +791,8 @@ function AdminBindCreateBody() {
           {treeModeChosen ? (
             <>
               <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-                It&apos;ll install the skill, set up the tree, and open a PR back to your source repo.
+                It&apos;ll install the skill, set up the tree, and open a PR back to{" "}
+                {selectedRepoUrls.length > 1 ? "each source repo" : "your source repo"}.
               </p>
 
               {error ? <ErrorBanner style={{ marginTop: "var(--sp-3)" }}>{error}</ErrorBanner> : null}
@@ -872,14 +893,14 @@ function RepoPickerSection({
   disabled,
   repos,
   error,
-  selectedRepoUrl,
-  onSelect,
+  selectedRepoUrls,
+  onToggle,
 }: {
   disabled: boolean;
   repos: GithubRepo[] | null;
   error: string | null;
-  selectedRepoUrl: string | null;
-  onSelect: (url: string | null) => void;
+  selectedRepoUrls: readonly string[];
+  onToggle: (url: string) => void;
 }) {
   const heading = (
     <h2
@@ -889,7 +910,7 @@ function RepoPickerSection({
         fontWeight: disabled ? 500 : 600,
       }}
     >
-      Pick the source repo
+      Pick source repos
     </h2>
   );
 
@@ -939,26 +960,29 @@ function RepoPickerSection({
     <div style={{ animation: "subtle-fade 200ms ease-out" }}>
       {heading}
       <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-        The code your tree will organize knowledge about.
+        The code your tree will organize knowledge about. Pick one or more.
       </p>
-      <RepoPickerPopover repos={repos} selectedRepoUrl={selectedRepoUrl} onSelect={onSelect} />
+      <RepoPickerPopover repos={repos} selectedRepoUrls={selectedRepoUrls} onToggle={onToggle} />
     </div>
   );
 }
 
 function RepoPickerPopover({
   repos,
-  selectedRepoUrl,
-  onSelect,
+  selectedRepoUrls,
+  onToggle,
 }: {
   repos: GithubRepo[];
-  selectedRepoUrl: string | null;
-  onSelect: (url: string | null) => void;
+  selectedRepoUrls: readonly string[];
+  onToggle: (url: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // Click-outside + Escape, mirroring user-menu.tsx's popover pattern.
+  // Multi-select: clicking a row toggles selection without closing — the
+  // user closes the popover explicitly by clicking outside, hitting Escape,
+  // or clicking the trigger button again.
   useEffect(() => {
     if (!open) return;
     const onMouseDown = (e: MouseEvent) => {
@@ -990,10 +1014,27 @@ function RepoPickerPopover({
     return [...byOwner.entries()].sort(([a], [b]) => a.localeCompare(b));
   }, [repos]);
 
-  const selectedRepo = repos.find((r) => r.cloneUrl === selectedRepoUrl) ?? null;
+  const selectedSet = useMemo(() => new Set(selectedRepoUrls), [selectedRepoUrls]);
+  const selectedRepos = useMemo(() => repos.filter((r) => selectedSet.has(r.cloneUrl)), [repos, selectedSet]);
+  const triggerLabel = selectedRepos.length === 0 ? "Select repositories…" : "Add another repository";
 
   return (
     <div ref={ref} className="relative" style={{ marginTop: "var(--sp-2)" }}>
+      {selectedRepos.length > 0 && (
+        <div
+          style={{
+            marginBottom: "var(--sp-2)",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "var(--sp-1_5)",
+          }}
+        >
+          {selectedRepos.map((repo) => (
+            <SelectedRepoChip key={repo.cloneUrl} fullName={repo.fullName} onRemove={() => onToggle(repo.cloneUrl)} />
+          ))}
+        </div>
+      )}
+
       <button
         type="button"
         aria-haspopup="listbox"
@@ -1010,14 +1051,14 @@ function RepoPickerPopover({
           background: "var(--bg)",
           border: "var(--hairline) solid var(--border)",
           borderRadius: "var(--radius-input)",
-          color: selectedRepo ? "var(--fg)" : "var(--fg-3)",
+          color: "var(--fg-3)",
           outline: "none",
           cursor: "pointer",
           textAlign: "left",
         }}
       >
         <span className="truncate" style={{ minWidth: 0, flex: 1 }}>
-          {selectedRepo ? selectedRepo.fullName : "Select a repository…"}
+          {triggerLabel}
         </span>
         <ChevronDown
           className="h-4 w-4"
@@ -1033,7 +1074,8 @@ function RepoPickerPopover({
       {open && (
         <div
           role="listbox"
-          aria-label="GitHub repository"
+          aria-label="GitHub repositories"
+          aria-multiselectable="true"
           className="absolute z-30 rounded-md border bg-popover shadow-md"
           style={{
             top: "calc(100% + var(--sp-1))",
@@ -1046,27 +1088,20 @@ function RepoPickerPopover({
         >
           {groups.map(([owner, ownerRepos], groupIdx) => (
             <div key={owner}>
-              {groupIdx > 0 && (
-                <div
-                  aria-hidden="true"
-                  style={{
-                    margin: "var(--sp-1) 0",
-                    height: "var(--hairline)",
-                    background: "var(--border-faint)",
-                  }}
-                />
-              )}
               <div
                 className="text-eyebrow"
                 style={{
-                  padding: "var(--sp-1) var(--sp-3)",
-                  color: "var(--fg-3)",
+                  paddingTop: groupIdx > 0 ? "var(--sp-3)" : "var(--sp-1)",
+                  paddingBottom: "var(--sp-1)",
+                  paddingLeft: "calc(var(--sp-3) + var(--sp-3_5) + var(--sp-2))",
+                  paddingRight: "var(--sp-3)",
+                  color: "var(--fg-2)",
                 }}
               >
                 {owner}
               </div>
               {ownerRepos.map((repo) => {
-                const selected = repo.cloneUrl === selectedRepoUrl;
+                const selected = selectedSet.has(repo.cloneUrl);
                 const repoName = repo.fullName.slice(owner.length + 1);
                 return (
                   <button
@@ -1074,16 +1109,13 @@ function RepoPickerPopover({
                     type="button"
                     role="option"
                     aria-selected={selected}
-                    onClick={() => {
-                      onSelect(repo.cloneUrl);
-                      setOpen(false);
-                    }}
+                    onClick={() => onToggle(repo.cloneUrl)}
                     className="text-body transition-colors w-full"
                     style={{
                       display: "flex",
                       alignItems: "center",
                       gap: "var(--sp-2)",
-                      padding: "var(--sp-1_5) var(--sp-3)",
+                      padding: "var(--sp-1) var(--sp-3)",
                       background: selected ? "var(--accent-bg)" : "transparent",
                       color: selected ? "var(--accent)" : "var(--fg)",
                       border: "none",
@@ -1097,8 +1129,25 @@ function RepoPickerPopover({
                       if (!selected) e.currentTarget.style.background = "transparent";
                     }}
                   >
-                    <span style={{ width: 14, display: "inline-flex", flexShrink: 0 }}>
-                      {selected ? <Check className="h-3.5 w-3.5" /> : null}
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        width: "var(--sp-3_5)",
+                        height: "var(--sp-3_5)",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        flexShrink: 0,
+                        border: selected
+                          ? "var(--hairline) solid var(--accent)"
+                          : "var(--hairline) solid var(--border)",
+                        borderRadius: "var(--radius-chip)",
+                        background: selected ? "var(--accent)" : "transparent",
+                        color: "var(--bg)",
+                        transition: "background 120ms ease, border-color 120ms ease",
+                      }}
+                    >
+                      {selected ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
                     </span>
                     <span className="truncate" style={{ minWidth: 0, flex: 1 }}>
                       {repoName}
@@ -1109,8 +1158,8 @@ function RepoPickerPopover({
                         style={{
                           padding: "var(--hairline) var(--sp-1_75)",
                           borderRadius: "var(--radius-chip)",
-                          color: "var(--fg-3)",
-                          border: "var(--hairline) solid var(--border)",
+                          color: "var(--fg-4)",
+                          border: "var(--hairline) solid var(--border-faint)",
                           background: "var(--bg-sunken)",
                           flexShrink: 0,
                         }}
@@ -1126,5 +1175,59 @@ function RepoPickerPopover({
         </div>
       )}
     </div>
+  );
+}
+
+function SelectedRepoChip({ fullName, onRemove }: { fullName: string; onRemove: () => void }) {
+  return (
+    <span
+      className="text-label inline-flex items-center"
+      style={{
+        gap: "var(--sp-1)",
+        paddingLeft: "var(--sp-2)",
+        paddingRight: "var(--sp-0_5)",
+        paddingTop: "var(--sp-0_5)",
+        paddingBottom: "var(--sp-0_5)",
+        background: "var(--surface-1)",
+        border: "var(--hairline) solid var(--border-faint)",
+        borderRadius: "var(--radius-chip)",
+        color: "var(--fg-2)",
+        maxWidth: "20rem",
+      }}
+    >
+      <span className="mono truncate" style={{ minWidth: 0 }}>
+        {fullName}
+      </span>
+      <button
+        type="button"
+        aria-label={`Remove ${fullName}`}
+        onClick={onRemove}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "var(--sp-4)",
+          height: "var(--sp-4)",
+          border: 0,
+          padding: 0,
+          background: "transparent",
+          color: "var(--fg-3)",
+          cursor: "pointer",
+          borderRadius: "var(--radius-chip)",
+          flexShrink: 0,
+          transition: "background 120ms ease, color 120ms ease",
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = "var(--surface-2)";
+          e.currentTarget.style.color = "var(--fg)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "transparent";
+          e.currentTarget.style.color = "var(--fg-3)";
+        }}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- **Step 3 multi-select source-repo picker.** Single-select dropdown → real multi-select. Selected-repo chip row above the trigger (× to remove without re-opening), proper checkbox visual in popover rows, owner header realigned to repo-name column, density tightened (row padding sp-1_5 → sp-1), hairline group dividers replaced with breathing-room padding. Bootstrap-prose builders take `readonly string[]` and switch singular/plural; N>1 create branch asks the user when source repos span multiple GitHub owners (no more ambiguous "first source").
- **Step 2 reframe — decouple from code.** Lead "a code agent that helps with your code" → "it'll run on a computer you connect". Default name "Coder" → "Assistant". Placeholder "e.g. Code Reviewer" → "e.g. Buddy, Helper". Step 2 sets up an individual agent online; Step 3 is where the team's shared knowledge layer (context-tree) gets built — not "code awareness".
- **Copy / consistency fixes.** `InviteeWaitingBody` "anything that doesn't need code context" → "doesn't depend on your team's shared knowledge"; "Once they bind a source repo and a context-tree" → "Once they finish setup". `InviteeConfirmBody` `useState` initializer gained a comment locking the no-refetch invariant.

Backend / DB / agent config were already array-shaped — the entire surface from `organization_settings.source_repos` to `agents.gitRepos` accepted N repos. The onboarding picker was the lone single-select bottleneck.

Reviewed by two independent passes (first pass on commit 1 + staged step 2; second pass on the full branch). All blockers / actionable nits addressed; remaining open items (listbox keyboard nav, DOM-model drift between native checkbox vs `<button role="option">`, gate-variable naming drift) deferred — captured in [memory](https://github.com/agent-team-foundation/first-tree-hub/blob/main/.gitignore) per repo convention.

A separate follow-up was filed as a local memory entry: explicit **tree destination** picker in Step 3 (the agent currently asks at runtime when source repos span owners; better is a UI-layer pick before the chat starts). Out of scope for this PR.

## Test plan

- [ ] Admin onboarding step 3: multi-select picker opens, picking N repos shows N chips above the trigger, popover stays open across picks, owner header aligns to repo-name column
- [ ] Chip × removes the chip AND unchecks the popover row (state sync both directions)
- [ ] Continue submits all selected repos to `gitRepos` on the agent + `source_repos` namespace on the team
- [ ] Bootstrap message to agent: N=1 reads singular prose, N>1 reads plural with markdown bullet list of URLs
- [ ] N>1 cross-owner case: bootstrap tells agent to ask the user which owner the tree should live under
- [ ] Step 2 lead: "Set up your first agent — it'll run on a computer you connect."
- [ ] Step 2 default agent name: "Assistant"; placeholder: "e.g. Buddy, Helper"
- [ ] Step 3 lead unchanged: "Build the context-tree — your team's shared knowledge that grows with your code."
- [ ] InviteeWaitingBody (invitee whose team has neither tree nor repos): copy says "Once they finish setup" and "anything that doesn't depend on your team's shared knowledge"
- [ ] InviteeConfirmBody (invitee whose team has both): all team repos pre-checked by default; uncheck still allows Confirm if at least one remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)