### PR TITLE
feat(webhook): event/action-aware GitHub entity chat titles

### DIFF
--- a/packages/server/src/__tests__/github-entity-helpers.test.ts
+++ b/packages/server/src/__tests__/github-entity-helpers.test.ts
@@ -142,25 +142,77 @@ describe("parseFixesRefs", () => {
 
 describe("formatEntityTitle", () => {
   it("renders Issue title", () => {
-    expect(formatEntityTitle({ type: "issue", key: "owner/repo#42", title: "Refactor inbox" })).toBe(
-      "Issue owner/repo#42: Refactor inbox",
-    );
+    expect(
+      formatEntityTitle({ type: "issue", key: "owner/repo#42", title: "Refactor inbox" }, "issues", "opened"),
+    ).toBe("Issue repo#42: Refactor inbox");
   });
 
-  it("renders PR title", () => {
-    expect(formatEntityTitle({ type: "pull_request", key: "owner/repo#50", title: "Implement refactor" })).toBe(
-      "PR owner/repo#50: Implement refactor",
-    );
+  it("renders Issue title for issue_comment.created", () => {
+    expect(
+      formatEntityTitle({ type: "issue", key: "owner/repo#42", title: "Refactor inbox" }, "issue_comment", "created"),
+    ).toBe("Issue repo#42: Refactor inbox");
+  });
+
+  it("renders PR title for pull_request.opened", () => {
+    expect(
+      formatEntityTitle(
+        { type: "pull_request", key: "owner/repo#307", title: "Improve context overview map" },
+        "pull_request",
+        "opened",
+      ),
+    ).toBe("PR repo#307: Improve context overview map");
+  });
+
+  it("renders PR Review title for pull_request.review_requested", () => {
+    expect(
+      formatEntityTitle(
+        { type: "pull_request", key: "owner/repo#307", title: "Improve context overview map" },
+        "pull_request",
+        "review_requested",
+      ),
+    ).toBe("PR Review repo#307: Improve context overview map");
+  });
+
+  it("renders PR Review title for pull_request_review.submitted", () => {
+    expect(
+      formatEntityTitle(
+        { type: "pull_request", key: "owner/repo#50", title: "Implement refactor" },
+        "pull_request_review",
+        "submitted",
+      ),
+    ).toBe("PR Review repo#50: Implement refactor");
+  });
+
+  it("renders PR Review title for pull_request_review_comment.created", () => {
+    expect(
+      formatEntityTitle(
+        { type: "pull_request", key: "owner/repo#50", title: "Implement refactor" },
+        "pull_request_review_comment",
+        "created",
+      ),
+    ).toBe("PR Review repo#50: Implement refactor");
   });
 
   it("renders Discussion title", () => {
-    expect(formatEntityTitle({ type: "discussion", key: "owner/repo#discussion-9", title: "RFC" })).toBe(
-      "Discussion owner/repo#discussion-9: RFC",
+    expect(
+      formatEntityTitle({ type: "discussion", key: "owner/repo#discussion-9", title: "RFC" }, "discussion", "created"),
+    ).toBe("Discussion repo#discussion-9: RFC");
+  });
+
+  it("renders Commit title (no entity title)", () => {
+    expect(formatEntityTitle({ type: "commit", key: "owner/repo@abc1234" }, "commit_comment", "created")).toBe(
+      "Commit repo@abc1234",
     );
   });
 
   it("falls back to key when title is missing", () => {
-    expect(formatEntityTitle({ type: "issue", key: "owner/repo#42" })).toBe("Issue owner/repo#42");
+    expect(formatEntityTitle({ type: "issue", key: "owner/repo#42" }, "issues", "opened")).toBe("Issue repo#42");
+  });
+
+  it("keeps the full key when no owner segment is present", () => {
+    // Defensive — entity keys are always `owner/repo...` in practice, but the
+    // helper shouldn't choke if a future caller drops the slash.
+    expect(formatEntityTitle({ type: "issue", key: "repo#42" }, "issues", "opened")).toBe("Issue repo#42");
   });
 });
 

--- a/packages/server/src/__tests__/github-webhook-entity-routing.test.ts
+++ b/packages/server/src/__tests__/github-webhook-entity-routing.test.ts
@@ -157,7 +157,7 @@ describe("GitHub webhook — entity-clustering routing (Phase 0)", () => {
       .from(chats)
       .where(eq(chats.id, mappingsAfter1[0]?.chatId ?? ""))
       .limit(1);
-    expect(chat1?.topic).toBe(`Issue owner/repo#42: Refactor inbox #42`);
+    expect(chat1?.topic).toBe(`Issue repo#42: Refactor inbox #42`);
     expect(chat1?.metadata).toMatchObject({ source: "github", entityType: "issue", entityKey: "owner/repo#42" });
 
     // Follow-up comment on the same issue → reuses the same chat.

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -55,6 +55,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
 
     expect(result.created).toBe(true);
@@ -72,7 +74,7 @@ describe("resolveTargetChat", () => {
 
     // Chat topic = formatEntityTitle(entity); metadata carries entity fields.
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, result.chatId)).limit(1);
-    expect(chat?.topic).toBe("Issue owner/repo#42: Refactor inbox");
+    expect(chat?.topic).toBe("Issue repo#42: Refactor inbox");
     expect(chat?.metadata).toMatchObject({
       source: "github",
       entityType: "issue",
@@ -92,6 +94,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
     const second = await resolveTargetChat(app.db, {
       organizationId: admin.organizationId,
@@ -99,6 +103,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
 
     expect(second.chatId).toBe(first.chatId);
@@ -120,6 +126,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
     const prResolved = await resolveTargetChat(app.db, {
       organizationId: admin.organizationId,
@@ -127,6 +135,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: pr50,
       relatedEntities: [issue42],
+      eventType: "pull_request",
+      action: "opened",
     });
 
     expect(prResolved.chatId).toBe(issueResolved.chatId);
@@ -152,6 +162,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: pr50,
       relatedEntities: [issue43],
+      eventType: "pull_request",
+      action: "opened",
     });
 
     expect(prResolved.created).toBe(true);
@@ -170,6 +182,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
     const issue43Resolved = await resolveTargetChat(app.db, {
       organizationId: admin.organizationId,
@@ -177,6 +191,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: issue43,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
     expect(issue42Resolved.chatId).not.toBe(issue43Resolved.chatId);
 
@@ -187,6 +203,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegate,
       entity: pr50,
       relatedEntities: [issue42, issue43],
+      eventType: "pull_request",
+      action: "opened",
     });
 
     expect(prResolved.chatId).toBe(issue42Resolved.chatId);
@@ -216,6 +234,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegateA,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
     const resolvedB = await resolveTargetChat(app.db, {
       organizationId: adminB.organizationId,
@@ -223,6 +243,8 @@ describe("resolveTargetChat", () => {
       delegateAgentId: delegateB,
       entity: issue42,
       relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
     });
 
     expect(resolvedA.chatId).not.toBe(resolvedB.chatId);
@@ -245,6 +267,8 @@ describe("resolveTargetChat", () => {
         delegateAgentId: delegate,
         entity: issue42,
         relatedEntities: [],
+        eventType: "issues",
+        action: "opened",
       }),
       resolveTargetChat(app.db, {
         organizationId: admin.organizationId,
@@ -252,6 +276,8 @@ describe("resolveTargetChat", () => {
         delegateAgentId: delegate,
         entity: issue42,
         relatedEntities: [],
+        eventType: "issues",
+        action: "opened",
       }),
     ]);
 
@@ -263,5 +289,54 @@ describe("resolveTargetChat", () => {
       .where(eq(githubEntityChatMappings.entityKey, issue42.key));
     expect(mappings).toHaveLength(1);
     expect(mappings[0]?.chatId).toBe(r1.chatId);
+  });
+
+  it("renders 'PR Review' topic when a PR chat is first created by review_requested", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegate(app, admin.organizationId, admin.memberId, `dlg-${randomUUID().slice(0, 6)}`);
+
+    const resolved = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [],
+      eventType: "pull_request",
+      action: "review_requested",
+    });
+
+    const [chat] = await app.db.select().from(chats).where(eq(chats.id, resolved.chatId)).limit(1);
+    expect(chat?.topic).toBe("PR Review repo#50: Implement refactor");
+  });
+
+  it("keeps the original topic when a follow-up event with a different prefix reuses the chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegate(app, admin.organizationId, admin.memberId, `dlg-${randomUUID().slice(0, 6)}`);
+
+    // PR chat first created by `pull_request.opened` → title prefix is "PR".
+    const first = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [],
+      eventType: "pull_request",
+      action: "opened",
+    });
+    // A later review-flow event for the same PR must NOT rewrite the title.
+    await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [],
+      eventType: "pull_request_review",
+      action: "submitted",
+    });
+
+    const [chat] = await app.db.select().from(chats).where(eq(chats.id, first.chatId)).limit(1);
+    expect(chat?.topic).toBe("PR repo#50: Implement refactor");
   });
 });

--- a/packages/server/src/api/webhooks/github-entity.ts
+++ b/packages/server/src/api/webhooks/github-entity.ts
@@ -136,26 +136,59 @@ export function parseFixesRefs(text: string | null | undefined, repoFullName: st
 }
 
 /**
+ * Pick a chat-title prefix from (entity, eventType, action).
+ *
+ * PR review-flow events (`pull_request.review_requested`,
+ * `pull_request_review.*`, `pull_request_review_comment.*`) collapse into a
+ * single "PR Review" prefix so a chat first-touched by a review event is
+ * visibly distinct from one first-touched by `pull_request.opened`. Everything
+ * else just renders the entity type.
+ *
+ * Note: chat titles are written once at chat creation (see
+ * `github-entity-chat.ts::createEntityChat`) — subsequent events for the same
+ * entity reuse the existing title even if their (event, action) maps to a
+ * different prefix. This matches the "entity is the container" semantic.
+ */
+function entityTitlePrefix(entity: GithubEntity, eventType: string, action: string): string {
+  if (eventType === "pull_request" && action === "review_requested") return "PR Review";
+  if (eventType === "pull_request_review") return "PR Review";
+  if (eventType === "pull_request_review_comment") return "PR Review";
+  switch (entity.type) {
+    case "issue":
+      return "Issue";
+    case "pull_request":
+      return "PR";
+    case "discussion":
+      return "Discussion";
+    case "commit":
+      return "Commit";
+  }
+}
+
+/**
+ * Strip the leading `owner/` segment from an entity key so the chat title
+ * stays compact. `owner/repo#42` → `repo#42`; `owner/repo@abc1234` →
+ * `repo@abc1234`. The full `owner/repo#N` form is still used as the
+ * clustering primary key (`github_entity_chat_mappings.entity_key`); only the
+ * display string is shortened.
+ */
+function shortEntityKey(key: string): string {
+  const slash = key.indexOf("/");
+  return slash === -1 ? key : key.slice(slash + 1);
+}
+
+/**
  * Render a chat topic from an entity. Used as the chat title; kept short so
  * the chat-list row doesn't truncate aggressively.
  *
- *   { type: "issue", key: "owner/repo#42", title: "Refactor inbox" }
- *     → "Issue owner/repo#42: Refactor inbox"
+ *   formatEntityTitle({ type: "pull_request", key: "owner/repo#307", title: "Improve overview" }, "pull_request", "opened")
+ *     → "PR repo#307: Improve overview"
+ *   formatEntityTitle(<same>, "pull_request", "review_requested")
+ *     → "PR Review repo#307: Improve overview"
  */
-export function formatEntityTitle(entity: GithubEntity): string {
-  const prefix = (() => {
-    switch (entity.type) {
-      case "issue":
-        return "Issue";
-      case "pull_request":
-        return "PR";
-      case "discussion":
-        return "Discussion";
-      case "commit":
-        return "Commit";
-    }
-  })();
-  const head = `${prefix} ${entity.key}`;
+export function formatEntityTitle(entity: GithubEntity, eventType: string, action: string): string {
+  const prefix = entityTitlePrefix(entity, eventType, action);
+  const head = `${prefix} ${shortEntityKey(entity.key)}`;
   if (entity.title && entity.title.length > 0) {
     return `${head}: ${entity.title}`;
   }

--- a/packages/server/src/api/webhooks/github.ts
+++ b/packages/server/src/api/webhooks/github.ts
@@ -165,6 +165,13 @@ async function routeMentionDelegations(
         delegateAgentId: agent.delegateMention,
         entity,
         relatedEntities: relatedRefs,
+        eventType: ctx.event,
+        // `ctx.action` is narrowed to a non-empty string upstream
+        // (`MENTION_ACTIONS` gating in the webhook route), but the
+        // `MentionContext` type keeps it optional. Fall back to "" for the
+        // unreachable case so the prefix table just picks the entity-type
+        // default.
+        action: ctx.action ?? "",
       });
       log.info(
         {

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -30,9 +30,15 @@ export async function resolveTargetChat(
     delegateAgentId: string;
     entity: GithubEntity;
     relatedEntities: GithubEntity[];
+    /** GitHub event type that triggered this resolution, used only when path
+     * (c) creates a fresh chat to pick the title prefix. Existing chats reuse
+     * their original title regardless. */
+    eventType: string;
+    /** GitHub action on `eventType`. Same scope as `eventType`. */
+    action: string;
   },
 ): Promise<{ chatId: string; created: boolean; boundVia: "direct" | "fixes_link" }> {
-  const { organizationId, humanAgentId, delegateAgentId, entity, relatedEntities } = params;
+  const { organizationId, humanAgentId, delegateAgentId, entity, relatedEntities, eventType, action } = params;
 
   // (a) Direct hit.
   const direct = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, entity);
@@ -62,7 +68,7 @@ export async function resolveTargetChat(
   // first chat. The orphan chat is harmless (no participants beyond the two
   // agents, no messages — we have not yet written one) and the design accepts
   // it as the cost of avoiding a serialisable transaction on every webhook.
-  const chat = await createEntityChat(db, humanAgentId, delegateAgentId, entity);
+  const chat = await createEntityChat(db, humanAgentId, delegateAgentId, entity, eventType, action);
   const inserted = await insertMappingIfAbsent(db, {
     organizationId,
     humanAgentId,
@@ -164,6 +170,8 @@ async function createEntityChat(
   humanAgentId: string,
   delegateAgentId: string,
   entity: GithubEntity,
+  eventType: string,
+  action: string,
 ): Promise<{ id: string }> {
   // Symmetric with the feishu raw-INSERT path in
   // `services/adapter-mapping.ts::findOrCreateChatForChannel`: parse the
@@ -181,7 +189,7 @@ async function createEntityChat(
   const chat = await createChat(db, humanAgentId, {
     type: "direct",
     participantIds: [delegateAgentId],
-    topic: formatEntityTitle(entity),
+    topic: formatEntityTitle(entity, eventType, action),
     metadata,
   });
   return { id: chat.id };


### PR DESCRIPTION
## Summary
- Chat title generated by webhook routing now reflects the GitHub event + action that first created the chat (e.g. `PR Review first-tree-hub#307: ...` when triggered by `review_requested`, vs. `PR first-tree-hub#307: ...` when triggered by `opened`).
- Repo segment shortened (`first-tree-hub#307` instead of `agent-team-foundation/first-tree-hub#307`). `entity.key` itself is unchanged — `github_entity_chat_mappings` PK stays stable, no migration.
- Titles are write-once: paths (a) direct hit and (b) fixes_link reuse keep the original title, matching the entity-clustering "chat is the entity's container" semantic.

## Prefix decision table

| event | action | prefix |
|---|---|---|
| `issues` | opened / edited | **Issue** |
| `issue_comment` | created | **Issue** |
| `pull_request` | opened / edited | **PR** |
| `pull_request` | review_requested | **PR Review** |
| `pull_request_review` | submitted | **PR Review** |
| `pull_request_review_comment` | created | **PR Review** |
| `discussion` | created / edited | **Discussion** |
| `discussion_comment` | created | **Discussion** |
| `commit_comment` | created | **Commit** |

## Out of scope
Many-to-one / many-to-many fan-in (e.g. an issue chat later joined by multiple PRs via `fixes_link`) still shows the originally-creating entity's title. This is inherent to #304's clustering policy; a separate "multi-entity hint" feature is left for a follow-up.

## Test plan
- [x] `pnpm check` (biome) — clean
- [x] `pnpm typecheck` — 9 workspace tasks, all pass
- [x] `pnpm --filter @first-tree-hub/server test` — 101 files / 748 tests pass, including 8 new cases:
  - 6 unit cases on `formatEntityTitle` covering the prefix-table branches + short-repo extraction
  - 2 integration cases on `resolveTargetChat`: `review_requested` first-creates a `PR Review` chat; follow-up review event does NOT rewrite a chat originally created by `pull_request.opened`
- [ ] Manual smoke: trigger a real `review_requested` webhook in dev, confirm the resulting chat title contains `PR Review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)