### PR TITLE
fix(web): carry text @mentions onto group-chat image sends (#387)

### DIFF
--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -94,10 +94,15 @@ export function sendFileMessage(
   content: SendFileMessageBody,
   metadata?: SendFileMessageMetadata,
 ): Promise<Message> {
+  // Project explicit fields rather than spreading `metadata` whole so future
+  // additions to SendFileMessageMetadata don't ride out on the `mentions`
+  // truthiness check by accident — each new field must be opted in here.
+  const mentions = metadata?.mentions;
+  const hasMentions = Array.isArray(mentions) && mentions.length > 0;
   return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "file",
     content,
-    ...(metadata?.mentions && metadata.mentions.length > 0 ? { metadata } : {}),
+    ...(hasMentions ? { metadata: { mentions } } : {}),
   });
 }
 

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -80,10 +80,24 @@ export type ImageRefContent = {
  */
 type SendFileMessageBody = FileMessageContent & { imageId?: string };
 
-export function sendFileMessage(chatId: string, content: SendFileMessageBody): Promise<Message> {
+/**
+ * Optional message metadata for a file send. Today only `mentions` is wired
+ * — it lets a multi-image send carry the @-mentions parsed from the user's
+ * accompanying text so the server's group-chat mention guard accepts each
+ * image POST. Without this, the image messages arrive with no addressees and
+ * are rejected before the text is sent (issue 387).
+ */
+export type SendFileMessageMetadata = { mentions?: string[] };
+
+export function sendFileMessage(
+  chatId: string,
+  content: SendFileMessageBody,
+  metadata?: SendFileMessageMetadata,
+): Promise<Message> {
   return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "file",
     content,
+    ...(metadata?.mentions && metadata.mentions.length > 0 ? { metadata } : {}),
   });
 }
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -762,6 +762,10 @@ export function ChatView({
       if (img) URL.revokeObjectURL(img.previewUrl);
       return prev.filter((i) => i.id !== id);
     });
+    // Mirror addImages: removing an image is also a "user is fixing it"
+    // signal — a prior "image too large" or "no @mention" error is now
+    // potentially stale and shouldn't stay pinned under the composer.
+    setUploadError(null);
   }, []);
 
   const handleSend = async () => {
@@ -778,7 +782,9 @@ export function ChatView({
     // doesn't look like a stuck send.
     if (requiresMention && draftMentions.length === 0) {
       if (images.length > 0) {
-        setUploadError("群聊发图请在文本里 @ 一位群成员（图片消息会沿用同一条 @）");
+        // English matches the other uploadError strings in this file
+        // (Failed to send image / Failed to add participants / Image too large).
+        setUploadError("@mention a group member in the text — images will be addressed to the same recipient(s).");
       }
       return;
     }
@@ -1475,6 +1481,10 @@ export function ChatView({
                     onChange={(e) => {
                       setDraft(e.target.value);
                       setCursor(e.target.selectionStart ?? e.target.value.length);
+                      // Dismiss a stale upload error (e.g. the "no @mention"
+                      // hint) the moment the user starts fixing it. Mirrors
+                      // the implicit clear in `addImages` at line ~756.
+                      if (uploadError !== null) setUploadError(null);
                     }}
                     onSelect={(e) => {
                       setCursor(e.currentTarget.selectionStart ?? draft.length);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -771,7 +771,17 @@ export function ChatView({
     if (uploading) return;
     // Group-chat send guard: don't fire requests we know the server (with
     // proposal §3 enforcement) or downstream `mention_only` agents will drop.
-    if (requiresMention && draftMentions.length === 0) return;
+    // Applies to image-only sends too — the server-side mention check runs
+    // per message regardless of format, so an image without an addressee
+    // would 400 just like a text without an addressee (issue 387). Surface
+    // a hint when the user has only attached images so the silent-return
+    // doesn't look like a stuck send.
+    if (requiresMention && draftMentions.length === 0) {
+      if (images.length > 0) {
+        setUploadError("群聊发图请在文本里 @ 一位群成员（图片消息会沿用同一条 @）");
+      }
+      return;
+    }
 
     // "Mention to invite": any `@<name>` pointing at an agent outside the
     // current chat is treated as both an address and an invitation. We add
@@ -793,6 +803,14 @@ export function ChatView({
       setUploading(true);
       setUploadError(null);
       try {
+        // Carry the text-draft mentions onto each image message so the
+        // server's group-chat mention guard (services/message.ts) accepts
+        // file-format sends. Without this, every image POST is missing
+        // recipient mentions and 400s before the text message is sent
+        // (issue 387). In direct chats `draftMentions` is empty and the
+        // metadata field is omitted entirely — server check is skipped
+        // anyway, so this is a no-op for 1:1.
+        const imageMetadata = draftMentions.length > 0 ? { mentions: draftMentions } : undefined;
         for (const img of images) {
           const data = await readFileAsBase64(img.file);
           const imageId = crypto.randomUUID();
@@ -800,13 +818,17 @@ export function ChatView({
           // its own message via the imageRef shape immediately on refetch,
           // even if the server write races ahead of the response.
           await putImage({ imageId, base64: data, mimeType: img.file.type });
-          await sendFileMessage(chatId, {
-            data,
-            mimeType: img.file.type,
-            filename: img.file.name,
-            size: img.file.size,
-            imageId,
-          });
+          await sendFileMessage(
+            chatId,
+            {
+              data,
+              mimeType: img.file.type,
+              filename: img.file.name,
+              size: img.file.size,
+              imageId,
+            },
+            imageMetadata,
+          );
           URL.revokeObjectURL(img.previewUrl);
         }
         setPendingImages([]);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1483,8 +1483,10 @@ export function ChatView({
                       setCursor(e.target.selectionStart ?? e.target.value.length);
                       // Dismiss a stale upload error (e.g. the "no @mention"
                       // hint) the moment the user starts fixing it. Mirrors
-                      // the implicit clear in `addImages` at line ~756.
-                      if (uploadError !== null) setUploadError(null);
+                      // the unconditional clears in `addImages` / `removeImage`
+                      // — React bails on identical setState so the null→null
+                      // case is free.
+                      setUploadError(null);
                     }}
                     onSelect={(e) => {
                       setCursor(e.currentTarget.selectionStart ?? draft.length);


### PR DESCRIPTION
Closes #387

## Summary

- 群聊里同时发文字 + 图片时，前端把每张图作为独立 `format=file` 消息 POST，不带 `metadata.mentions`，被服务端群聊护栏（`packages/server/src/services/message.ts:164`）逐条拦下，文字也发不出去。
- 修复：前端把文本里的 `draftMentions` 透传到每条图片消息的 `metadata.mentions`。服务端零改动——`sendMessage` 已经合并 `metadata.mentions` 进 `mergedMentions`，护栏自然过。
- 顺手把"只选了图、文本空着没 @"的场景从静默吞噬改成弹一行英文提示。

## Why this approach

故意**没改服务端**：那条群聊护栏在概念上是对的——群里发消息不指明收件人，`mention_only` 模式的 agent 会全静默丢弃，发送方还以为送达了。给 `format=file` 开口子等于把这个洞凿穿。前端透传 mention 是更小、更对的改法。

## 边界情况

- **DM**：`draftMentions` 在直接聊天里为空，`metadata` 字段在 wire 上整段省略；服务端也不对 direct 跑护栏，no-op。
- **图片-only 无 mention**：以前是 silent return（按下发送啥也没发生），现在弹 `@mention a group member in the text — images will be addressed to the same recipient(s).`，并在用户开始编辑文本框或移除图片时自动清除。
- **部分失败**：保留原有"图先文后"的发送顺序——中途某张图失败 = 后续都不发，用户可以原状重试。**没有**改成"文先图后"，否则一旦图失败会出现"文字到了图没到"的更糟语义。这个 commit 不解决"重试会重发已成功的图"——属于和 #387 不同的 bug，留 follow-up。

## Out of scope (follow-ups)

- N 张图 = N 次唤醒：相同 mention 集合在同一发送批次内应该被 `result-sink`/notifier 层 debounce 成一次。
- 部分失败重试会重发已成功的图：for-loop 结构问题，独立 bug。

## Commits

- `76038db` 主修复
- `01f070a` 应对 code review 三条 nit：（a）`chats.ts` 显式 project `mentions` 字段不再 spread 整个 metadata；（b）错误文案从中文改成英文与文件里其他 `uploadError` 一致；（c）`uploadError` 在 textarea edit / removeImage 时自动清

## Test plan

- [ ] 群聊：写 `@xxx 看一下` + 1 张图 → 文字 + 图都发送成功，被 @ 的人正常被唤醒
- [ ] 群聊：写 `@xxx 看一下` + 3 张图 → 3 张图 + 文字都到了，顺序正确
- [ ] 群聊：只选 1 张图、文本空 → 弹出 `@mention a group member ...` 提示；在文本框开始输入后提示消失
- [ ] 群聊：只选 1 张图、文本写 `@xxx`（已经 @）→ 文字 + 图都发送成功
- [ ] DM：文本 + 图 → 正常发出（无任何 mention 干预）
- [ ] 群聊"mention-to-invite"：`@` 一个不在 chat 的 agent + 图片 → 先把人加入 chat、再发图、再发文字

🤖 Generated with [Claude Code](https://claude.com/claude-code)