### PR TITLE
feat(server): GitHub App foundation — schema, services, config (PR 1/3)

### DIFF
--- a/packages/server/drizzle/0037_github_app_installations.sql
+++ b/packages/server/drizzle/0037_github_app_installations.sql
@@ -1,0 +1,52 @@
+-- GitHub App installation registry. See packages/server/src/db/schema/github-app-installations.ts
+-- for the Drizzle types, and docs/github-app-design-zh.md for the design rationale.
+--
+-- One row per (GitHub account ↔ Hub team) binding. Replaces the per-repo
+-- OAuth + webhook-secret model that lived in
+-- `organization_settings.github_integration.webhookSecretCipher` — both
+-- coexist during the transition, the old path is dropped in a later PR
+-- (D3 hard cut, design doc §7 step 7).
+--
+-- Per the team's "integrity in service layer" convention, NO foreign-key
+-- constraints on hub_organization_id beyond the optional reference — the
+-- 1:1 binding (D2 / §8 Q1) is enforced by a UNIQUE INDEX rather than by
+-- ON DELETE CASCADE so deleting a Hub org doesn't tombstone the
+-- GitHub-side record (which still exists upstream).
+
+CREATE TABLE IF NOT EXISTS "github_app_installations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "installation_id" bigint NOT NULL,
+  "account_type" text NOT NULL,
+  "account_login" text NOT NULL,
+  "account_github_id" bigint NOT NULL,
+  "hub_organization_id" text,
+  "permissions" jsonb NOT NULL,
+  "events" jsonb NOT NULL,
+  "suspended_at" timestamp with time zone,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "ck_github_app_installations_account_type"
+    CHECK ("account_type" IN ('User', 'Organization'))
+);
+
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "github_app_installations"
+    ADD CONSTRAINT "github_app_installations_hub_organization_id_organizations_id_fk"
+    FOREIGN KEY ("hub_organization_id") REFERENCES "organizations"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_github_app_installations_installation_id"
+  ON "github_app_installations" ("installation_id");
+
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_github_app_installations_hub_org"
+  ON "github_app_installations" ("hub_organization_id");
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_github_app_installations_account"
+  ON "github_app_installations" ("account_github_id");

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1778544000000,
       "tag": "0036_github_entity_chat_mappings",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1778803200000,
+      "tag": "0037_github_app_installations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/github-app-installations.test.ts
+++ b/packages/server/src/__tests__/github-app-installations.test.ts
@@ -1,0 +1,300 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { organizations } from "../db/schema/organizations.js";
+import type { AppInstallation } from "../services/github-app.js";
+import {
+  bindInstallationToOrg,
+  countInstallationsForOrg,
+  deleteInstallationByGithubId,
+  findInstallationByGithubId,
+  findInstallationByOrg,
+  markInstallationSuspended,
+  markInstallationUnsuspended,
+  upsertInstallationFromMetadata,
+} from "../services/github-app-installations.js";
+import { uuidv7 } from "../uuid.js";
+import { useTestApp } from "./helpers.js";
+
+const baseInstallation: AppInstallation = {
+  id: 1_000_001,
+  accountType: "Organization",
+  accountLogin: "acme-inc",
+  accountGithubId: 9_000_001,
+  permissions: { contents: "write", pull_requests: "write", issues: "read" },
+  events: ["issues", "pull_request", "push"],
+  suspendedAt: null,
+};
+
+describe("services/github-app-installations", () => {
+  const getApp = useTestApp();
+
+  // UUIDv7's first 8 hex chars are ms-timestamp bits; consecutive calls
+  // inside the same millisecond collide. Use the full uuid as the slug
+  // disambiguator so rapid `makeOrg()` calls in one test stay unique.
+  async function makeOrg(slug?: string): Promise<string> {
+    const app = getApp();
+    const id = uuidv7();
+    const safeSlug = slug ?? `gh-app-test-${id}`;
+    await app.db.insert(organizations).values({ id, name: safeSlug, displayName: safeSlug });
+    return id;
+  }
+
+  describe("upsertInstallationFromMetadata", () => {
+    it("INSERTs a fresh row when the installation_id is unseen", async () => {
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_000_100 };
+      const row = await upsertInstallationFromMetadata(app.db, { installation });
+      expect(row.installationId).toBe(1_000_100);
+      expect(row.accountType).toBe("Organization");
+      expect(row.accountLogin).toBe("acme-inc");
+      expect(row.permissions).toEqual({ contents: "write", pull_requests: "write", issues: "read" });
+      expect(row.events).toEqual(["issues", "pull_request", "push"]);
+      expect(row.hubOrganizationId).toBeNull();
+      expect(row.suspendedAt).toBeNull();
+    });
+
+    it("UPDATEs metadata on re-install but preserves hub_organization_id", async () => {
+      const app = getApp();
+      const orgId = await makeOrg();
+      const installation = { ...baseInstallation, id: 1_000_200 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+      await bindInstallationToOrg(app.db, installation.id, orgId);
+
+      // Re-install with a permission upgrade — no hubOrganizationId on the input.
+      const upgraded: AppInstallation = {
+        ...installation,
+        permissions: { ...installation.permissions, members: "read" },
+        events: [...installation.events, "member"],
+      };
+      const row = await upsertInstallationFromMetadata(app.db, { installation: upgraded });
+      expect(row.permissions).toMatchObject({ members: "read" });
+      expect(row.events).toContain("member");
+      // Critical: the binding survives the re-install.
+      expect(row.hubOrganizationId).toBe(orgId);
+    });
+
+    it("persists suspendedAt when GitHub reports it", async () => {
+      const app = getApp();
+      const installation: AppInstallation = {
+        ...baseInstallation,
+        id: 1_000_300,
+        suspendedAt: "2026-05-11T10:00:00Z",
+      };
+      const row = await upsertInstallationFromMetadata(app.db, { installation });
+      expect(row.suspendedAt?.toISOString()).toBe("2026-05-11T10:00:00.000Z");
+    });
+  });
+
+  describe("bindInstallationToOrg", () => {
+    it("first bind sets hub_organization_id; idempotent re-bind is a no-op at the row level", async () => {
+      const app = getApp();
+      const orgId = await makeOrg();
+      const installation = { ...baseInstallation, id: 1_001_001 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      expect(await bindInstallationToOrg(app.db, installation.id, orgId)).toBe(true);
+      const first = await findInstallationByGithubId(app.db, installation.id);
+      expect(first?.hubOrganizationId).toBe(orgId);
+
+      // Second call to the same org is allowed (idempotent retry-safe);
+      // the row's hub_organization_id is unchanged.
+      expect(await bindInstallationToOrg(app.db, installation.id, orgId)).toBe(true);
+      const second = await findInstallationByGithubId(app.db, installation.id);
+      expect(second?.hubOrganizationId).toBe(orgId);
+    });
+
+    it("refuses to rebind installation X to a different org (D2 1:1) — ConflictError", async () => {
+      const app = getApp();
+      const orgA = await makeOrg();
+      const orgB = await makeOrg();
+      const installation = { ...baseInstallation, id: 1_001_002 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+      await bindInstallationToOrg(app.db, installation.id, orgA);
+      const err = await bindInstallationToOrg(app.db, installation.id, orgB).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe("ConflictError");
+      expect((err as Error).message).toMatch(/already bound to a different Hub team/);
+    });
+
+    it("refuses to bind installation Y when org A already has install X bound (H2 / codex P0-3 follow-up)", async () => {
+      const app = getApp();
+      const orgA = await makeOrg();
+      const installX = { ...baseInstallation, id: 1_001_010 };
+      const installY = { ...baseInstallation, id: 1_001_011, accountGithubId: 9_000_010 };
+      await upsertInstallationFromMetadata(app.db, { installation: installX });
+      await upsertInstallationFromMetadata(app.db, { installation: installY });
+      await bindInstallationToOrg(app.db, installX.id, orgA);
+
+      // Now try to bind installY to orgA — UNIQUE(hub_organization_id)
+      // would surface as 23505; the service translates to ConflictError
+      // with a clean user-facing message.
+      const err = await bindInstallationToOrg(app.db, installY.id, orgA).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe("ConflictError");
+      expect((err as Error).message).toMatch(/already bound to a different GitHub installation/);
+
+      // installY remains unbound.
+      const y = await findInstallationByGithubId(app.db, installY.id);
+      expect(y?.hubOrganizationId).toBeNull();
+    });
+
+    it("NotFoundError when the installation row does not exist", async () => {
+      const app = getApp();
+      const orgId = await makeOrg();
+      const err = await bindInstallationToOrg(app.db, 9_999_999, orgId).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).name).toBe("NotFoundError");
+      expect((err as Error).message).toMatch(/no installation row/i);
+    });
+
+    it("race-safe: two concurrent binds to different orgs — exactly one wins, other gets ConflictError", async () => {
+      const app = getApp();
+      const orgA = await makeOrg();
+      const orgB = await makeOrg();
+      const installation = { ...baseInstallation, id: 1_001_020 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      // Fire both calls concurrently. With the old SELECT-then-UPDATE
+      // both could see NULL and the second UPDATE would silently win;
+      // with the conditional UPDATE the second loses cleanly.
+      const results = await Promise.allSettled([
+        bindInstallationToOrg(app.db, installation.id, orgA),
+        bindInstallationToOrg(app.db, installation.id, orgB),
+      ]);
+      const fulfilled = results.filter((r): r is PromiseFulfilledResult<boolean> => r.status === "fulfilled");
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0]?.reason?.name).toBe("ConflictError");
+
+      // The row's binding is one of the two orgs (whichever won the
+      // race), not silently both / neither.
+      const row = await findInstallationByGithubId(app.db, installation.id);
+      expect([orgA, orgB]).toContain(row?.hubOrganizationId);
+    });
+  });
+
+  describe("suspend / unsuspend", () => {
+    it("markInstallationSuspended sets the timestamp; markInstallationUnsuspended clears it", async () => {
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_002_001 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      await markInstallationSuspended(app.db, installation.id, new Date("2026-05-11T12:00:00Z"));
+      const suspended = await findInstallationByGithubId(app.db, installation.id);
+      expect(suspended?.suspendedAt?.toISOString()).toBe("2026-05-11T12:00:00.000Z");
+
+      // Unsuspend timestamp after the suspension → clears.
+      await markInstallationUnsuspended(app.db, installation.id, new Date("2026-05-11T13:00:00Z"));
+      const unsuspended = await findInstallationByGithubId(app.db, installation.id);
+      expect(unsuspended?.suspendedAt).toBeNull();
+    });
+
+    it("a stale suspend (older timestamp) does not overwrite a newer suspend (codex P1-7)", async () => {
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_002_002 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      const newer = new Date("2026-05-11T12:05:00Z");
+      const stale = new Date("2026-05-11T12:00:00Z");
+      await markInstallationSuspended(app.db, installation.id, newer);
+      await markInstallationSuspended(app.db, installation.id, stale); // out-of-order redelivery
+      const row = await findInstallationByGithubId(app.db, installation.id);
+      expect(row?.suspendedAt?.toISOString()).toBe(newer.toISOString());
+    });
+
+    it("a stale unsuspend (timestamp before the current suspension) does not clear it (codex P1-7)", async () => {
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_002_003 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      const suspendedAt = new Date("2026-05-11T12:10:00Z");
+      await markInstallationSuspended(app.db, installation.id, suspendedAt);
+      // Stale unsuspend whose receive-time predates the suspension → no-op.
+      await markInstallationUnsuspended(app.db, installation.id, new Date("2026-05-11T12:00:00Z"));
+      expect((await findInstallationByGithubId(app.db, installation.id))?.suspendedAt?.toISOString()).toBe(
+        suspendedAt.toISOString(),
+      );
+      // A later unsuspend does clear it.
+      await markInstallationUnsuspended(app.db, installation.id, new Date("2026-05-11T12:20:00Z"));
+      expect((await findInstallationByGithubId(app.db, installation.id))?.suspendedAt).toBeNull();
+    });
+  });
+
+  describe("deleteInstallationByGithubId", () => {
+    it("deletes the row outright and is idempotent on a missing installation", async () => {
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_003_001 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+
+      await deleteInstallationByGithubId(app.db, installation.id);
+      expect(await findInstallationByGithubId(app.db, installation.id)).toBeNull();
+      // Repeated delete is a no-op (no row matches), not an error.
+      await deleteInstallationByGithubId(app.db, installation.id);
+    });
+
+    it("deletes a freshly-created row — install-then-immediate-uninstall must be honored", async () => {
+      // Was previously a "do NOT delete within grace window" test (codex P1-7).
+      // Reverted after a post-Phase-C codex challenge: a real install +
+      // immediate uninstall (within 60s) was being permanently swallowed —
+      // GitHub got a 200 no-op delete, never redelivered, and the row stayed
+      // bound forever even though the App was gone upstream. The grace was
+      // guarding a non-issue (GitHub mints a fresh installation.id per
+      // install, so a stale `deleted` for id N can't wipe a fresh re-install
+      // with id M ≠ N).
+      const app = getApp();
+      const installation = { ...baseInstallation, id: 1_003_002 };
+      await upsertInstallationFromMetadata(app.db, { installation }); // createdAt ≈ now
+      await deleteInstallationByGithubId(app.db, installation.id);
+      expect(await findInstallationByGithubId(app.db, installation.id)).toBeNull();
+    });
+  });
+
+  describe("ON DELETE SET NULL behavior survives org deletion", () => {
+    it("nulls hub_organization_id when the bound org is deleted", async () => {
+      const app = getApp();
+      const orgId = await makeOrg();
+      const installation = { ...baseInstallation, id: 1_004_001 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+      await bindInstallationToOrg(app.db, installation.id, orgId);
+
+      await app.db.delete(organizations).where(eq(organizations.id, orgId));
+
+      const row = await findInstallationByGithubId(app.db, installation.id);
+      expect(row).not.toBeNull();
+      expect(row?.hubOrganizationId).toBeNull();
+    });
+  });
+
+  describe("findInstallationByOrg / countInstallationsForOrg", () => {
+    it("returns the bound row by org, or null when nothing is bound", async () => {
+      const app = getApp();
+      const orgId = await makeOrg();
+      expect(await findInstallationByOrg(app.db, orgId)).toBeNull();
+      expect(await countInstallationsForOrg(app.db, orgId)).toBe(0);
+
+      const installation = { ...baseInstallation, id: 1_005_001 };
+      await upsertInstallationFromMetadata(app.db, { installation });
+      await bindInstallationToOrg(app.db, installation.id, orgId);
+
+      const found = await findInstallationByOrg(app.db, orgId);
+      expect(found?.installationId).toBe(1_005_001);
+      expect(await countInstallationsForOrg(app.db, orgId)).toBe(1);
+    });
+  });
+
+  describe("schema sanity", () => {
+    it("the github_app_installations table is wired up via the schema barrel", async () => {
+      const app = getApp();
+      // Cheap smoke: query the table by a known column. Fails if the schema
+      // forgot to export the table or the migration didn't run.
+      const rows = await app.db
+        .select()
+        .from(githubAppInstallations)
+        .where(eq(githubAppInstallations.installationId, -1))
+        .limit(1);
+      expect(rows).toEqual([]);
+    });
+  });
+});

--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -1,0 +1,529 @@
+import { generateKeyPairSync } from "node:crypto";
+import { decodeJwt, decodeProtectedHeader, importPKCS8, jwtVerify } from "jose";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  buildAppAuthorizeUrl,
+  createAppJwt,
+  exchangeCodeForAppUserProfile,
+  fetchInstallation,
+  GithubAppApiError,
+  listUserAccessibleInstallationIds,
+  mintInstallationToken,
+  refreshAppUserToken,
+} from "../services/github-app.js";
+
+/**
+ * Service-layer unit tests for `services/github-app.ts`. Pure module tests;
+ * no Fastify test app, no DB. A throwaway RSA-2048 keypair is generated
+ * per `describe` block so we never check a real (or even "test-real") key
+ * into the repo — there's nothing for a curious reader to mistake for a
+ * production secret.
+ *
+ * The `mintInstallationToken` / `refreshAppUserToken` tests inject a
+ * `fetcher` so the GitHub round-trip is replaced by an in-process stub.
+ * That mirrors the pattern used by `listUserRepos` in `github-oauth.ts`.
+ */
+describe("services/github-app", () => {
+  let appId: string;
+  let privateKeyPem: string;
+  let publicKeyPem: string;
+
+  beforeAll(() => {
+    appId = "123456";
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    });
+    privateKeyPem = privateKey;
+    publicKeyPem = publicKey;
+  });
+
+  describe("createAppJwt", () => {
+    it("returns a JWT signed with RS256 carrying iss=appId", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const header = decodeProtectedHeader(jwt);
+      expect(header.alg).toBe("RS256");
+      const payload = decodeJwt(jwt);
+      expect(payload.iss).toBe(appId);
+      expect(typeof payload.iat).toBe("number");
+      expect(typeof payload.exp).toBe("number");
+    });
+
+    it("backdates iat by ~60s to absorb clock skew", async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const after = Math.floor(Date.now() / 1000);
+      const payload = decodeJwt(jwt);
+      // iat is "now - 60s" rounded down to a whole second; allow ±2s slop
+      // for the work between the `before` capture and the `setIssuedAt`
+      // call inside `createAppJwt`.
+      const iat = payload.iat;
+      if (typeof iat !== "number") throw new Error("expected numeric iat");
+      expect(iat).toBeGreaterThanOrEqual(before - 62);
+      expect(iat).toBeLessThanOrEqual(after - 58);
+    });
+
+    it("expires within the 10-minute GitHub upper bound", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      const payload = decodeJwt(jwt);
+      const iat = payload.iat;
+      const exp = payload.exp;
+      if (typeof iat !== "number" || typeof exp !== "number") throw new Error("expected numeric iat/exp");
+      // 9-minute expiry plus 60s iat skew = ≤600s span; GitHub rejects >600s.
+      expect(exp - iat).toBeLessThanOrEqual(600);
+    });
+
+    it("verifies against the matching public key", async () => {
+      const jwt = await createAppJwt({ appId, privateKeyPem });
+      // Build a SPKI key for verification — this is what GitHub's edge
+      // does on receipt. If the signature is malformed jwtVerify throws.
+      const pubKey = await importPKCS8(privateKeyPem, "RS256");
+      // Use the private key for verify too — RS256 verifies with a public
+      // key derived from the same keypair. We re-derive via `crypto` to
+      // confirm the signature actually validates end-to-end.
+      const { createPublicKey } = await import("node:crypto");
+      const pub = createPublicKey(publicKeyPem);
+      const { payload } = await jwtVerify(jwt, pub);
+      expect(payload.iss).toBe(appId);
+      // No-op reference to pubKey to silence "declared but never used" —
+      // confirms importPKCS8 accepted the PEM, which is part of the test.
+      expect(pubKey).toBeDefined();
+    });
+
+    it("rejects an invalid PEM", async () => {
+      await expect(createAppJwt({ appId, privateKeyPem: "not a pem" })).rejects.toThrow();
+    });
+  });
+
+  describe("mintInstallationToken", () => {
+    it("POSTs to /app/installations/:id/access_tokens with bearer header and parses success", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            token: "ghs_installation_token",
+            expires_at: "2026-05-11T18:00:00Z",
+            permissions: { contents: "write", issues: "read" },
+            repository_selection: "selected",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await mintInstallationToken("app-jwt-stub", 7777, { fetcher: fakeFetch });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("https://api.github.com/app/installations/7777/access_tokens");
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer app-jwt-stub");
+      expect(headers.get("accept")).toBe("application/vnd.github+json");
+      expect(headers.get("x-github-api-version")).toBe("2022-11-28");
+      expect(calls[0]?.init?.method).toBe("POST");
+      expect(result).toEqual({
+        token: "ghs_installation_token",
+        expiresAt: "2026-05-11T18:00:00Z",
+        permissions: { contents: "write", issues: "read" },
+        repositorySelection: "selected",
+      });
+    });
+
+    it("defaults repositorySelection to 'all' when GitHub omits the field", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ token: "t", expires_at: "2026-01-01T00:00:00Z" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      const result = await mintInstallationToken("jwt", 1, { fetcher: fakeFetch });
+      expect(result.repositorySelection).toBe("all");
+      expect(result.permissions).toEqual({});
+    });
+
+    it("throws GithubAppApiError with status on non-2xx", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+      await expect(mintInstallationToken("jwt", 1, { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 401,
+      });
+    });
+  });
+
+  describe("fetchInstallation", () => {
+    it("GETs /app/installations/:id with bearer header and parses the account block", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            id: 5555,
+            account: { id: 999, login: "acme", type: "Organization" },
+            permissions: { contents: "write", issues: "read" },
+            events: ["push", "issues"],
+            suspended_at: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await fetchInstallation("jwt-stub", 5555, { fetcher: fakeFetch });
+      expect(calls[0]?.url).toBe("https://api.github.com/app/installations/5555");
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer jwt-stub");
+      expect(headers.get("x-github-api-version")).toBe("2022-11-28");
+      expect(result).toEqual({
+        id: 5555,
+        accountType: "Organization",
+        accountLogin: "acme",
+        accountGithubId: 999,
+        permissions: { contents: "write", issues: "read" },
+        events: ["push", "issues"],
+        suspendedAt: null,
+      });
+    });
+
+    it("normalizes a suspended installation to a non-null suspendedAt", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(
+          JSON.stringify({
+            id: 1,
+            account: { id: 2, login: "u", type: "User" },
+            suspended_at: "2026-05-11T10:00:00Z",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      const result = await fetchInstallation("jwt", 1, { fetcher: fakeFetch });
+      expect(result.suspendedAt).toBe("2026-05-11T10:00:00Z");
+      expect(result.accountType).toBe("User");
+    });
+
+    it("throws GithubAppApiError on 404 (installation deleted upstream)", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
+      await expect(fetchInstallation("jwt", 1, { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 404,
+      });
+    });
+  });
+
+  describe("listUserAccessibleInstallationIds (P0-2 authz primitive)", () => {
+    it("returns the set of installation IDs from a single-page /user/installations", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), init });
+        return new Response(
+          JSON.stringify({
+            total_count: 2,
+            installations: [{ id: 1001 }, { id: 1002 }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      };
+      const ids = await listUserAccessibleInstallationIds("ghu_token", { fetcher: fakeFetch });
+      expect(ids).toEqual(new Set([1001, 1002]));
+      expect(calls).toHaveLength(1);
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer ghu_token");
+      expect(headers.get("x-github-api-version")).toBe("2022-11-28");
+      expect(calls[0]?.url).toContain("/user/installations?per_page=");
+    });
+
+    it("paginates until a short page is seen", async () => {
+      const pages = [
+        // Page 1: full
+        Array.from({ length: 100 }, (_, i) => ({ id: 5000 + i })),
+        // Page 2: partial (terminates the loop)
+        [{ id: 6001 }, { id: 6002 }],
+      ];
+      let pageIdx = 0;
+      const fakeFetch: typeof fetch = async () => {
+        const installations = pages[pageIdx++] ?? [];
+        return new Response(JSON.stringify({ installations }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      };
+      const ids = await listUserAccessibleInstallationIds("t", { fetcher: fakeFetch, perPage: 100 });
+      expect(ids.size).toBe(102);
+      expect(ids.has(5000)).toBe(true);
+      expect(ids.has(6002)).toBe(true);
+    });
+
+    it("returns an empty set when the user has no installations", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ total_count: 0, installations: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      const ids = await listUserAccessibleInstallationIds("t", { fetcher: fakeFetch });
+      expect(ids.size).toBe(0);
+    });
+
+    it("throws GithubAppApiError on 401 (stale or revoked user token)", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+      await expect(listUserAccessibleInstallationIds("stale", { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 401,
+      });
+    });
+
+    it("authz semantics: hostile installation_id not in the set is correctly excluded", async () => {
+      // Models the P0-2 hijack attempt — user passes installation_id of an
+      // org they don't admin. /user/installations returns only the orgs
+      // they actually admin, so the .has(hostileId) check returns false
+      // and the OAuth callback drops the install rather than binding it.
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ installations: [{ id: 100 }, { id: 200 }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      const ids = await listUserAccessibleInstallationIds("t", { fetcher: fakeFetch });
+      expect(ids.has(100)).toBe(true);
+      expect(ids.has(9999_999)).toBe(false); // attacker's installation_id
+    });
+  });
+
+  describe("refreshAppUserToken", () => {
+    it("trades a refresh token for a fresh access + refresh pair", async () => {
+      const fixedNow = new Date("2026-05-11T10:00:00.000Z");
+      const calls: Array<{ url: string; body: string }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), body: String(init?.body ?? "") });
+        return new Response(
+          JSON.stringify({
+            access_token: "ghu_new_access",
+            expires_in: 28800, // 8h
+            refresh_token: "ghr_new_refresh",
+            refresh_token_expires_in: 15897600, // ~6mo
+            scope: "repo,user:email",
+            token_type: "bearer",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await refreshAppUserToken("client-id", "client-secret", "old-refresh", {
+        fetcher: fakeFetch,
+        now: () => fixedNow,
+      });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("https://github.com/login/oauth/access_token");
+      const body = JSON.parse(calls[0]?.body ?? "{}");
+      expect(body).toEqual({
+        client_id: "client-id",
+        client_secret: "client-secret",
+        grant_type: "refresh_token",
+        refresh_token: "old-refresh",
+      });
+      expect(result).toEqual({
+        accessToken: "ghu_new_access",
+        // fixedNow + 28800s = 18:00:00Z
+        accessTokenExpiresAt: "2026-05-11T18:00:00.000Z",
+        refreshToken: "ghr_new_refresh",
+        // fixedNow + 15897600s = +184 days = 2026-11-11
+        refreshTokenExpiresAt: "2026-11-11T10:00:00.000Z",
+        scope: "repo,user:email",
+      });
+    });
+
+    it("maps GitHub's 200-with-`error` body to a 401 GithubAppApiError so callers re-login", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(
+          JSON.stringify({
+            error: "bad_refresh_token",
+            error_description: "The refresh token passed is incorrect or expired.",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      await expect(refreshAppUserToken("cid", "csec", "stale", { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 401,
+      });
+    });
+
+    it("rejects loudly when GitHub omits expires_in (App misconfigured)", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "a",
+            refresh_token: "r",
+            // expires_in / refresh_token_expires_in deliberately omitted
+            scope: "repo",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      const err = (await refreshAppUserToken("cid", "csec", "x", { fetcher: fakeFetch }).catch(
+        (e: unknown) => e,
+      )) as GithubAppApiError;
+      expect(err).toBeInstanceOf(GithubAppApiError);
+      expect(err.status).toBe(500);
+      expect(err.message).toContain("expires_in");
+    });
+
+    it("surfaces transport errors as GithubAppApiError with upstream status", async () => {
+      const fakeFetch: typeof fetch = async () => new Response("", { status: 502 });
+      await expect(refreshAppUserToken("cid", "csec", "x", { fetcher: fakeFetch })).rejects.toMatchObject({
+        name: "GithubAppApiError",
+        status: 502,
+      });
+    });
+  });
+
+  describe("buildAppAuthorizeUrl", () => {
+    it("builds an authorize URL with client_id / redirect_uri / state / allow_signup", () => {
+      const url = buildAppAuthorizeUrl({
+        clientId: "Iv23liABCDEF",
+        redirectUri: "https://hub.example.com/api/v1/auth/github/callback",
+        state: "signed.state.jwt",
+      });
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe("https://github.com/login/oauth/authorize");
+      expect(parsed.searchParams.get("client_id")).toBe("Iv23liABCDEF");
+      expect(parsed.searchParams.get("redirect_uri")).toBe("https://hub.example.com/api/v1/auth/github/callback");
+      expect(parsed.searchParams.get("state")).toBe("signed.state.jwt");
+      expect(parsed.searchParams.get("allow_signup")).toBe("true");
+      // Permissions are declared on the App's GitHub-side settings page,
+      // NOT in the URL (design doc D0b). Including them here would let
+      // an attacker craft a downgrade prompt.
+      expect(parsed.searchParams.get("scope")).toBeNull();
+      expect(parsed.searchParams.get("permissions")).toBeNull();
+    });
+  });
+
+  describe("exchangeCodeForAppUserProfile", () => {
+    const fixedNow = new Date("2026-05-11T10:00:00.000Z");
+
+    it("trades the code for profile + token pair + expiries", async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fakeFetch: typeof fetch = async (url, init) => {
+        calls.push({ url: String(url), init });
+        if (String(url) === "https://github.com/login/oauth/access_token") {
+          return new Response(
+            JSON.stringify({
+              access_token: "ghu_initial",
+              expires_in: 28800,
+              refresh_token: "ghr_initial",
+              refresh_token_expires_in: 15897600,
+              scope: "repo,user:email",
+              token_type: "bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (String(url) === "https://api.github.com/user") {
+          return new Response(
+            JSON.stringify({
+              id: 583231,
+              login: "octocat",
+              name: "Octo Cat",
+              email: "octo@example.com",
+              avatar_url: "https://github.com/avatars/octocat.png",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      };
+      const result = await exchangeCodeForAppUserProfile(
+        {
+          clientId: "cid",
+          clientSecret: "csec",
+          code: "code-from-callback",
+          redirectUri: "https://hub.example.com/cb",
+          installationId: 9999,
+        },
+        { fetcher: fakeFetch, now: () => fixedNow },
+      );
+      // The token-exchange POST and the /user GET — no /user/emails because
+      // the profile carried a public email.
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.init?.method).toBe("POST");
+      expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+        client_id: "cid",
+        client_secret: "csec",
+        code: "code-from-callback",
+        redirect_uri: "https://hub.example.com/cb",
+      });
+      expect(result.profile).toEqual({
+        githubId: "583231",
+        login: "octocat",
+        email: "octo@example.com",
+        displayName: "Octo Cat",
+        avatarUrl: "https://github.com/avatars/octocat.png",
+      });
+      expect(result.accessToken).toBe("ghu_initial");
+      expect(result.accessTokenExpiresAt).toBe("2026-05-11T18:00:00.000Z");
+      expect(result.refreshToken).toBe("ghr_initial");
+      expect(result.refreshTokenExpiresAt).toBe("2026-11-11T10:00:00.000Z");
+      expect(result.installationId).toBe(9999);
+    });
+
+    it("falls back to /user/emails when the profile hides the primary email", async () => {
+      const fakeFetch: typeof fetch = async (url) => {
+        if (String(url) === "https://github.com/login/oauth/access_token") {
+          return new Response(
+            JSON.stringify({
+              access_token: "a",
+              expires_in: 28800,
+              refresh_token: "r",
+              refresh_token_expires_in: 15897600,
+              scope: "",
+              token_type: "bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (String(url) === "https://api.github.com/user") {
+          return new Response(JSON.stringify({ id: 1, login: "u", email: null, name: null, avatar_url: null }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (String(url) === "https://api.github.com/user/emails") {
+          return new Response(
+            JSON.stringify([
+              { email: "secondary@example.com", primary: false, verified: true },
+              { email: "primary@example.com", primary: true, verified: true },
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      };
+      const result = await exchangeCodeForAppUserProfile(
+        { clientId: "c", clientSecret: "s", code: "x", redirectUri: "r", installationId: null },
+        { fetcher: fakeFetch, now: () => fixedNow },
+      );
+      expect(result.profile.email).toBe("primary@example.com");
+      expect(result.installationId).toBeNull();
+    });
+
+    it("normalizes a 200-with-error body to a 401 GithubAppApiError", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ error: "bad_verification_code", error_description: "Wrong code." }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      await expect(
+        exchangeCodeForAppUserProfile(
+          { clientId: "c", clientSecret: "s", code: "x", redirectUri: "r", installationId: null },
+          { fetcher: fakeFetch },
+        ),
+      ).rejects.toMatchObject({ name: "GithubAppApiError", status: 401 });
+    });
+
+    it("rejects loudly when expires_in is missing (App misconfigured)", async () => {
+      const fakeFetch: typeof fetch = async () =>
+        new Response(JSON.stringify({ access_token: "a", refresh_token: "r", scope: "" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      const err = (await exchangeCodeForAppUserProfile(
+        { clientId: "c", clientSecret: "s", code: "x", redirectUri: "r", installationId: null },
+        { fetcher: fakeFetch },
+      ).catch((e: unknown) => e)) as GithubAppApiError;
+      expect(err).toBeInstanceOf(GithubAppApiError);
+      expect(err.status).toBe(500);
+      expect(err.message).toContain("expires_in");
+    });
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -91,6 +91,21 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
         clientId: "test-github-client",
         clientSecret: "test-github-secret",
       },
+      // Stub GitHub App creds for PR-A foundation. Tests that exercise
+      // the App service primitives inject fetchers / mocks at the
+      // service-call layer and never actually consume these values —
+      // see github-app.test.ts. The `privateKeyPem` must contain the
+      // BEGIN PRIVATE KEY header so the boot guard (codex P1-8) passes;
+      // body is junk and never used to actually sign.
+      githubApp: {
+        appId: "test-app-id",
+        clientId: "test-app-client-id",
+        clientSecret: "test-app-client-secret",
+        privateKeyPem:
+          "-----BEGIN PRIVATE KEY-----\nstub-base64-key-body-not-actually-signed\n-----END PRIVATE KEY-----\n",
+        webhookSecret: "test-app-webhook-secret",
+        slug: "test-app-slug",
+      },
     },
     trustProxy: false,
     rateLimit: { ...baseRateLimit, ...opts.rateLimit },

--- a/packages/server/src/__tests__/oauth-state.test.ts
+++ b/packages/server/src/__tests__/oauth-state.test.ts
@@ -8,6 +8,16 @@ describe("OAuth state JWT", () => {
     const { token, nonce } = await signOAuthState(SECRET, "/welcome");
     const result = await verifyOAuthState(SECRET, token, nonce);
     expect(result.next).toBe("/welcome");
+    expect(result.targetOrganizationId).toBeUndefined();
+  });
+
+  it("round-trips a targetOrganizationId when supplied", async () => {
+    const { token, nonce } = await signOAuthState(SECRET, "/settings/github", {
+      targetOrganizationId: "01961234-aaaa-7000-8000-000000000001",
+    });
+    const result = await verifyOAuthState(SECRET, token, nonce);
+    expect(result.next).toBe("/settings/github");
+    expect(result.targetOrganizationId).toBe("01961234-aaaa-7000-8000-000000000001");
   });
 
   it("rejects a tampered state token", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -55,6 +55,7 @@ import { orgWsRoutes } from "./api/orgs/ws.js";
 import { sessionRoutes } from "./api/sessions.js";
 // Public agent discovery removed — visibility is now handled via agent.visibility field
 import { githubWebhookRoutes } from "./api/webhooks/github.js";
+import { assertBootConfigValid } from "./boot-guards.js";
 import type { Config } from "./config.js";
 import { connectDatabase, sslOptions } from "./db/connection.js";
 import { AppError } from "./errors.js";
@@ -138,6 +139,13 @@ export async function buildApp(config: Config) {
       `${msg} — check FIRST_TREE_HUB_AUTH_*_EXPIRY env vars (got access=${config.auth.accessTokenExpiry}, refresh=${config.auth.refreshTokenExpiry}, connect=${config.auth.connectTokenExpiry}).`,
     );
   }
+
+  // GitHub App config sanity (PEM header / blank-secret / half-config).
+  // Runs here so a misconfigured App env block fails the boot, not the
+  // first App JWT call hours later. Both server entry points (standalone
+  // bin and CLI `server start`) flow through buildApp, so this single
+  // check covers both — cheap, only fires when the App block is present.
+  assertBootConfigValid(config);
 
   applyLoggerConfig({
     level: config.observability.logging.level,

--- a/packages/server/src/boot-guards.ts
+++ b/packages/server/src/boot-guards.ts
@@ -1,0 +1,87 @@
+import type { Config } from "./config.js";
+
+/**
+ * Boot-time configuration sanity checks. Called from `buildApp` so BOTH
+ * server entry points are covered:
+ *   - `packages/server/src/index.ts` (the standalone bin)
+ *   - `packages/command/src/core/server.ts` (the CLI `server start` path)
+ *
+ * The previous incarnation lived in `index.ts` and was only run by the
+ * standalone bin — the CLI path could boot a misconfigured prod with no
+ * surface complaint (codex P1-8).
+ *
+ * Throws on misconfiguration; never returns a value.
+ */
+export function assertBootConfigValid(config: Config): void {
+  assertProductionRequiresPublicUrl(config);
+  assertGithubAppConfigComplete(config);
+}
+
+function assertProductionRequiresPublicUrl(config: Config): void {
+  // `server.publicUrl` is what the connect-token `iss` claim and OAuth
+  // callback URL are built off of. Booting prod without it means the CLI's
+  // `connect <token>` form would have no anchor and OAuth would echo back
+  // to whatever the inbound proxy injected via Host headers (forgery
+  // risk). Fail closed.
+  if (process.env.NODE_ENV === "production" && !config.server.publicUrl) {
+    throw new Error("FIRST_TREE_HUB_PUBLIC_URL is required in production — set the public-facing hub URL.");
+  }
+}
+
+function assertGithubAppConfigComplete(config: Config): void {
+  // Half-configured guard for the GitHub App block. All five fields ride
+  // together — App user-OAuth uses clientId/clientSecret, App JWT uses
+  // appId/privateKeyPem, webhook endpoint verifies signatures with
+  // webhookSecret. A partially-set block almost always means the
+  // operator copied the env recipe but missed one var; fail loud rather
+  // than serve a half-working install flow OR — worse — accept a blank
+  // webhookSecret that turns HMAC-SHA256 into a forgeable hash
+  // (codex P1-8: any actor who knows the SHA-256 of the request body
+  // with empty key could spoof webhooks).
+  //
+  // The Zod schema on `oauth.githubApp.*` enforces `.min(1)` so blank
+  // env values never make it this far — but this guard is the
+  // belt-and-braces defense in case the schema is ever loosened or a
+  // future field is added without the same constraint.
+  const ghApp = config.oauth?.githubApp;
+  if (!ghApp) return;
+
+  const required: Record<string, string | undefined> = {
+    FIRST_TREE_HUB_GITHUB_APP_ID: ghApp.appId,
+    FIRST_TREE_HUB_GITHUB_APP_CLIENT_ID: ghApp.clientId,
+    FIRST_TREE_HUB_GITHUB_APP_CLIENT_SECRET: ghApp.clientSecret,
+    FIRST_TREE_HUB_GITHUB_APP_PRIVATE_KEY: ghApp.privateKeyPem,
+    FIRST_TREE_HUB_GITHUB_APP_WEBHOOK_SECRET: ghApp.webhookSecret,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v || v.trim().length === 0)
+    .map(([k]) => k);
+  // The "0 < missing < all" check catches the half-configured case
+  // (some set, some not). All-empty is a no-op (block resolves to
+  // undefined via the `optional({...})` semantics, but we double-check
+  // here because `field(z.string().min(1))` will surface a Zod error
+  // BEFORE this code runs anyway — the trim-check above is the
+  // belt-and-braces backstop).
+  if (missing.length > 0 && missing.length < Object.keys(required).length) {
+    throw new Error(`GitHub App is half-configured — missing env vars: ${missing.join(", ")}. Set all five or none.`);
+  }
+  if (missing.length === Object.keys(required).length) {
+    // All empty post-trim — treat as "not configured" by failing the
+    // present-but-empty block. Operators who want the App disabled
+    // should leave the env vars unset (which makes `oauth.githubApp`
+    // undefined entirely); a present-but-empty block is ambiguous and
+    // suggests env-file copy mistakes.
+    throw new Error(
+      "GitHub App env block is present but every value is empty — unset the FIRST_TREE_HUB_GITHUB_APP_* vars to disable App sign-in.",
+    );
+  }
+  // Belt-and-braces: a real PKCS#8 PEM starts with this header. Catches
+  // the common operator mistake of pasting only the body or leaving in
+  // literal `\n` sequences instead of newlines. Cheap to check at boot.
+  if (ghApp.privateKeyPem && !ghApp.privateKeyPem.includes("-----BEGIN PRIVATE KEY-----")) {
+    throw new Error(
+      "FIRST_TREE_HUB_GITHUB_APP_PRIVATE_KEY does not look like a PKCS#8 PEM — expected `-----BEGIN PRIVATE KEY-----` header. " +
+        "If the value came from a single-line env file, replace literal `\\n` with real newlines.",
+    );
+  }
+}

--- a/packages/server/src/db/schema/github-app-installations.ts
+++ b/packages/server/src/db/schema/github-app-installations.ts
@@ -1,0 +1,110 @@
+import type {
+  GithubAccountType,
+  GithubAppInstallationEvents,
+  GithubAppInstallationPermissions,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { sql } from "drizzle-orm";
+import { bigint, check, index, jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations.js";
+
+/**
+ * GitHub App installation records — one row per (GitHub account → Hub team)
+ * binding. Replaces the per-repo OAuth + webhook-secret model that lived in
+ * `organization_settings.github_integration.webhookSecretCipher`.
+ *
+ * One installation simultaneously unlocks three capabilities (see design
+ * doc `docs/github-app-design-zh.md` §3):
+ *   1. User OAuth (user-to-server access + refresh tokens) — persisted on
+ *      `auth_identities.metadata` for the signing-in user, not here.
+ *   2. Webhook stream — `installation_id` resolves the inbound webhook to
+ *      the bound Hub org by joining on this table.
+ *   3. Installation token (server-to-server) — minted on demand from the
+ *      App private key; not persisted (1h TTL, cheap to re-issue).
+ *
+ * The (GitHub account ↔ Hub team) binding is 1:1 (D2 / §8 Q1). The
+ * `hub_organization_id` UNIQUE constraint enforces that; the column is
+ * nullable solely to accommodate the install-callback handler inserting
+ * the row before the owning Hub team exists (fresh-signup flow). Once a
+ * binding exists it never moves — re-installing the App on the same GitHub
+ * account UPDATEs this row by `installation_id`.
+ *
+ * ON DELETE SET NULL on `hub_organization_id` rather than CASCADE because
+ * the GitHub-side installation still exists upstream when a Hub team is
+ * deleted — keeping the row lets a future re-binding flow recover without
+ * a re-install dance.
+ */
+export const githubAppInstallations = pgTable(
+  "github_app_installations",
+  {
+    /** UUID v7 primary key, app-generated. */
+    id: text("id").primaryKey(),
+    /**
+     * GitHub-issued installation ID. Stable for the lifetime of the
+     * installation; survives uninstall + re-install on the same account if
+     * the user re-uses the same App, otherwise a fresh ID is issued.
+     * BIGINT because GitHub assigns 64-bit IDs; `mode: "number"` is safe
+     * for the foreseeable future (current IDs are ~8 digits, far below
+     * Number.MAX_SAFE_INTEGER).
+     */
+    installationId: bigint("installation_id", { mode: "number" }).notNull(),
+    /** "User" (personal install) | "Organization" (org install). */
+    accountType: text("account_type").$type<GithubAccountType>().notNull(),
+    /**
+     * GitHub login slug, e.g. "octocat". Mutable — GitHub permits account
+     * renames. Refreshed on every webhook that carries the account block.
+     */
+    accountLogin: text("account_login").notNull(),
+    /**
+     * GitHub numeric id of the account. Immutable for the account's
+     * lifetime; survives login renames. Use this — not `accountLogin` —
+     * as the stable identifier when reconciling with GitHub state.
+     */
+    accountGithubId: bigint("account_github_id", { mode: "number" }).notNull(),
+    /**
+     * Hub org this installation is bound to (1:1, see D2 / §8 Q1).
+     * Nullable to allow inserting the row in the install callback before
+     * the owning Hub team is provisioned. Once bound, the value never
+     * changes — there is no "rebind" flow.
+     */
+    hubOrganizationId: text("hub_organization_id").references(() => organizations.id, { onDelete: "set null" }),
+    /**
+     * Granted permissions snapshot, e.g.
+     *   {contents: "write", pull_requests: "write", issues: "read", ...}
+     * Refreshed on `installation` / `installation_repositories` webhooks.
+     * Keys are free-form because GitHub adds new permission names over
+     * time; the type is enforced at the service layer via the shared
+     * `githubAppInstallationPermissionsSchema`.
+     */
+    permissions: jsonb("permissions").$type<GithubAppInstallationPermissions>().notNull(),
+    /**
+     * Subscribed event-name list, e.g. ["issues", "pull_request", "push"].
+     * Mirrors `installation.events` on webhook payloads.
+     */
+    events: jsonb("events").$type<GithubAppInstallationEvents>().notNull(),
+    /**
+     * Set when GitHub fires `installation: suspend`; cleared on
+     * `installation: unsuspend`. While non-null, webhook delivery is
+     * paused upstream and installation-token requests are refused — Hub
+     * code should treat the binding as inactive.
+     */
+    suspendedAt: timestamp("suspended_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // Installation ID is GitHub's stable primary key — UNIQUE so re-install
+    // webhooks UPSERT by it instead of creating duplicate rows.
+    uniqueIndex("uq_github_app_installations_installation_id").on(table.installationId),
+    // 1:1 binding enforcement (D2 / §8 Q1). Postgres treats multiple NULLs
+    // as distinct by default, so rows pending org-binding don't collide.
+    uniqueIndex("uq_github_app_installations_hub_org").on(table.hubOrganizationId),
+    // Lookup by account id when resolving webhooks that name only the
+    // account block (rare, but happens for account-rename events).
+    index("idx_github_app_installations_account").on(table.accountGithubId),
+    // Defense-in-depth: the Drizzle column type narrows to the union but
+    // a manual INSERT bypassing the ORM would otherwise be able to write
+    // arbitrary strings. Mirrors how auth_identities pins credential_type
+    // values via a CHECK in the DB.
+    check("ck_github_app_installations_account_type", sql`${table.accountType} IN ('User', 'Organization')`),
+  ],
+);

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -9,6 +9,7 @@ export { agents } from "./agents.js";
 export { authIdentities } from "./auth-identities.js";
 export { chatParticipants, chatSubscriptions, chats } from "./chats.js";
 export { clients } from "./clients.js";
+export { githubAppInstallations } from "./github-app-installations.js";
 export { githubEntityChatMappings } from "./github-entity-chat-mappings.js";
 export { inboxEntries } from "./inbox-entries.js";
 export { invitationRedemptions, invitations } from "./invitations.js";

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -1,0 +1,380 @@
+import { and, desc, eq, isNull, lt, or, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { ConflictError, NotFoundError } from "../errors.js";
+import { uuidv7 } from "../uuid.js";
+import type { AppInstallation } from "./github-app.js";
+
+/** Postgres `unique_violation` SQLSTATE — emitted on UNIQUE constraint trips. */
+const PG_UNIQUE_VIOLATION = "23505";
+
+function isUniqueViolation(err: unknown): boolean {
+  const code = (err as { code?: string })?.code ?? (err as { cause?: { code?: string } })?.cause?.code;
+  return code === PG_UNIQUE_VIOLATION;
+}
+
+/**
+ * State-machine layer for the `github_app_installations` table. Two
+ * write paths converge here:
+ *
+ *   1. OAuth-callback install (user just installed the App and landed on
+ *      `/auth/github/callback?...&installation_id=...`). The callback
+ *      route fetches the installation metadata from GitHub
+ *      (`services/github-app.fetchInstallation`) then calls
+ *      `upsertInstallationFromMetadata` here.
+ *
+ *   2. Webhook (`installation: created` / `installation: deleted` /
+ *      `installation: suspend` / `installation: unsuspend`). The webhook
+ *      payload already carries the full installation block, so it lands
+ *      directly via `upsertInstallationFromMetadata` /
+ *      `markInstallationSuspended` / `markInstallationUnsuspended` /
+ *      `deleteInstallationByGithubId`.
+ *
+ * Both paths can fire in either order (GitHub delivers them out-of-band
+ * relative to the redirect). UPSERT on `installation_id` lets either
+ * arrive first without producing duplicate rows; the column UNIQUE index
+ * is the dedup mechanism.
+ *
+ * `bindInstallationToOrg` is the second-half of the OAuth-callback flow —
+ * it links a freshly-inserted-or-rebound installation to the user's Hub
+ * team. Idempotent: subsequent sign-ins by the same user re-bind to the
+ * same org via the UNIQUE(hub_organization_id) constraint (a different
+ * user signing in with the same installation_id MUST NOT rebind to their
+ * org, per D2 1:1).
+ */
+
+export type UpsertInstallationInput = {
+  installation: AppInstallation;
+  /**
+   * Optional Hub org id to bind. Used when the install-callback path
+   * already knows the user's primary org at insert time. Webhook path
+   * omits this — webhooks don't know which Hub user installed the App;
+   * the binding is established by the callback path's
+   * `bindInstallationToOrg` instead.
+   */
+  hubOrganizationId?: string;
+};
+
+export type InstallationRow = typeof githubAppInstallations.$inferSelect;
+
+/**
+ * UPSERT by `installation_id`. INSERTs a new row when the installation
+ * is unseen; UPDATEs the metadata fields on re-install / permission
+ * change / event-subscription change.
+ *
+ * Does NOT touch `hub_organization_id` on UPDATE — that column is
+ * managed by `bindInstallationToOrg`. Otherwise a webhook arriving
+ * after a manual rebind could clobber the binding back to null.
+ */
+export async function upsertInstallationFromMetadata(
+  db: Database,
+  input: UpsertInstallationInput,
+): Promise<InstallationRow> {
+  const now = new Date();
+  const suspendedAt = input.installation.suspendedAt ? new Date(input.installation.suspendedAt) : null;
+  const values = {
+    id: uuidv7(),
+    installationId: input.installation.id,
+    accountType: input.installation.accountType,
+    accountLogin: input.installation.accountLogin,
+    accountGithubId: input.installation.accountGithubId,
+    hubOrganizationId: input.hubOrganizationId ?? null,
+    permissions: input.installation.permissions,
+    events: input.installation.events,
+    suspendedAt,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const [row] = await db
+    .insert(githubAppInstallations)
+    .values(values)
+    .onConflictDoUpdate({
+      target: githubAppInstallations.installationId,
+      set: {
+        accountType: values.accountType,
+        accountLogin: values.accountLogin,
+        accountGithubId: values.accountGithubId,
+        permissions: values.permissions,
+        events: values.events,
+        suspendedAt: values.suspendedAt,
+        updatedAt: now,
+        // Deliberately NOT updating `hubOrganizationId` here —
+        // binding is owned by `bindInstallationToOrg`. See jsdoc.
+      },
+    })
+    .returning();
+  if (!row) {
+    throw new Error("upsertInstallationFromMetadata: INSERT returned no row");
+  }
+  return row;
+}
+
+/**
+ * Bind an installation to a Hub team. Idempotent: re-binding to the same
+ * org is a no-op (returns `false`).
+ *
+ * Race-safe (codex P0-3): the previous SELECT-then-UPDATE implementation
+ * had a TOCTOU window — two concurrent callbacks for the same unbound
+ * installation but different Hub orgs could both see `hubOrganizationId
+ * IS NULL`, both pass the in-memory validation, and then the second
+ * UPDATE would silently rebind. This implementation:
+ *
+ *   1. Runs a conditional UPDATE: WHERE installation_id = $1 AND
+ *      (hub_organization_id IS NULL OR hub_organization_id = $2).
+ *      Postgres serializes the rowlock so the second concurrent caller
+ *      sees the freshly-set value and the WHERE clause filters it out
+ *      — the UPDATE matches 0 rows for the loser.
+ *   2. On 0 rows updated, SELECTs the current row to decide which
+ *      structured error to throw (not-found vs. already-bound-elsewhere).
+ *   3. Catches the 23505 path that fires when two ROWS get rebound to
+ *      the SAME hub_organization_id (covers the case where org A
+ *      already has installation X bound and a different callback tries
+ *      to bind installation Y to org A — the UPDATE on Y succeeds the
+ *      WHERE filter but violates UNIQUE(hub_organization_id)).
+ *      Surfaces as a clean ConflictError instead of a 23505 leaking
+ *      through the route layer.
+ *
+ * Throws:
+ *   - NotFoundError if no installation row exists with installationId.
+ *   - ConflictError if (a) the installation is already bound to a
+ *     different Hub team (D2 1:1), or (b) the target Hub team is
+ *     already bound to a different installation.
+ *
+ * Returns true on first bind, false on idempotent re-bind to the same org.
+ */
+export async function bindInstallationToOrg(
+  db: Database,
+  installationId: number,
+  hubOrganizationId: string,
+): Promise<boolean> {
+  // Conditional UPDATE that only matches rows whose hub_organization_id
+  // is either NULL (fresh bind) or already equal to the target
+  // (idempotent re-bind). Two concurrent callbacks for different orgs
+  // will serialize on the row lock — the loser's WHERE clause filters
+  // out the freshly-set value and matches 0 rows.
+  let updatedCount: number;
+  try {
+    const result = await db
+      .update(githubAppInstallations)
+      .set({ hubOrganizationId, updatedAt: new Date() })
+      .where(
+        and(
+          eq(githubAppInstallations.installationId, installationId),
+          or(
+            isNull(githubAppInstallations.hubOrganizationId),
+            eq(githubAppInstallations.hubOrganizationId, hubOrganizationId),
+          ),
+        ),
+      )
+      .returning({ id: githubAppInstallations.id });
+    updatedCount = result.length;
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      // WHERE clause let us through (target was NULL on this row), but
+      // UNIQUE(hub_organization_id) rejected the write because ANOTHER
+      // row is already bound to the target org. This is the H2 codex
+      // scenario: user installs App #Y on a fresh account, tries to
+      // bind it to a Hub org that already has install #X bound.
+      throw new ConflictError(
+        "Hub team is already bound to a different GitHub installation. Uninstall the existing one from GitHub first, or transfer the binding from Settings.",
+      );
+    }
+    throw err;
+  }
+
+  if (updatedCount === 0) {
+    // The UPDATE matched zero rows — either no row exists with that
+    // installation_id, or the row exists but is bound to a DIFFERENT
+    // Hub org (WHERE clause filtered it out). One SELECT to give the
+    // caller a precise error.
+    const [row] = await db
+      .select({ hubOrganizationId: githubAppInstallations.hubOrganizationId })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    if (!row) {
+      throw new NotFoundError(`No installation row for installation_id=${installationId}`);
+    }
+    // row.hubOrganizationId is guaranteed non-null AND not equal to
+    // hubOrganizationId (otherwise the WHERE would have matched).
+    throw new ConflictError(
+      `Installation ${installationId} is already bound to a different Hub team — refusing to rebind (D2 1:1).`,
+    );
+  }
+
+  // The UPDATE succeeded — either a fresh bind (null→target) or an
+  // idempotent re-bind (target→target). The boolean exists for the
+  // existing test that asserts no-op semantics, but the post-UPDATE
+  // row no longer carries the prior value, so we can't tell them
+  // apart without a third query. The contract simplifies to "true on
+  // any successful UPDATE" — tests assert state at the row level
+  // (which is identical in both cases anyway), not on the return.
+  return true;
+}
+
+/**
+ * Webhook handler for `installation: suspend`. Sets `suspended_at` to the
+ * timestamp GitHub put on `installation.suspended_at`.
+ *
+ * Out-of-order safety (codex P1-7): GitHub doesn't guarantee delivery
+ * order and redelivers on failure, so a *stale* `suspend` event could
+ * arrive after a newer one. The conditional UPDATE only writes when the
+ * row is currently unsuspended OR carries an *earlier* `suspended_at` —
+ * a stale re-suspend with an older timestamp is a no-op.
+ *
+ * (Limitation: once an `unsuspend` has cleared `suspended_at` to NULL we
+ * no longer know *when* that happened, so a stale `suspend` arriving after
+ * an `unsuspend` would still re-suspend. Proper handling would need a
+ * dedicated lifecycle-sequence column; in practice suspend/unsuspend are
+ * minutes-apart human actions, well outside any realistic reorder window.)
+ */
+export async function markInstallationSuspended(
+  db: Database,
+  installationId: number,
+  suspendedAt: Date,
+): Promise<void> {
+  await db
+    .update(githubAppInstallations)
+    .set({ suspendedAt, updatedAt: new Date() })
+    .where(
+      and(
+        eq(githubAppInstallations.installationId, installationId),
+        or(isNull(githubAppInstallations.suspendedAt), lt(githubAppInstallations.suspendedAt, suspendedAt)),
+      ),
+    );
+}
+
+/**
+ * Webhook handler for `installation: unsuspend`. Clears `suspended_at`.
+ *
+ * `unsuspendedAt` is the time we received the event (GitHub's `unsuspend`
+ * payload, unlike `suspend`, carries no event timestamp). The conditional
+ * UPDATE only clears when the current `suspended_at` predates that — i.e.
+ * a stale `unsuspend` that lost the race to a newer `suspend` won't undo
+ * it. A row that's already unsuspended (`suspended_at IS NULL`) is left
+ * alone (the `< unsuspendedAt` comparison is NULL → no match), which is
+ * the desired no-op.
+ */
+export async function markInstallationUnsuspended(
+  db: Database,
+  installationId: number,
+  unsuspendedAt: Date,
+): Promise<void> {
+  await db
+    .update(githubAppInstallations)
+    .set({ suspendedAt: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(githubAppInstallations.installationId, installationId),
+        lt(githubAppInstallations.suspendedAt, unsuspendedAt),
+      ),
+    );
+}
+
+/**
+ * Webhook handler for `installation: deleted`. Removes the row outright —
+ * the user uninstalled the App from their account; the row has no value.
+ *
+ * The earlier 60-s `createdAt`-based grace window (added in C.12 codex P1-7
+ * to guard against delayed `deleted` events clobbering fresh re-installs)
+ * was reverted after a post-Phase-C codex challenge flagged a worse bug:
+ * a real install + immediate uninstall (within 60 s) became permanent —
+ * the handler returned a 200 no-op so GitHub never redelivered, and the
+ * Hub-side row lived forever even though the App was gone upstream.
+ *
+ * The original race the grace was meant to solve doesn't actually exist:
+ * GitHub mints a fresh `installation.id` per install, so a delayed
+ * `deleted` for id N cannot wipe a fresh re-install (which has id M ≠ N).
+ * Same-id replays are handled by the `processed_events` dedup table.
+ *
+ * The remaining "stale `created` after `deleted` resurrects the row" risk
+ * is a pre-existing hole in `upsertInstallationFromMetadata` (not
+ * introduced by Phase C). Tracked as a Phase D follow-up — the upsert
+ * path needs a `last_lifecycle_event_at` column or tombstone to be
+ * order-safe.
+ *
+ * Note: deleting the org on the Hub side is the inverse case — handled
+ * by the `ON DELETE SET NULL` FK on `hub_organization_id`, which keeps
+ * the installation row alive so a future rebind can recover.
+ */
+export async function deleteInstallationByGithubId(db: Database, installationId: number): Promise<void> {
+  await db.delete(githubAppInstallations).where(eq(githubAppInstallations.installationId, installationId));
+}
+
+/**
+ * Lookup an installation by GitHub-side id. Used by the webhook router
+ * to resolve `installation.id` → `hub_organization_id` so downstream
+ * event handlers (issues, PRs) know which Hub team the event belongs to.
+ */
+export async function findInstallationByGithubId(
+  db: Database,
+  installationId: number,
+): Promise<InstallationRow | null> {
+  const [row] = await db
+    .select()
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.installationId, installationId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Lookup the installation bound to a Hub team. Used by Settings →
+ * Integrations to render the connected-account panel. Returns null when
+ * no install is bound.
+ *
+ * `LIMIT 1` is belt-and-braces — UNIQUE(hub_organization_id) already
+ * guarantees at most one row.
+ */
+export async function findInstallationByOrg(db: Database, hubOrganizationId: string): Promise<InstallationRow | null> {
+  const [row] = await db
+    .select()
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.hubOrganizationId, hubOrganizationId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * List the installations for a GitHub account that aren't bound to any Hub
+ * team yet. Newest-first.
+ *
+ * The orphan-recovery path (codex P1-5 + H1): if the OAuth callback's
+ * `upsertInstallationFromMetadata` lands but the follow-up
+ * `bindInstallationToOrg` fails (transient DB error, a racing invite that
+ * errors out, …), the row sits unbound forever — GitHub only puts
+ * `installation_id` in the redirect on the *initial* install, so a later
+ * sign-in never re-attempts the bind. On every subsequent sign-in we sweep
+ * for unbound rows whose `accountGithubId` matches the user's own GitHub
+ * account and auto-claim the single one (and surface a manual "Claim
+ * install" button when there are several).
+ */
+export async function findUnboundInstallationsByAccount(
+  db: Database,
+  accountGithubId: number,
+): Promise<InstallationRow[]> {
+  return db
+    .select()
+    .from(githubAppInstallations)
+    .where(
+      and(
+        eq(githubAppInstallations.accountGithubId, accountGithubId),
+        isNull(githubAppInstallations.hubOrganizationId),
+      ),
+    )
+    .orderBy(desc(githubAppInstallations.createdAt));
+}
+
+/**
+ * Belt-and-braces helper for tests / debugging: how many installations
+ * currently bound to this Hub team. Should always be 0 or 1 — anything
+ * higher means the UNIQUE index was somehow violated and the rest of the
+ * system is in undefined territory.
+ */
+export async function countInstallationsForOrg(db: Database, hubOrganizationId: string): Promise<number> {
+  const [row] = await db
+    .select({ c: sql<number>`count(*)::int` })
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.hubOrganizationId, hubOrganizationId));
+  return row?.c ?? 0;
+}

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -111,7 +111,7 @@ export async function upsertInstallationFromMetadata(
 
 /**
  * Bind an installation to a Hub team. Idempotent: re-binding to the same
- * org is a no-op (returns `false`).
+ * org is a no-op at the row level.
  *
  * Race-safe (codex P0-3): the previous SELECT-then-UPDATE implementation
  * had a TOCTOU window — two concurrent callbacks for the same unbound
@@ -140,7 +140,11 @@ export async function upsertInstallationFromMetadata(
  *     different Hub team (D2 1:1), or (b) the target Hub team is
  *     already bound to a different installation.
  *
- * Returns true on first bind, false on idempotent re-bind to the same org.
+ * Returns `true` on any successful UPDATE — fresh bind and idempotent
+ * re-bind both succeed identically and we don't pay the extra SELECT to
+ * tell them apart. The boolean exists for forward-compat with callers
+ * that may want to surface a "freshly bound" log line; today both paths
+ * leave the row in the same state, so the value is advisory.
  */
 export async function bindInstallationToOrg(
   db: Database,

--- a/packages/server/src/services/github-app.ts
+++ b/packages/server/src/services/github-app.ts
@@ -1,0 +1,559 @@
+import { importPKCS8, SignJWT } from "jose";
+import type { GithubProfile } from "./auth-identity.js";
+
+/**
+ * GitHub App service helpers. Two surfaces that ride on top of an App's
+ * private key + OAuth client credentials:
+ *
+ *   App-private-key (server-to-server):
+ *   - `createAppJwt`           — short-lived (≤10min) JWT identifying
+ *                                 Hub-as-this-App to GitHub.
+ *   - `mintInstallationToken`  — exchange the App JWT for a per-installation
+ *                                 token (~1h TTL). Used when Hub acts as the
+ *                                 App on a tenant's repos (Phase 4 identity
+ *                                 convergence — not yet wired into request
+ *                                 paths).
+ *
+ *   App-OAuth (user-to-server, replaces the legacy OAuth App flow):
+ *   - `buildAppAuthorizeUrl`         — the start URL for the combined OAuth
+ *                                       + install flow (design doc D1).
+ *   - `exchangeCodeForAppUserProfile` — callback-side token exchange that
+ *                                       returns the user's profile, the
+ *                                       access + refresh tokens, and their
+ *                                       absolute expiries.
+ *   - `refreshAppUserToken`           — slide an expiring access token by
+ *                                       trading in its refresh token.
+ *
+ * Design context: `docs/github-app-design-zh.md` §3 ("one installation,
+ * three capabilities") + §5.4 ("services/github-app.ts").
+ *
+ * Stateless by construction: no DB / config singletons. Callers thread
+ * credentials in explicitly so the module is trivially safe under
+ * concurrent request handlers.
+ */
+
+const APP_JWT_ALG = "RS256";
+/**
+ * GitHub rejects App JWTs past 10 minutes; we ride 9 minutes so callers
+ * don't trip the upper bound from clock skew. Generous-but-safe — the JWT
+ * is cheap to mint (one RS256 signature) so caching is unnecessary.
+ */
+const APP_JWT_EXPIRY = "9m";
+/**
+ * GitHub allows a small backdated `iat` to absorb clock skew on the
+ * caller's side; the docs recommend 60 seconds. We mirror that.
+ */
+const APP_JWT_IAT_SKEW_SECONDS = 60;
+
+const APP_INSTALLATION_TOKEN_URL = (id: number) => `https://api.github.com/app/installations/${id}/access_tokens`;
+const APP_INSTALLATION_URL = (id: number) => `https://api.github.com/app/installations/${id}`;
+const OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+const USER_API_URL = "https://api.github.com/user";
+const USER_EMAILS_API_URL = "https://api.github.com/user/emails";
+const USER_INSTALLATIONS_API_URL = "https://api.github.com/user/installations";
+
+/**
+ * Errors from any GitHub API call this module makes. Carries the HTTP
+ * status so route layers can disambiguate auth/permission failures (401 /
+ * 403 / 404) from transient upstream errors (5xx / network).
+ *
+ * Distinct from `github-oauth.ts`'s `GithubApiError` because the App API
+ * surface is a different concern (App-private-key vs. OAuth client
+ * credentials) and we want logs / metrics to tell them apart at a glance.
+ */
+export class GithubAppApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GithubAppApiError";
+  }
+}
+
+export type GithubAppCredentials = {
+  /** App ID from the GitHub App's settings page (numeric, but GitHub returns it as a string in some envs). */
+  appId: string;
+  /** RSA private key in PKCS#8 PEM form (`-----BEGIN PRIVATE KEY-----…`). */
+  privateKeyPem: string;
+};
+
+/**
+ * Mint an App JWT. RS256-signed; identifies Hub-as-this-App to GitHub for
+ * the next ~9 minutes. Use this directly for `/app/...` endpoints and as
+ * the input to `mintInstallationToken` for `/installation/...` endpoints.
+ *
+ * The PEM is imported on every call. The cost is negligible (microseconds)
+ * and avoids a global mutable cache — keeps this module trivially safe to
+ * call from parallel request handlers without locking. If profiling ever
+ * shows this is a hotspot, add a per-key memoization at the caller side.
+ */
+export async function createAppJwt(creds: GithubAppCredentials): Promise<string> {
+  const key = await importPKCS8(creds.privateKeyPem, APP_JWT_ALG);
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: APP_JWT_ALG })
+    .setIssuer(creds.appId)
+    .setIssuedAt(now - APP_JWT_IAT_SKEW_SECONDS)
+    .setExpirationTime(APP_JWT_EXPIRY)
+    .sign(key);
+}
+
+/**
+ * Installation metadata as returned by `GET /app/installations/:id`.
+ * Mirrors the `installation` block on webhook payloads (intentional —
+ * the same shape lands in `github_app_installations` whether it was
+ * pulled via this endpoint or pushed by webhook).
+ */
+export type AppInstallation = {
+  id: number;
+  accountType: "User" | "Organization";
+  accountLogin: string;
+  accountGithubId: number;
+  permissions: Record<string, "read" | "write" | "admin">;
+  events: string[];
+  /** ISO-8601 if suspended upstream; null when active. */
+  suspendedAt: string | null;
+};
+
+/**
+ * Fetch the installation metadata. Used by the OAuth callback path to
+ * resolve the bare `installation_id` query param into a full row before
+ * UPSERTing into `github_app_installations` — so the callback doesn't
+ * depend on the `installation: created` webhook arriving first
+ * (delivery order between callback and webhook is not guaranteed).
+ *
+ * The webhook handler skips this call entirely because the payload it
+ * receives already carries the same shape.
+ */
+export async function fetchInstallation(
+  appJwt: string,
+  installationId: number,
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<AppInstallation> {
+  const fetcher = opts.fetcher ?? fetch;
+  const res = await fetcher(APP_INSTALLATION_URL(installationId), {
+    headers: {
+      Authorization: `Bearer ${appJwt}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    throw new GithubAppApiError(res.status, `GitHub App installation fetch failed (${res.status})`);
+  }
+  const body = (await res.json()) as {
+    id: number;
+    account: { id: number; login: string; type: "User" | "Organization" };
+    permissions?: Record<string, "read" | "write" | "admin">;
+    events?: string[];
+    suspended_at?: string | null;
+  };
+  return {
+    id: body.id,
+    accountType: body.account.type,
+    accountLogin: body.account.login,
+    accountGithubId: body.account.id,
+    permissions: body.permissions ?? {},
+    events: body.events ?? [],
+    suspendedAt: body.suspended_at ?? null,
+  };
+}
+
+/**
+ * List the installation IDs the authenticated GitHub user can administer.
+ * Wraps `GET /user/installations` — GitHub's documented "what installs is
+ * this user allowed to touch" endpoint. Covers both User-type installs
+ * (the user owns the personal account) and Organization-type installs
+ * (the user has admin rights on the org).
+ *
+ * Critical security primitive: the OAuth callback uses this to verify
+ * that an `installation_id` query parameter — which arrives over an
+ * insecure channel (the user's browser address bar) — actually belongs
+ * to the authenticated user. Without this check, any signed-in user
+ * could attach an arbitrary installation_id to their callback URL and
+ * bind another team's installation to their own Hub org (installation
+ * IDs are NOT secrets — they appear in webhook URLs, GitHub-side
+ * Settings pages, and the install dialog's post-install redirect).
+ *
+ * Returns the bare ID set so callers can do O(1) membership checks. The
+ * full installation metadata is fetched separately via `fetchInstallation`
+ * once authorization has cleared.
+ */
+export async function listUserAccessibleInstallationIds(
+  userAccessToken: string,
+  opts: { fetcher?: typeof fetch; perPage?: number; maxPages?: number } = {},
+): Promise<Set<number>> {
+  const fetcher = opts.fetcher ?? fetch;
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 5;
+  const out = new Set<number>();
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `${USER_INSTALLATIONS_API_URL}?per_page=${perPage}&page=${page}`;
+    const res = await fetcher(url, {
+      headers: {
+        Authorization: `Bearer ${userAccessToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) {
+      throw new GithubAppApiError(res.status, `GitHub /user/installations failed (${res.status})`);
+    }
+    const body = (await res.json()) as {
+      total_count?: number;
+      installations?: Array<{ id: number }>;
+    };
+    const installs = body.installations ?? [];
+    for (const inst of installs) {
+      if (typeof inst.id === "number") out.add(inst.id);
+    }
+    if (installs.length < perPage) break;
+  }
+  return out;
+}
+
+export type InstallationToken = {
+  /** Opaque server-to-server token. Bearer-style. */
+  token: string;
+  /** ISO-8601, ~1h after issue. Re-mint past this. */
+  expiresAt: string;
+  /** Permissions GitHub actually granted on this installation (may be a subset of what the App declares). */
+  permissions: Record<string, "read" | "write" | "admin">;
+  /** "all" (all repos in the account) | "selected" (subset; webhook payload carries the list). */
+  repositorySelection: "all" | "selected";
+};
+
+/**
+ * Mint a per-installation token (server-to-server). The token is cheap
+ * (one signature + one HTTP round-trip) and the upstream TTL is ~1h, so
+ * the recommended caller pattern is "mint per request" rather than caching
+ * — caching forces the caller to also track expiry, suspended state, and
+ * GitHub-side permission churn, which the design explicitly punts to Phase
+ * 4. We give callers a typed result and let them cache if profiling shows
+ * the round-trip is hot.
+ *
+ * Throws `GithubAppApiError` on non-2xx. 401 means the App JWT is bad or
+ * the App's key has been rotated upstream; 404 means the installation
+ * was uninstalled. Callers SHOULD persist the suspension state when 403
+ * comes back with `suspended` (the design tracks this as `suspended_at`
+ * on `github_app_installations`).
+ */
+export async function mintInstallationToken(
+  appJwt: string,
+  installationId: number,
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<InstallationToken> {
+  const fetcher = opts.fetcher ?? fetch;
+  const res = await fetcher(APP_INSTALLATION_TOKEN_URL(installationId), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${appJwt}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    throw new GithubAppApiError(res.status, `GitHub App installation-token request failed (${res.status})`);
+  }
+  const body = (await res.json()) as {
+    token: string;
+    expires_at: string;
+    permissions?: Record<string, "read" | "write" | "admin">;
+    repository_selection?: "all" | "selected";
+  };
+  return {
+    token: body.token,
+    expiresAt: body.expires_at,
+    permissions: body.permissions ?? {},
+    // GitHub omits `repository_selection` for personal installs where the
+    // distinction is degenerate; default to "all" so downstream code has
+    // one fewer optional to thread through.
+    repositorySelection: body.repository_selection ?? "all",
+  };
+}
+
+export type RefreshedUserToken = {
+  accessToken: string;
+  /** ISO-8601. Typically ~8h after issue. */
+  accessTokenExpiresAt: string;
+  /**
+   * GitHub re-issues a fresh refresh token on every refresh (rotation).
+   * Callers MUST persist this — using the old refresh token after a
+   * successful rotation will fail with `bad_refresh_token`.
+   */
+  refreshToken: string;
+  /** ISO-8601. Typically ~6mo after issue. */
+  refreshTokenExpiresAt: string;
+  /** Granted scopes, comma-joined. Forwarded verbatim from GitHub. */
+  scope: string;
+};
+
+/**
+ * Trade an expiring user-to-server access token for a fresh pair using
+ * its refresh token. Thrown on:
+ *   - Network / 5xx           — `GithubAppApiError(status, …)`
+ *   - 4xx with no JSON body   — `GithubAppApiError(status, …)`
+ *   - 200 with `error` field  — `GithubAppApiError(401, …)` (GitHub returns
+ *     200 OK for an unusable refresh token but signals the error in the
+ *     body; we normalize to 401 so route layers can map to "re-login")
+ *
+ * Designed to be called from the OAuth callback / token-refresh path
+ * landing in PR-C. The caller decrypts the stored refresh token, hands
+ * the plaintext in here, encrypts the returned pair, and writes both
+ * tokens + expiries back to `auth_identities.metadata`.
+ */
+export async function refreshAppUserToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  opts: { fetcher?: typeof fetch; now?: () => Date } = {},
+): Promise<RefreshedUserToken> {
+  const fetcher = opts.fetcher ?? fetch;
+  const now = opts.now ?? (() => new Date());
+  const res = await fetcher(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!res.ok) {
+    throw new GithubAppApiError(res.status, `GitHub user-token refresh failed (${res.status})`);
+  }
+  const body = (await res.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    refresh_token_expires_in?: number;
+    scope?: string;
+    token_type?: string;
+    error?: string;
+    error_description?: string;
+  };
+  if (body.error || !body.access_token || !body.refresh_token) {
+    // GitHub returns 200 OK with `error` / `error_description` when the
+    // refresh token is malformed, expired, or already-rotated. Normalize
+    // to 401 because the caller's only sane response is "re-login".
+    const description = body.error_description ?? body.error ?? "missing access_token / refresh_token";
+    throw new GithubAppApiError(401, `GitHub user-token refresh rejected: ${description}`);
+  }
+  if (typeof body.expires_in !== "number" || typeof body.refresh_token_expires_in !== "number") {
+    // GitHub Apps always include both `*_expires_in` fields in the refresh
+    // response. If one is missing the deployment is misconfigured (e.g.
+    // App still has "Expire user authorization tokens" disabled in the
+    // settings page) — fail loudly rather than persist a row that lies
+    // about when the token expires.
+    throw new GithubAppApiError(
+      500,
+      "GitHub user-token refresh response missing expires_in fields — App likely has user-token expiration disabled",
+    );
+  }
+  const issuedAt = now();
+  const accessExpiresAt = new Date(issuedAt.getTime() + body.expires_in * 1000);
+  const refreshExpiresAt = new Date(issuedAt.getTime() + body.refresh_token_expires_in * 1000);
+  return {
+    accessToken: body.access_token,
+    accessTokenExpiresAt: accessExpiresAt.toISOString(),
+    refreshToken: body.refresh_token,
+    refreshTokenExpiresAt: refreshExpiresAt.toISOString(),
+    scope: body.scope ?? "",
+  };
+}
+
+/**
+ * Build the App's combined OAuth + install authorization URL. Per design
+ * doc D1 ("login → install in one redirect"), this is the SAME endpoint
+ * GitHub uses for both flows when the App has "Request user authorization
+ * (OAuth) during installation" enabled — first install lands the user on
+ * the install dialog → consents → GitHub bounces back to `redirect_uri`
+ * with both `code` (OAuth) and `installation_id` (the new install).
+ * Returning users skip the install dialog and just receive `code`.
+ *
+ * `state` is the signed JWT minted by `oauth-state.ts` — same CSRF defense
+ * as the legacy OAuth flow.
+ *
+ * Permissions are NOT in the URL — the App declares them once in its
+ * GitHub-side settings (design doc D0b) and the install dialog renders
+ * them automatically. Asking again in the URL would let an attacker
+ * craft a downgrade prompt.
+ */
+export function buildAppAuthorizeUrl(opts: { clientId: string; redirectUri: string; state: string }): string {
+  const url = new URL(OAUTH_AUTHORIZE_URL);
+  url.searchParams.set("client_id", opts.clientId);
+  url.searchParams.set("redirect_uri", opts.redirectUri);
+  url.searchParams.set("state", opts.state);
+  url.searchParams.set("allow_signup", "true");
+  return url.toString();
+}
+
+const APP_INSTALL_URL = (slug: string) => `https://github.com/apps/${encodeURIComponent(slug)}/installations/new`;
+
+/**
+ * Build the App's `installations/new` URL — the one that actually surfaces
+ * GitHub's install dialog (repo picker + permission review). Distinct from
+ * `buildAppAuthorizeUrl`:
+ *
+ *   - `authorize` (login URL) → for a user who already has the App
+ *     installed, returns `code`. For one who DOESN'T, it only triggers
+ *     OAuth consent — no install dialog, no `installation_id` ever comes
+ *     back. So "Install on GitHub" CTAs that point at `authorize` silently
+ *     never produce an install (codex P1-1).
+ *   - `installations/new` → always shows the install picker. After the
+ *     user confirms, GitHub redirects to the App's configured callback /
+ *     setup URL with `installation_id` and (because the App has "Request
+ *     user authorization (OAuth) during installation" enabled, D1) also
+ *     `code` + the `state` we threaded through here.
+ *
+ * `state` is the same signed JWT minted by `oauth-state.ts` — GitHub
+ * round-trips it on the post-install redirect, so the callback can verify
+ * CSRF + recover `next` + (codex P1-3) the target org to bind to.
+ */
+export function buildAppInstallUrl(opts: { appSlug: string; state: string }): string {
+  const url = new URL(APP_INSTALL_URL(opts.appSlug));
+  url.searchParams.set("state", opts.state);
+  return url.toString();
+}
+
+export type ExchangeAppCodeResult = {
+  profile: GithubProfile;
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+  scope: string;
+  /**
+   * Forwarded from the callback `installation_id` query param, NOT from
+   * the token response. GitHub puts it in the redirect URL when the user
+   * just installed the App; returning users (who already had the App
+   * installed) won't carry it. Caller is responsible for plumbing this
+   * through alongside the exchanged code.
+   */
+  installationId: number | null;
+};
+
+/**
+ * App-flavoured `exchangeCodeForProfile`: trade the callback `code` for
+ * the user's profile + a full token pair (access + refresh + expiries).
+ *
+ * Why this exists alongside `github-oauth.ts.exchangeCodeForProfile`:
+ *   - Same endpoint (`/login/oauth/access_token`) but with App
+ *     client_id/secret instead of OAuth App credentials.
+ *   - Response carries `refresh_token` + `expires_in` +
+ *     `refresh_token_expires_in` (8h / 6mo TTLs) that the OAuth-only
+ *     version doesn't return.
+ *   - The token-rotation semantics (`refresh_token` will be reissued on
+ *     every refresh) mean the caller MUST persist all four fields, not
+ *     just `accessToken`.
+ *
+ * The OAuth-only helper stays put for the brief window between this
+ * commit and the OAuth-flow rewrite; D3 cutover deletes it outright.
+ */
+export async function exchangeCodeForAppUserProfile(
+  opts: {
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    redirectUri: string;
+    installationId: number | null;
+  },
+  callOpts: { fetcher?: typeof fetch; now?: () => Date } = {},
+): Promise<ExchangeAppCodeResult> {
+  const fetcher = callOpts.fetcher ?? fetch;
+  const now = callOpts.now ?? (() => new Date());
+
+  const tokenRes = await fetcher(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      code: opts.code,
+      redirect_uri: opts.redirectUri,
+    }),
+  });
+  if (!tokenRes.ok) {
+    throw new GithubAppApiError(tokenRes.status, `GitHub App user-token exchange failed (${tokenRes.status})`);
+  }
+  const body = (await tokenRes.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    refresh_token_expires_in?: number;
+    scope?: string;
+    token_type?: string;
+    error?: string;
+    error_description?: string;
+  };
+  if (body.error || !body.access_token || !body.refresh_token) {
+    // Same 200-with-error convention as `refreshAppUserToken` — normalize
+    // to 401 so route layer maps to "re-login / re-consent".
+    const description = body.error_description ?? body.error ?? "missing access_token / refresh_token";
+    throw new GithubAppApiError(401, `GitHub App user-token exchange rejected: ${description}`);
+  }
+  if (typeof body.expires_in !== "number" || typeof body.refresh_token_expires_in !== "number") {
+    // App MUST have "Expire user authorization tokens" enabled in its
+    // settings page — otherwise we'd persist a row that lies about its
+    // TTL. Fail loud rather than silently downgrade to "never expires".
+    throw new GithubAppApiError(
+      500,
+      "GitHub App user-token exchange missing expires_in — App must have user-token expiration enabled",
+    );
+  }
+  const issuedAt = now();
+  const accessExpiresAt = new Date(issuedAt.getTime() + body.expires_in * 1000);
+  const refreshExpiresAt = new Date(issuedAt.getTime() + body.refresh_token_expires_in * 1000);
+
+  // Fetch profile via `/user`; fall back to `/user/emails` when GitHub
+  // hides the primary email on the public profile (private-email setting).
+  // Mirrors `github-oauth.ts.exchangeCodeForProfile`; the legacy helper
+  // stays put until D3 cutover deletes it.
+  const userRes = await fetcher(USER_API_URL, {
+    headers: { Authorization: `Bearer ${body.access_token}`, Accept: "application/vnd.github+json" },
+  });
+  if (!userRes.ok) {
+    throw new GithubAppApiError(userRes.status, `GitHub /user fetch failed (${userRes.status})`);
+  }
+  const user = (await userRes.json()) as {
+    id: number;
+    login: string;
+    name?: string | null;
+    email?: string | null;
+    avatar_url?: string | null;
+  };
+
+  let email = user.email ?? null;
+  if (!email) {
+    const emailsRes = await fetcher(USER_EMAILS_API_URL, {
+      headers: { Authorization: `Bearer ${body.access_token}`, Accept: "application/vnd.github+json" },
+    });
+    if (emailsRes.ok) {
+      const emails = (await emailsRes.json()) as Array<{ email: string; primary: boolean; verified: boolean }>;
+      const primary = emails.find((e) => e.primary && e.verified) ?? emails.find((e) => e.verified);
+      email = primary?.email ?? null;
+    }
+  }
+
+  return {
+    profile: {
+      githubId: String(user.id),
+      login: user.login,
+      email,
+      displayName: user.name ?? null,
+      avatarUrl: user.avatar_url ?? null,
+    },
+    accessToken: body.access_token,
+    accessTokenExpiresAt: accessExpiresAt.toISOString(),
+    refreshToken: body.refresh_token,
+    refreshTokenExpiresAt: refreshExpiresAt.toISOString(),
+    scope: body.scope ?? "",
+    installationId: opts.installationId,
+  };
+}

--- a/packages/server/src/services/oauth-state.ts
+++ b/packages/server/src/services/oauth-state.ts
@@ -28,16 +28,37 @@ type StatePayload = {
   nonce: string;
   /** Pre-validated relative path the SPA navigates to after consuming the fragment. */
   next: string;
+  /**
+   * Hub org the resulting GitHub App installation should bind to. Set when
+   * the flow was kicked off from an org's Settings → GitHub panel (codex
+   * P1-3) — without it the callback would bind to the user's *primary*
+   * org, which is wrong when an admin of org B installs the App. Absent on
+   * the plain `/auth/github/start` sign-in flow.
+   */
+  targetOrganizationId?: string;
+};
+
+export type SignOAuthStateOptions = {
+  /** See `StatePayload.targetOrganizationId`. */
+  targetOrganizationId?: string;
 };
 
 /**
  * Sign a fresh state token + return the matching cookie nonce. Caller is
  * responsible for setting the cookie (HttpOnly + Secure in prod).
  */
-export async function signOAuthState(jwtSecret: string, next: string): Promise<{ token: string; nonce: string }> {
+export async function signOAuthState(
+  jwtSecret: string,
+  next: string,
+  opts: SignOAuthStateOptions = {},
+): Promise<{ token: string; nonce: string }> {
   const nonce = randomBytes(NONCE_BYTES).toString("base64url");
   const secret = new TextEncoder().encode(jwtSecret);
-  const token = await new SignJWT({ nonce, next })
+  const claims: StatePayload = { nonce, next };
+  if (opts.targetOrganizationId) {
+    claims.targetOrganizationId = opts.targetOrganizationId;
+  }
+  const token = await new SignJWT({ ...claims })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime(STATE_EXPIRY)
@@ -59,7 +80,7 @@ export async function verifyOAuthState(
   jwtSecret: string,
   token: string,
   cookieNonce: string | null,
-): Promise<{ next: string }> {
+): Promise<{ next: string; targetOrganizationId?: string }> {
   const secret = new TextEncoder().encode(jwtSecret);
   let payload: StatePayload;
   try {
@@ -72,10 +93,16 @@ export async function verifyOAuthState(
   if (typeof payload.nonce !== "string" || typeof payload.next !== "string") {
     throw new Error("OAuth state payload malformed");
   }
+  if (payload.targetOrganizationId !== undefined && typeof payload.targetOrganizationId !== "string") {
+    throw new Error("OAuth state payload malformed");
+  }
 
   if (!cookieNonce || cookieNonce !== payload.nonce) {
     throw new Error("OAuth state nonce / cookie mismatch");
   }
 
-  return { next: payload.next };
+  return {
+    next: payload.next,
+    ...(payload.targetOrganizationId ? { targetOrganizationId: payload.targetOrganizationId } : {}),
+  };
 }

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -84,6 +84,10 @@ export const serverConfigSchema = defineConfig({
      * shape (only one of clientId/clientSecret set) is rejected at boot so a
      * misconfigured production instance can't accidentally expose the
      * dev-callback bypass with no real OAuth wired up.
+     *
+     * NOTE (PR-A of GitHub App split): the legacy OAuth client coexists with
+     * the new GitHub App block during the transition. PR-B removes this block
+     * and all callers as part of the D3 hard cut.
      */
     github: optional({
       clientId: field(z.string(), { env: "FIRST_TREE_HUB_GITHUB_OAUTH_CLIENT_ID" }),
@@ -91,6 +95,66 @@ export const serverConfigSchema = defineConfig({
         env: "FIRST_TREE_HUB_GITHUB_OAUTH_CLIENT_SECRET",
         secret: true,
       }),
+    }),
+    /**
+     * GitHub App credentials — new sign-in surface introduced in PR-A of the
+     * GitHub App split. Wired into actual sign-in / webhook routes by PR-B/PR-C.
+     * Until then this block is read at boot (so misconfig is caught early) but
+     * not consumed by any user-facing flow. See design doc
+     * `docs/github-app-design-zh.md` §5.2. A single App installation
+     * simultaneously unlocks user-OAuth, the webhook stream, and
+     * installation-token minting (§3). All five fields are required
+     * together; partial configuration is rejected at boot for the same
+     * reason as the legacy block — a half-wired App is worse than no App.
+     *
+     * Dev / staging / prod each have a separate App with its own set of
+     * values; the env file selects which to load.
+     *
+     * `privateKeyPem` is the raw PKCS#8 PEM (multi-line, starts with
+     * `-----BEGIN PRIVATE KEY-----`). Self-hosters typically inline it via
+     * a `.env` file with `\n` escapes; SaaS operators should source it
+     * from their secret manager (design doc §6 risk 4 — pending
+     * team-wide pattern).
+     */
+    // `.min(1)` on every field: blank env values (empty string env
+    // sets that resolve to `""` after substitution) must NOT make the
+    // block resolve to a truthy object. The HMAC-empty-key forgery
+    // path codex flagged (P1-8) trips exactly when `webhookSecret`
+    // sneaks through as `""` — `createHmac("sha256", "")` is a valid
+    // hash any attacker can reproduce. Same defense applies to all
+    // five fields: empty appId would make App JWTs unverifiable
+    // upstream, empty clientId would let GitHub round-trip an
+    // anonymous OAuth, etc. Fail loud at Zod parse time.
+    githubApp: optional({
+      appId: field(z.string().min(1), { env: "FIRST_TREE_HUB_GITHUB_APP_ID" }),
+      clientId: field(z.string().min(1), { env: "FIRST_TREE_HUB_GITHUB_APP_CLIENT_ID" }),
+      clientSecret: field(z.string().min(1), {
+        env: "FIRST_TREE_HUB_GITHUB_APP_CLIENT_SECRET",
+        secret: true,
+      }),
+      privateKeyPem: field(z.string().min(1), {
+        env: "FIRST_TREE_HUB_GITHUB_APP_PRIVATE_KEY",
+        secret: true,
+      }),
+      webhookSecret: field(z.string().min(1), {
+        env: "FIRST_TREE_HUB_GITHUB_APP_WEBHOOK_SECRET",
+        secret: true,
+      }),
+      /**
+       * The App's URL slug — the last path segment of
+       * `https://github.com/apps/<slug>`. Used to build the
+       * `installations/new` URL that surfaces GitHub's install dialog
+       * (the OAuth `authorize` URL only triggers consent, never the
+       * install picker, for users who haven't installed the App yet —
+       * codex P1-1).
+       *
+       * Optional *within* the App block (unlike the five fields above):
+       * the rest of the App surface — sign-in, webhook verification,
+       * installation-token minting — works without it. Only the
+       * "Install on GitHub" CTA in Settings needs the slug, and that
+       * endpoint returns 503 when it's unset rather than blocking boot.
+       */
+      slug: field(z.string().min(1).optional(), { env: "FIRST_TREE_HUB_GITHUB_APP_SLUG" }),
     }),
   }),
   cors: optional({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -209,6 +209,24 @@ export {
   contextTreeUpdateSchema,
 } from "./schemas/context-tree.js";
 export {
+  GITHUB_ACCOUNT_TYPES,
+  GITHUB_PERMISSION_LEVELS,
+  type GithubAccountType,
+  type GithubAppInstallationClaimBody,
+  type GithubAppInstallationEvents,
+  type GithubAppInstallationOutput,
+  type GithubAppInstallationPermissions,
+  type GithubAppUserTokenMetadata,
+  type GithubPermissionLevel,
+  githubAccountTypeSchema,
+  githubAppInstallationClaimBodySchema,
+  githubAppInstallationEventsSchema,
+  githubAppInstallationOutputSchema,
+  githubAppInstallationPermissionsSchema,
+  githubAppUserTokenMetadataSchema,
+  githubPermissionLevelSchema,
+} from "./schemas/github-app.js";
+export {
   IMAGE_MIME_TO_EXT,
   type ImageInlineContent,
   type ImagePayloadFrame,

--- a/packages/shared/src/schemas/github-app.ts
+++ b/packages/shared/src/schemas/github-app.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+/**
+ * GitHub App installation — schemas shared between server and web.
+ *
+ * Background: Hub is migrating from a per-repo OAuth + webhook model to a
+ * GitHub App installation model. Each Hub team binds 1:1 to a single GitHub
+ * account (User or Organization). The binding row lives in
+ * `github_app_installations`; this file owns the public-facing Zod shapes
+ * (account type, permissions, output DTO) so server and web agree on the
+ * wire format without duplicating literals.
+ *
+ * See `docs/github-app-design-zh.md` (decisions D0a / D0b / D1 / D2 / D3 / D4)
+ * for the rationale.
+ */
+
+/**
+ * GitHub installation account kinds.
+ *   - "User" — personal-account install. `members` sync is a no-op or
+ *     only-owner; see design doc §6 risk 1.
+ *   - "Organization" — org-account install. Eligible for full
+ *     identity-convergence (Phase 4).
+ *
+ * Mirrors the `installation.account.type` field on GitHub webhook payloads.
+ */
+export const GITHUB_ACCOUNT_TYPES = ["User", "Organization"] as const;
+export const githubAccountTypeSchema = z.enum(GITHUB_ACCOUNT_TYPES);
+export type GithubAccountType = z.infer<typeof githubAccountTypeSchema>;
+
+/**
+ * Permission levels GitHub grants per resource.
+ *   "read"  — pull permission only
+ *   "write" — pull + push (write implies read in GitHub's model)
+ *   "admin" — full administrative control (rarely required)
+ *
+ * Mirrors the value side of `installation.permissions` on webhook payloads.
+ */
+export const GITHUB_PERMISSION_LEVELS = ["read", "write", "admin"] as const;
+export const githubPermissionLevelSchema = z.enum(GITHUB_PERMISSION_LEVELS);
+export type GithubPermissionLevel = z.infer<typeof githubPermissionLevelSchema>;
+
+/**
+ * `installation.permissions` blob from GitHub. Key is the permission name
+ * (`contents`, `pull_requests`, `issues`, `members`, …) — we keep this as a
+ * free-form `z.record` because GitHub adds new permission keys over time
+ * and we don't want a Hub-side `app_id` upgrade just to surface a new key
+ * in the integrations panel.
+ */
+export const githubAppInstallationPermissionsSchema = z.record(z.string(), githubPermissionLevelSchema);
+export type GithubAppInstallationPermissions = z.infer<typeof githubAppInstallationPermissionsSchema>;
+
+/**
+ * Subscribed event-name list, e.g. `["issues", "pull_request", "push"]`.
+ * Free-form for the same forward-compat reason as `permissions`.
+ */
+export const githubAppInstallationEventsSchema = z.array(z.string());
+export type GithubAppInstallationEvents = z.infer<typeof githubAppInstallationEventsSchema>;
+
+/**
+ * `auth_identities.metadata` shape for GitHub App user-to-server tokens.
+ *
+ * Pre-App (legacy OAuth) rows have only `accessToken` (encrypted OAuth
+ * token, never-expires). After the App switch:
+ *   - `accessToken`        — encrypted user-to-server token, ~8h TTL
+ *   - `accessTokenExpiresAt` — ISO-8601, used to decide pre-emptive refresh
+ *   - `refreshToken`       — encrypted refresh token, ~6mo TTL
+ *   - `refreshTokenExpiresAt` — ISO-8601; once past, force re-login
+ *   - `login`              — GitHub login snapshot (already present pre-App)
+ *
+ * Rows may temporarily be in the legacy shape (no expiry fields) until the
+ * user re-OAuths through the App. Service code MUST tolerate both shapes
+ * and treat absence of expiry fields as "still on legacy OAuth token".
+ *
+ * The token strings themselves are AES-256-GCM ciphertext — same pattern as
+ * `adapter_configs` / `organization_settings.github_integration`. Plaintext
+ * never touches the row.
+ */
+export const githubAppUserTokenMetadataSchema = z.object({
+  login: z.string().optional(),
+  /** AES-256-GCM ciphertext via crypto.ts.encryptValue. */
+  accessToken: z.string().optional(),
+  /** ISO-8601. Absent on legacy non-App tokens. */
+  accessTokenExpiresAt: z.string().datetime({ offset: true }).optional(),
+  /** AES-256-GCM ciphertext via crypto.ts.encryptValue. */
+  refreshToken: z.string().optional(),
+  /** ISO-8601. Absent on legacy non-App tokens. */
+  refreshTokenExpiresAt: z.string().datetime({ offset: true }).optional(),
+});
+export type GithubAppUserTokenMetadata = z.infer<typeof githubAppUserTokenMetadataSchema>;
+
+/**
+ * GET-side projection returned by the Hub admin API for the Integrations
+ * panel. Secrets are never echoed — only the metadata needed to render
+ * "you're connected as @octocat (Organization), 7 repos selected".
+ *
+ * `selectedRepoCount` is derived from a separate join (App webhook
+ * `installation_repositories` events update a children table not modeled
+ * here yet); included now so the panel's API shape is stable from the
+ * first ship.
+ */
+/**
+ * Body for `POST /orgs/:orgId/github-app-installation/claim` — manual
+ * recovery for an installation row that ended up unbound (codex P1-5 + H1).
+ * The orphan-reclaim sweep at sign-in auto-claims the single-orphan case;
+ * this endpoint backs the Settings "Claim install" buttons when there's
+ * more than one (or the account is an org, where auto-claim is too risky).
+ */
+export const githubAppInstallationClaimBodySchema = z.object({
+  installationId: z.number().int().positive(),
+});
+export type GithubAppInstallationClaimBody = z.infer<typeof githubAppInstallationClaimBodySchema>;
+
+export const githubAppInstallationOutputSchema = z.object({
+  installationId: z.number().int().positive(),
+  accountType: githubAccountTypeSchema,
+  accountLogin: z.string(),
+  accountGithubId: z.number().int().positive(),
+  permissions: githubAppInstallationPermissionsSchema,
+  events: githubAppInstallationEventsSchema,
+  suspended: z.boolean(),
+  /**
+   * GitHub-side management URL for this installation, e.g.
+   * `https://github.com/settings/installations/123` (User) or
+   * `https://github.com/organizations/<login>/settings/installations/123`
+   * (Organization). Server resolves the right form by `accountType`.
+   */
+  manageUrl: z.string().url(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type GithubAppInstallationOutput = z.infer<typeof githubAppInstallationOutputSchema>;


### PR DESCRIPTION
## Summary

**First of 3 PRs splitting the original PR #300** (GitHub App migration). This PR is the foundation — all schema, service primitives, and config infrastructure that PR-2 (OAuth + Settings UI) and PR-3 (webhook + D3 hard cut) build on. **NO user-facing behavior changes.** New tables / services are added but no route consumes them yet.

See [docs/pr-300-as-built-design.md](docs/pr-300-as-built-design.md) for the full architectural review of the combined work, and [docs/pr-300-split-plan.md](docs/pr-300-split-plan.md) for the rationale of this 3-way split (was originally proposed as 4-way; merged Settings UI into PR-2 because of OAuth dependency).

## What lands

### Schema
- `packages/server/drizzle/0037_github_app_installations.sql` — new table for one-row-per-(GitHub-account ↔ Hub-team) binding
- `packages/server/src/db/schema/github-app-installations.ts` — Drizzle types
- Exported from `db/schema/index.ts` so drizzle-kit + `db.query.*` see it

### Service primitives
- `services/github-app.ts` — App JWT (RS256), installation token, user token refresh (8h TTL)
- `services/github-app-installations.ts` — state machine: upsert / find / bind / suspend / unsuspend / delete + orphan-reclaim helper
- `services/oauth-state.ts` — extended with `targetOrganizationId` field in the signed state JWT (codex P1-3)

### Config
- `oauth.githubApp` block in `shared/config/server-config.ts` — 6 fields: appId, clientId, clientSecret, privateKeyPem, webhookSecret, slug. All required except `slug` (only the install URL CTA needs it).
- Legacy `oauth.github` block intact — PR-2 removes as part of D3 hard cut.

### Boot guard
- `server/boot-guards.ts:assertBootConfigValid` — validates PEM header (PKCS#8), rejects half-config + blank webhookSecret (codex P1-8). **Wired into `buildApp` so it actually runs at startup.**

### DTOs
- `shared/schemas/github-app.ts` — Zod schemas for installation output, claim body, account types, permission levels.

## Codex hardening already included

The original PR-300 picked up these codex fixes; they're carried forward:

- **P0-3 + H2** race-safe `bindInstallationToOrg` + `ConflictError` on collisions
- **P1-8** boot guards in `buildApp` + `.min(1)` on every App secret field
- **P1-7** suspend/unsuspend timestamp guards
- **P1-3** `targetOrganizationId` in signed state JWT
- **P1-5 + H1** `findUnboundInstallationsByAccount` helper for orphan reclaim
- Codex challenge follow-up: deleted the 60-s grace window in `deleteInstallationByGithubId`

## Codex post-rollup review pass

Ran `codex review --base origin/main` against this branch. Result: **GATE: PASS** — 2 [P2]'s found and **fixed**:
1. Boot guard not invoked anywhere — fixed by calling `assertBootConfigValid(config)` from `buildApp`
2. New table missing from `db/schema/index.ts` barrel — fixed

No [P0] / [P1] introduced.

## Verification

- [x] `pnpm check` (Biome) — clean (647 files)
- [x] `pnpm typecheck` — 9 packages clean
- [x] `pnpm --filter @first-tree-hub/server test` — **794/794 pass** (testcontainers PG)
- [x] Migration `0037` smoke-tested via test suite's template DB

## What's NOT here (in PR-2 / PR-3)

- `/auth/github/start` + `/callback` rewrite → PR-2
- Admin API endpoints (`/orgs/:orgId/github-app-installation/*`) → PR-2
- Web Settings panel → PR-2
- D3 cut: legacy OAuth client + per-org webhook + `github_integration` namespace deletion → PR-2 + PR-3
- `/api/v1/webhooks/github` App endpoint → PR-3
- Migration `0038_drop_github_integration_namespace.sql` → PR-3

## Risk

🟢 **Low**. New tables + services with no callers. Boot guard runs at startup but is a no-op when the App env block is unset. Legacy OAuth client + per-org webhook still work unchanged.

## Stacked PR sequence

This PR → **PR-2** (OAuth + Settings UI) → **PR-3** (Webhook + D3 cut)

Closes part of #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)