### PR TITLE
Tighten agent config action states

### DIFF
--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -33,6 +33,7 @@ import { StateChip } from "./../components/ui/state-chip.js";
 import { Tile } from "./../components/ui/tile.js";
 import { cn, formatDate } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
+import { getAgentTestActionState, isBindableClient } from "./agent-detail/action-state.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import { DangerZone } from "./agent-detail/danger-zone.js";
 import { EnvSection } from "./agent-detail/env-section.js";
@@ -146,6 +147,7 @@ export function AgentDetailPage() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [conflictMsg, setConflictMsg] = useState<string | null>(null);
   const [dangerError, setDangerError] = useState<string | null>(null);
+  const [remoteReloading, setRemoteReloading] = useState(false);
   // Flash an inline "Saved" check in the SaveBar for a short window after a
   // successful save. Cleared by any subsequent edit, error, or timer.
   const [justSaved, setJustSaved] = useState(false);
@@ -187,8 +189,8 @@ export function AgentDetailPage() {
 
   const resetDraftToConfig = draft.resetToConfig;
   const reloadRemote = useCallback(async () => {
-    setConflictMsg(null);
     setSaveError(null);
+    setRemoteReloading(true);
     try {
       const latest = await queryClient.fetchQuery({
         queryKey: ["agent-config", uuid],
@@ -198,6 +200,9 @@ export function AgentDetailPage() {
       resetDraftToConfig(latest);
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRemoteReloading(false);
+      setConflictMsg(null);
     }
   }, [queryClient, uuid, resetDraftToConfig]);
 
@@ -387,8 +392,21 @@ export function AgentDetailPage() {
 
   const clientStatus: ClientStatusInfo | undefined = clientStatusQuery.data;
   const activeSessions = sessionsQuery.data?.length ?? 0;
-  const isUnclaimed = !isHuman && !clientStatus?.clientId;
+  const clientStatusInitialLoading = !isHuman && !clientStatus && clientStatusQuery.isLoading;
+  const clientStatusError =
+    clientStatusQuery.error instanceof Error
+      ? clientStatusQuery.error.message
+      : clientStatusQuery.error
+        ? "Unknown"
+        : null;
+  const isUnclaimed = !isHuman && clientStatusQuery.isSuccess && !clientStatus?.clientId;
   const isOffline = !isHuman && clientStatus ? !clientStatus.online && !!clientStatus.clientId : false;
+  const testAction = getAgentTestActionState({
+    agentStatus: agent.status,
+    clientStatus,
+    clientStatusLoading: clientStatusInitialLoading,
+    testPending: testMutation.isPending,
+  });
 
   const runtimeExt = agent as Record<string, unknown>;
   const runtimeState = (runtimeExt.runtimeState as string | null) ?? null;
@@ -546,7 +564,8 @@ export function AgentDetailPage() {
                     testMutation.reset();
                     testMutation.mutate();
                   }}
-                  disabled={testMutation.isPending}
+                  disabled={testAction.disabled}
+                  title={testAction.title}
                 >
                   <Play className="h-3 w-3" />
                   {testMutation.isPending ? "Testing…" : "Test"}
@@ -650,6 +669,8 @@ export function AgentDetailPage() {
                   <SetupSection
                     runtimeProvider={setupRuntimeProvider}
                     computerLabel={boundClientLabel}
+                    computerStatusLoading={clientStatusInitialLoading}
+                    computerStatusError={clientStatusError}
                     canBindComputer={isUnclaimed && agent.status === "active"}
                     bindComputerPending={bindClientMutation.isPending}
                     onBindComputer={() => setBindClientOpen(true)}
@@ -785,6 +806,7 @@ export function AgentDetailPage() {
             conflictMessage={conflictMsg}
             errorMessage={saveError}
             saving={saveMutation.isPending}
+            reloadingRemote={remoteReloading}
             justSaved={justSaved}
             onSave={() => saveMutation.mutate()}
             onDiscard={() => {
@@ -1018,7 +1040,7 @@ function BindClientList({
   selected: string;
   onSelect: (id: string) => void;
 }) {
-  const bindable = clients.filter((c) => c.status === "connected");
+  const bindable = clients.filter(isBindableClient);
   if (bindable.length === 0) {
     return (
       <div
@@ -1050,7 +1072,6 @@ function BindClientList({
     >
       {bindable.map((c) => {
         const picked = c.id === selected;
-        const online = c.status === "online" || c.status === "active";
         return (
           <li key={c.id} style={{ borderTop: "var(--hairline) solid var(--border-faint)" }}>
             <button
@@ -1066,7 +1087,7 @@ function BindClientList({
             >
               <span
                 className={cn("inline-block h-2 w-2 rounded-full shrink-0")}
-                style={{ background: online ? "var(--state-idle)" : "var(--fg-4)" }}
+                style={{ background: isBindableClient(c) ? "var(--state-idle)" : "var(--fg-4)" }}
                 aria-hidden
               />
               <span className="flex-1 min-w-0">

--- a/packages/web/src/pages/agent-detail/__tests__/action-state.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/action-state.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { getAgentTestActionState, isBindableClient } from "../action-state.js";
+
+describe("agent detail action state", () => {
+  it("blocks connection tests until the agent has an online bound computer", () => {
+    expect(
+      getAgentTestActionState({
+        agentStatus: "active",
+        clientStatus: undefined,
+        clientStatusLoading: true,
+        testPending: false,
+      }),
+    ).toMatchObject({ disabled: true, title: "Checking the bound computer before testing." });
+
+    expect(
+      getAgentTestActionState({
+        agentStatus: "active",
+        clientStatus: { online: true, clientId: null, offlineSince: null },
+        clientStatusLoading: false,
+        testPending: false,
+      }),
+    ).toMatchObject({ disabled: true, title: "Bind a computer before testing this agent." });
+
+    expect(
+      getAgentTestActionState({
+        agentStatus: "active",
+        clientStatus: { online: false, clientId: "client-1", offlineSince: "2026-05-13T10:00:00.000Z" },
+        clientStatusLoading: false,
+        testPending: false,
+      }),
+    ).toMatchObject({ disabled: true, title: "The bound computer is offline." });
+
+    expect(
+      getAgentTestActionState({
+        agentStatus: "active",
+        clientStatus: { online: true, clientId: "client-1", offlineSince: null },
+        clientStatusLoading: false,
+        testPending: false,
+      }),
+    ).toMatchObject({ disabled: false });
+  });
+
+  it("uses the same connected-client rule for bindability and row state", () => {
+    expect(isBindableClient({ status: "connected" })).toBe(true);
+    expect(isBindableClient({ status: "online" })).toBe(false);
+    expect(isBindableClient({ status: "active" })).toBe(false);
+    expect(isBindableClient({ status: "disconnected" })).toBe(false);
+  });
+});

--- a/packages/web/src/pages/agent-detail/action-state.ts
+++ b/packages/web/src/pages/agent-detail/action-state.ts
@@ -1,0 +1,35 @@
+import type { HubClient } from "../../api/activity.js";
+import type { ClientStatusInfo } from "../../api/agent-config.js";
+
+export type AgentTestActionState = {
+  disabled: boolean;
+  title: string;
+};
+
+export function getAgentTestActionState(input: {
+  agentStatus: string;
+  clientStatus: ClientStatusInfo | undefined;
+  clientStatusLoading: boolean;
+  testPending: boolean;
+}): AgentTestActionState {
+  if (input.agentStatus !== "active") {
+    return { disabled: true, title: "Only active agents can be tested." };
+  }
+  if (input.clientStatusLoading) {
+    return { disabled: true, title: "Checking the bound computer before testing." };
+  }
+  if (!input.clientStatus?.clientId) {
+    return { disabled: true, title: "Bind a computer before testing this agent." };
+  }
+  if (!input.clientStatus.online) {
+    return { disabled: true, title: "The bound computer is offline." };
+  }
+  if (input.testPending) {
+    return { disabled: true, title: "Test in progress." };
+  }
+  return { disabled: false, title: "Send a test message to verify this agent can respond." };
+}
+
+export function isBindableClient(client: Pick<HubClient, "status">): boolean {
+  return client.status === "connected";
+}

--- a/packages/web/src/pages/agent-detail/save-bar.tsx
+++ b/packages/web/src/pages/agent-detail/save-bar.tsx
@@ -18,6 +18,7 @@ export type SaveBarProps = {
   conflictMessage: string | null;
   errorMessage: string | null;
   saving: boolean;
+  reloadingRemote?: boolean;
   /** Emits true for a short window after a successful save, so the bar can flash an inline check. */
   justSaved: boolean;
   onSave: () => void;
@@ -38,6 +39,7 @@ export function SaveBar(props: SaveBarProps) {
   if (!props.summary.anyDirty && !props.conflictMessage && !props.errorMessage && !props.justSaved) return null;
 
   const dirtyCount = props.summary.dirtySections.length;
+  const showDraftActions = props.summary.anyDirty || props.saving;
 
   return (
     <div
@@ -108,23 +110,34 @@ export function SaveBar(props: SaveBarProps) {
         </div>
         <div className="flex gap-2 shrink-0">
           {props.conflictMessage && (
-            <Button variant="outline" size="sm" onClick={props.onReloadRemote}>
-              Discard mine, load latest
+            <Button variant="outline" size="sm" onClick={props.onReloadRemote} disabled={!!props.reloadingRemote}>
+              {props.reloadingRemote ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                  Loading latest…
+                </span>
+              ) : (
+                "Discard mine, load latest"
+              )}
             </Button>
           )}
-          <Button variant="ghost" size="sm" onClick={props.onDiscard} disabled={props.saving}>
-            Discard changes
-          </Button>
-          <Button size="sm" onClick={props.onSave} disabled={props.saving || !props.summary.anyDirty}>
-            {props.saving ? (
-              <span className="inline-flex items-center gap-1.5">
-                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
-                Saving…
-              </span>
-            ) : (
-              "Save"
-            )}
-          </Button>
+          {showDraftActions && (
+            <>
+              <Button variant="ghost" size="sm" onClick={props.onDiscard} disabled={props.saving}>
+                Discard changes
+              </Button>
+              <Button size="sm" onClick={props.onSave} disabled={props.saving || !props.summary.anyDirty}>
+                {props.saving ? (
+                  <span className="inline-flex items-center gap-1.5">
+                    <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                    Saving…
+                  </span>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/pages/agent-detail/setup-section.tsx
+++ b/packages/web/src/pages/agent-detail/setup-section.tsx
@@ -15,6 +15,8 @@ export type SetupSectionProps = {
   runtimeProvider: RuntimeProvider;
   /** Display label of the bound computer; null when no computer is bound yet. */
   computerLabel: string | null;
+  computerStatusLoading?: boolean;
+  computerStatusError?: string | null;
   /** Whether the "Bind computer" CTA should be shown (only when no client is bound and agent is active). */
   canBindComputer: boolean;
   bindComputerPending?: boolean;
@@ -45,6 +47,8 @@ export function SetupSection(props: SetupSectionProps) {
 
       <ComputerCard
         computerLabel={props.computerLabel}
+        statusLoading={props.computerStatusLoading ?? false}
+        statusError={props.computerStatusError ?? null}
         canBindComputer={props.canBindComputer}
         bindPending={props.bindComputerPending ?? false}
         onBindComputer={props.onBindComputer}
@@ -87,31 +91,48 @@ function RuntimeCard({ name, caption, locked }: { name: string; caption: string;
 
 function ComputerCard(props: {
   computerLabel: string | null;
+  statusLoading: boolean;
+  statusError: string | null;
   canBindComputer: boolean;
   bindPending: boolean;
   onBindComputer: (() => void) | undefined;
   onRebind: (() => void) | undefined;
 }) {
   const bound = !!props.computerLabel;
+  const canShowActions = !props.statusLoading && !props.statusError;
   return (
     <Panel>
       <PanelHeader>
         <PanelTitle>Bound computer</PanelTitle>
-        {props.canBindComputer && props.onBindComputer && !bound && (
-          <Button size="xs" variant="outline" onClick={props.onBindComputer} disabled={props.bindPending}>
+        {canShowActions && props.canBindComputer && props.onBindComputer && !bound && (
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={props.onBindComputer}
+            disabled={props.bindPending}
+            title={props.bindPending ? "Binding computer…" : "Pick a connected computer for this agent"}
+          >
             <Link2 className="h-3 w-3" />
             {props.bindPending ? "Binding…" : "Bind computer"}
           </Button>
         )}
-        {bound && props.onRebind && (
-          <Button size="xs" variant="outline" onClick={props.onRebind}>
+        {canShowActions && bound && props.onRebind && (
+          <Button size="xs" variant="outline" onClick={props.onRebind} title="Move this agent to another computer">
             <Link2 className="h-3 w-3" />
             Re-bind
           </Button>
         )}
       </PanelHeader>
       <PanelBody className="text-body">
-        {bound ? (
+        {props.statusLoading ? (
+          <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+            Checking computer binding…
+          </p>
+        ) : props.statusError ? (
+          <p className="text-caption" style={{ color: "var(--state-error)" }}>
+            Could not verify computer binding: {props.statusError}
+          </p>
+        ) : bound ? (
           <div className="mono" style={{ color: "var(--fg-2)" }}>
             {props.computerLabel}
           </div>


### PR DESCRIPTION
## Summary
- disable Test until client status is known, bound, online, and no test is running
- add Bound computer loading/error states so the page does not show bind/rebind actions prematurely
- make SaveBar hide draft actions during the saved-only flash and show loading for conflict reloads
- reuse one connected-client predicate for bindable computer rows
- fix Model dirty-chip navigation to the Setup section

## Why
Several action buttons were technically present before the page knew whether they could succeed, or remained visible when they no longer represented a valid action.

## Validation
- `pnpm --filter @first-tree-hub/web test`
- `pnpm --filter @first-tree-hub/web typecheck`

## Merge note
This PR overlaps with #360 and #361 in `agent-detail.tsx`. I already validated the combined result in local integration branch `review/agent-config-final-integration`; keep permission gating from #361 and action-state disabling from this PR when resolving conflicts.