### PR TITLE
refactor(server): simplify notification infra — cross-instance fanout, DB-backed dedup, push-only bell

### DIFF
--- a/docs/chat-first-workspace-product-design.md
+++ b/docs/chat-first-workspace-product-design.md
@@ -632,8 +632,6 @@ Notification bell
 ├─ agent_error
 ├─ agent_blocked
 ├─ agent_stale
-├─ agent_disconnected
-├─ agent_connected
 ├─ session_error
 ├─ session_completed
 └─ computer / system / organisation events

--- a/packages/server/drizzle/0041_notifications_dedup_key.sql
+++ b/packages/server/drizzle/0041_notifications_dedup_key.sql
@@ -1,0 +1,29 @@
+-- DB-backed deduplication for the notifications table.
+--
+-- Before this migration, the server kept an in-memory Map keyed by
+-- `(agentId, notificationType)` to suppress duplicate notifications within a
+-- five-minute window. That broke in two important ways:
+--
+--   1. Multi-instance deployments: each server process owned its own Map, so
+--      a notification produced on instance A passed instance B's dedupe gate
+--      unchanged. Operators saw the same row inserted multiple times during
+--      load-balancer failover or rolling restart.
+--   2. Process restart wiped the Map, re-opening the dedupe window for
+--      whatever events had fired just before.
+--
+-- The new model is purely DB-driven. A producer optionally supplies a
+-- `dedup_key` (e.g. `agent:{uuid}:error`, `chat:{uuid}:completed`). The
+-- partial unique index below scopes uniqueness to `(organization_id,
+-- dedup_key)` *while the prior row is still unread*. Re-emitting the same
+-- key while the previous notification sits unread is a no-op (the
+-- application uses `ON CONFLICT DO NOTHING`); after the user acknowledges
+-- the prior row, a fresh notification can land again.
+--
+-- Producers without a `dedup_key` keep the legacy always-insert behaviour,
+-- so this column is purely additive — no back-fill, no NOT NULL constraint.
+
+ALTER TABLE "notifications" ADD COLUMN "dedup_key" text;
+
+CREATE UNIQUE INDEX "uq_notifications_org_dedup_unread"
+  ON "notifications" ("organization_id", "dedup_key")
+  WHERE read = false AND dedup_key IS NOT NULL;

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1779235200000,
       "tag": "0040_chat_user_state_engagement",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1779321600000,
+      "tag": "0041_notifications_dedup_key",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/pulse-aggregator.test.ts
+++ b/packages/server/src/__tests__/pulse-aggregator.test.ts
@@ -28,6 +28,7 @@ function makeMockNotifier(): {
     notifySessionStateChange: vi.fn(async () => {}),
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
+    notifyAdminBroadcast: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
     onSessionStateChange: vi.fn(),
@@ -35,6 +36,7 @@ function makeMockNotifier(): {
       handlers.push(handler);
     }),
     onChatMessage: vi.fn(),
+    onAdminBroadcast: vi.fn(),
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
   } satisfies Notifier;

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -85,24 +85,6 @@ const wsMessageSchema = z.object({
  * SDK can refresh and reconnect without silently half-opening the socket.
  */
 
-/** Notification cooldown: prevents duplicate notifications for same (agentId, type) within window. */
-const NOTIFICATION_COOLDOWN_MS = 300_000; // 5 minutes
-const notificationCooldowns = new Map<string, number>();
-
-function shouldNotify(agentId: string, notificationType: string): boolean {
-  const key = `${agentId}:${notificationType}`;
-  const now = Date.now();
-  const lastSent = notificationCooldowns.get(key);
-  if (lastSent && now - lastSent < NOTIFICATION_COOLDOWN_MS) return false;
-  notificationCooldowns.set(key, now);
-  if (notificationCooldowns.size > 1000) {
-    for (const [k, ts] of notificationCooldowns) {
-      if (now - ts > NOTIFICATION_COOLDOWN_MS) notificationCooldowns.delete(k);
-    }
-  }
-  return true;
-}
-
 /**
  * Authenticated WS session state.
  *
@@ -788,9 +770,12 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 notifier,
               });
 
-              if (payload.runtimeState === "error" && shouldNotify(agentId, "agent_error")) {
+              // Dedup happens at the DB layer via the default agent:{id}:{type}
+              // dedup_key — repeated runtime-state errors for the same agent
+              // collapse to a single unread row until the user acks.
+              if (payload.runtimeState === "error") {
                 notificationService.notifyAgentEvent(app.db, agentId, "agent_error", "high").catch(() => {});
-              } else if (payload.runtimeState === "blocked" && shouldNotify(agentId, "agent_blocked")) {
+              } else if (payload.runtimeState === "blocked") {
                 notificationService.notifyAgentEvent(app.db, agentId, "agent_blocked", "medium").catch(() => {});
               }
             } else if (type === "session:event") {
@@ -822,11 +807,12 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
               const payload = sessionCompletionMessageSchema.parse(msg);
 
-              if (shouldNotify(agentId, `session_completed:${payload.chatId}`)) {
-                notificationService
-                  .notifyAgentEvent(app.db, agentId, "session_completed", "low", payload.chatId)
-                  .catch(() => {});
-              }
+              // Dedup happens at the DB layer via the default
+              // chat:{chatId}:session_completed key — a noisy reconcile loop
+              // can't produce N rows for the same chat completion.
+              notificationService
+                .notifyAgentEvent(app.db, agentId, "session_completed", "low", { chatId: payload.chatId })
+                .catch(() => {});
             } else if (type === "inbox:ack") {
               const payloadResult = inboxAckFrameSchema.safeParse(msg);
               if (!payloadResult.success) {

--- a/packages/server/src/api/orgs/notifications.ts
+++ b/packages/server/src/api/orgs/notifications.ts
@@ -12,6 +12,12 @@ export async function orgNotificationRoutes(app: FastifyInstance): Promise<void>
     return notificationService.listNotifications(app.db, scope.organizationId, scope.memberId, query);
   });
 
+  app.get<{ Params: { orgId: string } }>("/unread-count", async (request) => {
+    const scope = await requireOrgMembership(request, app.db);
+    const count = await notificationService.unreadCount(app.db, scope.organizationId, scope.memberId);
+    return { count };
+  });
+
   app.post<{ Params: { orgId: string; id: string } }>("/:id/read", async (request) => {
     const scope = await requireOrgMembership(request, app.db);
     const result = await notificationService.markRead(app.db, request.params.id, scope.organizationId, scope.memberId);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -74,7 +74,7 @@ import {
   rootLogger,
 } from "./observability/index.js";
 import { type AdapterManager, createAdapterManager } from "./services/adapter-manager.js";
-import { broadcastToAdmins } from "./services/admin-broadcast.js";
+import { broadcastToAdmins, registerCrossInstanceBroadcaster } from "./services/admin-broadcast.js";
 import { expiryToSeconds } from "./services/auth.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
@@ -285,6 +285,21 @@ export async function buildApp(config: Config) {
   // Notifier: dedicated PG connection for LISTEN/NOTIFY
   const listenClient = postgres(config.database.url, { max: 1, ...sslOptions(config.database.url) });
   const notifier = createNotifier(listenClient);
+
+  // Cross-instance admin-broadcast wiring. Producers call
+  // `broadcastAdminsCrossInstance` which routes through pg_notify; every
+  // server instance LISTENs and feeds the envelope back into its own
+  // per-instance fanout (`broadcastToAdmins`). Registering both ends here
+  // keeps the bootstrap ordering obvious — producer -> NOTIFY -> LISTEN ->
+  // local fanout — without scattering wiring across services.
+  registerCrossInstanceBroadcaster((payload) => {
+    notifier.notifyAdminBroadcast(payload).catch(() => {
+      // fire-and-forget: admin UI tolerates an occasional dropped frame
+    });
+  });
+  notifier.onAdminBroadcast((payload) => {
+    broadcastToAdmins(payload);
+  });
 
   // WebSocket plugin. `maxPayload` caps a single inbound frame so a hostile
   // or buggy client cannot OOM the server with one giant message. Frames in

--- a/packages/server/src/db/schema/notifications.ts
+++ b/packages/server/src/db/schema/notifications.ts
@@ -1,5 +1,6 @@
 import type { NotificationSeverity, NotificationType } from "@agent-team-foundation/first-tree-hub-shared";
-import { boolean, index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { boolean, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 
 /**
  * Notifications — M1 event notifications for admin dashboard.
@@ -17,11 +18,23 @@ export const notifications = pgTable(
     chatId: text("chat_id"),
     message: text("message").notNull(),
     read: boolean("read").notNull().default(false),
+    /**
+     * Optional producer-supplied key used to suppress duplicate notifications
+     * while a prior one is still unread. Examples: `agent:{uuid}:error`,
+     * `chat:{uuid}:completed`. The partial unique index below scopes uniqueness
+     * to `(organization_id, dedup_key)` rows where `read=false`, so a fresh
+     * notification fires as soon as the user acknowledges the previous one.
+     * Producers without a dedup_key keep the legacy always-insert behaviour.
+     */
+    dedupKey: text("dedup_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     index("idx_notifications_org_created").on(table.organizationId, table.createdAt),
     index("idx_notifications_agent").on(table.agentId),
     index("idx_notifications_org_read").on(table.organizationId, table.read),
+    uniqueIndex("uq_notifications_org_dedup_unread")
+      .on(table.organizationId, table.dedupKey)
+      .where(sql`read = false AND dedup_key IS NOT NULL`),
   ],
 );

--- a/packages/server/src/services/admin-broadcast.ts
+++ b/packages/server/src/services/admin-broadcast.ts
@@ -1,23 +1,60 @@
-/** Service-layer seam for pushing payloads to admin WebSocket sockets. */
+/**
+ * Service-layer seam for pushing payloads to admin WebSocket sockets.
+ *
+ * Two registration points:
+ *  - `registerAdminBroadcaster` — per-instance fanout to admin sockets attached
+ *    to THIS server process. Wired by orgWsRoutes once the admin route is up.
+ *  - `registerCrossInstanceBroadcaster` — cross-instance pg_notify fanout.
+ *    Wired by app.ts during boot; the LISTEN handler on every instance feeds
+ *    the inbound envelope back into `broadcastToAdmins` so all admin sockets
+ *    across all instances see the same event.
+ *
+ * Producers (notification.ts) should call `broadcastAdminsCrossInstance`. Tests
+ * and per-instance subsystems (pulse aggregator) call `broadcastToAdmins`
+ * directly because their fanout is scoped to the local process anyway.
+ */
 
 export type AdminBroadcastPayload = Record<string, unknown>;
 export type AdminBroadcaster = (payload: AdminBroadcastPayload) => void;
 
-let registered: AdminBroadcaster | null = null;
+let localBroadcaster: AdminBroadcaster | null = null;
+let crossInstanceBroadcaster: AdminBroadcaster | null = null;
 
 export function registerAdminBroadcaster(fn: AdminBroadcaster): void {
-  registered = fn;
+  localBroadcaster = fn;
+}
+
+export function registerCrossInstanceBroadcaster(fn: AdminBroadcaster): void {
+  crossInstanceBroadcaster = fn;
 }
 
 export function resetAdminBroadcaster(): void {
-  registered = null;
+  localBroadcaster = null;
+  crossInstanceBroadcaster = null;
 }
 
 export function broadcastToAdmins(payload: AdminBroadcastPayload): void {
-  if (!registered) return;
+  if (!localBroadcaster) return;
   try {
-    registered(payload);
+    localBroadcaster(payload);
   } catch {
     // fire-and-forget
   }
+}
+
+/**
+ * Fan out to every admin socket across every server instance via PG NOTIFY.
+ * Falls back to single-instance fanout when no cross-instance broadcaster is
+ * registered (e.g. unit tests that don't boot a notifier).
+ */
+export function broadcastAdminsCrossInstance(payload: AdminBroadcastPayload): void {
+  if (crossInstanceBroadcaster) {
+    try {
+      crossInstanceBroadcaster(payload);
+    } catch {
+      // fire-and-forget
+    }
+    return;
+  }
+  broadcastToAdmins(payload);
 }

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -5,7 +5,7 @@ import {
   type NotificationSeverity,
   type NotificationType,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, desc, eq, inArray, isNull, lt, ne, or } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
@@ -111,31 +111,28 @@ export async function listNotifications(db: Database, orgId: string, memberId: s
     return { items: [], nextCursor: null };
   }
 
-  const conditions = [eq(notifications.organizationId, orgId)];
+  const targetLimit = query.limit;
+
+  const conditions = [eq(notifications.organizationId, orgId), buildVisibilityCondition([...visibleAgents])];
   if (query.cursor) conditions.push(lt(notifications.createdAt, new Date(query.cursor)));
   if (query.severity) conditions.push(eq(notifications.severity, query.severity));
   if (query.read !== undefined) conditions.push(eq(notifications.read, query.read));
   if (query.agentId) conditions.push(eq(notifications.agentId, query.agentId));
 
-  const where = and(...conditions);
-
-  // Overscan to absorb rows discarded by the visibility post-filter. Without
-  // overscan, a page containing many invisible-agent rows could silently
-  // return an empty payload even when more visible rows exist past the cursor.
-  const overscanFactor = 4;
-  const targetLimit = query.limit;
-  const rawLimit = Math.min(targetLimit * overscanFactor + 1, 400);
-
+  // Visibility is now part of the SQL predicate (`agent_id IS NULL OR
+  // agent_id IN visible`) instead of an in-Node post-filter, so we fetch
+  // exactly `limit + 1` rows and rely on the DB to discard invisible rows.
+  // This eliminates the 400-row overscan ceiling that previously made
+  // long-tail visible rows invisible when invisible-agent noise dominated.
   const rows = await db
     .select()
     .from(notifications)
-    .where(where)
+    .where(and(...conditions))
     .orderBy(desc(notifications.createdAt))
-    .limit(rawLimit);
+    .limit(targetLimit + 1);
 
-  const visible = rows.filter((n) => n.agentId === null || visibleAgents.has(n.agentId));
-  const hasMore = visible.length > targetLimit;
-  const items = hasMore ? visible.slice(0, targetLimit) : visible;
+  const hasMore = rows.length > targetLimit;
+  const items = hasMore ? rows.slice(0, targetLimit) : rows;
   const last = items[items.length - 1];
   const nextCursor = hasMore && last ? last.createdAt.toISOString() : null;
 
@@ -146,6 +143,27 @@ export async function listNotifications(db: Database, orgId: string, memberId: s
     })),
     nextCursor,
   };
+}
+
+/**
+ * Return the unread notification count for this member's visible agents.
+ * Single `SELECT COUNT(*)` — no row fetch — so the topbar bell badge can
+ * surface an accurate number (>100) without paying for a list query.
+ */
+export async function unreadCount(db: Database, orgId: string, memberId: string): Promise<number> {
+  const visibleAgents = await loadVisibleAgentIds(db, orgId, memberId);
+
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.organizationId, orgId),
+        eq(notifications.read, false),
+        buildVisibilityCondition([...visibleAgents]),
+      ),
+    );
+  return row?.count ?? 0;
 }
 
 /** Mark a single notification as read, scoped to organization + visible agents. */
@@ -173,22 +191,32 @@ export async function markRead(db: Database, notificationId: string, orgId: stri
 /** Mark all notifications visible to this member as read. */
 export async function markAllRead(db: Database, orgId: string, memberId: string) {
   const visible = await loadVisibleAgentIds(db, orgId, memberId);
-  const visibleIds = [...visible];
 
   // Single UPDATE covering every visible unread row in the org. Org-wide rows
   // (agentId IS NULL) are always visible; agent-scoped rows are filtered to
-  // the member's visible agent set. Without this single-statement form a
-  // burst of notifications past the prior 1000-row select cap would leave
-  // unread rows behind, and the bell badge would never clear.
-  const visibilityCondition =
-    visibleIds.length > 0
-      ? or(isNull(notifications.agentId), inArray(notifications.agentId, visibleIds))
-      : isNull(notifications.agentId);
-
+  // the member's visible agent set. The same visibility predicate is reused
+  // by listNotifications and unreadCount so the three surfaces agree.
   await db
     .update(notifications)
     .set({ read: true })
-    .where(and(eq(notifications.organizationId, orgId), eq(notifications.read, false), visibilityCondition));
+    .where(
+      and(
+        eq(notifications.organizationId, orgId),
+        eq(notifications.read, false),
+        buildVisibilityCondition([...visible]),
+      ),
+    );
+}
+
+/**
+ * SQL fragment matching every notification visible to a member: org-wide
+ * (`agent_id IS NULL`) plus rows tied to an agent in the member's visible
+ * set. Centralised so listNotifications, markAllRead, and unreadCount can
+ * never drift apart.
+ */
+function buildVisibilityCondition(visibleAgentIds: string[]) {
+  if (visibleAgentIds.length === 0) return isNull(notifications.agentId);
+  return or(isNull(notifications.agentId), inArray(notifications.agentId, visibleAgentIds));
 }
 
 /**

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -257,16 +257,12 @@ function composeMessage(type: NotificationType, agentCtx: AgentContext, chatCtx:
       return chat ? `${chat} completed` : `${agent} completed a task`;
     case "session_error":
       return chat ? `${chat} hit an error` : `${agent} hit a session error`;
-    case "agent_connected":
-      return `Computer ${computer} reconnected`;
     case "agent_stale":
       return `Computer ${computer} is unresponsive`;
     case "agent_error":
       return `${agent} entered error state`;
     case "agent_blocked":
       return `${agent} is blocked`;
-    case "agent_needs_decision":
-      return chat ? `${agent} needs a decision in ${chat}` : `${agent} needs a decision`;
     default:
       return `${agent} event`;
   }

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -12,7 +12,7 @@ import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { notifications } from "../db/schema/notifications.js";
 import { uuidv7 } from "../uuid.js";
-import { broadcastToAdmins } from "./admin-broadcast.js";
+import { broadcastAdminsCrossInstance } from "./admin-broadcast.js";
 
 export type CreateNotificationData = {
   organizationId: string;
@@ -312,7 +312,13 @@ function pushToAdminWs(notification: Record<string, unknown>): void {
   // can filter strictly (no `!orgId` fallback that silently fans out to every
   // org). `agentId` is also hoisted so the WS route can additionally scope by
   // per-member agent visibility before relaying to a given socket.
-  broadcastToAdmins({
+  //
+  // Cross-instance: the envelope goes onto the `admin_broadcast_envelopes`
+  // PG NOTIFY channel; every server instance LISTENs and feeds the envelope
+  // back into its local `broadcastToAdmins` fanout. With a single instance the
+  // round-trip is sub-millisecond; with multiple, every admin socket on every
+  // instance sees the same event without an extra delivery hop.
+  broadcastAdminsCrossInstance({
     type: "notification",
     organizationId: notification.organizationId as string,
     agentId: (notification.agentId as string | null) ?? null,

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -159,8 +159,13 @@ export async function listNotifications(db: Database, orgId: string, memberId: s
 export async function unreadCount(db: Database, orgId: string, memberId: string): Promise<number> {
   const visibleAgents = await loadVisibleAgentIds(db, orgId, memberId);
 
+  // count(*) is `bigint` in PG. postgres-js returns bigint as string by
+  // default, so we tell TS to expect a string and parse it through Number(),
+  // which is safe up to 2^53. Casting to int in SQL would overflow past
+  // 2.1B rows; the string path is bounded by JS's safe integer range
+  // instead and matches the on-the-wire shape.
   const [row] = await db
-    .select({ count: sql<number>`count(*)::int` })
+    .select({ count: sql<string>`count(*)` })
     .from(notifications)
     .where(
       and(
@@ -169,7 +174,7 @@ export async function unreadCount(db: Database, orgId: string, memberId: string)
         buildVisibilityCondition([...visibleAgents]),
       ),
     );
-  return row?.count ?? 0;
+  return Number(row?.count ?? "0");
 }
 
 /** Mark a single notification as read, scoped to organization + visible agents. */

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -47,9 +47,12 @@ export type CreateNotificationData = {
 export async function createNotification(db: Database, data: CreateNotificationData) {
   const id = uuidv7();
 
-  // ON CONFLICT DO NOTHING on the partial unique index. The index only
-  // applies when read=false AND dedup_key IS NOT NULL, so producers without
-  // a dedup_key never collide and keep their always-insert semantics.
+  // ON CONFLICT DO NOTHING on the partial unique index. The `where` clause is
+  // mandatory when the target index is partial — PG raises "there is no
+  // unique or exclusion constraint matching the ON CONFLICT specification"
+  // unless the predicate matches the index definition exactly. Rows without
+  // a dedup_key never satisfy the predicate, so the conflict path never
+  // fires for them and they keep the legacy always-insert behaviour.
   const inserted = await db
     .insert(notifications)
     .values({
@@ -62,7 +65,10 @@ export async function createNotification(db: Database, data: CreateNotificationD
       message: data.message,
       dedupKey: data.dedupKey ?? null,
     })
-    .onConflictDoNothing({ target: [notifications.organizationId, notifications.dedupKey] })
+    .onConflictDoNothing({
+      target: [notifications.organizationId, notifications.dedupKey],
+      where: sql`${notifications.read} = false AND ${notifications.dedupKey} IS NOT NULL`,
+    })
     .returning();
 
   const row = inserted[0];

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -27,13 +27,30 @@ export type CreateNotificationData = {
    */
   clientId?: string | null;
   message: string;
+  /**
+   * Optional dedup key. While a prior unread notification with the same
+   * `(organizationId, dedupKey)` exists, repeated inserts are suppressed at
+   * the DB layer (partial unique index `uq_notifications_org_dedup_unread`).
+   * After the user marks the prior row read, a new notification can fire.
+   * Producers without a dedup key get the legacy always-insert behaviour.
+   */
+  dedupKey?: string | null;
 };
 
-/** Create a notification, persist it, and fire-and-forget push to all channels. */
+/**
+ * Create a notification, persist it, and fire-and-forget push to all channels.
+ *
+ * Returns `null` when the insert was suppressed by the dedup partial unique
+ * index — i.e. an unread notification with the same `(orgId, dedupKey)`
+ * already exists and the producer should treat this call as a no-op.
+ */
 export async function createNotification(db: Database, data: CreateNotificationData) {
   const id = uuidv7();
 
-  const [row] = await db
+  // ON CONFLICT DO NOTHING on the partial unique index. The index only
+  // applies when read=false AND dedup_key IS NOT NULL, so producers without
+  // a dedup_key never collide and keep their always-insert semantics.
+  const inserted = await db
     .insert(notifications)
     .values({
       id,
@@ -43,10 +60,17 @@ export async function createNotification(db: Database, data: CreateNotificationD
       agentId: data.agentId ?? null,
       chatId: data.chatId ?? null,
       message: data.message,
+      dedupKey: data.dedupKey ?? null,
     })
+    .onConflictDoNothing({ target: [notifications.organizationId, notifications.dedupKey] })
     .returning();
 
-  if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
+  const row = inserted[0];
+  if (!row) {
+    // Dedup suppressed the insert. Callers should treat this as a no-op —
+    // the prior unread row is still in flight to the admin UI.
+    return null;
+  }
 
   const notification = {
     id: row.id,
@@ -271,8 +295,15 @@ function composeMessage(type: NotificationType, agentCtx: AgentContext, chatCtx:
 /**
  * Convenience: create a notification for an agent event, resolving org,
  * agent display name, computer hostname, and chat topic automatically.
- * Callers supply the event type and severity; the message text is generated
- * here so language/phrasing is centralized (see {@link composeMessage}).
+ * Callers supply the event type, severity, and (recommended) dedup_key; the
+ * message text is generated here so language/phrasing is centralized (see
+ * {@link composeMessage}).
+ *
+ * Default dedup_key when none is supplied: `agent:{agentId}:{type}` or, when
+ * a chatId is present, `chat:{chatId}:{type}`. This makes "burst of identical
+ * events for the same agent/chat surfaces a single unread row" the default
+ * behaviour rather than an opt-in — pass `dedupKey: null` if you want the
+ * legacy "every event creates a new row" semantics.
  *
  * Fire-and-forget — errors are swallowed so event producers never fail just
  * because the notification pipeline is unhealthy.
@@ -282,23 +313,32 @@ export async function notifyAgentEvent(
   agentId: string,
   type: NotificationType,
   severity: NotificationSeverity,
-  chatId?: string | null,
+  options: { chatId?: string | null; dedupKey?: string | null } = {},
 ): Promise<void> {
   try {
     const agentCtx = await resolveAgentContext(db, agentId);
     if (!agentCtx) return;
 
+    const chatId = options.chatId ?? null;
     const chatCtx = chatId ? await resolveChatContext(db, chatId) : null;
     const message = composeMessage(type, agentCtx, chatCtx);
+
+    const dedupKey =
+      options.dedupKey === undefined
+        ? chatId
+          ? `chat:${chatId}:${type}`
+          : `agent:${agentId}:${type}`
+        : options.dedupKey;
 
     await createNotification(db, {
       organizationId: agentCtx.organizationId,
       type,
       severity,
       agentId,
-      chatId: chatId ?? null,
+      chatId,
       clientId: agentCtx.clientId,
       message,
+      dedupKey,
     });
   } catch {
     // fire-and-forget

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -205,17 +205,31 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
     },
 
     async notifyAdminBroadcast(payload: Record<string, unknown>) {
+      let encoded: string;
       try {
-        const encoded = JSON.stringify(payload);
-        // PG NOTIFY payload limit is ~8000 bytes. Notification envelopes are
-        // ~600 bytes worst-case; refuse to emit anything larger so a buggy
-        // producer surfaces loudly instead of silently truncating.
-        if (encoded.length > 7500) {
-          throw new Error(`admin broadcast payload too large: ${encoded.length} bytes`);
-        }
+        encoded = JSON.stringify(payload);
+      } catch {
+        // Non-serialisable producer payload — nothing useful to forward.
+        return;
+      }
+      // PG NOTIFY payload limit is ~8000 bytes. Notification envelopes are
+      // ~600 bytes in practice; anything over 7500 means a producer bug
+      // (e.g. someone stuffing message bodies / attachments into the
+      // envelope). Log loudly via console — the rest of `notifier.ts` is
+      // intentionally logger-free to keep the module portable, but a
+      // truncated NOTIFY would silently break admin UI fan-out, which is
+      // exactly the kind of failure we don't want fire-and-forget'd into
+      // the void.
+      if (encoded.length > 7500) {
+        console.error(`[notifier] admin broadcast payload too large (${encoded.length} bytes); refusing to NOTIFY`);
+        return;
+      }
+      try {
         await listenClient`SELECT pg_notify(${ADMIN_BROADCAST_CHANNEL}, ${encoded})`;
       } catch {
-        // fire-and-forget — admin UI tolerates an occasional dropped frame
+        // Transient PG errors are best-effort; admin UI tolerates a
+        // dropped frame, and the next reconnect-time catch-up will
+        // re-sync via REST.
       }
     },
 

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -12,6 +12,14 @@ const RUNTIME_STATE_CHANNEL = "runtime_state_changes";
  * inbox NOTIFY path that only reaches speakers.
  */
 const CHAT_MESSAGE_CHANNEL = "chat_message_events";
+/**
+ * Generic admin-broadcast envelope channel. Producers (e.g. notification.ts)
+ * emit a JSON-stringified `AdminBroadcastPayload`; every server instance
+ * LISTENs and hands the envelope to its local admin-socket fanout. Keeps
+ * cross-instance and single-instance code paths identical from the admin WS
+ * route's perspective.
+ */
+const ADMIN_BROADCAST_CHANNEL = "admin_broadcast_envelopes";
 
 export type ConfigChangeHandler = (channel: string) => void;
 export type SessionStateChangeHandler = (payload: {
@@ -22,6 +30,7 @@ export type SessionStateChangeHandler = (payload: {
 }) => void;
 export type RuntimeStateChangeHandler = (payload: { agentId: string; state: string; organizationId: string }) => void;
 export type ChatMessageChangeHandler = (payload: { chatId: string; messageId: string }) => void;
+export type AdminBroadcastHandler = (payload: Record<string, unknown>) => void;
 
 /**
  * Per-socket push handler for the WS data plane. When a NOTIFY arrives on
@@ -59,6 +68,12 @@ export type Notifier = {
   /** Chat-first workspace: kick admin WS sockets to invalidate ["me","chats"] and the timeline of `chatId`. */
   notifyChatMessage(chatId: string, messageId: string): Promise<void>;
   /**
+   * Emit a generic admin-broadcast envelope cross-instance. Every server
+   * instance's LISTEN handler receives the JSON-decoded payload and hands it
+   * to its registered admin-socket fanout (typically `broadcastToAdmins`).
+   */
+  notifyAdminBroadcast(payload: Record<string, unknown>): Promise<void>;
+  /**
    * Push a raw JSON frame to every socket currently subscribed to `inboxId`
    * on **this server instance only**. Unlike `notify`, does not fan out
    * across PG NOTIFY — used for payloads that are too large for NOTIFY
@@ -74,6 +89,8 @@ export type Notifier = {
   onRuntimeStateChange(handler: RuntimeStateChangeHandler): void;
   /** Register a handler for chat:message change notifications. */
   onChatMessage(handler: ChatMessageChangeHandler): void;
+  /** Register a handler for cross-instance admin-broadcast envelopes. */
+  onAdminBroadcast(handler: AdminBroadcastHandler): void;
   /** Start listening for PG notifications */
   start(): Promise<void>;
   /** Stop listening */
@@ -89,11 +106,13 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   const sessionStateChangeHandlers: SessionStateChangeHandler[] = [];
   const runtimeStateChangeHandlers: RuntimeStateChangeHandler[] = [];
   const chatMessageHandlers: ChatMessageChangeHandler[] = [];
+  const adminBroadcastHandlers: AdminBroadcastHandler[] = [];
   let unlistenInboxFn: (() => Promise<void>) | null = null;
   let unlistenConfigFn: (() => Promise<void>) | null = null;
   let unlistenSessionStateFn: (() => Promise<void>) | null = null;
   let unlistenRuntimeStateFn: (() => Promise<void>) | null = null;
   let unlistenChatMessageFn: (() => Promise<void>) | null = null;
+  let unlistenAdminBroadcastFn: (() => Promise<void>) | null = null;
 
   function handleNotification(payload: string) {
     // payload format: "inboxId:messageId"
@@ -185,6 +204,21 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       }
     },
 
+    async notifyAdminBroadcast(payload: Record<string, unknown>) {
+      try {
+        const encoded = JSON.stringify(payload);
+        // PG NOTIFY payload limit is ~8000 bytes. Notification envelopes are
+        // ~600 bytes worst-case; refuse to emit anything larger so a buggy
+        // producer surfaces loudly instead of silently truncating.
+        if (encoded.length > 7500) {
+          throw new Error(`admin broadcast payload too large: ${encoded.length} bytes`);
+        }
+        await listenClient`SELECT pg_notify(${ADMIN_BROADCAST_CHANNEL}, ${encoded})`;
+      } catch {
+        // fire-and-forget — admin UI tolerates an occasional dropped frame
+      }
+    },
+
     async pushFrameToInbox(inboxId: string, frame: string): Promise<number> {
       const map = subscriptions.get(inboxId);
       if (!map) return 0;
@@ -219,6 +253,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
 
     onChatMessage(handler: ChatMessageChangeHandler) {
       chatMessageHandlers.push(handler);
+    },
+
+    onAdminBroadcast(handler: AdminBroadcastHandler) {
+      adminBroadcastHandlers.push(handler);
     },
 
     async start() {
@@ -289,6 +327,28 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
         }
       });
       unlistenChatMessageFn = chatMessageResult.unlisten;
+
+      const adminBroadcastResult = await listenClient.listen(ADMIN_BROADCAST_CHANNEL, (payload) => {
+        if (!payload) return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(payload);
+        } catch {
+          // Malformed payload — drop. A producer bug should never poison the
+          // LISTEN loop for other handlers.
+          return;
+        }
+        if (typeof parsed !== "object" || parsed === null) return;
+        const envelope = parsed as Record<string, unknown>;
+        for (const handler of adminBroadcastHandlers) {
+          try {
+            handler(envelope);
+          } catch {
+            // swallow — handler errors must not poison fan-out
+          }
+        }
+      });
+      unlistenAdminBroadcastFn = adminBroadcastResult.unlisten;
     },
 
     async stop() {
@@ -311,6 +371,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       if (unlistenChatMessageFn) {
         await unlistenChatMessageFn();
         unlistenChatMessageFn = null;
+      }
+      if (unlistenAdminBroadcastFn) {
+        await unlistenAdminBroadcastFn();
+        unlistenAdminBroadcastFn = null;
       }
     },
   };

--- a/packages/shared/src/schemas/notification.ts
+++ b/packages/shared/src/schemas/notification.ts
@@ -5,20 +5,16 @@ import { z } from "zod";
 export const NOTIFICATION_TYPES = {
   AGENT_ERROR: "agent_error",
   SESSION_ERROR: "session_error",
-  AGENT_NEEDS_DECISION: "agent_needs_decision",
   AGENT_BLOCKED: "agent_blocked",
   AGENT_STALE: "agent_stale",
-  AGENT_CONNECTED: "agent_connected",
   SESSION_COMPLETED: "session_completed",
 } as const;
 
 export const notificationTypeSchema = z.enum([
   "agent_error",
   "session_error",
-  "agent_needs_decision",
   "agent_blocked",
   "agent_stale",
-  "agent_connected",
   "session_completed",
 ]);
 export type NotificationType = z.infer<typeof notificationTypeSchema>;

--- a/packages/web/src/api/notifications.ts
+++ b/packages/web/src/api/notifications.ts
@@ -41,3 +41,7 @@ export function markNotificationRead(id: string): Promise<unknown> {
 export function markAllNotificationsRead(): Promise<unknown> {
   return api.post(withOrg("/notifications/read-all"));
 }
+
+export function getUnreadNotificationCount(): Promise<{ count: number }> {
+  return api.get<{ count: number }>(withOrg("/notifications/unread-count"));
+}

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,7 +1,6 @@
 import { Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
-import { useAdminWs } from "../hooks/use-admin-ws.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
@@ -22,13 +21,6 @@ export function Layout() {
 
   const location = useLocation();
   const isWorkspace = location.pathname === "/" || location.search.includes("a=");
-
-  // The topbar bell renders on every page that uses this layout, but the
-  // admin WS connection was previously only opened by the workspace page.
-  // Move it up here so the bell receives notification pushes everywhere it
-  // is visible — without this, the bell would silently stale once polling
-  // was removed.
-  useAdminWs();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
+import { useAdminWs } from "../hooks/use-admin-ws.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
@@ -21,6 +22,13 @@ export function Layout() {
 
   const location = useLocation();
   const isWorkspace = location.pathname === "/" || location.search.includes("a=");
+
+  // The topbar bell renders on every page that uses this layout, but the
+  // admin WS connection was previously only opened by the workspace page.
+  // Move it up here so the bell receives notification pushes everywhere it
+  // is visible — without this, the bell would silently stale once polling
+  // was removed.
+  useAdminWs();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/packages/web/src/components/notification-bell.tsx
+++ b/packages/web/src/components/notification-bell.tsx
@@ -22,12 +22,14 @@ export function NotificationBell() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  // Both queries refetch on demand only — the admin WS hook (wired into
-  // Layout) invalidates `["notifications", …]` on every inbound
-  // `notification` frame, which is what drives the bell to refresh. Polling
-  // was previously the safety net for an in-memory cross-instance fanout
-  // that could silently drop frames; with PG NOTIFY routing pushes across
-  // every server instance, polling adds nothing but network noise.
+  // Both queries refetch on demand only — the admin WS hook (mounted by
+  // `PulseProvider` at the auth-shell root) invalidates `["notifications",
+  // …]` on every inbound `notification` frame, which is what drives the
+  // bell to refresh. Polling was previously the safety net for an in-memory
+  // cross-instance fanout that could silently drop frames; with PG NOTIFY
+  // routing pushes across every server instance, polling adds nothing but
+  // network noise. Reconnect-time catch-up (sleep/wake, network partition)
+  // is handled by `use-admin-ws.ts` invalidating the same key on `onopen`.
   const { data } = useQuery({
     queryKey: ["notifications", "bell"],
     queryFn: () => listNotifications({ limit: 8 }),

--- a/packages/web/src/components/notification-bell.tsx
+++ b/packages/web/src/components/notification-bell.tsx
@@ -2,7 +2,12 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import { listNotifications, markAllNotificationsRead, markNotificationRead } from "../api/notifications.js";
+import {
+  getUnreadNotificationCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "../api/notifications.js";
 import { NotificationItem, type NotificationRow } from "./notification-item.js";
 
 /**
@@ -17,19 +22,23 @@ export function NotificationBell() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
+  // Both queries refetch on demand only — the admin WS hook (wired into
+  // Layout) invalidates `["notifications", …]` on every inbound
+  // `notification` frame, which is what drives the bell to refresh. Polling
+  // was previously the safety net for an in-memory cross-instance fanout
+  // that could silently drop frames; with PG NOTIFY routing pushes across
+  // every server instance, polling adds nothing but network noise.
   const { data } = useQuery({
     queryKey: ["notifications", "bell"],
     queryFn: () => listNotifications({ limit: 8 }),
-    refetchInterval: 10_000,
   });
 
   const { data: unreadData } = useQuery({
     queryKey: ["notifications", "unread-count"],
-    queryFn: () => listNotifications({ read: false, limit: 100 }),
-    refetchInterval: 10_000,
+    queryFn: () => getUnreadNotificationCount(),
   });
 
-  const unreadCount = unreadData?.items?.length ?? 0;
+  const unreadCount = unreadData?.count ?? 0;
   const hasUnread = unreadCount > 0;
 
   const handleClickNotification = useCallback(

--- a/packages/web/src/components/notification-item.tsx
+++ b/packages/web/src/components/notification-item.tsx
@@ -18,8 +18,6 @@ const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   session_error: "Error",
   agent_blocked: "Blocked",
   agent_stale: "Stale",
-  agent_connected: "Connected",
-  agent_needs_decision: "Decision",
   session_completed: "Completed",
 };
 

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -93,6 +93,18 @@ function connect() {
   socket.onopen = () => {
     if (socket !== ws) return;
     reconnectAttempt = 0;
+    // Catch up on every (re)open — including initial connect after a
+    // sleep / network partition. Without this, push-only consumers like
+    // the notification bell would miss any frame that fired while the WS
+    // was down: the next inbound push would invalidate, but until then the
+    // local cache is stale. Invalidating broadly keeps every push-driven
+    // query (notifications, sessions, chat list) in sync on reconnect.
+    if (latestQc) {
+      latestQc.invalidateQueries({ queryKey: ["notifications"] });
+      latestQc.invalidateQueries({ queryKey: ["activity"] });
+      latestQc.invalidateQueries({ queryKey: ["sessions"] });
+      latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
+    }
   };
   socket.onclose = (ev) => {
     // Only the current (latest) socket's close triggers reconnect.


### PR DESCRIPTION
## Summary

Refactors the hub-wide notification pipeline along the proposal lines from the prior PR review thread (#348). Five atomic commits, each independently reviewable; squash-merge picks whichever framing reads best in the log.

Five changes, in order of dependency:

1. **`refactor(server): delete dead notification types`** — `agent_connected` and `agent_needs_decision` had schema entries, message composers, and UI labels but zero producers anywhere in the tree. Removed end-to-end.

2. **`feat(server): cross-instance notification fanout via pg_notify`** — extends the existing `Notifier` with a generic `admin_broadcast_envelopes` channel. Producers call `broadcastAdminsCrossInstance(payload)`; every server instance LISTENs, JSON-parses the envelope, and feeds it into its local `broadcastToAdmins` fanout. Today's in-memory broadcaster delivered notifications only to admin sockets on the producing instance — admins connected elsewhere silently missed events during failover or rolling restart. Tests + per-instance subsystems (pulse aggregator) keep calling `broadcastToAdmins` directly because their fanout is intentionally process-local.

3. **`feat(server): DB-backed notification dedup via dedup_key partial unique index`** — replaces the in-memory `shouldNotify` Map with `(organization_id, dedup_key) WHERE read = false` uniqueness. Migration `0041` adds the column + index; `createNotification` uses `ON CONFLICT DO NOTHING`. `notifyAgentEvent` now defaults `dedup_key` to `chat:{chatId}:{type}` or `agent:{agentId}:{type}`, so per-event dedupe is opt-out rather than opt-in. All three `shouldNotify` call sites in `ws-client.ts` are dropped — one fewer place where a new event type forgets to dedup.

4. **`feat(server): unread-count endpoint + SQL-pushed visibility filter for list`** — `GET /orgs/:orgId/notifications/unread-count` returns a single `SELECT COUNT(*)`. The visibility filter (`agent_id IS NULL OR agent_id IN visible`) moves from in-Node post-filter to SQL predicate, so the old 4× overscan + 400-row ceiling that hid long-tail visible rows behind invisible-agent noise is gone. The fragment is centralised in `buildVisibilityCondition` so list / markAllRead / unreadCount can't drift apart on what 'visible' means.

5. **`refactor(web): notification bell drops 10s polling, runs push-only`** — wires `useAdminWs()` into Layout so the bell receives pushes on every page where it renders. Drops `refetchInterval: 10_000` from both bell queries. Switches the unread-count source from `listNotifications({ read: false, limit: 100 }).length` (capped at 100) to the new `/unread-count` endpoint (accurate past 100). Mark-all-read responds immediately now that there is no 10s ceiling.

## Migration

`packages/server/drizzle/0041_notifications_dedup_key.sql`

- `ALTER TABLE notifications ADD COLUMN dedup_key text;`
- `CREATE UNIQUE INDEX uq_notifications_org_dedup_unread ON notifications (organization_id, dedup_key) WHERE read = false AND dedup_key IS NOT NULL;`

Purely additive — `dedup_key` is nullable, no back-fill required, producers without a key keep their always-insert semantics.

Generated by hand because `drizzle-kit generate` is blocked by a pre-existing snapshot collision in `drizzle/meta/_journal.json` (0016/0018) unrelated to this change. Other recent migrations in the repo (0038–0040) are similarly hand-written with rationale comments, so this matches existing practice.

## Cross-package version impact

None — `command` / `client` source doesn't import any of the touched `shared` modules (`packages/shared/src/schemas/notification.ts` is server+web only). No version bump needed.

## Test plan

- [ ] Local: `pnpm typecheck` clean (verified)
- [ ] Local: `pnpm check` clean (verified)
- [ ] Local: server vitest (skipped — testcontainers needs Docker, not available in author env)
- [ ] `migrate up` on a fresh DB produces the new column + partial unique index
- [ ] Two-instance manual smoke: notification produced on instance A reaches an admin socket on instance B
- [ ] Floods of identical `agent_error` events for one agent collapse to a single unread row until acked
- [ ] Bell badge updates within one WS round-trip after mark-all-read (no 10s lag)
- [ ] Bell shows accurate unread count past 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)