### PR TITLE
ops(server): add pre-flight + post-deploy probes for migration 0038

### DIFF
--- a/packages/server/drizzle/probes/0038_chat_membership_user_state.post-deploy.sql
+++ b/packages/server/drizzle/probes/0038_chat_membership_user_state.post-deploy.sql
@@ -1,0 +1,165 @@
+-- Post-deploy validation for migration 0038_chat_membership_user_state.
+--
+-- Run AFTER 0038 has been applied (staging first, then prod). The
+-- migration itself has embedded row-count assertions that abort if the
+-- back-fill diverges from the source legacy tables — these probes are a
+-- second-pass *external* check (the migration's assertions ran inside
+-- the same transaction; these run from outside).
+--
+-- HOW to run (read-only, safe to repeat):
+--   psql "$DATABASE_URL" -f packages/server/drizzle/probes/0038_chat_membership_user_state.post-deploy.sql > 0038.post-deploy.<env>.txt
+--
+-- WHAT to look for: see the comment above each check.
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 1: chat_membership row count matches UNION over legacy tables.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: `delta = 0`. A non-zero value means the back-fill dropped or
+-- duplicated rows. The migration's own assertion should have caught this
+-- inside the migration TX, so a non-zero here implies post-migration
+-- divergence — somewhere a service is writing to one set of tables but
+-- not the other (legacy tables still exist; PR-B drops them).
+
+SELECT
+  (SELECT COUNT(*) FROM chat_membership) AS membership_count,
+  (SELECT COUNT(*)
+     FROM (SELECT chat_id, agent_id FROM chat_participants
+           UNION
+           SELECT chat_id, agent_id FROM chat_subscriptions) u) AS legacy_union_count,
+  (SELECT COUNT(*) FROM chat_membership)
+    - (SELECT COUNT(*)
+         FROM (SELECT chat_id, agent_id FROM chat_participants
+               UNION
+               SELECT chat_id, agent_id FROM chat_subscriptions) u) AS delta;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 2: chat_user_state row count matches UNION over legacy rows
+-- that carry non-default state.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: `delta = 0`. Same rationale as Check 1, narrowed to the
+-- state-carrying subset.
+
+SELECT
+  (SELECT COUNT(*) FROM chat_user_state) AS user_state_count,
+  (SELECT COUNT(*)
+     FROM (SELECT chat_id, agent_id FROM chat_participants
+            WHERE last_read_at IS NOT NULL OR unread_mention_count > 0
+            UNION
+           SELECT chat_id, agent_id FROM chat_subscriptions
+            WHERE last_read_at IS NOT NULL OR unread_mention_count > 0) u)
+    AS legacy_state_union_count,
+  (SELECT COUNT(*) FROM chat_user_state)
+    - (SELECT COUNT(*)
+         FROM (SELECT chat_id, agent_id FROM chat_participants
+                WHERE last_read_at IS NOT NULL OR unread_mention_count > 0
+                UNION
+               SELECT chat_id, agent_id FROM chat_subscriptions
+                WHERE last_read_at IS NOT NULL OR unread_mention_count > 0) u)
+    AS delta;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 3: speaker-wins merge preserved on collision.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: 0 rows.
+-- For every (chat_id, agent_id) pair that appears in BOTH legacy tables,
+-- the resulting chat_membership row MUST be access_mode='speaker' (per
+-- migration 0038's "DO NOTHING on the subscription branch" merge policy).
+-- A non-zero result means the merge policy was violated.
+
+SELECT cp.chat_id, cp.agent_id, cm.access_mode
+  FROM chat_participants cp
+  JOIN chat_subscriptions cs USING (chat_id, agent_id)
+  JOIN chat_membership cm ON cm.chat_id = cp.chat_id AND cm.agent_id = cp.agent_id
+ WHERE cm.access_mode <> 'speaker';
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 4: listMeChats query plan uses the new indexes.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: the plan should reference at least one of
+--   - `chat_membership_pkey` (PK on chat_id, agent_id) for the JOIN
+--   - `idx_membership_agent` for the cm.agent_id filter
+--   - `idx_user_state_agent` for the cus LEFT JOIN
+-- A plan that falls back to a Seq Scan on `chat_membership` or
+-- `chat_user_state` is a regression — the row counts on staging may be
+-- low enough for the planner to *prefer* a seq scan, in which case re-run
+-- with a known-active human agent that has many chats.
+--
+-- Replace `__AGENT_ID__` with a real human agent uuid and `__ORG_ID__`
+-- with that agent's manager.organization_id, both from staging.
+
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT
+  c.id                  AS chat_id,
+  c.type                AS type,
+  c.topic               AS topic,
+  c.parent_chat_id      AS parent_chat_id,
+  c.last_message_at     AS last_message_at,
+  c.last_message_preview AS last_message_preview,
+  (SELECT count(*) FROM chat_membership
+    WHERE chat_id = c.id AND access_mode = 'speaker') AS participant_count,
+  cm.access_mode AS access_mode,
+  COALESCE(cus.unread_mention_count, 0) AS unread_mention_count
+  FROM chats c
+  JOIN chat_membership cm
+    ON cm.chat_id = c.id AND cm.agent_id = '__AGENT_ID__'
+  LEFT JOIN chat_user_state cus
+    ON cus.chat_id = c.id AND cus.agent_id = '__AGENT_ID__'
+ WHERE c.parent_chat_id IS NULL
+   AND c.organization_id = '__ORG_ID__'
+ ORDER BY c.last_message_at DESC NULLS LAST, c.id DESC
+ LIMIT 21;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 5: index scan stats since deploy.
+-- ──────────────────────────────────────────────────────────────────────
+-- Informational — run a few hours after traffic resumes. The new indexes
+-- should have non-zero `idx_scan` counts (proving the planner does pick
+-- them); zero scans means the planner is bypassing them entirely.
+
+SELECT relname, indexrelname, idx_scan, idx_tup_read, idx_tup_fetch
+  FROM pg_stat_user_indexes
+ WHERE indexrelname IN (
+     'chat_membership_pkey',
+     'idx_membership_agent',
+     'idx_membership_chat_role',
+     'chat_user_state_pkey',
+     'idx_user_state_agent',
+     'idx_user_state_unread'
+   )
+ ORDER BY indexrelname;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Check 6: unread badge consistency with listMeChats scope.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: 0 rows.
+-- For any human agent, the unread badge (countUnreadMeChats) and the
+-- list view (listMeChats) must agree — both must JOIN chat_membership +
+-- chats and filter by parent_chat_id IS NULL + organization_id. A
+-- chat_user_state row whose owner has been fully detached (no
+-- chat_membership row) is allowed (preserved-on-detach per design
+-- §11.4), but it must NOT contribute to the badge.
+--
+-- Replace `__AGENT_ID__` + `__ORG_ID__` as in Check 4. The output is
+-- the count surfaced to the badge minus the count of unread chats the
+-- list view would actually show; both must match.
+
+WITH badge AS (
+  SELECT count(*)::int AS n
+    FROM chat_user_state cus
+    JOIN chat_membership cm ON cm.chat_id = cus.chat_id AND cm.agent_id = cus.agent_id
+    JOIN chats c            ON c.id = cus.chat_id
+   WHERE cus.agent_id = '__AGENT_ID__'
+     AND cus.unread_mention_count > 0
+     AND c.parent_chat_id IS NULL
+     AND c.organization_id = '__ORG_ID__'
+), list AS (
+  SELECT count(*)::int AS n
+    FROM chats c
+    JOIN chat_membership cm ON cm.chat_id = c.id AND cm.agent_id = '__AGENT_ID__'
+    LEFT JOIN chat_user_state cus ON cus.chat_id = c.id AND cus.agent_id = '__AGENT_ID__'
+   WHERE c.parent_chat_id IS NULL
+     AND c.organization_id = '__ORG_ID__'
+     AND COALESCE(cus.unread_mention_count, 0) > 0
+)
+SELECT badge.n AS badge_count, list.n AS list_count, badge.n - list.n AS delta
+  FROM badge, list;

--- a/packages/server/drizzle/probes/0038_chat_membership_user_state.pre-flight.sql
+++ b/packages/server/drizzle/probes/0038_chat_membership_user_state.pre-flight.sql
@@ -1,0 +1,129 @@
+-- Pre-flight collision probe for the chat data model restructure
+-- (migration 0038_chat_membership_user_state).
+--
+-- WHEN to run:
+--   1. Against staging FIRST — archive output for review.
+--   2. Then against a prod read replica — archive output too.
+--   Both must come back clean before 0038 enters prod. If Probe 1
+--   surfaces collisions, investigate the write path before deploying;
+--   the migration's speaker-wins ON CONFLICT DO UPDATE will still
+--   resolve the row, but the surprise itself is a service-layer bug.
+--
+-- HOW to run (read-only, safe on prod replica):
+--   psql "$DATABASE_URL" -f packages/server/drizzle/probes/0038_chat_membership_user_state.pre-flight.sql > 0038.pre-flight.<env>.txt
+--
+-- Background: this artifact was originally drafted in the design proposal
+-- (first-tree-context PR #253) but executable SQL belongs alongside the
+-- migration it probes, not in design-docs.
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Probe 1: invariant-1 (mutual exclusion) violations.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: 0 rows.
+-- If non-zero, the speaker row WILL win during the back-fill (0038
+-- explicit merge policy: chat_membership ← chat_participants then
+-- DO NOTHING on the chat_subscriptions branch), but the surprise should
+-- be investigated first — it indicates a write path that bypassed the
+-- service-layer mutual-exclusion guard.
+
+SELECT
+  cp.chat_id,
+  cp.agent_id,
+  cp.last_read_at AS participant_last_read_at,
+  cs.last_read_at AS subscription_last_read_at,
+  cp.unread_mention_count AS participant_unread,
+  cs.unread_mention_count AS subscription_unread
+FROM chat_participants cp
+JOIN chat_subscriptions cs USING (chat_id, agent_id);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Probe 2: orphan agent_id references.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: 0 rows.
+-- An agent_id that exists in chat_participants / chat_subscriptions but
+-- has no matching agents.uuid is a soft-delete-after-hard-delete leak.
+-- The migration's data back-fill will carry these rows over (no agent FK
+-- on the new tables either) but they will never be reachable by any
+-- service — they should be cleaned up pre-cutover so the new tables
+-- start clean.
+
+SELECT 'chat_participants' AS source, chat_id, agent_id
+  FROM chat_participants cp
+ WHERE NOT EXISTS (SELECT 1 FROM agents a WHERE a.uuid = cp.agent_id)
+UNION ALL
+SELECT 'chat_subscriptions' AS source, chat_id, agent_id
+  FROM chat_subscriptions cs
+ WHERE NOT EXISTS (SELECT 1 FROM agents a WHERE a.uuid = cs.agent_id);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Probe 3: orphan chat_id references.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: 0 rows.
+-- Both legacy tables have `ON DELETE CASCADE` on chat_id, so an orphan
+-- chat_id should be impossible by construction. A non-zero result here
+-- means the migration history is inconsistent and needs investigation
+-- before back-filling.
+
+SELECT 'chat_participants' AS source, chat_id, agent_id
+  FROM chat_participants cp
+ WHERE NOT EXISTS (SELECT 1 FROM chats c WHERE c.id = cp.chat_id)
+UNION ALL
+SELECT 'chat_subscriptions' AS source, chat_id, agent_id
+  FROM chat_subscriptions cs
+ WHERE NOT EXISTS (SELECT 1 FROM chats c WHERE c.id = cs.chat_id);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Probe 4: chats projection (last_message_at) drift.
+-- ──────────────────────────────────────────────────────────────────────
+-- Expected: small number of rows (transient: the millisecond gap between
+-- message INSERT and the projection UPDATE).
+-- Large drift (> a few minutes, or chats with messages but NULL
+-- last_message_at) indicates a stale projection — fix with a single
+-- DISTINCT ON re-run before the migration so the cursor pagination in
+-- the new listMeChats query plan does not surprise the user with
+-- skipped chats.
+
+SELECT
+  c.id           AS chat_id,
+  c.last_message_at AS chats_last_message_at,
+  m.created_at   AS actual_latest_message_at,
+  c.last_message_at - m.created_at AS drift
+FROM chats c
+JOIN LATERAL (
+  SELECT created_at
+    FROM messages
+   WHERE chat_id = c.id
+   ORDER BY created_at DESC
+   LIMIT 1
+) m ON true
+WHERE c.last_message_at IS NULL
+   OR ABS(EXTRACT(EPOCH FROM (c.last_message_at - m.created_at))) > 60
+ORDER BY drift DESC NULLS LAST
+LIMIT 100;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Row-count sanity (informational, not a gate).
+-- ──────────────────────────────────────────────────────────────────────
+-- Print expected back-fill volumes so the post-migration row-count
+-- assertion inside 0038 has an external check.
+--
+-- `user_state_estimated_count` uses UNION (not SUM) over (chat_id,
+-- agent_id) so a pair counted twice in both legacy tables — exactly the
+-- collision Probe 1 hunts for — does NOT inflate the estimate. The
+-- migration's speaker-wins merge collapses such pairs into a single
+-- chat_user_state row, and this estimate must match that.
+
+SELECT
+  (SELECT COUNT(*) FROM chat_participants) AS participants_count,
+  (SELECT COUNT(*) FROM chat_subscriptions) AS subscriptions_count,
+  (SELECT COUNT(*)
+     FROM (SELECT chat_id, agent_id FROM chat_participants
+           UNION
+           SELECT chat_id, agent_id FROM chat_subscriptions) u) AS union_count,
+  (SELECT COUNT(*)
+     FROM (SELECT chat_id, agent_id FROM chat_participants
+            WHERE last_read_at IS NOT NULL OR unread_mention_count > 0
+            UNION
+           SELECT chat_id, agent_id FROM chat_subscriptions
+            WHERE last_read_at IS NOT NULL OR unread_mention_count > 0) u)
+    AS user_state_estimated_count;

--- a/packages/server/drizzle/probes/README.md
+++ b/packages/server/drizzle/probes/README.md
@@ -1,0 +1,39 @@
+# drizzle/probes
+
+Read-only SQL artifacts that **accompany** a migration but are **not**
+themselves migrations. drizzle-kit ignores everything outside
+`meta/_journal.json`, so files in this subdirectory are never
+auto-applied — they exist purely for ops to run by hand against a real
+database during a deploy window.
+
+## Naming convention
+
+```
+NNNN_<migration-tag>.<phase>.sql
+```
+
+Where `<phase>` is one of:
+
+- `pre-flight` — run **before** the migration enters prod. Validates the
+  *input* data (orphan rows, invariant violations, projection drift).
+  Migration must not proceed if a probe returns unexpected rows.
+- `post-deploy` — run **after** the migration has been applied.
+  Validates the *output* (row counts, query plans, index usage).
+
+## Current artifacts
+
+| File | Migration | Purpose |
+|------|-----------|---------|
+| `0038_chat_membership_user_state.pre-flight.sql` | 0038 | Collision + orphan probe before the legacy → new-table back-fill. See first-tree-context proposal §9.1. |
+| `0038_chat_membership_user_state.post-deploy.sql` | 0038 | Row-count + speaker-wins + EXPLAIN ANALYZE + index-scan + badge-consistency checks after 0038 has run. |
+
+## How to run
+
+```bash
+psql "$DATABASE_URL" \
+  -f packages/server/drizzle/probes/0038_chat_membership_user_state.pre-flight.sql \
+  > 0038.pre-flight.staging.txt
+```
+
+Archive the `.txt` somewhere reachable (PR comment, ops drive). Both
+staging and prod runs are expected before each phase advances.


### PR DESCRIPTION
## Summary

Adds two read-only SQL artifacts that accompany [migration 0038](https://github.com/agent-team-foundation/first-tree-hub/blob/main/packages/server/drizzle/0038_chat_membership_user_state.sql) (the chat data model 3-layer separation from #325). Both live under `packages/server/drizzle/probes/` — a subdirectory drizzle-kit ignores (it only reads `meta/_journal.json`), so they are never auto-applied. Ops runs them by hand against staging / prod.

- **`0038_chat_membership_user_state.pre-flight.sql`** — collision + orphan + projection-drift probes against the legacy `chat_participants` / `chat_subscriptions` tables. Originally §9.1 of the design proposal ([first-tree-context#253](https://github.com/agent-team-foundation/first-tree-context/pull/253)). Two fixes vs the draft that briefly lived in the proposal:
  - `user_state_estimated_count` now uses `UNION` over `(chat_id, agent_id)` instead of `SUM` — the latter double-counts pairs that appear in both legacy tables, which is exactly what Probe 1 hunts for. (Caught by @baixiaohang during #325 review.)
  - Header references updated from `migration 0037` → `migration 0038` (the version that actually landed in #325).

- **`0038_chat_membership_user_state.post-deploy.sql`** — runs **after** 0038 has been applied. Second-pass external check covering:
  - Row counts: `chat_membership` vs UNION of legacy tables, `chat_user_state` vs UNION of state-carrying legacy rows.
  - Speaker-wins merge integrity (every collision pair must resolve to `access_mode='speaker'`).
  - `EXPLAIN ANALYZE` on the real `listMeChats` query — verifies the planner picks `chat_membership_pkey` / `idx_membership_agent` / `idx_user_state_agent`. Has `__AGENT_ID__` / `__ORG_ID__` placeholders ops fills in.
  - `pg_stat_user_indexes` scan counts after traffic resumes.
  - Badge vs list-view consistency for unread count (the bug @baixiaohang spotted at `me-chat.ts:501-502` in #325 — guards against regression).

- **`README.md`** — documents the `NNNN_<tag>.<phase>.sql` convention so future migrations have an obvious place to drop the same artifacts.

## Why

Originally drafted inside the design proposal. Removed from there per the workspace "no executable code in design docs" convention — executable SQL belongs alongside the migration it probes.

Staging deploy of #325 is already done; this PR makes the validation runbook discoverable in-repo so ops can execute `post-deploy.sql` against staging now, and run both files against prod before that deploy.

## Test plan

- [x] `pnpm check` clean (no new TS/biome files, only SQL + markdown)
- [x] `drizzle-kit` is not affected — probes/ is outside the journal, files in `meta/_journal.json` are unchanged

This is a docs/ops-only PR. No code or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)