### PR TITLE
Preserve agent env and MCP edits

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/env-mcp-section.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/env-mcp-section.test.ts
@@ -1,0 +1,64 @@
+import { ENV_REDACTED_PLACEHOLDER, type EnvEntry } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { canKeepExistingSensitiveValue, envDialogInitialValue, resolveEnvDialogValue } from "../env-section.js";
+import { formatMcpArgsInput, formatMcpHeadersInput, parseMcpArgsText, parseMcpHeadersText } from "../mcp-section.js";
+
+describe("EnvSection sensitive value handling", () => {
+  const persistedRedacted: EnvEntry = {
+    key: "OPENAI_API_KEY",
+    value: ENV_REDACTED_PLACEHOLDER,
+    sensitive: true,
+  };
+
+  it("allows empty input to keep only persisted redacted sensitive values", () => {
+    expect(canKeepExistingSensitiveValue(persistedRedacted, "unchanged")).toBe(true);
+    expect(resolveEnvDialogValue({ value: "", sensitive: true, allowKeepExisting: true })).toEqual({
+      ok: true,
+      value: ENV_REDACTED_PLACEHOLDER,
+    });
+  });
+
+  it("does not treat a newly added redacted-looking sensitive env as persisted", () => {
+    expect(canKeepExistingSensitiveValue(persistedRedacted, "added")).toBe(false);
+    expect(resolveEnvDialogValue({ value: "", sensitive: true, allowKeepExisting: false })).toEqual({
+      ok: false,
+      error: "Value is required for sensitive entries.",
+    });
+  });
+
+  it("prefills unsaved sensitive plaintext instead of clearing it", () => {
+    const unsaved: EnvEntry = { key: "TOKEN", value: "secret-value", sensitive: true };
+    expect(envDialogInitialValue(unsaved, false)).toBe("secret-value");
+  });
+});
+
+describe("McpSection structured args and headers", () => {
+  it("round-trips stdio args with spaces and quotes through JSON array input", () => {
+    const args = ["--label", "workspace with spaces", 'quoted "value"'];
+    const formatted = formatMcpArgsInput(args);
+    expect(parseMcpArgsText(formatted)).toEqual({ ok: true, value: args });
+  });
+
+  it("rejects non-string stdio args", () => {
+    expect(parseMcpArgsText('["--port", 3000]')).toEqual({
+      ok: false,
+      error: "Args must be a JSON array of strings.",
+    });
+  });
+
+  it("round-trips HTTP/SSE headers without dropping them", () => {
+    const headers = {
+      Authorization: "Bearer token",
+      "X-Workspace": "default",
+    };
+    const formatted = formatMcpHeadersInput(headers);
+    expect(parseMcpHeadersText(formatted)).toEqual({ ok: true, value: headers });
+  });
+
+  it("rejects header values that are not strings", () => {
+    expect(parseMcpHeadersText('{"Authorization": 123}')).toEqual({
+      ok: false,
+      error: "Headers must be a JSON object with string values.",
+    });
+  });
+});

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -109,6 +109,10 @@ export function EnvSection(props: EnvSectionProps) {
           open={!!dialog}
           onOpenChange={(open) => !open && setDialog(null)}
           initial={dialog.mode === "edit" ? dialog.initial : null}
+          allowKeepExisting={
+            dialog.mode === "edit" &&
+            canKeepExistingSensitiveValue(dialog.initial, props.items.find((item) => item.key === dialog.key)?.status)
+          }
           forbiddenKeys={props.otherKeys(dialog.mode === "edit" ? dialog.key : null)}
           onSubmit={(value) => {
             if (dialog.mode === "edit") props.onUpdate(dialog.key, value);
@@ -125,23 +129,51 @@ type EnvDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   initial: EnvEntry | null;
+  allowKeepExisting: boolean;
   forbiddenKeys: ReadonlySet<string>;
   onSubmit: (value: EnvEntry) => void;
 };
 
-function EnvDialog({ open, onOpenChange, initial, forbiddenKeys, onSubmit }: EnvDialogProps) {
+export function canKeepExistingSensitiveValue(
+  initial: EnvEntry,
+  status: DraftListItem<EnvEntry>["status"] | undefined,
+) {
+  return initial.sensitive && initial.value === ENV_REDACTED_PLACEHOLDER && status !== undefined && status !== "added";
+}
+
+export function envDialogInitialValue(initial: EnvEntry | null, allowKeepExisting: boolean) {
+  if (!initial) return "";
+  if (allowKeepExisting) return "";
+  return initial.value;
+}
+
+export function resolveEnvDialogValue(input: {
+  value: string;
+  sensitive: boolean;
+  allowKeepExisting: boolean;
+}): { ok: true; value: string } | { ok: false; error: string } {
+  if (input.sensitive && input.allowKeepExisting && !input.value) {
+    return { ok: true, value: ENV_REDACTED_PLACEHOLDER };
+  }
+  if (input.sensitive && !input.value) {
+    return { ok: false, error: "Value is required for sensitive entries." };
+  }
+  return { ok: true, value: input.value };
+}
+
+function EnvDialog({ open, onOpenChange, initial, allowKeepExisting, forbiddenKeys, onSubmit }: EnvDialogProps) {
   const [key, setKey] = useState(initial?.key ?? "");
-  const [value, setValue] = useState(initial?.sensitive ? "" : (initial?.value ?? ""));
+  const [value, setValue] = useState(envDialogInitialValue(initial, allowKeepExisting));
   const [sensitive, setSensitive] = useState(initial?.sensitive ?? false);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
     setKey(initial?.key ?? "");
-    setValue(initial?.sensitive ? "" : (initial?.value ?? ""));
+    setValue(envDialogInitialValue(initial, allowKeepExisting));
     setSensitive(initial?.sensitive ?? false);
     setErr(null);
-  }, [open, initial]);
+  }, [open, initial, allowKeepExisting]);
 
   function submit(e: FormEvent) {
     e.preventDefault();
@@ -153,16 +185,16 @@ function EnvDialog({ open, onOpenChange, initial, forbiddenKeys, onSubmit }: Env
       setErr(`Another entry already uses key "${key}".`);
       return;
     }
-    let finalValue = value;
-    if (sensitive && initial?.sensitive && !value) {
-      // Keep existing ciphertext: tell the backend via the redaction placeholder.
-      finalValue = ENV_REDACTED_PLACEHOLDER;
+    const resolved = resolveEnvDialogValue({ value, sensitive, allowKeepExisting });
+    if (!resolved.ok) {
+      setErr(resolved.error);
+      return;
     }
     if (!sensitive && !initial && !value) {
       setErr("Value is required for non-sensitive entries.");
       return;
     }
-    onSubmit({ key, value: finalValue, sensitive });
+    onSubmit({ key, value: resolved.value, sensitive });
   }
 
   return (
@@ -193,7 +225,7 @@ function EnvDialog({ open, onOpenChange, initial, forbiddenKeys, onSubmit }: Env
               value={value}
               onChange={(e) => setValue(e.target.value)}
               placeholder={
-                initial?.sensitive ? "Leave empty to keep existing value" : sensitive ? "new secret" : "value"
+                allowKeepExisting ? "Leave empty to keep existing value" : sensitive ? "new secret" : "value"
               }
               className="font-mono"
             />

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -23,9 +23,8 @@ export type McpSectionProps = {
   otherNames: (exceptKey: string | null) => ReadonlySet<string>;
   /**
    * Optional per-tool runtime-health lookup. Takes the MCP server name (case
-   * sensitive) and returns its status. When the page does not yet know (no
-   * runtime API wired), return "unknown" or leave undefined — the badge falls
-   * back to "unknown" automatically.
+   * sensitive) and returns its status. Leave undefined until a real runtime
+   * health source is wired; the row will omit the health badge.
    */
   toolHealth?: (name: string) => McpToolHealth;
   onAdd: (value: McpServer) => void;
@@ -62,10 +61,11 @@ export function McpSection(props: McpSectionProps) {
           <p className="text-body text-muted-foreground">No MCP servers. Add one to extend the agent's tools.</p>
         ) : (
           props.items.map((item) => {
-            // Runtime health is "unknown" until the caller wires a real lookup.
-            // Deleted rows always render as unknown since the binding is going away.
-            const health: McpToolHealth =
-              item.status === "deleted" || !props.toolHealth ? "unknown" : props.toolHealth(item.value.name);
+            const health: McpToolHealth | null = props.toolHealth
+              ? item.status === "deleted"
+                ? "unknown"
+                : props.toolHealth(item.value.name)
+              : null;
             return (
               <ListRow
                 key={item.key}
@@ -77,7 +77,7 @@ export function McpSection(props: McpSectionProps) {
               >
                 <span className="text-caption rounded bg-muted px-1.5 py-0.5 font-mono">{item.value.transport}</span>
                 <span className="font-medium font-mono">{item.value.name}</span>
-                <DenseBadge tone={toolHealthBadgeTone(health)}>{health}</DenseBadge>
+                {health && <DenseBadge tone={toolHealthBadgeTone(health)}>{health}</DenseBadge>}
                 <span className="text-caption text-muted-foreground truncate">{describeMcp(item.value)}</span>
               </ListRow>
             );
@@ -104,10 +104,54 @@ export function McpSection(props: McpSectionProps) {
 
 function describeMcp(m: McpServer): string {
   if (m.transport === "stdio") {
-    const args = m.args?.length ? ` ${m.args.join(" ")}` : "";
+    const args = m.args?.length ? ` ${m.args.map((arg) => JSON.stringify(arg)).join(" ")}` : "";
     return `${m.command}${args}`;
   }
   return m.url;
+}
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function formatMcpArgsInput(args: readonly string[] | undefined): string {
+  return args?.length ? JSON.stringify(args, null, 2) : "";
+}
+
+export function parseMcpArgsText(text: string): ParseResult<string[] | undefined> {
+  const trimmed = text.trim();
+  if (!trimmed) return { ok: true, value: undefined };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { ok: false, error: "Args must be a JSON array of strings." };
+  }
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+    return { ok: false, error: "Args must be a JSON array of strings." };
+  }
+  return { ok: true, value: parsed };
+}
+
+export function formatMcpHeadersInput(headers: Record<string, string> | undefined): string {
+  return headers && Object.keys(headers).length > 0 ? JSON.stringify(headers, null, 2) : "";
+}
+
+export function parseMcpHeadersText(text: string): ParseResult<Record<string, string> | undefined> {
+  const trimmed = text.trim();
+  if (!trimmed) return { ok: true, value: undefined };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { ok: false, error: "Headers must be a JSON object with string values." };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, error: "Headers must be a JSON object with string values." };
+  }
+  const entries = Object.entries(parsed);
+  if (entries.some(([key, value]) => !key || typeof value !== "string")) {
+    return { ok: false, error: "Headers must be a JSON object with string values." };
+  }
+  return { ok: true, value: entries.length > 0 ? Object.fromEntries(entries) : undefined };
 }
 
 type McpDialogProps = {
@@ -123,10 +167,15 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
   const [name, setName] = useState(initial?.name ?? "");
   const [command, setCommand] = useState(initial?.transport === "stdio" ? initial.command : "");
   const [argsText, setArgsText] = useState(
-    initial?.transport === "stdio" && initial.args ? initial.args.join(" ") : "",
+    formatMcpArgsInput(initial?.transport === "stdio" ? initial.args : undefined),
   );
   const [url, setUrl] = useState(
     initial && (initial.transport === "http" || initial.transport === "sse") ? initial.url : "",
+  );
+  const [headersText, setHeadersText] = useState(
+    formatMcpHeadersInput(
+      initial && (initial.transport === "http" || initial.transport === "sse") ? initial.headers : undefined,
+    ),
   );
   const [err, setErr] = useState<string | null>(null);
 
@@ -135,8 +184,13 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
     setTransport(initial?.transport ?? "stdio");
     setName(initial?.name ?? "");
     setCommand(initial?.transport === "stdio" ? initial.command : "");
-    setArgsText(initial?.transport === "stdio" && initial.args ? initial.args.join(" ") : "");
+    setArgsText(formatMcpArgsInput(initial?.transport === "stdio" ? initial.args : undefined));
     setUrl(initial && (initial.transport === "http" || initial.transport === "sse") ? initial.url : "");
+    setHeadersText(
+      formatMcpHeadersInput(
+        initial && (initial.transport === "http" || initial.transport === "sse") ? initial.headers : undefined,
+      ),
+    );
     setErr(null);
   }, [open, initial]);
 
@@ -156,11 +210,17 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
         setErr("stdio transport requires a command.");
         return;
       }
-      const args = argsText
-        .trim()
-        .split(/\s+/)
-        .filter((s) => s.length > 0);
-      value = { name, transport: "stdio", command: command.trim(), ...(args.length ? { args } : {}) };
+      const argsResult = parseMcpArgsText(argsText);
+      if (!argsResult.ok) {
+        setErr(argsResult.error);
+        return;
+      }
+      value = {
+        name,
+        transport: "stdio",
+        command: command.trim(),
+        ...(argsResult.value ? { args: argsResult.value } : {}),
+      };
     } else {
       const parsed = url.trim();
       try {
@@ -169,7 +229,12 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
         setErr("URL is not valid.");
         return;
       }
-      value = { name, transport, url: parsed };
+      const headersResult = parseMcpHeadersText(headersText);
+      if (!headersResult.ok) {
+        setErr(headersResult.error);
+        return;
+      }
+      value = { name, transport, url: parsed, ...(headersResult.value ? { headers: headersResult.value } : {}) };
     }
     onSubmit(value);
   }
@@ -217,27 +282,39 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="mcp-args">Args (space-separated, optional)</Label>
-                <Input
+                <Label htmlFor="mcp-args">Args (JSON array, optional)</Label>
+                <textarea
                   id="mcp-args"
                   value={argsText}
                   onChange={(e) => setArgsText(e.target.value)}
-                  placeholder="--port 3000"
-                  className="font-mono"
+                  placeholder={'["--port", "3000"]'}
+                  className="flex min-h-24 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-2 text-body font-mono shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
               </div>
             </>
           ) : (
-            <div className="space-y-2">
-              <Label htmlFor="mcp-url">URL</Label>
-              <Input
-                id="mcp-url"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                placeholder="https://internal.api/mcp"
-                className="font-mono"
-              />
-            </div>
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="mcp-url">URL</Label>
+                <Input
+                  id="mcp-url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="https://internal.api/mcp"
+                  className="font-mono"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mcp-headers">Headers (JSON object, optional)</Label>
+                <textarea
+                  id="mcp-headers"
+                  value={headersText}
+                  onChange={(e) => setHeadersText(e.target.value)}
+                  placeholder={'{"Authorization": "Bearer ..."}'}
+                  className="flex min-h-24 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-2 text-body font-mono shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              </div>
+            </>
           )}
           {err && <p className="text-body text-destructive">{err}</p>}
           <DialogFooter>

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -104,7 +104,9 @@ export function McpSection(props: McpSectionProps) {
 
 function describeMcp(m: McpServer): string {
   if (m.transport === "stdio") {
-    const args = m.args?.length ? ` ${m.args.map((arg) => JSON.stringify(arg)).join(" ")}` : "";
+    const args = m.args?.length
+      ? ` ${m.args.map((arg) => (/[\s"']/.test(arg) ? JSON.stringify(arg) : arg)).join(" ")}`
+      : "";
     return `${m.command}${args}`;
   }
   return m.url;
@@ -283,6 +285,9 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
               </div>
               <div className="space-y-2">
                 <Label htmlFor="mcp-args">Args (JSON array, optional)</Label>
+                <p className="text-caption text-muted-foreground">
+                  Each arg as a separate JSON string. Use this when an arg contains spaces or quotes.
+                </p>
                 <textarea
                   id="mcp-args"
                   value={argsText}
@@ -306,6 +311,9 @@ function McpDialog({ open, onOpenChange, initial, forbiddenNames, onSubmit }: Mc
               </div>
               <div className="space-y-2">
                 <Label htmlFor="mcp-headers">Headers (JSON object, optional)</Label>
+                <p className="text-caption text-muted-foreground">
+                  JSON object of request headers, for example auth headers required by the MCP server.
+                </p>
                 <textarea
                   id="mcp-headers"
                   value={headersText}


### PR DESCRIPTION
## Summary
- only allow empty sensitive env edits to keep an existing persisted redacted value
- preserve unsaved sensitive plaintext and reject empty new sensitive values
- switch MCP stdio args to JSON array input so spaces and quotes round-trip
- add HTTP/SSE headers JSON input so headers are not dropped on edit
- omit MCP health badges until a real health source is wired

## Why
The agent config page could turn new sensitive env values into placeholders and silently lose MCP args/header structure. These are data integrity issues in the draft editor before save.

## Validation
- `pnpm --filter @first-tree-hub/web test`
- `pnpm --filter @first-tree-hub/web typecheck`