### PR TITLE
feat(web): new-chat default agent + picker grouping + composer auto-grow

### DIFF
--- a/packages/server/src/__tests__/admin-agents-activity.test.ts
+++ b/packages/server/src/__tests__/admin-agents-activity.test.ts
@@ -2,10 +2,11 @@ import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
+import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import { bindAgent } from "../services/presence.js";
 import { uuidv7 } from "../uuid.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { createAdminContext, INVALID_BCRYPT_PLACEHOLDER, seedClient, useTestApp } from "./helpers.js";
 
 /**
  * Follow-up to #220. The `GET /admin/agents/activity` route used to read
@@ -122,5 +123,103 @@ describe("GET /admin/agents/activity org scoping", () => {
       headers: { authorization: `Bearer ${alice.accessToken}` },
     });
     expect(res.statusCode).toBe(403);
+  });
+});
+
+/**
+ * `managedByMe` powers the workspace new-chat view's default-seed logic
+ * (`pickDefault` in `new-chat-draft.tsx`): a fresh draft should only seed
+ * a chip from agents the caller personally manages, never another
+ * member's org-visible agent. The server is the only place that knows
+ * the join (agent.managerId === caller's memberId for the URL org), so
+ * the boolean is computed here and shipped on each row of `/activity`.
+ */
+describe("GET /orgs/:orgId/activity — managedByMe field", () => {
+  const getApp = useTestApp();
+
+  async function setup() {
+    const app = getApp();
+    // Alice (the caller) and Bob (another member of the same org), each
+    // owning one autonomous agent. Both agents are org-visible, so the
+    // visibility filter returns both rows to Alice — `managedByMe` is
+    // what differentiates them.
+    const alice = await createAdminContext(app);
+    const bobMemberId = uuidv7();
+    const bobUserId = uuidv7();
+    // Insert bob as a second member of alice's org. Same FK-cycle dance
+    // as createTestAdmin (helpers.ts): user → agent (with FK to member,
+    // deferred via migration 0019) → member (FK back to the agent), all
+    // in one transaction.
+    await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: bobUserId,
+        username: `bob-${crypto.randomUUID().slice(0, 8)}`,
+        passwordHash: INVALID_BCRYPT_PLACEHOLDER,
+        displayName: "Bob",
+      });
+      const bobHuman = await createAgent(tx as unknown as typeof app.db, {
+        name: `bob-h-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: "Bob",
+        managerId: bobMemberId,
+        organizationId: alice.organizationId,
+      });
+      await tx.insert(members).values({
+        id: bobMemberId,
+        userId: bobUserId,
+        organizationId: alice.organizationId,
+        agentId: bobHuman.uuid,
+        role: "member",
+      });
+    });
+
+    // Each manager's agent must pin to a client owned by that manager's
+    // user (services/agent.ts::resolveAgentClient enforces this), so bob
+    // needs his own seeded client.
+    const bobClientId = await seedClient(app, bobUserId, alice.organizationId);
+
+    const aliceAgent = await createAgent(app.db, {
+      name: `mbm-a-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Alice bot",
+      managerId: alice.memberId,
+      clientId: alice.clientId,
+    });
+    const bobAgent = await createAgent(app.db, {
+      name: `mbm-b-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Bob bot",
+      managerId: bobMemberId,
+      clientId: bobClientId,
+    });
+
+    const instance = `inst-${crypto.randomUUID().slice(0, 6)}`;
+    await bindAgent(app.db, aliceAgent.uuid, {
+      clientId: alice.clientId,
+      instanceId: instance,
+      runtimeType: "claude-code",
+    });
+    await bindAgent(app.db, bobAgent.uuid, {
+      clientId: bobClientId,
+      instanceId: instance,
+      runtimeType: "claude-code",
+    });
+
+    return { app, alice, aliceAgent, bobAgent };
+  }
+
+  it("marks the caller's own agents as managedByMe=true and others' as false", async () => {
+    const { app, alice, aliceAgent, bobAgent } = await setup();
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(alice.organizationId)}/activity`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const agents = res.json<{ agents: Array<{ agentId: string; managedByMe: boolean }> }>().agents;
+    const byId = new Map(agents.map((a) => [a.agentId, a.managedByMe]));
+    // Both agents are org-visible, so both reach the caller.
+    expect(byId.get(aliceAgent.uuid)).toBe(true);
+    expect(byId.get(bobAgent.uuid)).toBe(false);
   });
 });

--- a/packages/server/src/api/orgs/activity.ts
+++ b/packages/server/src/api/orgs/activity.ts
@@ -20,6 +20,10 @@ export async function orgActivityRoutes(app: FastifyInstance): Promise<void> {
         totalSessions: a.totalSessions,
         runtimeUpdatedAt: a.runtimeUpdatedAt?.toISOString() ?? null,
         type: "type" in a ? a.type : null,
+        // Whether the caller's member personally manages this agent. Used by
+        // the workspace new-chat view to scope the default-seed agent to
+        // agents the caller manages (rather than any org-visible agent).
+        managedByMe: "managerId" in a ? a.managerId === scope.memberId : false,
       })),
     };
   });

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -163,6 +163,7 @@ export async function listAgentsWithRuntime(db: Database, scope?: OrgScope) {
       totalSessions: agentPresence.totalSessions,
       runtimeUpdatedAt: agentPresence.runtimeUpdatedAt,
       type: agents.type,
+      managerId: agents.managerId,
     })
     .from(agentPresence)
     .innerJoin(agents, eq(agentPresence.agentId, agents.uuid))

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -12,6 +12,11 @@ export type RuntimeAgent = {
   totalSessions: number | null;
   runtimeUpdatedAt: string | null;
   type: AgentType | null;
+  /** True iff the caller's member is the agent's `managerId`. Server-derived;
+   *  the client never receives raw `managerId`. Used by the workspace
+   *  new-chat view to seed the default chip from agents the caller
+   *  personally manages. */
+  managedByMe: boolean;
 };
 
 export type ActivityOverview = {

--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { buildMentionInsert, detectMentionTrigger, type MentionCandidate } from "../mention-autocomplete.js";
+import {
+  buildMentionInsert,
+  type CandidateDivider,
+  detectMentionTrigger,
+  groupAndSortCandidates,
+  type MentionCandidate,
+  rankCandidates,
+} from "../mention-autocomplete.js";
+
+/** Test helper — build a candidate with only the fields the test cares
+ *  about and sensible defaults for the rest. */
+function cand(partial: Partial<MentionCandidate> & Pick<MentionCandidate, "agentId">): MentionCandidate {
+  return {
+    name: partial.agentId,
+    displayName: partial.agentId,
+    managedByMe: false,
+    ...partial,
+  };
+}
+
+function isDivider(item: MentionCandidate | CandidateDivider): item is CandidateDivider {
+  return "divider" in item;
+}
 
 /**
  * Pure-function unit tests for the `@mention` trigger detection + insertion
@@ -40,7 +62,12 @@ describe("detectMentionTrigger", () => {
 });
 
 describe("buildMentionInsert", () => {
-  const candidate: MentionCandidate = { agentId: "id-1", name: "alice", displayName: "Alice Wang" };
+  const candidate: MentionCandidate = {
+    agentId: "id-1",
+    name: "alice",
+    displayName: "Alice Wang",
+    managedByMe: false,
+  };
 
   it("replaces `@<query>` with `@<name>` + trailing space", () => {
     const source = "hi @al";
@@ -65,6 +92,7 @@ describe("buildMentionInsert", () => {
       agentId: "id-x",
       name: null,
       displayName: "No Name",
+      managedByMe: false,
     });
     expect(result).toBeNull();
   });
@@ -74,5 +102,140 @@ describe("buildMentionInsert", () => {
     const trigger = { triggerIndex: 3, query: "" };
     const result = buildMentionInsert(source, trigger, source.length, candidate);
     expect(result).toEqual({ text: "hi @alice ", cursor: "hi @alice ".length });
+  });
+});
+
+/**
+ * Locks in the participant-picker grouping contract: my-managed agents
+ * come first, teammates' second, alphabetical within each group, with a
+ * divider marker injected only when both groups are non-empty. The
+ * [+] dropdown in both the new-chat draft and the existing-chat
+ * ParticipantsHeader render dividers from the same helper so they
+ * share visual semantics — this test guards that promise.
+ */
+describe("groupAndSortCandidates", () => {
+  it("returns my-managed first, then others, alphabetical within each, with a divider between", () => {
+    const input = [
+      cand({ agentId: "zoe", managedByMe: true }),
+      cand({ agentId: "Bob's Helper", managedByMe: false, name: "bob", displayName: "Bob's Helper" }),
+      cand({ agentId: "alice", managedByMe: true }),
+      cand({ agentId: "Diana", managedByMe: false, name: "diana", displayName: "Diana" }),
+    ];
+    const result = groupAndSortCandidates(input);
+    expect(result.map((item) => (isDivider(item) ? "---" : item.agentId))).toEqual([
+      "alice",
+      "zoe",
+      "---",
+      "Bob's Helper",
+      "Diana",
+    ]);
+  });
+
+  it("omits the divider when only my-managed agents exist", () => {
+    const result = groupAndSortCandidates([
+      cand({ agentId: "alice", managedByMe: true }),
+      cand({ agentId: "bob", managedByMe: true }),
+    ]);
+    expect(result.some(isDivider)).toBe(false);
+    expect(result.map((item) => (isDivider(item) ? "---" : item.agentId))).toEqual(["alice", "bob"]);
+  });
+
+  it("omits the divider when only teammates' agents exist", () => {
+    const result = groupAndSortCandidates([
+      cand({ agentId: "alice", managedByMe: false }),
+      cand({ agentId: "bob", managedByMe: false }),
+    ]);
+    expect(result.some(isDivider)).toBe(false);
+    expect(result.map((item) => (isDivider(item) ? "---" : item.agentId))).toEqual(["alice", "bob"]);
+  });
+
+  it("returns empty for an empty input", () => {
+    expect(groupAndSortCandidates([])).toEqual([]);
+  });
+
+  it("inserts exactly one divider at the boundary regardless of group sizes", () => {
+    const result = groupAndSortCandidates([
+      cand({ agentId: "alice", managedByMe: true }),
+      cand({ agentId: "bob", managedByMe: false }),
+      cand({ agentId: "carol", managedByMe: false }),
+      cand({ agentId: "dan", managedByMe: false }),
+    ]);
+    const dividerIndices = result.flatMap((item, i) => (isDivider(item) ? [i] : []));
+    expect(dividerIndices).toEqual([1]);
+  });
+
+  it("treats null displayName / null name without throwing — sorts by what's left", () => {
+    const result = groupAndSortCandidates([
+      cand({ agentId: "agent-x", managedByMe: false, name: null, displayName: null }),
+      cand({ agentId: "agent-y", managedByMe: false, name: "bob", displayName: "Bob" }),
+    ]);
+    // Both treated as non-empty strings via the `?? ""` fallback; the
+    // null-everything row sorts first because "" < "Bob".
+    expect(result).toHaveLength(2);
+    const first = result[0];
+    expect(first).toBeDefined();
+    if (first) expect(isDivider(first)).toBe(false);
+  });
+});
+
+/**
+ * Locks in the @-autocomplete ranking contract: with an empty query
+ * (just typed `@`), surface caller's own agents at the top. With a
+ * non-empty query the user is targeting a specific name — reordering
+ * by managedByMe would shuffle matches under their cursor, so the
+ * managedByMe signal is intentionally ignored once they've typed.
+ */
+describe("rankCandidates", () => {
+  it("empty query: my-managed first, then alpha within each group, capped at 8", () => {
+    const input = [
+      cand({ agentId: "zoe", managedByMe: false, displayName: "Zoe" }),
+      cand({ agentId: "alice", managedByMe: true, displayName: "Alice" }),
+      cand({ agentId: "bob", managedByMe: false, displayName: "Bob" }),
+      cand({ agentId: "carl", managedByMe: true, displayName: "Carl" }),
+    ];
+    const result = rankCandidates(input, "");
+    expect(result.map((c) => c.agentId)).toEqual(["alice", "carl", "bob", "zoe"]);
+  });
+
+  it("empty query: divider is stripped (popover doesn't render it)", () => {
+    const input = [cand({ agentId: "alice", managedByMe: true }), cand({ agentId: "bob", managedByMe: false })];
+    const result = rankCandidates(input, "");
+    // The result type is MentionCandidate[]; no `"divider" in item` shape.
+    for (const item of result) {
+      expect("divider" in item).toBe(false);
+    }
+  });
+
+  it("non-empty query: managedByMe does NOT reorder matches — match score wins", () => {
+    const input = [
+      // Teammate's "alice" — exact name prefix match (score 0).
+      cand({ agentId: "alice", managedByMe: false, name: "alice", displayName: "Alice (theirs)" }),
+      // My "altimeter" — name prefix match but a longer name (still score 0, alpha-broken).
+      cand({ agentId: "alt", managedByMe: true, name: "altimeter", displayName: "Altimeter (mine)" }),
+      // My "carl" — no match at all.
+      cand({ agentId: "carl", managedByMe: true, name: "carl", displayName: "Carl (mine)" }),
+    ];
+    const result = rankCandidates(input, "al");
+    // Both match-score-0 rows are returned; the un-related my-managed
+    // "carl" is filtered out. Ordering within a tie is alphabetical by
+    // displayName — NOT by managedByMe.
+    expect(result.map((c) => c.agentId)).toEqual(["alice", "alt"]);
+  });
+
+  it("non-empty query: scoring tiers are respected (name-prefix < displayName-prefix < displayName-contains)", () => {
+    const input = [
+      cand({ agentId: "x", managedByMe: false, name: "x", displayName: "I have a banana" }), // contains
+      cand({ agentId: "y", managedByMe: false, name: "y", displayName: "Banana Republic" }), // displayName prefix
+      cand({ agentId: "z", managedByMe: false, name: "banana-z", displayName: "Zed" }), // name prefix
+    ];
+    const result = rankCandidates(input, "banana");
+    expect(result.map((c) => c.agentId)).toEqual(["z", "y", "x"]);
+  });
+
+  it("empty query: caps the popover at 8 entries even when more match", () => {
+    const input = Array.from({ length: 12 }, (_, i) =>
+      cand({ agentId: `agent-${i.toString().padStart(2, "0")}`, managedByMe: i < 3 }),
+    );
+    expect(rankCandidates(input, "").length).toBe(8);
   });
 });

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -28,6 +28,13 @@ export type MentionCandidate = {
   agentId: string;
   name: string | null;
   displayName: string | null;
+  /** True iff the caller's member is this agent's `managerId`. Drives
+   *  participant-picker grouping (mine first, then teammates') and the
+   *  empty-query branch of mention autocomplete so the user's own agents
+   *  always surface first. Populated from `/activity` (server-derived);
+   *  callers that can't determine it should pass `false` rather than
+   *  omitting — there's no "unknown" state. */
+  managedByMe: boolean;
 };
 
 /**
@@ -139,15 +146,57 @@ export function detectMentionTrigger(text: string, cursor: number): ActiveTrigge
   return { triggerIndex: i, query };
 }
 
+/** Alphabetical comparator over a candidate's user-visible label. */
+function byDisplayName(a: MentionCandidate, b: MentionCandidate): number {
+  return (a.displayName ?? a.name ?? "").localeCompare(b.displayName ?? b.name ?? "");
+}
+
+/**
+ * Marker emitted by {@link groupAndSortCandidates} between the
+ * my-managed group and the others group. Renderers should detect it
+ * via `"divider" in item` and emit a separator instead of a list row.
+ */
+export type CandidateDivider = { divider: true };
+
+/**
+ * Group candidates into "mine first, others second" with each group
+ * sorted alphabetically by display name, and insert a divider marker
+ * between groups iff both are non-empty.
+ *
+ * Used by participant pickers (`[+]` dropdown in new-chat draft and in
+ * existing chats' ParticipantsHeader) so the user can scan their own
+ * agents at the top without reading any header text — the gap speaks
+ * for itself. Both pickers share this helper so the visual contract
+ * stays identical across the app.
+ */
+export function groupAndSortCandidates(candidates: MentionCandidate[]): Array<MentionCandidate | CandidateDivider> {
+  const mine = candidates.filter((c) => c.managedByMe).sort(byDisplayName);
+  const others = candidates.filter((c) => !c.managedByMe).sort(byDisplayName);
+  if (mine.length > 0 && others.length > 0) {
+    return [...mine, { divider: true }, ...others];
+  }
+  return [...mine, ...others];
+}
+
 /**
  * Rank candidates against a lowercased query. Empty query returns every
- * candidate sorted by display name so the popover still shows useful
- * suggestions immediately after typing `@`.
+ * candidate sorted my-managed-first, then alphabetically within each
+ * group, so the popover surfaces the caller's own agents immediately
+ * after typing `@`. With a query, matches are scored by match position
+ * (name prefix > displayName prefix > displayName contains) and ties
+ * are still broken alphabetically — managedByMe is intentionally NOT a
+ * scoring signal once the user has typed something, because at that
+ * point they're targeting a specific name and we shouldn't reorder
+ * matches under them.
  */
-function rankCandidates(candidates: MentionCandidate[], query: string): MentionCandidate[] {
+export function rankCandidates(candidates: MentionCandidate[], query: string): MentionCandidate[] {
   if (!query) {
-    return [...candidates]
-      .sort((a, b) => (a.displayName ?? a.name ?? "").localeCompare(b.displayName ?? b.name ?? ""))
+    // Reuse the picker's grouping logic, strip the divider marker, and
+    // cap at 8. Keeping the empty-query path in lockstep with the
+    // picker means changing one (mine-first, alpha) tomorrow won't
+    // silently leave the other behind.
+    return groupAndSortCandidates(candidates)
+      .filter((item): item is MentionCandidate => !("divider" in item))
       .slice(0, 8);
   }
   const scored: Array<{ c: MentionCandidate; score: number }> = [];

--- a/packages/web/src/lib/use-autoresize-textarea.ts
+++ b/packages/web/src/lib/use-autoresize-textarea.ts
@@ -1,0 +1,36 @@
+import { useLayoutEffect } from "react";
+
+/**
+ * Grow a textarea's height to fit its content, capped by the element's
+ * own CSS `max-height`. Pair with `style={{ minHeight: ..., maxHeight:
+ * ..., overflow: "auto", resize: "none" }}` so:
+ *
+ *   - empty / short content sits at the min,
+ *   - typing or pasting expands the box one line at a time,
+ *   - past the cap the textarea stops growing and content scrolls
+ *     inside.
+ *
+ * Why this instead of `react-textarea-autosize`: the library handles a
+ * handful of edge cases (font-load delays, ResizeObserver-based width
+ * tracking) but adds ~3KB of dependency for a composer that doesn't
+ * exercise any of them. The two real edge cases users hit — paste a
+ * long block, clear after send — are both covered by re-measuring on
+ * every `value` change.
+ *
+ * Implementation note: setting `height = "auto"` before reading
+ * `scrollHeight` is the canonical reset — without it scrollHeight just
+ * reports the current rendered height, so the textarea never shrinks
+ * back after deletions.
+ */
+export function useAutoResizeTextarea(ref: React.RefObject<HTMLTextAreaElement | null>, value: string): void {
+  // `value` is the trigger: it changes the textarea's content, which
+  // changes scrollHeight, which is what we re-measure. Biome can't see
+  // the causal link because the effect reads scrollHeight, not value.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: value IS the dep — its change is what should re-measure.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [ref, value]);
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -39,6 +39,7 @@ import {
 import { FirstTreeLogo } from "../../../components/first-tree-logo.js";
 import {
   ambiguousDisplayNames,
+  groupAndSortCandidates,
   MentionAutocompletePopover,
   type MentionCandidate,
   MentionLabel,
@@ -856,12 +857,30 @@ export function ChatView({
     for (const p of chatDetail?.participants ?? []) ids.add(p.agentId);
     for (const a of activity?.agents ?? []) ids.add(a.agentId);
     if (ids.size === 0) ids.add(agentId);
+    // Build a lookup from `/activity` so we can attach `managedByMe`
+    // per candidate. Known limitation: agents that appear only via
+    // `chatDetail.participants` (no runtime presence row, e.g. an
+    // autonomous agent that has never been bound to a client) default
+    // to false. That means a caller's own offline agent can be
+    // misclassified into the "teammates" group of the [+] picker.
+    // The picker grouping is a visual hint, not a security boundary,
+    // so we accept this fidelity loss rather than widen `/activity`'s
+    // shape (which is also consumed by roster / team / clients pages).
+    // To revisit: surface `managedByMe` independently of runtime via a
+    // dedicated `/me/managed-agents` endpoint and intersect here.
+    const managedByMeMap = new Map<string, boolean>();
+    for (const a of activity?.agents ?? []) managedByMeMap.set(a.agentId, a.managedByMe);
     const out: MentionCandidate[] = [];
     for (const id of ids) {
       if (id === myAgentId) continue;
       const ident = agentIdentity(id);
       if (!ident || !ident.name) continue;
-      out.push({ agentId: id, name: ident.name, displayName: ident.displayName });
+      out.push({
+        agentId: id,
+        name: ident.name,
+        displayName: ident.displayName,
+        managedByMe: managedByMeMap.get(id) ?? false,
+      });
     }
     return out;
   }, [chatDetail?.participants, activity?.agents, agentId, agentIdentity, myAgentId]);
@@ -1641,27 +1660,46 @@ function ParticipantsHeader({
             >
               {(() => {
                 const ambiguous = ambiguousDisplayNames(outsideCandidates);
-                return outsideCandidates.map((c) => (
-                  <button
-                    key={c.agentId}
-                    type="button"
-                    role="option"
-                    aria-selected="false"
-                    title={c.name ? `@${c.name}` : undefined}
-                    onClick={() => addMut.mutate(c.agentId)}
-                    disabled={addMut.isPending}
-                    className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
-                    style={{
-                      background: "transparent",
-                      color: "var(--fg)",
-                      border: "none",
-                      cursor: "pointer",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    <MentionLabel candidate={c} ambiguous={ambiguous} />
-                  </button>
-                ));
+                // Same grouping contract as the new-chat picker: mine
+                // first, teammates' second, --border-faint hairline
+                // between (only when both groups are non-empty).
+                return groupAndSortCandidates(outsideCandidates).map((item) => {
+                  if ("divider" in item) {
+                    return (
+                      <div
+                        key="__divider"
+                        // See new-chat-draft.tsx — same a11y reasoning.
+                        role="presentation"
+                        style={{
+                          height: "var(--hairline)",
+                          background: "var(--border-faint)",
+                          margin: "var(--sp-0_5) var(--sp-3)",
+                        }}
+                      />
+                    );
+                  }
+                  return (
+                    <button
+                      key={item.agentId}
+                      type="button"
+                      role="option"
+                      aria-selected="false"
+                      title={item.name ? `@${item.name}` : undefined}
+                      onClick={() => addMut.mutate(item.agentId)}
+                      disabled={addMut.isPending}
+                      className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+                      style={{
+                        background: "transparent",
+                        color: "var(--fg)",
+                        border: "none",
+                        cursor: "pointer",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      <MentionLabel candidate={item} ambiguous={ambiguous} />
+                    </button>
+                  );
+                });
               })()}
             </div>
           )}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -48,6 +48,7 @@ import {
 import { Button } from "../../../components/ui/button.js";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
+import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { cn } from "../../../lib/utils.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 
@@ -612,6 +613,11 @@ export function ChatView({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Auto-grow the composer up to the CSS `max-height` cap (10.5rem ≈ 8
+  // visible lines). Same hook as the new-chat composer for a consistent
+  // typing experience across both entry points.
+  useAutoResizeTextarea(textareaRef, draft);
   /** Once-per-chat guard for the focus auto-prime: after the user has
    * focused the input even once, we don't keep slapping `@` back into an
    * empty draft. Reset when switching chats. */
@@ -1400,6 +1406,19 @@ export function ChatView({
                       padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
                       background: "transparent",
                       border: "none",
+                      // `rows={2}` alone won't survive the auto-resize hook:
+                      // useLayoutEffect immediately sets `height = scrollHeight`,
+                      // which collapses an empty textarea to ~1 line and
+                      // breaks chat-view's pre-auto-grow 2-line contract.
+                      // CSS `min-height` is a hard floor that wins over the
+                      // hook's inline `height`, so we restate the 2-line
+                      // starting size here: 2 line-heights + top + bottom
+                      // padding. Cap at 10.5rem (~8 visible lines) so long
+                      // pastes scroll inside instead of pushing the footer
+                      // toolbar off-screen.
+                      minHeight: "calc(2lh + var(--sp-2_25) + var(--sp-7_5))",
+                      maxHeight: "10.5rem",
+                      overflowY: "auto",
                       resize: "none",
                       color: "var(--fg)",
                     }}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -461,15 +461,36 @@ function ParticipantChips({
 }
 
 /** Pick a default seed chip when the user opens an empty draft.
- *  Most-recently-active agent first, then any `personal_assistant`,
- *  then whatever sorts first in the candidate list. */
+ *
+ *  Scope: agents the caller **personally manages** — never another
+ *  member's agent (even if it's org-visible). Defaulting a new chat to
+ *  a coworker's agent is a footgun: the user might fire off a message
+ *  thinking it's their own assistant. When the caller manages no
+ *  agents, return `null` and let the user pick — better an empty chip
+ *  row than a wrong default.
+ *
+ *  Within the my-managed subset:
+ *    1. Most-recently-active (by `runtimeUpdatedAt`) — runtime presence
+ *       signal, not a true "last conversation" timestamp, but the only
+ *       MRU signal currently exposed by `/activity`.
+ *    2. Any `personal_assistant` — covers the case where my agents have
+ *       no runtime activity yet (fresh-install / cold-start).
+ *    3. First my-managed agent in the candidates list — final fallback
+ *       so we always seed something if I do manage at least one. */
 function pickDefault(candidates: MentionCandidate[], activity: RuntimeAgent[]): string | null {
   const ids = new Set(candidates.map((c) => c.agentId));
-  const mru = [...activity]
-    .filter((a) => ids.has(a.agentId) && a.runtimeUpdatedAt)
+  const mine = activity.filter((a) => ids.has(a.agentId) && a.managedByMe);
+  if (mine.length === 0) return null;
+
+  const mru = [...mine]
+    .filter((a) => a.runtimeUpdatedAt)
     .sort((a, b) => (b.runtimeUpdatedAt ?? "").localeCompare(a.runtimeUpdatedAt ?? ""))[0];
   if (mru) return mru.agentId;
-  const pa = activity.find((a) => ids.has(a.agentId) && a.type === "personal_assistant");
+
+  const pa = mine.find((a) => a.type === "personal_assistant");
   if (pa) return pa.agentId;
-  return candidates[0]?.agentId ?? null;
+
+  // Any my-managed agent — `mine` is already candidates ∩ managedByMe,
+  // so the first row is a valid seed without another candidates scan.
+  return mine[0]?.agentId ?? null;
 }

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -8,6 +8,7 @@ import { createMeChat } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
 import {
   ambiguousDisplayNames,
+  groupAndSortCandidates,
   MentionAutocompletePopover,
   type MentionCandidate,
   MentionLabel,
@@ -69,7 +70,12 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
       if (myAgentId && row.agentId === myAgentId) continue;
       const ident = agentIdentity(row.agentId);
       if (!ident || !ident.name) continue;
-      out.push({ agentId: row.agentId, name: ident.name, displayName: ident.displayName });
+      out.push({
+        agentId: row.agentId,
+        name: ident.name,
+        displayName: ident.displayName,
+        managedByMe: row.managedByMe,
+      });
     }
     return out;
   }, [activity, agentIdentity, myAgentId]);
@@ -432,26 +438,51 @@ function ParticipantChips({
           >
             {(() => {
               const ambiguous = ambiguousDisplayNames(chipCandidates);
-              return chipCandidates.map((c) => (
-                <button
-                  key={c.agentId}
-                  type="button"
-                  role="option"
-                  aria-selected="false"
-                  title={c.name ? `@${c.name}` : undefined}
-                  onClick={() => onAdd(c.agentId)}
-                  className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
-                  style={{
-                    background: "transparent",
-                    color: "var(--fg)",
-                    border: "none",
-                    cursor: "pointer",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  <MentionLabel candidate={c} ambiguous={ambiguous} />
-                </button>
-              ));
+              // My-managed agents first, then teammates', alphabetical
+              // within each group, divider between the two groups (only
+              // when both are non-empty). The thin --border-faint
+              // hairline is intentional: visible enough to read as
+              // grouping, quiet enough to not compete for attention.
+              return groupAndSortCandidates(chipCandidates).map((item) => {
+                if ("divider" in item) {
+                  return (
+                    <div
+                      key="__divider"
+                      // `role="presentation"` strips this from the a11y
+                      // tree: listbox semantics expect children to be
+                      // `option`s, and an announced separator inflates
+                      // the "N of M" count in some screen readers. The
+                      // grouping is purely a visual cue.
+                      role="presentation"
+                      style={{
+                        height: "var(--hairline)",
+                        background: "var(--border-faint)",
+                        margin: "var(--sp-0_5) var(--sp-3)",
+                      }}
+                    />
+                  );
+                }
+                return (
+                  <button
+                    key={item.agentId}
+                    type="button"
+                    role="option"
+                    aria-selected="false"
+                    title={item.name ? `@${item.name}` : undefined}
+                    onClick={() => onAdd(item.agentId)}
+                    className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+                    style={{
+                      background: "transparent",
+                      color: "var(--fg)",
+                      border: "none",
+                      cursor: "pointer",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    <MentionLabel candidate={item} ambiguous={ambiguous} />
+                  </button>
+                );
+              });
             })()}
           </div>
         )}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -15,6 +15,7 @@ import {
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { useAgentIdentityMap } from "../../../lib/use-agent-name-map.js";
+import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { cn } from "../../../lib/utils.js";
 
 /**
@@ -56,6 +57,11 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const seededDefaultRef = useRef(false);
   const pickerContainerRef = useRef<HTMLDivElement>(null);
+
+  // Auto-grow the textarea up to the CSS `max-height` cap (10.5rem ≈ 8
+  // visible lines). Re-measure on every keystroke so paste and delete
+  // both adjust instantly; past the cap content scrolls inside.
+  useAutoResizeTextarea(textareaRef, draft);
 
   const { data: activity } = useQuery({
     queryKey: ["activity"],
@@ -269,6 +275,12 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                   padding: "var(--sp-2) var(--sp-3)",
                   background: "transparent",
                   border: "none",
+                  // `rows={1}` sets the initial height; useAutoResizeTextarea
+                  // expands it on each keystroke. Cap at 10.5rem (~8 visible
+                  // lines) so long pastes scroll inside the textarea instead
+                  // of pushing the send button off-screen.
+                  maxHeight: "10.5rem",
+                  overflowY: "auto",
                   resize: "none",
                   color: "var(--fg)",
                 }}


### PR DESCRIPTION
## Summary

Three workspace UX fixes, layered. Each commit ships independently:

1. **`feat(web): default new-chat to an agent the caller manages`** — opening "new chat" used to seed its default chip from the most-recently-active org-visible agent, which could be a coworker's. Scope the default to agents the caller's member personally manages; if they manage none, leave the chip empty.
2. **`feat(web): group participant pickers by manager`** — `[+]` dropdowns (both new-chat and existing-chat header) and the `@`-autocomplete empty-query branch now group by `managedByMe`: mine first, teammates' second, alphabetical within each, thin `--border-faint` hairline divider between. Same helper across all three entry points.
3. **`fix(web): auto-grow composer textarea up to 8 lines`** — both composers had `rows={1}` / `rows={2}` + `resize: none` with no auto-grow JS, so long task descriptions scrolled inside a fixed-height box. Adds a small `useAutoResizeTextarea` hook (~10 LOC, no dep), capped at `10.5rem` (~8 lines, matches ChatGPT/Claude.ai's composer).

## Architecture notes

- Server now derives `managedByMe: boolean` per agent on `/orgs/:orgId/activity` (`agent.managerId === scope.memberId`). Raw `managerId` is never sent to the client.
- `MentionCandidate.managedByMe` is required, not optional — fails fast for callers that forget to populate it (test fixtures + chat-view's lookup were updated accordingly).
- Picker grouping helper (`groupAndSortCandidates`) lives in `mention-autocomplete.tsx` and is shared by all three pickers / autocomplete branches so they can't drift.
- Known limitation, documented at the call site in `chat-view.tsx`: agents in a chat with no runtime presence row default to `managedByMe: false`. Picker grouping is a visual cue, not a security boundary, so we accept this fidelity loss rather than widen `/activity`'s shape.
- Auto-grow hook uses `useLayoutEffect` so it measures before paint (no flicker on mount). `chat-view`'s textarea gets an explicit `min-height: calc(2lh + ...)` to preserve its pre-auto-grow 2-line starting height.

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — 9/9 packages
- [x] `pnpm --filter @first-tree-hub/web test` — 87/87 (added 11 new tests for `groupAndSortCandidates` + `rankCandidates`)
- [x] `pnpm --filter @first-tree-hub/server test` — 827/827 (added 1 contract test pinning `managedByMe` server-derived semantics)
- [x] Local dev hub end-to-end:
  - [x] New chat default chip = my MRU agent (verified `coder` selected over teammate's more-recently-active `zeta`)
  - [x] `[+]` dropdown shows mine on top, hairline, teammates below (alpha within each)
  - [x] Existing chat `[+]` shows same grouping
  - [x] `@` autocomplete empty-query: mine first
  - [x] Composer expands per line, caps ~8 lines, paste-long-text long-opens

## Independent review

Ran [codex](https://github.com/openai/codex) review (`codex review --uncommitted`) → PASS, no findings. Also dispatched a fresh general-purpose agent for an adversarial second look — it flagged 4 P2 + 7 P3 issues, all addressed in subsequent commits before this PR:

- P2-1: chat-view `rows={2}` regression (auto-grow hook collapsed empty textarea to 1 line) → fixed with `min-height: calc(2lh + ...)`.
- P2-2: `rankCandidates` duplicated `groupAndSortCandidates`'s body → now calls the shared helper.
- P2-3: chat-view's `managedByMe` lookup gap for agents w/o runtime presence → documented as known limitation.
- P2-4: missing tests for grouping/ranking → added 11 tests.
- P3-2: `<hr role="separator">` confused screen-reader option counts → changed to `<div role="presentation">`.
- P3-5: `pickDefault`'s final fallback re-iterated `candidates` instead of using `mine[0]` → cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)