### PR TITLE
feat(web): refine team delegate roster

### DIFF
--- a/docs/team-page-product-design.zh-CN.md
+++ b/docs/team-page-product-design.zh-CN.md
@@ -10,9 +10,9 @@
 
 ## 摘要
 
-First Tree Hub 的 `/team` 从原本的 master-detail(Members / Agents / Settings 三个子 tab)统一为**单页两表**:**Humans**(org members)+ **Agents**(filter type=human 之后的真 bot)。
+First Tree Hub 的 `/team` 从原本的 master-detail(Members / Agents / Settings 三个子 tab)统一为**单页 roster**:**Humans**(org members)+ agent sections(filter type=human 之后的真 bot)共享一套表格列。
 
-Page-level subtitle 用 "1 human and 2 agents working together" 在产品入口直接体现 AI-native team 叙事 —— "team = 人 + agent 共同体" 这一观念。
+页面不再用 page-level subtitle 或 role badge 承载二级信息。主扫描层只保留 section、count、delegate、manager、runtime / status 等任务相关事实;admin role 留在 profile edit / governance 操作里。
 
 `Team settings` 仍作为 admin-only sub-route 保留,但主入口默认进 `/team` 单页,无需先选 tab。
 
@@ -57,8 +57,10 @@ agents       — agent 系统的 actor,type ∈ {human, personal_assistant, auto
 `/team` 页面是这两份数据的视图聚合:
 
 ```text
-Humans 表       ← members JOIN users(列出 org members)
-Agents 表       ← agents WHERE type ≠ "human"(列出团队的 bot)
+Humans section              ← members JOIN users(列出 org members)
+Shared agents section       ← agents WHERE type ≠ "human" AND visibility = organization
+Your private agents section ← agents WHERE type ≠ "human" AND visibility = private AND manager = self
+Other private agents        ← admin governance view,collapsed by default
 ```
 
 ### `human`-type agent 在 UI 中的定位
@@ -74,22 +76,24 @@ Agents 表       ← agents WHERE type ≠ "human"(列出团队的 bot)
 UI 层面应该跟这一立场对齐 —— **不把 `type=human` 暴露成"agent 实体"**:
 
 - 用户在产品里"是" Ta 自己,不是"Ta 自己的 human-type agent record"
-- 用户去 `/team` 看团队人员时,应只看到 humans 一次(在 Humans 表里),不应该在 Agents 表里再看到自己一行被标 `HUMAN`
+- 用户去 `/team` 看团队人员时,应只看到 humans 一次(在 Humans section 里),不应该在 agent sections 里再看到自己一行被标 `HUMAN`
 - 类比:用户不会在某个 settings 页里看到一个叫 "Apple ID record" 的"东西"等待管理 — 用户**就是**自己的 Apple ID
 
-实施上,Agents 表的查询结果在前端 `filter((a) => a.type !== "human")`。
+实施上,agent section 的查询结果在前端 `filter((a) => a.type !== "human")`。
 
 ### Members / Agents 平级而非嵌套
 
-不把 Agents 作为 Members 的子集或反过来。两者是**两份不同来源的数据**(`members` 表 vs `agents` 表),代表团队的两类参与者。在 `/team` 页面用两段平行的 section 展示:
+不把 Agents 作为 Members 的子集或反过来。两者是**两份不同来源的数据**(`members` 表 vs `agents` 表),代表团队的两类参与者。在 `/team` 页面用一个统一 roster 的多个平行 section 展示:
 
 ```text
 Team
-├─ Humans · [count]   ← members 表数据
-└─ Agents · [count]   ← agents 表数据(filter type=human)
+├─ Humans · [count]                 ← members 表数据
+├─ Shared agents · [count]          ← organization visibility
+├─ Your private agents · [count]    ← private visibility,managed by self
+└─ Other members' private agents    ← admin-only governance view
 ```
 
-count 信息通过 page-level subtitle 表达(`1 human and 2 agents working together`),section header 自身保持纯文字标识(`Humans` / `Agents`)。
+count 信息就近放在 section header。Role / type 不再通过额外 badge 重复表达:Humans section 已经说明这些行是人;admin 不是主浏览维度,不进入 filter chip、row badge 或 section subtitle。
 
 ## 决策:UI 层级和命名
 
@@ -155,10 +159,10 @@ admin:
 
 跟 chat-first workspace 一致,/team 也走克制现代风:
 
-- **Panel 边框移除** —— Members / Agents 表直接坐在页面上
+- **Panel 边框移除** —— roster sections 直接坐在页面上
 - **PageHeader 去 bg-fill 和 border-bottom** —— 标题靠字号区分层级,不靠灰条
 - **DenseTable 表头 sentence-case** —— 不再 mono uppercase
-- **Type / Visibility / Role 改纯文字**(去 DenseBadge)—— 文字本身的"Admin / Personal assistant / Private"已含信号,不需要色块
+- **Role 不进入主扫描层** —— admin role 影响权限和管理操作,但不是 roster 的主要浏览维度;不提供 Admins filter、per-row admin badge 或 Humans section admin count
 - **Status 保留 StateChip** —— 实时变化(working / offline)需要可扫描的色 dot
 
 ## 决策:Admin 高频动作的入口位置
@@ -169,9 +173,9 @@ admin:
 
 未来 invite 扩展为复杂面板(history / 邀请角色控制 / 链接 rotation 等)时,再考虑迁入 Team settings。
 
-### `+ New agent` 在 Agents section 右侧
+### `+ New agent` 在 PageHeader 右侧
 
-跟 GitHub / Linear 等 SaaS 一致 —— section 级 action 放 section header 右。
+创建 agent 是 Team 页的主动作,放在 PageHeader 右侧;visibility 在 NewAgentDialog 内选择,不为 shared/private section 分裂多个 CTA。
 
 ## 决策:Members 表中 admin 的 self-delete 防护
 
@@ -196,12 +200,12 @@ admin 看 Members 时,自己那行**不渲染 Delete 按钮**(Edit 仍渲染,以
 ├─ Context              tree visualization(占位,#101)
 ├─ Team
 │  ├─ /team(默认)
-│  │  ├─ PageHeader     "Team / 1 human and 2 agents working together"
-│  │  │                 + admin: [Invite link] popover
-│  │  ├─ Humans 区
-│  │  │  └─ table       Display name | Username | Role | Created | (admin: Edit/Delete)
-│  │  └─ Agents 区      + [+ New agent]
-│  │     └─ table       Display name | Agent name | Type | Managed by | Visibility | Status | Created
+│  │  ├─ PageHeader     "Team" + [New agent] + admin: [Invite link]
+│  │  └─ roster         Name | Delegate | Manager | Runs on | Status | Created | Actions
+│  │     ├─ Humans
+│  │     ├─ Shared agents
+│  │     ├─ Your private agents
+│  │     └─ Other members' private agents(admin-only,collapsed)
 │  └─ /team/settings   admin only(Team identity + System configuration)
 └─ Settings
    ├─ /settings/computers

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -44,6 +44,12 @@ describe("Team page grouping", () => {
     expect(result.map((a) => a.uuid)).toEqual(["human-1", "assistant-1"]);
   });
 
+  it("fails fast if agent pagination does not terminate", async () => {
+    await expect(fetchAllAgents(async () => ({ items: [], nextCursor: "same-cursor" }))).rejects.toThrow(
+      "fetchAllAgents exceeded 100 pages",
+    );
+  });
+
   it("resolves a human delegate from the fully loaded agent map", () => {
     const human = agent({ uuid: "human-1", type: "human", displayName: "Ada", delegateMention: "assistant-1" });
     const assistant = agent({
@@ -98,9 +104,15 @@ describe("Team page grouping", () => {
       displayName: "Suspended Assistant",
       status: "suspended",
     });
+    const humanAgent = agent({ uuid: "human-1", type: "human", displayName: "Ada" });
+    const autonomousAgent = agent({
+      uuid: "auto-1",
+      type: "autonomous_agent",
+      displayName: "Cron Bot",
+    });
 
-    expect(selectDelegateCandidates([privateAssistant, suspendedAssistant]).map((a) => a.uuid)).toEqual([
-      "private-assistant",
-    ]);
+    expect(
+      selectDelegateCandidates([humanAgent, autonomousAgent, privateAssistant, suspendedAssistant]).map((a) => a.uuid),
+    ).toEqual(["private-assistant"]);
   });
 });

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -1,0 +1,106 @@
+import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { buildGroups, fetchAllAgents, selectDelegateCandidates } from "../index.js";
+
+function agent(input: {
+  uuid: string;
+  type: Agent["type"];
+  displayName: string;
+  name?: string | null;
+  delegateMention?: string | null;
+  managerId?: string | null;
+  visibility?: Agent["visibility"];
+  status?: string;
+  createdAt?: string;
+}): Agent {
+  return {
+    uuid: input.uuid,
+    name: input.name ?? input.uuid,
+    organizationId: "org-1",
+    type: input.type,
+    displayName: input.displayName,
+    delegateMention: input.delegateMention ?? null,
+    inboxId: `inbox-${input.uuid}`,
+    status: input.status ?? "active",
+    source: null,
+    visibility: input.visibility ?? "organization",
+    metadata: {},
+    managerId: input.managerId ?? "member-1",
+    clientId: input.type === "human" ? null : "client-1",
+    runtimeProvider: "claude-code",
+    createdAt: input.createdAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: input.createdAt ?? "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("Team page grouping", () => {
+  it("fetches every agent page before building delegate state", async () => {
+    const first = agent({ uuid: "human-1", type: "human", displayName: "Ada", delegateMention: "assistant-1" });
+    const second = agent({ uuid: "assistant-1", type: "personal_assistant", displayName: "Ada Assistant" });
+    const result = await fetchAllAgents(async ({ cursor }) =>
+      cursor ? { items: [second], nextCursor: null } : { items: [first], nextCursor: "next-page" },
+    );
+
+    expect(result.map((a) => a.uuid)).toEqual(["human-1", "assistant-1"]);
+  });
+
+  it("resolves a human delegate from the fully loaded agent map", () => {
+    const human = agent({ uuid: "human-1", type: "human", displayName: "Ada", delegateMention: "assistant-1" });
+    const assistant = agent({
+      uuid: "assistant-1",
+      type: "personal_assistant",
+      displayName: "Ada Assistant",
+      name: "ada-helper",
+    });
+    const groups = buildGroups({
+      filter: "all",
+      search: "",
+      isAdmin: false,
+      selfMemberId: "member-1",
+      members: [
+        {
+          id: "member-1",
+          agentId: "human-1",
+          username: "ada",
+          displayName: "Ada",
+          role: "member",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      sharedAgents: [],
+      yourPrivateAgents: [],
+      otherPrivateAgents: [],
+      resolveMember: (id) => id,
+      agentByUuid: new Map([
+        [human.uuid, human],
+        [assistant.uuid, assistant],
+      ]),
+      openDelegate: () => {},
+    });
+
+    const row = groups[0]?.rows[0];
+    if (row?.kind !== "human") throw new Error("expected first row to be human");
+    expect(row.delegate).toEqual({ name: "ada-helper", displayName: "Ada Assistant" });
+    expect(row.canEditDelegate).toBe(true);
+  });
+
+  it("keeps private active assistants selectable for admin delegate edits", () => {
+    const privateAssistant = agent({
+      uuid: "private-assistant",
+      type: "personal_assistant",
+      displayName: "Private Assistant",
+      visibility: "private",
+      managerId: "member-2",
+    });
+    const suspendedAssistant = agent({
+      uuid: "suspended-assistant",
+      type: "personal_assistant",
+      displayName: "Suspended Assistant",
+      status: "suspended",
+    });
+
+    expect(selectDelegateCandidates([privateAssistant, suspendedAssistant]).map((a) => a.uuid)).toEqual([
+      "private-assistant",
+    ]);
+  });
+});

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -73,18 +73,20 @@ type DelegateTarget = {
 type FilterKey = "all" | "humans" | "shared" | "private";
 
 const AGENT_PAGE_SIZE = 100;
+const MAX_AGENT_PAGES = 100;
 
 export async function fetchAllAgents(
   fetchPage: (params: { limit: number; cursor?: string }) => Promise<{ items: Agent[]; nextCursor: string | null }>,
 ): Promise<Agent[]> {
   const items: Agent[] = [];
   let cursor: string | undefined;
-  do {
+  for (let pageCount = 0; pageCount < MAX_AGENT_PAGES; pageCount++) {
     const page = await fetchPage(cursor ? { limit: AGENT_PAGE_SIZE, cursor } : { limit: AGENT_PAGE_SIZE });
     items.push(...page.items);
-    cursor = page.nextCursor ?? undefined;
-  } while (cursor);
-  return items;
+    if (!page.nextCursor) return items;
+    cursor = page.nextCursor;
+  }
+  throw new Error(`fetchAllAgents exceeded ${MAX_AGENT_PAGES} pages; server cursor pagination may be broken`);
 }
 
 export function TeamPage() {

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -436,9 +436,10 @@ function FilterBar({
   counts: { humans: number; shared: number; private: number };
 }) {
   // Admins-only filter was dropped: it duplicated the Humans filter for
-  // small orgs (typical case is 1–5 admins) and the per-row `admin` badge
-  // now surfaces role inline so users don't need a filter click to find
-  // who's an admin.
+  // small orgs (typical case is 1–5 admins). Admin role distribution now
+  // surfaces as a subtitle on the Humans section header (`Humans 2 · 1
+  // admin`) — same information, placed next to the rows it describes
+  // instead of in a filter chip you have to click to use.
   const chips: Array<{ key: FilterKey; label: string; count?: number }> = [
     { key: "all", label: "All" },
     { key: "humans", label: "Humans", count: counts.humans },
@@ -567,6 +568,15 @@ export function buildGroups(args: {
   const yourPrivateRows: AgentRow[] = yourPrivateAgents.filter(matchAgent).map(toAgentRow);
   const otherPrivateRows: AgentRow[] = otherPrivateAgents.filter(matchAgent).map(toAgentRow);
 
+  // Surface admin role distribution alongside the Humans section count,
+  // since the page-level subtitle was removed and the Admins filter chip
+  // was dropped in favor of inline visibility. We compute against the
+  // unfiltered members list so the admin count stays meaningful even when
+  // a search trims `humanRows`. Omitted when 0 (no info worth surfacing).
+  const totalAdminCount = members.filter((m) => m.role === "admin").length;
+  const humansSubtitle =
+    totalAdminCount > 0 ? `${totalAdminCount} ${totalAdminCount === 1 ? "admin" : "admins"}` : undefined;
+
   const groups: TeamGroup[] = [];
   if (showHumans) {
     groups.push({
@@ -574,6 +584,7 @@ export function buildGroups(args: {
       title: "Humans",
       count: humanRows.length,
       rows: humanRows,
+      subtitle: humansSubtitle,
       emptyMessage: search ? "No humans match this search." : undefined,
     });
   }

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -435,11 +435,10 @@ function FilterBar({
   onQuery: (q: string) => void;
   counts: { humans: number; shared: number; private: number };
 }) {
-  // Admins-only filter was dropped: it duplicated the Humans filter for
-  // small orgs (typical case is 1–5 admins). Admin role distribution now
-  // surfaces as a subtitle on the Humans section header (`Humans 2 · 1
-  // admin`) — same information, placed next to the rows it describes
-  // instead of in a filter chip you have to click to use.
+  // Admins-only filter was dropped: role governance is not a primary
+  // browsing mode for this roster. Role remains editable in the profile
+  // dialog, but the main scan surface stays focused on identity, delegate,
+  // manager, runtime, and status.
   const chips: Array<{ key: FilterKey; label: string; count?: number }> = [
     { key: "all", label: "All" },
     { key: "humans", label: "Humans", count: counts.humans },
@@ -568,15 +567,6 @@ export function buildGroups(args: {
   const yourPrivateRows: AgentRow[] = yourPrivateAgents.filter(matchAgent).map(toAgentRow);
   const otherPrivateRows: AgentRow[] = otherPrivateAgents.filter(matchAgent).map(toAgentRow);
 
-  // Surface admin role distribution alongside the Humans section count,
-  // since the page-level subtitle was removed and the Admins filter chip
-  // was dropped in favor of inline visibility. We compute against the
-  // unfiltered members list so the admin count stays meaningful even when
-  // a search trims `humanRows`. Omitted when 0 (no info worth surfacing).
-  const totalAdminCount = members.filter((m) => m.role === "admin").length;
-  const humansSubtitle =
-    totalAdminCount > 0 ? `${totalAdminCount} ${totalAdminCount === 1 ? "admin" : "admins"}` : undefined;
-
   const groups: TeamGroup[] = [];
   if (showHumans) {
     groups.push({
@@ -584,7 +574,6 @@ export function buildGroups(args: {
       title: "Humans",
       count: humanRows.length,
       rows: humanRows,
-      subtitle: humansSubtitle,
       emptyMessage: search ? "No humans match this search." : undefined,
     });
   }

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -4,8 +4,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Search, UserPlus } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { getActivityOverview, type RuntimeAgent } from "../../api/activity.js";
-import { deleteAgent, listAgents, listAllAgents, reactivateAgent, suspendAgent } from "../../api/agents.js";
+import { getActivityOverview, listClients, type RuntimeAgent } from "../../api/activity.js";
+import {
+  deleteAgent,
+  listAgents,
+  listAllAgents,
+  reactivateAgent,
+  suspendAgent,
+  updateAgent,
+} from "../../api/agents.js";
 import { deleteMember, listMembers, updateMember } from "../../api/members.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { NewAgentDialog } from "../../components/new-agent-dialog.js";
@@ -39,6 +46,8 @@ import { type AgentRow, type HumanRow, type RowAction, type TeamGroup, TeamTable
 
 type MemberListItem = {
   id: string;
+  /** UUID of the human-mirror agent (members.agent_id). Needed by the Set-delegate dialog so it can PATCH the right agent row. */
+  agentId: string;
   username: string;
   displayName: string;
   role: string;
@@ -52,7 +61,31 @@ type MemberEditTarget = {
   role: string;
 };
 
-type FilterKey = "all" | "humans" | "shared" | "private" | "admins";
+type DelegateTarget = {
+  /** UUID of the human agent whose delegateMention we are editing. */
+  humanAgentId: string;
+  /** Display name of the human — shown in the dialog body so the user knows whose delegate they're configuring. */
+  humanDisplayName: string;
+  /** Current value of delegateMention on the human agent, or null. */
+  currentDelegate: string | null;
+};
+
+type FilterKey = "all" | "humans" | "shared" | "private";
+
+const AGENT_PAGE_SIZE = 100;
+
+export async function fetchAllAgents(
+  fetchPage: (params: { limit: number; cursor?: string }) => Promise<{ items: Agent[]; nextCursor: string | null }>,
+): Promise<Agent[]> {
+  const items: Agent[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await fetchPage(cursor ? { limit: AGENT_PAGE_SIZE, cursor } : { limit: AGENT_PAGE_SIZE });
+    items.push(...page.items);
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
+  return items;
+}
 
 export function TeamPage() {
   const { role, memberId } = useAuth();
@@ -64,6 +97,7 @@ export function TeamPage() {
   const [inviteOpen, setInviteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<MemberEditTarget | null>(null);
+  const [delegateTarget, setDelegateTarget] = useState<DelegateTarget | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
 
@@ -77,7 +111,7 @@ export function TeamPage() {
   // on what's *in* the list, not on the query key.
   const agentsQuery = useQuery({
     queryKey: ["agents", "team-page", isAdmin ? "admin" : "member"],
-    queryFn: () => (isAdmin ? listAllAgents({ limit: 100 }) : listAgents({ limit: 100 })),
+    queryFn: () => fetchAllAgents((params) => (isAdmin ? listAllAgents(params) : listAgents(params))),
   });
 
   const { data: activity } = useQuery({
@@ -91,19 +125,44 @@ export function TeamPage() {
     return m;
   }, [activity?.agents]);
 
+  // `/me/clients` is the cross-org list of clients the caller owns. We use
+  // it to enrich each agent's Runtime cell with the host it's bound to
+  // (e.g. `claude-code @ alice-macbook`). Agents bound to clients we don't
+  // own (other members' machines hosting shared agents) won't resolve — the
+  // cell falls back to just the runtime provider, which is acceptable: a
+  // dedicated org-admin clients endpoint exists server-side but isn't wired
+  // here yet.
+  const { data: clientsData } = useQuery({
+    queryKey: ["clients", "team-page"],
+    queryFn: listClients,
+    staleTime: 30_000,
+  });
+  const clientHostMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of clientsData ?? []) {
+      if (c.hostname) m.set(c.id, c.hostname);
+    }
+    return m;
+  }, [clientsData]);
+
   // Each derivation is memoized so the downstream `groups` useMemo (which
   // depends on these arrays) can actually cache — without these, every
   // render produced fresh array refs and `groups` recomputed every time.
   const members = useMemo<MemberListItem[]>(() => membersQuery.data ?? [], [membersQuery.data]);
+  // Full agents list — includes humans, used to resolve a member's
+  // delegateMention into a display identity. The visible agent groups
+  // filter humans out below (they're already shown in the Humans section).
+  const allAgents = useMemo<Agent[]>(() => agentsQuery.data ?? [], [agentsQuery.data]);
+  const agentByUuid = useMemo(() => {
+    const m = new Map<string, Agent>();
+    for (const a of allAgents) m.set(a.uuid, a);
+    return m;
+  }, [allAgents]);
   // type === "human" agents are the user-mirrors auto-created for every
   // member (chat-identity proxies). The Humans section above already shows
   // them as people, so the agents groups must hide them to avoid double-listing.
-  const agents = useMemo<Agent[]>(
-    () => (agentsQuery.data?.items ?? []).filter((a) => a.type !== "human"),
-    [agentsQuery.data?.items],
-  );
+  const agents = useMemo<Agent[]>(() => allAgents.filter((a) => a.type !== "human"), [allAgents]);
 
-  const adminCount = useMemo(() => members.filter((m) => m.role === "admin").length, [members]);
   const sharedAgents = useMemo(() => agents.filter((a) => a.visibility === "organization"), [agents]);
   const yourPrivateAgents = useMemo(
     () => agents.filter((a) => a.visibility === "private" && a.managerId === memberId),
@@ -113,12 +172,6 @@ export function TeamPage() {
     () => agents.filter((a) => a.visibility === "private" && a.managerId !== memberId),
     [agents, memberId],
   );
-
-  const subtitle = [
-    `${members.length} ${plural(members.length, "human")} (${adminCount} ${plural(adminCount, "admin")})`,
-    `${sharedAgents.length} shared ${plural(sharedAgents.length, "agent")}`,
-    `${yourPrivateAgents.length} of your private`,
-  ].join(" · ");
 
   const updateMemberMut = useMutation({
     mutationFn: async (vars: { id: string; patch: { displayName?: string; role?: "admin" | "member" } }) =>
@@ -150,6 +203,11 @@ export function TeamPage() {
     mutationFn: reactivateAgent,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agents"] }),
   });
+  const setDelegateMut = useMutation({
+    mutationFn: async (vars: { humanAgentId: string; delegateMention: string | null }) =>
+      updateAgent(vars.humanAgentId, { delegateMention: vars.delegateMention }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agents"] }),
+  });
 
   const search = query.trim().toLowerCase();
   const groups = useMemo(
@@ -164,15 +222,34 @@ export function TeamPage() {
         yourPrivateAgents,
         otherPrivateAgents,
         resolveMember,
+        agentByUuid,
+        openDelegate: (humanAgentId, humanDisplayName) =>
+          setDelegateTarget({
+            humanAgentId,
+            humanDisplayName,
+            currentDelegate: agentByUuid.get(humanAgentId)?.delegateMention ?? null,
+          }),
       }),
-    [filter, search, isAdmin, memberId, members, sharedAgents, yourPrivateAgents, otherPrivateAgents, resolveMember],
+    [
+      filter,
+      search,
+      isAdmin,
+      memberId,
+      members,
+      sharedAgents,
+      yourPrivateAgents,
+      otherPrivateAgents,
+      resolveMember,
+      agentByUuid,
+    ],
   );
 
   function getHumanActions(row: HumanRow): RowAction[] {
     const actions: RowAction[] = [];
-    // PATCH /orgs/:orgId/members/:id is admin-only (server gates with
-    // requireOrgAdmin). Surfacing "Edit profile" to non-admin self would
-    // produce a guaranteed 403 on submit — match the server's rule.
+    // Delegate edits live inline in the Manager · Delegate column (see
+    // HumanDelegateCell) — no kebab entry needed. PATCH /orgs/:orgId/members/:id
+    // is admin-only (server gates with requireOrgAdmin), so "Edit profile"
+    // only appears for admins; surfacing it to non-admin self would 403.
     if (isAdmin) {
       actions.push({
         key: "edit",
@@ -238,7 +315,6 @@ export function TeamPage() {
     <>
       <PageHeader
         title="Team"
-        subtitle={subtitle}
         right={
           <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
             <Button size="xs" onClick={() => setCreateOpen(true)}>
@@ -271,7 +347,6 @@ export function TeamPage() {
             humans: members.length,
             shared: sharedAgents.length,
             private: yourPrivateAgents.length,
-            admins: adminCount,
           }}
         />
 
@@ -287,6 +362,7 @@ export function TeamPage() {
           <TeamTable
             groups={groups}
             runtimeMap={runtimeMap}
+            clientHostMap={clientHostMap}
             onAgentClick={(uuid) => navigate(`/agents/${encodeURIComponent(uuid)}`)}
             getHumanActions={getHumanActions}
             getAgentActions={getAgentActions}
@@ -324,12 +400,20 @@ export function TeamPage() {
           setEditTarget(null);
         }}
       />
+
+      <SetDelegateDialog
+        target={delegateTarget}
+        candidates={selectDelegateCandidates(allAgents)}
+        isSaving={setDelegateMut.isPending}
+        onClose={() => setDelegateTarget(null)}
+        onSave={async (delegateMention) => {
+          if (!delegateTarget) return;
+          await setDelegateMut.mutateAsync({ humanAgentId: delegateTarget.humanAgentId, delegateMention });
+          setDelegateTarget(null);
+        }}
+      />
     </>
   );
-}
-
-function plural(n: number, word: string): string {
-  return n === 1 ? word : `${word}s`;
 }
 
 function formatError(err: unknown): string {
@@ -347,14 +431,17 @@ function FilterBar({
   onFilter: (k: FilterKey) => void;
   query: string;
   onQuery: (q: string) => void;
-  counts: { humans: number; shared: number; private: number; admins: number };
+  counts: { humans: number; shared: number; private: number };
 }) {
+  // Admins-only filter was dropped: it duplicated the Humans filter for
+  // small orgs (typical case is 1–5 admins) and the per-row `admin` badge
+  // now surfaces role inline so users don't need a filter click to find
+  // who's an admin.
   const chips: Array<{ key: FilterKey; label: string; count?: number }> = [
     { key: "all", label: "All" },
     { key: "humans", label: "Humans", count: counts.humans },
     { key: "shared", label: "Shared agents", count: counts.shared },
     { key: "private", label: "Your private", count: counts.private },
-    { key: "admins", label: "Admins", count: counts.admins },
   ];
   return (
     <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2)" }}>
@@ -365,13 +452,19 @@ function FilterBar({
           </FilterPill>
         ))}
       </div>
-      <div className="flex-1 relative" style={{ minWidth: 180, maxWidth: 320 }}>
+      {/* Search input is sized to match the FilterPill rhythm (short
+          height, text-caption, tiny corner radius) rather than the default
+          Input atom (h-9, text-body, larger radius) — that way the filter
+          row reads as one homogenous chip strip instead of a tall input
+          sitting beside short pills. The radius matches FilterPill's
+          inline `borderRadius: 3` so the two atoms read as siblings. */}
+      <div className="relative" style={{ width: 220 }}>
         <Search
           aria-hidden
           className="h-3.5 w-3.5"
           style={{
             position: "absolute",
-            left: "var(--sp-2)",
+            left: "var(--sp-1_5)",
             top: "50%",
             transform: "translateY(-50%)",
             color: "var(--fg-4)",
@@ -381,15 +474,16 @@ function FilterBar({
           value={query}
           onChange={(e) => onQuery(e.target.value)}
           placeholder="Search name or @handle"
-          style={{ paddingLeft: "var(--sp-7)" }}
           aria-label="Search team"
+          className="h-7 text-caption"
+          style={{ paddingLeft: "var(--sp-5)", borderRadius: 3 }}
         />
       </div>
     </div>
   );
 }
 
-function buildGroups(args: {
+export function buildGroups(args: {
   filter: FilterKey;
   search: string;
   isAdmin: boolean;
@@ -399,32 +493,66 @@ function buildGroups(args: {
   yourPrivateAgents: Agent[];
   otherPrivateAgents: Agent[];
   resolveMember: (id: string) => string;
+  agentByUuid: Map<string, Agent>;
+  openDelegate: (humanAgentId: string, humanDisplayName: string) => void;
 }): TeamGroup[] {
-  const { filter, search, isAdmin, selfMemberId, members, sharedAgents, yourPrivateAgents, otherPrivateAgents } = args;
+  const {
+    filter,
+    search,
+    isAdmin,
+    selfMemberId,
+    members,
+    sharedAgents,
+    yourPrivateAgents,
+    otherPrivateAgents,
+    agentByUuid,
+    openDelegate,
+  } = args;
+
+  // Returns the resolved identity of the human's delegate agent, or null
+  // if no delegate is configured / the target agent isn't in the loaded
+  // page (e.g. soft-deleted, beyond the 100-row cap).
+  const resolveDelegate = (humanAgentId: string): { name: string | null; displayName: string } | null => {
+    const human = agentByUuid.get(humanAgentId);
+    if (!human?.delegateMention) return null;
+    const d = agentByUuid.get(human.delegateMention);
+    if (!d) return null;
+    return { name: d.name, displayName: d.displayName };
+  };
 
   const matchHuman = (m: MemberListItem) =>
     !search || m.displayName.toLowerCase().includes(search) || m.username.toLowerCase().includes(search);
   const matchAgent = (a: Agent) =>
     !search || a.displayName.toLowerCase().includes(search) || (a.name ?? "").toLowerCase().includes(search);
 
-  const adminOnly = filter === "admins";
-  const showHumans = filter === "all" || filter === "humans" || filter === "admins";
+  const showHumans = filter === "all" || filter === "humans";
   const showShared = filter === "all" || filter === "shared";
   const showPrivate = filter === "all" || filter === "private";
   const showOtherPrivate = isAdmin && filter === "all";
 
   const humanRows: HumanRow[] = members
     .filter(matchHuman)
-    .filter((m) => !adminOnly || m.role === "admin")
-    .map((m) => ({
-      kind: "human",
-      id: m.id,
-      username: m.username,
-      displayName: m.displayName,
-      role: m.role,
-      createdAt: m.createdAt,
-      isSelf: selfMemberId === m.id,
-    }));
+    .map((m): HumanRow => {
+      const isSelf = selfMemberId === m.id;
+      return {
+        kind: "human",
+        id: m.id,
+        agentId: m.agentId,
+        username: m.username,
+        displayName: m.displayName,
+        role: m.role,
+        createdAt: m.createdAt,
+        isSelf,
+        delegate: resolveDelegate(m.agentId),
+        canEditDelegate: isSelf || isAdmin,
+        onEditDelegate: () => openDelegate(m.agentId, m.displayName),
+      };
+    })
+    // Pin (you) to the top of the Humans section — when scanning a roster the
+    // viewer almost always wants their own row first, and it's where the
+    // "Set delegate →" inline CTA lives. Stable sort keeps backend order for
+    // the rest.
+    .sort((a, b) => Number(b.isSelf) - Number(a.isSelf));
 
   const toAgentRow = (agent: Agent): AgentRow => ({
     kind: "agent",
@@ -439,12 +567,9 @@ function buildGroups(args: {
 
   const groups: TeamGroup[] = [];
   if (showHumans) {
-    // Distinct key per filter so a future collapsible-Humans group doesn't
-    // leak its open/closed state across "all" ↔ "admins" toggles (React
-    // reconciles GroupBody by key).
     groups.push({
-      key: adminOnly ? "admins" : "humans",
-      title: adminOnly ? "Admins" : "Humans",
+      key: "humans",
+      title: "Humans",
       count: humanRows.length,
       rows: humanRows,
       emptyMessage: search ? "No humans match this search." : undefined,
@@ -480,6 +605,10 @@ function buildGroups(args: {
     });
   }
   return groups;
+}
+
+export function selectDelegateCandidates(agents: Agent[]): Agent[] {
+  return agents.filter((a) => a.type === "personal_assistant" && a.status === "active");
 }
 
 const roleValues = Object.values(MEMBER_ROLES);
@@ -577,6 +706,107 @@ function EditMemberDialog({
                 </p>
               </div>
             )}
+            {error && (
+              <p className="text-body" style={{ color: "var(--state-error)" }}>
+                {error}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={onClose} disabled={isSaving}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? "Saving…" : "Save"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Focused dialog for the "configure my delegate" flow. The full identity
+ * editor (display name + visibility + delegate) lives on the agent-detail
+ * page, but the Team page surfaces this single decision directly so a
+ * non-admin self has a one-click path that doesn't require visiting their
+ * mirror agent's detail page.
+ *
+ * The candidate list mirrors what the identity-section editor uses:
+ * active `personal_assistant` agents from the Team page's fully-paginated
+ * agent query. Admins receive the all-agent source so private assistants
+ * owned by other members remain selectable when editing another human.
+ */
+function SetDelegateDialog({
+  target,
+  candidates,
+  isSaving,
+  onClose,
+  onSave,
+}: {
+  target: DelegateTarget | null;
+  candidates: Agent[];
+  isSaving: boolean;
+  onClose: () => void;
+  onSave: (delegateMention: string | null) => Promise<void>;
+}) {
+  const [delegate, setDelegate] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (target) {
+      setDelegate(target.currentDelegate ?? "");
+      setError(null);
+    }
+  }, [target]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!target) return;
+    setError(null);
+    try {
+      await onSave(delegate || null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const open = target !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Set delegate</DialogTitle>
+        </DialogHeader>
+        {target && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <p className="text-body" style={{ color: "var(--fg-2)" }}>
+              Pick a personal assistant to act on behalf of <strong>{target.humanDisplayName}</strong>. When teammates
+              @mention this human, the assistant receives the message and can reply in their place.
+            </p>
+            <div className="space-y-2">
+              <Label htmlFor="set-delegate-pick">Delegate</Label>
+              <select
+                id="set-delegate-pick"
+                value={delegate}
+                onChange={(e) => setDelegate(e.target.value)}
+                className="flex h-9 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-1 text-body shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="">None — no delegate</option>
+                {candidates.map((a) => (
+                  <option key={a.uuid} value={a.uuid}>
+                    {a.displayName ? `${a.displayName} (@${a.name ?? a.uuid})` : a.name ? `@${a.name}` : a.uuid}
+                  </option>
+                ))}
+              </select>
+              {candidates.length === 0 && (
+                <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+                  No personal assistants available. Create one from the <em>New agent</em> button above first.
+                </p>
+              )}
+            </div>
             {error && (
               <p className="text-body" style={{ color: "var(--state-error)" }}>
                 {error}

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -1,7 +1,9 @@
 import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
-import { Bot, Lock, MoreHorizontal, User } from "lucide-react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Bot, Lock, type LucideIcon, MoreHorizontal, User } from "lucide-react";
+import { type CSSProperties, useEffect, useRef, useState } from "react";
 import type { RuntimeAgent } from "../../api/activity.js";
+import { AgentChip } from "../../components/agent-chip.js";
+import { DenseBadge } from "../../components/ui/dense-badge.js";
 import {
   DenseTable,
   DenseTableBody,
@@ -30,11 +32,19 @@ import { formatDay } from "../../lib/utils.js";
 export type HumanRow = {
   kind: "human";
   id: string;
+  /** UUID of the type="human" mirror agent — needed when the row action edits the agent (e.g. setting delegateMention). */
+  agentId: string;
   username: string;
   displayName: string;
   role: string;
   createdAt: string;
   isSelf: boolean;
+  /** Resolved identity of the personal assistant this human delegates to, or null if none configured. */
+  delegate: { name: string | null; displayName: string } | null;
+  /** Whether the current viewer can edit this human's delegate (self, or admin viewing anyone). */
+  canEditDelegate: boolean;
+  /** Open the delegate dialog for this row; only called when canEditDelegate is true. */
+  onEditDelegate: () => void;
 };
 
 export type AgentRow = {
@@ -68,6 +78,8 @@ export type RowAction = {
 type Props = {
   groups: TeamGroup[];
   runtimeMap: Map<string, RuntimeAgent>;
+  /** clientId → hostname; agents whose client isn't in the map render runtime alone. */
+  clientHostMap: Map<string, string>;
   onAgentClick: (uuid: string) => void;
   getHumanActions: (row: HumanRow) => RowAction[];
   getAgentActions: (row: AgentRow) => RowAction[];
@@ -75,19 +87,63 @@ type Props = {
 
 const COLUMNS = [
   { key: "name", label: "Name", width: 260 },
-  { key: "manager", label: "Manager", width: 140 },
-  { key: "runtime", label: "Runtime · Status", width: 170 },
-  { key: "created", label: "Created", width: 120 },
+  // Delegate and Manager are split into separate columns so each header
+  // carries exactly one meaning. Human rows fill Delegate (the assistant
+  // acting on their behalf) and leave Manager as `—`; agent rows fill
+  // Manager (the human who owns the agent) and leave Delegate as `—`.
+  // Order: Delegate before Manager so the Humans section — which renders
+  // first in the table — has its populated cell immediately right of the
+  // Name column, no `—` gap before the data. Each section uniformly fills
+  // one column and leaves the other empty — the half-blank pattern reads
+  // as section structure, not missing data, and neither column has to
+  // mean two things at once.
+  { key: "delegate", label: "Delegate", width: 160 },
+  { key: "manager", label: "Manager", width: 160 },
+  // The cell renders `<runtime-provider> @ <host>` in one line — covers
+  // both framework and host together (plain "Runtime" only described the
+  // framework half). Wider than the other middle columns because the
+  // combined `claude-code @ alice-macbook` form runs roughly 25-30 chars;
+  // this wider column fits most everyday cases, and longer corporate
+  // FQDNs gracefully truncate with the `title` tooltip showing full value.
+  // Status (live operational state) is the orthogonal axis and stays in
+  // its own column so config and live state don't share a cell. Both
+  // blank for human rows.
+  { key: "runtime", label: "Runs on", width: 220 },
+  { key: "status", label: "Status", width: 160 },
+  { key: "created", label: "Created", width: 160 },
+  // Middle columns mostly pin to 160 for grid rhythm. Runs on opts out at
+  // 220 because its content (provider + host) is denser than the others.
+  // Name stays wider (variable display-name + @handle) and Actions stays
+  // narrow (single kebab icon) — those sit at the content-density extremes.
   { key: "actions", label: "", width: 44 },
 ] as const;
 
-export function TeamTable({ groups, runtimeMap, onAgentClick, getHumanActions, getAgentActions }: Props) {
+function sectionCellStyle(isLast: boolean, style?: CSSProperties): CSSProperties | undefined {
+  if (!isLast) return style;
+  return { ...style, borderBottom: 0 };
+}
+
+export function TeamTable({
+  groups,
+  runtimeMap,
+  clientHostMap,
+  onAgentClick,
+  getHumanActions,
+  getAgentActions,
+}: Props) {
   return (
     <DenseTable className="table-fixed">
       <DenseTableHeader>
         <DenseTableRow>
           {COLUMNS.map((col) => (
-            <DenseTableHead key={col.key} style={{ width: col.width }} aria-hidden={col.key === "actions"}>
+            <DenseTableHead
+              key={col.key}
+              // The first column (Name) also shifts to `sp-6` left padding
+              // so the column header sits in the same vertical alignment
+              // line as the section title text and the row name text.
+              style={{ width: col.width, ...(col.key === "name" ? { paddingLeft: "var(--sp-6)" } : null) }}
+              aria-hidden={col.key === "actions"}
+            >
               {col.label}
             </DenseTableHead>
           ))}
@@ -98,6 +154,7 @@ export function TeamTable({ groups, runtimeMap, onAgentClick, getHumanActions, g
           key={group.key}
           group={group}
           runtimeMap={runtimeMap}
+          clientHostMap={clientHostMap}
           onAgentClick={onAgentClick}
           getHumanActions={getHumanActions}
           getAgentActions={getAgentActions}
@@ -110,12 +167,14 @@ export function TeamTable({ groups, runtimeMap, onAgentClick, getHumanActions, g
 function GroupBody({
   group,
   runtimeMap,
+  clientHostMap,
   onAgentClick,
   getHumanActions,
   getAgentActions,
 }: {
   group: TeamGroup;
   runtimeMap: Map<string, RuntimeAgent>;
+  clientHostMap: Map<string, string>;
   onAgentClick: (uuid: string) => void;
   getHumanActions: (row: HumanRow) => RowAction[];
   getAgentActions: (row: AgentRow) => RowAction[];
@@ -129,38 +188,89 @@ function GroupBody({
         <DenseTableRow>
           <DenseTableCell
             colSpan={COLUMNS.length}
-            style={{ color: "var(--fg-4)", textAlign: "center", padding: "var(--sp-4)" }}
+            style={{
+              color: "var(--fg-4)",
+              textAlign: "left",
+              padding: "0 var(--sp-3_5) var(--sp-3) var(--sp-6)",
+              borderBottom: 0,
+            }}
           >
             {group.emptyMessage}
           </DenseTableCell>
         </DenseTableRow>
       )}
       {open &&
-        group.rows.map((row) =>
-          row.kind === "human" ? (
-            <HumanRowView key={`h:${row.id}`} row={row} actions={getHumanActions(row)} />
+        group.rows.map((row, index) => {
+          const isLast = index === group.rows.length - 1;
+          return row.kind === "human" ? (
+            <HumanRowView key={`h:${row.id}`} row={row} actions={getHumanActions(row)} isLast={isLast} />
           ) : (
             <AgentRowView
               key={`a:${row.agent.uuid}`}
               row={row}
               runtime={runtimeMap.get(row.agent.uuid) ?? null}
+              clientHost={row.agent.clientId ? (clientHostMap.get(row.agent.clientId) ?? null) : null}
               actions={getAgentActions(row)}
               onClick={() => onAgentClick(row.agent.uuid)}
+              isLast={isLast}
             />
-          ),
-        )}
+          );
+        })}
     </DenseTableBody>
   );
 }
 
+/**
+ * Map a section's key to the lucide icon that ties it back to the row icons
+ * inside it. Humans use User (matches HumanRowView's name-cell icon), Shared
+ * agents use Bot, and private agent buckets use Lock — same visual vocabulary
+ * the rows themselves use, so the section header becomes a "tab" for that
+ * row-type rather than a separate label scheme.
+ */
+function sectionIcon(key: string): LucideIcon | null {
+  switch (key) {
+    case "humans":
+      return User;
+    case "shared":
+      return Bot;
+    case "private":
+    case "other-private":
+      return Lock;
+    default:
+      return null;
+  }
+}
+
 function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boolean; onToggle: () => void }) {
+  const Icon = sectionIcon(group.key);
+  const inner = (
+    <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
+      {group.collapsible && (
+        <span aria-hidden style={{ display: "inline-block", width: 10, color: "var(--fg-4)" }}>
+          {open ? "▾" : "▸"}
+        </span>
+      )}
+      {Icon && <Icon className="h-4 w-4" aria-hidden style={{ color: "var(--fg-3)" }} />}
+      <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+        {group.title}
+      </span>
+      <DenseBadge tone="outline">{group.count}</DenseBadge>
+    </span>
+  );
   return (
     <DenseTableRow>
       <td
         colSpan={COLUMNS.length}
         style={{
-          padding: "var(--sp-3) var(--sp-3_5) var(--sp-1_5)",
-          borderBottom: "var(--hairline) solid var(--border-faint)",
+          // Section header sits at the table's left edge (padding-left: 0);
+          // its icon (sp-4 wide) + gap (sp-2) puts the section TITLE TEXT
+          // at sp-6 from the cell edge. Row first-cells override their
+          // padding-left to sp-6 (see HumanRowView / AgentRowView) so row
+          // names line up vertically with the section title text, while
+          // the section icon "hangs out" to the left as a section marker.
+          // sp-6 top, sp-2 bottom — generous breathing room above, tight
+          // below so the section visually "owns" the rows under it.
+          padding: "var(--sp-6) var(--sp-3_5) var(--sp-2) 0",
         }}
       >
         {group.collapsible ? (
@@ -168,150 +278,194 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
             type="button"
             onClick={onToggle}
             aria-expanded={open}
-            className="inline-flex items-baseline gap-2 text-eyebrow uppercase"
             style={{
-              color: "var(--fg-3)",
               background: "transparent",
               border: 0,
               padding: 0,
               cursor: "pointer",
+              color: "inherit",
             }}
           >
-            <span aria-hidden style={{ display: "inline-block", width: 10 }}>
-              {open ? "▾" : "▸"}
-            </span>
-            <span>{group.title}</span>
-            <span style={{ color: "var(--fg-4)" }}>({group.count})</span>
+            {inner}
           </button>
         ) : (
-          <div className="inline-flex items-baseline gap-2 text-eyebrow uppercase" style={{ color: "var(--fg-3)" }}>
-            <span>{group.title}</span>
-            <span style={{ color: "var(--fg-4)" }}>({group.count})</span>
-          </div>
+          inner
         )}
       </td>
     </DenseTableRow>
   );
 }
 
-function HumanRowView({ row, actions }: { row: HumanRow; actions: RowAction[] }) {
+function HumanRowView({ row, actions, isLast }: { row: HumanRow; actions: RowAction[]; isLast: boolean }) {
   return (
     <DenseTableRow>
-      <DenseTableCell>
-        <NameCell
-          icon={<User className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--fg-3)" }} />}
-          displayName={row.displayName}
-          handle={`@${row.username}`}
-          selfTag={row.isSelf}
-        />
+      <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
+        <NameCell displayName={row.displayName} handle={`@${row.username}`} selfTag={row.isSelf} />
       </DenseTableCell>
-      <DenseTableCell className="text-label" style={{ color: "var(--fg-4)" }}>
+      <DenseTableCell style={sectionCellStyle(isLast)}>
+        <HumanDelegateCell row={row} />
+      </DenseTableCell>
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         —
       </DenseTableCell>
-      <DenseTableCell className="text-label" style={{ color: "var(--fg-4)" }}>
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         —
       </DenseTableCell>
-      <DenseTableCell className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
+        —
+      </DenseTableCell>
+      <DenseTableCell className="mono text-caption" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         {formatDay(row.createdAt)}
       </DenseTableCell>
-      <DenseTableCell style={{ padding: 0, textAlign: "right" }}>
+      <DenseTableCell style={sectionCellStyle(isLast, { padding: 0, textAlign: "right" })}>
         <RowActionsMenu actions={actions} ariaLabel={`Actions for ${row.displayName}`} />
       </DenseTableCell>
     </DenseTableRow>
   );
 }
 
+/**
+ * The Manager column has no meaning for humans (they don't have a manager —
+ * they ARE the principals). We repurpose the cell to surface the
+ * `delegateMention` linkage instead: who the human has delegated their
+ * @mention handling to. Showing it inline (rather than only in the kebab
+ * menu) turned an invisible feature into an obvious one — the screenshot
+ * audit found the row felt empty because three of four columns rendered "—".
+ *
+ * Editable affordance shows only when the viewer can persist the change
+ * (self, or admin). For other viewers, the chip is shown read-only or "—".
+ */
+function HumanDelegateCell({ row }: { row: HumanRow }) {
+  // Read-only viewer + no delegate → just the em-dash.
+  if (!row.delegate && !row.canEditDelegate) {
+    return (
+      <span className="text-label" style={{ color: "var(--fg-4)" }}>
+        —
+      </span>
+    );
+  }
+
+  const value = row.delegate ? (
+    <AgentChip name={row.delegate.name} displayName={row.delegate.displayName} />
+  ) : (
+    <span style={{ color: "var(--accent-dim)" }}>Set delegate →</span>
+  );
+
+  const tooltip = row.delegate ? (row.canEditDelegate ? "Change delegate" : undefined) : "Set delegate";
+
+  if (!row.canEditDelegate) {
+    return (
+      <span className="text-label" title={tooltip}>
+        {value}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={row.onEditDelegate}
+      className="text-label hover:underline"
+      style={{
+        background: "transparent",
+        border: 0,
+        padding: 0,
+        cursor: "pointer",
+        color: "inherit",
+        textAlign: "left",
+      }}
+      title={tooltip}
+    >
+      {value}
+    </button>
+  );
+}
+
 function AgentRowView({
   row,
   runtime,
+  clientHost,
   actions,
   onClick,
+  isLast,
 }: {
   row: AgentRow;
   runtime: RuntimeAgent | null;
+  clientHost: string | null;
   actions: RowAction[];
   onClick: () => void;
+  isLast: boolean;
 }) {
   const { agent, managerLabel, isOwnedBySelf } = row;
-  const isPrivate = agent.visibility === "private";
-  const icon = isPrivate ? (
-    <Lock className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--fg-3)" }} />
-  ) : (
-    <Bot className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--fg-3)" }} />
-  );
 
   return (
     <DenseTableRow interactive onClick={onClick}>
-      <DenseTableCell>
-        <NameCell icon={icon} displayName={agent.displayName} handle={agent.name ? `@${agent.name}` : null} />
+      <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
+        <NameCell displayName={agent.displayName} handle={agent.name ? `@${agent.name}` : null} />
       </DenseTableCell>
-      <DenseTableCell className="text-label" style={{ color: "var(--fg-2)" }}>
-        {managerLabel ?? "—"}
-        {isOwnedBySelf && (
-          <span className="text-label italic" style={{ marginLeft: 6, color: "var(--fg-3)" }}>
-            (you)
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
+        —
+      </DenseTableCell>
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-2)" })}>
+        {managerLabel ? (
+          <span className="truncate inline-block max-w-full" title={managerLabel}>
+            {managerLabel}
+            {isOwnedBySelf && (
+              <span className="text-label italic" style={{ marginLeft: 6, color: "var(--fg-3)" }}>
+                (you)
+              </span>
+            )}
           </span>
+        ) : (
+          <span style={{ color: "var(--fg-4)" }}>—</span>
         )}
       </DenseTableCell>
-      <DenseTableCell>
-        <RuntimeStatusCell runtimeState={runtime?.runtimeState ?? null} runtimeProvider={agent.runtimeProvider} />
+      <DenseTableCell className="mono text-caption" style={sectionCellStyle(isLast, { color: "var(--fg-3)" })}>
+        <div
+          className="truncate"
+          title={clientHost ? `${agent.runtimeProvider} @ ${clientHost}` : agent.runtimeProvider}
+        >
+          {agent.runtimeProvider}
+          {clientHost && (
+            <span style={{ color: "var(--fg-4)" }}>
+              {" @ "}
+              {clientHost}
+            </span>
+          )}
+        </div>
       </DenseTableCell>
-      <DenseTableCell className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+      <DenseTableCell style={sectionCellStyle(isLast)}>
+        <StateChip state={runtime?.runtimeState ?? null} />
+      </DenseTableCell>
+      <DenseTableCell className="mono text-caption" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         {formatDay(agent.createdAt)}
       </DenseTableCell>
-      <DenseTableCell style={{ padding: 0, textAlign: "right" }} onClick={(e) => e.stopPropagation()}>
+      <DenseTableCell
+        style={sectionCellStyle(isLast, { padding: 0, textAlign: "right" })}
+        onClick={(e) => e.stopPropagation()}
+      >
         <RowActionsMenu actions={actions} ariaLabel={`Actions for ${agent.displayName}`} />
       </DenseTableCell>
     </DenseTableRow>
   );
 }
 
-function NameCell({
-  icon,
-  displayName,
-  handle,
-  selfTag,
-}: {
-  icon: ReactNode;
-  displayName: string;
-  handle: string | null;
-  selfTag?: boolean;
-}) {
+function NameCell({ displayName, handle, selfTag }: { displayName: string; handle: string | null; selfTag?: boolean }) {
   return (
-    <div className="flex items-start gap-2">
-      <span style={{ marginTop: 2 }}>{icon}</span>
-      <div className="min-w-0">
-        <div className="font-medium text-body truncate" style={{ color: "var(--fg)" }} title={displayName}>
-          {displayName}
-          {selfTag && (
-            <span className="text-label italic" style={{ marginLeft: 6, color: "var(--fg-3)" }}>
-              (you)
-            </span>
-          )}
-        </div>
-        {handle && (
-          <div className="mono text-caption truncate" style={{ color: "var(--fg-4)" }} title={handle}>
-            {handle}
-          </div>
+    <div className="min-w-0">
+      <div className="font-medium text-body truncate" style={{ color: "var(--fg)" }} title={displayName}>
+        {displayName}
+        {selfTag && (
+          <span className="text-label italic" style={{ marginLeft: 6, color: "var(--fg-3)" }}>
+            (you)
+          </span>
         )}
       </div>
-    </div>
-  );
-}
-
-function RuntimeStatusCell({
-  runtimeState,
-  runtimeProvider,
-}: {
-  runtimeState: string | null;
-  runtimeProvider: string;
-}) {
-  return (
-    <div className="flex flex-col" style={{ gap: 2 }}>
-      <StateChip state={runtimeState} />
-      <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-        {runtimeProvider}
-      </span>
+      {handle && (
+        <div className="mono text-caption truncate" style={{ color: "var(--fg-4)" }} title={handle}>
+          {handle}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -65,6 +65,13 @@ export type TeamGroup = {
   emptyMessage?: string;
   /** When set, the group renders as a collapsible disclosure starting collapsed. */
   collapsible?: boolean;
+  /**
+   * Optional secondary fact rendered next to the count badge in `text-caption` /
+   * `--fg-4`. Used by the Humans section to surface admin count (`1 admin`) —
+   * the role distribution was previously in the page subtitle, now lives next
+   * to the rows it describes.
+   */
+  subtitle?: string;
 };
 
 export type RowAction = {
@@ -255,6 +262,11 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
         {group.title}
       </span>
       <DenseBadge tone="outline">{group.count}</DenseBadge>
+      {group.subtitle && (
+        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+          · {group.subtitle}
+        </span>
+      )}
     </span>
   );
   return (

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -65,13 +65,6 @@ export type TeamGroup = {
   emptyMessage?: string;
   /** When set, the group renders as a collapsible disclosure starting collapsed. */
   collapsible?: boolean;
-  /**
-   * Optional secondary fact rendered next to the count badge in `text-caption` /
-   * `--fg-4`. Used by the Humans section to surface admin count (`1 admin`) —
-   * the role distribution was previously in the page subtitle, now lives next
-   * to the rows it describes.
-   */
-  subtitle?: string;
 };
 
 export type RowAction = {
@@ -262,11 +255,6 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
         {group.title}
       </span>
       <DenseBadge tone="outline">{group.count}</DenseBadge>
-      {group.subtitle && (
-        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          · {group.subtitle}
-        </span>
-      )}
     </span>
   );
   return (

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -300,7 +300,16 @@ function HumanRowView({ row, actions, isLast }: { row: HumanRow; actions: RowAct
   return (
     <DenseTableRow>
       <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
-        <NameCell displayName={row.displayName} handle={`@${row.username}`} selfTag={row.isSelf} />
+        <div className="flex min-w-0 items-start" style={{ gap: "var(--sp-2)" }}>
+          <div className="min-w-0 flex-1">
+            <NameCell displayName={row.displayName} handle={`@${row.username}`} selfTag={row.isSelf} />
+          </div>
+          {row.role === "admin" && (
+            <DenseBadge tone="outline" style={{ flexShrink: 0, marginTop: 1 }}>
+              admin
+            </DenseBadge>
+          )}
+        </div>
       </DenseTableCell>
       <DenseTableCell style={sectionCellStyle(isLast)}>
         <HumanDelegateCell row={row} />

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -312,16 +312,7 @@ function HumanRowView({ row, actions, isLast }: { row: HumanRow; actions: RowAct
   return (
     <DenseTableRow>
       <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
-        <div className="flex min-w-0 items-start" style={{ gap: "var(--sp-2)" }}>
-          <div className="min-w-0 flex-1">
-            <NameCell displayName={row.displayName} handle={`@${row.username}`} selfTag={row.isSelf} />
-          </div>
-          {row.role === "admin" && (
-            <DenseBadge tone="outline" style={{ flexShrink: 0, marginTop: 1 }}>
-              admin
-            </DenseBadge>
-          )}
-        </div>
+        <NameCell displayName={row.displayName} handle={`@${row.username}`} selfTag={row.isSelf} />
       </DenseTableCell>
       <DenseTableCell style={sectionCellStyle(isLast)}>
         <HumanDelegateCell row={row} />


### PR DESCRIPTION
## Summary

- Load the complete paginated agent roster on the Team page so delegate display/editing does not silently drop agents beyond the first 100.
- Reuse the Team page roster for the delegate picker, allowing admins to choose active private assistants across members.
- Tighten Team roster visual density by removing duplicate subtitle counts, compacting empty sections, and removing terminal row hairlines inside sections.
- Keep role/admin metadata out of the main roster scan surface: no Admins filter, no per-row admin badge, and no Humans admin-count subtitle; role remains available through profile editing/governance flows.
- Add focused tests for pagination, delegate resolution, and delegate candidate filtering.

## Validation

- pnpm check
- pnpm typecheck
- pnpm test