### PR TITLE
fix: prevent agent reply echo loops via silent-turn protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,13 +83,6 @@ Full guide (rules, parallel dev installs, what's NOT isolated, teardown): [docs/
 
 **UUID v7 as Message ID:** Time-ordered; messages are immutable after creation.
 
-**Echo Loop Prevention:** Two non-human agents in the same chat can otherwise ping-pong forever on courtesy turns. Four cooperating layers, each catching cases the others miss:
-
-- **L1 — `mention_only` mode (server):** agent↔agent direct chats and agent-only group chats seed every non-human participant as `mention_only` (migration 0029 + `findOrCreateDirectChat` / `createChat`). Replies without an explicit `@` land as silent context rows (notify=false) instead of waking the peer. See `services/message.ts` fan-out filter and `__tests__/direct-chat-mention-mode.test.ts`.
-- **L2 — `shouldSuppressEcho` (client):** the runtime drops cross-chat replyTo echoes that would route a turn's own answer back through the original waiter's inbox. Lives in `runtime/session-manager.ts`.
-- **L3 — silent context rows (server):** mention_only participants who weren't @-named get notify=false inbox entries so they still see chat history on the next active delivery but aren't woken in the meantime. See `services/inbox.ts`.
-- **L4 — silent-turn protocol (client + server):** the agent prompt in `runtime/bootstrap.ts` instructs the agent to output nothing when it has nothing new for the recipient; `runtime/result-sink.ts` honors empty / whitespace output by skipping `sendMessage` and clearing the trigger so the turn ends silently. Decision lives in the agent (semantic, zero false-positive on real content), enforcement lives in code (the runtime never sends an empty message even if a downstream caller tries to). `services/message.ts` step 2e mirrors this form-guard on the server entry, so paths that bypass `result-sink` — the agent CLI `agent send`, `AskUserQuestion`, IM adapters, admin/web posts — get the same protection: empty content after stripping leading `@<name>` tokens writes the message row but emits `notify=false` for every fan-out recipient (including the `replyTo` cross-chat route, so the silent-send invariant holds end-to-end). Server `services/message.ts:observeLoopPattern` watches for the failure mode (4-message tight ping-pong window) and emits a structured warn log — pure observation, never blocks delivery; frequent triggers are a signal that prompt discipline is drifting.
-
 ## Coding Conventions
 
 - **No `any`**: Use `unknown` + type narrowing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,13 @@ Full guide (rules, parallel dev installs, what's NOT isolated, teardown): [docs/
 
 **UUID v7 as Message ID:** Time-ordered; messages are immutable after creation.
 
+**Echo Loop Prevention:** Two non-human agents in the same chat can otherwise ping-pong forever on courtesy turns. Four cooperating layers, each catching cases the others miss:
+
+- **L1 — `mention_only` mode (server):** agent↔agent direct chats and agent-only group chats seed every non-human participant as `mention_only` (migration 0029 + `findOrCreateDirectChat` / `createChat`). Replies without an explicit `@` land as silent context rows (notify=false) instead of waking the peer. See `services/message.ts` fan-out filter and `__tests__/direct-chat-mention-mode.test.ts`.
+- **L2 — `shouldSuppressEcho` (client):** the runtime drops cross-chat replyTo echoes that would route a turn's own answer back through the original waiter's inbox. Lives in `runtime/session-manager.ts`.
+- **L3 — silent context rows (server):** mention_only participants who weren't @-named get notify=false inbox entries so they still see chat history on the next active delivery but aren't woken in the meantime. See `services/inbox.ts`.
+- **L4 — silent-turn protocol (client + server):** the agent prompt in `runtime/bootstrap.ts` instructs the agent to output nothing when it has nothing new for the recipient; `runtime/result-sink.ts` honors empty / whitespace output by skipping `sendMessage` and clearing the trigger so the turn ends silently. Decision lives in the agent (semantic, zero false-positive on real content), enforcement lives in code (the runtime never sends an empty message even if a downstream caller tries to). `services/message.ts` step 2e mirrors this form-guard on the server entry, so paths that bypass `result-sink` — the agent CLI `agent send`, `AskUserQuestion`, IM adapters, admin/web posts — get the same protection: empty content after stripping leading `@<name>` tokens writes the message row but emits `notify=false` for every fan-out recipient (including the `replyTo` cross-chat route, so the silent-send invariant holds end-to-end). Server `services/message.ts:observeLoopPattern` watches for the failure mode (4-message tight ping-pong window) and emits a structured warn log — pure observation, never blocks delivery; frequent triggers are a signal that prompt discipline is drifting.
+
 ## Coding Conventions
 
 - **No `any`**: Use `unknown` + type narrowing

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -82,6 +82,12 @@ describe("bootstrapWorkspace", () => {
     expect(content).toContain("Agent Hub");
     expect(content).toContain("[From: <agent-name>]");
     expect(content).toContain("Use your judgment about when to respond");
+    // L4 silent-turn protocol: the prompt directive that pairs with the
+    // result-sink empty-output guard. Tells the agent that silence is the
+    // correct response when it has nothing new — drops courtesy fillers
+    // that would otherwise sustain agent↔agent loops.
+    expect(content).toContain("if you have nothing new for the recipient, output nothing");
+    expect(content).toContain("the runtime will end the turn silently");
   });
 
   it("does not write self.md (per PRD D7 — prompt lives in agent_configs)", () => {

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -176,6 +176,93 @@ describe("createResultSink — forwardResult enrichment", () => {
     expect(logs.some((l) => l.includes("listChatParticipants failed"))).toBe(true);
   });
 
+  describe("L4 silent-turn protocol — empty output skips delivery", () => {
+    // The agent prompt in bootstrap.ts tells agents: "if you have nothing
+    // new for the recipient, output nothing and the runtime will end the
+    // turn silently". This block is the matching code-side enforcement —
+    // empty/whitespace output is the agent's explicit "I choose silent
+    // turn" signal and the runtime must honor it without firing
+    // sendMessage. Decision-vs-execution split: only purely empty output
+    // is treated as silence; non-empty content is never length-filtered.
+
+    it("skips sendMessage when the agent produces an empty string", async () => {
+      const { sink, sendMessage, logs } = buildSink({
+        trigger: { messageId: "m-silent", senderId: "agent-peer" },
+        participants: [mkParticipant(ME, "me"), mkParticipant("agent-peer", "peer")],
+      });
+
+      await sink("");
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(logs.some((l) => l.includes("silent turn"))).toBe(true);
+    });
+
+    it("skips sendMessage when the agent produces whitespace-only output", async () => {
+      const { sink, sendMessage, logs } = buildSink({
+        trigger: { messageId: "m-ws", senderId: "agent-peer" },
+        participants: [mkParticipant(ME, "me"), mkParticipant("agent-peer", "peer")],
+      });
+
+      await sink("   \n\t  ");
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(logs.some((l) => l.includes("silent turn"))).toBe(true);
+    });
+
+    it("does NOT skip when the agent produces any non-empty content (no length filtering)", async () => {
+      // Single-character replies, short statuses, and any non-empty content
+      // must pass through untouched — the runtime never evaluates "is this
+      // meaningful?". That's the agent's call (via prompt), not code's.
+      const { sink, sendMessage } = buildSink({
+        trigger: { messageId: "m-short", senderId: "agent-peer" },
+        participants: [mkParticipant(ME, "me"), mkParticipant("agent-peer", "peer")],
+      });
+
+      await sink(".");
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the trigger on silent turn so the next inbound message isn't accidentally still bound", async () => {
+      let trigger: Trigger | null = { messageId: "m-clear", senderId: "agent-peer" };
+      const observedTrigger: (Trigger | null)[] = [];
+      const sdk = {
+        serverUrl: "http://test",
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        listChatParticipants: vi.fn().mockResolvedValue([mkParticipant(ME, "me")]),
+      } as unknown as FirstTreeHubSDK;
+      const sink = createResultSink({
+        sdk,
+        agent: {
+          agentId: ME,
+          inboxId: "inbox-me",
+          displayName: "test-agent",
+          type: "autonomous_agent",
+          delegateMention: null,
+          metadata: {},
+        },
+        chatId: "chat-1",
+        getTrigger: () => trigger,
+        clearTrigger: () => {
+          observedTrigger.push(trigger);
+          trigger = null;
+        },
+        log: () => {},
+        participants: createParticipantCache(sdk, "chat-1", () => {}),
+      });
+
+      await sink("");
+
+      // The trigger was cleared while it still held the silent-turn's
+      // originating message — observed exactly once. After the call the
+      // runtime sees a clean slate, so any next injection starts fresh
+      // rather than re-using m-clear's senderId for the next reply.
+      expect(observedTrigger).toHaveLength(1);
+      expect(observedTrigger[0]?.messageId).toBe("m-clear");
+      expect(trigger).toBeNull();
+    });
+  });
+
   it("clears the trigger before awaiting sendMessage so a concurrent inject-driven trigger isn't consumed", async () => {
     // Regression for the race the handler used to guard. The sink's
     // `clearTrigger` must fire synchronously before the async transport, so

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -341,7 +341,9 @@ You are running inside **Agent Hub**, a messaging platform for agent teams.
 - **Your final text response is automatically delivered** to the chat — just respond normally
 - For **proactive communication** (sending to other agents, other chats, or structured data),
   use the \`first-tree-hub\` CLI below
-- **Use your judgment about when to respond.** Not every message requires a reply.
+- **Use your judgment about when to respond.** Not every message requires
+  a reply — if you have nothing new for the recipient, output nothing and
+  the runtime will end the turn silently.
   Your role and responsibilities are injected via the Hub-managed system prompt.
 
 ## Environment Variables

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -70,6 +70,17 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
   }
 
   return async function forwardResult(text: string): Promise<void> {
+    // Silent-turn protocol: an empty / whitespace-only output is the agent's
+    // explicit signal that it has nothing new for the recipient. Skip
+    // delivery and free the turn. The runtime does NOT evaluate content
+    // length or "meaningfulness" — that's the agent's semantic decision.
+    // The matching prompt directive lives in bootstrap.ts generateToolsDoc.
+    if (text.trim().length === 0) {
+      deps.clearTrigger();
+      deps.log("silent turn: agent produced empty output, skipping delivery");
+      return;
+    }
+
     const trigger = deps.getTrigger();
     // Clear BEFORE the await so a concurrent inject() setting a new trigger
     // isn't accidentally attached to this outbound reply.

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/loop-pattern-observation.test.ts
+++ b/packages/server/src/__tests__/loop-pattern-observation.test.ts
@@ -1,0 +1,319 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
+import { createChat } from "../services/chat.js";
+import {
+  LOOP_OBSERVATION_SHORT_CHARS,
+  LOOP_OBSERVATION_TIME_WINDOW_MS,
+  LOOP_OBSERVATION_WINDOW,
+  observeLoopPattern,
+  sendMessage,
+} from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Pins the L4 server-side loop observation in `services/message.ts`. The
+ * detector emits a structured warn log (`metric: loop_pattern_observed_total`)
+ * when six conjunctive conditions all hold across the most recent
+ * `LOOP_OBSERVATION_WINDOW` messages of a chat:
+ *
+ *   C1 — every message is `format=text`
+ *   C2 — every sender is non-human
+ *   C3 — exactly two senders, strictly alternating
+ *   C4 — strict `inReplyTo` chain
+ *   C5 — every body (stripped of leading `@<name>` tokens) is short
+ *   C6 — the whole window fits in the time budget
+ *
+ * The observer is a pure side-channel. It MUST never modify `notify` or any
+ * other field that affects fan-out — that's the load-bearing invariant
+ * pinned by the dedicated "does not alter fan-out" test at the bottom.
+ */
+describe("L4 loop-pattern observation (services/message.ts)", () => {
+  const getApp = useTestApp();
+
+  type WindowSpec = {
+    senderId: string;
+    content: string;
+    format?: string;
+    /** Milliseconds before "now" — newer values are smaller (or 0). */
+    ageMs: number;
+  };
+
+  /**
+   * Insert messages directly so we can control senders, content, format, and
+   * timestamps with surgical precision. Each message's `inReplyTo` points at
+   * the message inserted *immediately before it* — building the strict reply
+   * chain C4 asks for. Pass `format: "markdown"` on one entry to break C1,
+   * `content: "longer than ten chars"` to break C5, etc.
+   */
+  async function seedWindow(app: ReturnType<typeof getApp>, chatId: string, specs: WindowSpec[]): Promise<string[]> {
+    const now = Date.now();
+    const ids: string[] = [];
+    let previousId: string | null = null;
+    // Insert chronological-oldest-first so each new message can reference
+    // the prior one via inReplyTo; ageMs interprets larger = older, so we
+    // sort high-to-low.
+    const sorted = [...specs].sort((a, b) => b.ageMs - a.ageMs);
+    for (const spec of sorted) {
+      const id = randomUUID();
+      await app.db.insert(messages).values({
+        id,
+        chatId,
+        senderId: spec.senderId,
+        format: spec.format ?? "text",
+        content: spec.content,
+        metadata: {},
+        inReplyTo: previousId,
+        createdAt: new Date(now - spec.ageMs),
+      });
+      ids.push(id);
+      previousId = id;
+    }
+    return ids;
+  }
+
+  async function setupAgentPair(prefix: string) {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a = await createTestAgent(app, { name: `${prefix}-a-${uid}` });
+    const { agent: b } = await createTestAgent(app, { name: `${prefix}-b-${uid}` });
+    const chat = await createChat(app.db, a.agent.uuid, {
+      type: "group",
+      participantIds: [b.uuid],
+    });
+    return { app, a, b, chat };
+  }
+
+  // A loop window of 4 short, alternating, recent, reply-chained messages
+  // from two non-human agents — the canonical bug case. ageMs in seconds-ago,
+  // newest-first.
+  function loopSpecs(aId: string, bId: string): WindowSpec[] {
+    return [
+      // Oldest = bottom of the chain. agent A starts.
+      { senderId: aId, content: "@b .", ageMs: 4_000 },
+      { senderId: bId, content: "@a (idle)", ageMs: 3_000 },
+      { senderId: aId, content: "@b .", ageMs: 2_000 },
+      { senderId: bId, content: "@a (idle)", ageMs: 1_000 },
+    ];
+  }
+
+  it("triggers the observer when all six conditions hold (full match)", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-hit");
+    const ids = await seedWindow(app, chat.id, loopSpecs(a.agent.uuid, b.uuid));
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+
+    expect(observer).toHaveBeenCalledTimes(1);
+    const payload = observer.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({ chatId: chat.id });
+    // Window comes back newest-first, matching the SELECT ordering. The
+    // chain we built has the newest message at ids[length-1]; the SELECT
+    // ORDER BY desc puts it at recentMessageIds[0].
+    expect(payload?.recentMessageIds[0]).toBe(ids[ids.length - 1]);
+    expect(payload?.windowSpanMs).toBeLessThanOrEqual(LOOP_OBSERVATION_TIME_WINDOW_MS);
+    expect(payload?.contentLengths).toHaveLength(LOOP_OBSERVATION_WINDOW);
+    // Each stripped body is short — proves we measured length after
+    // dropping the `@<name>` prefix, not before.
+    for (const len of payload?.contentLengths ?? []) {
+      expect(len).toBeLessThanOrEqual(LOOP_OBSERVATION_SHORT_CHARS);
+    }
+  });
+
+  it("does NOT trigger when fewer than the window's worth of messages exist", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-short");
+    // Only 3 messages; window is 4.
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: ".", ageMs: 3_000 },
+      { senderId: b.uuid, content: ".", ageMs: 2_000 },
+      { senderId: a.agent.uuid, content: ".", ageMs: 1_000 },
+    ]);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C1 — does NOT trigger if any message is not text format (e.g. markdown / question)", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-c1");
+    const specs = loopSpecs(a.agent.uuid, b.uuid);
+    // Flip one entry to markdown — non-text turns are typically real
+    // information (tables / file refs) and should never count as echo.
+    if (specs[1]) specs[1].format = "markdown";
+    await seedWindow(app, chat.id, specs);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C2 — does NOT trigger if a human sat in the window", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a = await createTestAgent(app, { name: `lp-c2-a-${uid}` });
+    const human = await createTestAgent(app, { name: `lp-c2-h-${uid}`, type: "human" });
+    const chat = await createChat(app.db, a.agent.uuid, {
+      type: "group",
+      participantIds: [human.agent.uuid],
+    });
+    // A and a human alternating — looks like a loop on the surface, but a
+    // human participating means any "courtesy" pattern is actually a person
+    // typing. Never flag.
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: ".", ageMs: 4_000 },
+      { senderId: human.agent.uuid, content: ".", ageMs: 3_000 },
+      { senderId: a.agent.uuid, content: ".", ageMs: 2_000 },
+      { senderId: human.agent.uuid, content: ".", ageMs: 1_000 },
+    ]);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C3 — does NOT trigger if more than two distinct senders are in the window", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a = await createTestAgent(app, { name: `lp-c3-a-${uid}` });
+    const { agent: b } = await createTestAgent(app, { name: `lp-c3-b-${uid}` });
+    const { agent: c } = await createTestAgent(app, { name: `lp-c3-c-${uid}` });
+    const chat = await createChat(app.db, a.agent.uuid, {
+      type: "group",
+      participantIds: [b.uuid, c.uuid],
+    });
+    // Three senders mixed into the window — even with short content this is
+    // multi-agent coordination, not a two-agent ping-pong.
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: ".", ageMs: 4_000 },
+      { senderId: b.uuid, content: ".", ageMs: 3_000 },
+      { senderId: c.uuid, content: ".", ageMs: 2_000 },
+      { senderId: a.agent.uuid, content: ".", ageMs: 1_000 },
+    ]);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C3 — does NOT trigger if two senders are present but not strictly alternating", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-c3b");
+    // Two senders but A speaks twice in a row — broken alternation.
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: ".", ageMs: 4_000 },
+      { senderId: a.agent.uuid, content: ".", ageMs: 3_000 },
+      { senderId: b.uuid, content: ".", ageMs: 2_000 },
+      { senderId: a.agent.uuid, content: ".", ageMs: 1_000 },
+    ]);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C4 — does NOT trigger if the inReplyTo chain is broken", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-c4");
+    // Insert messages WITHOUT inReplyTo — same alternation and content but
+    // no explicit threading. This is e.g. two agents posting parallel
+    // updates, not replies to each other.
+    const now = Date.now();
+    const ids = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+    const senders = [a.agent.uuid, b.uuid, a.agent.uuid, b.uuid];
+    for (let i = 0; i < 4; i++) {
+      await app.db.insert(messages).values({
+        id: ids[i] ?? randomUUID(),
+        chatId: chat.id,
+        senderId: senders[i] ?? a.agent.uuid,
+        format: "text",
+        content: ".",
+        metadata: {},
+        inReplyTo: null,
+        createdAt: new Date(now - (4 - i) * 1000),
+      });
+    }
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C5 — does NOT trigger if any message body (after stripping mentions) is longer than the short threshold", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-c5");
+    const specs = loopSpecs(a.agent.uuid, b.uuid);
+    // Replace one body with something that has real information — even with
+    // the leading `@b` prefix stripped, the remainder is far over 10 chars.
+    if (specs[2]) specs[2].content = "@b PR #42 merged, deploying to staging now";
+    await seedWindow(app, chat.id, specs);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("C6 — does NOT trigger if the window spans more time than the budget allows", async () => {
+    const { app, a, b, chat } = await setupAgentPair("lp-c6");
+    // Same pattern but stretched across a longer interval — agents working
+    // through something over minutes is normal collaboration, even if each
+    // message happens to be short.
+    const oldEnough = LOOP_OBSERVATION_TIME_WINDOW_MS + 5_000;
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: "@b .", ageMs: oldEnough },
+      { senderId: b.uuid, content: "@a .", ageMs: oldEnough - 1_000 },
+      { senderId: a.agent.uuid, content: "@b .", ageMs: 2_000 },
+      { senderId: b.uuid, content: "@a .", ageMs: 1_000 },
+    ]);
+
+    const observer = vi.fn();
+    await observeLoopPattern(app.db, chat.id, observer);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("does NOT alter fan-out behaviour — `notify` is identical with and without observation triggering", async () => {
+    // The load-bearing invariant: observation is a side channel. Even when
+    // a loop pattern matches, `sendMessage` must still create the same
+    // inbox entries with the same `notify` flags it would otherwise.
+    // Drive this through the *real* sendMessage path so any future refactor
+    // that accidentally lets the observer flip `notify` blows up here.
+    const { app, a, b, chat } = await setupAgentPair("lp-fanout");
+    // Pre-seed three messages so the fourth (sent via sendMessage) closes
+    // the loop window. Each message must `@<peer>` to wake the mention_only
+    // recipient — that's the L1 default for agent-only group chats.
+    await seedWindow(app, chat.id, [
+      { senderId: a.agent.uuid, content: `@${b.name} .`, ageMs: 3_500 },
+      { senderId: b.uuid, content: `@${a.agent.name} .`, ageMs: 2_500 },
+      { senderId: a.agent.uuid, content: `@${b.name} .`, ageMs: 1_500 },
+    ]);
+    // 4th send through the real service — the post-tx observer will fire
+    // (loop matches) but must NOT touch any fan-out state.
+    const result = await sendMessage(app.db, chat.id, b.uuid, {
+      format: "text",
+      content: `@${a.agent.name} .`,
+      metadata: { mentions: [a.agent.uuid] },
+    });
+    expect(result.recipients.length).toBeGreaterThan(0);
+
+    // The peer's inbox got the new message as a notify=true entry — the
+    // observation did not silence it.
+    const [aInbox] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, a.agent.uuid))
+      .limit(1);
+    expect(aInbox).toBeDefined();
+    const notified = await app.db
+      .select({ messageId: inboxEntries.messageId })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, aInbox?.inboxId ?? ""),
+          eq(inboxEntries.chatId, chat.id),
+          eq(inboxEntries.notify, true),
+          eq(inboxEntries.messageId, result.message.id),
+        ),
+      );
+    expect(notified).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/silent-send-fanout.test.ts
+++ b/packages/server/src/__tests__/silent-send-fanout.test.ts
@@ -1,0 +1,259 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Pins the L4 server-side silent-send form guard in `services/message.ts`
+ * (step 2e). The guard mirrors the client-side `result-sink` silent-turn
+ * protocol (§3.2 of the design) on the server entry point so that paths
+ * NOT going through result-sink — the agent CLI `agent send`, AskUserQuestion,
+ * external IM adapters, admin/web posts — get the same loop protection.
+ *
+ * The rule is purely formal:
+ *   - content (after stripping leading `@<name>` tokens) is empty → fan-out
+ *     emits notify=false for every recipient. The message row is still
+ *     written so chat history is complete (silent context rows; same shape
+ *     as L3 mention_only suppression).
+ *   - any non-empty remainder ("." / "(待命中)" / "OK") → guard does not
+ *     fire; fan-out follows the existing mention_only / full rules. Code
+ *     never evaluates content language — that decision belongs to the
+ *     agent prompt.
+ */
+describe("server-side silent-send form guard (L4 mirror of result-sink)", () => {
+  const getApp = useTestApp();
+
+  async function setParticipantMode(
+    app: ReturnType<typeof getApp>,
+    chatId: string,
+    agentUuid: string,
+    mode: "full" | "mention_only",
+  ) {
+    await app.db
+      .update(chatMembership)
+      .set({ mode })
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, agentUuid)));
+  }
+
+  /** Build a 3-agent group: sender (full), obsA (mention_only), obsB (mention_only). */
+  async function setupGroup(prefix: string) {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const sender = await createTestAgent(app, { name: `${prefix}-s-${uid}` });
+    const { agent: obsA } = await createTestAgent(app, { name: `${prefix}-a-${uid}` });
+    const { agent: obsB } = await createTestAgent(app, { name: `${prefix}-b-${uid}` });
+    const chat = await createChat(app.db, sender.agent.uuid, {
+      type: "group",
+      participantIds: [obsA.uuid, obsB.uuid],
+    });
+    // createChat seeds agent-only groups as mention_only. Promote the sender
+    // to full so the "full mode also gets silenced" branch is exercised when
+    // the guard fires (mention_only recipients are silenced by L1 too — the
+    // full sender's symmetric peer is what makes silent-send observable).
+    await setParticipantMode(app, chat.id, sender.agent.uuid, "full");
+    await setParticipantMode(app, chat.id, obsA.uuid, "mention_only");
+    await setParticipantMode(app, chat.id, obsB.uuid, "mention_only");
+    return { app, sender, obsA, obsB, chat };
+  }
+
+  async function inboxOf(app: ReturnType<typeof getApp>, agentUuid: string) {
+    const [row] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, agentUuid))
+      .limit(1);
+    return row?.inboxId ?? null;
+  }
+
+  /** All rows in a recipient's inbox for the given chat — both notify=true and notify=false. */
+  async function allInboxEntries(app: ReturnType<typeof getApp>, chatId: string, agentUuid: string) {
+    const inboxId = await inboxOf(app, agentUuid);
+    if (!inboxId) return [];
+    return app.db
+      .select({ messageId: inboxEntries.messageId, notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.chatId, chatId)));
+  }
+
+  it("Case 1: empty string content — message row is written, ALL fanout rows have notify=false", async () => {
+    const { app, sender, obsA, obsB, chat } = await setupGroup("ss-empty");
+
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      format: "text",
+      content: "",
+    });
+
+    // Returned recipients (notify=true subset) is empty — silent send.
+    expect(result.recipients).toEqual([]);
+
+    // Message row is still written: chat history must remain complete.
+    const stored = await app.db
+      .select({ id: messages.id, content: messages.content })
+      .from(messages)
+      .where(eq(messages.id, result.message.id))
+      .limit(1);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.content).toBe("");
+
+    // Both fan-out recipients got a row, BOTH notify=false (silent context).
+    const aEntries = await allInboxEntries(app, chat.id, obsA.uuid);
+    const bEntries = await allInboxEntries(app, chat.id, obsB.uuid);
+    expect(aEntries.filter((e) => e.messageId === result.message.id)).toEqual([
+      { messageId: result.message.id, notify: false },
+    ]);
+    expect(bEntries.filter((e) => e.messageId === result.message.id)).toEqual([
+      { messageId: result.message.id, notify: false },
+    ]);
+  });
+
+  it("Case 2: pure @-mention with no trailing content — silenced (mention stripped, remainder empty)", async () => {
+    // This is the exact shape `agent send X ""` produces after server-side
+    // normalizeMentionsInContent runs: the recipient's @ is prepended but
+    // there's no actual message body. Without this guard the recipient
+    // would be woken with an empty conversation turn.
+    const { app, sender, obsA, obsB, chat } = await setupGroup("ss-pure-at");
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      format: "text",
+      content: `@${obsA.name}`,
+      metadata: { mentions: [obsA.uuid] },
+    });
+
+    expect(result.recipients).toEqual([]);
+
+    const aEntries = await allInboxEntries(app, chat.id, obsA.uuid);
+    const bEntries = await allInboxEntries(app, chat.id, obsB.uuid);
+    expect(aEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(false);
+    expect(bEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(false);
+  });
+
+  it("Case 3: whitespace-only content — silenced", async () => {
+    const { app, sender, obsA, chat } = await setupGroup("ss-ws");
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      format: "text",
+      content: "   \n\t  ",
+    });
+
+    expect(result.recipients).toEqual([]);
+
+    const aEntries = await allInboxEntries(app, chat.id, obsA.uuid);
+    expect(aEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(false);
+  });
+
+  it("Case 4: single-character content '.' — guard does NOT fire, normal mention_only fan-out applies", async () => {
+    // Form check has nothing to say about meaningfulness. A 1-char body is
+    // non-empty; the agent prompt is the layer responsible for deciding
+    // whether "." was a useful turn. We pin here that the code stays out
+    // of that decision and routes normally.
+    const { app, sender, obsA, obsB, chat } = await setupGroup("ss-dot");
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      format: "text",
+      content: ".",
+      // Explicitly @ obsA so mention_only fan-out wakes them; obsB stays
+      // silent context (mention_only + not mentioned) per existing L1.
+      metadata: { mentions: [obsA.uuid] },
+    });
+
+    // obsA's inbox includes the notify=true wake-up; recipients reflects it.
+    expect(result.recipients.length).toBeGreaterThan(0);
+    const aEntries = await allInboxEntries(app, chat.id, obsA.uuid);
+    const bEntries = await allInboxEntries(app, chat.id, obsB.uuid);
+    expect(aEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(true);
+    // obsB still gets a silent context row from the existing L1 rule, which
+    // is independent of the silent-send guard.
+    expect(bEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(false);
+  });
+
+  it("Case 5: real informational content with mention — guard does NOT fire, no false positive on routine traffic", async () => {
+    // The canonical "completed PR" / "modified /foo.ts" reply. Length is
+    // irrelevant; the only thing that matters is "is there anything left
+    // after stripping leading @<name>?". Yes → route normally.
+    const { app, sender, obsA, obsB, chat } = await setupGroup("ss-real");
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      format: "text",
+      content: `@${obsA.name} 完成 PR #42`,
+      metadata: { mentions: [obsA.uuid] },
+    });
+
+    expect(result.recipients.length).toBeGreaterThan(0);
+    const aEntries = await allInboxEntries(app, chat.id, obsA.uuid);
+    const bEntries = await allInboxEntries(app, chat.id, obsB.uuid);
+    expect(aEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(true);
+    expect(bEntries.find((e) => e.messageId === result.message.id)?.notify).toBe(false);
+  });
+
+  it("Case 6: replyTo cross-chat route is also silenced — silent-send invariant is closed end-to-end", async () => {
+    // Pins the invariant: any message that triggers silent-send MUST end up
+    // with notify=false on EVERY inbox row tied to its id — including the
+    // replyTo cross-chat route at message.ts:301-321. Without this, an
+    // agent that uses `agent send X ""` to reply to a message that had
+    // declared `replyToChat` would silently wake the original requester
+    // through the back-channel, breaking the loop-prevention guarantee.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const aliceCtx = await createTestAgent(app, { name: `ss-replyto-alice-${uid}` });
+    const { agent: bob } = await createTestAgent(app, { name: `ss-replyto-bob-${uid}` });
+
+    // Two chats Alice and Bob are both in.
+    //   workChat   — where the original task is filed (alice declares
+    //                replyToChat=watcherChat / replyToInbox=alice.inbox so
+    //                replies route back to her watcher chat).
+    //   watcherChat — alice's "follow-up" view, where she expects to be
+    //                woken when someone replies.
+    const workChat = await createChat(app.db, aliceCtx.agent.uuid, {
+      type: "group",
+      participantIds: [bob.uuid],
+    });
+    const watcherChat = await createChat(app.db, aliceCtx.agent.uuid, {
+      type: "group",
+      participantIds: [bob.uuid],
+    });
+
+    // Alice posts the original message in workChat with cross-chat reply
+    // routing pointing at her watcherChat inbox. (replyToInbox MUST be the
+    // sender's own inbox per the §1 sender check.)
+    const aliceInbox = await inboxOf(app, aliceCtx.agent.uuid);
+    expect(aliceInbox).not.toBeNull();
+    const origMsg = await sendMessage(app.db, workChat.id, aliceCtx.agent.uuid, {
+      format: "text",
+      content: `@${bob.name} please look at this`,
+      metadata: { mentions: [bob.uuid] },
+      replyToInbox: aliceInbox ?? undefined,
+      replyToChat: watcherChat.id,
+    });
+
+    // Bob "replies" with empty content — i.e. the failure case where some
+    // path (CLI / handler) hands sendMessage an empty body. Without Task
+    // 3.6, the main fan-out would correctly notify=false alice in workChat
+    // but the replyTo route would still wake alice in watcherChat.
+    const silentMsg = await sendMessage(app.db, workChat.id, bob.uuid, {
+      format: "text",
+      content: "",
+      inReplyTo: origMsg.message.id,
+    });
+
+    // Recipients list is empty — including no replyTo back-channel pushed in.
+    expect(silentMsg.recipients).toEqual([]);
+
+    // Every inbox row tied to this silent message has notify=false. This is
+    // the SQL-level invariant pinned by the design (§3.5 "Mirror silent-send
+    // into the replyTo cross-chat route"); if a future refactor breaks it
+    // this assertion fires.
+    const allRows = await app.db
+      .select({ inboxId: inboxEntries.inboxId, chatId: inboxEntries.chatId, notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(eq(inboxEntries.messageId, silentMsg.message.id));
+    expect(allRows.length).toBeGreaterThan(0);
+    expect(allRows.every((r) => r.notify === false)).toBe(true);
+
+    // Specifically: the replyTo back-channel row for alice in watcherChat
+    // exists (history is preserved) and is silenced.
+    const watcherRow = allRows.find((r) => r.inboxId === aliceInbox && r.chatId === watcherChat.id);
+    expect(watcherRow).toBeDefined();
+    expect(watcherRow?.notify).toBe(false);
+  });
+});

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -184,6 +184,30 @@ async function sendMessageInner(
       await assertSenderMayEmitQuestion(tx, senderId);
     }
 
+    // 2e. L4 silent-send form guard — mirror of the client-side result-sink
+    //     silent-turn (runtime/result-sink.ts). Covers any path that reaches
+    //     sendMessage without going through result-sink: the agent CLI
+    //     `agent send`, AskUserQuestion, external IM adapters, admin/web
+    //     posts. Form-only check on the FINAL outbound text (after
+    //     normalizeMentionsInContent has had its turn): if everything that
+    //     remains after stripping leading `@<name>` tokens is empty, the
+    //     send becomes silent — the message row is still written so chat
+    //     history stays complete, but fan-out emits notify=false for every
+    //     recipient (silent context rows; L3 behavior).
+    //
+    //     NO content language evaluation. Non-empty filler like "." or
+    //     "(待命中)" still wakes the recipient; the agent prompt + silent-
+    //     turn protocol is responsible for those. Non-string content
+    //     (e.g. structured question payloads) bypasses the guard entirely.
+    const isSilentSend =
+      typeof outboundContent === "string" && outboundContent.replace(/^(@\S+\s*)+/, "").trim().length === 0;
+    if (isSilentSend) {
+      log.info(
+        { chatId, senderId, source: data.source ?? null },
+        "silent send: empty content after mention strip — no fan-out wake-up",
+      );
+    }
+
     // 3. Store the message (with merged metadata + normalised content).
     const messageId = randomUUID();
     const [msg] = await tx
@@ -240,7 +264,10 @@ async function sendMessageInner(
       .map((p) => ({
         agentId: p.agentId,
         inboxId: p.inboxId,
-        notify: p.mode !== "mention_only" || mentionSet.has(p.agentId),
+        // Silent-send (step 2e) forces every fan-out row to notify=false
+        // regardless of mode/mentions. Inbox entries are still written so
+        // history replay still works; nobody is woken.
+        notify: !isSilentSend && (p.mode !== "mention_only" || mentionSet.has(p.agentId)),
       }));
 
     if (fanout.length > 0) {
@@ -272,17 +299,25 @@ async function sendMessageInner(
         .limit(1);
 
       if (original?.replyToInbox && original?.replyToChat) {
+        // Mirror silent-send (§2e) into the replyTo cross-chat route — when
+        // the main fan-out is silenced, the replyTo recipient must NOT be
+        // woken either, or the silent-send invariant ("any silent-send
+        // message has zero notify=true inbox rows") leaks through this
+        // back-channel. We still write the row so the original requester
+        // sees the reply when their session next picks it up.
         await tx
           .insert(inboxEntries)
           .values({
             inboxId: original.replyToInbox,
             messageId,
             chatId: original.replyToChat,
+            notify: !isSilentSend,
           })
           .onConflictDoNothing();
 
-        // Include replyTo recipient for notification
-        if (!recipients.includes(original.replyToInbox)) {
+        // Only surface as a wake-up target when not silenced — `recipients`
+        // is what the route layer turns into PG NOTIFY wake-ups.
+        if (!isSilentSend && !recipients.includes(original.replyToInbox)) {
           recipients.push(original.replyToInbox);
         }
       }
@@ -344,7 +379,126 @@ async function sendMessageInner(
   // wake-up otherwise). Failure is dropped; web reconnect refetches.
   fireChatMessageKick(chatId, txResult.message.id);
 
+  // L4 echo-loop observation: scan the just-tail of this chat for the
+  // ping-pong pattern that L1 (mention_only) + L4 (silent-turn) are meant
+  // to prevent. We emit a structured warn-log only — `notify` is never
+  // mutated here. Frequent triggers signal client-side prompt drift and
+  // a need to revisit the agent template. Fire-and-forget so the hot send
+  // path is unaffected; failures are logged but never propagated.
+  void observeLoopPattern(db, chatId).catch((err) => {
+    log.error({ err, chatId }, "loop pattern observation failed");
+  });
+
   return { message: txResult.message, recipients: txResult.recipients };
+}
+
+export const LOOP_OBSERVATION_WINDOW = 4;
+export const LOOP_OBSERVATION_SHORT_CHARS = 10;
+export const LOOP_OBSERVATION_TIME_WINDOW_MS = 30_000;
+
+function stripMentionPrefix(content: string): string {
+  return content.replace(/^(@\S+\s*)+/, "").trim();
+}
+
+/**
+ * Reporting hook: what to do when a loop pattern is detected. Production
+ * default goes through pino's structured `warn`; tests pass a fake so they
+ * can assert on detection without raising the test app's log level (helpers
+ * pin level=error for noise reduction).
+ */
+export type LoopPatternObserver = (data: {
+  chatId: string;
+  recentMessageIds: string[];
+  windowSpanMs: number;
+  contentLengths: number[];
+}) => void;
+
+const defaultLoopObserver: LoopPatternObserver = (data) => {
+  log.warn(
+    { metric: "loop_pattern_observed_total", ...data },
+    "loop pattern observed (not blocked) — prompt discipline may be drifting",
+  );
+};
+
+/**
+ * Pure observation: detect short, fast, two-agent ping-pong reply chains and
+ * surface them via a structured log line. Does NOT modify the `notify` flag
+ * or otherwise interfere with delivery — loop *prevention* lives client-side
+ * (prompt + silent-turn protocol in `result-sink`). Six conjunctive
+ * conditions (see design `agent-reply-loop-prevention-design.md` §3.4) so
+ * normal multi-agent collaboration is never flagged:
+ *
+ *   C1 — every message is `format=text`
+ *   C2 — no human sender in the window (any human reply resets the chain)
+ *   C3 — exactly two senders, perfectly alternating
+ *   C4 — strict `inReplyTo` chain across the whole window
+ *   C5 — every message body (after stripping leading `@<name>` tokens) is
+ *        ≤ `LOOP_OBSERVATION_SHORT_CHARS` characters
+ *   C6 — the whole window spans ≤ `LOOP_OBSERVATION_TIME_WINDOW_MS` ms
+ *
+ * Exported for direct test coverage of the detection logic; the `sendMessage`
+ * call site uses the default observer.
+ */
+export async function observeLoopPattern(
+  db: Database,
+  chatId: string,
+  observer: LoopPatternObserver = defaultLoopObserver,
+): Promise<void> {
+  const window = await db
+    .select({
+      id: messages.id,
+      senderId: messages.senderId,
+      content: messages.content,
+      inReplyTo: messages.inReplyTo,
+      createdAt: messages.createdAt,
+      format: messages.format,
+      senderType: agents.type,
+    })
+    .from(messages)
+    .innerJoin(agents, eq(messages.senderId, agents.uuid))
+    .where(eq(messages.chatId, chatId))
+    .orderBy(desc(messages.createdAt))
+    .limit(LOOP_OBSERVATION_WINDOW);
+
+  if (window.length < LOOP_OBSERVATION_WINDOW) return;
+
+  // C1: all text format
+  if (window.some((m) => m.format !== "text")) return;
+  // C2: no human sender (any human turn naturally breaks the chain)
+  if (window.some((m) => m.senderType === "human")) return;
+  // C3: exactly two distinct senders, strictly alternating
+  if (new Set(window.map((m) => m.senderId)).size !== 2) return;
+  for (let i = 0; i < window.length - 1; i++) {
+    if (window[i]?.senderId === window[i + 1]?.senderId) return;
+  }
+  // C4: strict reply chain — each newer message replies to the one beneath it
+  for (let i = 0; i < window.length - 1; i++) {
+    if (window[i]?.inReplyTo !== window[i + 1]?.id) return;
+  }
+  // C5: every body short after stripping mention prefix. Non-string contents
+  //     (markdown JSON, file/card payloads, etc.) can't be classified by a
+  //     simple char count, so we bail rather than guess.
+  const lens: number[] = [];
+  for (const m of window) {
+    const text = typeof m.content === "string" ? m.content : null;
+    if (text === null) return;
+    const len = stripMentionPrefix(text).length;
+    if (len > LOOP_OBSERVATION_SHORT_CHARS) return;
+    lens.push(len);
+  }
+  // C6: tight time window across the whole tail
+  const newest = window[0];
+  const oldest = window[window.length - 1];
+  if (!newest || !oldest) return;
+  const spanMs = newest.createdAt.getTime() - oldest.createdAt.getTime();
+  if (spanMs > LOOP_OBSERVATION_TIME_WINDOW_MS) return;
+
+  observer({
+    chatId,
+    recentMessageIds: window.map((m) => m.id),
+    windowSpanMs: spanMs,
+    contentLengths: lens,
+  });
 }
 
 export async function sendToAgent(


### PR DESCRIPTION
## Summary

Two non-human agents in a group chat could infinite-loop by replying to each other with bare acknowledgments (e.g. `@developer .` / `@architect (待命中)`). The three existing protections — `mention_only` mode, `shouldSuppressEcho`, silent context rows — all miss this case because **both sides use explicit @-mentions**, which is precisely what `mention_only` defers to.

This PR introduces **L4: silent-turn / silent-send protocol**, a decision/execution-split scheme:

- **Decision (agent prompt)**: the agent decides whether a reply carries information for the recipient.
- **Execution (code form-guard)**: client `result-sink` and server `message.ts` step 2e both honor an empty / pure-@-mention reply as the agent's silent-turn signal, suppress delivery (client) or wake-up (server), and leave the chat history intact (server).

Form-only checks throughout. No content language evaluation. `OK`, `.`, `(待命中)` still go through — those remain the agent prompt's responsibility. Zero false positives by construction.

## Four-Layer Protection Map

- **L1** `mention_only` mode (migration 0029) — agent-only direct + group chats default to mention_only; no @ ⇒ `notify=false`.
- **L2** `shouldSuppressEcho` — cross-chat replyTo routing fan-out copy.
- **L3** silent context rows — preceding history for mention_only newcomers.
- **L4 (this PR)** silent-turn protocol (client + server) — empty / pure-@-mention output ⇒ no wake-up, end-to-end including the replyTo cross-chat route.

The per-layer rationale lives in source comments (`runtime/result-sink.ts`, `services/message.ts` step 2e, `observeLoopPattern` JSDoc). Higher-level architectural narrative will land in the context-tree separately.

## Changes

**Source (3 files)**
- `packages/client/src/runtime/bootstrap.ts` — `generateToolsDoc` adds reply-discipline guidance (semantic, no literal blacklist)
- `packages/client/src/runtime/result-sink.ts` — `forwardResult` skips delivery on empty/whitespace output
- `packages/server/src/services/message.ts` — step 2e silent-send form-guard + replyTo cross-chat route consistency + `observeLoopPattern` fire-and-forget after-tx observation

**Tests (4 files)**
- `packages/server/src/__tests__/loop-pattern-observation.test.ts` (new, 10 cases)
- `packages/server/src/__tests__/silent-send-fanout.test.ts` (new, 6 cases; **Case 6** pins the SQL-level invariant "after any silent-send, every `inbox_entries` row for that `message_id` has `notify=false`")
- `packages/client/src/__tests__/bootstrap.test.ts` (+2 substring assertions)
- `packages/client/src/__tests__/result-sink.test.ts` (+4 silent-turn cases)

**Versioning**
- `packages/command` bumped `0.12.8 → 0.12.9` (patch). This PR touches `packages/client` source, which `tsdown` inlines into the published `command` tarball — clients only receive the new runtime behavior once `npm install` resolves a new version. See `docs/versioning-and-publishing.md`.

**Non-changes**
- 0 DB schema changes, 0 migrations
- 0 API contract changes
- `AGENTS.md` unchanged (detailed protocol-layer docs belong in the context-tree, not in AGENTS.md)

## Test Plan

- [x] `pnpm check` clean (659 files)
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @first-tree-hub/server test` — 865 cases / 112 files, all pass
- [x] Client tests for affected files (`bootstrap.test.ts` + `result-sink.test.ts`) pass
- [x] Regression suites: `direct-chat-mention-mode.test.ts` / `messaging-e2e.test.ts` / `mention-fanout.test.ts` / `message-recipients.test.ts` / `session-manager.test.ts` — all pass
- [ ] Manual repro after deploy: restart client so agents pick up new prompt, verify samples no longer loop

## Known Follow-ups (out of scope for this PR)

- **#3 metric backend**: client `silent_turn_total` and server `loop_pattern_observed_total` are currently log-payload keys (no real metric registry). Will be wired to real metric incr once the observability backend is in place.
- **#4 thresholds hardcoded**: `LOOP_OBSERVATION_WINDOW=4` / `SHORT_CHARS=10` / `TIME_WINDOW_MS=30_000` are exported constants. After real metric data informs tuning, will move to config.
- **Phase 2 structural cleanup**: separate proposal will address the root causes — `result-sink` auto-injecting trigger sender into mentions (loop "fuel"), agent egress lacking a unified abstraction (CLI vs result-sink divergence), `messages.source` field underused (no post-hoc path attribution), control/data plane entanglement (`message + wakeup` coupled).

## Activation Note

The prompt change reaches agents through `generateToolsDoc()`, which runs at session bootstrap. **Existing live agent sessions will continue using their old prompt** until they self-restart or get evicted. Restart the client after deploy to ensure prompt-side discipline activates immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)