### PR TITLE
Improve context overview map

### DIFF
--- a/docs/user-facing-context-tree-ui-design.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-design.zh-CN.md
@@ -106,7 +106,7 @@ Added 3 · Edited 8 · Removed 1                 [1 day] [7 days] [30 days]
 │ Where Context Changed                                                  │
 │ Numbers = updated areas under each branch                              │
 │ Selected Context Tree / Agent Hub / Web Console                        │
-│ Selected path · Changed branch · Quiet / hidden                        │
+│ Selected path · Added · Edited · Removed · Quiet                       │
 │ root                                                                   │
 │ ├─ agent-hub       4                                                    │
 │ │  ├─ web-console   ~                                                   │
@@ -158,7 +158,7 @@ Where Context Changed 是全局态势视图,不是当前 update detail,也不是
 - 标题使用 `Where Context Changed`,不使用泛泛的 `Context Tree Overview`。
 - 副标题明确数字语义:`Numbers = updated areas under each branch.`
 - 图上方必须轻量显示当前 selected path,例如 `Selected Context Tree / Agent Hub / Web Console`。
-- 图上方必须显示轻量 legend:`Selected path` / `Updated` / `Quiet / hidden`,避免用户猜颜色,但不能做成占注意力的说明 banner。
+- 图上方必须显示轻量 legend:`Selected path` / `Added` / `Edited` / `Removed` / `Quiet`,避免用户猜颜色,但不能做成占注意力的说明 banner。
 - 默认展示语义压缩后的全貌,而不是全量展开的 tree canvas。
 - 默认节点层级只保留 root、一级 domain、二级重点 domain、最近有变化的 branch,以及当前 selected update 的 ancestor path。
 - 未展开区域折叠成聚合节点,例如 `6 hidden · 2 updated` 或 `1 hidden quiet area`,让用户知道这里有内容但当前不是重点。

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
@@ -28,6 +29,10 @@ const queryClient = new QueryClient({
   },
 });
 
+const ContextPreviewPage = import.meta.env.DEV
+  ? lazy(() => import("./pages/context-preview.js").then((module) => ({ default: module.ContextPreviewPage })))
+  : null;
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -41,6 +46,16 @@ export function App() {
               <Route path="/signup" element={<Navigate to="/login" replace />} />
               <Route path="/auth/github/complete" element={<OAuthCompletePage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
+              {ContextPreviewPage ? (
+                <Route
+                  path="/preview/context"
+                  element={
+                    <Suspense fallback={null}>
+                      <ContextPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
               {/* Auth-required pages. Onboarding is now an inline view inside
                 CenterPanel (OnboardingView) — no separate /welcome route, no
                 provider, no banner. */}

--- a/packages/web/src/pages/__tests__/context-overview.test.ts
+++ b/packages/web/src/pages/__tests__/context-overview.test.ts
@@ -1,0 +1,67 @@
+import type { ContextTreeNode } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { buildOverviewNodes } from "../context.js";
+
+const node = (
+  id: string,
+  parentId: string | null,
+  path: string,
+  title: string,
+  changeType: ContextTreeNode["changeType"] = null,
+): ContextTreeNode => ({
+  id,
+  parentId,
+  path,
+  sourcePath: null,
+  title,
+  kind: parentId === null ? "root" : "domain",
+  owners: [],
+  preview: null,
+  relatedNodeIds: [],
+  affectedContextArea: title,
+  changeType,
+  changedAtCommit: changeType ? "commit" : null,
+});
+
+const nodes: ContextTreeNode[] = [
+  node("root", null, "/", "Context Tree"),
+  node("agents", "root", "/agents", "Agents"),
+  node("agents/runtime", "agents", "/agents/runtime", "Runtime"),
+  node("members", "root", "/members", "Members"),
+  node("members/yzw", "members", "/members/yzw", "Yuezengwu"),
+  node("members/yzw/notebook", "members/yzw", "/members/yzw/notebook", "Notebook", "added"),
+  node("members/yzw/journal", "members/yzw", "/members/yzw/journal", "Journal"),
+];
+
+function realNodeIds(overviewNodes: ReturnType<typeof buildOverviewNodes>): string[] {
+  return overviewNodes.filter((overviewNode) => !overviewNode.isSummary).map((overviewNode) => overviewNode.id);
+}
+
+describe("buildOverviewNodes", () => {
+  it("shows only root and top-level areas when there are no changed counts or selected path", () => {
+    expect(realNodeIds(buildOverviewNodes(nodes, null, new Map(), new Set()))).toEqual(["root", "agents", "members"]);
+  });
+
+  it("brings selected leaf ancestors back into the visible set", () => {
+    expect(realNodeIds(buildOverviewNodes(nodes, "members/yzw/notebook", new Map(), new Set()))).toEqual([
+      "root",
+      "agents",
+      "members",
+      "members/yzw",
+      "members/yzw/notebook",
+    ]);
+  });
+
+  it("keeps the quiet-area summary toggle after expanding a parent", () => {
+    const overviewNodes = buildOverviewNodes(nodes, null, new Map(), new Set(["members"]));
+    const membersSummary = overviewNodes.find((overviewNode) => overviewNode.id === "summary:members");
+
+    expect(realNodeIds(overviewNodes)).toEqual(["root", "agents", "members", "members/yzw"]);
+    expect(membersSummary).toMatchObject({
+      isSummary: true,
+      isExpanded: true,
+      parentId: "members",
+      title: "Hide 1 quiet area",
+    });
+  });
+});

--- a/packages/web/src/pages/context-preview-mock.ts
+++ b/packages/web/src/pages/context-preview-mock.ts
@@ -1,0 +1,135 @@
+// TEMPORARY: mock snapshot for /preview/context. Delete with the route.
+import type {
+  ContextTreeNode,
+  ContextTreeSnapshot,
+  ContextTreeUpdate,
+} from "@agent-team-foundation/first-tree-hub-shared";
+
+const node = (
+  id: string,
+  parentId: string | null,
+  path: string,
+  title: string,
+  kind: "root" | "domain" | "subdomain" | "leaf",
+  changeType: ContextTreeNode["changeType"],
+): ContextTreeNode => ({
+  id,
+  parentId,
+  path,
+  sourcePath: kind === "leaf" ? `${path}.md` : null,
+  title,
+  kind,
+  owners: [],
+  preview: changeType ? `Mock preview content for **${title}**.` : null,
+  relatedNodeIds: [] as string[],
+  affectedContextArea: title,
+  changeType,
+  changedAtCommit: changeType ? "83c3939" : null,
+});
+
+const update = (
+  id: string,
+  nodeId: string,
+  path: string,
+  title: string,
+  changeType: ContextTreeUpdate["changeType"],
+  changedBy: string,
+  area: string,
+  owners: string[] = [],
+): ContextTreeUpdate => ({
+  id,
+  nodeId,
+  path,
+  title,
+  changeType,
+  affectedContextArea: area,
+  reason: "Recent commit",
+  summary: `${changedBy} ${changeType} ${title}: clarified scope and refreshed examples.`,
+  changedBy,
+  owners,
+  relatedNodeIds: [],
+  sourceCommit: "83c3939e",
+  riskLevel: "low",
+});
+
+export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
+  repo: "agent-team-foundation/first-tree-context",
+  branch: "main",
+  headCommit: "83c3939e90b",
+  syncedAt: new Date().toISOString(),
+  snapshotStatus: "active",
+  contextStatus: {
+    label: "Context Tree is up to date",
+    detail: "Agents have a synced team context snapshot available.",
+    severity: "ok",
+  },
+  summary: { addedCount: 1, editedCount: 4, removedCount: 1, changedNodeCount: 6 },
+  nodes: [
+    node("root", null, "/", "Context Tree", "root", null),
+
+    // AGENTS: quiet branch with 3 quiet L2 children.
+    node("agents", "root", "/agents", "AGENTS", "domain", null),
+    node("agents/msg", "agents", "/agents/msg", "Messaging System", "subdomain", null),
+    node("agents/prod", "agents", "/agents/prod", "Product Direction", "subdomain", null),
+    node("agents/wc", "agents", "/agents/wc", "Web Console — Workspace", "subdomain", null),
+
+    // First Tree Skill CLI: quiet branch with 5 quiet L2 children.
+    node("ftskill", "root", "/ftskill", "First Tree Skill CLI", "domain", null),
+    node("ftskill/build", "ftskill", "/ftskill/build", "Build And Distribution", "subdomain", null),
+    node("ftskill/cred", "ftskill", "/ftskill/cred", "Credential-Free Core Onboarding", "subdomain", null),
+    node("ftskill/onb", "ftskill", "/ftskill/onb", "Onboarding", "subdomain", null),
+    node("ftskill/repo", "ftskill", "/ftskill/repo", "Repo Architecture", "subdomain", null),
+    node("ftskill/src", "ftskill", "/ftskill/src", "Source/Workspace Installation Contract", "subdomain", null),
+
+    // Kael: 1 own edit, 1 hidden quiet child.
+    node("kael", "root", "/kael", "Kael", "domain", "edited"),
+    node("kael/legacy", "kael", "/kael/legacy", "Legacy CLI Notes", "subdomain", null),
+
+    // Members: 4 updates including selected Notebook.
+    node("members", "root", "/members", "Members", "domain", "edited"),
+    node("members/yzw", "members", "/members/yzw", "yuezengwu", "subdomain", "edited"),
+    node("members/yzw/notebook", "members/yzw", "/members/yzw/notebook", "Notebook", "leaf", "added"),
+    node("members/yzw/journal", "members/yzw", "/members/yzw/journal", "Journal", "leaf", null),
+    node("members/yzw/scratch", "members/yzw", "/members/yzw/scratch", "Scratch", "leaf", null),
+    node("members/bxh", "members", "/members/bxh", "baixiaohang", "subdomain", null),
+    node("members/lc", "members", "/members/lc", "liuchao", "subdomain", null),
+
+    // Practices: Tree Maintenance has its own removed change, plus 1 hidden quiet child.
+    node("practices", "root", "/practices", "Practices", "domain", "edited"),
+    node("practices/tm", "practices", "/practices/tm", "Tree Maintenance", "subdomain", "removed"),
+    node("practices/cr", "practices", "/practices/cr", "Code Review", "subdomain", null),
+  ],
+  edges: [],
+  changes: [],
+  updates: [
+    update(
+      "u1",
+      "members/yzw/notebook",
+      "/members/yzw/notebook",
+      "Notebook",
+      "added",
+      "yuezengwu",
+      "members / yuezengwu / notebook",
+      ["yuezengwu"],
+    ),
+    update("u2", "members/yzw", "/members/yzw", "yuezengwu", "edited", "yuezengwu", "members / yuezengwu", [
+      "yuezengwu",
+    ]),
+    update("u3", "members", "/members", "Members", "edited", "yuezengwu", "members", []),
+    update("u4", "kael", "/kael", "Kael", "edited", "yuezengwu", "kael", ["liuchao-001", "yuezengwu"]),
+    update(
+      "u5",
+      "practices/tm",
+      "/practices/tm",
+      "Tree Maintenance Practices",
+      "removed",
+      "yuezengwu",
+      "practices / tree maintenance",
+      [],
+    ),
+    update("u6", "practices", "/practices", "Practices", "edited", "baixiaohang", "practices", [
+      "liuchao-001",
+      "bingran-you",
+    ]),
+  ],
+};

--- a/packages/web/src/pages/context-preview.tsx
+++ b/packages/web/src/pages/context-preview.tsx
@@ -1,0 +1,6 @@
+import { ContextPage } from "./context.js";
+import { MOCK_CONTEXT_SNAPSHOT } from "./context-preview-mock.js";
+
+export function ContextPreviewPage() {
+  return <ContextPage previewSnapshot={MOCK_CONTEXT_SNAPSHOT} />;
+}

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -6,8 +6,8 @@ import type {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery } from "@tanstack/react-query";
 import { stratify, tree } from "d3-hierarchy";
-import { AlertTriangle, CheckCircle2, Copy, FolderTree, RefreshCw } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, CheckCircle2, ChevronRight, Copy, FolderTree, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type ContextTreeWindow, getContextTreeSnapshot } from "../api/context-tree.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
@@ -21,22 +21,23 @@ const CONTEXT_WINDOWS: Array<{ value: ContextTreeWindow; label: string; summary:
   { value: "30d", label: "30 days", summary: "last 30 days" },
 ];
 
-export function ContextPage() {
+export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTreeSnapshot } = {}) {
   const { organizationId } = useAuth();
   const [window, setWindow] = useState<ContextTreeWindow>("7d");
   const [selectedUpdateId, setSelectedUpdateId] = useState<string | null>(null);
   const [selectedOverviewNodeId, setSelectedOverviewNodeId] = useState<string | null>(null);
+  const preview = previewSnapshot !== undefined;
 
   const query = useQuery({
-    queryKey: ["context-tree-snapshot", organizationId, window],
+    queryKey: ["context-tree-snapshot", organizationId, window, preview],
     queryFn: () => {
       if (!organizationId) throw new Error("No organization selected");
       return getContextTreeSnapshot(organizationId, window);
     },
-    enabled: !!organizationId,
+    enabled: !preview && !!organizationId,
   });
 
-  const snapshot = query.data;
+  const snapshot = previewSnapshot ?? query.data;
   const selectedUpdate = useMemo(() => {
     if (!snapshot) return null;
     return snapshot.updates.find((update) => update.id === selectedUpdateId) ?? snapshot.updates[0] ?? null;
@@ -59,11 +60,11 @@ export function ContextPage() {
     <div className="-m-6">
       <PageHeader title="Context" subtitle="Team context available to agents, and how it is changing" />
       <div style={{ padding: "var(--sp-4) var(--sp-5) var(--sp-7)" }}>
-        {query.isLoading ? <LoadingState /> : null}
-        {query.error ? (
+        {!preview && query.isLoading ? <LoadingState /> : null}
+        {!preview && query.error ? (
           <ErrorState message={query.error instanceof Error ? query.error.message : "Failed to load"} />
         ) : null}
-        {snapshot && !query.isLoading ? (
+        {snapshot && (preview || !query.isLoading) ? (
           <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
             {snapshot.snapshotStatus === "unavailable" ? (
               <UnavailableState snapshot={snapshot} />
@@ -412,18 +413,35 @@ function TreeOverview({
   selectedNodeId: string | null;
   onSelectNode: (nodeId: string) => void;
 }) {
+  const [expandedParents, setExpandedParents] = useState<Set<string>>(() => new Set());
   const counts = useMemo(() => changedCounts(snapshot.nodes), [snapshot.nodes]);
   const visibleNodes = useMemo(
-    () => layoutTree(snapshot.nodes, selectedNodeId, counts),
-    [selectedNodeId, snapshot.nodes, counts],
+    () => layoutTree(snapshot.nodes, selectedNodeId, counts, expandedParents),
+    [selectedNodeId, snapshot.nodes, counts, expandedParents],
   );
+
+  // Callback ref attached only to the currently selected node's button. Fires
+  // when the selected button mounts (after a selection change) so it scrolls
+  // into view if it was off-screen — no separate effect / dep dance.
+  const scrollSelectedIntoView = useCallback((el: HTMLButtonElement | null) => {
+    el?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, []);
+
+  const toggleAggregate = useCallback((parentId: string) => {
+    setExpandedParents((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentId)) next.delete(parentId);
+      else next.add(parentId);
+      return next;
+    });
+  }, []);
   const width = Math.max(760, ...visibleNodes.map((node) => node.x + 280));
   const height = Math.max(280, ...visibleNodes.map((node) => node.y + 48));
   // Render the SVG at its natural pixel height so nodes never get squished by
   // `preserveAspectRatio="meet"`. When the tree is taller than the soft cap, the
   // container scrolls instead — keeps small trees compact, big trees readable.
-  const naturalHeight = Math.max(220, height + 24);
-  const SOFT_HEIGHT_CAP = 360;
+  const naturalHeight = height + 24;
+  const SOFT_HEIGHT_CAP = 560;
   const overflowsCap = naturalHeight > SOFT_HEIGHT_CAP;
   const selectedPath = overviewSelectedPath(snapshot.nodes, selectedNodeId);
 
@@ -471,6 +489,7 @@ function TreeOverview({
               style={{
                 overflow: overflowsCap ? "auto" : "hidden",
                 maxHeight: overflowsCap ? `${SOFT_HEIGHT_CAP}px` : undefined,
+                minHeight: `${Math.min(naturalHeight, SOFT_HEIGHT_CAP)}px`,
               }}
             >
               <svg
@@ -495,35 +514,62 @@ function TreeOverview({
                   ) : null,
                 )}
                 {visibleNodes.map((node) => {
+                  const interactive = node.isSummary || node.sourceNodeId !== null;
+                  const handleClick = () => {
+                    if (node.isSummary && node.parentId) {
+                      toggleAggregate(node.parentId);
+                    } else if (node.sourceNodeId) {
+                      onSelectNode(node.sourceNodeId);
+                    }
+                  };
                   return (
                     <foreignObject key={node.id} x={node.x - 10} y={node.y - 15} width={width - node.x - 8} height={30}>
                       <button
+                        ref={node.selected ? scrollSelectedIntoView : undefined}
                         type="button"
-                        disabled={node.sourceNodeId === null}
-                        onClick={() => {
-                          if (node.sourceNodeId) onSelectNode(node.sourceNodeId);
-                        }}
-                        className="flex w-full items-center text-left text-label"
+                        disabled={!interactive}
+                        onClick={handleClick}
+                        className="flex w-full items-center text-left text-label transition-colors"
                         style={{
+                          background: "transparent",
                           color: node.muted ? "var(--fg-3)" : "var(--fg)",
-                          cursor: node.sourceNodeId ? "pointer" : "default",
+                          cursor: interactive ? "pointer" : "default",
                           gap: "var(--sp-2)",
                           opacity: node.muted ? 0.66 : 1,
+                          padding: "0 var(--sp-1)",
+                        }}
+                        onMouseEnter={(event) => {
+                          if (interactive) event.currentTarget.style.background = "var(--bg-sunken)";
+                        }}
+                        onMouseLeave={(event) => {
+                          event.currentTarget.style.background = "transparent";
                         }}
                       >
-                        <span
-                          aria-hidden="true"
-                          style={{
-                            width: node.selected ? "var(--sp-4)" : "var(--sp-3)",
-                            height: node.selected ? "var(--sp-4)" : "var(--sp-3)",
-                            borderRadius: "50%",
-                            background: overviewNodeColor(node),
-                            border: `${node.selected ? "var(--hairline-bold)" : "var(--hairline)"} solid ${
-                              node.selected ? "var(--accent)" : "var(--border-strong)"
-                            }`,
-                            flex: "0 0 auto",
-                          }}
-                        />
+                        {node.isSummary ? (
+                          <ChevronRight
+                            size={12}
+                            style={{
+                              color: "var(--fg-4)",
+                              flex: "0 0 auto",
+                              transform: node.isExpanded ? "rotate(90deg)" : undefined,
+                              transition: "transform 120ms",
+                            }}
+                          />
+                        ) : (
+                          <span
+                            aria-hidden="true"
+                            style={{
+                              width: node.selected ? "var(--sp-4)" : "var(--sp-3)",
+                              height: node.selected ? "var(--sp-4)" : "var(--sp-3)",
+                              borderRadius: "50%",
+                              background: overviewNodeColor(node),
+                              border: `${node.selected ? "var(--hairline-bold)" : "var(--hairline)"} solid ${
+                                node.selected ? "var(--accent)" : overviewNodeBorder(node)
+                              }`,
+                              flex: "0 0 auto",
+                            }}
+                          />
+                        )}
                         <span
                           className={node.selectedPath ? "font-semibold" : "font-medium"}
                           style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
@@ -780,7 +826,11 @@ function EmptyChanges() {
   );
 }
 
-const OVERVIEW_DEFAULT_DEPTH = 2;
+// Always show root + top-level branches. Anything deeper only shows when it
+// actually has activity (own changes or descendants with changes) or sits on
+// the selected lineage. Keeps the overview focused on "where things changed"
+// instead of flooding the canvas with quiet L2 children.
+const OVERVIEW_DEFAULT_DEPTH = 1;
 const OVERVIEW_CHANGED_BRANCH_DEPTH = 3;
 
 type OverviewDatum = {
@@ -792,6 +842,10 @@ type OverviewDatum = {
   changeType: ContextTreeChangeType | null;
   updateCount: number;
   isSummary: boolean;
+  // For summary aggregates only: whether the parent is currently expanded
+  // (children that would normally be hidden are showing). Drives chevron
+  // orientation and click semantics (toggle off vs toggle on).
+  isExpanded: boolean;
   selected: boolean;
   selectedPath: boolean;
   muted: boolean;
@@ -807,8 +861,9 @@ function layoutTree(
   nodes: ContextTreeNode[],
   selectedNodeId: string | null,
   counts: Map<string, number>,
+  expandedParents: Set<string>,
 ): LayoutNode[] {
-  const overviewNodes = buildOverviewNodes(nodes, selectedNodeId, counts);
+  const overviewNodes = buildOverviewNodes(nodes, selectedNodeId, counts, expandedParents);
   if (overviewNodes.length === 0) return [];
 
   const root = stratify<OverviewDatum>()
@@ -818,7 +873,7 @@ function layoutTree(
       if (a.data.isSummary !== b.data.isSummary) return a.data.isSummary ? 1 : -1;
       return a.data.path.localeCompare(b.data.path);
     });
-  const pointRoot = tree<OverviewDatum>().nodeSize([42, 190])(root);
+  const pointRoot = tree<OverviewDatum>().nodeSize([30, 170])(root);
   const points = pointRoot.descendants();
   const minX = Math.min(...points.map((point) => point.x));
   const laidOut = points.map((point) => ({
@@ -838,6 +893,7 @@ function buildOverviewNodes(
   nodes: ContextTreeNode[],
   selectedNodeId: string | null,
   counts: Map<string, number>,
+  expandedParents: Set<string>,
 ): OverviewDatum[] {
   const byId = new Map(nodes.map((node) => [node.id, node]));
   const validNodes = nodes
@@ -847,7 +903,11 @@ function buildOverviewNodes(
 
   const childrenByParent = childMap(validNodes);
   const selectedPath = selectedPathIds(selectedNodeId, byId);
-  const visibleIds = new Set<string>();
+  // compactVisibleIds = what the default depth/changed-branch rule shows. We
+  // track this separately from visibleIds so the "X hidden quiet areas"
+  // summary stays as a *toggle* even after the user expands a parent —
+  // otherwise expanding hides the only way to collapse again.
+  const compactVisibleIds = new Set<string>();
   const depthById = new Map<string, number>();
 
   for (const node of validNodes) {
@@ -856,9 +916,17 @@ function buildOverviewNodes(
     if (
       depth <= OVERVIEW_DEFAULT_DEPTH ||
       selectedPath.has(node.id) ||
-      (updateCount > 0 && depth <= OVERVIEW_CHANGED_BRANCH_DEPTH && node.kind !== "leaf")
+      (updateCount > 0 && depth <= OVERVIEW_CHANGED_BRANCH_DEPTH)
     ) {
-      addWithAncestors(node.id, byId, visibleIds);
+      addWithAncestors(node.id, byId, compactVisibleIds);
+    }
+  }
+
+  const visibleIds = new Set(compactVisibleIds);
+  for (const parentId of expandedParents) {
+    if (!visibleIds.has(parentId)) continue;
+    for (const child of childrenByParent.get(parentId) ?? []) {
+      visibleIds.add(child.id);
     }
   }
 
@@ -877,6 +945,7 @@ function buildOverviewNodes(
         changeType: node.changeType,
         updateCount,
         isSummary: false,
+        isExpanded: false,
         selected: selectedNodeId === node.id,
         selectedPath: selectedPathNode,
         muted: selectedActive && !selectedPathNode && updateCount === 0,
@@ -886,18 +955,22 @@ function buildOverviewNodes(
   const summaryNodes: OverviewDatum[] = [];
   for (const node of validNodes) {
     if (!visibleIds.has(node.id)) continue;
-    const hiddenChildren = (childrenByParent.get(node.id) ?? []).filter((child) => !visibleIds.has(child.id));
-    if (hiddenChildren.length === 0) continue;
-    const changedHiddenCount = hiddenChildren.filter((child) => (counts.get(child.id) ?? 0) > 0).length;
+    const naturallyHidden = (childrenByParent.get(node.id) ?? []).filter((child) => !compactVisibleIds.has(child.id));
+    if (naturallyHidden.length === 0) continue;
+    const isExpanded = expandedParents.has(node.id);
+    const changedHiddenCount = naturallyHidden.filter((child) => (counts.get(child.id) ?? 0) > 0).length;
     summaryNodes.push({
       id: `summary:${node.id}`,
       parentId: node.id,
       sourceNodeId: null,
-      title: summaryTitle(hiddenChildren.length, changedHiddenCount),
+      title: isExpanded
+        ? `Hide ${naturallyHidden.length} quiet area${naturallyHidden.length === 1 ? "" : "s"}`
+        : summaryTitle(naturallyHidden.length, changedHiddenCount),
       path: `${node.path}/~summary`,
       changeType: null,
       updateCount: changedHiddenCount,
       isSummary: true,
+      isExpanded,
       selected: false,
       selectedPath: selectedPath.has(node.id),
       muted: selectedActive && !selectedPath.has(node.id),
@@ -1094,9 +1167,15 @@ function changeColor(type: ContextTreeChangeType): string {
 function overviewNodeColor(node: LayoutNode): string {
   if (node.isSummary) return "var(--bg-sunken)";
   if (node.selected) return "var(--accent)";
-  // Any updated node (leaf with a changeType, or branch with rollup updates) uses
-  // accent-bg so the legend stays honest. Type details (added/edited/removed) are
-  // still surfaced via ChangePill in the update list and Selected Change panel.
-  if (node.changeType || node.updateCount > 0) return "var(--accent-bg)";
+  // Nodes with their own change-type get severity color (added=ok / edited=warn /
+  // removed=danger) so the map surfaces *what kind* of change happened, not just
+  // that something changed. Pure rollup branches stay neutral accent-bg.
+  if (node.changeType) return changeColor(node.changeType);
+  if (node.updateCount > 0) return "var(--accent-bg)";
   return "var(--bg-raised)";
+}
+
+function overviewNodeBorder(node: LayoutNode): string {
+  if (node.changeType) return changeColor(node.changeType);
+  return "var(--border-strong)";
 }

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -481,8 +481,10 @@ function TreeOverview({
               </div>
               <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2)" }}>
                 <OverviewLegendItem color="var(--accent)" label="Selected path" />
-                <OverviewLegendItem color="var(--accent-bg)" label="Updated" />
-                <OverviewLegendItem color="var(--bg-raised)" label="Quiet / hidden" />
+                <OverviewLegendItem color="var(--ok)" label="Added" />
+                <OverviewLegendItem color="var(--warn)" label="Edited" />
+                <OverviewLegendItem color="var(--danger)" label="Removed" />
+                <OverviewLegendItem color="var(--bg-raised)" label="Quiet" />
               </div>
             </div>
             <div
@@ -528,6 +530,7 @@ function TreeOverview({
                         ref={node.selected ? scrollSelectedIntoView : undefined}
                         type="button"
                         disabled={!interactive}
+                        aria-expanded={node.isSummary ? node.isExpanded : undefined}
                         onClick={handleClick}
                         className="flex w-full items-center text-left text-label transition-colors"
                         style={{
@@ -857,7 +860,7 @@ type LayoutNode = OverviewDatum & {
   parent: LayoutNode | null;
 };
 
-function layoutTree(
+export function layoutTree(
   nodes: ContextTreeNode[],
   selectedNodeId: string | null,
   counts: Map<string, number>,
@@ -889,7 +892,7 @@ function layoutTree(
   }));
 }
 
-function buildOverviewNodes(
+export function buildOverviewNodes(
   nodes: ContextTreeNode[],
   selectedNodeId: string | null,
   counts: Map<string, number>,


### PR DESCRIPTION
## Summary

- Adds a dev-only `/preview/context` route with mock Context Tree data for UI review.
- Refines the Context overview map so it uses a full-width tree view, adaptive height, selected-path scrolling, quiet-branch aggregation, and change severity coloring.
- Keeps preview mock data out of production bundles by loading the preview page through a dev-only lazy import.

## Why

The previous overview panel duplicated information from the update list and made the tree hard to scan. This change focuses the lower panel on its core job: showing where context changed in the tree while keeping details in the existing update list and selected-change panel.

## Validation

- `pnpm check && pnpm --filter @first-tree-hub/web typecheck`
- `pnpm test`
- Verified `/preview/context` in the in-app browser.
- Verified production `packages/web/dist` does not contain preview mock strings.