### PR TITLE
feat(server): auto-mention DM peers for chat-list unread counter

### DIFF
--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -145,6 +145,28 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
     expect(await loadMessageContent(chatId)).toBe("plain hi");
   });
 
+  it("silent-send DM (text = '@peer' only) does NOT bump the peer's counter", async () => {
+    // Silent-send invariant (services/message.ts step 2e): a message whose
+    // text is purely `@<name>` tokens with no body is recorded for history
+    // but every fan-out row gets `notify=false`. The badge must respect
+    // the same intent — bumping `unread_mention_count` would contradict
+    // the "no user-visible signal" guarantee that callers (agent runtime
+    // `result-sink`, AskUserQuestion, etc.) rely on for silent turns.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `dmslnt-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, admin.humanAgentUuid, {
+      format: "text",
+      content: `@${peer.agent.name}`,
+    });
+
+    expect(await loadUnread(chatId, peer.agent.uuid, peer.organizationId)).toBe(0);
+  });
+
   it("group chat: plain text still produces zero counter bumps (no auto-mention)", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);

--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -1,0 +1,167 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { messages } from "../db/schema/messages.js";
+import { createChat, findOrCreateDirectChat } from "../services/chat.js";
+import { createMeChat, listMeChats } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Direct-chat auto-mention for the chat-first workspace.
+ *
+ * Background: `applyAfterFanOut` increments `chat_user_state.unread_mention_count`
+ * only when the message names someone via `@<token>` or `metadata.mentions`. In
+ * a 1-on-1 the recipient is implicit by chat structure, so `extractMentions`
+ * returns [] and the conversation-list badge never rises — DMs would always
+ * show zero unread.
+ *
+ * Fix: when `chat.type === "direct"`, `services/message.ts` builds a
+ * `projectionMentions` list that includes every non-sender speaker and passes
+ * it to `applyAfterFanOut` for the counter bump. The original `mergedMentions`
+ * is untouched so fan-out, `metadata.mentions`, and the `mention_only` anti-
+ * loop rule from migration 0029 all behave exactly as before.
+ *
+ * Invariants this file pins:
+ *   1. Human → agent DM bumps the agent's unread counter on plain text.
+ *   2. Agent → human DM bumps the human's unread counter on plain text.
+ *   3. Agent ↔ agent DM (`mention_only`) bumps the peer's counter BUT
+ *      still produces a silent inbox row (no `notify = true` wake) — the
+ *      counter is for the UI, the fan-out mute is for the loop-free runtime.
+ *   4. Plain-text DMs are NOT rewritten — content stays exactly as sent
+ *      (no `@<peer-name>` prepend by `normalizeMentionsInContent`).
+ *   5. Group chats keep the explicit-`@` discipline — a plain-text group
+ *      message still produces zero counter bumps.
+ */
+describe("direct-chat auto-mention for chat-list unread counter", () => {
+  const getApp = useTestApp();
+
+  async function loadUnread(chatId: string, agentUuid: string, organizationId: string): Promise<number> {
+    const app = getApp();
+    const { rows } = await listMeChats(app.db, agentUuid, organizationId, {
+      limit: 10,
+      filter: "all",
+      engagement: "all",
+    });
+    return rows.find((r) => r.chatId === chatId)?.unreadMentionCount ?? 0;
+  }
+
+  async function notifyInboxRows(chatId: string, agentUuid: string) {
+    const app = getApp();
+    const [row] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, agentUuid))
+      .limit(1);
+    if (!row) return [];
+    return app.db
+      .select({ messageId: inboxEntries.messageId })
+      .from(inboxEntries)
+      .where(
+        and(eq(inboxEntries.inboxId, row.inboxId), eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)),
+      );
+  }
+
+  async function loadMessageContent(chatId: string): Promise<string> {
+    const app = getApp();
+    const [row] = await app.db
+      .select({ content: messages.content })
+      .from(messages)
+      .where(eq(messages.chatId, chatId))
+      .limit(1);
+    return typeof row?.content === "string" ? row.content : "";
+  }
+
+  it("human → agent DM: agent's unread counter bumps on plain text", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `dmh2a-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, admin.humanAgentUuid, {
+      format: "text",
+      content: "hi, no explicit @ here",
+    });
+
+    expect(await loadUnread(chatId, peer.agent.uuid, peer.organizationId)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("agent → human DM: human's unread counter bumps on plain text", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `dma2h-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      format: "text",
+      content: "ack",
+    });
+
+    expect(await loadUnread(chatId, admin.humanAgentUuid, admin.organizationId)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("agent ↔ agent DM: counter bumps but inbox stays silent (migration 0029 preserved)", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `aa1-${uid}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `aa2-${uid}` });
+
+    const chat = await findOrCreateDirectChat(app.db, a1.agent.uuid, a2.uuid);
+    await sendMessage(app.db, chat.id, a1.agent.uuid, {
+      format: "text",
+      content: "ok thanks",
+    });
+
+    // Counter side: a2's unread for this chat bumps to 1 (the chat-list signal).
+    expect(await loadUnread(chat.id, a2.uuid, a1.organizationId)).toBeGreaterThanOrEqual(1);
+
+    // Inbox side: no notify=true row — a2's runtime should NOT wake on a
+    // plain-text courtesy reply, matching migration 0029's anti-loop intent.
+    expect(await notifyInboxRows(chat.id, a2.uuid)).toHaveLength(0);
+  });
+
+  it("DM content is never rewritten with `@<peer-name>` prefix", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `dmnorw-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { format: "text", content: "plain hi" },
+      // Match the production agent send path which sets this flag.
+      { normalizeMentionsInContent: true },
+    );
+
+    expect(await loadMessageContent(chatId)).toBe("plain hi");
+  });
+
+  it("group chat: plain text still produces zero counter bumps (no auto-mention)", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `g1-${uid}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `g2-${uid}` });
+    const { agent: a3 } = await createTestAgent(app, { name: `g3-${uid}` });
+
+    const chat = await createChat(app.db, a1.agent.uuid, {
+      type: "group",
+      participantIds: [a2.uuid, a3.uuid],
+    });
+    await sendMessage(app.db, chat.id, a1.agent.uuid, {
+      format: "text",
+      content: "anyone around",
+    });
+
+    expect(await loadUnread(chat.id, a2.uuid, a1.organizationId)).toBe(0);
+    expect(await loadUnread(chat.id, a3.uuid, a1.organizationId)).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -435,27 +435,35 @@ describe("chat-first workspace service layer", () => {
   });
 
   it("watcher cannot be a mention recipient (mention-candidate invariant)", async () => {
+    // The invariant under test: an `@<watcher-name>` token must not bump
+    // the watcher's `unread_mention_count` — mention extraction reads only
+    // chat_membership.access_mode = 'speaker', so a watcher's name resolves
+    // to nothing even when typed verbatim. We pin this in a group chat
+    // (≥3 speakers) so the direct-chat auto-mention path is not exercised
+    // here; admin watches no one in this chat, so the manager-of-mentioned
+    // branch can't fire either, isolating the name-resolution invariant.
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const { createAgent } = await import("../services/agent.js");
-    const managed = await createAgent(app.db, {
-      name: `mng-mc-${crypto.randomUUID().slice(0, 6)}`,
-      type: "autonomous_agent",
-      displayName: "Mng-MC",
-      managerId: admin.memberId,
-      organizationId: admin.organizationId,
-      clientId: undefined,
-    });
-    const peer = await createTestAgent(app, { name: "peer-mc" });
+    const peer = await createTestAgent(app, { name: `peer-mc-${crypto.randomUUID().slice(0, 6)}` });
+    const peer2 = await createTestAgent(app, { name: `peer2-mc-${crypto.randomUUID().slice(0, 6)}` });
+    const peer3 = await createTestAgent(app, { name: `peer3-mc-${crypto.randomUUID().slice(0, 6)}` });
 
+    // Add a watcher row for admin against this chat via raw INSERT — admin
+    // doesn't manage any participant, so the standard auto-watcher path
+    // doesn't apply, but the invariant we're pinning is about name
+    // resolution, not how the watcher row got there.
     const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
-      participantIds: [managed.uuid],
+      participantIds: [peer2.agent.uuid, peer3.agent.uuid],
     });
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source)
+      VALUES (${chatId}, ${admin.humanAgentUuid}, 'member', 'watcher', 'full', 'manual')
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
 
     // peer @-mentions admin (the watcher) by name. Mention extraction reads
-    // speakers only (chat_membership where access_mode = 'speaker'), so
-    // admin is NOT in the candidate set — the resulting message must NOT
-    // bump admin's `unread_mention_count` in chat_user_state.
+    // speakers only, so admin is NOT in the candidate set — the resulting
+    // message must NOT bump admin's `unread_mention_count`.
     await sendMessage(app.db, chatId, peer.agent.uuid, {
       format: "text",
       content: `Hi @${admin.username}, please look`,
@@ -466,10 +474,8 @@ describe("chat-first workspace service layer", () => {
        WHERE chat_id = ${chatId} AND agent_id = ${admin.humanAgentUuid}
     `);
     // Either the row was never created (lazy materialisation, no event
-    // touched it) or the count was bumped via the watcher-manager path
-    // (which IS the legitimate channel for a manager-of-mentioned-non-human).
-    // In this test the mention target is admin themselves, not the managed
-    // agent — so neither the speaker nor the watcher branch should fire.
+    // touched it) or its count stayed at zero — the @-name path cannot
+    // reach a watcher, by design.
     expect(adminStateRow?.unread_mention_count ?? 0).toBe(0);
   });
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -134,6 +134,23 @@ async function sendMessageInner(
     const mergedMentions = [...new Set([...explicitMentions, ...resolved])];
     const metadataToStore = mergedMentions.length > 0 ? { ...incomingMeta, mentions: mergedMentions } : incomingMeta;
 
+    // Direct-chat auto-mention for the unread-counter projection (chat-first
+    // workspace). In a 1-on-1 the recipient is implicit, so the conversation
+    // list should red-dot every DM message — without this, `extractMentions`
+    // returns [] on plain text and `applyAfterFanOut` short-circuits the
+    // counter bump, leaving DM rows at zero unread.
+    //
+    // This list is **projection-only** — it deliberately does NOT join
+    // `mergedMentions`. Folding it in would make the auto-mention also
+    // drive fan-out (`notify=true` inbox), which would reintroduce the
+    // agent↔agent courtesy loop migration 0029 fixed: A's "ok thanks"
+    // would wake B in `mention_only` mode again. Keep the two lists
+    // separate so unread badges are correct without unmuting agent wakes.
+    const projectionMentions =
+      chatType === "direct"
+        ? [...new Set([...mergedMentions, ...participants.filter((p) => p.agentId !== senderId).map((p) => p.agentId)])]
+        : mergedMentions;
+
     // 2b. Group-chat receiver enforcement (agent-only). Stop a misuse where an
     //     agent calls `send --chat <id>` against a group without naming who
     //     should pick it up — every mention_only participant would silently
@@ -158,6 +175,7 @@ async function sendMessageInner(
     //
     //     Driven by its own opt-in flag (separate from enforceGroupMention) so
     //     admin/web and adapter paths can validate without mutating content.
+    //
     let outboundContent = data.content;
     if (options.normalizeMentionsInContent && typeof outboundContent === "string") {
       const present = new Set(scanMentionTokens(outboundContent));
@@ -337,7 +355,7 @@ async function sendMessageInner(
       chatId,
       messageId: msg.id,
       senderId,
-      mentionedAgentIds: mergedMentions,
+      mentionedAgentIds: projectionMentions,
       contentPreview: previewText,
       messageCreatedAt: msg.createdAt,
     });

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -146,7 +146,12 @@ async function sendMessageInner(
     // agent↔agent courtesy loop migration 0029 fixed: A's "ok thanks"
     // would wake B in `mention_only` mode again. Keep the two lists
     // separate so unread badges are correct without unmuting agent wakes.
-    const projectionMentions =
+    //
+    // Silent-send (step 2e) overrides this back to [] so the badge stays
+    // off — a silent turn whose entire text is `@<name>` tokens is meant
+    // to land in history without bothering anyone; bumping unread
+    // contradicts that intent.
+    const dmAutoProjection: string[] =
       chatType === "direct"
         ? [...new Set([...mergedMentions, ...participants.filter((p) => p.agentId !== senderId).map((p) => p.agentId)])]
         : mergedMentions;
@@ -175,7 +180,6 @@ async function sendMessageInner(
     //
     //     Driven by its own opt-in flag (separate from enforceGroupMention) so
     //     admin/web and adapter paths can validate without mutating content.
-    //
     let outboundContent = data.content;
     if (options.normalizeMentionsInContent && typeof outboundContent === "string") {
       const present = new Set(scanMentionTokens(outboundContent));
@@ -225,6 +229,12 @@ async function sendMessageInner(
         "silent send: empty content after mention strip — no fan-out wake-up",
       );
     }
+
+    // Silent-send overrides the direct-chat auto-mention projection: a
+    // silent turn is "this exists in history but nobody needs to know",
+    // so the recipient's red-dot badge stays off too. Mirrors the
+    // fan-out `notify=false` guarantee at step 4 below.
+    const projectionMentions: string[] = isSilentSend ? [] : dmAutoProjection;
 
     // 3. Store the message (with merged metadata + normalised content).
     const messageId = randomUUID();


### PR DESCRIPTION
## Summary

In a 1-on-1 chat the recipient is implicit by structure, but the unread-counter projection only fires when the message explicitly names someone via \`@<token>\` or \`metadata.mentions\`. Plain DMs therefore left \`chat_user_state.unread_mention_count = 0\`, so the chat-first conversation list could never show a red badge on a DM.

## Approach

When \`chat.type === \"direct\"\`, build a separate \`projectionMentions\` list that adds every non-sender speaker on top of \`mergedMentions\` and pass **that** to \`applyAfterFanOut\`. The original \`mergedMentions\` is untouched.

**Why two lists** — folding the DM peer into \`mergedMentions\` would make the auto-mention also drive fan-out (\`notify=true\` inbox row), which reintroduces the agent↔agent courtesy loop migration 0029 fixed. Splitting the concerns:

| List | Drives | DM behaviour |
|---|---|---|
| \`mergedMentions\` | metadata.mentions storage, group-mention enforcement, content normalization, fan-out wake selection | Unchanged |
| \`projectionMentions\` | \`unread_mention_count\` bump only | DM peers added |

## Tests

New \`direct-chat-auto-mention.test.ts\` pins five invariants:

1. Human → agent DM: agent's unread counter bumps on plain text.
2. Agent → human DM: human's unread counter bumps on plain text.
3. Agent ↔ agent DM (\`mention_only\`): counter bumps **but** inbox stays silent — migration 0029's anti-loop intent preserved.
4. Plain-text DMs are never rewritten with \`@<peer-name>\` prefix (\`normalizeMentionsInContent\` doesn't fire on the auto-mention).
5. Group chats keep the explicit-\`@\` discipline (regression guard — plain group message → zero counter bumps).

Existing \`me-chat-service.test.ts > watcher cannot be a mention recipient\` moves to a group-chat fixture so the invariant under test (\`@<watcher-name>\` token cannot resolve to a watcher) is isolated from the new direct-chat auto-mention path. In the previous DM setup admin's counter now **legitimately** bumps via the manager-of-mentioned-non-human watcher branch — which is the intended chat-list behaviour for managers of agents that just got DM'd.

## Test plan

- [x] \`pnpm check\` — clean
- [x] \`pnpm typecheck\` — all 9 tasks green
- [x] \`pnpm --filter @first-tree-hub/server test\` — 115 files / 905 tests pass
- [x] New tests confirm the invariants in both directions

## Out of scope

- \`workingAgentIds\` server field + LATERAL join (next PR — depends on this one for DM unread to be visible)
- Frontend refactor (PR after)
- Light theme toggle (independent PR)