### PR TITLE
fix(web): chat picker source — show humans + stabilize new-chat default

### DIFF
--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -688,4 +688,40 @@ describe("chat-first workspace service layer", () => {
     });
     expect(res.rows.find((r) => r.chatId === chatId)?.engagementStatus).toBe("active");
   });
+
+  /**
+   * Regression for #343 — the picker-source widening (#343) is only useful if
+   * the server's add-participant path also accepts human agents. The service
+   * already had no `type` filter, but a regression here would silently undo
+   * the picker fix. Lock the invariant: a human added via `addMeChatParticipants`
+   * lands as `access_mode = 'speaker'`, identical to adding an AI agent today.
+   *
+   * `createTestAdmin` lands every member in the shared default org, so the
+   * owner + invitee live in the same org without extra wiring.
+   */
+  it("addMeChatParticipants: accepts a human agent and inserts a speaker row (#343)", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const teammate = await createTestAdmin(app);
+    expect(teammate.organizationId).toBe(owner.organizationId);
+
+    // Seed a direct chat with one AI agent so owner is a speaker.
+    const aiAgent = await createTestAgent(app, { name: "agp-h-ai" });
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [aiAgent.agent.uuid],
+    });
+
+    await addMeChatParticipants(app.db, chatId, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [teammate.humanAgentUuid],
+    });
+
+    // Raw SQL: `access_mode` isn't surfaced by any service-level read
+    // path (listMeChats etc. project it as `membershipKind`, not as the
+    // raw column). Going to the table directly is the cleanest way to
+    // assert what the writer produced.
+    const rows = await app.db.execute<{ access_mode: string }>(
+      sql`SELECT access_mode FROM chat_membership WHERE chat_id = ${chatId} AND agent_id = ${teammate.humanAgentUuid}`,
+    );
+    expect(rows[0]?.access_mode).toBe("speaker");
+  });
 });

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -31,7 +31,8 @@ export type MentionCandidate = {
   /** True iff the caller's member is this agent's `managerId`. Drives
    *  participant-picker grouping (mine first, then teammates') and the
    *  empty-query branch of mention autocomplete so the user's own agents
-   *  always surface first. Populated from `/activity` (server-derived);
+   *  always surface first. Derived client-side by callers from the agent
+   *  row's `managerId` against the caller's `memberId` (see `useAuth`);
    *  callers that can't determine it should pass `false` rather than
    *  omitting — there's no "unknown" state. */
   managedByMe: boolean;

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -8,7 +8,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, AtSign, Check, ExternalLink, Eye, MessageSquare, Paperclip, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getActivityOverview } from "../../../api/activity.js";
+import { listAgents } from "../../../api/agents.js";
 import {
   type FileMessageContent,
   getChat,
@@ -606,7 +606,7 @@ export function ChatView({
   const queryClient = useQueryClient();
   const agentName = useAgentNameMap();
   const agentIdentity = useAgentIdentityMap();
-  const { agentId: myAgentId } = useAuth();
+  const { agentId: myAgentId, memberId: myMemberId } = useAuth();
   const [draft, setDraft] = useState("");
   const [cursor, setCursor] = useState(0);
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([]);
@@ -656,13 +656,23 @@ export function ChatView({
     enabled: !!chatId,
   });
 
-  /** Org-wide agent list for the `@` picker. We surface every agent the
-   *  user can address — not just current chat participants — so `@`-ing
-   *  someone outside the chat acts as both an invite and a mention. */
-  const { data: activity } = useQuery({
-    queryKey: ["activity"],
-    queryFn: getActivityOverview,
-    refetchInterval: 15_000,
+  /** Org-wide addressable agents (humans + AI), used to populate the
+   *  `[+]` participant picker in `ParticipantsHeader`. The `@`-autocomplete
+   *  in the composer is intentionally scoped to current chat participants
+   *  only — see `composerMentionCandidates` below.
+   *
+   *  Backed by `GET /api/v1/orgs/:orgId/agents` (see issue 343 for why not
+   *  `/activity`). `limit: 100` is the server's enforced cap in
+   *  `paginationQuerySchema`; orgs above that threshold need pagination
+   *  here, but small-org defaults are fine on a single page. */
+  const { data: orgAgentsPage } = useQuery({
+    queryKey: ["org-agents"],
+    queryFn: () => listAgents({ limit: 100 }),
+    refetchInterval: 30_000,
+    // Watchers can't add participants and don't see the [+] picker, so
+    // the org-agents query is pure waste in read-only mode. The auto-
+    // mention-prime path in the composer is also disabled there.
+    enabled: !readOnly,
   });
 
   const sendMut = useMutation({
@@ -719,21 +729,13 @@ export function ChatView({
     // proposal §3 enforcement) or downstream `mention_only` agents will drop.
     if (requiresMention && draftMentions.length === 0) return;
 
-    // "Mention to invite": any `@<name>` pointing at an agent outside the
-    // current chat is treated as both an address and an invitation. We add
-    // them first so by the time the message is processed, the server's
-    // `extractMentions` resolves successfully and direct-chats auto-upgrade
-    // to groups via the server's `changeChatType` service. Idempotent on
-    // the server.
-    if (draftOutsiders.length > 0) {
-      try {
-        await addMeChatParticipants(chatId, { participantIds: draftOutsiders });
-        await queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] });
-      } catch (err) {
-        setUploadError(err instanceof Error ? err.message : "Failed to add participants");
-        return;
-      }
-    }
+    // Note: the pre-issue 343 "@-to-invite" path (auto-`POST /participants` for
+    // any `@<outsider>` in the draft) is gone — the composer's `@`
+    // autocomplete is now scoped to current participants only, so
+    // `extractMentions` won't resolve outsiders and `draftMentions`
+    // contains in-chat agents by construction. Inviting new participants
+    // is an explicit `[+]` action in the header. See `ParticipantsHeader`
+    // + `orgAddressableCandidates`.
 
     if (images.length > 0) {
       setUploading(true);
@@ -850,58 +852,75 @@ export function ChatView({
 
   const displayName = agentName(agentId);
 
-  /** Set of agentIds currently in the chat. Used to (a) detect "outsiders"
-   *  the user `@`-mentions and (b) skip the redundant addParticipants call
-   *  when everyone they mention is already in the room. */
-  const chatParticipantIds = useMemo(() => {
-    return new Set(chatDetail?.participants?.map((p) => p.agentId) ?? []);
-  }, [chatDetail?.participants]);
+  /** `managedByMe` is `managerId === myMemberId`. The org-agents endpoint
+   *  surfaces `managerId`; we derive the boolean once per render so both
+   *  candidate lists share the same source of truth. */
+  const managedByMeMap = useMemo(() => {
+    const m = new Map<string, boolean>();
+    if (!myMemberId) return m;
+    for (const a of orgAgentsPage?.items ?? []) m.set(a.uuid, a.managerId === myMemberId);
+    return m;
+  }, [orgAgentsPage, myMemberId]);
 
-  // Mention autocomplete candidates: every org agent the user might address,
-  // resolved to their `{name, displayName}` via the shared identity map.
-  // Includes BOTH chat participants and outsiders — picking an outsider
-  // implicitly invites them via `addMeChatParticipants` at send time, which
-  // turns a 1:1 into a group server-side. Self is excluded; any agent
-  // without a slug (`name`) is skipped because mentions need one — even
-  // current chat participants. This is intentional: the server's
-  // `extractMentions` matches `@<token>` against `agents.name`, so a
-  // participant with `name=null` (legacy / soft-deleted row) cannot be
-  // addressed via `@` regardless. They still show in `ParticipantsHeader`
-  // chips (which uses `agentIdentity.displayName`); the picker just won't
-  // offer them. Fixing this requires the server to backfill missing
-  // `agents.name`, not a client-side workaround.
-  const mentionCandidates = useMemo<MentionCandidate[]>(() => {
-    const ids = new Set<string>();
-    for (const p of chatDetail?.participants ?? []) ids.add(p.agentId);
-    for (const a of activity?.agents ?? []) ids.add(a.agentId);
-    if (ids.size === 0) ids.add(agentId);
-    // Build a lookup from `/activity` so we can attach `managedByMe`
-    // per candidate. Known limitation: agents that appear only via
-    // `chatDetail.participants` (no runtime presence row, e.g. an
-    // autonomous agent that has never been bound to a client) default
-    // to false. That means a caller's own offline agent can be
-    // misclassified into the "teammates" group of the [+] picker.
-    // The picker grouping is a visual hint, not a security boundary,
-    // so we accept this fidelity loss rather than widen `/activity`'s
-    // shape (which is also consumed by roster / team / clients pages).
-    // To revisit: surface `managedByMe` independently of runtime via a
-    // dedicated `/me/managed-agents` endpoint and intersect here.
-    const managedByMeMap = new Map<string, boolean>();
-    for (const a of activity?.agents ?? []) managedByMeMap.set(a.agentId, a.managedByMe);
+  /**
+   * `@`-autocomplete candidates: ONLY agents currently in this chat. Per
+   * issue 343 design decision, the composer's `@` picker is scoped to the
+   * current participant set — inviting an outsider is an explicit `[+]`
+   * action, not a side-effect of `@`. Self is excluded (no self-mention);
+   * any participant with `name=null` is skipped because the server's
+   * `extractMentions` matches `@<token>` against `agents.name` (a
+   * soft-deleted row with null `name` cannot be addressed via `@`
+   * regardless — `ParticipantsHeader` chips still show them via
+   * `agentIdentity.displayName`).
+   */
+  const composerMentionCandidates = useMemo<MentionCandidate[]>(() => {
     const out: MentionCandidate[] = [];
-    for (const id of ids) {
-      if (id === myAgentId) continue;
-      const ident = agentIdentity(id);
+    for (const p of chatDetail?.participants ?? []) {
+      if (p.agentId === myAgentId) continue;
+      const ident = agentIdentity(p.agentId);
       if (!ident || !ident.name) continue;
       out.push({
-        agentId: id,
+        agentId: p.agentId,
         name: ident.name,
         displayName: ident.displayName,
-        managedByMe: managedByMeMap.get(id) ?? false,
+        managedByMe: managedByMeMap.get(p.agentId) ?? false,
       });
     }
     return out;
-  }, [chatDetail?.participants, activity?.agents, agentId, agentIdentity, myAgentId]);
+  }, [chatDetail?.participants, agentIdentity, myAgentId, managedByMeMap]);
+
+  /**
+   * `[+]` participant-picker candidates: every org-addressable agent
+   * (humans + AI), regardless of runtime state. `ParticipantsHeader`
+   * subtracts the current participants itself (its `outsideCandidates`
+   * derivation) so we hand it the full org list. Self is excluded so the
+   * user can never invite themselves. Any agent with `name=null` is
+   * skipped — same `@<token>`-against-`agents.name` rule as the composer
+   * candidates above (the row would be unaddressable post-add anyway).
+   *
+   * Sourced from `GET /orgs/:orgId/agents` (`listAgents`), which already
+   * applies the visibility filter and includes humans via LEFT JOIN on
+   * `agent_presence`. Pre-issue 343 this list came from `/activity` and lost
+   * humans entirely to `runtimeState IS NOT NULL`.
+   */
+  const orgAddressableCandidates = useMemo<MentionCandidate[]>(() => {
+    const out: MentionCandidate[] = [];
+    for (const a of orgAgentsPage?.items ?? []) {
+      if (a.uuid === myAgentId) continue;
+      if (!a.name) continue;
+      // Server returns suspended rows (only deleted are filtered by
+      // `agentVisibilityCondition`); exclude here so the picker never
+      // offers a row the server would refuse on add.
+      if (a.status === "suspended") continue;
+      out.push({
+        agentId: a.uuid,
+        name: a.name,
+        displayName: a.displayName,
+        managedByMe: managedByMeMap.get(a.uuid) ?? false,
+      });
+    }
+    return out;
+  }, [orgAgentsPage, myAgentId, managedByMeMap]);
 
   /**
    * "Needs explicit @mention" guard: a real group, OR a direct chat where the
@@ -965,28 +984,20 @@ export function ChatView({
     readOnly,
   ]);
 
-  /** All agentIds the draft text addresses via `@<name>` tokens — computed
-   * unconditionally (not just for groups) so the "outsider invite" path
-   * below can detect mentions of agents not yet in the chat. The send-gate
-   * for groups still uses `requiresMention && draftMentions.length === 0`. */
+  /** All agentIds the draft text addresses via `@<name>` tokens. Resolved
+   * against the composer candidate set (chat participants only), so
+   * `@<outsider>` no longer resolves — outsiders must be added via the
+   * `[+]` picker before they can be addressed. Drives the group-chat
+   * send-gate: `requiresMention && draftMentions.length === 0`. */
   const draftMentions = useMemo(() => {
-    const ps: MentionParticipant[] = mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name }));
+    const ps: MentionParticipant[] = composerMentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name }));
     return extractMentions(draft, ps);
-  }, [draft, mentionCandidates]);
-
-  /** Mentions in the draft that point at agents NOT currently in the chat.
-   * Sending a message that addresses these will first POST to
-   * `/me/chats/:id/participants` to add them, which turns a direct chat
-   * into a group via the server's `changeChatType` service. */
-  const draftOutsiders = useMemo(() => {
-    if (chatParticipantIds.size === 0) return [];
-    return draftMentions.filter((id) => !chatParticipantIds.has(id));
-  }, [draftMentions, chatParticipantIds]);
+  }, [draft, composerMentionCandidates]);
 
   const mention = useMentionAutocomplete({
     value: draft,
     cursor,
-    candidates: mentionCandidates,
+    candidates: composerMentionCandidates,
     disabled: sendMut.isPending || uploading,
     onSelect: (update) => {
       setDraft(update.text);
@@ -1161,15 +1172,17 @@ export function ChatView({
               the viewer's own agent: in chat-first the user is a real
               participant and seeing themselves in the audience makes
               the membership state explicit. Self's display name comes
-              through `agentIdentity` rather than `mentionCandidates`
-              (the latter excludes self by design — you don't @ yourself).
-              The [+] dropdown anchors to the right edge of the button
-              so it grows leftward, avoiding panel-edge overflow when
-              the chip row is long. */}
+              through `agentIdentity` rather than the candidate lists
+              (both `composerMentionCandidates` and
+              `orgAddressableCandidates` exclude self by design — you
+              don't @-mention or re-invite yourself). The [+] dropdown
+              anchors to the right edge of the button so it grows
+              leftward, avoiding panel-edge overflow when the chip row
+              is long. */}
           <ParticipantsHeader
             chatId={chatId}
             participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
-            candidates={mentionCandidates}
+            candidates={orgAddressableCandidates}
             agentIdentity={agentIdentity}
             onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
             readOnly={readOnly}
@@ -1413,7 +1426,7 @@ export function ChatView({
                       // empty message without addressing anyone (e.g. paste over).
                       if (!requiresMention) return;
                       if (focusPrimedRef.current) return;
-                      if (draft.length > 0 || mentionCandidates.length === 0) return;
+                      if (draft.length > 0 || composerMentionCandidates.length === 0) return;
                       focusPrimedRef.current = true;
                       setDraft("@");
                       setCursor(1);
@@ -1629,8 +1642,8 @@ function ParticipantsHeader({
   participantIds: string[];
   candidates: MentionCandidate[];
   /** Identity resolver covering ALL agents (incl. the viewer's own,
-   *  which `mentionCandidates` excludes). Lets the chip row label
-   *  self correctly instead of falling back to a UUID prefix. */
+   *  which `candidates` excludes). Lets the chip row label self
+   *  correctly instead of falling back to a UUID prefix. */
   agentIdentity: (uuid: string | null | undefined) => { name: string | null; displayName: string } | null;
   onAdded: () => void;
   readOnly?: boolean;

--- a/packages/web/src/pages/workspace/conversations/__tests__/pick-default.test.ts
+++ b/packages/web/src/pages/workspace/conversations/__tests__/pick-default.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { type PickDefaultAgent, pickDefault } from "../new-chat-draft.js";
+
+/**
+ * Pure-function tests for the New Chat default-chip seed (`pickDefault`).
+ *
+ * Locks the post-issue 343 / issue 342 behavior:
+ *   - my-managed scope (never seed a coworker's agent — see PR 328)
+ *   - PA-first, then any my-managed AI agent
+ *   - humans never seed (a human "self-mirror" chip is nonsense)
+ *   - suspended rows ignored
+ *   - no MRU keyed on `runtimeUpdatedAt` (used to flip between clicks)
+ *   - returns null when `myMemberId` is null or no managed agents exist
+ */
+
+const ME = "member-me-1";
+const OTHER = "member-other-1";
+
+/** Build an agent slice with only the fields `pickDefault` reads. */
+function agent(partial: Partial<PickDefaultAgent> & Pick<PickDefaultAgent, "uuid">): PickDefaultAgent {
+  return {
+    type: "autonomous_agent",
+    managerId: ME,
+    status: "active",
+    ...partial,
+  };
+}
+
+describe("pickDefault", () => {
+  it("returns null when myMemberId is null (logged-out or org not yet selected)", () => {
+    const agents = [agent({ uuid: "a1", type: "personal_assistant" })];
+    expect(pickDefault(agents, null)).toBeNull();
+  });
+
+  it("returns null when the caller manages no agents", () => {
+    const agents = [
+      agent({ uuid: "a1", managerId: OTHER }),
+      agent({ uuid: "a2", managerId: OTHER, type: "personal_assistant" }),
+    ];
+    expect(pickDefault(agents, ME)).toBeNull();
+  });
+
+  it("prefers a my-managed personal_assistant", () => {
+    const agents = [
+      agent({ uuid: "a1" }), // autonomous, mine
+      agent({ uuid: "a2", type: "personal_assistant" }), // PA, mine — winner
+      agent({ uuid: "a3", type: "personal_assistant", managerId: OTHER }), // PA, NOT mine
+    ];
+    expect(pickDefault(agents, ME)).toBe("a2");
+  });
+
+  it("falls back to the first my-managed agent when no PA is mine", () => {
+    const agents = [
+      agent({ uuid: "a1", type: "personal_assistant", managerId: OTHER }), // PA but coworker's
+      agent({ uuid: "a2", type: "autonomous_agent" }), // mine, winner
+      agent({ uuid: "a3", type: "autonomous_agent" }), // mine, but later
+    ];
+    expect(pickDefault(agents, ME)).toBe("a2");
+  });
+
+  it("excludes humans even when managerId matches (humans self-manage; chip = self is nonsense)", () => {
+    const agents = [
+      agent({ uuid: "me-human", type: "human" }), // my human mirror
+      agent({ uuid: "a1", type: "autonomous_agent" }), // my AI agent — winner
+    ];
+    expect(pickDefault(agents, ME)).toBe("a1");
+  });
+
+  it("returns null if the ONLY my-managed row is my human mirror", () => {
+    const agents = [agent({ uuid: "me-human", type: "human" })];
+    expect(pickDefault(agents, ME)).toBeNull();
+  });
+
+  it("excludes suspended agents", () => {
+    const agents = [
+      agent({ uuid: "a1", type: "personal_assistant", status: "suspended" }), // suspended PA — skip
+      agent({ uuid: "a2", type: "autonomous_agent" }), // active AI — winner
+    ];
+    expect(pickDefault(agents, ME)).toBe("a2");
+  });
+
+  it("returns null when every my-managed agent is suspended", () => {
+    const agents = [
+      agent({ uuid: "a1", type: "personal_assistant", status: "suspended" }),
+      agent({ uuid: "a2", type: "autonomous_agent", status: "suspended" }),
+    ];
+    expect(pickDefault(agents, ME)).toBeNull();
+  });
+
+  it("is stable across calls — does not depend on `runtimeUpdatedAt` (issue 342 regression lock)", () => {
+    // Identical input set yields identical output. The pre-issue 343 implementation
+    // sorted by `runtimeUpdatedAt` and could flip between adjacent calls when
+    // runtime presence shifted; the new implementation has no such dependency,
+    // so two passes over the same input must agree.
+    const agents = [
+      agent({ uuid: "a1", type: "autonomous_agent" }),
+      agent({ uuid: "a2", type: "autonomous_agent" }),
+      agent({ uuid: "a3", type: "personal_assistant" }),
+    ];
+    const first = pickDefault(agents, ME);
+    const second = pickDefault(agents, ME);
+    expect(first).toBe(second);
+    expect(first).toBe("a3"); // PA wins
+  });
+
+  it("ignores agents managed by others mixed with my agents", () => {
+    const agents = [
+      agent({ uuid: "a1", managerId: OTHER }),
+      agent({ uuid: "a2", managerId: OTHER, type: "personal_assistant" }),
+      agent({ uuid: "a3", managerId: ME, type: "autonomous_agent" }), // winner
+      agent({ uuid: "a4", managerId: OTHER }),
+    ];
+    expect(pickDefault(agents, ME)).toBe("a3");
+  });
+});

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -1,8 +1,9 @@
+import type { Agent } from "@agent-team-foundation/first-tree-hub-shared";
 import { extractMentions, type MentionParticipant } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Plus, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getActivityOverview, type RuntimeAgent } from "../../../api/activity.js";
+import { listAgents } from "../../../api/agents.js";
 import { sendChatMessage } from "../../../api/chats.js";
 import { createMeChat } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
@@ -25,7 +26,9 @@ import { cn } from "../../../lib/utils.js";
  *   - Chip row at the top of the composer is the participants list for
  *     the chat being created. Independent of the textarea — adding a
  *     chip never injects text, removing one never strips an `@<name>`.
- *     Default state seeds a single MRU chip so 1:1 sends are zero-step.
+ *     Default state seeds a single chip (the caller's personal assistant
+ *     or any of their managed agents — see `pickDefault`) so the common
+ *     "ask my PA something" case is zero-step.
  *
  *   - Textarea carries the message content. For 1:1 (single chip), no
  *     `@` is required — server treats the chat as direct and skips
@@ -34,10 +37,14 @@ import { cn } from "../../../lib/utils.js";
  *     Send is gated client-side to mirror this.
  *
  *   - Typing `@` in the textarea opens the autocomplete (candidates =
- *     all org agents). Picking an agent that isn't in the chip row
- *     promotes them to a chip — "I want to address X" subsumes "X is
- *     in the room". This unifies entry points without making them
- *     mutually exclusive.
+ *     all org-addressable agents — humans + AI, post-issue 343). Picking an
+ *     agent that isn't in the chip row promotes them to a chip —
+ *     "I want to address X" subsumes "X is in the room". This unifies
+ *     entry points without making them mutually exclusive. Note: this
+ *     differs from the existing-chat composer (`chat-view.tsx`), which
+ *     scopes `@`-autocomplete to current participants only — because
+ *     here there's no "participant set" yet; the chips ARE the set
+ *     being constructed, and `@`-to-chip is how you build it.
  *
  * On send: createMeChat({participantIds: chips}) → sendChatMessage with
  * the verbatim body. Empty body with at least one chip is allowed.
@@ -45,7 +52,7 @@ import { cn } from "../../../lib/utils.js";
 
 export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => void }) {
   const queryClient = useQueryClient();
-  const { agentId: myAgentId } = useAuth();
+  const { agentId: myAgentId, memberId: myMemberId } = useAuth();
   const agentIdentity = useAgentIdentityMap();
 
   const [chips, setChips] = useState<string[]>([]);
@@ -63,38 +70,48 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
   // both adjust instantly; past the cap content scrolls inside.
   useAutoResizeTextarea(textareaRef, draft);
 
-  const { data: activity } = useQuery({
-    queryKey: ["activity"],
-    queryFn: getActivityOverview,
-    refetchInterval: 15_000,
+  /** Candidate source: org-wide addressable agents (humans + AI), backed
+   *  by `GET /orgs/:orgId/agents` (see issue 343 for why not `/activity`).
+   *  `limit: 100` is the server's enforced cap in `paginationQuerySchema`;
+   *  orgs above that threshold need pagination here. */
+  const { data: orgAgentsPage } = useQuery({
+    queryKey: ["org-agents"],
+    queryFn: () => listAgents({ limit: 100 }),
+    refetchInterval: 30_000,
   });
 
   const candidates = useMemo<MentionCandidate[]>(() => {
-    const rows = activity?.agents ?? [];
     const out: MentionCandidate[] = [];
-    for (const row of rows) {
-      if (myAgentId && row.agentId === myAgentId) continue;
-      const ident = agentIdentity(row.agentId);
-      if (!ident || !ident.name) continue;
+    for (const a of orgAgentsPage?.items ?? []) {
+      if (myAgentId && a.uuid === myAgentId) continue;
+      if (!a.name) continue;
+      if (a.status === "suspended") continue;
+      const ident = agentIdentity(a.uuid);
+      // Prefer the shared identity map (kept fresh by other queries) but
+      // fall back to the agent row itself — `listAgents` is the only
+      // source that's guaranteed to return humans, so an identity-map
+      // miss for a never-seen human shouldn't drop them from the picker.
+      const name = ident?.name ?? a.name;
+      const displayName = ident?.displayName ?? a.displayName;
       out.push({
-        agentId: row.agentId,
-        name: ident.name,
-        displayName: ident.displayName,
-        managedByMe: row.managedByMe,
+        agentId: a.uuid,
+        name,
+        displayName,
+        managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
       });
     }
     return out;
-  }, [activity, agentIdentity, myAgentId]);
+  }, [orgAgentsPage, agentIdentity, myAgentId, myMemberId]);
 
   useEffect(() => {
     if (seededDefaultRef.current) return;
     if (chips.length > 0) return;
     if (candidates.length === 0) return;
-    const defaultId = pickDefault(candidates, activity?.agents ?? []);
+    const defaultId = pickDefault(orgAgentsPage?.items ?? [], myMemberId);
     if (!defaultId) return;
     setChips([defaultId]);
     seededDefaultRef.current = true;
-  }, [candidates, activity, chips.length]);
+  }, [candidates, orgAgentsPage, myMemberId, chips.length]);
 
   const bodyMentions = useMemo(() => {
     const ps: MentionParticipant[] = candidates.map((c) => ({ agentId: c.agentId, name: c.name }));
@@ -512,28 +529,34 @@ function ParticipantChips({
  *  agents, return `null` and let the user pick — better an empty chip
  *  row than a wrong default.
  *
- *  Within the my-managed subset:
- *    1. Most-recently-active (by `runtimeUpdatedAt`) — runtime presence
- *       signal, not a true "last conversation" timestamp, but the only
- *       MRU signal currently exposed by `/activity`.
- *    2. Any `personal_assistant` — covers the case where my agents have
- *       no runtime activity yet (fresh-install / cold-start).
- *    3. First my-managed agent in the candidates list — final fallback
- *       so we always seed something if I do manage at least one. */
-function pickDefault(candidates: MentionCandidate[], activity: RuntimeAgent[]): string | null {
-  const ids = new Set(candidates.map((c) => c.agentId));
-  const mine = activity.filter((a) => ids.has(a.agentId) && a.managedByMe);
+ *  Within the my-managed subset (in priority order):
+ *    1. Any `personal_assistant` — the user's primary AI representative.
+ *    2. First my-managed agent — final fallback so we always seed
+ *       something if I do manage at least one.
+ *
+ *  Humans never seed: `personal_assistant` filter eliminates them at
+ *  step 1, and step 2's "first my-managed" is keyed on the same
+ *  list — humans are mirrors of the caller themselves, defaulting to
+ *  self in a new chat is nonsense.
+ *
+ *  Pre-issue 343 there was also a "most-recently-active by
+ *  `runtimeUpdatedAt`" step 1, which made the default flip between
+ *  clicks whenever runtime presence shifted (see issue 342). Dropped
+ *  here — stability across clicks is more important than "show me my
+ *  busiest agent". A more deliberate default (e.g. the caller's
+ *  `delegateMention`) is tracked separately in issue 342. */
+/** Exported for `__tests__/pick-default.test.ts`. The signature accepts a
+ *  `Pick<Agent, ...>` slice rather than `Agent` so callers (and tests) can
+ *  pass minimal fixtures without inventing inboxIds, metadata, etc. */
+export type PickDefaultAgent = Pick<Agent, "uuid" | "type" | "managerId" | "status">;
+
+export function pickDefault(orgAgents: ReadonlyArray<PickDefaultAgent>, myMemberId: string | null): string | null {
+  if (!myMemberId) return null;
+  const mine = orgAgents.filter((a) => a.managerId === myMemberId && a.status !== "suspended" && a.type !== "human");
   if (mine.length === 0) return null;
 
-  const mru = [...mine]
-    .filter((a) => a.runtimeUpdatedAt)
-    .sort((a, b) => (b.runtimeUpdatedAt ?? "").localeCompare(a.runtimeUpdatedAt ?? ""))[0];
-  if (mru) return mru.agentId;
-
   const pa = mine.find((a) => a.type === "personal_assistant");
-  if (pa) return pa.agentId;
+  if (pa) return pa.uuid;
 
-  // Any my-managed agent — `mine` is already candidates ∩ managedByMe,
-  // so the first row is a valid seed without another candidates scan.
-  return mine[0]?.agentId ?? null;
+  return mine[0]?.uuid ?? null;
 }


### PR DESCRIPTION
## Summary

- **Closes #343**: web participant pickers (`ParticipantsHeader` `[+]` in existing chats, chip picker in `NewChatDraft`) couldn't surface human members of the org. Root cause: both consumed `/orgs/:orgId/activity`, whose `listAgentsWithRuntime` service filters on `runtimeState IS NOT NULL`; humans never bind a runtime, so they were silently dropped. Switched picker data source to the existing `/orgs/:orgId/agents` endpoint (`listAgentsForMember`), which already `LEFT JOIN`s `agent_presence` and surfaces humans natively. Server unchanged.
- **Partial #342**: dropped the `runtimeUpdatedAt` MRU branch from `pickDefault` in `new-chat-draft.tsx`. Default chip is now stable across clicks (was flipping with runtime activity). A more deliberate default (e.g. `delegateMention`) stays out of scope and tracked in #342.

## Design choices

- **Server zero-change.** `listAgentsWithRuntime` keeps "AI agents with a runtime" semantics for Roster / Cmd-K / Computers / Pulse. The picker had been borrowing this endpoint; the fix is to swap the picker's data source, not widen `/activity`.
- **`@` vs `[+]` semantic split** in `chat-view.tsx`:
  - Composer `@`-autocomplete → only current chat participants.
  - Header `[+]` picker → org-wide (humans + AI).
  - The pre-existing "type `@<outsider>` auto-invites them" path is removed — inviting a new participant is now an explicit `[+]` action.
- **`pickDefault` priorities** post-fix: my-managed `personal_assistant` → first my-managed AI agent → `null`. Humans never seed.

## Test plan

- [x] `pnpm check` — clean
- [x] `pnpm typecheck` — 9/9 packages
- [x] `pnpm --filter @first-tree-hub/server test` — 850/850 tests pass
- [x] `pnpm --filter @first-tree-hub/web test` — 12 files / 101 tests pass (includes 10 new `pickDefault` unit tests)
- [x] New server-side regression test: `addMeChatParticipants` accepts a human as `access_mode='speaker'` (locks the server contract so a future `type` filter can't silently undo the picker fix).
- [x] New web-side unit test: `pickDefault` — 10 cases, including a "stable across calls" regression lock for #342.
- [ ] Manual UI verification (deferred to deploy):
  - [ ] Existing chat `[+]` picker shows humans
  - [ ] Existing chat composer `@` candidates = current participants only
  - [ ] New chat chip `[+]` picker shows humans + AI
  - [ ] New chat default chip is stable across multiple open/close cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)