### PR TITLE
feat(server): expose workingAgentIds on MeChatRow

### DIFF
--- a/packages/server/src/__tests__/me-chat-working-agents.test.ts
+++ b/packages/server/src/__tests__/me-chat-working-agents.test.ts
@@ -1,0 +1,160 @@
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { createMeChat, listMeChats } from "../services/me-chat.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * `MeChatRow.workingAgentIds` derivation.
+ *
+ * Decision (chat-status-icons preview spec §⑦.② / §⑦.⑦):
+ *
+ *   - The field is populated server-side from the participants' GLOBAL
+ *     `agent_presence.runtime_state` (PK lookup, zero new index).
+ *   - Per-chat precision is NOT modelled — an agent working in any chat
+ *     surfaces as `working` on every chat they speak in. The web layer
+ *     compensates by only rendering the working ring for direct chats
+ *     and deferring group-chat working signals to a future per-chat
+ *     data source.
+ *
+ * This file pins the field contract, the speaker-only inclusion rule,
+ * the runtime-state filter, and the lazy-presence-row default.
+ */
+describe("listMeChats: workingAgentIds derivation from agent_presence", () => {
+  const getApp = useTestApp();
+
+  async function setPresence(agentId: string, runtimeState: string | null): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO agent_presence (agent_id, status, runtime_state)
+      VALUES (${agentId}, 'online', ${runtimeState})
+      ON CONFLICT (agent_id) DO UPDATE SET runtime_state = EXCLUDED.runtime_state
+    `);
+  }
+
+  async function rowFor(chatId: string, viewerAgentId: string, organizationId: string) {
+    const app = getApp();
+    const { rows } = await listMeChats(app.db, viewerAgentId, organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    return rows.find((r) => r.chatId === chatId) ?? null;
+  }
+
+  it("empty array when no participant has runtime_state = 'working'", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `wa-empty-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    // peer is idle; agent_presence row may or may not exist — both should
+    // resolve to "no working agents". Seed an explicit idle row to prove
+    // the runtime_state filter (not the row's existence) drives the field.
+    await setPresence(peer.agent.uuid, "idle");
+
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    expect(row?.workingAgentIds).toEqual([]);
+  });
+
+  it("includes the peer in 1-on-1 when its runtime_state = 'working'", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `wa-direct-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await setPresence(peer.agent.uuid, "working");
+
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    expect(row?.workingAgentIds).toEqual([peer.agent.uuid]);
+  });
+
+  it("emits empty array when agent_presence row is missing entirely (lazy presence)", async () => {
+    // agent_presence is lazy-materialised — a freshly created agent has
+    // no row until its first WS frame. The LEFT JOIN must tolerate this
+    // and produce `workingAgentIds: []`, NOT crash on `runtime_state IS NULL`.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `wa-lazy-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    // No setPresence call — agent_presence row never exists.
+
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    expect(row?.workingAgentIds).toEqual([]);
+  });
+
+  it("error / idle / null states do NOT count as working", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `wa-err-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    for (const state of ["idle", "error", "blocked", null]) {
+      await setPresence(peer.agent.uuid, state);
+      const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+      expect(row?.workingAgentIds, `runtime_state=${state}`).toEqual([]);
+    }
+
+    await setPresence(peer.agent.uuid, "working");
+    const final = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    expect(final?.workingAgentIds).toEqual([peer.agent.uuid]);
+  });
+
+  it("group chat: lists every speaker with runtime_state = 'working' (precision deferred to UI)", async () => {
+    // Server is honest — it returns every working speaker. The web layer
+    // is the one that decides to only render the ring for direct chats.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `wag-1-${uid}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `wag-2-${uid}` });
+    const { agent: a3 } = await createTestAgent(app, { name: `wag-3-${uid}` });
+
+    // a1 creates a DM, then upgrades to group by adding a2 + a3 — uses
+    // the standard createMeChat-then-add flow rather than raw INSERTs.
+    const { chatId } = await createMeChat(app.db, a1.agent.uuid, a1.organizationId, {
+      participantIds: [a2.uuid, a3.uuid],
+    });
+
+    await setPresence(a2.uuid, "working");
+    await setPresence(a3.uuid, "working");
+
+    const row = await rowFor(chatId, a1.agent.uuid, a1.organizationId);
+    expect(row?.workingAgentIds.sort()).toEqual([a2.uuid, a3.uuid].sort());
+  });
+
+  it("watcher rows are excluded — only speakers can appear in workingAgentIds", async () => {
+    // Mention candidacy and projection both target speakers; the working
+    // signal follows the same rule. A watcher whose runtime_state is
+    // 'working' must NOT surface on chats they only watch.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `wa-spk-${crypto.randomUUID().slice(0, 6)}` });
+    const watcher = await createTestAgent(app, { name: `wa-w-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    // Forge a watcher row for `watcher` — they only watch, never speak.
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source)
+      VALUES (${chatId}, ${watcher.agent.uuid}, 'member', 'watcher', 'full', 'manual')
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
+
+    await setPresence(peer.agent.uuid, "idle");
+    await setPresence(watcher.agent.uuid, "working");
+
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    // Speaker peer is idle, watcher is working but excluded → empty.
+    expect(row?.workingAgentIds).toEqual([]);
+  });
+});

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -31,6 +31,7 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, inArray, type SQL, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
@@ -262,23 +263,35 @@ export async function listMeChats(
   const chatIds = pageRaw.map((r) => r.chat_id);
 
   // Lookup participants (speakers only — watchers do not appear in
-  // the conversation row's participant chip list).
+  // the conversation row's participant chip list). Also pick up each
+  // speaker's `agent_presence.runtime_state` so we can derive
+  // `workingAgentIds` per chat without a second query — `agent_presence`
+  // PK is `agent_id`, so the LEFT JOIN is a row-by-row PK lookup with
+  // no extra index needed.
   const participantRows = await db
     .select({
       chatId: chatMembership.chatId,
       agentId: chatMembership.agentId,
       displayName: agents.displayName,
       type: agents.type,
+      runtimeState: agentPresence.runtimeState,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+    .leftJoin(agentPresence, eq(agentPresence.agentId, chatMembership.agentId))
     .where(and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.accessMode, "speaker")));
 
   const participantsByChat = new Map<string, MeChatRow["participants"]>();
+  const workingByChat = new Map<string, string[]>();
   for (const p of participantRows) {
     const list = participantsByChat.get(p.chatId) ?? [];
     list.push({ agentId: p.agentId, displayName: p.displayName, type: p.type });
     participantsByChat.set(p.chatId, list);
+    if (p.runtimeState === "working") {
+      const working = workingByChat.get(p.chatId) ?? [];
+      working.push(p.agentId);
+      workingByChat.set(p.chatId, working);
+    }
   }
 
   // First-message lookup for auto-title fallback. Mirrors
@@ -318,6 +331,7 @@ export async function listMeChats(
       unreadMentionCount: r.unread_mention_count,
       canReply: isSpeaker,
       engagementStatus: r.engagement_status,
+      workingAgentIds: workingByChat.get(r.chat_id) ?? [],
     };
   });
 

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -54,6 +54,17 @@ export const meChatRowSchema = z.object({
   unreadMentionCount: z.number().int(),
   canReply: z.boolean(),
   engagementStatus: chatEngagementStatusSchema,
+  /**
+   * Speakers in this chat whose `agent_presence.runtime_state === 'working'`.
+   * Derived from the global presence table — NOT per-chat — so an agent
+   * running in any chat appears here for every chat they speak in. The web
+   * client only renders the working ring for `type === "direct"` and
+   * defers group-chat working signals to a future per-chat data source.
+   *
+   * Always returned, possibly empty. No schema migration required: this
+   * field is derived at query time from existing tables.
+   */
+  workingAgentIds: z.array(z.string()),
 });
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 


### PR DESCRIPTION
## Summary

Adds a server-derived \`workingAgentIds: string[]\` field to every \`MeChatRow\` returned by \`/me/chats\`, populated from each speaker's GLOBAL \`agent_presence.runtime_state === 'working'\`. Powers the chat-first conversation-list working ring in the upcoming web refactor.

**Zero DB migration. Zero new index.**

## Decision context

The chat-list spec needs a per-chat \"agent is working now\" signal. Precise per-chat tracking would require a partial index on \`agent_chat_sessions(chat_id) WHERE state = 'active'\` — a schema change we're avoiding. **Option A** trades precision for zero DDL:

- Field is derived from the **global** presence table at query time. \`agent_presence.agent_id\` is the PK so the JOIN is a single-row lookup per speaker.
- An agent working in any chat appears as \"working\" on every chat they speak in.
- The web layer compensates: it **only renders the working ring for \`type === 'direct'\`** so the cross-chat false positive stays invisible (1-on-1 user-with-agent is the common case; group-chat working signals defer to a future per-chat data source).

Full spec: \`chat-status-icons-preview.html\` §⑦.② / §⑦.⑦ / §⑦.⑨ (Option A).

## Changes

| File | Change |
|---|---|
| \`packages/shared/src/schemas/me-chat.ts\` | Additive \`workingAgentIds: z.array(z.string())\` on \`meChatRowSchema\`. Old clients ignore. |
| \`packages/server/src/services/me-chat.ts\` | Participants second query: add \`leftJoin(agentPresence)\`; collect \"working\" speakers into a per-chat map; thread into row assembly. Main query untouched. |
| \`packages/server/src/__tests__/me-chat-working-agents.test.ts\` | 6 new invariants (see Test plan). |

## What is **not** changed (deliberate)

- **No schema migration, no new index** — \`agent_presence\` PK on \`agent_id\` is sufficient.
- **No main-query change** — the LEFT JOIN sits on the existing participants second query that already runs once per page.
- **No version bump for \`packages/command\`** — \`MeChatRow\` is server/web-only; \`command\`/\`client\` don't import it.
- **Frontend not touched here** — wiring + ring rendering arrive in the follow-up web PR.

## Test plan

- [x] \`pnpm check\` + \`pnpm typecheck\` clean
- [x] \`pnpm --filter @first-tree-hub/server test\` — **116 files / 912 tests** pass
- [x] 6 new invariants in \`me-chat-working-agents.test.ts\`:
  1. No speaker working → \`workingAgentIds === []\`
  2. 1-on-1 peer \`runtime_state = 'working'\` → \`[peerId]\`
  3. Missing \`agent_presence\` row (lazy materialization) → \`[]\` (LEFT JOIN tolerates NULL)
  4. \`idle\` / \`error\` / \`blocked\` / null states do not count
  5. Group chat lists every working speaker honestly (UI gates rendering)
  6. Watcher rows excluded — speakers only

## Follow-ups (separate PRs)

- Web component refactor (\`ChatAvatar\` / \`WorkingRing\` / \`UnreadBadge\` / skeleton / empty + \`agent:presence\` WS invalidation)
- Light theme toggle (independent, parallel)