### PR TITLE
feat(web): Step 2 visibility sub-step + personalized default name + toast copy

### DIFF
--- a/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step2-body.tsx
@@ -1,10 +1,11 @@
-import type { ClientCapabilities, OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
+import type { AgentVisibility, ClientCapabilities, OrgBrief } from "@agent-team-foundation/first-tree-hub-shared";
 import { ArrowRight, Check, Copy } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { getClientCapabilities, type HubClient, listClients } from "../../../../api/activity.js";
 import { api, withOrg } from "../../../../api/client.js";
 import { reportOnboardingEvent } from "../../../../api/onboarding-events.js";
+import { useAuth } from "../../../../auth/auth-context.js";
 import { Button } from "../../../../components/ui/button.js";
 import { slugify } from "../../../../utils/agent-naming.js";
 import {
@@ -40,6 +41,7 @@ export function Step2Body({
   refreshMe: () => Promise<void>;
 }) {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const draftScope = onboardingDraftScope(organizationId, memberId);
   const initialDraft = readOnboardingDraft(draftScope);
   const initialConnectToken =
@@ -48,12 +50,22 @@ export function Step2Body({
       : null;
   const initialConnectTokenExpiresAt = initialConnectToken ? (initialDraft?.connectTokenExpiresAt ?? null) : null;
 
-  // Default agent name: "Assistant" — neutral on capability domain, since
-  // Step 2 just brings a personal agent online (Step 3 is where the team's
-  // context-tree gets built). User can rename in the input or via agent
-  // settings later. The draft override wins so we don't clobber a name
-  // a returning user already typed.
-  const [displayName, setDisplayName] = useState(() => initialDraft?.displayName ?? "Assistant");
+  // Default agent name: `${login}'s assistant` — mirrors the `${login}'s team`
+  // idiom already used at OAuth bootstrap (see auth/github.ts). Personalizing
+  // by login avoids "Assistant" colliding across teammates and keeps the
+  // first agent's name visibly tied to its owner. Falls back to "Assistant"
+  // for the edge case where /me hasn't loaded yet. The draft override wins
+  // so we don't clobber a name a returning user already typed.
+  const [displayName, setDisplayName] = useState(
+    () => initialDraft?.displayName ?? (user?.username ? `${user.username}'s assistant` : "Assistant"),
+  );
+  // Default visibility: "organization" (Shared with team). Aligns with the
+  // product's agent-team collaboration framing — a teammate's onboarding
+  // agent should be reachable by the rest of the org by default. The
+  // standalone NewAgentDialog keeps its own "private" default (different
+  // product decision: dialog is also used by power users creating personal
+  // throwaways), so we do NOT touch that surface.
+  const [visibility, setVisibility] = useState<AgentVisibility>(() => initialDraft?.visibility ?? "organization");
   const [selectedRuntime, setSelectedRuntime] = useState<string | null>(() => initialDraft?.selectedRuntime ?? null);
   const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
   const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
@@ -81,8 +93,9 @@ export function Step2Body({
       selectedRuntime,
       connectToken,
       connectTokenExpiresAt,
+      visibility,
     });
-  }, [draftScope, displayName, selectedRuntime, connectToken, connectTokenExpiresAt]);
+  }, [draftScope, displayName, selectedRuntime, connectToken, connectTokenExpiresAt, visibility]);
 
   useEffect(() => {
     void (async () => {
@@ -269,6 +282,12 @@ export function Step2Body({
         ...(slug ? { name: slug } : {}),
         clientId: connectedClient.id,
         runtimeProvider: selectedRuntime,
+        // Explicit pass — the server's `defaultVisibility(personal_assistant)`
+        // returns "private" (kept that way intentionally), but onboarding
+        // defaults to "organization" (the agent-team framing). Sending the
+        // chosen value avoids any reliance on server defaults that would
+        // diverge from the radio's visible selection.
+        visibility,
         ...(organizationId ? { organizationId } : {}),
       });
       agentUuid = res.uuid;
@@ -287,7 +306,7 @@ export function Step2Body({
     }
 
     await pollUntilReady(agentUuid);
-  }, [trimmedName, connectedClient, selectedRuntime, pollUntilReady, organizationId]);
+  }, [trimmedName, connectedClient, selectedRuntime, visibility, pollUntilReady, organizationId]);
 
   const handleRetry = useCallback(async () => {
     const agentUuid = createdAgentRef.current;
@@ -324,6 +343,8 @@ export function Step2Body({
       okRuntimes={okRuntimes}
       selectedRuntime={selectedRuntime}
       setSelectedRuntime={setSelectedRuntime}
+      visibility={visibility}
+      setVisibility={setVisibility}
       error={error}
       canCreate={canCreate}
       onCreate={handleCreate}
@@ -351,6 +372,8 @@ function Step2FormBody({
   okRuntimes,
   selectedRuntime,
   setSelectedRuntime,
+  visibility,
+  setVisibility,
   error,
   canCreate,
   onCreate,
@@ -366,12 +389,16 @@ function Step2FormBody({
   okRuntimes: string[];
   selectedRuntime: string | null;
   setSelectedRuntime: (next: string | null) => void;
+  visibility: AgentVisibility;
+  setVisibility: (next: AgentVisibility) => void;
   error: string | null;
   canCreate: boolean;
   onCreate: () => void;
 }) {
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const inviteHasTeam = joinPath === "invite" && teamName;
+  const computerReady =
+    !!connectedClient && !!selectedRuntime && capabilitiesLoaded && okRuntimes.includes(selectedRuntime);
 
   const noRuntime = capabilitiesLoaded && okRuntimes.length === 0 && !!connectedClient;
   const nextStepText = !trimmedName
@@ -398,10 +425,10 @@ function Step2FormBody({
             <span className="font-semibold" style={{ color: "var(--fg-2)" }}>
               {teamName}
             </span>
-            . Set up your first agent — it&apos;ll run on a computer you connect.
+            . Let&apos;s set up your first agent.
           </>
         ) : (
-          <>Set up your first agent — it&apos;ll run on a computer you connect.</>
+          <>Let&apos;s set up your first agent.</>
         )}
       </p>
 
@@ -451,7 +478,7 @@ function Step2FormBody({
           </div>
         </StepFrame>
 
-        <StepFrame number="02" state={canCreate ? "complete" : trimmedName ? "active" : "idle"}>
+        <StepFrame number="02" state={computerReady ? "complete" : trimmedName ? "active" : "idle"}>
           <div style={{ animation: trimmedName ? "subtle-fade 200ms ease-out" : undefined }}>
             <h2
               className="text-subtitle font-semibold"
@@ -494,6 +521,22 @@ function Step2FormBody({
                 )}
               </>
             ) : null}
+          </div>
+        </StepFrame>
+
+        <StepFrame number="03" state={computerReady ? "active" : "idle"}>
+          <div style={{ animation: computerReady ? "subtle-fade 200ms ease-out" : undefined }}>
+            <h2
+              className="text-subtitle font-semibold"
+              style={{
+                color: computerReady ? "var(--fg)" : "var(--fg-4)",
+                fontWeight: computerReady ? 600 : 500,
+              }}
+            >
+              Pick who can use it
+            </h2>
+
+            {computerReady ? <VisibilityPicker value={visibility} onChange={setVisibility} /> : null}
           </div>
         </StepFrame>
       </div>
@@ -738,6 +781,113 @@ function RuntimeChips({
         })}
       </fieldset>
     </div>
+  );
+}
+
+/**
+ * Visibility radio for Step 2 — "Shared with team" vs "Private to you".
+ * Copy is intentionally identical to NewAgentDialog (`new-agent-dialog.tsx`)
+ * so the two surfaces describe the same product semantics with the same
+ * words; only the default differs (onboarding defaults to "organization"
+ * to lean into the agent-team framing; the dialog defaults to "private").
+ *
+ * Visual: card-style labels with an accent border + tinted background on
+ * the active option — matches the multi-repo checkbox cards in
+ * InviteeConfirmBody so the onboarding flow stays stylistically coherent.
+ * Intentionally NOT a shared component (per spec) — the dialog uses
+ * Tailwind utility classes while onboarding uses inline CSS-variable
+ * styles, and forcing them through one component would muddy both.
+ *
+ * No "(default)" label on either option: radio selected-state already
+ * conveys which one is picked, so the suffix is redundant noise.
+ */
+function VisibilityPicker({ value, onChange }: { value: AgentVisibility; onChange: (next: AgentVisibility) => void }) {
+  const options: ReadonlyArray<{
+    value: AgentVisibility;
+    title: string;
+    description: string;
+  }> = [
+    {
+      value: "organization",
+      title: "Shared with team",
+      description: "Anyone in your org can @mention and chat with this agent.",
+    },
+    {
+      value: "private",
+      title: "Private to you",
+      description: "Only you can see this agent and chat with it. Others on the team won't see it listed.",
+    },
+  ];
+  return (
+    <fieldset
+      className="flex flex-col"
+      style={{ gap: "var(--sp-2)", margin: "var(--sp-2) 0 0", padding: 0, border: 0 }}
+    >
+      <legend className="sr-only">Agent visibility</legend>
+      {options.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <label
+            key={opt.value}
+            className="text-body"
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: "var(--sp-2)",
+              padding: "var(--sp-2) var(--sp-3)",
+              background: active ? "color-mix(in oklch, var(--accent) 8%, var(--bg))" : "var(--bg)",
+              border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-faint)",
+              borderRadius: "var(--radius-input)",
+              cursor: "pointer",
+              color: active ? "var(--fg)" : "var(--fg-2)",
+              transition: "background 120ms ease, border-color 120ms ease",
+            }}
+          >
+            <input
+              type="radio"
+              name="onboarding-visibility"
+              value={opt.value}
+              checked={active}
+              onChange={() => onChange(opt.value)}
+              className="sr-only"
+            />
+            <span
+              aria-hidden="true"
+              className="inline-flex items-center justify-center"
+              style={{
+                width: "var(--sp-3_5)",
+                height: "var(--sp-3_5)",
+                marginTop: "var(--sp-0_5)",
+                borderRadius: "50%",
+                border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-strong)",
+                background: active ? "color-mix(in oklch, var(--accent) 8%, transparent)" : "transparent",
+                flexShrink: 0,
+                transition: "border-color 160ms ease, background 160ms ease",
+              }}
+            >
+              {active && (
+                <span
+                  style={{
+                    width: "var(--sp-1_5)",
+                    height: "var(--sp-1_5)",
+                    borderRadius: "50%",
+                    background: "var(--accent)",
+                  }}
+                />
+              )}
+            </span>
+            <span className="flex flex-col" style={{ gap: "var(--sp-0_5)", minWidth: 0 }}>
+              <span className="font-medium" style={{ color: active ? "var(--fg)" : "var(--fg-2)" }}>
+                {opt.title}
+              </span>
+              <span className="text-label" style={{ color: "var(--fg-3)" }}>
+                {opt.description}
+              </span>
+            </span>
+          </label>
+        );
+      })}
+    </fieldset>
   );
 }
 

--- a/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
+++ b/packages/web/src/pages/workspace/center/onboarding/step3-intro-body.tsx
@@ -859,11 +859,14 @@ async function resolveOnboardingAgent(): Promise<ManagedAgent> {
 }
 
 function buildSetupHiddenToast(navigate: ReturnType<typeof useNavigate>): ToastInput {
+  // Description must match the action label: previously pointed at a
+  // non-existent "Agent settings" tab, which was a dead end. The Settings
+  // surface that actually resumes Step 3 is Settings → Onboarding, so the
+  // action takes the user there and the copy says so.
   return {
     title: "Setup hidden",
-    description:
-      "Resume any time in Settings → Onboarding. Your agent isn't bound to a source repo yet — add one in Agent settings when ready.",
-    action: { label: "Open settings", onClick: () => navigate("/settings/onboarding") },
+    description: "Your agent isn't bound to a source repo yet. Resume from Settings → Onboarding any time to finish.",
+    action: { label: "Resume setup", onClick: () => navigate("/settings/onboarding") },
   };
 }
 

--- a/packages/web/src/utils/onboarding-flags.ts
+++ b/packages/web/src/utils/onboarding-flags.ts
@@ -9,6 +9,8 @@
  *   the user navigates between app tabs before creating their first agent.
  */
 
+import type { AgentVisibility } from "@agent-team-foundation/first-tree-hub-shared";
+
 const JOIN_PATH_KEY = "onboarding:joinPath";
 const DRAFT_KEY_PREFIX = "onboarding:draft";
 const STEP1_CONFIRMED_KEY = "onboarding:step1Confirmed";
@@ -55,6 +57,12 @@ export type OnboardingDraft = {
   selectedRuntime: string | null;
   connectToken: string | null;
   connectTokenExpiresAt: number | null;
+  /**
+   * Selected agent visibility for the Step 2 sub-step. `null` for drafts
+   * written before this field existed — readers should fall back to the
+   * step's own default ("organization") in that case.
+   */
+  visibility: AgentVisibility | null;
 };
 
 /**
@@ -100,11 +108,17 @@ function parseOnboardingDraft(value: unknown): OnboardingDraft | null {
   if (connectToken !== null && typeof connectToken !== "string") return null;
   const connectTokenExpiresAt = "connectTokenExpiresAt" in value ? value.connectTokenExpiresAt : null;
   if (connectTokenExpiresAt !== null && typeof connectTokenExpiresAt !== "number") return null;
+  // Tolerate drafts written before the visibility field existed: treat
+  // anything that isn't a known literal as `null`, never reject the whole
+  // draft. Step 2 falls back to its own default when this is null.
+  const rawVisibility = "visibility" in value ? value.visibility : null;
+  const visibility = rawVisibility === "private" || rawVisibility === "organization" ? rawVisibility : null;
   return {
     displayName: value.displayName,
     selectedRuntime,
     connectToken,
     connectTokenExpiresAt,
+    visibility,
   };
 }
 


### PR DESCRIPTION
## Summary
Three small onboarding UX improvements landed together.

- **Step 2 heading trim** — drop the "it'll run on a computer you connect" tail (StepFrame 02 already covers it). Invite path becomes _"You've joined {team}. Let's set up your first agent."_; solo path becomes _"Let's set up your first agent."_

- **Personalized default agent name** — `${login}'s assistant` instead of generic `Assistant`, matching the existing `${login}'s team` idiom at OAuth bootstrap and avoiding name collisions across teammates. Falls back to `Assistant` only if `user.username` is missing; the per-tab draft override still wins so a returning user's typed name is preserved.

- **New StepFrame 03 "Pick who can use it"** — two radio cards (Shared with team / Private to you), default **Shared with team** for the agent-team framing. Descriptions are verbatim copies from `NewAgentDialog`'s visibility options so both surfaces speak with one voice; no `(default)` suffix since the radio's selected state conveys that. Visibility is sent explicitly on `POST /agents` rather than relying on the server's `defaultVisibility(personal_assistant)` (still `private` — separate product decision).

- **Step 3 dismiss toast copy aligned** — previous description pointed at a non-existent "Agent settings" tab. Description now reads _"Your agent isn't bound to a source repo yet. Resume from Settings → Onboarding any time to finish."_ and the action label changes from _Open settings_ to _Resume setup_. Navigate target unchanged.

`OnboardingDraft` gains a `visibility` field so a tab switch doesn't reset the radio; the parser tolerates pre-existing drafts that lack the field.

`NewAgentDialog` is intentionally left alone — its `private` default and `(default)` label are a separate product decision for power users creating throwaway agents.

## Test plan
- [x] `pnpm --filter @first-tree-hub/web run typecheck` — clean
- [x] `pnpm exec biome check` on the three changed files — clean
- [x] `pnpm --filter @first-tree-hub/web run test` — 107/107 pass
- [ ] Solo onboarding: Step 2 heading reads _"Let's set up your first agent."_; default name input pre-fills as `${login}'s assistant`
- [ ] Invite onboarding: heading reads _"You've joined {team}. Let's set up your first agent."_
- [ ] Once a computer + runtime are detected, StepFrame 03 appears with **Shared with team** preselected; clicking _Private to you_ updates the active card border and persists across tab switches (sessionStorage draft)
- [ ] Click Create — `POST /agents` body contains `"visibility": "organization"` (or `"private"` if toggled); created agent appears in the org roster as expected for the chosen visibility
- [ ] Step 3 "I'll do it later" toast says _Resume setup_ and links to Settings → Onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)