### PR TITLE
fix(cli,server): respect FIRST_TREE_HUB_AGENT_ID and route agent-to-agent sends to current chat

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -80,7 +80,7 @@ describe("bootstrapWorkspace", () => {
     expect(content).toContain("FIRST_TREE_HUB_ACCESS_TOKEN");
     expect(content).toContain("How You Communicate");
     expect(content).toContain("Agent Hub");
-    expect(content).toContain("[From: sender-id]");
+    expect(content).toContain("[From: <agent-name>]");
     expect(content).toContain("Use your judgment about when to respond");
   });
 

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -336,7 +336,8 @@ function generateToolsDoc(): string {
 You are running inside **Agent Hub**, a messaging platform for agent teams.
 
 - Messages from other team members arrive as your prompt input
-- Each message includes a \`[From: sender-id]\` header so you know who sent it
+- Each message includes a \`[From: <agent-name>]\` header — that name is also
+  what you pass back to \`agent send\` to reply to or address that agent
 - **Your final text response is automatically delivered** to the chat — just respond normally
 - For **proactive communication** (sending to other agents, other chats, or structured data),
   use the \`first-tree-hub\` CLI below
@@ -351,8 +352,8 @@ These are injected automatically when the agent process starts:
 |----------|-------------|
 | \`FIRST_TREE_HUB_SERVER_URL\` | Server address for API calls |
 | \`FIRST_TREE_HUB_ACCESS_TOKEN\` | User member access JWT (short-lived) |
-| \`FIRST_TREE_HUB_AGENT_ID\` | Your agent UUID — send as \`X-Agent-Id\` |
-| \`FIRST_TREE_HUB_CHAT_ID\` | Current chat context ID |
+| \`FIRST_TREE_HUB_AGENT_ID\` | YOUR own agent UUID. The CLI reads it to identify you as the sender — never pass it as a \`send\` target. |
+| \`FIRST_TREE_HUB_CHAT_ID\` | The chat this session is currently bound to. The CLI uses it to route messages — you don't need to pass it manually. |
 
 The \`first-tree-hub\` CLI reads these automatically — no extra setup needed.
 
@@ -362,13 +363,18 @@ Use the \`first-tree-hub agent send\` CLI — it reads the env vars above and
 attaches the \`Authorization\` + \`X-Agent-Id\` headers automatically:
 
 \`\`\`bash
-# Send to another agent — target is the agent NAME, NOT a uuid.
-# Names are stable (set on creation, immutable, unique in the org).
+# Send to another agent — first positional argument is the recipient's NAME
+# (NOT a uuid; uuids in chat history / participant lists are not accepted).
 # Run \`first-tree-hub agent list\` to see available names.
+#
+# Routing: if the recipient is a participant of your current chat (typically
+# the case in a group chat where someone @-mentioned you to talk to them),
+# the message stays in that chat. Otherwise it falls back to a direct chat
+# between you and the recipient. You don't need to think about which.
 first-tree-hub agent send <agentName> "your message"
 
-# Send to a chat (target is a chat UUID; use this when replying into a
-# specific chat, e.g. a group where you were mentioned)
+# Send into a specific chat by id — use this only when you explicitly want
+# to address a chat your current session is NOT bound to.
 first-tree-hub agent send --chat <chatId> "your message"
 
 # Send markdown (default format is text)

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/command/src/__tests__/agent-messaging.test.ts
+++ b/packages/command/src/__tests__/agent-messaging.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveReplyToFromEnv } from "../core/agent-messaging.js";
+import { resolveReplyToFromEnv, resolveSenderName } from "../core/agent-messaging.js";
 
 /**
  * Pins the env-based `replyTo` inference used by `agent send`. The rule has
@@ -48,5 +48,61 @@ describe("resolveReplyToFromEnv", () => {
     // we must NOT guess an inbox.
     const out = resolveReplyToFromEnv({}, { replyToChat: "forced-chat" });
     expect(out).toEqual({ replyToInbox: undefined, replyToChat: "forced-chat" });
+  });
+});
+
+/**
+ * Pins sender resolution for `agent send` (and every other agent-scoped CLI
+ * command) on a multi-agent client. Issue #192: when a single machine runs
+ * more than one agent, the agent sub-process used to have to thread
+ * `--agent <name>` into every CLI call, which trips up LLMs that don't
+ * realise their own identity is already in env. The env-reverse-lookup
+ * branch (axis 2) is the fix.
+ */
+describe("resolveSenderName", () => {
+  const a1 = { agentId: "uuid-a1" };
+  const a2 = { agentId: "uuid-a2" };
+
+  it("'none' when no agents are configured locally", () => {
+    expect(resolveSenderName({ agents: new Map() })).toEqual({ kind: "none" });
+  });
+
+  it("'ok' from --agent override even when env disagrees (explicit always wins)", () => {
+    const agents = new Map([
+      ["a1", a1],
+      ["a2", a2],
+    ]);
+    expect(resolveSenderName({ override: "a2", envAgentId: "uuid-a1", agents })).toEqual({ kind: "ok", name: "a2" });
+  });
+
+  it("'ok' by reverse-looking FIRST_TREE_HUB_AGENT_ID against the local agents map", () => {
+    // The fix for #192 — multi-agent client + agent-process env should NOT
+    // require the caller to repeat --agent.
+    const agents = new Map([
+      ["architect", { agentId: "uuid-architect" }],
+      ["developer", { agentId: "uuid-developer" }],
+    ]);
+    expect(resolveSenderName({ envAgentId: "uuid-developer", agents })).toEqual({ kind: "ok", name: "developer" });
+  });
+
+  it("'envMismatch' when env points at a uuid not present locally (stale or unconfigured)", () => {
+    const agents = new Map([
+      ["a1", a1],
+      ["a2", a2],
+    ]);
+    const result = resolveSenderName({ envAgentId: "uuid-stranger", agents });
+    expect(result).toEqual({ kind: "envMismatch", envAgentId: "uuid-stranger", available: ["a1", "a2"] });
+  });
+
+  it("'ok' single-agent shortcut when there's exactly one configured agent and no env hint", () => {
+    expect(resolveSenderName({ agents: new Map([["solo", a1]]) })).toEqual({ kind: "ok", name: "solo" });
+  });
+
+  it("'ambiguous' on multi-agent client with no override and no env hint (legacy behaviour)", () => {
+    const agents = new Map([
+      ["a1", a1],
+      ["a2", a2],
+    ]);
+    expect(resolveSenderName({ agents })).toEqual({ kind: "ambiguous", available: ["a1", "a2"] });
   });
 });

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -14,7 +14,7 @@ import { cleanWorkspaces, FirstTreeHubSDK, SdkError, SessionRegistry } from "@fi
 import { confirm } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { fail, success } from "../cli/output.js";
-import { resolveReplyToFromEnv } from "../core/agent-messaging.js";
+import { resolveReplyToFromEnv, resolveSenderName } from "../core/agent-messaging.js";
 import { ensureFreshAccessToken, resolveServerUrl, saveAgentConfig } from "../core/bootstrap.js";
 import { cliFetch } from "../core/cli-fetch.js";
 import { bindFeishuBot, bindFeishuUser } from "../core/feishu.js";
@@ -42,21 +42,33 @@ type ResolvedAgentConfig = {
 function resolveLocalAgent(agentName?: string): ResolvedAgentConfig {
   const agentsDir = join(DEFAULT_CONFIG_DIR, "agents");
   const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
-  if (agents.size === 0) {
-    fail("MISSING_AGENT", "No agent configured. Run `first-tree-hub agent add` first.", 2);
-  }
+
+  const resolution = resolveSenderName({
+    override: agentName,
+    envAgentId: process.env.FIRST_TREE_HUB_AGENT_ID,
+    agents,
+  });
 
   let resolvedName: string;
-  if (agentName) {
-    resolvedName = agentName;
-  } else if (agents.size === 1) {
-    const [only] = [...agents.keys()];
-    if (!only) fail("MISSING_AGENT", "No agent configured. Run `first-tree-hub agent add` first.", 2);
-    resolvedName = only;
+  if (resolution.kind === "ok") {
+    resolvedName = resolution.name;
+  } else if (resolution.kind === "none") {
+    fail("MISSING_AGENT", "No agent configured. Run `first-tree-hub agent add` first.", 2);
+  } else if (resolution.kind === "envMismatch") {
+    fail(
+      "ENV_AGENT_NOT_LOCAL",
+      `FIRST_TREE_HUB_AGENT_ID="${resolution.envAgentId}" is not configured on this machine. ` +
+        `Available local agents: ${resolution.available.join(", ")}. ` +
+        `Pick one explicitly: \`first-tree-hub agent send --agent <senderName> <recipientName> "..."\`.`,
+      2,
+    );
   } else {
     fail(
       "AMBIGUOUS_AGENT",
-      `Multiple agents configured — specify --agent <name>. Available: ${[...agents.keys()].join(", ")}`,
+      `Multiple agents are configured on this machine (${resolution.available.join(", ")}) and ` +
+        `FIRST_TREE_HUB_AGENT_ID is not set, so the CLI can't tell which one is the sender. ` +
+        `Specify it explicitly: \`first-tree-hub agent send --agent <senderName> <recipientName> "..."\` ` +
+        `(--agent picks the SENDER; the recipient is the next positional argument).`,
       2,
     );
   }

--- a/packages/command/src/core/agent-messaging.ts
+++ b/packages/command/src/core/agent-messaging.ts
@@ -20,3 +20,58 @@ export function resolveReplyToFromEnv(
     replyToChat: override.replyToChat ?? (envComplete ? envChatId : undefined),
   };
 }
+
+/**
+ * Resolve which locally-configured agent the CLI should authenticate as
+ * (the SENDER) for an outbound `agent send` / `agent chats` / etc. call.
+ *
+ * Resolution order:
+ *   1. Explicit `--agent <name>` override.
+ *   2. `FIRST_TREE_HUB_AGENT_ID` env — set by the runtime when the CLI is
+ *      shelled out from inside an agent sub-process. Reverse-look the uuid
+ *      back to a local agent name. Without this, a multi-agent client (e.g.
+ *      one machine running both `architect` and `developer`) forces every
+ *      sub-process call to repeat `--agent <name>`, which trips up LLMs that
+ *      don't realise their own identity is already in env (issue #192).
+ *   3. The single configured agent on this machine (no ambiguity).
+ *   4. Otherwise: no automatic pick — caller must select with `--agent`.
+ *
+ * Pure / IO-free so the four resolution branches can be unit-pinned without
+ * mocking the filesystem; the caller (`commands/agent.ts`) maps each kind to
+ * its own CLI exit message.
+ */
+export type ResolveSenderResult =
+  | { kind: "ok"; name: string }
+  | { kind: "none" }
+  | { kind: "ambiguous"; available: string[] }
+  | { kind: "envMismatch"; envAgentId: string; available: string[] };
+
+export function resolveSenderName(input: {
+  override?: string;
+  envAgentId?: string;
+  agents: ReadonlyMap<string, { agentId: string }>;
+}): ResolveSenderResult {
+  const { override, envAgentId, agents } = input;
+
+  if (agents.size === 0) return { kind: "none" };
+
+  if (override) return { kind: "ok", name: override };
+
+  if (envAgentId) {
+    for (const [name, cfg] of agents) {
+      if (cfg.agentId === envAgentId) return { kind: "ok", name };
+    }
+    // Env says we're agent <uuid> but no local config matches it. Could be
+    // a fresh agent the user hasn't `agent add`-ed locally yet, or stale env
+    // leaking from a sibling process. Fall through with a hint instead of
+    // silently picking the wrong agent.
+    return { kind: "envMismatch", envAgentId, available: [...agents.keys()] };
+  }
+
+  if (agents.size === 1) {
+    const [only] = [...agents.keys()];
+    if (only) return { kind: "ok", name: only };
+  }
+
+  return { kind: "ambiguous", available: [...agents.keys()] };
+}

--- a/packages/server/src/__tests__/agent-send-to-agent.test.ts
+++ b/packages/server/src/__tests__/agent-send-to-agent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createChat } from "../services/chat.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 describe("Agent Send-to-Agent API", () => {
@@ -101,11 +102,91 @@ describe("Agent Send-to-Agent API", () => {
       format: "text",
       content: "Need approval",
       replyToInbox: a1.agent.inboxId,
-      replyToChat: "some-chat-id",
+      // replyToChat must NOT be a real chat where a2 is a participant — that
+      // path now triggers current-chat routing (covered separately below).
+      // Use a synthetic id so the membership check fails and we exercise the
+      // unchanged direct-chat fallback that this test was written for.
+      replyToChat: "00000000-0000-0000-0000-000000000000",
     });
     expect(res.statusCode).toBe(201);
     const msg = res.json();
     expect(msg.replyToInbox).toBe(a1.agent.inboxId);
-    expect(msg.replyToChat).toBe("some-chat-id");
+    expect(msg.replyToChat).toBe("00000000-0000-0000-0000-000000000000");
+  });
+
+  // ─── current-chat routing (replyToChat hint) ──────────────────────────
+  //
+  // When the CLI runs inside an agent sub-process, `resolveReplyToFromEnv`
+  // auto-injects `FIRST_TREE_HUB_CHAT_ID` into `replyToChat`. The server uses
+  // that as a routing hint: if the recipient is a member of that chat, the
+  // message lands there; otherwise it falls back to the pair's direct chat.
+  // Three scenarios pinned below — group hit / unrelated chat / direct chat.
+
+  describe("current-chat routing via replyToChat", () => {
+    it("lands in the existing chat when target is a participant (group hit)", async () => {
+      const app = getApp();
+      const sender = await createTestAgent(app, { name: "rtcr-grp-s" });
+      const { agent: peer } = await createTestAgent(app, { name: "rtcr-grp-p" });
+      const group = await createChat(app.db, sender.agent.uuid, {
+        type: "group",
+        participantIds: [peer.uuid],
+      });
+
+      const res = await sender.request("POST", `/api/v1/agent/agents/${peer.name}/messages`, {
+        format: "text",
+        content: "in the group",
+        replyToChat: group.id,
+        replyToInbox: sender.agent.inboxId,
+      });
+      expect(res.statusCode).toBe(201);
+      const msg = res.json();
+      expect(msg.chatId).toBe(group.id);
+      // Routing already landed in replyToChat — server should strip the
+      // envelope so future inbound replies fan out via normal participant
+      // rules rather than self-referencing.
+      expect(msg.replyToChat).toBeNull();
+      expect(msg.replyToInbox).toBeNull();
+    });
+
+    it("falls back to direct chat when target is NOT a participant of the current chat", async () => {
+      // Group chat (sender + bystander) — recipient `loner` is NOT in it. The
+      // hint must NOT cause a misroute into an unrelated chat.
+      const app = getApp();
+      const sender = await createTestAgent(app, { name: "rtcr-fall-s" });
+      const { agent: bystander } = await createTestAgent(app, { name: "rtcr-fall-by" });
+      const { agent: loner } = await createTestAgent(app, { name: "rtcr-fall-loner" });
+      const unrelated = await createChat(app.db, sender.agent.uuid, {
+        type: "group",
+        participantIds: [bystander.uuid],
+      });
+
+      const res = await sender.request("POST", `/api/v1/agent/agents/${loner.name}/messages`, {
+        format: "text",
+        content: "private DM",
+        replyToChat: unrelated.id,
+      });
+      expect(res.statusCode).toBe(201);
+      const msg = res.json();
+      // Lands in the (auto-created) direct chat, not the unrelated group.
+      expect(msg.chatId).not.toBe(unrelated.id);
+    });
+
+    it("ignores the hint when replyToChat is missing (no env, no flag)", async () => {
+      // The bare-script / explicit DM case — original behaviour preserved.
+      const app = getApp();
+      const sender = await createTestAgent(app, { name: "rtcr-bare-s" });
+      const { agent: peer } = await createTestAgent(app, { name: "rtcr-bare-p" });
+
+      const res = await sender.request("POST", `/api/v1/agent/agents/${peer.name}/messages`, {
+        format: "text",
+        content: "no hint",
+      });
+      expect(res.statusCode).toBe(201);
+      const msg = res.json();
+      // Auto-created direct chat — was the only path before this routing
+      // change and remains the default when no hint is supplied.
+      expect(msg.chatId).toBeDefined();
+      expect(msg.content).toBe(`@${peer.name} no hint`);
+    });
   });
 });

--- a/packages/server/src/__tests__/agent-send-to-agent.test.ts
+++ b/packages/server/src/__tests__/agent-send-to-agent.test.ts
@@ -188,5 +188,44 @@ describe("Agent Send-to-Agent API", () => {
       expect(msg.chatId).toBeDefined();
       expect(msg.content).toBe(`@${peer.name} no hint`);
     });
+
+    it("falls back when sender is NOT a participant (spoofing guard, even if target IS)", async () => {
+      // Without the sender-side participant check, this routing branch is a
+      // write-anywhere primitive — any agent who knows a chat id and one
+      // member's name (both readable from /agent/chats output for chats they
+      // ARE in, or guessable in adversarial scenarios) could drop a message
+      // into a chat they were never a member of. Pin the invariant here.
+      const app = getApp();
+      const spoofer = await createTestAgent(app, { name: "rtcr-spoof-s" });
+      const insiderA = await createTestAgent(app, { name: "rtcr-spoof-ia" });
+      const insiderB = await createTestAgent(app, { name: "rtcr-spoof-ib" });
+      // A chat containing insiderA + insiderB; spoofer is NOT a participant.
+      const insidersOnly = await createChat(app.db, insiderA.agent.uuid, {
+        type: "group",
+        participantIds: [insiderB.agent.uuid],
+      });
+
+      const res = await spoofer.request("POST", `/api/v1/agent/agents/${insiderB.agent.name}/messages`, {
+        format: "text",
+        content: "drop into a chat I'm not in",
+        // The target IS a participant of replyToChat — under the buggy
+        // sender-not-checked logic this would land inside `insidersOnly`.
+        replyToChat: insidersOnly.id,
+      });
+      expect(res.statusCode).toBe(201);
+      const msg = res.json();
+      // The fix routes to the spoofer↔insiderB direct chat instead.
+      expect(msg.chatId).not.toBe(insidersOnly.id);
+
+      // Belt-and-suspenders: poll insiderA's inbox and confirm nothing from
+      // spoofer landed in `insidersOnly` — direct DB read would also work
+      // but the inbox path mirrors what real recipients see.
+      const inboxA = await insiderA.request("GET", "/api/v1/agent/inbox");
+      const entriesA = inboxA.json() as Array<{ message: { chatId: string; senderId: string } }>;
+      const leakedToA = entriesA.some(
+        (e) => e.message.chatId === insidersOnly.id && e.message.senderId === spoofer.agent.uuid,
+      );
+      expect(leakedToA).toBe(false);
+    });
   });
 });

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -197,6 +197,20 @@ export async function assertParticipant(db: Database, chatId: string, agentId: s
   }
 }
 
+/**
+ * Non-throwing membership check. Used by routing logic that needs to fall
+ * back to a different chat when the candidate target isn't a member of the
+ * caller's current chat (see `sendToAgent`'s current-chat routing branch).
+ */
+export async function isParticipant(db: Database, chatId: string, agentId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(and(eq(chatParticipants.chatId, chatId), eq(chatParticipants.agentId, agentId)))
+    .limit(1);
+  return Boolean(row);
+}
+
 /** Ensure an agent is a participant of a chat. Silently adds them if not already. */
 export async function ensureParticipant(db: Database, chatId: string, agentId: string): Promise<void> {
   // Short-circuit if already a participant so we don't spuriously trigger the

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -14,7 +14,7 @@ import { messages } from "../db/schema/messages.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { createLogger, messageAttrs, withSpan } from "../observability/index.js";
 import { upsertSessionState } from "./activity.js";
-import { findOrCreateDirectChat } from "./chat.js";
+import { findOrCreateDirectChat, isParticipant } from "./chat.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { assertSenderMayEmitQuestion, recordPendingQuestionFromMessage } from "./questions.js";
 
@@ -381,13 +381,9 @@ export async function sendToAgent(
     throw new NotFoundError(`Agent "${targetName}" not found${hint}`);
   }
 
-  // Find or create direct chat
-  const chat = await findOrCreateDirectChat(db, senderUuid, target.uuid);
-
-  // The receiver is explicit (`<name>`); merge them into metadata.mentions so
-  // sendMessage's step 2c will prepend `@<name>` to content. One uniform
-  // injection path means agent-to-agent and result-sink replies use exactly
-  // the same logic — no risk of the two drifting on edge cases.
+  // Build the merged-mentions metadata once — both the current-chat routing
+  // branch and the direct-chat fallback need the receiver in `metadata.mentions`
+  // so sendMessage's step 2c will prepend `@<name>` to the content.
   const incomingMeta = (data.metadata ?? {}) as Record<string, unknown>;
   const existingMentionsRaw = incomingMeta.mentions;
   const existingMentions = Array.isArray(existingMentionsRaw)
@@ -395,6 +391,41 @@ export async function sendToAgent(
     : [];
   const mergedMentions = existingMentions.includes(target.uuid) ? existingMentions : [...existingMentions, target.uuid];
   const metadata = { ...incomingMeta, mentions: mergedMentions };
+
+  // Routing: if the caller is currently sitting in a chat (CLI auto-injects
+  // FIRST_TREE_HUB_CHAT_ID into `replyToChat` via resolveReplyToFromEnv) AND
+  // the target is already a participant of that chat, deliver the message
+  // there instead of opening a parallel direct chat. This is what every
+  // observed group-chat flow wants: "agent A in group G calls `agent send B`"
+  // should land in G when B is a member.
+  //
+  // Falls through to the direct-chat path when:
+  //   - replyToChat is missing (caller isn't in a session)
+  //   - target isn't a participant of replyToChat (caller in unrelated chat,
+  //     wants a private DM with B)
+  //   - replyToChat doesn't exist anymore (isParticipant returns false)
+  if (data.replyToChat && (await isParticipant(db, data.replyToChat, target.uuid))) {
+    return sendMessage(
+      db,
+      data.replyToChat,
+      senderUuid,
+      {
+        format: data.format,
+        content: data.content,
+        metadata,
+        // The message lands in replyToChat itself, so the reply-routing
+        // envelope is redundant — strip it so future replies fan out via
+        // normal participant rules instead of self-referencing.
+        replyToInbox: undefined,
+        replyToChat: undefined,
+        source: data.source,
+      },
+      { normalizeMentionsInContent: true },
+    );
+  }
+
+  // Direct-chat fallback: find or create the pair's direct chat.
+  const chat = await findOrCreateDirectChat(db, senderUuid, target.uuid);
 
   return sendMessage(
     db,

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -394,34 +394,49 @@ export async function sendToAgent(
 
   // Routing: if the caller is currently sitting in a chat (CLI auto-injects
   // FIRST_TREE_HUB_CHAT_ID into `replyToChat` via resolveReplyToFromEnv) AND
-  // the target is already a participant of that chat, deliver the message
-  // there instead of opening a parallel direct chat. This is what every
-  // observed group-chat flow wants: "agent A in group G calls `agent send B`"
-  // should land in G when B is a member.
+  // BOTH the sender and target are participants of that chat, deliver the
+  // message there instead of opening a parallel direct chat. This is what
+  // every observed group-chat flow wants: "agent A in group G calls
+  // `agent send B`" should land in G when B is a member.
+  //
+  // BOTH ends are checked because replyToChat is caller-supplied (env or
+  // explicit flag) and otherwise unconstrained. The /agent/chats/:id/messages
+  // path enforces sender membership via assertParticipant; this routing
+  // branch must hold the same invariant or it becomes a write-anywhere
+  // primitive — any agent who knows a chat id and one member's name could
+  // drop a message into a chat they aren't in. Concurrent because both
+  // checks are independent reads.
   //
   // Falls through to the direct-chat path when:
   //   - replyToChat is missing (caller isn't in a session)
-  //   - target isn't a participant of replyToChat (caller in unrelated chat,
-  //     wants a private DM with B)
-  //   - replyToChat doesn't exist anymore (isParticipant returns false)
-  if (data.replyToChat && (await isParticipant(db, data.replyToChat, target.uuid))) {
-    return sendMessage(
-      db,
-      data.replyToChat,
-      senderUuid,
-      {
-        format: data.format,
-        content: data.content,
-        metadata,
-        // The message lands in replyToChat itself, so the reply-routing
-        // envelope is redundant — strip it so future replies fan out via
-        // normal participant rules instead of self-referencing.
-        replyToInbox: undefined,
-        replyToChat: undefined,
-        source: data.source,
-      },
-      { normalizeMentionsInContent: true },
-    );
+  //   - target isn't a participant (caller in unrelated chat, wants a DM)
+  //   - sender isn't a participant (stale env, spoofing attempt, or the
+  //     caller left the chat between fetching the env and sending)
+  //   - replyToChat doesn't exist anymore (both isParticipant return false)
+  if (data.replyToChat) {
+    const [targetIsMember, senderIsMember] = await Promise.all([
+      isParticipant(db, data.replyToChat, target.uuid),
+      isParticipant(db, data.replyToChat, senderUuid),
+    ]);
+    if (targetIsMember && senderIsMember) {
+      return sendMessage(
+        db,
+        data.replyToChat,
+        senderUuid,
+        {
+          format: data.format,
+          content: data.content,
+          metadata,
+          // The message lands in replyToChat itself, so the reply-routing
+          // envelope is redundant — strip it so future replies fan out via
+          // normal participant rules instead of self-referencing.
+          replyToInbox: undefined,
+          replyToChat: undefined,
+          source: data.source,
+        },
+        { normalizeMentionsInContent: true },
+      );
+    }
   }
 
   // Direct-chat fallback: find or create the pair's direct chat.


### PR DESCRIPTION
## Summary

Two long-observed agent-to-agent messaging papercuts, fixed in one pass.

- **CLI: `agent send` no longer demands `--agent` on a multi-agent client.** When the runtime injects `FIRST_TREE_HUB_AGENT_ID`, the CLI now reverse-looks it back to a local agent name. Closes #192.
- **Server: agent-to-agent sends route to the caller's current chat when the recipient is a member.** `sendToAgent` previously hard-routed to the pair's direct chat via `findOrCreateDirectChat`, ignoring session context — so a group chat where A says \"go ask B\" would silently land in a parallel A↔B direct chat. The CLI already auto-injects `FIRST_TREE_HUB_CHAT_ID` into `replyToChat`; the server now uses that as a routing hint, falling back to the direct-chat path when the recipient isn't a member of the current chat.
- **CLI errors now include paste-ready command templates** for the still-ambiguous edge cases (`AMBIGUOUS_AGENT`, new `ENV_AGENT_NOT_LOCAL`), clarifying that `--agent` selects the SENDER while the recipient is positional. (#192's screenshot showed an LLM mis-positioning `--agent` in its recovery attempt.)
- **`bootstrap.ts` (system prompt injected into every agent):**
  - `[From: sender-id]` → `[From: <agent-name>]` — matches what `agent-io.ts` actually renders, and the token agents can pass back to `agent send`.
  - `FIRST_TREE_HUB_AGENT_ID` description now warns it's the caller's own uuid; never use as a `send` target.
  - `FIRST_TREE_HUB_CHAT_ID` description notes the CLI uses it for routing — agents don't pass it manually.
  - `agent send` example block calls out the new auto-routing rule.

Bumps `@agent-team-foundation/first-tree-hub` to `0.12.5` per `docs/versioning-and-publishing.md` (touches `command` + `client/runtime`).

## Test plan

- [x] `pnpm check` (biome) — 625 files, clean
- [x] `pnpm typecheck` — 9/9 tasks pass
- [x] `packages/command` vitest — **104/104** (incl. 6 new `resolveSenderName` cases)
- [x] `packages/server` vitest — **751/751** (incl. 3 new current-chat-routing integration tests, 1 prior test adjusted to keep exercising the direct-chat fallback under the new routing rule)
- [x] `packages/client/src/__tests__/bootstrap.test.ts` — 16/16 (assertion updated to match new `[From: <agent-name>]` wording)
- [ ] Manual: install the new tarball and reproduce issue #192's setup (multi-agent client, two agents in one group) — `agent send <name>` should now succeed in one tool call and the message should appear in the group, not a new direct chat.

> Note: `packages/client/src/__tests__/git-mirror-manager.test.ts > does NOT classify a non-credential https failure as auth` fails on `main` too — pre-existing flake unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)