### PR TITLE
fix(client): isolate worktrees per agent + signal session init failures

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -96,10 +96,11 @@ describe("GitMirrorManager — lifecycle", () => {
       url: fixtureUrl,
       targetPath: target,
       sessionKey: "chat-1",
+      agentName: "agent-x",
     });
     expect(worktreePath).toBe(target);
     expect(headCommit).toMatch(/^[0-9a-f]{40}$/);
-    expect(branchName).toBe(deriveSessionBranchName("chat-1", fixtureUrl));
+    expect(branchName).toBe(deriveSessionBranchName("chat-1", "agent-x", fixtureUrl));
     // HEAD should be a symbolic ref to the session branch (not detached).
     expect(gitIn(target, "symbolic-ref HEAD")).toBe(`refs/heads/${branchName}`);
     expect(existsSync(join(target, "README.md"))).toBe(true);
@@ -110,12 +111,45 @@ describe("GitMirrorManager — lifecycle", () => {
     await m.ensureMirror(fixtureUrl);
     const a = join(workRoot, "two-sess-a");
     const b = join(workRoot, "two-sess-b");
-    const ra = await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "chat-A" });
-    const rb = await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "chat-B" });
+    const ra = await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "chat-A", agentName: "agent-x" });
+    const rb = await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "chat-B", agentName: "agent-x" });
     expect(ra.branchName).not.toBe(rb.branchName);
     writeFileSync(join(a, "scratch.txt"), "in A only");
     expect(existsSync(join(a, "scratch.txt"))).toBe(true);
     expect(existsSync(join(b, "scratch.txt"))).toBe(false);
+  });
+
+  it("(sameSessionKey, differentAgents) produces disjoint branches — fixes group-chat collision", async () => {
+    // Reproduces the bug from docs/workspace-session-branch-collision-fix-design.md
+    // §1: in a group chat, multiple agents reach `createWorktree` with the
+    // SAME `sessionKey` (= chatId). Pre-fix the derived branch name was
+    // `(sessionKey, url)`-only, so the second agent's `git worktree add`
+    // failed with `fatal: '<branch>' is already used by worktree at ...`.
+    // Post-fix the branch name also folds in `agentName`, so peer agents
+    // get disjoint branches and both worktrees succeed.
+    const m = makeManager();
+    await m.ensureMirror(fixtureUrl);
+    const sharedChat = "shared-chat-1";
+    const targetA = join(workRoot, "peer-agent-a");
+    const targetB = join(workRoot, "peer-agent-b");
+    const ra = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: targetA,
+      sessionKey: sharedChat,
+      agentName: "architect",
+    });
+    const rb = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: targetB,
+      sessionKey: sharedChat,
+      agentName: "developer",
+    });
+    expect(ra.branchName).not.toBe(rb.branchName);
+    expect(ra.branchName).toBe(deriveSessionBranchName(sharedChat, "architect", fixtureUrl));
+    expect(rb.branchName).toBe(deriveSessionBranchName(sharedChat, "developer", fixtureUrl));
+    // Both worktrees materialise — pre-fix the second one would have thrown.
+    expect(existsSync(join(targetA, "README.md"))).toBe(true);
+    expect(existsSync(join(targetB, "README.md"))).toBe(true);
   });
 
   it("createWorktree rejects a non-Hub occupant (D13)", async () => {
@@ -125,7 +159,7 @@ describe("GitMirrorManager — lifecycle", () => {
     mkdirSync(occupied, { recursive: true });
     writeFileSync(join(occupied, "user-data.txt"), "important");
     await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: occupied, sessionKey: "chat-C" }),
+      m.createWorktree({ url: fixtureUrl, targetPath: occupied, sessionKey: "chat-C", agentName: "agent-x" }),
     ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
     expect(existsSync(join(occupied, "user-data.txt"))).toBe(true);
   });
@@ -138,6 +172,7 @@ describe("GitMirrorManager — lifecycle", () => {
       url: fixtureUrl,
       targetPath: target,
       sessionKey: "chat-rm",
+      agentName: "agent-x",
     });
     expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(true);
     await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
@@ -174,6 +209,7 @@ describe("GitMirrorManager — session isolation regressions", () => {
       url: fixtureUrl,
       targetPath: target,
       sessionKey: "incident-1",
+      agentName: "agent-x",
     });
 
     // Advance upstream by one commit (plain commit, not force-push — good enough
@@ -216,8 +252,8 @@ describe("GitMirrorManager — session isolation regressions", () => {
     await m.ensureMirror(fixtureUrl);
     const a = join(workRoot, "incident-3-a");
     const b = join(workRoot, "incident-3-b");
-    await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "incident-3-A" });
-    await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "incident-3-B" });
+    await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "incident-3-A", agentName: "agent-x" });
+    await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "incident-3-B", agentName: "agent-x" });
     await expect(m.fetchMirror(fixtureUrl)).resolves.toBeDefined();
   });
 });
@@ -258,6 +294,7 @@ describe("GitMirrorManager — crash recovery", () => {
       url: fixtureUrl,
       targetPath: firstTarget,
       sessionKey: "crashy",
+      agentName: "agent-x",
     });
     // User or an external process removed the worktree dir without running
     // `git worktree remove`. Git marks it prunable on next access.
@@ -269,6 +306,7 @@ describe("GitMirrorManager — crash recovery", () => {
       url: fixtureUrl,
       targetPath: firstTarget,
       sessionKey: "crashy",
+      agentName: "agent-x",
     });
     expect(reopened.branchName).toBe(branchName);
     expect(reopened.headCommit).toBe(headCommit);
@@ -299,6 +337,7 @@ describe("GitMirrorManager — crash recovery", () => {
       url: fixtureUrl,
       targetPath: target,
       sessionKey: "self-heal-1",
+      agentName: "agent-x",
     });
     expect(result.headCommit).toMatch(/^[0-9a-f]{40}$/);
     expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/remotes/origin/HEAD").ok).toBe(true);
@@ -316,6 +355,7 @@ describe("GitMirrorManager — crash recovery", () => {
       url: fixtureUrl,
       targetPath: target,
       sessionKey: "ghosty",
+      agentName: "agent-x",
     });
     // Bypass git's safety net and delete the ref file directly. Works against
     // loose refs; a freshly-created branch never reaches packed-refs.
@@ -323,7 +363,7 @@ describe("GitMirrorManager — crash recovery", () => {
     rmSync(refPath, { force: true });
 
     await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "ghosty" }),
+      m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "ghosty", agentName: "agent-x" }),
     ).rejects.toBeInstanceOf(GitMirrorError);
   });
 });
@@ -600,8 +640,8 @@ describe("GitMirrorManager — concurrency", () => {
     const a = join(workRoot, "conc-a");
     const b = join(workRoot, "conc-b");
     const [ra, rb] = await Promise.all([
-      m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "conc-A" }),
-      m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "conc-B" }),
+      m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "conc-A", agentName: "agent-x" }),
+      m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "conc-B", agentName: "agent-x" }),
     ]);
     expect(ra.branchName).not.toBe(rb.branchName);
     expect(existsSync(a)).toBe(true);

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -1,0 +1,172 @@
+import type { SessionState } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import { SessionManager } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { silentLogger } from "./_logger-helpers.js";
+import { mockEntry } from "./test-helpers.js";
+
+/**
+ * Pin the F2 contract from
+ * docs/workspace-session-branch-collision-fix-design.md §3.3:
+ *
+ * When `handler.start` or `handler.resume` throws, the SessionManager must
+ *   1) emit `session:state=errored` to the server so admin / UI see it,
+ *   2) forward a user-visible chat message via the result-sink so the chat
+ *      doesn't go silent, and
+ *   3) recover so the next inbound message for the same chat can start a
+ *      fresh session.
+ *
+ * Pre-fix the catch block only torn local state down — the server still
+ * thought the session was `active`, and no chat message surfaced the
+ * failure to the user.
+ */
+
+function mockSdk(): {
+  sdk: FirstTreeHubSDK;
+  sendMessage: ReturnType<typeof vi.fn>;
+} {
+  const sendMessage = vi.fn().mockResolvedValue({ id: "msg-reply" });
+  const listChatParticipants = vi.fn().mockResolvedValue([
+    { agentId: "agent-1", role: "member", mode: "full", name: "agent", displayName: "Agent", type: "autonomous_agent" },
+    { agentId: "user-1", role: "member", mode: "full", name: "user", displayName: "User", type: "human" },
+  ]);
+  return {
+    sdk: {
+      register: vi.fn(),
+      pull: vi.fn(),
+      ack: vi.fn().mockResolvedValue(undefined),
+      renew: vi.fn().mockResolvedValue(undefined),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+      listChatParticipants,
+    } as unknown as FirstTreeHubSDK,
+    sendMessage,
+  };
+}
+
+function makeSessionManager(opts: {
+  handlers: AgentHandler[];
+  onStateChange?: (chatId: string, state: SessionState) => void;
+  sdk?: FirstTreeHubSDK;
+}) {
+  const factory: HandlerFactory = () => {
+    const next = opts.handlers.shift();
+    if (!next) throw new Error("handler factory exhausted");
+    return next;
+  };
+  return new SessionManager({
+    session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    concurrency: 5,
+    handlerFactory: factory,
+    handlerConfig: { workspaceRoot: "/tmp/test" },
+    agentIdentity: {
+      agentId: "agent-1",
+      inboxId: "inbox-agent-1",
+      displayName: "Test Agent",
+      type: "autonomous_agent",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: opts.sdk ?? mockSdk().sdk,
+    log: silentLogger(),
+    onStateChange: opts.onStateChange,
+  });
+}
+
+function failingHandler(): AgentHandler {
+  return {
+    start: vi.fn().mockRejectedValue(new Error("git worktree add failed: branch already in use")),
+    resume: vi.fn(),
+    inject: vi.fn(),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function workingHandler(sessionId = "session-after-recovery"): AgentHandler {
+  return {
+    start: vi.fn().mockResolvedValue(sessionId),
+    resume: vi.fn().mockResolvedValue(sessionId),
+    inject: vi.fn(),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("SessionManager: session-start failure signalling (F2)", () => {
+  it("emits onStateChange('errored') when handler.start throws", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const sm = makeSessionManager({
+      handlers: [failingHandler()],
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-fail" }));
+
+    expect(stateChanges).toEqual([{ chatId: "chat-fail", state: "errored" }]);
+
+    await sm.shutdown();
+  });
+
+  it("forwards a user-visible error message via the result sink", async () => {
+    const { sdk, sendMessage } = mockSdk();
+    const sm = makeSessionManager({ handlers: [failingHandler()], sdk });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-fail" }));
+
+    // sendMessage gets called once — the forwarded user-visible error.
+    // The chat shows `Session start failed (<agent>): <truncated err>`.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [, payload] = sendMessage.mock.calls[0] ?? [];
+    const content = (payload as { content?: string })?.content ?? "";
+    expect(content).toContain("Session start failed");
+    expect(content).toContain("Test Agent");
+    expect(content).toContain("git worktree add failed");
+
+    await sm.shutdown();
+  });
+
+  it("truncates the forwarded error to ~800 characters to keep stderr out of the chat", async () => {
+    const { sdk, sendMessage } = mockSdk();
+    const giant = `boom: ${"x".repeat(2000)}`;
+    const handler = workingHandler();
+    handler.start = vi.fn().mockRejectedValue(new Error(giant));
+    const sm = makeSessionManager({ handlers: [handler], sdk });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-huge-err" }));
+
+    const [, payload] = sendMessage.mock.calls[0] ?? [];
+    const content = (payload as { content?: string })?.content ?? "";
+    // The forwarded body keeps a short prefix ("Session start failed (…): "),
+    // then up to 800 chars of the original message. Headers + prefix put a
+    // floor on total length but the bulk of `xxx…` cap is 800.
+    expect(content.length).toBeLessThan(900);
+    expect(content).toContain("boom: ");
+  });
+
+  it("allows the next inbound message for the same chat to start a fresh session", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const failing = failingHandler();
+    const working = workingHandler("session-after-recovery");
+    const sm = makeSessionManager({
+      handlers: [failing, working],
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    // First dispatch: fails.
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-recover" }));
+    expect(stateChanges).toEqual([{ chatId: "chat-recover", state: "errored" }]);
+
+    // Second dispatch: routes as a fresh start (no `existing` entry).
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recover" }));
+
+    // The recovered session emits `active` (notifySessionState dedupes against
+    // the last reported state per chat, so going `errored → active` is a real
+    // notification, not a no-op).
+    expect(stateChanges.at(-1)).toEqual({ chatId: "chat-recover", state: "active" });
+    expect(working.start).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+});

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -170,3 +170,98 @@ describe("SessionManager: session-start failure signalling (F2)", () => {
     await sm.shutdown();
   });
 });
+
+describe("SessionManager: session-resume failure signalling (F2, resume path)", () => {
+  /**
+   * Build a manager whose concurrency is 1 so two consecutive dispatches
+   * to different chats preempt the first onto the resume path. The handler
+   * factory threads a per-chat queue so each test can stage the exact
+   * start/resume outcomes it needs.
+   */
+  function makeSerializedManager(opts: {
+    handlerQueue: AgentHandler[];
+    onStateChange?: (chatId: string, state: SessionState) => void;
+    sdk?: FirstTreeHubSDK;
+  }) {
+    const queue = [...opts.handlerQueue];
+    return new SessionManager({
+      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      concurrency: 1,
+      handlerFactory: () => queue.shift() ?? workingHandler(),
+      handlerConfig: { workspaceRoot: "/tmp/test" },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Test Agent",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: opts.sdk ?? mockSdk().sdk,
+      log: silentLogger(),
+      onStateChange: opts.onStateChange,
+    });
+  }
+
+  it("emits onStateChange('errored') and forwards a chat-visible error when handler.resume throws", async () => {
+    // Stage: handlerA.start() succeeds; chat-B start preempts chat-A to
+    // suspended; the third dispatch then hits resume on chat-A which throws.
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const { sdk, sendMessage } = mockSdk();
+    const handlerA: AgentHandler = {
+      start: vi.fn().mockResolvedValue("session-A"),
+      resume: vi.fn().mockRejectedValue(new Error("git mirror fetch failed: connection refused")),
+      inject: vi.fn(),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const sm = makeSerializedManager({
+      handlerQueue: [handlerA, workingHandler("session-B")],
+      sdk,
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" })); // start succeeds
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" })); // preempts chat-A
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → throws
+
+    const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
+    expect(chatAStates.at(-1)).toBe("errored");
+    const resumeFwd = sendMessage.mock.calls.find((call) =>
+      ((call[1] as { content?: string })?.content ?? "").includes("Session resume failed"),
+    );
+    expect(resumeFwd).toBeDefined();
+    expect(handlerA.resume).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("allows the next inbound message for the same chat to start a fresh session after a resume failure", async () => {
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const handlerA: AgentHandler = {
+      start: vi.fn().mockResolvedValue("session-A"),
+      resume: vi.fn().mockRejectedValue(new Error("resume blew up")),
+      inject: vi.fn(),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const handlerARecovery = workingHandler("session-A-fresh");
+    const sm = makeSerializedManager({
+      handlerQueue: [handlerA, workingHandler("session-B"), handlerARecovery],
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" }));
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → errored
+
+    // A fresh inbound for chat-A should route as start (entry was dropped
+    // on resume failure — the resume catch tears down the same way the
+    // start catch does, so there's no "stuck suspended" entry blocking it).
+    await sm.dispatch(mockEntry({ id: 4, chatId: "chat-A" }));
+    expect(handlerARecovery.start).toHaveBeenCalledTimes(1);
+    expect(stateChanges.filter((c) => c.chatId === "chat-A").at(-1)?.state).toBe("active");
+
+    await sm.shutdown();
+  });
+});

--- a/packages/client/src/__tests__/workspace.test.ts
+++ b/packages/client/src/__tests__/workspace.test.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+import { acquireWorkspace, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
+
+/**
+ * Pin the F3 self-healing contract from
+ * docs/workspace-session-branch-collision-fix-design.md §3.4:
+ *
+ * `acquireWorkspace` wipes a directory iff it carries the boundary marker
+ * (`.first-tree-workspace`, written in stage 1) BUT is missing the
+ * completion sentinel (`.agent/init-complete`, written after stage 2). That
+ * shape only arises when the previous session start crashed between the
+ * two writes; healing makes the next start get a clean slate instead of
+ * trying to attach to a phantom worktree.
+ */
+
+let root: string;
+const CHAT_ID = "chat-abc";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ftt-ws-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("acquireWorkspace — self-healing", () => {
+  it("creates a fresh directory when nothing exists", () => {
+    const cwd = acquireWorkspace(root, CHAT_ID);
+    expect(cwd).toBe(join(root, CHAT_ID));
+    expect(existsSync(cwd)).toBe(true);
+  });
+
+  it("preserves a healthy directory (boundary marker + sentinel both present)", () => {
+    const cwd = join(root, CHAT_ID);
+    mkdirSync(join(cwd, ".agent"), { recursive: true });
+    writeFileSync(join(cwd, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
+    writeFileSync(join(cwd, INIT_COMPLETE_SENTINEL_REL), JSON.stringify({ schemaVersion: 1 }), "utf-8");
+    writeFileSync(join(cwd, "user-data.txt"), "keep me", "utf-8");
+
+    acquireWorkspace(root, CHAT_ID);
+
+    expect(existsSync(join(cwd, "user-data.txt"))).toBe(true);
+    expect(readFileSync(join(cwd, "user-data.txt"), "utf-8")).toBe("keep me");
+  });
+
+  it("wipes a half-baked directory (boundary marker present, sentinel missing)", () => {
+    const cwd = join(root, CHAT_ID);
+    mkdirSync(join(cwd, ".agent"), { recursive: true });
+    writeFileSync(join(cwd, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
+    // No init-complete — half-baked.
+    writeFileSync(join(cwd, "stale-data.txt"), "should be wiped", "utf-8");
+
+    acquireWorkspace(root, CHAT_ID);
+
+    expect(existsSync(cwd)).toBe(true);
+    expect(existsSync(join(cwd, "stale-data.txt"))).toBe(false);
+    expect(existsSync(join(cwd, FIRST_TREE_WORKSPACE_MARKER))).toBe(false);
+  });
+
+  it("does NOT wipe a directory that lacks the boundary marker entirely", () => {
+    // No boundary marker means stage 1 never ran here — could be a user-
+    // created scratch dir or a partially-populated workspace from a
+    // pre-F3 version. Either way, healing rules don't apply.
+    const cwd = join(root, CHAT_ID);
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(cwd, "user-data.txt"), "keep me", "utf-8");
+
+    acquireWorkspace(root, CHAT_ID);
+
+    expect(existsSync(join(cwd, "user-data.txt"))).toBe(true);
+  });
+});
+
+describe("markWorkspaceInitComplete", () => {
+  it("writes the sentinel with a timestamped JSON body", () => {
+    const cwd = acquireWorkspace(root, CHAT_ID);
+    markWorkspaceInitComplete(cwd);
+
+    const sentinelPath = join(cwd, INIT_COMPLETE_SENTINEL_REL);
+    expect(existsSync(sentinelPath)).toBe(true);
+    const body = JSON.parse(readFileSync(sentinelPath, "utf-8"));
+    expect(body.schemaVersion).toBe(1);
+    expect(typeof body.completedAt).toBe("string");
+    expect(new Date(body.completedAt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("creates .agent/ if missing (defensive — callers normally bootstrap first)", () => {
+    const cwd = acquireWorkspace(root, CHAT_ID);
+    markWorkspaceInitComplete(cwd);
+    expect(existsSync(join(cwd, ".agent"))).toBe(true);
+  });
+
+  it("is idempotent — writing twice leaves a valid sentinel", () => {
+    const cwd = acquireWorkspace(root, CHAT_ID);
+    markWorkspaceInitComplete(cwd);
+    const firstBody = readFileSync(join(cwd, INIT_COMPLETE_SENTINEL_REL), "utf-8");
+    markWorkspaceInitComplete(cwd);
+    const secondBody = readFileSync(join(cwd, INIT_COMPLETE_SENTINEL_REL), "utf-8");
+    // Body may differ (timestamp updates), but the JSON shape is valid both times.
+    expect(JSON.parse(firstBody).schemaVersion).toBe(1);
+    expect(JSON.parse(secondBody).schemaVersion).toBe(1);
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -37,7 +37,7 @@ import type {
 } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
-import { acquireWorkspace } from "../runtime/workspace.js";
+import { acquireWorkspace, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { clearPendingForAgent, registerPendingQuestion, rejectPendingForAgent } from "./ask-user-bridge.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 
@@ -839,16 +839,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // D10: fresh fetch on every new dialog. Failure aborts session creation.
       await gitMirrorManager.fetchMirror(repo.url);
 
+      // Group-chat agents share a `chatId`, so the branch name must fold in
+      // the agent dimension or peers collide on `git worktree add`. Prefer
+      // the operator-stable `agentName` (factory-closure value); fall back
+      // to the agent UUID, which is globally unique. See
+      // docs/workspace-session-branch-collision-fix-design.md §3.2.
+      const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
+
       // If a prior session left a worktree behind at the same path, reuse it
       // rather than fighting the `git worktree add` lock. The matching session
-      // branch is re-derived deterministically from (chatId, url) so cleanup
-      // later can still drop it.
+      // branch is re-derived deterministically from (chatId, agentName, url)
+      // so cleanup later can still drop it.
       if (existsSync(targetPath) && isHubWorktreeMarker(targetPath)) {
         sessionCtx.log(`Git: reusing existing worktree at ${localPath}`);
         ownedWorktrees.push({
           url: repo.url,
           path: targetPath,
-          branchName: deriveSessionBranchName(sessionCtx.chatId, repo.url),
+          branchName: deriveSessionBranchName(sessionCtx.chatId, branchAgentKey, repo.url),
         });
         continue;
       }
@@ -858,6 +865,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         ref: repo.ref,
         targetPath,
         sessionKey: sessionCtx.chatId,
+        agentName: branchAgentKey,
       });
       ownedWorktrees.push({ url: repo.url, path: targetPath, branchName });
       sessionCtx.log(`Git: worktree at ${localPath} @ ${headCommit.slice(0, 7)} on ${branchName}`);
@@ -921,6 +929,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
       await prepareGitWorktrees(cwd, payload, sessionCtx);
 
+      // Stage-2 sentinel: only written after all setup succeeded. A future
+      // `acquireWorkspace` that sees the boundary marker but not this file
+      // treats the directory as half-baked and wipes it. See workspace.ts.
+      markWorkspaceInitComplete(cwd);
+
       sessionCtx.log(
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
       );
@@ -938,8 +951,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       retryCount = 0;
       cwd = acquireWorkspace(workspaceRoot, sessionCtx.chatId);
 
-      // Bootstrap on resume only if .agent/ is missing
-      if (!existsSync(join(cwd, ".agent", "identity.json"))) {
+      // Bootstrap on resume only if the stage-2 sentinel is missing. Pre-F3
+      // this check looked at `.agent/identity.json`; now `.agent/init-complete`
+      // is the authoritative "stage 2 finished" signal, written by
+      // `markWorkspaceInitComplete` after worktrees materialise.
+      if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
         runBootstrap(cwd, sessionCtx);
       }
 
@@ -948,6 +964,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // worktree is reused if still present (handled inside prepareGitWorktrees).
       const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
       await prepareGitWorktrees(cwd, payload, sessionCtx);
+
+      // Ensure the sentinel is present after resume too. Idempotent — only
+      // matters when the bootstrap branch above ran (e.g. resume of a
+      // half-baked workspace that `acquireWorkspace` just wiped).
+      markWorkspaceInitComplete(cwd);
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
       spawnQuery(sessionId, sessionCtx, sessionId);

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -10,7 +10,7 @@ import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { bootstrapWorkspace, FIRST_TREE_WORKSPACE_MARKER, installFirstTreeIntegration } from "../runtime/bootstrap.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
-import { acquireWorkspace } from "../runtime/workspace.js";
+import { acquireWorkspace, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
 
 /**
  * Codex SDK does not export its `CodexConfigObject` type, so reproduce the
@@ -159,9 +159,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
   async function prepareGitWorktrees(
     payload: AgentRuntimeConfigPayload,
     workspaceCwd: string,
-    chatId: string,
+    sessionCtx: SessionContext,
   ): Promise<void> {
     if (!gitMirrorManager) return;
+    // See claude-code's `prepareGitWorktrees`: fold the agent dimension into
+    // the branch hash so group-chat peers don't collide on `git worktree add`.
+    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
     for (const repo of payload.gitRepos) {
       const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
       if (!localPath) continue;
@@ -174,7 +177,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
           url: repo.url,
           ref: repo.ref,
           targetPath,
-          sessionKey: chatId,
+          sessionKey: sessionCtx.chatId,
+          agentName: branchAgentKey,
         });
         ownedWorktrees.push({ url: repo.url, path: targetPath, branchName: result.branchName });
       } catch (err) {
@@ -476,7 +480,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
       });
       ensureFirstTreeBinding(cwd, sessionCtx);
 
-      await prepareGitWorktrees(payload, cwd, sessionCtx.chatId);
+      await prepareGitWorktrees(payload, cwd, sessionCtx);
+
+      // Stage-2 sentinel — see workspace.ts. Only written after all setup
+      // succeeded so a future `acquireWorkspace` can detect and wipe
+      // half-baked directories from a previous failed start.
+      markWorkspaceInitComplete(cwd);
 
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
       thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
@@ -515,11 +524,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
       }
 
       // Mirror claude-code's resume fast-path: skip workspace bootstrap and
-      // the `first-tree tree integrate` shell-out when `.agent/identity.json`
-      // already exists. Idempotent doesn't mean free — integrate forks the
-      // CLI (or falls back to `npx -y first-tree@latest`) every time, which
-      // is unnecessary latency once the workspace is already populated.
-      if (!existsSync(join(cwd, ".agent", "identity.json"))) {
+      // the `first-tree tree integrate` shell-out when the stage-2 sentinel
+      // is present. Pre-F3 we keyed on `.agent/identity.json`; now the
+      // explicit `.agent/init-complete` is the authoritative "stage 2
+      // succeeded" signal, written by `markWorkspaceInitComplete` after
+      // worktrees materialise.
+      if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
         bootstrapWorkspace({
           workspacePath: cwd,
           identity: sessionCtx.agent,
@@ -531,7 +541,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
         ensureFirstTreeBinding(cwd, sessionCtx);
       }
 
-      await prepareGitWorktrees(payload, cwd, sessionCtx.chatId);
+      await prepareGitWorktrees(payload, cwd, sessionCtx);
+
+      // Stage-2 sentinel. Idempotent on a healthy resume; only matters when
+      // the bootstrap branch above ran (e.g. resume of a half-baked
+      // workspace that `acquireWorkspace` just wiped).
+      markWorkspaceInitComplete(cwd);
 
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
       // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -53,6 +53,12 @@ export interface GitMirrorManager {
     ref?: string;
     targetPath: string;
     sessionKey: string;
+    /**
+     * Identifier for the agent owning this worktree. Required so the derived
+     * branch name does not collide with peer agents in the same chat — see
+     * `deriveSessionBranchName` docblock.
+     */
+    agentName: string;
   }): Promise<{ worktreePath: string; headCommit: string; branchName: string }>;
   removeWorktree(args: { url: string; path: string; branchName: string }): Promise<void>;
   gcMirrors(stillReferencedUrls: Set<string>): Promise<{ removed: string[] }>;
@@ -141,8 +147,26 @@ function shortHash(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 8);
 }
 
-export function deriveSessionBranchName(sessionKey: string, url: string): string {
-  return `${SESSION_BRANCH_PREFIX}-${shortHash(sessionKey)}-${shortHash(url)}`;
+/**
+ * Branch name a session's worktree attaches to. The hash inputs include the
+ * agent dimension because `(chat, url)` alone is not unique: two agents that
+ * share a chat each open their own worktree at
+ * `<workspaces>/<agent>/<chatId>/...`, and git refuses to point two worktrees
+ * at the same branch (`fatal: '<branch>' is already used by worktree at …`).
+ * Hash inputs are joined with `:` so `(chatA, agentB)` cannot collide with
+ * `(chatAB, "")`.
+ *
+ * The caller picks `agentName`. Prefer the operator-stable name
+ * (`config.yaml::agents.<name>`); fall back to `agent.agentId` (a UUID,
+ * globally unique) when the stable name isn't available. Anything stable
+ * across `start` and `resume` for the same `(agent, chat)` pair will do —
+ * the contract is "no collision with a peer agent in the same chat", not
+ * "human-readable in the branch name".
+ *
+ * See docs/workspace-session-branch-collision-fix-design.md §3.2.
+ */
+export function deriveSessionBranchName(sessionKey: string, agentName: string, url: string): string {
+  return `${SESSION_BRANCH_PREFIX}-${shortHash(`${sessionKey}:${agentName}`)}-${shortHash(url)}`;
 }
 
 /**
@@ -518,14 +542,14 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
       });
     },
 
-    createWorktree({ url, ref, targetPath, sessionKey }) {
+    createWorktree({ url, ref, targetPath, sessionKey, agentName }) {
       return withUrlLock(url, async () => {
         const mirror = mirrorDir(url);
         if (!existsSync(join(mirror, "HEAD"))) {
           throw new GitMirrorError(`Cannot create worktree — no mirror exists for "${url}"`);
         }
         const absTarget = resolve(targetPath);
-        const branchName = deriveSessionBranchName(sessionKey, url);
+        const branchName = deriveSessionBranchName(sessionKey, agentName, url);
 
         // D13: target path must be free OR a Hub-managed worktree we can reuse.
         if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -432,7 +432,39 @@ export class SessionManager {
       this.persistRegistry();
       this.notifySessionState(chatId, "active");
     } catch (err) {
-      this.config.log.error({ chatId, err, phase: evicted ? "resume" : "start" }, "session start/resume failed");
+      // Pre-fix this catch only logged and torn local state down. The
+      // server's `agent_chat_sessions.state` stayed `active`, no chat
+      // message was emitted, and the agent looked silently failed to
+      // every observer. F2 (chat-participant-mode-fix-design.md §3.3)
+      // signals the failure three ways: structured log (existing),
+      // `session:state=errored` to the server (so admin/UI see it), and
+      // a single user-visible chat message via the result-sink (so the
+      // requester knows the agent didn't drop their message on purpose).
+      const errMsg = err instanceof Error ? err.message : String(err);
+      const phase: "start" | "resume" = evicted ? "resume" : "start";
+      this.config.log.error({ chatId, err, phase }, "session start/resume failed");
+
+      // 1) Server-side state. notifySessionState dedupes against the last
+      //    reported value, so even if we somehow already reported "active"
+      //    for this chat, this `errored` transition will go through.
+      this.notifySessionState(chatId, "errored");
+
+      // 2) User-visible chat message. Truncate to 800 chars so we don't
+      //    leak full stderr (which may include FS paths or git internals)
+      //    into the chat timeline; the full error is in the structured log.
+      try {
+        const preview = errMsg.slice(0, 800);
+        const agentLabel = this.config.agentIdentity.displayName ?? this.config.agentIdentity.agentId;
+        const userMsg = `⚠️ Session ${phase} failed (${agentLabel}): ${preview}`;
+        await ctx.forwardResult(userMsg);
+      } catch (forwardErr) {
+        this.config.log.warn({ chatId, forwardErr }, "session error forward failed");
+      }
+
+      // 3) Existing local cleanup. Order matters: forward FIRST while the
+      //    session entry is still live (forwardResult reads currentTrigger
+      //    / participant cache via the session context built above);
+      //    THEN tear down so a follow-up message can route as a fresh start.
       this.sessions.delete(chatId);
       this.sessionRuntimeStates.delete(chatId);
       this.recomputeRuntimeState();

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -461,10 +461,10 @@ export class SessionManager {
         this.config.log.warn({ chatId, forwardErr }, "session error forward failed");
       }
 
-      // 3) Existing local cleanup. Order matters: forward FIRST while the
-      //    session entry is still live (forwardResult reads currentTrigger
-      //    / participant cache via the session context built above);
-      //    THEN tear down so a follow-up message can route as a fresh start.
+      // 3) Existing local cleanup. Forward first, tear down second —
+      //    keeps the order obviously safe regardless of future cleanup-
+      //    block refactors. The follow-up message routes as a fresh
+      //    start once the entry is gone.
       this.sessions.delete(chatId);
       this.sessionRuntimeStates.delete(chatId);
       this.recomputeRuntimeState();
@@ -509,8 +509,29 @@ export class SessionManager {
       this.persistRegistry();
       this.notifySessionState(entry.chatId, "active");
     } catch (err) {
-      this.config.log.warn({ chatId: entry.chatId, err }, "resume failed");
-      entry.status = "suspended";
+      // Mirror `startNewSession`'s F2 contract (design §3.3): a resume that
+      // throws is not the same shape as a suspend (the entry is unusable,
+      // not just idle), so leaving `status = "suspended"` would lie to the
+      // server and let the broken entry persist locally. Notify `errored`,
+      // forward a chat-visible error, then drop the entry so the next
+      // inbound message routes through `startNewSession` for a clean restart.
+      const errMsg = err instanceof Error ? err.message : String(err);
+      this.config.log.error({ chatId: entry.chatId, err }, "resume failed");
+
+      this.notifySessionState(entry.chatId, "errored");
+
+      try {
+        const preview = errMsg.slice(0, 800);
+        const agentLabel = this.config.agentIdentity.displayName ?? this.config.agentIdentity.agentId;
+        const userMsg = `⚠️ Session resume failed (${agentLabel}): ${preview}`;
+        await ctx.forwardResult(userMsg);
+      } catch (forwardErr) {
+        this.config.log.warn({ chatId: entry.chatId, forwardErr }, "session error forward failed");
+      }
+
+      this.sessions.delete(entry.chatId);
+      this.sessionRuntimeStates.delete(entry.chatId);
+      this.recomputeRuntimeState();
       this._activeCount--;
     }
   }

--- a/packages/client/src/runtime/workspace.ts
+++ b/packages/client/src/runtime/workspace.ts
@@ -1,16 +1,62 @@
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { FIRST_TREE_WORKSPACE_MARKER } from "./bootstrap.js";
 
 export const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /**
+ * Sentinel that flags "stage-2 of session bootstrap (git worktree
+ * materialisation) completed successfully". Distinct from the
+ * `FIRST_TREE_WORKSPACE_MARKER` (`.first-tree-workspace`) which is the
+ * "agent workspace boundary" — Codex's `project_root_markers` uses that one
+ * to stop walking up the filesystem when looking for `AGENTS.md`. Splitting
+ * the two so the boundary marker can be written eagerly (stage 1) while the
+ * completion sentinel only appears after stage 2 lets `acquireWorkspace`
+ * detect half-baked directories from a previous failed start and self-heal.
+ *
+ * See docs/workspace-session-branch-collision-fix-design.md §3.4.
+ */
+export const INIT_COMPLETE_SENTINEL_REL = join(".agent", "init-complete");
+
+/**
  * Acquire a per-chat workspace directory.
- * Creates the directory if it does not exist; returns the path if it does.
+ *
+ * Healing rule: if the directory exists AND carries the boundary marker
+ * (`.first-tree-workspace`, written in stage 1) AND is missing the
+ * completion sentinel (`.agent/init-complete`, written after stage 2), the
+ * previous session start crashed between the two writes — wipe it so the
+ * fresh start gets a clean slate. The boundary marker alone (without the
+ * sentinel) is the unambiguous shape of a half-baked workspace: only stage 1
+ * writes it, and only stage 2 writes the sentinel.
  */
 export function acquireWorkspace(workspaceRoot: string, chatId: string): string {
   const dir = join(workspaceRoot, chatId);
+
+  if (
+    existsSync(dir) &&
+    existsSync(join(dir, FIRST_TREE_WORKSPACE_MARKER)) &&
+    !existsSync(join(dir, INIT_COMPLETE_SENTINEL_REL))
+  ) {
+    // Half-baked from a previous failed start — start over.
+    rmSync(dir, { recursive: true, force: true });
+  }
+
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+/**
+ * Write the stage-2 completion sentinel. Callers must invoke this AFTER all
+ * pre-handler-spawn setup (workspace bootstrap, git worktrees, first-tree
+ * integration) succeeded, so a process that crashes earlier leaves a
+ * half-baked workspace the next acquireWorkspace can heal.
+ */
+export function markWorkspaceInitComplete(workspaceCwd: string): void {
+  const path = join(workspaceCwd, INIT_COMPLETE_SENTINEL_REL);
+  // `.agent/` already exists after `bootstrapWorkspace`; createDir defensively
+  // in case a caller writes the sentinel without a prior bootstrap.
+  mkdirSync(join(workspaceCwd, ".agent"), { recursive: true });
+  writeFileSync(path, JSON.stringify({ completedAt: new Date().toISOString(), schemaVersion: 1 }), "utf-8");
 }
 
 /**

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -26,14 +26,23 @@ export const SESSION_STATES = {
   ACTIVE: "active",
   SUSPENDED: "suspended",
   EVICTED: "evicted",
+  /**
+   * Handler-start (or resume) raised an exception before the session was
+   * usable. Distinct from `suspended` (which is the client's idle / preempted
+   * state and means "resumable on next message"); `errored` records a
+   * concrete failure that ops / admin / the user should see. The next inbound
+   * message for the chat is still allowed to start a fresh session — see
+   * docs/workspace-session-branch-collision-fix-design.md §3.3.
+   */
+  ERRORED: "errored",
 } as const;
 
 /** DB + admin surface. `evicted` is server-only (admin Terminate); never carried on the wire. */
-export const sessionStateSchema = z.enum(["active", "suspended", "evicted"]);
+export const sessionStateSchema = z.enum(["active", "suspended", "evicted", "errored"]);
 export type SessionState = z.infer<typeof sessionStateSchema>;
 
 /** Wire-level states a client may report. `evicted` from a stale client is rejected. */
-export const clientSessionStateSchema = z.enum(["active", "suspended"]);
+export const clientSessionStateSchema = z.enum(["active", "suspended", "errored"]);
 export type ClientSessionState = z.infer<typeof clientSessionStateSchema>;
 
 export const sessionStateMessageSchema = z.object({


### PR DESCRIPTION
## ⚠️ Upgrade notice

This PR introduces a new sentinel `.agent/init-complete`. Existing workspaces
predating this PR lack the sentinel and will be detected as half-baked by
`acquireWorkspace`, triggering a one-time wipe + re-bootstrap on first
resume after upgrade. Safe (rebuilds from git mirror), but expect the first
message in each chat after upgrade to take ~git-clone time longer than usual.

## Summary

Fixes "agent silently fails to respond when multiple agents are mentioned in
a group chat" — root cause analysis in
`docs/workspace-session-branch-collision-fix-design.md` (architect workspace).

**What broke**: `deriveSessionBranchName(chatId, url)` did not include agent
identity, so every agent participating in the same chat tried to claim the
same git branch via `git worktree add` → second one onward fails with
`fatal: ... is already used by worktree at .../<first-agent>/...`. The
`startNewSession` catch block swallowed the error (logged only — no server
state update, no user-visible message), masking it as "agent failed to
respond". `resumeSession` had the same swallow path, additionally
mislabelling resume failures as `suspended`.

**What's fixed**:
- Branch derivation now includes agent identity (F0)
- Both `startNewSession` and `resumeSession` catch blocks: notify server
  with `errored` state + forward truncated error to chat (F2)
- Half-baked workspaces (stage-1 written but stage-2 failed) are detected
  and rebuilt on next acquire via a new `.agent/init-complete` sentinel,
  decoupled from the workspace-boundary marker `.first-tree-workspace` (F3)

## Changes

- **F0** — `deriveSessionBranchName(sessionKey, agentName, url)` + `createWorktree({...agentName})` signature update; callers in `claude-code.ts` (start + resume) and `codex.ts` adjusted to pass agentName (closure value, fallbacks to `agent.agentId` uuid)
- **F2** — both `startNewSession` and `resumeSession` catch blocks: server state notification + chat-visible error forward (truncated to 800 chars with `⚠️ Session start/resume failed (<agent>):` prefix); local entry cleanup retained
- **F3** — `.agent/init-complete` sentinel written after stage 2 completes; `acquireWorkspace` detects half-baked workspaces (boundary marker present + sentinel missing) and rebuilds; resume fast-path migrated to new sentinel
- **SessionState** — `errored` added to `SESSION_STATES` + `sessionStateSchema` + `clientSessionStateSchema` (no DB migration needed, column is text)

## Verification

- `pnpm check` ✅
- `pnpm typecheck` ✅ 9/9
- shared 202/202 + client 332+/332+ + server 826/826 (only pre-existing flaky network test fails, unrelated)
- New tests: F0 invariant (`(sameChat, differentAgents) → differentBranches`); F2 integration (6 total — 4 for start path + 2 for resume path); F3 unit (7 — fresh/healthy/half-baked/no-marker/sentinel/.agent/idempotent)
- Manual verification of original bug scenario equivalent: F0 invariant test covers it

## Out of scope

- F1 (handler.start timeout wrapper) — future work; current bug was a sync throw, not a hang
- F4 (stage-2 emit events) — future work; observability nice-to-have

## Ops

A one-time cleanup of the historical half-baked workspace + stale architect worktree from chat 1e0eaeee will be run by the operator (架构师 has details). Not strictly required: F3 auto-heals on next acquire.