### PR TITLE
refactor(web): drop in-product command shortcuts; widen Jump to… button

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
@@ -10,10 +10,10 @@ import { ThemeToggle } from "./ui/theme-toggle.js";
 import { UserMenu } from "./user-menu.js";
 
 const navTabs = [
-  { to: "/", label: "Workspace", end: true, kbd: "⌘1" },
-  { to: "/context", label: "Context", end: false, kbd: "⌘2" },
-  { to: "/team", label: "Team", end: false, kbd: "⌘3" },
-  { to: "/settings", label: "Settings", end: false, kbd: "⌘4" },
+  { to: "/", label: "Workspace", end: true },
+  { to: "/context", label: "Context", end: false },
+  { to: "/team", label: "Team", end: false },
+  { to: "/settings", label: "Settings", end: false },
 ];
 
 export function Layout() {
@@ -21,17 +21,6 @@ export function Layout() {
 
   const location = useLocation();
   const isWorkspace = location.pathname === "/" || location.search.includes("a=");
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        setPaletteOpen((o) => !o);
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
 
   return (
     <div className="flex flex-col overflow-hidden" style={{ height: "100vh", background: "var(--bg)" }}>
@@ -86,7 +75,6 @@ export function Layout() {
                   }}
                 >
                   {tab.label}
-                  {isActive && <span className="kbd">{tab.kbd}</span>}
                 </span>
               )}
             </NavLink>
@@ -102,7 +90,8 @@ export function Layout() {
             className="inline-flex items-center transition-colors text-body"
             style={{
               gap: 8,
-              padding: "var(--sp-1) var(--sp-2)",
+              padding: "var(--sp-1) var(--sp-3)",
+              minWidth: 200,
               color: "var(--fg-3)",
               border: "var(--hairline) solid var(--border)",
               borderRadius: "var(--radius-input)",
@@ -117,7 +106,6 @@ export function Layout() {
           >
             <Search className="h-4 w-4" />
             <span>Jump to…</span>
-            <span className="kbd">⌘K</span>
           </button>
           <span
             style={{

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -456,18 +456,6 @@
   .tnum {
     font-variant-numeric: tabular-nums;
   }
-  .kbd {
-    font-family: var(--font-mono-stack);
-    font-size: var(--text-eyebrow);
-    padding: 1px 5px;
-    border: 1px solid var(--border);
-    border-bottom-width: 2px;
-    border-radius: var(--radius-chip);
-    background: var(--bg-sunken);
-    color: var(--fg-2);
-    line-height: 1;
-    display: inline-block;
-  }
 
   /* Surface utilities — consolidate Panel / PageHeader / Tab containers.
      Prefer these over hand-rolled background/border/radius combinations. */


### PR DESCRIPTION
## Summary

- 移除产品内所有 command 快捷键：顶栏 tab 激活时显示的 ⌘1-⌘4 提示，以及 ⌘K 打开 command palette 的 keydown 监听 + 视觉提示
- 加宽顶栏 "Jump to…" 按钮（`minWidth: 200`，横向 padding 从 `var(--sp-2)` 升到 `var(--sp-3)`），让它读起来像一个真正的搜索入口
- 顺手删除已无引用的 `.kbd` CSS 工具类

Command palette 仍然可用 —— 通过点击 "Jump to…" 按钮打开。

## Why

仅看 tab 切换的 ⌘1-⌘4 提示不解释，且实际并没有对应的键盘处理器（只是视觉标签）。同时 ⌘K 在我们的产品中并没有形成肌肉记忆，去掉视觉与监听把心智成本降到 0。

## Test plan

- [ ] `pnpm check && pnpm --filter @first-tree-hub/web typecheck` 通过（已本地跑过）
- [ ] 顶栏 4 个 tab 激活态右侧不再显示 ⌘1-⌘4
- [ ] 按 ⌘K / Ctrl+K 不会再触发 command palette
- [ ] 点击 "Jump to…" 按钮仍能正常打开 palette
- [ ] "Jump to…" 按钮明显比之前更宽，视觉上更接近搜索框

🤖 Generated with [Claude Code](https://claude.com/claude-code)