### PR TITLE
feat(web): open all rendered links in a new tab

### DIFF
--- a/packages/web/src/components/chat/option-card.tsx
+++ b/packages/web/src/components/chat/option-card.tsx
@@ -4,12 +4,17 @@ import { useMemo } from "react";
 import { cn } from "../../lib/utils.js";
 import { Markdown } from "../ui/markdown.js";
 
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.tagName === "A") {
-    node.setAttribute("target", "_blank");
-    node.setAttribute("rel", "noopener noreferrer");
-  }
-});
+let openLinksInNewTabHookInstalled = false;
+function installOpenLinksInNewTabHook() {
+  if (openLinksInNewTabHookInstalled) return;
+  openLinksInNewTabHookInstalled = true;
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    if (node.tagName === "A") {
+      node.setAttribute("target", "_blank");
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+  });
+}
 
 /**
  * Single option inside a `<QuestionMessage />` — renders the SDK's
@@ -45,6 +50,7 @@ export function OptionCard({
 }) {
   const sanitisedHtml = useMemo(() => {
     if (!option.preview || previewFormat !== "html") return null;
+    installOpenLinksInNewTabHook();
     return DOMPurify.sanitize(option.preview, { USE_PROFILES: { html: true } });
   }, [option.preview, previewFormat]);
 

--- a/packages/web/src/components/chat/option-card.tsx
+++ b/packages/web/src/components/chat/option-card.tsx
@@ -4,6 +4,13 @@ import { useMemo } from "react";
 import { cn } from "../../lib/utils.js";
 import { Markdown } from "../ui/markdown.js";
 
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A") {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
 /**
  * Single option inside a `<QuestionMessage />` — renders the SDK's
  * `{ label, description, preview }` shape as a clickable card.

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -33,7 +33,14 @@ export function Markdown({ children, className }: MarkdownProps) {
         className,
       )}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        components={{
+          a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" />,
+        }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Markdown 渲染 (`Markdown` 组件) 通过 `react-markdown` 的 `components.a` 覆写，所有 markdown 链接（含 GFM autolink）默认 `target="_blank"` + `rel="noopener noreferrer"`。
- Option card 的 HTML 预览走 DOMPurify，注入 `afterSanitizeAttributes` hook 给 `<a>` 强制加同样的属性，覆盖另一条渲染路径。

## Why

Hub 内的 chat 消息、agent prompt、context 页等内容里点击外链会替换当前 SPA 页面，体验不好。统一让所有内容链接在新 tab 打开；站内导航 `<a>` (如 `/agents/...`、`/clients`) 不受影响。

## Test plan

- [ ] 在 chat 里发一条含链接的 markdown 消息，点击在新 tab 打开
- [ ] 在 chat 里发 GFM autolink (裸 URL)，点击在新 tab 打开
- [ ] 触发 `option-card` 的 HTML preview（带 `<a href>`），点击在新 tab 打开
- [ ] agent detail 页 prompt-section 里的 markdown 链接行为一致
- [ ] 站内导航链接 (`/agents/<id>`, `/clients`, footer 等) 行为符合各自原设置（已显式声明 `target="_blank"` 的保持，未声明的保持 SPA 内导航）

🤖 Generated with [Claude Code](https://claude.com/claude-code)