### PR TITLE
fix(server): mark-all-read clears all visible unread; drop agent_disconnected spam

### DIFF
--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -894,9 +894,6 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           if (currentOwner === clientId) {
             try {
               await presenceService.unbindAgent(app.db, agentId);
-              if (shouldNotify(agentId, "agent_disconnected")) {
-                notificationService.notifyAgentEvent(app.db, agentId, "agent_disconnected", "medium").catch(() => {});
-              }
             } catch {
               // best-effort
             }

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -5,7 +5,7 @@ import {
   type NotificationSeverity,
   type NotificationType,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, desc, eq, inArray, lt, ne, or } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, ne, or } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
@@ -149,32 +149,22 @@ export async function markRead(db: Database, notificationId: string, orgId: stri
 /** Mark all notifications visible to this member as read. */
 export async function markAllRead(db: Database, orgId: string, memberId: string) {
   const visible = await loadVisibleAgentIds(db, orgId, memberId);
+  const visibleIds = [...visible];
 
-  // Fetch unread rows (bounded: typical notification volume per org is small).
-  // Drizzle doesn't express "agentId IS NULL OR agentId IN (...)" cleanly over
-  // a potentially large id list, so we select then update by id. Cap the scan
-  // to avoid worst-case blowups.
-  const unread = await db
-    .select({ id: notifications.id, agentId: notifications.agentId })
-    .from(notifications)
-    .where(and(eq(notifications.organizationId, orgId), eq(notifications.read, false)))
-    .limit(1000);
+  // Single UPDATE covering every visible unread row in the org. Org-wide rows
+  // (agentId IS NULL) are always visible; agent-scoped rows are filtered to
+  // the member's visible agent set. Without this single-statement form a
+  // burst of notifications past the prior 1000-row select cap would leave
+  // unread rows behind, and the bell badge would never clear.
+  const visibilityCondition =
+    visibleIds.length > 0
+      ? or(isNull(notifications.agentId), inArray(notifications.agentId, visibleIds))
+      : isNull(notifications.agentId);
 
-  const idsToMark = unread.filter((n) => n.agentId === null || visible.has(n.agentId)).map((n) => n.id);
-
-  if (idsToMark.length === 0) return;
-
-  // Batch so query size stays bounded for the rare extreme tail.
-  const batchSize = 200;
-  for (let i = 0; i < idsToMark.length; i += batchSize) {
-    const batch = idsToMark.slice(i, i + batchSize);
-    await db
-      .update(notifications)
-      .set({ read: true })
-      .where(
-        and(eq(notifications.organizationId, orgId), eq(notifications.read, false), inArray(notifications.id, batch)),
-      );
-  }
+  await db
+    .update(notifications)
+    .set({ read: true })
+    .where(and(eq(notifications.organizationId, orgId), eq(notifications.read, false), visibilityCondition));
 }
 
 /**
@@ -267,8 +257,6 @@ function composeMessage(type: NotificationType, agentCtx: AgentContext, chatCtx:
       return chat ? `${chat} completed` : `${agent} completed a task`;
     case "session_error":
       return chat ? `${chat} hit an error` : `${agent} hit a session error`;
-    case "agent_disconnected":
-      return `Computer ${computer} disconnected`;
     case "agent_connected":
       return `Computer ${computer} reconnected`;
     case "agent_stale":

--- a/packages/shared/src/schemas/notification.ts
+++ b/packages/shared/src/schemas/notification.ts
@@ -8,7 +8,6 @@ export const NOTIFICATION_TYPES = {
   AGENT_NEEDS_DECISION: "agent_needs_decision",
   AGENT_BLOCKED: "agent_blocked",
   AGENT_STALE: "agent_stale",
-  AGENT_DISCONNECTED: "agent_disconnected",
   AGENT_CONNECTED: "agent_connected",
   SESSION_COMPLETED: "session_completed",
 } as const;
@@ -19,7 +18,6 @@ export const notificationTypeSchema = z.enum([
   "agent_needs_decision",
   "agent_blocked",
   "agent_stale",
-  "agent_disconnected",
   "agent_connected",
   "session_completed",
 ]);

--- a/packages/web/src/components/notification-item.tsx
+++ b/packages/web/src/components/notification-item.tsx
@@ -18,7 +18,6 @@ const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   session_error: "Error",
   agent_blocked: "Blocked",
   agent_stale: "Stale",
-  agent_disconnected: "Disconnected",
   agent_connected: "Connected",
   agent_needs_decision: "Decision",
   session_completed: "Completed",


### PR DESCRIPTION
## Summary

Two interacting notification reliability fixes:

- **`markAllRead` no longer caps at 1000 rows.** The prior implementation selected up to 1000 unread rows (no `ORDER BY`), in-memory filtered by visibility, then batched updates by id. Under any burst of notifications the top-of-list visible unread were not guaranteed to be in the marked set, so the badge would never clear. Replaced with a single `UPDATE notifications SET read=true WHERE org=$1 AND read=false AND (agent_id IS NULL OR agent_id IN visible)`. One statement, no cap, no batching.

- **Dropped `agent_disconnected` notifications.** The WS `onClose` handler fired one notification per bound agent with identical `"Computer X disconnected"` text, and the per-`(agentId, type)` in-memory cooldown couldn't dedupe across the N agents sharing one client. Combined with transient reconnects, the resulting flood dominated unread state and reinforced the "mark all does nothing" perception. Product surfaces client liveness through other paths now, so the type is removed end-to-end:
  - `shared/schemas/notification.ts`: remove from `NOTIFICATION_TYPES` + enum
  - `server/services/notification.ts`: remove case in `composeMessage`
  - `server/api/agent/ws-client.ts`: drop the `notifyAgentEvent` call in `onClose`
  - `web/components/notification-item.tsx`: remove label entry

`agent_error`, `agent_blocked`, `agent_stale`, `session_completed`, and the rest of the notification pipeline are untouched.

No DB migration. No version bump (changes don't touch `command`/`client` src or shared modules they import).

## Follow-up (separate PR)

A broader notify-infra refactor proposal has been drafted (PG `LISTEN/NOTIFY` cross-instance fanout, DB-backed dedup via partial unique index, push-driven bell, real `COUNT(*)` unread endpoint, removal of remaining dead notification types). Not in scope here.

## Test plan

- [ ] Local: typecheck + biome (verified, clean)
- [ ] Local: server vitest suite (skipped — testcontainers requires Docker, not available in author env)
- [ ] Bell badge clears immediately after **Mark all read** when there are >1000 unread rows in the org
- [ ] No `agent_disconnected` rows produced by a `systemctl restart` of a client with multiple bound agents
- [ ] Existing `agent_error` / `agent_blocked` / `session_completed` notifications still fire and render correctly