### PR TITLE
fix(web): skip Enter handlers while IME is composing

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1067,6 +1067,7 @@ export function ChatView({
                   value={renameDraft}
                   onChange={(e) => setRenameDraft(e.target.value)}
                   onKeyDown={(e) => {
+                    if (e.nativeEvent.isComposing) return;
                     if (e.key === "Enter") {
                       e.preventDefault();
                       commitRename();
@@ -1437,6 +1438,9 @@ export function ChatView({
                     }
                     rows={2}
                     onKeyDown={(e) => {
+                      // Skip while an IME is composing so Enter confirms the
+                      // candidate instead of sending / picking a mention.
+                      if (e.nativeEvent.isComposing) return;
                       // Mention autocomplete gets first crack at navigation keys so
                       // ArrowUp/Down/Enter/Tab/Escape cycle candidates instead of
                       // sending or moving the cursor.

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -263,6 +263,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                 }
                 rows={1}
                 onKeyDown={(e) => {
+                  if (e.nativeEvent.isComposing) return;
                   if (mention.handleKey(e)) return;
                   if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- Pressing Enter to confirm an IME candidate (中/日/韩 输入法) was incorrectly triggering send / submit / mention-pick across the web client. Added `e.nativeEvent.isComposing` guards on the affected `onKeyDown` handlers so Enter only takes effect after composition ends.
- Touched three sites in `packages/web/src/`:
  - `pages/workspace/center/chat-view.tsx` — main chat composer textarea (also protects the mention autocomplete reached via the same handler) and the chat rename input.
  - `pages/workspace/conversations/new-chat-draft.tsx` — new-chat draft composer.
- `components/chat/question-message.tsx` Enter is already a no-op (newline only, no submit), so no change needed. `components/mention-autocomplete.tsx` is invoked by the parent textarea's `onKeyDown`, so guarding the parent automatically protects it.

## Test plan
- [ ] In the chat composer, switch to a Chinese/Japanese/Korean IME, type pinyin/kana/jamo, press Enter to confirm the candidate — message must NOT send; second Enter (no composition) sends as before.
- [ ] Same flow in the new-chat draft composer.
- [ ] In the chat rename input, IME-confirm Enter must NOT commit the rename; non-composing Enter still commits; Escape still cancels.
- [ ] With the mention dropdown open in the composer, IME-confirm Enter must NOT pick a mention candidate; non-composing Enter still picks.
- [ ] Regression: with no IME (English keyboard), Enter still sends, Shift+Enter still inserts a newline, Arrow keys still cycle mention candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)