### PR TITLE
refactor(shared,server): drop "thread" from chat type enum

### DIFF
--- a/docs/chat-first-workspace-product-design.md
+++ b/docs/chat-first-workspace-product-design.md
@@ -535,7 +535,8 @@ Rules:
 - Returns rows where the current user's human agent has either a
   `chat_participants` row or a `chat_subscriptions` row for the chat.
 - `participant` → `canReply = true`. `watching` → `canReply = false`.
-- v1 filters threads out: `parent_chat_id IS NULL`.
+- Nested chats (rows with `parent_chat_id IS NOT NULL`) are filtered out;
+  the column is reserved for a future nested-chat model.
 - Sort: `(chats.last_message_at DESC NULLS LAST, chats.id DESC)`. Anchored
   on `idx_chats_org_last_message`.
 - Acceptance: p95 < 200ms at 1k chats.
@@ -731,7 +732,8 @@ To minimise regression risk in the message + inbox path:
 ### Resolved
 
 - Direct chats are NOT deduped; same for group exact-set.
-- Threads (`parent_chat_id IS NOT NULL`) do NOT appear in v1 list.
+- Nested chats (`parent_chat_id IS NOT NULL`) do NOT appear in the list;
+  `parent_chat_id` is reserved for a future nested-chat model.
 - SDK helpers move to a separate PR (out of scope here).
 - Watcher state lives in `chat_subscriptions`, not `chat_participants`.
 - `chat.type` upgrades direct → group; never downgrades.

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -516,22 +516,24 @@ describe("chat-first workspace service layer", () => {
     expect(seen.size).toBe(3);
   });
 
-  it("listMeChats threads filter: parent_chat_id IS NOT NULL is excluded in v1", async () => {
+  it("listMeChats nested-chat filter: parent_chat_id IS NOT NULL is excluded", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const peer = await createTestAgent(app, { name: "peer-th" });
+    const peer = await createTestAgent(app, { name: "peer-nested" });
 
     const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [peer.agent.uuid],
     });
-    // forge a thread row anchored to the parent chat
+    // Forge a nested chat row anchored to the parent. `parent_chat_id` is
+    // currently unused at the product level but the listMeChats filter
+    // keeps nested rows out of the conversation list.
     await app.db.execute(sql`
       INSERT INTO chats (id, organization_id, type, parent_chat_id)
-      VALUES ('thread-x', ${admin.organizationId}, 'thread', ${chatId})
+      VALUES ('nested-x', ${admin.organizationId}, 'group', ${chatId})
     `);
     await app.db.execute(sql`
       INSERT INTO chat_membership (chat_id, agent_id, role, access_mode)
-      VALUES ('thread-x', ${admin.humanAgentUuid}, 'member', 'speaker')
+      VALUES ('nested-x', ${admin.humanAgentUuid}, 'member', 'speaker')
     `);
 
     const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
@@ -541,7 +543,7 @@ describe("chat-first workspace service layer", () => {
     });
     const ids = list.rows.map((r) => r.chatId);
     expect(ids).toContain(chatId);
-    expect(ids).not.toContain("thread-x");
+    expect(ids).not.toContain("nested-x");
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/db/schema/chats.ts
+++ b/packages/server/src/db/schema/chats.ts
@@ -10,11 +10,15 @@ export const chats = pgTable(
     organizationId: text("organization_id")
       .notNull()
       .references(() => organizations.id),
-    /** "direct" | "group" | "thread" */
+    /** "direct" | "group" */
     type: text("type").notNull().default("direct"),
     topic: text("topic"),
     lifecyclePolicy: text("lifecycle_policy").default("persistent"),
-    /** Parent chat ID for thread (sub-discussion) scenarios */
+    /**
+     * Anchor for nested chats. Currently unused at the product level — listMeChats
+     * filters `parent_chat_id IS NULL`, so any non-null row is hidden from the
+     * conversation list. Reserved as scaffolding for a future nested-chat model.
+     */
     parentChatId: text("parent_chat_id"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
     /**

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -160,7 +160,7 @@ export async function getCallerEngagement(
  *     (speaker → "participant" / watcher → "watching"); the user
  *     state row supplies the unread counter (COALESCE → 0 when
  *     row is missing).
- *   - Filter `parent_chat_id IS NULL` (threads excluded in v1).
+ *   - Filter `parent_chat_id IS NULL` (nested chats not surfaced in v1).
  *   - Filter `c.organization_id = ?` to defend against historical
  *     cross-org pollution rows that may still reference the caller
  *     (see fix/cross-org-direct-chat-pollution).
@@ -581,7 +581,7 @@ export async function leaveMeChat(db: Database, chatId: string, humanAgentId: st
  * contributing to the badge even though the chat no longer appears in
  * the list. The `chats` join applies the same org-scoping +
  * `parent_chat_id IS NULL` filter as `listMeChats` so the two counts
- * cannot drift in the cross-org pollution or thread-chat cases either.
+ * cannot drift in the cross-org pollution or nested-chat cases either.
  *
  * Engagement parity: deleted chats are excluded from `listMeChats`
  * (any `engagement` view), so the badge must exclude them too — otherwise

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -100,7 +100,7 @@ export type AddChatParticipantsOptions = {
  *   - for each row, `peerAgentTypes` is the type of every OTHER participant
  *     being inserted in the same call PLUS every EXISTING speaker of
  *     the chat. This matters only for `direct` chats; the helper ignores
- *     it for `group` / `thread`.
+ *     it for `group`.
  *
  * Writes one INSERT (multi-row) per call.
  *
@@ -123,7 +123,7 @@ export async function addChatParticipants(
   }
   // `chats.type` is `text` in the DB; narrow it to the discriminated
   // `ChatType` we accept. Any unknown value is a programming error.
-  if (chat.type !== "direct" && chat.type !== "group" && chat.type !== "thread") {
+  if (chat.type !== "direct" && chat.type !== "group") {
     throw new Error(`Unexpected chat type "${chat.type}" for chat "${chatId}"`);
   }
   const chatType = chat.type;
@@ -152,8 +152,8 @@ export async function addChatParticipants(
   }
 
   // For the `direct`-chat branch of `defaultParticipantMode`, peerAgentTypes
-  // is the set of EVERY OTHER active speaker on this chat. For `group`/
-  // `thread` it's ignored, so skip the lookup when we can.
+  // is the set of EVERY OTHER active speaker on this chat. For `group`
+  // it's ignored, so skip the lookup when we can.
   let existingAgentTypes: string[] = [];
   if (chatType === "direct") {
     existingAgentTypes = await loadExistingAgentTypes(tx, chatId, new Set(agentIds));
@@ -256,7 +256,7 @@ export async function changeChatType(tx: DbLike, chatId: string, newType: "group
   if (chat.type === newType) return;
   if (newType === "group" && chat.type !== "direct") {
     // Only `direct → group` is allowed in Phase 1. `group → direct` is
-    // ill-defined; `thread`-as-target isn't on the spec.
+    // ill-defined.
     throw new BadRequestError(`Cannot change chat type from "${chat.type}" to "${newType}"`);
   }
 

--- a/packages/shared/src/__tests__/participant-mode.test.ts
+++ b/packages/shared/src/__tests__/participant-mode.test.ts
@@ -12,7 +12,7 @@ import { defaultParticipantMode } from "../participant-mode.js";
  * `peerAgentTypes` dimension on the `direct` branch only.
  */
 
-describe("defaultParticipantMode — group / thread chats", () => {
+describe("defaultParticipantMode — group chats", () => {
   it("humans in a group are always 'full'", () => {
     expect(defaultParticipantMode("group", "human")).toBe("full");
     // `peerAgentTypes` is ignored for groups; pass a few to prove it.
@@ -22,11 +22,6 @@ describe("defaultParticipantMode — group / thread chats", () => {
   it("non-human agents in a group are always 'mention_only'", () => {
     expect(defaultParticipantMode("group", "autonomous_agent")).toBe("mention_only");
     expect(defaultParticipantMode("group", "personal_assistant")).toBe("mention_only");
-  });
-
-  it("threads inherit the group rule", () => {
-    expect(defaultParticipantMode("thread", "autonomous_agent")).toBe("mention_only");
-    expect(defaultParticipantMode("thread", "human")).toBe("full");
   });
 });
 

--- a/packages/shared/src/participant-mode.ts
+++ b/packages/shared/src/participant-mode.ts
@@ -36,9 +36,7 @@ export function defaultParticipantMode(
   peerAgentTypes: ReadonlyArray<AgentType> = [],
 ): ParticipantMode {
   if (agentType === "human") return "full";
-  // Threads are nested under a parent chat and behave like group chats for
-  // fan-out purposes — treat them the same.
-  if (chatType === "group" || chatType === "thread") return "mention_only";
+  if (chatType === "group") return "mention_only";
   // chatType === 'direct' + agent non-human:
   const allAgent = peerAgentTypes.every((t) => t !== "human");
   return allAgent ? "mention_only" : "full";

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -4,10 +4,9 @@ import { optionalChatMetadataSchema } from "./chat-metadata.js";
 export const CHAT_TYPES = {
   DIRECT: "direct",
   GROUP: "group",
-  THREAD: "thread",
 } as const;
 
-export const chatTypeSchema = z.enum(["direct", "group", "thread"]);
+export const chatTypeSchema = z.enum(["direct", "group"]);
 export type ChatType = z.infer<typeof chatTypeSchema>;
 
 /**


### PR DESCRIPTION
## Summary

- Removes the unused \`"thread"\` value from \`chatTypeSchema\` and associated business-logic branches.
- Pure dead-code cleanup: no DB migration, no API contract change, no behavior change for any path that actually ships.
- Tree-side companion PR: agent-team-foundation/first-tree-context#262

## Why

The \`thread\` chat type had **no product surface**:

- No UI creates or renders thread chats (\`web\` has zero \`type === "thread"\` checks).
- No HTTP endpoint accepts \`type: "thread"\` — \`createChatSchema\` doesn't expose \`type\` to callers, and the server derives it from participant count.
- No fan-out logic distinct from \`group\` — \`defaultParticipantMode\` treated thread identically to group.
- The conversation list **actively hides** thread rows via \`WHERE parent_chat_id IS NULL\` in \`listMeChats\`.

Keeping a third enum value with zero ship paths was misleading documentation.

## Changes

| File | Change |
|---|---|
| \`packages/shared/src/schemas/chat.ts\` | \`chatTypeSchema\` → \`z.enum(["direct", "group"])\`; drop \`CHAT_TYPES.THREAD\` |
| \`packages/shared/src/participant-mode.ts\` | Drop \`\|\| chatType === "thread"\` branch + comment |
| \`packages/server/src/services/participant-mode.ts\` | Validation 3-way → 2-way; remove \`thread\`-spec comment |
| \`packages/server/src/db/schema/chats.ts\` | Docstring updates; expand \`parent_chat_id\` docstring to record it as reserved scaffolding |
| \`packages/server/src/services/me-chat.ts\` | Reword filter comments (filter itself unchanged) |
| \`packages/shared/src/__tests__/participant-mode.test.ts\` | Drop "threads inherit the group rule" case |
| \`packages/server/src/__tests__/me-chat-service.test.ts\` | Rewrite the threads-filter test to assert \`parent_chat_id IS NULL\` filtering via \`type='group'\` — preserves the structural coverage without invoking the removed type |
| \`docs/chat-first-workspace-product-design.md\` | Rewords the two thread mentions to describe nested-chat filtering |

## What is **not** changed (deliberate)

- **\`parent_chat_id\` column stays**, with the same \`IS NULL\` filter in \`listMeChats\`. Reserved scaffolding for a future nested-chat model — no value in dropping it as part of this cleanup.
- **No DB migration.** \`chats.type\` is a \`text\` column, not a Postgres enum; production has no factory that writes \`type='thread'\`, so there's nothing to backfill.
- **\`inReplyTo\` and reply chains** — already chat-type agnostic; unaffected.
- **\`adapter_chat_mappings.thread_id\` / Feishu \`threadId\`** — external IM thread identifiers, orthogonal to \`chat.type\`; unaffected.

## Test plan

- [x] \`pnpm check\` — clean
- [x] \`pnpm typecheck\` — all 9 tasks green
- [x] \`pnpm --filter @first-tree-hub/server test\` — 114 files / 900 tests pass
- [x] \`pnpm --filter @agent-team-foundation/first-tree-hub-shared test\` — 17 files / 217 tests pass

## Versioning

No version bump: changes are confined to \`shared\` modules consumed by \`server\` / \`web\` only (no \`command\`/\`client\` import path touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)