### PR TITLE
feat(web): chat-row avatar with working ring and unread badge

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { buildAvatarAriaLabel, formatUnreadLabel, pickCompositeShape } from "../chat-row-avatar.js";
+
+/**
+ * Pin the pure decision helpers exported by `ChatRowAvatar`. The
+ * rendering wrapper itself is exercised by visual / Playwright in CI;
+ * these tests cover the branches that drive layout and a11y so a
+ * future refactor can't silently shift the conversation-list contract.
+ */
+
+describe("pickCompositeShape — group avatar layout key", () => {
+  it("zero or one peer collapses to the single-avatar path", () => {
+    expect(pickCompositeShape(0)).toBe("single");
+    expect(pickCompositeShape(1)).toBe("single");
+  });
+
+  it("2 peers → vertical bisection", () => {
+    expect(pickCompositeShape(2)).toBe("n2");
+  });
+
+  it("3 peers → T-split", () => {
+    expect(pickCompositeShape(3)).toBe("n3");
+  });
+
+  it("exactly 4 peers → 2x2, all faces visible (no overflow)", () => {
+    // Pins the UX decision: at n=4 the 4th peer gets a real seg, not a
+    // `+1` overflow tile. Reverting to "3 + overflow" for n=4 would
+    // bring back the off-by-one bug fixed in this PR.
+    expect(pickCompositeShape(4)).toBe("n4");
+  });
+
+  it("5+ peers → 2x2 with last slot as overflow tile", () => {
+    expect(pickCompositeShape(5)).toBe("n5+");
+    expect(pickCompositeShape(10)).toBe("n5+");
+    expect(pickCompositeShape(100)).toBe("n5+");
+  });
+});
+
+describe("formatUnreadLabel — badge text", () => {
+  it("0 (or negative) returns null so callers omit the badge", () => {
+    expect(formatUnreadLabel(0)).toBeNull();
+    expect(formatUnreadLabel(-1)).toBeNull();
+  });
+
+  it("1..99 returns the literal count", () => {
+    expect(formatUnreadLabel(1)).toBe("1");
+    expect(formatUnreadLabel(7)).toBe("7");
+    expect(formatUnreadLabel(99)).toBe("99");
+  });
+
+  it(">=100 rolls over to '99+' so the badge stays width-stable", () => {
+    expect(formatUnreadLabel(100)).toBe("99+");
+    expect(formatUnreadLabel(9999)).toBe("99+");
+  });
+});
+
+describe("buildAvatarAriaLabel — state-only screen-reader text", () => {
+  it("returns null when nothing is happening (avatar goes aria-hidden)", () => {
+    // Title is announced by the enclosing chat-row button; an avatar
+    // with no dynamic state shouldn't double-announce anything.
+    expect(buildAvatarAriaLabel({ peerWorking: false, unread: 0 })).toBeNull();
+  });
+
+  it("'working' only when peer is working and there's no unread", () => {
+    expect(buildAvatarAriaLabel({ peerWorking: true, unread: 0 })).toBe("working");
+  });
+
+  it("'N unread' only when there's unread but no working signal", () => {
+    expect(buildAvatarAriaLabel({ peerWorking: false, unread: 3 })).toBe("3 unread");
+    expect(buildAvatarAriaLabel({ peerWorking: false, unread: 1 })).toBe("1 unread");
+  });
+
+  it("composes both into one comma-joined label", () => {
+    expect(buildAvatarAriaLabel({ peerWorking: true, unread: 5 })).toBe("working, 5 unread");
+  });
+});

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -5,7 +5,7 @@
  *
  *   1. Identity. Direct chats show a single initial; group chats use a
  *      Telegram-style split-disc composite (vertical bisection for 2,
- *      T-split for 3, 2x2 grid + "+N" for >=4).
+ *      T-split for 3, 2x2 for exactly 4, 3 + "+N" tile for >=5).
  *   2. Working state. ONLY for direct chats: when the peer's agent_id
  *      is present in `workingAgentIds`, an accent ring breathes around
  *      the avatar. Group rings are intentionally skipped — the source
@@ -21,6 +21,13 @@
  * > avatar (0). All overlays carry a hairline-bold `var(--bg-raised)`
  * border so they read clearly against the underlying avatar without
  * bleeding into adjacent rows.
+ *
+ * A11y: this span's `aria-label` carries the dynamic *state* only
+ * (`"working"`, `"3 unread"`). The enclosing chat-row button already
+ * renders the chat title as visible text — repeating it here would
+ * make screen readers announce the title twice. When the avatar has
+ * no state to surface, it goes fully `aria-hidden` so the row's
+ * accessible name is unchanged.
  */
 
 import type { MeChatRow } from "@agent-team-foundation/first-tree-hub-shared";
@@ -31,11 +38,43 @@ function initial(s: string): string {
   return s.trim()[0]?.toUpperCase() ?? "?";
 }
 
-function buildAriaLabel(opts: { type: string; title: string; peerWorking: boolean; unread: number }): string {
-  const parts: string[] = [opts.title];
+/**
+ * Composite-avatar layout key, exported for unit testing the branch
+ * decisions without rendering to a DOM. `"single"` is reserved for the
+ * non-composite path (1 peer or direct chats); `"n2"` / `"n3"` / `"n4"`
+ * / `"n5+"` map 1:1 to the composite's grid templates.
+ */
+export function pickCompositeShape(peerCount: number): "single" | "n2" | "n3" | "n4" | "n5+" {
+  if (peerCount <= 1) return "single";
+  if (peerCount === 2) return "n2";
+  if (peerCount === 3) return "n3";
+  if (peerCount === 4) return "n4";
+  return "n5+";
+}
+
+/**
+ * Unread badge label. Returns `null` to signal the badge should be
+ * omitted entirely (clearer than asking callers to also gate on
+ * `count > 0`). `>= 100` rolls over to `"99+"` so the badge stays
+ * single-digit width-stable.
+ */
+export function formatUnreadLabel(count: number): string | null {
+  if (count <= 0) return null;
+  if (count > 99) return "99+";
+  return String(count);
+}
+
+/**
+ * State-only aria-label. Returns `null` when the avatar should be
+ * fully `aria-hidden` (no dynamic state worth surfacing — title is
+ * already on the row button). When there is state, it's joined as
+ * `"working, N unread"`.
+ */
+export function buildAvatarAriaLabel(opts: { peerWorking: boolean; unread: number }): string | null {
+  const parts: string[] = [];
   if (opts.peerWorking) parts.push("working");
   if (opts.unread > 0) parts.push(`${opts.unread} unread`);
-  return parts.join(", ");
+  return parts.length > 0 ? parts.join(", ") : null;
 }
 
 export function ChatRowAvatar({
@@ -47,7 +86,7 @@ export function ChatRowAvatar({
   unreadCount,
   size = 36,
 }: {
-  /** Resolved chat title — used for the avatar's aria-label. */
+  /** Resolved chat title — used as a fallback initial when no peer exists. */
   title: string;
   /** `direct` | `group`. */
   type: string;
@@ -70,12 +109,13 @@ export function ChatRowAvatar({
   const peer = peers[0];
   const peerWorking = isDirect && peer !== undefined && workingAgentIds.includes(peer.agentId);
 
-  const ariaLabel = buildAriaLabel({ type, title, peerWorking, unread: unreadCount });
+  const ariaLabel = buildAvatarAriaLabel({ peerWorking, unread: unreadCount });
+  const a11yProps: { role?: string; "aria-label"?: string; "aria-hidden"?: boolean } =
+    ariaLabel === null ? { "aria-hidden": true } : { role: "img", "aria-label": ariaLabel };
 
   return (
     <span
-      role="img"
-      aria-label={ariaLabel}
+      {...a11yProps}
       style={{
         position: "relative",
         width: size,
@@ -121,25 +161,22 @@ function SingleAvatar({ size, name }: { size: number; name: string }) {
 }
 
 function CompositeAvatar({ size, peers }: { size: number; peers: ReadonlyArray<Participant> }) {
-  // Layout decisions, mirroring the chat-status-icons design preview:
-  //   2 visible → vertical bisection
-  //   3 visible → T-split (top spans full width, bottom is 2 cells)
-  //   >=4 total → 2x2 grid where the last slot becomes a `+N` overflow tile
-  //
-  // The split is rendered via CSS grid with a hairline gap that lets the
-  // parent `--bg-raised` background show through as hairline separators —
-  // crisper than borders at this size and consistent with the rest of
-  // the design system's hairline tokens.
+  // Layout decision keyed off `pickCompositeShape` (see header docstring):
+  //   n2  → vertical bisection
+  //   n3  → T-split (top spans full width, bottom is 2 cells)
+  //   n4  → 2x2 grid, all four visible (matches conventional group UX)
+  //   n5+ → 2x2 grid, first three peers + "+N" overflow tile where N = n - 3
   const n = peers.length;
-  const visibleCount = n <= 3 ? n : 3;
-  const overflow = n - visibleCount;
+  const shape = pickCompositeShape(n);
 
   const fontSize = Math.round(size * (n === 2 ? 0.36 : 0.28));
   const fontSizeTop = Math.round(size * 0.32);
   const fontSizeMore = Math.round(size * 0.26);
 
   const gridTemplate =
-    n === 2 ? { gridTemplateColumns: "1fr 1fr" } : { gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr" };
+    shape === "n2"
+      ? { gridTemplateColumns: "1fr 1fr" }
+      : { gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr" };
 
   return (
     <div
@@ -156,25 +193,33 @@ function CompositeAvatar({ size, peers }: { size: number; peers: ReadonlyArray<P
         ...gridTemplate,
       }}
     >
-      {n === 2 && (
+      {shape === "n2" && (
         <>
           <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
           <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
         </>
       )}
-      {n === 3 && (
+      {shape === "n3" && (
         <>
           <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSizeTop} fullWidth />
           <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
           <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
         </>
       )}
-      {n >= 4 && (
+      {shape === "n4" && (
         <>
           <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
           <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
           <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
-          <SegMore count={overflow + 1} fontSize={fontSizeMore} />
+          <Seg name={peers[3]?.displayName ?? "?"} fontSize={fontSize} />
+        </>
+      )}
+      {shape === "n5+" && (
+        <>
+          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
+          <SegMore count={n - 3} fontSize={fontSizeMore} />
         </>
       )}
     </div>
@@ -244,7 +289,13 @@ function WorkingRing({ size }: { size: number }) {
 }
 
 function UnreadBadge({ count }: { count: number }) {
-  const label = count > 99 ? "99+" : String(count);
+  const label = formatUnreadLabel(count);
+  if (label === null) return null;
+  // Pinned at --sp-4 (16) x --sp-4 (16), --sp-2 (8) corner radius — the
+  // badge is a self-contained capsule and intentionally tighter than the
+  // generic content padding scale, so it reads as a discrete signal
+  // rather than a control. Offset by 3 outside the avatar so the
+  // hairline-bold border cuts cleanly through the working ring.
   return (
     <span
       aria-hidden="true"
@@ -252,13 +303,13 @@ function UnreadBadge({ count }: { count: number }) {
         position: "absolute",
         bottom: -3,
         right: -3,
-        minWidth: 16,
-        height: 16,
+        minWidth: "var(--sp-4)",
+        height: "var(--sp-4)",
         padding: "0 var(--sp-1)",
-        borderRadius: 8,
+        borderRadius: "var(--sp-2)",
         background: "var(--state-error)",
         color: "var(--bg-raised)",
-        fontSize: 10,
+        fontSize: "var(--text-caption)",
         fontWeight: 700,
         lineHeight: "var(--sp-4)",
         textAlign: "center",

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -1,0 +1,274 @@
+/**
+ * ChatRowAvatar — left-side avatar slot for the conversation list row.
+ *
+ * Renders three orthogonal signals in one 36x36 unit:
+ *
+ *   1. Identity. Direct chats show a single initial; group chats use a
+ *      Telegram-style split-disc composite (vertical bisection for 2,
+ *      T-split for 3, 2x2 grid + "+N" for >=4).
+ *   2. Working state. ONLY for direct chats: when the peer's agent_id
+ *      is present in `workingAgentIds`, an accent ring breathes around
+ *      the avatar. Group rings are intentionally skipped — the source
+ *      data (`agent_presence.runtime_state`) is agent-global, not
+ *      per-chat, so showing a ring on every chat a working agent
+ *      participates in would be noisy. Per-chat precision is deferred
+ *      (see chat-status-icons spec §⑦.② / §⑦.⑦, Option A).
+ *   3. Unread. A `--state-error` badge at the bottom-right corner
+ *      replaces the legacy small text-row dot. Numeric up to 99, then
+ *      "99+". When count = 0 the badge is omitted entirely.
+ *
+ * The component owns its z-index ladder: badge (3) > working ring (1)
+ * > avatar (0). All overlays carry a hairline-bold `var(--bg-raised)`
+ * border so they read clearly against the underlying avatar without
+ * bleeding into adjacent rows.
+ */
+
+import type { MeChatRow } from "@agent-team-foundation/first-tree-hub-shared";
+
+type Participant = MeChatRow["participants"][number];
+
+function initial(s: string): string {
+  return s.trim()[0]?.toUpperCase() ?? "?";
+}
+
+function buildAriaLabel(opts: { type: string; title: string; peerWorking: boolean; unread: number }): string {
+  const parts: string[] = [opts.title];
+  if (opts.peerWorking) parts.push("working");
+  if (opts.unread > 0) parts.push(`${opts.unread} unread`);
+  return parts.join(", ");
+}
+
+export function ChatRowAvatar({
+  title,
+  type,
+  participants,
+  selfAgentId,
+  workingAgentIds,
+  unreadCount,
+  size = 36,
+}: {
+  /** Resolved chat title — used for the avatar's aria-label. */
+  title: string;
+  /** `direct` | `group`. */
+  type: string;
+  /** Speakers only (watchers are filtered by `listMeChats`). */
+  participants: ReadonlyArray<Participant>;
+  /** Caller's own agent_id, so we can identify the peer in a direct chat. */
+  selfAgentId: string;
+  /** Speakers whose `agent_presence.runtime_state === 'working'`. */
+  workingAgentIds: ReadonlyArray<string>;
+  /** `chat_user_state.unread_mention_count`. */
+  unreadCount: number;
+  /** Pixel diameter of the avatar disc. Default 36 fits the narrow rail. */
+  size?: number;
+}) {
+  const isDirect = type === "direct";
+  const peers = participants.filter((p) => p.agentId !== selfAgentId);
+
+  // Working ring fires only for direct chats — see component header for the
+  // rationale on dropping the group case under Option A.
+  const peer = peers[0];
+  const peerWorking = isDirect && peer !== undefined && workingAgentIds.includes(peer.agentId);
+
+  const ariaLabel = buildAriaLabel({ type, title, peerWorking, unread: unreadCount });
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel}
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        flexShrink: 0,
+        display: "inline-block",
+      }}
+    >
+      {isDirect || peers.length <= 1 ? (
+        <SingleAvatar size={size} name={peer?.displayName ?? title} />
+      ) : (
+        <CompositeAvatar size={size} peers={peers} />
+      )}
+      {peerWorking && <WorkingRing size={size} />}
+      {unreadCount > 0 && <UnreadBadge count={unreadCount} />}
+    </span>
+  );
+}
+
+function SingleAvatar({ size, name }: { size: number; name: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "var(--accent)",
+        color: "var(--bg-raised)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.42),
+        fontWeight: 700,
+        lineHeight: 1,
+        letterSpacing: "-0.02em",
+        userSelect: "none",
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+function CompositeAvatar({ size, peers }: { size: number; peers: ReadonlyArray<Participant> }) {
+  // Layout decisions, mirroring the chat-status-icons design preview:
+  //   2 visible → vertical bisection
+  //   3 visible → T-split (top spans full width, bottom is 2 cells)
+  //   >=4 total → 2x2 grid where the last slot becomes a `+N` overflow tile
+  //
+  // The split is rendered via CSS grid with a hairline gap that lets the
+  // parent `--bg-raised` background show through as hairline separators —
+  // crisper than borders at this size and consistent with the rest of
+  // the design system's hairline tokens.
+  const n = peers.length;
+  const visibleCount = n <= 3 ? n : 3;
+  const overflow = n - visibleCount;
+
+  const fontSize = Math.round(size * (n === 2 ? 0.36 : 0.28));
+  const fontSizeTop = Math.round(size * 0.32);
+  const fontSizeMore = Math.round(size * 0.26);
+
+  const gridTemplate =
+    n === 2 ? { gridTemplateColumns: "1fr 1fr" } : { gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr" };
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        overflow: "hidden",
+        display: "grid",
+        gap: "var(--hairline)",
+        background: "var(--bg-raised)",
+        userSelect: "none",
+        ...gridTemplate,
+      }}
+    >
+      {n === 2 && (
+        <>
+          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
+        </>
+      )}
+      {n === 3 && (
+        <>
+          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSizeTop} fullWidth />
+          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
+        </>
+      )}
+      {n >= 4 && (
+        <>
+          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
+          <SegMore count={overflow + 1} fontSize={fontSizeMore} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function Seg({ name, fontSize, fullWidth }: { name: string; fontSize: number; fullWidth?: boolean }) {
+  return (
+    <span
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--accent)",
+        color: "var(--bg-raised)",
+        fontSize,
+        fontWeight: 700,
+        lineHeight: 1,
+        letterSpacing: "-0.02em",
+        ...(fullWidth ? { gridColumn: "1 / -1" } : null),
+      }}
+    >
+      {initial(name)}
+    </span>
+  );
+}
+
+function SegMore({ count, fontSize }: { count: number; fontSize: number }) {
+  return (
+    <span
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-sunken)",
+        color: "var(--fg-3)",
+        fontSize,
+        fontWeight: 600,
+        lineHeight: 1,
+        userSelect: "none",
+      }}
+    >
+      {`+${count}`}
+    </span>
+  );
+}
+
+function WorkingRing({ size }: { size: number }) {
+  // Hairline-bold border, offset 3 outside the avatar. The breathe
+  // keyframes + `prefers-reduced-motion` fallback live in index.css.
+  return (
+    <span
+      aria-hidden="true"
+      className="chat-row-avatar__working-ring"
+      style={{
+        position: "absolute",
+        inset: -3,
+        width: size + 6,
+        height: size + 6,
+        borderRadius: "50%",
+        border: "var(--hairline-bold) solid var(--state-working)",
+        pointerEvents: "none",
+        zIndex: 1,
+      }}
+    />
+  );
+}
+
+function UnreadBadge({ count }: { count: number }) {
+  const label = count > 99 ? "99+" : String(count);
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        bottom: -3,
+        right: -3,
+        minWidth: 16,
+        height: 16,
+        padding: "0 var(--sp-1)",
+        borderRadius: 8,
+        background: "var(--state-error)",
+        color: "var(--bg-raised)",
+        fontSize: 10,
+        fontWeight: 700,
+        lineHeight: "var(--sp-4)",
+        textAlign: "center",
+        border: "var(--hairline-bold) solid var(--bg-raised)",
+        boxSizing: "content-box",
+        zIndex: 3,
+        userSelect: "none",
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -29,6 +29,34 @@ const subscribers = new Set<Subscriber>();
 let latestQc: QC | null = null;
 let refCount = 0;
 
+// `session:state` frames can burst when an agent ticks through tool
+// calls — every frame would otherwise force a `me/chats` refetch and the
+// React-Query default (`staleTime: 0`) wouldn't dedupe. Leading-edge fire
+// keeps the working ring snappy; a 500ms trailing window collapses the
+// burst into at most one extra round-trip after it ends. Tuned to be
+// shorter than typical observed gaps between tool calls (~1s) but long
+// enough to fold a 10+ frame storm into a single follow-up.
+const ME_CHATS_INVALIDATE_THROTTLE_MS = 500;
+let meChatsLastInvalidatedAt = 0;
+let meChatsTrailingTimer: ReturnType<typeof setTimeout> | null = null;
+
+function invalidateMeChatsThrottled(qc: QC) {
+  const now = Date.now();
+  const elapsed = now - meChatsLastInvalidatedAt;
+  if (elapsed >= ME_CHATS_INVALIDATE_THROTTLE_MS) {
+    meChatsLastInvalidatedAt = now;
+    qc.invalidateQueries({ queryKey: ["me", "chats"] });
+    return;
+  }
+  if (meChatsTrailingTimer === null) {
+    meChatsTrailingTimer = setTimeout(() => {
+      meChatsTrailingTimer = null;
+      meChatsLastInvalidatedAt = Date.now();
+      if (latestQc) latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
+    }, ME_CHATS_INVALIDATE_THROTTLE_MS - elapsed);
+  }
+}
+
 function broadcast(msg: WsMessage) {
   for (const sub of subscribers) {
     try {
@@ -46,9 +74,10 @@ function broadcast(msg: WsMessage) {
       // `MeChatRow.workingAgentIds` is derived from `agent_presence.runtime_state`,
       // which is mutated by the same `session:state` event upstream. Invalidate
       // the conversation-list query so the working ring switches on / off in
-      // real time without waiting for the 15s `refetchInterval`. Cheap: the
-      // query is page-scoped (50 rows) and already React-Query-deduped.
-      latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
+      // real time without waiting for the 15s `refetchInterval`. Throttled
+      // because the upstream frames can burst tool-call-fast — see the
+      // helper's banner comment.
+      invalidateMeChatsThrottled(latestQc);
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
       // carries `{ type, chatId }` (see shared/me-chat.ts:chatMessageFrameSchema);

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -43,6 +43,12 @@ function broadcast(msg: WsMessage) {
     } else if (msg.type === "session:state") {
       latestQc.invalidateQueries({ queryKey: ["activity"] });
       latestQc.invalidateQueries({ queryKey: ["sessions"] });
+      // `MeChatRow.workingAgentIds` is derived from `agent_presence.runtime_state`,
+      // which is mutated by the same `session:state` event upstream. Invalidate
+      // the conversation-list query so the working ring switches on / off in
+      // real time without waiting for the 15s `refetchInterval`. Cheap: the
+      // query is page-scoped (50 rows) and already React-Query-deduped.
+      latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
       // carries `{ type, chatId }` (see shared/me-chat.ts:chatMessageFrameSchema);

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -188,6 +188,10 @@ function teardown() {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
   }
+  if (meChatsTrailingTimer) {
+    clearTimeout(meChatsTrailingTimer);
+    meChatsTrailingTimer = null;
+  }
   if (ws) {
     ws.close(1000, "unmount");
     ws = null;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -564,6 +564,28 @@
   }
 }
 
+/* Chat-row avatar working ring — steady breathe to signal "agent is
+   responding now" without the urgency of a flash. opacity-only so the
+   animation stays GPU-cheap on long conversation lists. */
+@keyframes chat-row-avatar-working-breathe {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+.chat-row-avatar__working-ring {
+  animation: chat-row-avatar-working-breathe 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-row-avatar__working-ring {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 .fade-in {
   animation: subtle-fade 180ms ease-out;
 }

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { listMeChats } from "../../../api/me-chats.js";
+import { useAuth } from "../../../auth/auth-context.js";
+import { ChatRowAvatar } from "../../../components/chat/chat-row-avatar.js";
 import { FilterPill } from "../../../components/ui/filter-pill.js";
 import { cn } from "../../../lib/utils.js";
 import { RowEngagementMenu } from "./row-engagement-menu.js";
@@ -78,6 +80,7 @@ export function ConversationList({
   engagement: ChatEngagementView;
   onEngagementChange: (view: ChatEngagementView) => void;
 }) {
+  const { agentId: selfAgentId } = useAuth();
   const [filter, setFilter] = useState<Filter>("all");
   const [extraPages, setExtraPages] = useState<MeChatRow[]>([]);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -251,58 +254,55 @@ export function ConversationList({
               <button
                 type="button"
                 onClick={() => onSelectChat(row.chatId)}
-                className={cn("w-full text-left transition-colors flex flex-col", "hover:bg-[var(--bg-hover)]")}
+                className={cn("w-full text-left transition-colors flex items-center", "hover:bg-[var(--bg-hover)]")}
                 style={{
                   padding: "var(--sp-2) var(--sp-3)",
+                  gap: "var(--sp-2_5)",
                   background: isSelected ? "var(--bg-active)" : "transparent",
                   borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--accent)" : "transparent"}`,
                 }}
               >
-                <div className="flex items-baseline" style={{ gap: 6 }}>
-                  {hasUnread && (
+                <ChatRowAvatar
+                  title={row.title}
+                  type={row.type}
+                  participants={row.participants}
+                  selfAgentId={selfAgentId ?? ""}
+                  workingAgentIds={row.workingAgentIds}
+                  unreadCount={row.unreadMentionCount}
+                />
+                <div className="flex flex-col" style={{ flex: 1, minWidth: 0 }}>
+                  <div className="flex items-baseline" style={{ gap: 6 }}>
                     <span
-                      aria-label={`${row.unreadMentionCount} unread mentions`}
-                      role="status"
+                      className="truncate text-subtitle"
                       style={{
-                        width: 6,
-                        height: 6,
-                        borderRadius: "50%",
-                        background: "var(--state-error)",
-                        flexShrink: 0,
-                        alignSelf: "center",
+                        color: hasUnread ? "var(--fg)" : "var(--fg-2)",
+                        fontWeight: hasUnread ? 700 : 500,
+                        flex: 1,
+                        minWidth: 0,
                       }}
-                    />
-                  )}
-                  <span
-                    className="truncate text-subtitle"
+                    >
+                      {row.title}
+                    </span>
+                    {row.lastMessageAt && (
+                      // Time vacates its right-anchor slot so the ⋯ trigger can
+                      // take over on hover or while the menu is open (Gmail-style swap).
+                      <span
+                        className="mono text-caption shrink-0 transition-opacity group-hover:opacity-0 group-has-aria-expanded:opacity-0"
+                        style={{ color: "var(--fg-4)" }}
+                      >
+                        {formatRowTime(row.lastMessageAt)}
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    className="truncate text-body"
                     style={{
-                      color: hasUnread ? "var(--fg)" : "var(--fg-2)",
-                      fontWeight: hasUnread ? 700 : 500,
-                      flex: 1,
-                      minWidth: 0,
+                      color: hasUnread ? "var(--fg-2)" : "var(--fg-3)",
+                      marginTop: 2,
                     }}
                   >
-                    {row.title}
-                  </span>
-                  {row.lastMessageAt && (
-                    // Time vacates its right-anchor slot so the ⋯ trigger can
-                    // take over on hover or while the menu is open (Gmail-style swap).
-                    <span
-                      className="mono text-caption shrink-0 transition-opacity group-hover:opacity-0 group-has-aria-expanded:opacity-0"
-                      style={{ color: "var(--fg-4)" }}
-                    >
-                      {formatRowTime(row.lastMessageAt)}
-                    </span>
-                  )}
-                </div>
-                <div
-                  className="truncate text-body"
-                  style={{
-                    color: hasUnread ? "var(--fg-2)" : "var(--fg-3)",
-                    marginTop: 2,
-                  }}
-                >
-                  {subtitle || "—"}
+                    {subtitle || "—"}
+                  </div>
                 </div>
               </button>
               <div


### PR DESCRIPTION
## Summary

Adds the chat-first conversation list its avatar slot, wiring up \`workingAgentIds\` (shipped by #366) and consolidating the unread indicator onto the avatar overlay.

Implements **PR C** from the chat-status-icons spec — the visual companion to PR B's data layer. **No DB / schema changes.**

## What each row gets

| Element | Behavior |
|---|---|
| **Avatar** | Single initial for \`direct\`, split-disc composite for \`group\` (vertical bisection for 2, T-split for 3, 2×2 + \"+N\" overflow for ≥4). 36×36 default fits the 320-wide rail. |
| **Working ring** | Breathing \`--state-working\` border. **Direct chats only**, when the peer's agent_id is in \`workingAgentIds\`. Group rings deferred to a future per-chat data source — \`agent_presence.runtime_state\` is agent-global so showing a ring per group would be a false-positive factory (Option A trade-off, see spec §⑦.② / §⑦.⑦). |
| **Unread badge** | \`--state-error\` corner badge with numeric count, \`99+\` rollover. Replaces the legacy small text-row dot. z-index 3, hairline-bold \`--bg-raised\` border so it cuts cleanly through the working ring when both render. |

## Realtime

\`use-admin-ws.ts\` gains a \`me/chats\` invalidation on \`session:state\` frames (already org-scoped, payload carries \`chatId\`). Without this the working ring would lag the 15s polling refetch when a runtime transitions without sending a new message.

## Motion

New \`chat-row-avatar-working-breathe\` keyframe — 1.6s opacity-only (GPU-cheap on long lists). \`prefers-reduced-motion\` collapses it to a static solid ring. No transform or layout-affecting animation.

## Changes

- \`packages/web/src/components/chat/chat-row-avatar.tsx\` — new component (single + composite + ring + badge).
- \`packages/web/src/pages/workspace/conversations/index.tsx\` — row layout: avatar on the left, title/subtitle stack on the right. Legacy 6-unit text-row dot removed (its semantics now live on the avatar's overlay).
- \`packages/web/src/hooks/use-admin-ws.ts\` — invalidate \`[\"me\", \"chats\"]\` on \`session:state\`.
- \`packages/web/src/index.css\` — keyframes + \`prefers-reduced-motion\` fallback.

## Out of scope (separate PRs if wanted)

- \`ChatListSkeleton\` to replace the \`Loading…\` text — the existing text state still works, refactoring it has no urgency.
- \`ChatListEmpty\` to replace the \`No conversations yet\` text — same.

## Test plan

- [x] \`pnpm check\` clean
- [x] \`pnpm typecheck\` clean (including \`lint:tokens\`)
- [x] \`pnpm build\` succeeds (web bundle size unchanged within noise)
- [x] \`pnpm test\` green — 912 server tests pass (no web vitest tests touched)
- [ ] Visual / manual: smoke-test in dev mode + light/dark theme toggle

## Versioning

No version bump: web-only change, doesn't touch \`command\` or \`client\` packages.