### PR TITLE
feat(server): github-app service primitives — App JWT, installation token, user-token refresh

### DIFF
--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -1,0 +1,226 @@
+import { generateKeyPairSync } from "node:crypto";
+import { decodeJwt, decodeProtectedHeader, importPKCS8, jwtVerify } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import { createAppJwt, GithubAppApiError, mintInstallationToken, refreshAppUserToken } from "../services/github-app.js";
+
+/**
+ * Service-layer unit tests for `services/github-app.ts`. Pure module tests;
+ * no Fastify test app, no DB. A throwaway RSA-2048 keypair is generated
+ * per `describe` block so we never check a real (or even "test-real") key
+ * into the repo — there's nothing for a curious reader to mistake for a
+ * production secret.
+ *
+ * The `mintInstallationToken` / `refreshAppUserToken` tests inject a
+ * `fetcher` so the GitHub round-trip is replaced by an in-process stub.
+ * That mirrors the pattern used by `listUserRepos` in `github-oauth.ts`.
+ */
+describe("services/github-app", () => {
+  let appId: string;
+  let privateKeyPem: string;
+  let publicKeyPem: string;
+
+  beforeAll(() => {
+    appId = "123456";
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    privateKeyPem = privateKey;
+    publicKeyPem = publicKey;
+  });
+
+  describe("createAppJwt", () => {
+    it("returns a JWT signed with RS256 carrying iss=appId", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const header = decodeProtectedHeader(jwt);
+      expect(header.alg).toBe("RS256");
+      const payload = decodeJwt(jwt);
+      expect(payload.iss).toBe(appId);
+      expect(typeof payload.iat).toBe("number");
+      expect(typeof payload.exp).toBe("number");
+    });
+
+    it("backdates iat by ~60s to absorb clock skew", async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const after = Math.floor(Date.now() / 1000);
+      const payload = decodeJwt(jwt);
+      // iat is "now - 60s" rounded down to a whole second; allow ±2s slop
+      // for the work between the `before` capture and the `setIssuedAt`
+      // call inside `createAppJwt`.
+      const iat = payload.iat;
+      if (typeof iat !== "number") throw new Error("expected numeric iat");
+      expect(iat).toBeGreaterThanOrEqual(before - 62);
+      expect(iat).toBeLessThanOrEqual(after - 58);
+    });
+
+    it("expires within the 10-minute GitHub upper bound", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const payload = decodeJwt(jwt);
+      const iat = payload.iat;
+      const exp = payload.exp;
+      if (typeof iat !== "number" || typeof exp !== "number") throw new Error("expected numeric iat/exp");
+      // 9-minute expiry plus 60s iat skew = ≤600s span; GitHub rejects >600s.
+      expect(exp - iat).toBeLessThanOrEqual(600);
+    });
+
+    it("verifies against the matching public key", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      // Build a SPKI key for verification — this is what GitHub's edge
+      // does on receipt. If the signature is malformed jwtVerify throws.
+      const pubKey = await importPKCS8(privateKeyPem, "RS256");
+      // Use the private key for verify too — RS256 verifies with a public
+      // key derived from the same keypair. We re-derive via `crypto` to
+      // confirm the signature actually validates end-to-end.
+      const { createPublicKey } = await import("node:crypto");
+      const pub = createPublicKey(publicKeyPem);
+      const { payload } = await jwtVerify(jwt, pub);
+      expect(payload.iss).toBe(appId);
+      // No-op reference to pubKey to silence "declared but never used" —
+      // confirms importPKCS8 accepted the PEM, which is part of the test.
+      expect(pubKey).toBeDefined();
+    });
+
+    it("rejects an invalid PEM", async () => {
+      await expect(createAppJwt({ appId, privateKeyPem: "not a pem" })).rejects.toThrow();
+    });
+  });
+
+  describe("mintInstallationToken", () => {
+    it("POSTs to /app/installations/:id/access_tokens with bearer header and parses success", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            token: "ghs_installation_token",
+            expires_at: "2026-05-11T18:00:00Z",
+            permissions: { contents: "write", issues: "read" },
+            repository_selection: "selected",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await mintInstallationToken("app-jwt-stub", 7777, { fetcher: fakeFetch });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("https://api.github.com/app/installations/7777/access_tokens");
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer app-jwt-stub");
+      expect(headers.get("accept")).toBe("application/vnd.github+json");
+      expect(headers.get("x-github-api-version")).toBe("2022-11-28");
+      expect(calls[0]?.init?.method).toBe("POST");
+      expect(result).toEqual({
+        token: "ghs_installation_token",
+        expiresAt: "2026-05-11T18:00:00Z",
+        permissions: { contents: "write", issues: "read" },
+        repositorySelection: "selected",
+      });
+    });
+
+    it("defaults repositorySelection to 'all' when GitHub omits the field", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ token: "t", expires_at: "2026-01-01T00:00:00Z" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      const result = await mintInstallationToken("jwt", 1, { fetcher: fakeFetch });
+      expect(result.repositorySelection).toBe("all");
+      expect(result.permissions).toEqual({});
+    });
+
+    it("throws GithubAppApiError with status on non-2xx", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+      await expect(mintInstallationToken("jwt", 1, { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 401,
+      });
+    });
+  });
+
+  describe("refreshAppUserToken", () => {
+    it("trades a refresh token for a fresh access + refresh pair", async () => {
+      const fixedNow = new Date("2026-05-11T10:00:00.000Z");
+      const calls: Array<{ url: string; body: string }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), body: String(init?.body ?? "") });
+        return new Response(
+          JSON.stringify({
+            access_token: "ghu_new_access",
+            expires_in: 28800, // 8h
+            refresh_token: "ghr_new_refresh",
+            refresh_token_expires_in: 15897600, // ~6mo
+            scope: "repo,user:email",
+            token_type: "bearer",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await refreshAppUserToken("client-id", "client-secret", "old-refresh", {
+        fetcher: fakeFetch,
+        now: () => fixedNow,
+      });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("https://github.com/login/oauth/access_token");
+      const body = JSON.parse(calls[0]?.body ?? "{}");
+      expect(body).toEqual({
+        client_id: "client-id",
+        client_secret: "client-secret",
+        grant_type: "refresh_token",
+        refresh_token: "old-refresh",
+      });
+      expect(result).toEqual({
+        accessToken: "ghu_new_access",
+        // fixedNow + 28800s = 18:00:00Z
+        accessTokenExpiresAt: "2026-05-11T18:00:00.000Z",
+        refreshToken: "ghr_new_refresh",
+        // fixedNow + 15897600s = +184 days = 2026-11-11
+        refreshTokenExpiresAt: "2026-11-11T10:00:00.000Z",
+        scope: "repo,user:email",
+      });
+    });
+
+    it("maps GitHub's 200-with-`error` body to a 401 GithubAppApiError so callers re-login", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(
+          JSON.stringify({
+            error: "bad_refresh_token",
+            error_description: "The refresh token passed is incorrect or expired.",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      await expect(refreshAppUserToken("cid", "csec", "stale", { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 401,
+      });
+    });
+
+    it("rejects loudly when GitHub omits expires_in (App misconfigured)", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "a",
+            refresh_token: "r",
+            // expires_in / refresh_token_expires_in deliberately omitted
+            scope: "repo",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      const err = (await refreshAppUserToken("cid", "csec", "x", { fetcher: fakeFetch }).catch(
+        (e: unknown) => e,
+      )) as GithubAppApiError;
+      expect(err).toBeInstanceOf(GithubAppApiError);
+      expect(err.status).toBe(500);
+      expect(err.message).toContain("expires_in");
+    });
+
+    it("surfaces transport errors as GithubAppApiError with upstream status", async () => {
+      const fakeFetch: typeof fetch = async () => new Response("", { status: 502 });
+      await expect(refreshAppUserToken("cid", "csec", "x", { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 502,
+      });
+    });
+  });
+});

--- a/packages/server/src/services/github-app.ts
+++ b/packages/server/src/services/github-app.ts
@@ -1,0 +1,242 @@
+import { importPKCS8, SignJWT } from "jose";
+
+/**
+ * GitHub App service helpers — the three primitives that ride on top of an
+ * App's private key:
+ *
+ *   1. `createAppJwt`        — sign the short-lived (≤10min) App JWT that
+ *                              identifies Hub-as-an-App to GitHub.
+ *   2. `mintInstallationToken` — exchange the App JWT for a per-installation
+ *                              server-to-server token (~1h TTL). Used when
+ *                              Hub itself needs to act as the App on a
+ *                              tenant's repos (Phase 4 identity convergence;
+ *                              not yet wired into request paths).
+ *   3. `refreshAppUserToken` — slide an expiring user-to-server access token
+ *                              by trading in its refresh token. Powers the
+ *                              ~8h-TTL user session that replaces the
+ *                              never-expires legacy OAuth token.
+ *
+ * Design context: `docs/github-app-design-zh.md` §3 ("one installation, three
+ * capabilities") + §5.4 ("services/github-app.ts").
+ *
+ * Stateless by construction: this module imports no DB / config singletons.
+ * Callers thread the App credentials in explicitly — the wiring layer that
+ * pulls them from env arrives in PR-C.
+ */
+
+const APP_JWT_ALG = "RS256";
+/**
+ * GitHub rejects App JWTs past 10 minutes; we ride 9 minutes so callers
+ * don't trip the upper bound from clock skew. Generous-but-safe — the JWT
+ * is cheap to mint (one RS256 signature) so caching is unnecessary.
+ */
+const APP_JWT_EXPIRY = "9m";
+/**
+ * GitHub allows a small backdated `iat` to absorb clock skew on the
+ * caller's side; the docs recommend 60 seconds. We mirror that.
+ */
+const APP_JWT_IAT_SKEW_SECONDS = 60;
+
+const APP_INSTALLATION_TOKEN_URL = (id: number) => `https://api.github.com/app/installations/${id}/access_tokens`;
+const OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+/**
+ * Errors from any GitHub API call this module makes. Carries the HTTP
+ * status so route layers can disambiguate auth/permission failures (401 /
+ * 403 / 404) from transient upstream errors (5xx / network).
+ *
+ * Distinct from `github-oauth.ts`'s `GithubApiError` because the App API
+ * surface is a different concern (App-private-key vs. OAuth client
+ * credentials) and we want logs / metrics to tell them apart at a glance.
+ */
+export class GithubAppApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GithubAppApiError";
+  }
+}
+
+export type GithubAppCredentials = {
+  /** App ID from the GitHub App's settings page (numeric, but GitHub returns it as a string in some envs). */
+  appId: string;
+  /** RSA private key in PKCS#8 PEM form (`-----BEGIN PRIVATE KEY-----…`). */
+  privateKeyPem: string;
+};
+
+/**
+ * Mint an App JWT. RS256-signed; identifies Hub-as-this-App to GitHub for
+ * the next ~9 minutes. Use this directly for `/app/...` endpoints and as
+ * the input to `mintInstallationToken` for `/installation/...` endpoints.
+ *
+ * The PEM is imported on every call. The cost is negligible (microseconds)
+ * and avoids a global mutable cache — keeps this module trivially safe to
+ * call from parallel request handlers without locking. If profiling ever
+ * shows this is a hotspot, add a per-key memoization at the caller side.
+ */
+export async function createAppJwt(creds: GithubAppCredentials): Promise<string> {
+  const key = await importPKCS8(creds.privateKeyPem, APP_JWT_ALG);
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: APP_JWT_ALG })
+    .setIssuer(creds.appId)
+    .setIssuedAt(now - APP_JWT_IAT_SKEW_SECONDS)
+    .setExpirationTime(APP_JWT_EXPIRY)
+    .sign(key);
+}
+
+export type InstallationToken = {
+  /** Opaque server-to-server token. Bearer-style. */
+  token: string;
+  /** ISO-8601, ~1h after issue. Re-mint past this. */
+  expiresAt: string;
+  /** Permissions GitHub actually granted on this installation (may be a subset of what the App declares). */
+  permissions: Record<string, "read" | "write" | "admin">;
+  /** "all" (all repos in the account) | "selected" (subset; webhook payload carries the list). */
+  repositorySelection: "all" | "selected";
+};
+
+/**
+ * Mint a per-installation token (server-to-server). The token is cheap
+ * (one signature + one HTTP round-trip) and the upstream TTL is ~1h, so
+ * the recommended caller pattern is "mint per request" rather than caching
+ * — caching forces the caller to also track expiry, suspended state, and
+ * GitHub-side permission churn, which the design explicitly punts to Phase
+ * 4. We give callers a typed result and let them cache if profiling shows
+ * the round-trip is hot.
+ *
+ * Throws `GithubAppApiError` on non-2xx. 401 means the App JWT is bad or
+ * the App's key has been rotated upstream; 404 means the installation
+ * was uninstalled. Callers SHOULD persist the suspension state when 403
+ * comes back with `suspended` (the design tracks this as `suspended_at`
+ * on `github_app_installations`).
+ */
+export async function mintInstallationToken(
+  appJwt: string,
+  installationId: number,
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<InstallationToken> {
+  const fetcher = opts.fetcher ?? fetch;
+  const res = await fetcher(APP_INSTALLATION_TOKEN_URL(installationId), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${appJwt}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    throw new GithubAppApiError(res.status, `GitHub App installation-token request failed (${res.status})`);
+  }
+  const body = (await res.json()) as {
+    token: string;
+    expires_at: string;
+    permissions?: Record<string, "read" | "write" | "admin">;
+    repository_selection?: "all" | "selected";
+  };
+  return {
+    token: body.token,
+    expiresAt: body.expires_at,
+    permissions: body.permissions ?? {},
+    // GitHub omits `repository_selection` for personal installs where the
+    // distinction is degenerate; default to "all" so downstream code has
+    // one fewer optional to thread through.
+    repositorySelection: body.repository_selection ?? "all",
+  };
+}
+
+export type RefreshedUserToken = {
+  accessToken: string;
+  /** ISO-8601. Typically ~8h after issue. */
+  accessTokenExpiresAt: string;
+  /**
+   * GitHub re-issues a fresh refresh token on every refresh (rotation).
+   * Callers MUST persist this — using the old refresh token after a
+   * successful rotation will fail with `bad_refresh_token`.
+   */
+  refreshToken: string;
+  /** ISO-8601. Typically ~6mo after issue. */
+  refreshTokenExpiresAt: string;
+  /** Granted scopes, comma-joined. Forwarded verbatim from GitHub. */
+  scope: string;
+};
+
+/**
+ * Trade an expiring user-to-server access token for a fresh pair using
+ * its refresh token. Thrown on:
+ *   - Network / 5xx           — `GithubAppApiError(status, …)`
+ *   - 4xx with no JSON body   — `GithubAppApiError(status, …)`
+ *   - 200 with `error` field  — `GithubAppApiError(401, …)` (GitHub returns
+ *     200 OK for an unusable refresh token but signals the error in the
+ *     body; we normalize to 401 so route layers can map to "re-login")
+ *
+ * Designed to be called from the OAuth callback / token-refresh path
+ * landing in PR-C. The caller decrypts the stored refresh token, hands
+ * the plaintext in here, encrypts the returned pair, and writes both
+ * tokens + expiries back to `auth_identities.metadata`.
+ */
+export async function refreshAppUserToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  opts: { fetcher?: typeof fetch; now?: () => Date } = {},
+): Promise<RefreshedUserToken> {
+  const fetcher = opts.fetcher ?? fetch;
+  const now = opts.now ?? (() => new Date());
+  const res = await fetcher(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!res.ok) {
+    throw new GithubAppApiError(res.status, `GitHub user-token refresh failed (${res.status})`);
+  }
+  const body = (await res.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    refresh_token_expires_in?: number;
+    scope?: string;
+    token_type?: string;
+    error?: string;
+    error_description?: string;
+  };
+  if (body.error || !body.access_token || !body.refresh_token) {
+    // GitHub returns 200 OK with `error` / `error_description` when the
+    // refresh token is malformed, expired, or already-rotated. Normalize
+    // to 401 because the caller's only sane response is "re-login".
+    const description = body.error_description ?? body.error ?? "missing access_token / refresh_token";
+    throw new GithubAppApiError(401, `GitHub user-token refresh rejected: ${description}`);
+  }
+  if (typeof body.expires_in !== "number" || typeof body.refresh_token_expires_in !== "number") {
+    // GitHub Apps always include both `*_expires_in` fields in the refresh
+    // response. If one is missing the deployment is misconfigured (e.g.
+    // App still has "Expire user authorization tokens" disabled in the
+    // settings page) — fail loudly rather than persist a row that lies
+    // about when the token expires.
+    throw new GithubAppApiError(
+      500,
+      "GitHub user-token refresh response missing expires_in fields — App likely has user-token expiration disabled",
+    );
+  }
+  const issuedAt = now();
+  const accessExpiresAt = new Date(issuedAt.getTime() + body.expires_in * 1000);
+  const refreshExpiresAt = new Date(issuedAt.getTime() + body.refresh_token_expires_in * 1000);
+  return {
+    accessToken: body.access_token,
+    accessTokenExpiresAt: accessExpiresAt.toISOString(),
+    refreshToken: body.refresh_token,
+    refreshTokenExpiresAt: refreshExpiresAt.toISOString(),
+    scope: body.scope ?? "",
+  };
+}


### PR DESCRIPTION
## Summary

PR-B of the GitHub App migration ([design doc](docs/github-app-design-zh.md), tracking PR #295, PR-A is #300). Stateless service module — no behavior change yet, nothing wired into request paths. Subsequent PRs (#300 + this) form the foundation that PR-C builds the actual OAuth / install / webhook handlers on top of.

This PR is **independent of #300** — no shared types in common — so they can land in either order.

### What's in

`packages/server/src/services/github-app.ts` — three primitives, all parameter-injected (no module-level config singletons, so the file is trivially safe to call from parallel request handlers):

1. **`createAppJwt({appId, privateKeyPem})`**
   RS256-signed App JWT. `iat` back-dated 60s for clock skew, 9-minute expiry (under the 10-minute GitHub upper bound). PEM is imported per call — microsecond cost, no global mutable cache.
2. **`mintInstallationToken(appJwt, installationId)`**
   `POST /app/installations/:id/access_tokens`. Returns `{token, expiresAt, permissions, repositorySelection}`. Defaults `repositorySelection` to `\"all\"` when GitHub omits it (personal installs).
3. **`refreshAppUserToken(clientId, clientSecret, refreshToken)`**
   `POST /login/oauth/access_token` with `grant_type=refresh_token`. Normalizes GitHub's two failure modes:
   - 200 OK with `\"error\"` body → `GithubAppApiError(401, …)` so route layer maps to \"re-login\"
   - Missing `expires_in` fields → `GithubAppApiError(500, …)` because the App was misconfigured upstream (token-expiration disabled) and persisting a row that lies about its TTL is worse than a loud failure

Plus `GithubAppApiError(status, message)` — mirrors the existing `GithubApiError` convention from `github-oauth.ts` but distinct, so logs/metrics can tell the App-private-key surface from the OAuth-client surface at a glance.

### Tests

`__tests__/github-app.test.ts` — 12 new unit tests, no Fastify test app, no DB. Coverage:

- **JWT**: alg/iss/iat/exp shape, 60s iat backdating, ≤600s exp-iat span, RS256 signature verifies against the matching public key end-to-end (round-trip via `node:crypto.createPublicKey` + `jose.jwtVerify`), invalid-PEM rejection.
- **mintInstallationToken**: URL + bearer header + API-version header, success-payload parsing, `repositorySelection` default, `GithubAppApiError` on non-2xx.
- **refreshAppUserToken**: success round-trip with deterministic `now` so the absolute expiry math is exact, the GitHub `error`-body-on-200 corner case, the missing-`expires_in` misconfig corner case, transport 5xx mapping.

A throwaway RSA-2048 keypair is generated per `describe` block — no PEM is checked into the repo so there's nothing for a curious reader to mistake for a production secret.

### Verification

- [x] `pnpm check` — clean
- [x] `pnpm typecheck` — 9 packages clean
- [x] `pnpm test` — 750 / 750 pass (738 baseline + 12 new)

### What's intentionally NOT in this PR

- Env wiring (`FIRST_TREE_HUB_GITHUB_APP_*`) — comes in PR-C with the OAuth-callback rewrite.
- Secret-manager surface for the private key — depends on team picking a pattern (design doc §6 risk 4 still open).
- Any new schema columns — the service is stateless; PR-A (#300) already lays down `github_app_installations` for callers to write into.

## Test plan

- [ ] CI green
- [ ] Reviewer to sanity-check the 200-with-`error` → 401 normalization (GitHub's behavior is documented but slightly unusual; happy to add a comment-link to the GitHub doc if useful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)