### PR TITLE
feat(web): pin "Your agents" first on Team tab + polish dialog & columns

### DIFF
--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -694,6 +694,14 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
             the surrounding form stays put. Empty `0 computers` and N-radio
             states can still grow taller — that's fine, the jump is only
             from the *initial detection* states which were the visible bug.
+
+            `minHeight: 168` is hand-calibrated to the steady-state height
+            of `SingleComputerCard` (border + 2-line content + p-3) plus
+            the `<Label>` + a single-line "Powered by" + a runtime chip
+            row. KEEP IN SYNC with `SingleComputerCard` /
+            `ComputerCardSkeleton` / `RuntimeChipsSkeleton` below — if any
+            of those grows or shrinks its padding / line count, the value
+            here must move with it or the dialog will jump again.
           */}
           <div className="space-y-3" style={{ minHeight: 168 }}>
             <Label>Where it runs</Label>
@@ -850,6 +858,13 @@ function ZeroComputerBlock({
  * Single-computer card. Used in the common case where the user only has
  * one computer connected — no radio, just a visual confirmation of where
  * the agent will live.
+ *
+ * Layout note: the "Where it runs" wrapper above reserves a `minHeight`
+ * calibrated to this card's steady-state dimensions plus the runtime
+ * chip row, so the dialog doesn't jump during async load. If you change
+ * this card's padding, border, or line count, also revisit `minHeight`
+ * in the wrapper (and `ComputerCardSkeleton` / `RuntimeChipsSkeleton`
+ * below, which mirror this card's dimensions).
  */
 function SingleComputerCard({ client }: { client: HubClient | undefined }) {
   if (!client) return null;

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -148,7 +148,13 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const [displayName, setDisplayName] = useState("");
   const [name, setName] = useState("");
   const [nameDirty, setNameDirty] = useState(false);
-  const [visibility, setVisibility] = useState<AgentVisibility>("organization");
+  // Default is "private": the surfaced agent type is `personal_assistant`
+  // (literally "personal"), so the conservative default is "only I see it".
+  // Sharing with the team is an explicit decision the user opts into; the
+  // previous default ("organization") quietly published every onboarding
+  // agent into the team roster, which surprised users who expected
+  // personal-assistant to mean personal.
+  const [visibility, setVisibility] = useState<AgentVisibility>("private");
   const [runtime, setRuntime] = useState<RuntimeProvider>("claude-code");
   // The @handle editor is collapsed by default — 99% of users keep the
   // auto-derived slug. The preview line under "Display name" surfaces it
@@ -182,7 +188,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
       setDisplayName("");
       setName("");
       setNameDirty(false);
-      setVisibility("organization");
+      setVisibility("private");
       setRuntime("claude-code");
       setEditingHandle(false);
       setConnectedClients([]);
@@ -649,7 +655,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                 <div>
                   <div className="text-body font-medium">Shared with team</div>
                   <div className="text-caption text-muted-foreground">
-                    Anyone in your org can @mention and chat with this agent. (default)
+                    Anyone in your org can @mention and chat with this agent.
                   </div>
                 </div>
               </label>
@@ -670,20 +676,32 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                 <div>
                   <div className="text-body font-medium">Private to you</div>
                   <div className="text-caption text-muted-foreground">
-                    Only you can see this agent and chat with it. Others on the team won't see it listed.
+                    Only you can see this agent and chat with it. Others on the team won't see it listed. (default)
                   </div>
                 </div>
               </label>
             </div>
           </div>
 
-          <div className="space-y-3">
+          {/*
+            "Where it runs" block. Reserves a stable minHeight so the dialog
+            doesn't visibly jump as async data (listClients → capabilities)
+            streams in. Three asynchronous loads used to swap a short
+            placeholder paragraph for a tall card, shifting the modal's
+            vertical center on every state transition. The reserved space
+            below covers the common single-computer + runtime-chip case
+            so loading skeletons render *inside* a stable box and
+            the surrounding form stays put. Empty `0 computers` and N-radio
+            states can still grow taller — that's fine, the jump is only
+            from the *initial detection* states which were the visible bug.
+          */}
+          <div className="space-y-3" style={{ minHeight: 168 }}>
             <Label>Where it runs</Label>
 
             {/* Computer picker. 0 / 1 / N branches keep the most common
                 case (1 connected computer) free of radio-button noise. */}
             {!clientsLoaded ? (
-              <p className="text-caption text-muted-foreground">Detecting connected computers…</p>
+              <ComputerCardSkeleton label="Detecting connected computers…" />
             ) : connectedClients.length === 0 ? (
               <ZeroComputerBlock
                 command={connectCommand}
@@ -729,13 +747,17 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
               </div>
             )}
 
-            {/* Runtime row — only when a computer is picked. The provider
-                list is filtered to whatever reports `ok` on that machine. */}
-            {pickedClientId && (
+            {/* Runtime row. Renders *whenever* a computer is picked OR while
+                we're still detecting computers — keeping a stable "Powered
+                by" slot below the computer card prevents the second jump
+                (skeleton paragraph being replaced by the runtime chip row).
+                Only the inner content swaps; the section header and a
+                skeleton chip row hold the space. */}
+            {(pickedClientId || !clientsLoaded) && (
               <div className="space-y-1.5">
                 <div className="text-caption text-muted-foreground">Powered by</div>
-                {activeCapabilities === null ? (
-                  <p className="text-caption text-muted-foreground">Detecting installed runtimes…</p>
+                {!pickedClientId || activeCapabilities === null ? (
+                  <RuntimeChipsSkeleton />
                 ) : okRuntimes.length === 0 ? (
                   <p className="text-caption text-destructive">
                     No runtime ready on this computer. Install Claude Code or Codex on it (and sign in), then come back.
@@ -837,6 +859,49 @@ function SingleComputerCard({ client }: { client: HubClient | undefined }) {
       <div className="text-caption text-muted-foreground">
         {client.os ?? "unknown OS"} · last seen {new Date(client.lastSeenAt).toLocaleString()}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder that mirrors `SingleComputerCard`'s dimensions
+ * (border + 2-line content + same padding) so the surrounding form keeps
+ * a stable height while `listClients` is in flight. The previous
+ * placeholder was a single-line paragraph, which is what made the dialog
+ * visibly jump when the real card replaced it.
+ */
+function ComputerCardSkeleton({ label }: { label: string }) {
+  return (
+    <div
+      className="rounded-md border border-border bg-muted/20 p-3"
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
+      <div className="text-body font-medium" style={{ color: "var(--fg-3)" }}>
+        {label}
+      </div>
+      <div className="text-caption text-muted-foreground">Looking for a machine running the Hub client…</div>
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder for the runtime chip row. A single greyed chip-shaped
+ * box reserves the height the real chips will occupy. Pairs with
+ * `ComputerCardSkeleton` so the whole "Where it runs" block reaches its
+ * steady-state height on first paint — no second jump when capabilities
+ * resolve.
+ */
+function RuntimeChipsSkeleton() {
+  return (
+    <div className="flex flex-wrap gap-2" role="status" aria-live="polite" aria-label="Detecting installed runtimes">
+      <span
+        className="inline-flex items-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-body"
+        style={{ color: "var(--fg-4)" }}
+      >
+        Detecting installed runtimes…
+      </span>
     </div>
   );
 }

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -73,8 +73,8 @@ describe("Team page grouping", () => {
           createdAt: "2026-01-01T00:00:00.000Z",
         },
       ],
-      sharedAgents: [],
-      yourPrivateAgents: [],
+      yourAgents: [],
+      teamAgents: [],
       otherPrivateAgents: [],
       resolveMember: (id) => id,
       agentByUuid: new Map([
@@ -84,10 +84,156 @@ describe("Team page grouping", () => {
       openDelegate: () => {},
     });
 
-    const row = groups[0]?.rows[0];
-    if (row?.kind !== "human") throw new Error("expected first row to be human");
+    // "Your agents" renders first (even when empty); humans is the second
+    // group. Locate it by key rather than positional indexing so the test
+    // doesn't rot if section order changes again.
+    const humansGroup = groups.find((g) => g.key === "humans");
+    if (!humansGroup) throw new Error("expected a humans group");
+    const row = humansGroup.rows[0];
+    if (row?.kind !== "human") throw new Error("expected first humans row to be human");
     expect(row.delegate).toEqual({ name: "ada-helper", displayName: "Ada Assistant" });
     expect(row.canEditDelegate).toBe(true);
+  });
+
+  it("places Your agents section first and partitions agents by manager", () => {
+    const myShared = agent({
+      uuid: "my-shared",
+      type: "personal_assistant",
+      displayName: "My Shared Bot",
+      visibility: "organization",
+      managerId: "member-1",
+    });
+    const myPrivate = agent({
+      uuid: "my-private",
+      type: "personal_assistant",
+      displayName: "My Private Bot",
+      visibility: "private",
+      managerId: "member-1",
+    });
+    const theirShared = agent({
+      uuid: "their-shared",
+      type: "personal_assistant",
+      displayName: "Their Shared Bot",
+      visibility: "organization",
+      managerId: "member-2",
+    });
+    const groups = buildGroups({
+      filter: "all",
+      search: "",
+      isAdmin: false,
+      selfMemberId: "member-1",
+      members: [],
+      yourAgents: [myShared, myPrivate],
+      teamAgents: [theirShared],
+      otherPrivateAgents: [],
+      resolveMember: (id) => id,
+      agentByUuid: new Map(),
+      openDelegate: () => {},
+    });
+
+    expect(groups.map((g) => g.key)).toEqual(["yours", "humans", "team"]);
+    const yoursGroup = groups[0];
+    if (!yoursGroup) throw new Error("expected yours group");
+    expect(yoursGroup.title).toBe("Your agents");
+    expect(yoursGroup.count).toBe(2);
+    // Private agents sort to the top of Your agents — governance attention
+    // belongs on the sensitive rows.
+    const yoursFirst = yoursGroup.rows[0];
+    if (yoursFirst?.kind !== "agent") throw new Error("expected agent row");
+    expect(yoursFirst.agent.uuid).toBe("my-private");
+    expect(yoursFirst.showVisibilityChip).toBe(true);
+
+    const teamGroup = groups.find((g) => g.key === "team");
+    if (!teamGroup) throw new Error("expected team group");
+    expect(teamGroup.count).toBe(1);
+    const teamFirst = teamGroup.rows[0];
+    if (teamFirst?.kind !== "agent") throw new Error("expected agent row");
+    // Homogeneous section — no per-row visibility chip needed.
+    expect(teamFirst.showVisibilityChip).toBe(false);
+  });
+
+  it("shows Other members' private agents collapsibly for admins only", () => {
+    const theirPrivate = agent({
+      uuid: "their-private",
+      type: "personal_assistant",
+      displayName: "Their Private Bot",
+      visibility: "private",
+      managerId: "member-2",
+    });
+
+    const memberView = buildGroups({
+      filter: "all",
+      search: "",
+      isAdmin: false,
+      selfMemberId: "member-1",
+      members: [],
+      yourAgents: [],
+      teamAgents: [],
+      otherPrivateAgents: [theirPrivate],
+      resolveMember: (id) => id,
+      agentByUuid: new Map(),
+      openDelegate: () => {},
+    });
+    expect(memberView.find((g) => g.key === "other-private")).toBeUndefined();
+
+    const adminView = buildGroups({
+      filter: "all",
+      search: "",
+      isAdmin: true,
+      selfMemberId: "member-1",
+      members: [],
+      yourAgents: [],
+      teamAgents: [],
+      otherPrivateAgents: [theirPrivate],
+      resolveMember: (id) => id,
+      agentByUuid: new Map(),
+      openDelegate: () => {},
+    });
+    const adminOtherPrivate = adminView.find((g) => g.key === "other-private");
+    expect(adminOtherPrivate).toBeDefined();
+    expect(adminOtherPrivate?.collapsible).toBe(true);
+    expect(adminOtherPrivate?.count).toBe(1);
+  });
+
+  it("respects the yours / team / humans filter pills", () => {
+    const myAgent = agent({
+      uuid: "my-agent",
+      type: "personal_assistant",
+      displayName: "Mine",
+      managerId: "member-1",
+    });
+    const theirAgent = agent({
+      uuid: "their-agent",
+      type: "personal_assistant",
+      displayName: "Theirs",
+      visibility: "organization",
+      managerId: "member-2",
+    });
+    const baseArgs = {
+      search: "",
+      isAdmin: false,
+      selfMemberId: "member-1",
+      members: [
+        {
+          id: "member-1",
+          agentId: "human-1",
+          username: "ada",
+          displayName: "Ada",
+          role: "member",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      yourAgents: [myAgent],
+      teamAgents: [theirAgent],
+      otherPrivateAgents: [],
+      resolveMember: (id: string) => id,
+      agentByUuid: new Map(),
+      openDelegate: () => {},
+    };
+
+    expect(buildGroups({ ...baseArgs, filter: "yours" }).map((g) => g.key)).toEqual(["yours"]);
+    expect(buildGroups({ ...baseArgs, filter: "humans" }).map((g) => g.key)).toEqual(["humans"]);
+    expect(buildGroups({ ...baseArgs, filter: "team" }).map((g) => g.key)).toEqual(["team"]);
   });
 
   it("keeps private active assistants selectable for admin delegate edits", () => {

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -152,6 +152,62 @@ describe("Team page grouping", () => {
     expect(teamFirst.showVisibilityChip).toBe(false);
   });
 
+  it("sorts Your agents deterministically: private first, then displayName tiebreaker", () => {
+    // Deliberately scrambled input order — without a stable secondary
+    // sort key the rendered order would follow this scramble and reshuffle
+    // visibly across refetches. The sort should pin private to the top
+    // and break ties alphabetically (case-insensitive).
+    const sharedZeta = agent({
+      uuid: "shared-z",
+      type: "personal_assistant",
+      displayName: "Zeta",
+      visibility: "organization",
+      managerId: "member-1",
+    });
+    const sharedAlpha = agent({
+      uuid: "shared-a",
+      type: "personal_assistant",
+      displayName: "alpha",
+      visibility: "organization",
+      managerId: "member-1",
+    });
+    const privateBeta = agent({
+      uuid: "private-b",
+      type: "personal_assistant",
+      displayName: "Beta",
+      visibility: "private",
+      managerId: "member-1",
+    });
+    const privateGamma = agent({
+      uuid: "private-g",
+      type: "personal_assistant",
+      displayName: "gamma",
+      visibility: "private",
+      managerId: "member-1",
+    });
+
+    const groups = buildGroups({
+      filter: "all",
+      search: "",
+      isAdmin: false,
+      selfMemberId: "member-1",
+      members: [],
+      // Order: shared, private, shared, private — guarantees the test
+      // exercises both the visibility partition and the alpha tiebreaker.
+      yourAgents: [sharedZeta, privateBeta, sharedAlpha, privateGamma],
+      teamAgents: [],
+      otherPrivateAgents: [],
+      resolveMember: (id) => id,
+      agentByUuid: new Map(),
+      openDelegate: () => {},
+    });
+
+    const yoursGroup = groups.find((g) => g.key === "yours");
+    if (!yoursGroup) throw new Error("expected yours group");
+    const uuids = yoursGroup.rows.map((r) => (r.kind === "agent" ? r.agent.uuid : "?"));
+    expect(uuids).toEqual(["private-b", "private-g", "shared-a", "shared-z"]);
+  });
+
   it("shows Other members' private agents collapsibly for admins only", () => {
     const theirPrivate = agent({
       uuid: "their-private",

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -28,15 +28,19 @@ import { type AgentRow, type HumanRow, type RowAction, type TeamGroup, TeamTable
 
 /**
  * Team page — single roster combining humans and agents into one merged
- * table. Sectioning carries the visibility/identity semantics:
+ * table. Section order is built around the two main reasons a user lands
+ * on this tab: creating a new agent (top-right CTA) and configuring agents
+ * they own. "Your agents" is therefore pinned to the top regardless of
+ * visibility, so the most likely target of "I want to tweak this" is the
+ * first thing in the user's eye-line.
  *
- *   - Humans                      (login users; org members)
- *   - Shared agents               (visibility = organization; team-mentionable)
- *   - Your private agents         (visibility = private && managerId = self)
+ *   - Your agents                 (managerId = self, any visibility — chip on row marks shared vs private)
+ *   - Humans                      (login users; org members — set-delegate flow lives here)
+ *   - Team agents                 (visibility = organization && managerId != self)
  *   - Other members' private agents (admin-only governance, collapsed)
  *
- * Per-page primary CTA is `+ New agent`; visibility is chosen inside
- * NewAgentDialog (so we don't multiply CTAs per section).
+ * The three agent sections form a clean partition: every agent belongs to
+ * exactly one section, so the table never double-lists a row.
  *
  * Admin role decides the data source: admins fetch `/agents/all` which
  * surfaces other members' private agents; members fetch the regular
@@ -70,7 +74,7 @@ type DelegateTarget = {
   currentDelegate: string | null;
 };
 
-type FilterKey = "all" | "humans" | "shared" | "private";
+type FilterKey = "all" | "yours" | "humans" | "team";
 
 const AGENT_PAGE_SIZE = 100;
 const MAX_AGENT_PAGES = 100;
@@ -165,9 +169,14 @@ export function TeamPage() {
   // them as people, so the agents groups must hide them to avoid double-listing.
   const agents = useMemo<Agent[]>(() => allAgents.filter((a) => a.type !== "human"), [allAgents]);
 
-  const sharedAgents = useMemo(() => agents.filter((a) => a.visibility === "organization"), [agents]);
-  const yourPrivateAgents = useMemo(
-    () => agents.filter((a) => a.visibility === "private" && a.managerId === memberId),
+  // Three-way partition of the loaded agent list — every agent appears in
+  // exactly one bucket so the table never double-lists a row.
+  //   - yourAgents:         managed by me (any visibility) → top section, the headline answer to "what did I build?"
+  //   - teamAgents:         org-shared agents managed by *others* → "what did the team build?"
+  //   - otherPrivateAgents: private agents managed by others (admin-only) → governance bucket, collapsed
+  const yourAgents = useMemo(() => agents.filter((a) => a.managerId === memberId), [agents, memberId]);
+  const teamAgents = useMemo(
+    () => agents.filter((a) => a.visibility === "organization" && a.managerId !== memberId),
     [agents, memberId],
   );
   const otherPrivateAgents = useMemo(
@@ -220,8 +229,8 @@ export function TeamPage() {
         isAdmin,
         selfMemberId: memberId,
         members,
-        sharedAgents,
-        yourPrivateAgents,
+        yourAgents,
+        teamAgents,
         otherPrivateAgents,
         resolveMember,
         agentByUuid,
@@ -238,8 +247,8 @@ export function TeamPage() {
       isAdmin,
       memberId,
       members,
-      sharedAgents,
-      yourPrivateAgents,
+      yourAgents,
+      teamAgents,
       otherPrivateAgents,
       resolveMember,
       agentByUuid,
@@ -346,9 +355,9 @@ export function TeamPage() {
           query={query}
           onQuery={setQuery}
           counts={{
+            yours: yourAgents.length,
             humans: members.length,
-            shared: sharedAgents.length,
-            private: yourPrivateAgents.length,
+            team: teamAgents.length,
           }}
         />
 
@@ -433,17 +442,18 @@ function FilterBar({
   onFilter: (k: FilterKey) => void;
   query: string;
   onQuery: (q: string) => void;
-  counts: { humans: number; shared: number; private: number };
+  counts: { yours: number; humans: number; team: number };
 }) {
-  // Admins-only filter was dropped: role governance is not a primary
-  // browsing mode for this roster. Role remains editable in the profile
-  // dialog, but the main scan surface stays focused on identity, delegate,
-  // manager, runtime, and status.
+  // Pills sit in the same order the sections render below: "Your agents"
+  // first because it's the primary scan target (creating + tweaking your
+  // own agents is the main reason people open this tab), then Humans
+  // (where the set-delegate flow lives), then Team agents. Each pill maps
+  // 1:1 to a section title so the filter mental model is trivial.
   const chips: Array<{ key: FilterKey; label: string; count?: number }> = [
     { key: "all", label: "All" },
+    { key: "yours", label: "Your agents", count: counts.yours },
     { key: "humans", label: "Humans", count: counts.humans },
-    { key: "shared", label: "Shared agents", count: counts.shared },
-    { key: "private", label: "Your private", count: counts.private },
+    { key: "team", label: "Team agents", count: counts.team },
   ];
   return (
     <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-2)" }}>
@@ -491,8 +501,11 @@ export function buildGroups(args: {
   isAdmin: boolean;
   selfMemberId: string | null;
   members: MemberListItem[];
-  sharedAgents: Agent[];
-  yourPrivateAgents: Agent[];
+  /** Agents managed by the viewer, any visibility. Rendered first. */
+  yourAgents: Agent[];
+  /** Shared agents managed by other members. */
+  teamAgents: Agent[];
+  /** Private agents managed by other members — admin governance bucket. */
   otherPrivateAgents: Agent[];
   resolveMember: (id: string) => string;
   agentByUuid: Map<string, Agent>;
@@ -504,8 +517,8 @@ export function buildGroups(args: {
     isAdmin,
     selfMemberId,
     members,
-    sharedAgents,
-    yourPrivateAgents,
+    yourAgents,
+    teamAgents,
     otherPrivateAgents,
     agentByUuid,
     openDelegate,
@@ -527,9 +540,11 @@ export function buildGroups(args: {
   const matchAgent = (a: Agent) =>
     !search || a.displayName.toLowerCase().includes(search) || (a.name ?? "").toLowerCase().includes(search);
 
+  const showYours = filter === "all" || filter === "yours";
   const showHumans = filter === "all" || filter === "humans";
-  const showShared = filter === "all" || filter === "shared";
-  const showPrivate = filter === "all" || filter === "private";
+  const showTeam = filter === "all" || filter === "team";
+  // Admin governance bucket only renders inside the All view; the
+  // dedicated pills don't surface it to keep their meaning literal.
   const showOtherPrivate = isAdmin && filter === "all";
 
   const humanRows: HumanRow[] = members
@@ -556,18 +571,43 @@ export function buildGroups(args: {
     // the rest.
     .sort((a, b) => Number(b.isSelf) - Number(a.isSelf));
 
-  const toAgentRow = (agent: Agent): AgentRow => ({
+  const toAgentRow = (agent: Agent, opts?: { showVisibilityChip?: boolean }): AgentRow => ({
     kind: "agent",
     agent,
     managerLabel: agent.managerId ? args.resolveMember(agent.managerId) : null,
     isOwnedBySelf: agent.managerId === selfMemberId,
+    showVisibilityChip: opts?.showVisibilityChip ?? false,
   });
 
-  const sharedRows: AgentRow[] = sharedAgents.filter(matchAgent).map(toAgentRow);
-  const yourPrivateRows: AgentRow[] = yourPrivateAgents.filter(matchAgent).map(toAgentRow);
-  const otherPrivateRows: AgentRow[] = otherPrivateAgents.filter(matchAgent).map(toAgentRow);
+  // "Your agents" mixes shared + private rows, so each row carries an
+  // inline visibility chip so the viewer can tell them apart at a glance.
+  // Sorted so private agents (the more sensitive ones) appear first inside
+  // the section — that's where governance attention belongs.
+  const yourRows: AgentRow[] = yourAgents
+    .filter(matchAgent)
+    .map((a) => toAgentRow(a, { showVisibilityChip: true }))
+    .sort((a, b) => {
+      const aPriv = a.agent.visibility === "private" ? 0 : 1;
+      const bPriv = b.agent.visibility === "private" ? 0 : 1;
+      return aPriv - bPriv;
+    });
+  // Team / Other-private rows are homogeneous in visibility (shared / private
+  // respectively); the section title already encodes that, so no chip.
+  const teamRows: AgentRow[] = teamAgents.filter(matchAgent).map((a) => toAgentRow(a));
+  const otherPrivateRows: AgentRow[] = otherPrivateAgents.filter(matchAgent).map((a) => toAgentRow(a));
 
   const groups: TeamGroup[] = [];
+  if (showYours) {
+    groups.push({
+      key: "yours",
+      title: "Your agents",
+      count: yourRows.length,
+      rows: yourRows,
+      emptyMessage: search
+        ? "No agents match this search."
+        : "You haven't created any agents yet. Click New agent above to add one.",
+    });
+  }
   if (showHumans) {
     groups.push({
       key: "humans",
@@ -577,24 +617,13 @@ export function buildGroups(args: {
       emptyMessage: search ? "No humans match this search." : undefined,
     });
   }
-  if (showShared) {
+  if (showTeam) {
     groups.push({
-      key: "shared",
-      title: "Shared agents",
-      count: sharedRows.length,
-      rows: sharedRows,
-      emptyMessage: search ? "No shared agents match this search." : "No shared agents yet.",
-    });
-  }
-  if (showPrivate) {
-    groups.push({
-      key: "private",
-      title: "Your private agents",
-      count: yourPrivateRows.length,
-      rows: yourPrivateRows,
-      emptyMessage: search
-        ? "No private agents match this search."
-        : "No private agents — pick Private in the create dialog to keep one to yourself.",
+      key: "team",
+      title: "Team agents",
+      count: teamRows.length,
+      rows: teamRows,
+      emptyMessage: search ? "No team agents match this search." : "No shared agents from other team members yet.",
     });
   }
   if (showOtherPrivate && otherPrivateRows.length > 0) {

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -581,15 +581,24 @@ export function buildGroups(args: {
 
   // "Your agents" mixes shared + private rows, so each row carries an
   // inline visibility chip so the viewer can tell them apart at a glance.
-  // Sorted so private agents (the more sensitive ones) appear first inside
-  // the section — that's where governance attention belongs.
+  // Sort:
+  //   1. Private agents first (governance attention belongs on the more
+  //      sensitive rows).
+  //   2. Tiebreaker on displayName so order stays deterministic across
+  //      paginated fetches and refetches — the source `yourAgents` array
+  //      arrives in whatever order /agents pages return, and without a
+  //      stable secondary key the section would visibly reshuffle when
+  //      the list refreshes.
   const yourRows: AgentRow[] = yourAgents
     .filter(matchAgent)
     .map((a) => toAgentRow(a, { showVisibilityChip: true }))
     .sort((a, b) => {
       const aPriv = a.agent.visibility === "private" ? 0 : 1;
       const bPriv = b.agent.visibility === "private" ? 0 : 1;
-      return aPriv - bPriv;
+      if (aPriv !== bPriv) return aPriv - bPriv;
+      // Case-insensitive locale-aware compare so "Coder" and "coder" sort
+      // adjacent rather than splitting by ASCII code point.
+      return a.agent.displayName.localeCompare(b.agent.displayName, undefined, { sensitivity: "base" });
     });
   // Team / Other-private rows are homogeneous in visibility (shared / private
   // respectively); the section title already encodes that, so no chip.

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -1,5 +1,5 @@
 import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
-import { Bot, Lock, type LucideIcon, MoreHorizontal, User } from "lucide-react";
+import { Bot, Lock, type LucideIcon, MoreHorizontal, User, Users } from "lucide-react";
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 import type { RuntimeAgent } from "../../api/activity.js";
 import { AgentChip } from "../../components/agent-chip.js";
@@ -52,6 +52,14 @@ export type AgentRow = {
   agent: Agent;
   managerLabel: string | null;
   isOwnedBySelf: boolean;
+  /**
+   * Whether to render the visibility chip (Shared / Private) next to the
+   * agent name. Set true for rows inside heterogeneous sections (e.g. "Your
+   * agents" mixes both visibilities); false for sections where visibility
+   * is already encoded by the section title (Team agents = shared, Other
+   * private = private). Keeps chips out of cells where they'd be redundant.
+   */
+  showVisibilityChip?: boolean;
 };
 
 export type TeamRow = HumanRow | AgentRow;
@@ -86,7 +94,12 @@ type Props = {
 };
 
 const COLUMNS = [
-  { key: "name", label: "Name", width: 260 },
+  // Name (220) holds displayName + @handle. The internal NameCell already
+  // truncates both lines with a `title` tooltip on overflow, so 220 covers
+  // the realistic 90th-percentile name pair and longer names degrade
+  // gracefully. Down from 260 — the freed width is redistributed to
+  // Delegate / Manager which were causing 2-line wraps at 160.
+  { key: "name", label: "Name", width: 220 },
   // Delegate and Manager are split into separate columns so each header
   // carries exactly one meaning. Human rows fill Delegate (the assistant
   // acting on their behalf) and leave Manager as `—`; agent rows fill
@@ -97,8 +110,13 @@ const COLUMNS = [
   // one column and leaves the other empty — the half-blank pattern reads
   // as section structure, not missing data, and neither column has to
   // mean two things at once.
-  { key: "delegate", label: "Delegate", width: 160 },
-  { key: "manager", label: "Manager", width: 160 },
+  //
+  // 180 (up from 160): the cell renders an AgentChip ("Display Name
+  // @handle") which at 160 wrapped onto two lines for typical agent names
+  // — the bump keeps it on one line and the inner truncate handles the
+  // long tail, mirroring Runs on.
+  { key: "delegate", label: "Delegate", width: 180 },
+  { key: "manager", label: "Manager", width: 180 },
   // The cell renders `<runtime-provider> @ <host>` in one line — covers
   // both framework and host together (plain "Runtime" only described the
   // framework half). Wider than the other middle columns because the
@@ -111,10 +129,11 @@ const COLUMNS = [
   { key: "runtime", label: "Runs on", width: 220 },
   { key: "status", label: "Status", width: 160 },
   { key: "created", label: "Created", width: 160 },
-  // Middle columns mostly pin to 160 for grid rhythm. Runs on opts out at
-  // 220 because its content (provider + host) is denser than the others.
-  // Name stays wider (variable display-name + @handle) and Actions stays
-  // narrow (single kebab icon) — those sit at the content-density extremes.
+  // Middle columns mostly pin to 160-180 for grid rhythm. Runs on opts out
+  // at 220 because its content (provider + host) is denser than the
+  // others. Name stays wider (variable display-name + @handle) and Actions
+  // stays narrow (single kebab icon) — those sit at the content-density
+  // extremes.
   { key: "actions", label: "", width: 44 },
 ] as const;
 
@@ -231,9 +250,12 @@ function sectionIcon(key: string): LucideIcon | null {
   switch (key) {
     case "humans":
       return User;
-    case "shared":
+    // "yours" mixes visibilities — use the generic Bot icon (same as the
+    // old "shared" section) because the per-row visibility chip carries
+    // the public/private signal at the row level.
+    case "yours":
+    case "team":
       return Bot;
-    case "private":
     case "other-private":
       return Lock;
     default:
@@ -243,10 +265,40 @@ function sectionIcon(key: string): LucideIcon | null {
 
 function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boolean; onToggle: () => void }) {
   const Icon = sectionIcon(group.key);
+  // Alignment contract (must hold across all 4 sections):
+  //   - Section icon at cell X=0 ("hangs out" as section marker).
+  //   - Section title text at X=sp-6 — same X as row-name text in the
+  //     Name column (HumanRowView / AgentRowView set paddingLeft: sp-6
+  //     on the first cell). Section titles and the data column align.
+  //   - For collapsible sections, the chevron is rendered OUT-OF-FLOW
+  //     to the LEFT of the icon (absolute positioning), so the icon
+  //     stays at X=0 and the title stays at X=sp-6 — same alignment as
+  //     the non-collapsible sections. The chevron visually "hangs" in
+  //     the container's left padding (the table sits inside a parent
+  //     with sp-5 left padding, plenty of room for the overhang).
+  //
+  // An earlier iteration reserved a uniform arrow SLOT on every section
+  // (transparent for non-collapsible) which aligned the 4 sections to
+  // each other but broke alignment with row names. This restores the
+  // dominant alignment (title ↔ row-name) and keeps the collapsible
+  // chevron from displacing the icon.
   const inner = (
-    <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
+    <span className="inline-flex items-center relative" style={{ gap: "var(--sp-2)" }}>
       {group.collapsible && (
-        <span aria-hidden style={{ display: "inline-block", width: 10, color: "var(--fg-4)" }}>
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            // Pull the chevron to the left of the icon column. sp-3 ≈ 12,
+            // enough clearance to read it as a separate glyph without
+            // running into the icon glyph.
+            left: "calc(-1 * var(--sp-3))",
+            top: "50%",
+            transform: "translateY(-50%)",
+            color: "var(--fg-4)",
+            lineHeight: 1,
+          }}
+        >
           {open ? "▾" : "▸"}
         </span>
       )}
@@ -281,9 +333,15 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
             style={{
               background: "transparent",
               border: 0,
-              padding: 0,
               cursor: "pointer",
               color: "inherit",
+              // padding-left + matching negative margin-left extends the
+              // click target leftward to include the hanging chevron,
+              // without visually shifting the icon/title. Users can
+              // click the chevron OR the title and either triggers the
+              // toggle.
+              padding: "0 0 0 var(--sp-3)",
+              marginLeft: "calc(-1 * var(--sp-3))",
             }}
           >
             {inner}
@@ -345,17 +403,39 @@ function HumanDelegateCell({ row }: { row: HumanRow }) {
     );
   }
 
+  // AgentChip is inline-flex by default which lets long display names
+  // wrap into the row. Wrapping the chip in a block-level truncate
+  // container (same recipe as the Runs-on column) keeps the cell to a
+  // single line, drops an ellipsis on overflow, and surfaces the full
+  // "Display Name (@handle)" via the title attribute on hover. Without
+  // this, a wide delegate name at the narrow Delegate column width
+  // wrapped to two lines — the issue reported by users.
+  const fullLabel = row.delegate
+    ? row.delegate.name
+      ? `${row.delegate.displayName} (@${row.delegate.name})`
+      : row.delegate.displayName
+    : "Set delegate";
+
   const value = row.delegate ? (
-    <AgentChip name={row.delegate.name} displayName={row.delegate.displayName} />
+    <span
+      className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
+      // Cell holds an inline AgentChip — wrapping in `block` + truncate
+      // utilities is necessary because the chip itself is inline-flex.
+    >
+      <AgentChip name={row.delegate.name} displayName={row.delegate.displayName} />
+    </span>
   ) : (
-    <span style={{ color: "var(--accent-dim)" }}>Set delegate →</span>
+    // Shorter placeholder ("Set →" instead of "Set delegate →") so the
+    // CTA fits comfortably at the Delegate column width with the
+    // tooltip carrying the full label.
+    <span style={{ color: "var(--accent-dim)" }}>Set →</span>
   );
 
-  const tooltip = row.delegate ? (row.canEditDelegate ? "Change delegate" : undefined) : "Set delegate";
+  const tooltip = row.delegate ? (row.canEditDelegate ? `Change delegate · ${fullLabel}` : fullLabel) : "Set delegate";
 
   if (!row.canEditDelegate) {
     return (
-      <span className="text-label" title={tooltip}>
+      <span className="text-label block max-w-full overflow-hidden" title={tooltip}>
         {value}
       </span>
     );
@@ -365,7 +445,7 @@ function HumanDelegateCell({ row }: { row: HumanRow }) {
     <button
       type="button"
       onClick={row.onEditDelegate}
-      className="text-label hover:underline"
+      className="text-label hover:underline block max-w-full overflow-hidden"
       style={{
         background: "transparent",
         border: 0,
@@ -396,12 +476,16 @@ function AgentRowView({
   onClick: () => void;
   isLast: boolean;
 }) {
-  const { agent, managerLabel, isOwnedBySelf } = row;
+  const { agent, managerLabel, isOwnedBySelf, showVisibilityChip } = row;
 
   return (
     <DenseTableRow interactive onClick={onClick}>
       <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
-        <NameCell displayName={agent.displayName} handle={agent.name ? `@${agent.name}` : null} />
+        <NameCell
+          displayName={agent.displayName}
+          handle={agent.name ? `@${agent.name}` : null}
+          visibility={showVisibilityChip ? agent.visibility : null}
+        />
       </DenseTableCell>
       <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         —
@@ -450,16 +534,35 @@ function AgentRowView({
   );
 }
 
-function NameCell({ displayName, handle, selfTag }: { displayName: string; handle: string | null; selfTag?: boolean }) {
+function NameCell({
+  displayName,
+  handle,
+  selfTag,
+  visibility,
+}: {
+  displayName: string;
+  handle: string | null;
+  selfTag?: boolean;
+  /**
+   * Optional visibility marker rendered to the right of the display name.
+   * Only used in heterogeneous sections (e.g. "Your agents" which mixes
+   * shared + private rows) — homogeneous sections skip this prop since
+   * the section title already encodes the visibility.
+   */
+  visibility?: Agent["visibility"] | null;
+}) {
   return (
     <div className="min-w-0">
-      <div className="font-medium text-body truncate" style={{ color: "var(--fg)" }} title={displayName}>
-        {displayName}
+      <div className="flex items-baseline gap-1.5 min-w-0">
+        <span className="font-medium text-body truncate" style={{ color: "var(--fg)" }} title={displayName}>
+          {displayName}
+        </span>
         {selfTag && (
-          <span className="text-label italic" style={{ marginLeft: 6, color: "var(--fg-3)" }}>
+          <span className="text-label italic shrink-0" style={{ color: "var(--fg-3)" }}>
             (you)
           </span>
         )}
+        {visibility && <VisibilityChip visibility={visibility} />}
       </div>
       {handle && (
         <div className="mono text-caption truncate" style={{ color: "var(--fg-4)" }} title={handle}>
@@ -467,6 +570,30 @@ function NameCell({ displayName, handle, selfTag }: { displayName: string; handl
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Inline visibility marker. `shared` = team-mentionable (DenseBadge accent
+ * tone matches the agent-detail page's chip). `private` = owner-only (the
+ * Lock icon + DenseBadge outline tone reuses the section-icon vocabulary,
+ * so a private chip next to a name and the Lock-icon section header carry
+ * the same meaning visually).
+ */
+function VisibilityChip({ visibility }: { visibility: Agent["visibility"] }) {
+  if (visibility === "private") {
+    return (
+      <DenseBadge tone="outline" title="Private — only you can see this agent" className="shrink-0">
+        <Lock className="h-2.5 w-2.5" aria-hidden style={{ marginRight: 3 }} />
+        Private
+      </DenseBadge>
+    );
+  }
+  return (
+    <DenseBadge tone="accent" title="Shared — anyone in the team can @mention this agent" className="shrink-0">
+      <Users className="h-2.5 w-2.5" aria-hidden style={{ marginRight: 3 }} />
+      Shared
+    </DenseBadge>
   );
 }
 

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -292,6 +292,15 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
             // Pull the chevron to the left of the icon column. sp-3 ≈ 12,
             // enough clearance to read it as a separate glyph without
             // running into the icon glyph.
+            //
+            // IMPLICIT CONTRACT: this only renders cleanly because the
+            // TeamPage container around the table has `padding-left: sp-5`
+            // (see packages/web/src/pages/team/index.tsx — the wrapper
+            // `<div>` with `padding: var(--sp-2) var(--sp-5) var(--sp-7)`).
+            // sp-3 overhang fits inside the sp-5 padding with sp-2 to
+            // spare. If that outer padding ever shrinks below sp-3 the
+            // chevron will clip against the page chrome — revisit either
+            // the outer padding or switch this back to an in-flow slot.
             left: "calc(-1 * var(--sp-3))",
             top: "50%",
             transform: "translateY(-50%)",
@@ -425,10 +434,7 @@ function HumanDelegateCell({ row }: { row: HumanRow }) {
       <AgentChip name={row.delegate.name} displayName={row.delegate.displayName} />
     </span>
   ) : (
-    // Shorter placeholder ("Set →" instead of "Set delegate →") so the
-    // CTA fits comfortably at the Delegate column width with the
-    // tooltip carrying the full label.
-    <span style={{ color: "var(--accent-dim)" }}>Set →</span>
+    <span style={{ color: "var(--accent-dim)" }}>Set delegate →</span>
   );
 
   const tooltip = row.delegate ? (row.canEditDelegate ? `Change delegate · ${fullLabel}` : fullLabel) : "Set delegate";


### PR DESCRIPTION
## Summary

- **Team tab restructure**: pin "Your agents" section first (manager=self, any visibility), then Humans → Team agents (others' shared) → Other members' private agents (admin-only, collapsed). Each agent appears in exactly one section. Rows inside Your agents carry an inline visibility chip (🔒 Private / 👥 Shared); homogeneous sections skip the chip. Filter pills updated: `All / Your agents / Humans / Team agents`.
- **NewAgentDialog**: default visibility flipped to `private` (matches the `personal_assistant` type name). "Where it runs" block reserves a stable min-height and renders SingleComputerCard-shaped skeletons during async detection — the dialog no longer visibly jumps as `listClients` / capabilities stream in.
- **Table polish**: Delegate column gets `truncate + title` (was wrapping to 2 lines at 160); widened 160 → 180. Name column shrunk 260 → 220 (inner truncate covers the long tail). Collapsible chevron on "Other members' private agents" now hangs out-of-flow to the left of the section icon, so all four section icons stay at the cell's left edge and section titles keep their vertical alignment with row-name text.

## Background

User feedback on the Team tab:
1. New Agent dialog visibly jumped in height as the "Where it runs" block streamed in.
2. Delegate column wrapped to 2 lines under tight widths.
3. The collapsible group ("Other members' private agents") had its 🔒 icon and title shifted right of the other three sections by the arrow + gap, breaking alignment.
4. The user's own agents were buried in "Shared agents" (default visibility was `organization`); finding "my own stuff" required scanning past everyone else's.

This PR addresses all four.

## Design decisions (locked with the user)

| # | Decision | Choice |
|---|---|---|
| 1 | Dialog height stability | `min-height` + skeleton cards that mirror the real cards' dimensions |
| 2 | Column widths | Name 220 / Delegate 180 / Manager 180 / Runs on 220 / Status 160 / Created 160 / Actions 44 |
| 3 | Section header alignment | Chevron hangs absolute-positioned to the left of the icon; icons stay at cell X=0 across all sections, titles keep aligning with row-name text at sp-6 |
| 4 | Section order | Your agents → Humans → Team agents → Other private (admin) |
| 5 | Your agents internal layout | Flat list + inline visibility chip per row (private sorted first) |
| 6 | Visibility chip range | Only in heterogeneous sections (Your agents); homogeneous sections rely on section title |
| 7 | Default visibility | Switched `organization` → `private` |
| 8 | Admin "Your agents" semantics | Still means "managed by me" — admin governance is expressed via the separate Other private bucket |

## Test plan

- [x] `pnpm --filter @first-tree-hub/web typecheck` (incl. `lint:tokens` design-token guardrails) ✓
- [x] `pnpm check` (biome) ✓
- [x] `pnpm --filter @first-tree-hub/web test` — 80 tests pass (was 76), including 8 in `team-groups.test.ts` (was 4; new tests cover section order, visibility-chip placement, admin-only governance bucket, filter-pill scoping)
- [x] Manual: open Team tab — verify "Your agents" renders first, visibility chips show only there, "Other members' private agents" section header aligns vertically with the other three sections
- [x] Manual: click "+ New agent" — verify dialog opens at stable height (no jump as computer/capabilities resolve), "Private to you" is pre-selected with `(default)` annotation
- [x] Manual: long delegate name — verify Delegate cell truncates on one line with tooltip showing full label
- [x] Manual (admin): verify "Other members' private agents" section is collapsible (▸ / ▾) and chevron hangs to the left without displacing the 🔒 icon
