### PR TITLE
feat(web): per-agent avatar hue palette + DEV preview route

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -33,6 +33,12 @@ const ContextPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/context-preview.js").then((module) => ({ default: module.ContextPreviewPage })))
   : null;
 
+const ChatRowAvatarPreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/chat-row-avatar-preview.js").then((module) => ({ default: module.ChatRowAvatarPreviewPage })),
+    )
+  : null;
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -52,6 +58,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <ContextPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {ChatRowAvatarPreviewPage ? (
+                <Route
+                  path="/preview/chat-row-avatar"
+                  element={
+                    <Suspense fallback={null}>
+                      <ChatRowAvatarPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
@@ -55,9 +55,11 @@ describe("formatUnreadLabel — badge text", () => {
 });
 
 describe("pickAvatarHue — deterministic per-agent fill color", () => {
-  it("returns an OkLCH string from the palette", () => {
-    const hue = pickAvatarHue("agent-1");
-    expect(hue).toMatch(/^oklch\(/);
+  it("returns a `var(--avatar-hue-N)` token reference", () => {
+    // Pins the contract that the helper hands back a CSS-token
+    // reference rather than a raw `oklch(...)` literal — index.css is
+    // the single source of palette truth.
+    expect(pickAvatarHue("agent-1")).toMatch(/^var\(--avatar-hue-[0-7]\)$/);
   });
 
   it("same seed yields the same hue across calls (stable per agent)", () => {
@@ -68,27 +70,30 @@ describe("pickAvatarHue — deterministic per-agent fill color", () => {
     expect(a).toBe(b);
   });
 
-  it("different seeds reach more than one palette entry", () => {
-    // Sanity check that the palette is actually being used and the
-    // hash isn't degenerate. A handful of UUIDs should land on at
-    // least 2 distinct hues.
+  it("spreads 8 realistic UUIDv7 seeds across at least 4 different hues", () => {
+    // Tighter than "more than one" — a regression that collapses
+    // 8 sample seeds onto 2 hues would pass the looser check. The
+    // seeds below are realistic-shape UUIDv7s (high-entropy random
+    // tail) rather than agent slugs with a common prefix; this
+    // matches production data, which is what the hash actually has
+    // to spread.
     const seeds = [
-      "agent-kael",
-      "agent-design",
-      "agent-marketing",
-      "agent-research",
-      "agent-support",
-      "agent-platform",
-      "agent-zeta",
-      "agent-omega",
+      "019e20a6-287b-71f7-b9ba-cb954e7fa144",
+      "019e3f12-91ac-7891-92e1-d2b3f5a8c192",
+      "019e5b78-12cd-7456-a7d4-e6f2c91b3856",
+      "019e7d92-45f1-7c23-8b9e-f1a4d5e89321",
+      "019ea1b3-78de-7e45-9c12-3b6d2f7a4c98",
+      "019ec5d4-aabb-7f67-bd34-5e8a9c1b2d65",
+      "019ee9f5-ccdd-7090-cf45-7a9b8d2c3e76",
+      "019f0d16-eeff-7211-e056-8c9bad3e4f87",
     ];
     const hues = new Set(seeds.map(pickAvatarHue));
-    expect(hues.size).toBeGreaterThan(1);
+    expect(hues.size).toBeGreaterThanOrEqual(4);
   });
 
-  it("empty seed falls back to the first palette entry without throwing", () => {
+  it("empty seed falls back to `--avatar-hue-0` without throwing", () => {
     expect(() => pickAvatarHue("")).not.toThrow();
-    expect(pickAvatarHue("")).toMatch(/^oklch\(/);
+    expect(pickAvatarHue("")).toBe("var(--avatar-hue-0)");
   });
 });
 

--- a/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildAvatarAriaLabel, formatUnreadLabel, pickCompositeShape } from "../chat-row-avatar.js";
+import { buildAvatarAriaLabel, formatUnreadLabel, pickAvatarHue, pickCompositeShape } from "../chat-row-avatar.js";
 
 /**
  * Pin the pure decision helpers exported by `ChatRowAvatar`. The
@@ -51,6 +51,44 @@ describe("formatUnreadLabel — badge text", () => {
   it(">=100 rolls over to '99+' so the badge stays width-stable", () => {
     expect(formatUnreadLabel(100)).toBe("99+");
     expect(formatUnreadLabel(9999)).toBe("99+");
+  });
+});
+
+describe("pickAvatarHue — deterministic per-agent fill color", () => {
+  it("returns an OkLCH string from the palette", () => {
+    const hue = pickAvatarHue("agent-1");
+    expect(hue).toMatch(/^oklch\(/);
+  });
+
+  it("same seed yields the same hue across calls (stable per agent)", () => {
+    // Pins the contract that powers consistent agent identity across
+    // direct chats, group composites, and page reloads.
+    const a = pickAvatarHue("019e20a6-287b-71f7-b9ba-cb954e7fa144");
+    const b = pickAvatarHue("019e20a6-287b-71f7-b9ba-cb954e7fa144");
+    expect(a).toBe(b);
+  });
+
+  it("different seeds reach more than one palette entry", () => {
+    // Sanity check that the palette is actually being used and the
+    // hash isn't degenerate. A handful of UUIDs should land on at
+    // least 2 distinct hues.
+    const seeds = [
+      "agent-kael",
+      "agent-design",
+      "agent-marketing",
+      "agent-research",
+      "agent-support",
+      "agent-platform",
+      "agent-zeta",
+      "agent-omega",
+    ];
+    const hues = new Set(seeds.map(pickAvatarHue));
+    expect(hues.size).toBeGreaterThan(1);
+  });
+
+  it("empty seed falls back to the first palette entry without throwing", () => {
+    expect(() => pickAvatarHue("")).not.toThrow();
+    expect(pickAvatarHue("")).toMatch(/^oklch\(/);
   });
 });
 

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -39,6 +39,43 @@ function initial(s: string): string {
 }
 
 /**
+ * Per-agent fill colors. Eight perceptually-distinct hues at the same
+ * OkLCH lightness/chroma so every avatar reads with the same visual
+ * weight. White-ish text (handled by the rendering site via
+ * `var(--bg-raised)` in light mode) carries enough contrast against
+ * every entry; same palette works light + dark because OkLCH stays
+ * perceptually stable across themes.
+ */
+const AVATAR_HUES: ReadonlyArray<string> = [
+  "oklch(0.66 0.16 150)", // green (kept first so the default-fallback hash collision still looks neutral)
+  "oklch(0.62 0.17 250)", // blue
+  "oklch(0.6 0.18 295)", // purple
+  "oklch(0.65 0.2 0)", // pink
+  "oklch(0.68 0.16 50)", // orange
+  "oklch(0.65 0.13 200)", // teal
+  "oklch(0.72 0.15 90)", // amber
+  "oklch(0.55 0.17 270)", // indigo
+];
+
+/**
+ * Hash a stable seed (usually an agent's UUID; falls back to display
+ * name if the UUID isn't around) into a fixed entry from `AVATAR_HUES`.
+ * Same agent → same hue across direct chats, group composites, and
+ * page reloads. Cheap djb2 variant; no allocations.
+ *
+ * Exported for unit testing the deterministic-mapping contract.
+ */
+export function pickAvatarHue(seed: string): string {
+  if (seed.length === 0) return AVATAR_HUES[0] ?? "oklch(0.66 0.16 150)";
+  let hash = 5381;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 33) ^ seed.charCodeAt(i);
+  }
+  const idx = Math.abs(hash) % AVATAR_HUES.length;
+  return AVATAR_HUES[idx] ?? AVATAR_HUES[0] ?? "oklch(0.66 0.16 150)";
+}
+
+/**
  * Composite-avatar layout key, exported for unit testing the branch
  * decisions without rendering to a DOM. `"single"` is reserved for the
  * non-composite path (1 peer or direct chats); `"n2"` / `"n3"` / `"n4"`
@@ -125,7 +162,7 @@ export function ChatRowAvatar({
       }}
     >
       {isDirect || peers.length <= 1 ? (
-        <SingleAvatar size={size} name={peer?.displayName ?? title} />
+        <SingleAvatar size={size} name={peer?.displayName ?? title} hueSeed={peer?.agentId ?? title} />
       ) : (
         <CompositeAvatar size={size} peers={peers} />
       )}
@@ -135,7 +172,7 @@ export function ChatRowAvatar({
   );
 }
 
-function SingleAvatar({ size, name }: { size: number; name: string }) {
+function SingleAvatar({ size, name, hueSeed }: { size: number; name: string; hueSeed: string }) {
   return (
     <span
       aria-hidden="true"
@@ -143,8 +180,8 @@ function SingleAvatar({ size, name }: { size: number; name: string }) {
         width: size,
         height: size,
         borderRadius: "50%",
-        background: "var(--accent)",
-        color: "var(--bg-raised)",
+        background: pickAvatarHue(hueSeed),
+        color: "oklch(0.985 0 0)",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -195,30 +232,35 @@ function CompositeAvatar({ size, peers }: { size: number; peers: ReadonlyArray<P
     >
       {shape === "n2" && (
         <>
-          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[0]?.displayName ?? "?"} hueSeed={peers[0]?.agentId ?? "0"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} hueSeed={peers[1]?.agentId ?? "1"} fontSize={fontSize} />
         </>
       )}
       {shape === "n3" && (
         <>
-          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSizeTop} fullWidth />
-          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg
+            name={peers[0]?.displayName ?? "?"}
+            hueSeed={peers[0]?.agentId ?? "0"}
+            fontSize={fontSizeTop}
+            fullWidth
+          />
+          <Seg name={peers[1]?.displayName ?? "?"} hueSeed={peers[1]?.agentId ?? "1"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} hueSeed={peers[2]?.agentId ?? "2"} fontSize={fontSize} />
         </>
       )}
       {shape === "n4" && (
         <>
-          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[3]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[0]?.displayName ?? "?"} hueSeed={peers[0]?.agentId ?? "0"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} hueSeed={peers[1]?.agentId ?? "1"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} hueSeed={peers[2]?.agentId ?? "2"} fontSize={fontSize} />
+          <Seg name={peers[3]?.displayName ?? "?"} hueSeed={peers[3]?.agentId ?? "3"} fontSize={fontSize} />
         </>
       )}
       {shape === "n5+" && (
         <>
-          <Seg name={peers[0]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[1]?.displayName ?? "?"} fontSize={fontSize} />
-          <Seg name={peers[2]?.displayName ?? "?"} fontSize={fontSize} />
+          <Seg name={peers[0]?.displayName ?? "?"} hueSeed={peers[0]?.agentId ?? "0"} fontSize={fontSize} />
+          <Seg name={peers[1]?.displayName ?? "?"} hueSeed={peers[1]?.agentId ?? "1"} fontSize={fontSize} />
+          <Seg name={peers[2]?.displayName ?? "?"} hueSeed={peers[2]?.agentId ?? "2"} fontSize={fontSize} />
           <SegMore count={n - 3} fontSize={fontSizeMore} />
         </>
       )}
@@ -226,15 +268,25 @@ function CompositeAvatar({ size, peers }: { size: number; peers: ReadonlyArray<P
   );
 }
 
-function Seg({ name, fontSize, fullWidth }: { name: string; fontSize: number; fullWidth?: boolean }) {
+function Seg({
+  name,
+  hueSeed,
+  fontSize,
+  fullWidth,
+}: {
+  name: string;
+  hueSeed: string;
+  fontSize: number;
+  fullWidth?: boolean;
+}) {
   return (
     <span
       style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "var(--accent)",
-        color: "var(--bg-raised)",
+        background: pickAvatarHue(hueSeed),
+        color: "oklch(0.985 0 0)",
         fontSize,
         fontWeight: 700,
         lineHeight: 1,
@@ -308,7 +360,7 @@ function UnreadBadge({ count }: { count: number }) {
         padding: "0 var(--sp-1)",
         borderRadius: "var(--sp-2)",
         background: "var(--state-error)",
-        color: "var(--bg-raised)",
+        color: "oklch(0.985 0 0)",
         fontSize: "var(--text-caption)",
         fontWeight: 700,
         lineHeight: "var(--sp-4)",

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -39,40 +39,36 @@ function initial(s: string): string {
 }
 
 /**
- * Per-agent fill colors. Eight perceptually-distinct hues at the same
- * OkLCH lightness/chroma so every avatar reads with the same visual
- * weight. White-ish text (handled by the rendering site via
- * `var(--bg-raised)` in light mode) carries enough contrast against
- * every entry; same palette works light + dark because OkLCH stays
- * perceptually stable across themes.
+ * Per-agent fill colors. References to the `--avatar-hue-0..7` tokens
+ * defined in `index.css`; this file holds the *selection* logic, not
+ * the colors themselves. Add or restyle hues in index.css.
+ *
+ * Initials are painted on top in `--fg-on-vivid` (a near-white token,
+ * also in index.css) so contrast holds in both themes without relying
+ * on `--bg-raised`, which inverts under `.dark`.
  */
-const AVATAR_HUES: ReadonlyArray<string> = [
-  "oklch(0.66 0.16 150)", // green (kept first so the default-fallback hash collision still looks neutral)
-  "oklch(0.62 0.17 250)", // blue
-  "oklch(0.6 0.18 295)", // purple
-  "oklch(0.65 0.2 0)", // pink
-  "oklch(0.68 0.16 50)", // orange
-  "oklch(0.65 0.13 200)", // teal
-  "oklch(0.72 0.15 90)", // amber
-  "oklch(0.55 0.17 270)", // indigo
-];
+const AVATAR_HUE_COUNT = 8;
+
+const FALLBACK_HUE = "var(--avatar-hue-0)";
 
 /**
  * Hash a stable seed (usually an agent's UUID; falls back to display
- * name if the UUID isn't around) into a fixed entry from `AVATAR_HUES`.
- * Same agent → same hue across direct chats, group composites, and
- * page reloads. Cheap djb2 variant; no allocations.
+ * name if the UUID isn't around) into a fixed entry from the
+ * `--avatar-hue-*` palette. Same agent → same hue across direct chats,
+ * group composites, and page reloads. Cheap djb2 variant; no
+ * allocations.
  *
- * Exported for unit testing the deterministic-mapping contract.
+ * Empty seed lands on `--avatar-hue-0` deterministically. Exported
+ * for unit testing the deterministic-mapping contract.
  */
 export function pickAvatarHue(seed: string): string {
-  if (seed.length === 0) return AVATAR_HUES[0] ?? "oklch(0.66 0.16 150)";
+  if (seed.length === 0) return FALLBACK_HUE;
   let hash = 5381;
   for (let i = 0; i < seed.length; i++) {
     hash = (hash * 33) ^ seed.charCodeAt(i);
   }
-  const idx = Math.abs(hash) % AVATAR_HUES.length;
-  return AVATAR_HUES[idx] ?? AVATAR_HUES[0] ?? "oklch(0.66 0.16 150)";
+  const idx = Math.abs(hash) % AVATAR_HUE_COUNT;
+  return `var(--avatar-hue-${idx})`;
 }
 
 /**
@@ -181,7 +177,7 @@ function SingleAvatar({ size, name, hueSeed }: { size: number; name: string; hue
         height: size,
         borderRadius: "50%",
         background: pickAvatarHue(hueSeed),
-        color: "oklch(0.985 0 0)",
+        color: "var(--fg-on-vivid)",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -286,7 +282,7 @@ function Seg({
         alignItems: "center",
         justifyContent: "center",
         background: pickAvatarHue(hueSeed),
-        color: "oklch(0.985 0 0)",
+        color: "var(--fg-on-vivid)",
         fontSize,
         fontWeight: 700,
         lineHeight: 1,
@@ -360,7 +356,7 @@ function UnreadBadge({ count }: { count: number }) {
         padding: "0 var(--sp-1)",
         borderRadius: "var(--sp-2)",
         background: "var(--state-error)",
-        color: "oklch(0.985 0 0)",
+        color: "var(--fg-on-vivid)",
         fontSize: "var(--text-caption)",
         fontWeight: 700,
         lineHeight: "var(--sp-4)",

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -246,6 +246,28 @@
   --warn: oklch(0.82 0.18 75);
   --danger: oklch(0.68 0.22 25);
 
+  /* Near-white text for content rendered on top of a vivid colored
+     surface (state-error badges, hashed-hue avatars, etc). Stable in
+     both themes — these surfaces don't track --fg, which inverts
+     under .dark and would yield dark-on-color in dark mode. */
+  --fg-on-vivid: oklch(0.985 0 0);
+
+  /* Per-agent avatar palette. Eight perceptually-balanced OkLCH hues
+     at matched lightness/chroma so every avatar reads with the same
+     visual weight. Consumed via `pickAvatarHue(agentId)` in
+     `components/chat/chat-row-avatar.tsx` — same agent → same hue
+     across direct chats and group composites. White-ish initials
+     (`--fg-on-vivid`) clear WCAG AA against every entry in both
+     themes. Add new entries in this block, not at the call site. */
+  --avatar-hue-0: oklch(0.66 0.16 150); /* green (also the empty-seed fallback) */
+  --avatar-hue-1: oklch(0.62 0.17 250); /* blue */
+  --avatar-hue-2: oklch(0.6 0.18 295); /* purple */
+  --avatar-hue-3: oklch(0.65 0.2 0); /* pink */
+  --avatar-hue-4: oklch(0.68 0.16 50); /* orange */
+  --avatar-hue-5: oklch(0.65 0.13 200); /* teal */
+  --avatar-hue-6: oklch(0.72 0.15 90); /* amber */
+  --avatar-hue-7: oklch(0.55 0.17 270); /* indigo */
+
   --radius: 0.5rem;
 
   /* Light theme (default when .dark class is absent) */

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -1,4 +1,5 @@
 import type { MeChatRow } from "@agent-team-foundation/first-tree-hub-shared";
+import { useEffect } from "react";
 import { ChatRowAvatar } from "../components/chat/chat-row-avatar.js";
 
 /**
@@ -171,9 +172,15 @@ export function ChatRowAvatarPreviewPage() {
   const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
   const freeze = params.get("freeze") === "1";
   const themeOverride = params.get("theme");
-  if (typeof document !== "undefined" && (themeOverride === "light" || themeOverride === "dark")) {
-    document.documentElement.classList.toggle("dark", themeOverride === "dark");
-  }
+  useEffect(() => {
+    // Push the `?theme=` override into `documentElement` so the page
+    // matches the param even when `localStorage.theme` says otherwise.
+    // Kept in an effect (not in render) so Strict Mode double-invokes
+    // and SSR don't trip the side effect.
+    if (themeOverride === "light" || themeOverride === "dark") {
+      document.documentElement.classList.toggle("dark", themeOverride === "dark");
+    }
+  }, [themeOverride]);
   return (
     <div
       className={freeze ? "chat-row-avatar-preview--freeze" : undefined}

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -1,0 +1,333 @@
+import type { MeChatRow } from "@agent-team-foundation/first-tree-hub-shared";
+import { ChatRowAvatar } from "../components/chat/chat-row-avatar.js";
+
+/**
+ * DEV-only visual review for `ChatRowAvatar` + the surrounding row layout.
+ *
+ * Mounted outside `<Layout>` so it needs no auth / no react-router context —
+ * mirrors the `/preview/context` page (see `context-preview.tsx`). Each
+ * variant gets a real `MeChatRow`-shaped fixture and the production
+ * `ChatRowAvatar` component is rendered against it; the surrounding
+ * `<button>` mimics the actual conversation-list row's DOM so spacing,
+ * typography, and the row's text-stack alignment are faithful to prod.
+ *
+ * Used to generate the static screenshots that ship with the chat-status-
+ * icons design preview. Do NOT ship in prod — gated by `import.meta.env.DEV`
+ * in `app.tsx`.
+ */
+
+const SELF_ID = "self-uuid";
+
+function row(overrides: Partial<MeChatRow>): MeChatRow {
+  return {
+    chatId: overrides.chatId ?? "preview",
+    type: overrides.type ?? "direct",
+    membershipKind: overrides.membershipKind ?? "participant",
+    title: overrides.title ?? "preview",
+    topic: overrides.topic ?? null,
+    participants: overrides.participants ?? [],
+    participantCount: overrides.participantCount ?? overrides.participants?.length ?? 0,
+    lastMessageAt: overrides.lastMessageAt ?? new Date().toISOString(),
+    lastMessagePreview: overrides.lastMessagePreview ?? null,
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    workingAgentIds: overrides.workingAgentIds ?? [],
+  };
+}
+
+function participant(name: string, agentId?: string): MeChatRow["participants"][number] {
+  return { agentId: agentId ?? `agent-${name.toLowerCase()}`, displayName: name, type: "autonomous_agent" };
+}
+
+const KAEL = participant("kael", "agent-kael");
+const DESIGN = participant("design-critique", "agent-design");
+const MARKET = participant("marketing-writer", "agent-market");
+const RES = participant("research", "agent-res");
+const SUPP = participant("support", "agent-supp");
+const ARCH = participant("architect", "agent-arch");
+const PLAT = participant("platform", "agent-plat");
+
+const VARIANTS: Array<{ name: string; row: MeChatRow; subtitle?: string }> = [
+  // ─── direct / single avatar ──────────────────────────────────────────────
+  {
+    name: "1-on-1 · idle",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      lastMessagePreview: "Will pick this up after lunch.",
+    }),
+  },
+  {
+    name: "1-on-1 · working ring",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      workingAgentIds: [KAEL.agentId],
+      lastMessagePreview: "Analyzing logs from the last 24h…",
+    }),
+  },
+  {
+    name: "1-on-1 · unread(1)",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      unreadMentionCount: 1,
+      lastMessagePreview: "Done — see PR 422.",
+    }),
+  },
+  {
+    name: "1-on-1 · unread(12)",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      unreadMentionCount: 12,
+      lastMessagePreview: "Lots of context for you.",
+    }),
+  },
+  {
+    name: "1-on-1 · unread(99+)",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      unreadMentionCount: 137,
+      lastMessagePreview: "Daily digest backlog…",
+    }),
+  },
+  {
+    name: "1-on-1 · working + unread(3)",
+    row: row({
+      title: "kael",
+      participants: [KAEL],
+      workingAgentIds: [KAEL.agentId],
+      unreadMentionCount: 3,
+      lastMessagePreview: "Pulling the next batch now.",
+    }),
+  },
+  {
+    name: "1-on-1 · watcher (read-only)",
+    row: row({
+      title: "marketing-writer",
+      participants: [MARKET],
+      membershipKind: "watching",
+      canReply: false,
+      lastMessagePreview: "Watching · weekly digest landed",
+    }),
+  },
+  // ─── group / composite avatar ────────────────────────────────────────────
+  {
+    name: "Group n=2",
+    row: row({
+      type: "group",
+      title: "Q2 hero copy",
+      participants: [KAEL, DESIGN],
+      lastMessagePreview: "Kael: Two variants up for review.",
+    }),
+  },
+  {
+    name: "Group n=3 (T-split)",
+    row: row({
+      type: "group",
+      title: "platform-trio",
+      participants: [KAEL, DESIGN, MARKET],
+      unreadMentionCount: 2,
+      lastMessagePreview: "design-critique: spacing nudge on the hero",
+    }),
+  },
+  {
+    name: "Group n=4 (all visible)",
+    row: row({
+      type: "group",
+      title: "research squad",
+      participants: [KAEL, DESIGN, MARKET, RES],
+      lastMessagePreview: "research: 12 papers summarized this week",
+    }),
+  },
+  {
+    name: "Group n=5 (+2 overflow)",
+    row: row({
+      type: "group",
+      title: "platform-design",
+      participants: [PLAT, ARCH, SUPP, KAEL, DESIGN],
+      lastMessagePreview: "platform: shipped the new tokens spec",
+    }),
+  },
+  {
+    name: "Group n=10 (+7 overflow)",
+    row: row({
+      type: "group",
+      title: "all-hands",
+      participants: [KAEL, DESIGN, MARKET, RES, SUPP, ARCH, PLAT, KAEL, DESIGN, MARKET],
+      unreadMentionCount: 4,
+      lastMessagePreview: "all-hands kickoff in 5 minutes",
+    }),
+  },
+];
+
+export function ChatRowAvatarPreviewPage() {
+  // `?freeze=1` pins the working ring at peak opacity so static
+  // screenshots aren't caught mid-breath. The class is read by the
+  // override rule at the bottom of this file.
+  const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
+  const freeze = params.get("freeze") === "1";
+  const themeOverride = params.get("theme");
+  if (typeof document !== "undefined" && (themeOverride === "light" || themeOverride === "dark")) {
+    document.documentElement.classList.toggle("dark", themeOverride === "dark");
+  }
+  return (
+    <div
+      className={freeze ? "chat-row-avatar-preview--freeze" : undefined}
+      style={{ background: "var(--bg)", minHeight: "100vh", padding: "var(--sp-6)" }}
+    >
+      <div style={{ maxWidth: 980, margin: "0 auto" }}>
+        <header style={{ marginBottom: "var(--sp-6)" }}>
+          <h1 className="text-title" style={{ color: "var(--fg)", marginBottom: "var(--sp-1)" }}>
+            Chat Row Avatar · Visual Preview
+          </h1>
+          <p className="text-body" style={{ color: "var(--fg-3)" }}>
+            DEV-only fixture covering every documented variant of the new conversation-list avatar slot. Toggle theme
+            via the moon/sun in the corner.
+          </p>
+        </header>
+
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--sp-4)",
+            gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+          }}
+        >
+          {VARIANTS.map((v) => (
+            <PreviewCard key={v.name} name={v.name} row={v.row} />
+          ))}
+        </div>
+
+        <ThemeToggleCorner />
+
+        <style>{`
+        .chat-row-avatar-preview--freeze .chat-row-avatar__working-ring {
+          animation: none !important;
+          opacity: 1 !important;
+        }
+      `}</style>
+      </div>
+    </div>
+  );
+}
+
+function PreviewCard({ name, row }: { name: string; row: MeChatRow }) {
+  const hasUnread = row.unreadMentionCount > 0;
+  return (
+    <div
+      style={{
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        className="text-caption mono"
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          color: "var(--fg-4)",
+          background: "var(--bg-sunken)",
+          borderBottom: "var(--hairline) solid var(--border-faint)",
+        }}
+      >
+        {name}
+      </div>
+
+      {/* Mimic the production conversation-list row geometry verbatim. */}
+      <button
+        type="button"
+        className="w-full text-left flex items-center"
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          gap: "var(--sp-2_5)",
+          background: "transparent",
+          borderLeft: "var(--hairline-bold) solid transparent",
+          width: 320,
+        }}
+      >
+        <ChatRowAvatar
+          title={row.title}
+          type={row.type}
+          participants={row.participants}
+          selfAgentId={SELF_ID}
+          workingAgentIds={row.workingAgentIds}
+          unreadCount={row.unreadMentionCount}
+        />
+        <div className="flex flex-col" style={{ flex: 1, minWidth: 0 }}>
+          <div className="flex items-baseline" style={{ gap: 6 }}>
+            <span
+              className="truncate text-subtitle"
+              style={{
+                color: hasUnread ? "var(--fg)" : "var(--fg-2)",
+                fontWeight: hasUnread ? 700 : 500,
+                flex: 1,
+                minWidth: 0,
+              }}
+            >
+              {row.title}
+            </span>
+            <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
+              now
+            </span>
+          </div>
+          <div
+            className="truncate text-body"
+            style={{
+              color: hasUnread ? "var(--fg-2)" : "var(--fg-3)",
+              marginTop: 2,
+            }}
+          >
+            {row.lastMessagePreview ?? "—"}
+          </div>
+        </div>
+      </button>
+    </div>
+  );
+}
+
+function ThemeToggleCorner() {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: "var(--sp-4)",
+        right: "var(--sp-4)",
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        padding: "var(--sp-1_5) var(--sp-2_5)",
+        boxShadow: "var(--shadow-md)",
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--sp-2)",
+      }}
+    >
+      <span className="text-label mono" style={{ color: "var(--fg-3)" }}>
+        theme
+      </span>
+      <button
+        type="button"
+        className="text-caption mono"
+        onClick={() => {
+          document.documentElement.classList.toggle("dark");
+          window.localStorage.setItem("theme", document.documentElement.classList.contains("dark") ? "dark" : "light");
+        }}
+        style={{
+          padding: "var(--sp-1) var(--sp-2)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          background: "var(--bg-hover)",
+          color: "var(--fg-2)",
+          cursor: "pointer",
+        }}
+      >
+        toggle
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Conversation-list avatars previously all painted with the brand accent — a vertical strip of identical green discs that made groups lose their per-member distinction and made 1-on-1 rows hard to scan. Discovered during the e2e visual review of #367. This PR introduces a hashed-per-agent hue palette so each avatar reads as that agent's identity.

Also lands a DEV-only \`/preview/chat-row-avatar\` route that mounts every documented variant in a single grid — useful for future visual review iterations.

**Zero schema. Zero API change.** All deltas are inside \`packages/web\`.

## Visual delta

| Before | After |
|---|---|
| All avatars \`var(--accent)\` green; groups indistinguishable | 8-hue OkLCH palette, stable per agent UUID; group composites carry real per-member color |
| Initials \`var(--bg-raised)\` → dark text on color in dark theme (poor contrast against several palette entries) | Initials fixed at \`oklch(0.985 0 0)\` near-white, passes WCAG AA against every hue in both themes |

Screenshots are in the local e2e review HTML (\`chat-list-e2e-review.html\` in the parent workspace, including v1 vs v2 side-by-side).

## Changes

| File | Change |
|---|---|
| \`packages/web/src/components/chat/chat-row-avatar.tsx\` | New \`AVATAR_HUES\` (8 OkLCH entries) + \`pickAvatarHue(seed)\` djb2-style hash. \`SingleAvatar\` / \`Seg\` consume the new bg; text colour hardened to near-white. Same hardening on \`UnreadBadge\` text. |
| \`packages/web/src/components/chat/__tests__/chat-row-avatar.test.ts\` | 4 new invariants for \`pickAvatarHue\` (OkLCH output, determinism, hue diversity across distinct seeds, empty-seed fallback). |
| \`packages/web/src/pages/chat-row-avatar-preview.tsx\` | DEV-only route. Renders \`ChatRowAvatar\` against 12 fixtures (1-on-1 idle/working/unread variants, watcher, group n=2/3/4/5+/10+). Mirrors the \`/preview/context\` pattern; gated by \`import.meta.env.DEV\`. Supports \`?theme=light|dark\` and \`?freeze=1\` for screenshot capture. |
| \`packages/web/src/app.tsx\` | Wires the preview route into the router (same lazy DEV-only pattern as ContextPreviewPage). |

## What is **not** changed (deliberate)

- **No schema migration, no API change.** Hue is derived client-side from the agent UUID already present in \`MeChatRow.participants\`.
- **No version bump** for \`packages/command\` — web-only.
- **Offline grayscale / error ring not implemented in this PR.** The original spec described both, but the data they need (\`agent_presence.client_id IS NULL\`, \`runtime_state === 'error'\`) isn't on \`MeChatRow\`. Adding them is a follow-up that mirrors the workingAgentIds approach (#366). Flagged transparently in the e2e review notes.

## Test plan

- [x] \`pnpm check\` clean
- [x] \`pnpm typecheck\` clean (including \`lint:tokens\`)
- [x] \`pnpm --filter @first-tree-hub/web test\` — **12 files / 107 tests** pass, including 4 new pickAvatarHue invariants
- [x] e2e dev verification: docker postgres + dev server + SQL-seeded 6 agents × 7 chats. Real \`ConversationList\` renders distinct hues per agent; v1 vs v2 comparison captured in local review HTML.