### PR TITLE
feat(web): split admin Settings → Computers into Your / Team groups

### DIFF
--- a/packages/web/src/api/__tests__/with-org.test.ts
+++ b/packages/web/src/api/__tests__/with-org.test.ts
@@ -25,6 +25,10 @@ describe("withOrg / withOrgAt", () => {
       expect(withOrg("/agents?limit=100")).toBe("/orgs/org-x/agents?limit=100");
       expect(withOrg("/agents/names/foo/availability")).toBe("/orgs/org-x/agents/names/foo/availability");
       expect(withOrg("/adapters/status")).toBe("/orgs/org-x/adapters/status");
+      // `listOrgClients()` in api/activity.ts wraps `/clients` with `withOrg` —
+      // pin the resulting path here so a future rename of the helper or the
+      // route prefix can't silently break the Computers page's admin view.
+      expect(withOrg("/clients")).toBe("/orgs/org-x/clients");
     });
 
     it("throws if no org is selected (fail-loud, not silent 404)", () => {

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -58,6 +58,17 @@ export function listClients(): Promise<HubClient[]> {
   return api.get<HubClient[]>("/me/clients");
 }
 
+/**
+ * Admin-only listing of every client registered in the current organization.
+ * Used by the Computers page when the viewer is an admin so they can see
+ * teammates' computers alongside their own. The server endpoint already
+ * returns `userId` + `lastSeenAt`, which is what powers the client-side
+ * "Your computers" / "Team computers" split.
+ */
+export function listOrgClients(): Promise<HubClient[]> {
+  return api.get<HubClient[]>(withOrg("/clients"));
+}
+
 export function getClient(clientId: string): Promise<HubClient> {
   return api.get<HubClient>(`/clients/${clientId}`);
 }

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -5,7 +5,7 @@ import {
   type RuntimeProvider,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, type LucideIcon, Plus, User, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
   type ClientWithCapabilities,
@@ -14,11 +14,15 @@ import {
   getClientCapabilities,
   type HubClient,
   listClients,
+  listOrgClients,
   type RuntimeAgent,
   retireClient,
 } from "../api/activity.js";
 import { ApiError } from "../api/client.js";
+import { listMembers } from "../api/members.js";
+import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
 import {
   DenseTable,
   DenseTableBody,
@@ -39,10 +43,25 @@ import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
  * `embedded` drops the full-bleed `-m-6` wrapper so this page can be rendered
  * inside another master-detail container (e.g. /settings) whose own outer
  * chrome has already escaped the parent padding.
+ *
+ * Data-source split (admin vs member):
+ *   - **member** mode reads `/me/clients` only — single block, no Owner column,
+ *     identical layout to pre-admin-view.
+ *   - **admin** mode reads `/orgs/:orgId/clients` as the *single source of truth*
+ *     and splits client-side into "Your computers" + "Team computers". The
+ *     admin happy path deliberately does NOT call `/me/clients` (the two
+ *     endpoints poll on a 10s cadence and a dual-source approach would let
+ *     the user's own rows briefly disagree between the blocks on each tick).
+ *     `/me/clients` is only resurrected as a *fallback* when the org-scoped
+ *     listing errors out, so admins still see something instead of an empty
+ *     page. Owner lookup uses `/orgs/:orgId/members` with `staleTime: 60s`
+ *     and no polling to keep the Owner cell from flickering.
  */
 export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const queryClient = useQueryClient();
   const agentName = useAgentNameMap();
+  const { role, user } = useAuth();
+  const isAdmin = role === "admin";
   // Personal scope: a user typically has 1-3 computers, so expand by default
   // and only let them collapse rows they actively want to hide. New clients
   // arriving via the 10s poll auto-expand too — we only treat the closed set
@@ -53,11 +72,42 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const [retireError, setRetireError] = useState<string | null>(null);
   const [newConnectionOpen, setNewConnectionOpen] = useState(false);
 
-  const { data: clients } = useQuery({
-    queryKey: ["clients"],
-    queryFn: listClients,
+  const orgClientsQuery = useQuery({
+    queryKey: ["clients", "org"],
+    queryFn: listOrgClients,
+    enabled: isAdmin,
     refetchInterval: 10_000,
   });
+
+  // member mode → primary data source. admin mode → only enabled as a
+  // fallback when `/orgs/:orgId/clients` errors out (see §6 of the design
+  // doc), so the admin happy path stays single-source.
+  const meClientsQuery = useQuery({
+    queryKey: ["clients", "me"],
+    queryFn: listClients,
+    enabled: !isAdmin || orgClientsQuery.isError,
+    refetchInterval: 10_000,
+  });
+
+  // Members are needed only to resolve the Owner column. They rarely change
+  // — `staleTime: 60s` + no polling keeps the Owner cell from flickering
+  // back to a short-id during the gap between a refetch firing and its
+  // response landing (Owner column relies on the cached map, not just the
+  // freshest fetch).
+  const membersQuery = useQuery({
+    queryKey: ["members"],
+    queryFn: listMembers,
+    enabled: isAdmin,
+    staleTime: 60_000,
+  });
+
+  // `grouped` decides whether to render the two-block admin layout (with the
+  // Owner column). When the org-scoped listing fails we collapse back to
+  // the single-block member-style view so the admin still sees their own
+  // computers instead of a broken page.
+  const grouped = isAdmin && !orgClientsQuery.isError;
+  const teamLoadError = isAdmin && orgClientsQuery.isError;
+  const clients = grouped ? orgClientsQuery.data : meClientsQuery.data;
 
   const { data: activity } = useQuery({
     queryKey: ["activity"],
@@ -100,6 +150,45 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   }, [activity?.agents]);
 
   const getClientAgents = (clientId: string): RuntimeAgent[] => agentsByClient.get(clientId) ?? [];
+
+  // admin grouped view: split the single org-scoped list into the viewer's
+  // own machines vs everyone else's, each sorted by recency. `userId === null`
+  // (legacy clients that pre-date user binding) lands in the team block — the
+  // viewer isn't its owner, so it doesn't belong in "yours".
+  const mineList = useMemo<HubClient[]>(() => {
+    if (!grouped || !orgClientsQuery.data || !user) return [];
+    return [...orgClientsQuery.data]
+      .filter((c) => c.userId === user.id)
+      .sort((a, b) => (a.lastSeenAt > b.lastSeenAt ? -1 : a.lastSeenAt < b.lastSeenAt ? 1 : 0));
+  }, [grouped, orgClientsQuery.data, user]);
+
+  const teamList = useMemo<HubClient[]>(() => {
+    if (!grouped || !orgClientsQuery.data || !user) return [];
+    return [...orgClientsQuery.data]
+      .filter((c) => c.userId !== user.id)
+      .sort((a, b) => (a.lastSeenAt > b.lastSeenAt ? -1 : a.lastSeenAt < b.lastSeenAt ? 1 : 0));
+  }, [grouped, orgClientsQuery.data, user]);
+
+  const membersById = useMemo<Map<string, string>>(() => {
+    const map = new Map<string, string>();
+    for (const m of membersQuery.data ?? []) map.set(m.userId, m.displayName);
+    return map;
+  }, [membersQuery.data]);
+
+  const resolveOwner = (client: HubClient): { text: string; title?: string } => {
+    if (client.userId === null) return { text: "—" };
+    if (client.userId === user?.id) {
+      const display = membersById.get(client.userId);
+      return { text: display ? `${display} (you)` : "you" };
+    }
+    const display = membersById.get(client.userId);
+    if (display) return { text: display };
+    // Owner is bound to a userId we can't resolve right now — either the
+    // members fetch is still in flight or the user was removed from the org
+    // mid-session. Show the short-id with a tooltip carrying the full uuid
+    // so the admin has something actionable to copy.
+    return { text: client.userId.slice(0, 8), title: client.userId };
+  };
 
   const connectedCount = (clients ?? []).filter((c) => c.status === "connected").length;
   const totalAgentsBound = (clients ?? []).reduce((n, c) => n + c.agentCount, 0);
@@ -263,18 +352,21 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
 
         {!clients || clients.length === 0 ? (
           <Panel>
+            {teamLoadError && <TeamLoadErrorBanner />}
             <div className="text-center py-10 text-body" style={{ color: "var(--fg-3)" }}>
               No computers connected. Use the button above to generate a connect command.
             </div>
           </Panel>
         ) : (
           <Panel>
+            {teamLoadError && <TeamLoadErrorBanner />}
             <SectionHeader>Registered · {clients.length}</SectionHeader>
             <DenseTable>
               <DenseTableHeader>
                 <DenseTableRow>
                   <DenseTableHead style={{ width: 16 }} />
                   <DenseTableHead>Hostname</DenseTableHead>
+                  {grouped && <DenseTableHead>Owner</DenseTableHead>}
                   <DenseTableHead>OS</DenseTableHead>
                   <DenseTableHead>SDK</DenseTableHead>
                   <DenseTableHead>Agents</DenseTableHead>
@@ -284,33 +376,121 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                 </DenseTableRow>
               </DenseTableHeader>
               <DenseTableBody>
-                {clients.map((client) => {
-                  const isExpanded = !collapsedIds.has(client.id);
-                  const boundAgents = getClientAgents(client.id);
-                  return (
-                    <ClientRow
-                      key={client.id}
-                      client={client}
-                      boundAgents={boundAgents}
-                      isExpanded={isExpanded}
-                      agentName={agentName}
-                      onToggle={() =>
-                        setCollapsedIds((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(client.id)) next.delete(client.id);
-                          else next.add(client.id);
-                          return next;
-                        })
-                      }
-                      onDisconnect={() => setConfirmDisconnect(client)}
-                      onRetire={() => {
-                        setRetireError(null);
-                        setConfirmRetire(client);
-                      }}
-                      onReconnect={() => setNewConnectionOpen(true)}
+                {grouped ? (
+                  <>
+                    <GroupHeaderRow
+                      icon={User}
+                      title="Your computers"
+                      count={mineList.length}
+                      colSpan={ADMIN_COLSPAN}
                     />
-                  );
-                })}
+                    {mineList.length === 0 ? (
+                      <EmptyGroupRow colSpan={ADMIN_COLSPAN} message="No computers of your own." />
+                    ) : (
+                      mineList.map((client) => {
+                        const isExpanded = !collapsedIds.has(client.id);
+                        const boundAgents = getClientAgents(client.id);
+                        return (
+                          <ClientRow
+                            key={client.id}
+                            client={client}
+                            boundAgents={boundAgents}
+                            isExpanded={isExpanded}
+                            agentName={agentName}
+                            onToggle={() =>
+                              setCollapsedIds((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(client.id)) next.delete(client.id);
+                                else next.add(client.id);
+                                return next;
+                              })
+                            }
+                            onDisconnect={() => setConfirmDisconnect(client)}
+                            onRetire={() => {
+                              setRetireError(null);
+                              setConfirmRetire(client);
+                            }}
+                            onReconnect={() => setNewConnectionOpen(true)}
+                            showOwner
+                            ownerLabel={resolveOwner(client)}
+                          />
+                        );
+                      })
+                    )}
+                    <GroupHeaderRow
+                      icon={Users}
+                      title="Team computers"
+                      count={teamList.length}
+                      colSpan={ADMIN_COLSPAN}
+                    />
+                    {teamList.length === 0 ? (
+                      <EmptyGroupRow colSpan={ADMIN_COLSPAN} message="No other team computers." />
+                    ) : (
+                      teamList.map((client) => {
+                        const isExpanded = !collapsedIds.has(client.id);
+                        const boundAgents = getClientAgents(client.id);
+                        return (
+                          <ClientRow
+                            key={client.id}
+                            client={client}
+                            boundAgents={boundAgents}
+                            isExpanded={isExpanded}
+                            agentName={agentName}
+                            onToggle={() =>
+                              setCollapsedIds((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(client.id)) next.delete(client.id);
+                                else next.add(client.id);
+                                return next;
+                              })
+                            }
+                            // Team rows are read-only for admins — see ClientRow:restricted
+                            // for the full story. Server enforces this too:
+                            // `DELETE /clients/:id` 403s on non-owners, and
+                            // `GET /clients/:id` (used by the expanded row's
+                            // capability matrix) does the same. We don't even
+                            // wire the open/close callbacks, since the row is
+                            // not interactive.
+                            onDisconnect={() => {}}
+                            onRetire={() => {}}
+                            onReconnect={() => {}}
+                            showOwner
+                            ownerLabel={resolveOwner(client)}
+                            restricted
+                          />
+                        );
+                      })
+                    )}
+                  </>
+                ) : (
+                  clients.map((client) => {
+                    const isExpanded = !collapsedIds.has(client.id);
+                    const boundAgents = getClientAgents(client.id);
+                    return (
+                      <ClientRow
+                        key={client.id}
+                        client={client}
+                        boundAgents={boundAgents}
+                        isExpanded={isExpanded}
+                        agentName={agentName}
+                        onToggle={() =>
+                          setCollapsedIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(client.id)) next.delete(client.id);
+                            else next.add(client.id);
+                            return next;
+                          })
+                        }
+                        onDisconnect={() => setConfirmDisconnect(client)}
+                        onRetire={() => {
+                          setRetireError(null);
+                          setConfirmRetire(client);
+                        }}
+                        onReconnect={() => setNewConnectionOpen(true)}
+                      />
+                    );
+                  })
+                )}
               </DenseTableBody>
             </DenseTable>
           </Panel>
@@ -464,6 +644,73 @@ function AuthExpiredChip() {
   );
 }
 
+// Column count in member mode — `chevron | Hostname | OS | SDK | Agents |
+// Connected | Status | Actions`. admin mode inserts an Owner column between
+// Hostname and OS, bumping the count by 1.
+const MEMBER_COLSPAN = 8;
+const ADMIN_COLSPAN = MEMBER_COLSPAN + 1;
+
+function TeamLoadErrorBanner() {
+  return (
+    <div
+      className="text-body"
+      style={{
+        margin: "var(--sp-3) var(--sp-3) 0",
+        padding: "var(--sp-2_5) var(--sp-3)",
+        borderRadius: "var(--radius-panel)",
+        background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+        border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
+        color: "var(--state-error)",
+      }}
+    >
+      Failed to load team computers. Showing only your computers.
+    </div>
+  );
+}
+
+function GroupHeaderRow({
+  icon: Icon,
+  title,
+  count,
+  colSpan,
+}: {
+  icon: LucideIcon;
+  title: string;
+  count: number;
+  colSpan: number;
+}) {
+  return (
+    <DenseTableRow>
+      <td colSpan={colSpan} style={{ padding: "var(--sp-6) var(--sp-3_5) var(--sp-2) 0" }}>
+        <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
+          <Icon className="h-4 w-4" aria-hidden style={{ color: "var(--fg-3)" }} />
+          <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+            {title}
+          </span>
+          <DenseBadge tone="outline">{count}</DenseBadge>
+        </span>
+      </td>
+    </DenseTableRow>
+  );
+}
+
+function EmptyGroupRow({ colSpan, message }: { colSpan: number; message: string }) {
+  return (
+    <DenseTableRow>
+      <td
+        colSpan={colSpan}
+        className="text-body"
+        style={{
+          padding: "var(--sp-3) var(--sp-3_5)",
+          color: "var(--fg-4)",
+        }}
+      >
+        {message}
+      </td>
+    </DenseTableRow>
+  );
+}
+
 function ClientRow({
   client,
   boundAgents,
@@ -473,6 +720,9 @@ function ClientRow({
   onDisconnect,
   onRetire,
   onReconnect,
+  showOwner = false,
+  ownerLabel,
+  restricted = false,
 }: {
   client: HubClient;
   boundAgents: RuntimeAgent[];
@@ -482,9 +732,32 @@ function ClientRow({
   onDisconnect: () => void;
   onRetire: () => void;
   onReconnect: () => void;
+  /** When true, render the Owner column between Hostname and OS (admin view). */
+  showOwner?: boolean;
+  /** Resolved owner display value. Required when `showOwner` is true. */
+  ownerLabel?: { text: string; title?: string };
+  /**
+   * Read-only mode for rows the viewer doesn't own (admin viewing team
+   * computers). Collapses three behaviors into one flag because they're
+   * always toggled together:
+   *   - Hides Reconnect / Disconnect / Retire (server-side owner check
+   *     would 403 anyway).
+   *   - Suppresses the expand chevron and ignores `onToggle` so clicking
+   *     the row does nothing (and the capability-matrix `GET /clients/:id`
+   *     — which also 403s on non-owners — is never fired, avoiding both
+   *     wasted retries and a misleading "not reported" fallback).
+   *   - Drops the `interactive` hover styling so the row reads as inert
+   *     metadata, not a clickable target.
+   */
+  restricted?: boolean;
 }) {
-  const colSpan = 8;
+  const colSpan = showOwner ? ADMIN_COLSPAN : MEMBER_COLSPAN;
   const isOffline = client.status !== "connected";
+  // The expanded sub-row carries owner-only capability data — we never let
+  // it render in restricted mode (see prop doc). `effectiveExpanded` mirrors
+  // `isExpanded` for owner rows and is forced to false for team rows so a
+  // stale collapsed-set never accidentally opens one.
+  const effectiveExpanded = restricted ? false : isExpanded;
   // Auth health takes priority over the connection state when rendering the
   // row's status pill: "auth expired" must outrank the plain "offline" so
   // the user knows it isn't going to come back without intervention.
@@ -492,13 +765,20 @@ function ClientRow({
   const statusState = client.status === "connected" ? "idle" : "offline";
   return (
     <>
-      <DenseTableRow interactive selected={isExpanded} onClick={onToggle}>
+      <DenseTableRow interactive={!restricted} selected={effectiveExpanded} onClick={restricted ? undefined : onToggle}>
         <DenseTableCell style={{ width: 16 }}>
-          <span style={{ color: "var(--fg-4)", display: "inline-flex" }}>
-            {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-          </span>
+          {restricted ? null : (
+            <span style={{ color: "var(--fg-4)", display: "inline-flex" }}>
+              {effectiveExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            </span>
+          )}
         </DenseTableCell>
         <DenseTableCell className="font-medium">{client.hostname ?? "—"}</DenseTableCell>
+        {showOwner && (
+          <DenseTableCell style={{ color: "var(--fg-3)" }} title={ownerLabel?.title}>
+            {ownerLabel?.text ?? "—"}
+          </DenseTableCell>
+        )}
         <DenseTableCell style={{ color: "var(--fg-3)" }}>{client.os ?? "—"}</DenseTableCell>
         <DenseTableCell className="mono text-label" style={{ color: "var(--fg-3)" }}>
           {client.sdkVersion ?? "—"}
@@ -512,52 +792,57 @@ function ClientRow({
         <DenseTableCell>{authBroken ? <AuthExpiredChip /> : <StateChip state={statusState} />}</DenseTableCell>
         {/* Plain text actions, always visible. The row already gives them a
             dedicated rightmost cell with whitespace-nowrap, so the three
-            options sit in their own column rather than crowding the data. */}
+            options sit in their own column rather than crowding the data.
+            Team rows in admin view render an empty cell — the underlying
+            ops are owner-checked server-side (DELETE /clients/:id 403s on
+            non-owners), so surfacing them here would just produce errors. */}
         <DenseTableCell style={{ width: 1, whiteSpace: "nowrap" }}>
-          <div className="flex items-center justify-end text-label" style={{ gap: "var(--sp-3_5)" }}>
-            {isOffline && (
+          {restricted ? null : (
+            <div className="flex items-center justify-end text-label" style={{ gap: "var(--sp-3_5)" }}>
+              {isOffline && (
+                <button
+                  type="button"
+                  className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  style={{ color: authBroken ? "var(--state-error)" : "var(--fg-2)" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReconnect();
+                  }}
+                >
+                  Reconnect
+                </button>
+              )}
               <button
                 type="button"
                 className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                style={{ color: authBroken ? "var(--state-error)" : "var(--fg-2)" }}
+                style={{ color: "var(--fg-2)" }}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onReconnect();
+                  onDisconnect();
                 }}
               >
-                Reconnect
+                Disconnect
               </button>
-            )}
-            <button
-              type="button"
-              className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              style={{ color: "var(--fg-2)" }}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDisconnect();
-              }}
-            >
-              Disconnect
-            </button>
-            <button
-              type="button"
-              className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              style={{ color: "var(--fg-4)" }}
-              onClick={(e) => {
-                e.stopPropagation();
-                onRetire();
-              }}
-            >
-              Retire
-            </button>
-          </div>
+              <button
+                type="button"
+                className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                style={{ color: "var(--fg-4)" }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRetire();
+                }}
+              >
+                Retire
+              </button>
+            </div>
+          )}
         </DenseTableCell>
       </DenseTableRow>
-      {isExpanded && (
+      {effectiveExpanded && (
         <tr style={{ background: "var(--bg-sunken)" }}>
           <DenseTableCell />
           <DenseTableCell colSpan={colSpan - 1} style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-3_5)" }}>
-            <CapabilityMatrix clientId={client.id} enabled={isExpanded} />
+            <CapabilityMatrix clientId={client.id} enabled={effectiveExpanded} />
             {boundAgents.length > 0 && (
               <>
                 <UppercaseLabel style={{ display: "block", marginTop: "var(--sp-3)", marginBottom: 6 }}>


### PR DESCRIPTION
## Summary
- Admin Settings → Computers now shows two sections: Your computers + Team computers (sorted by lastSeenAt desc), with an Owner column resolved via listMembers.
- Team rows are read-only and not expandable — admin can't fire owner-scoped GET /clients/:id (avoids 403 + misleading "not reported" capability fallback).
- Member view is pixel-equivalent to before (still hits /me/clients, no Owner column, no group headers).
- Adds banner + fallback to /me/clients when /orgs/:orgId/clients fails.

## Design doc
`/home/bai/.first-tree/hub/data/workspaces/architect/9a812de8-4299-436e-8115-77dbf5fa05e6/docs/admin-computer-team-view-design.md`

## Test plan
- [x] `pnpm check`
- [x] `pnpm --filter @first-tree-hub/web typecheck`
- [x] `pnpm --filter @first-tree-hub/web test` (111/111)
- [ ] Manual smoke: admin view shows Your + Team sections, team row is read-only & not expandable
- [ ] Manual smoke: member view unchanged (no Owner column, no group headers)
- [ ] Manual smoke: simulate `/orgs/:orgId/clients` 5xx → fallback banner + single-section view