### PR TITLE
fix(web): clear chat selection when switching workspace tabs

### DIFF
--- a/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { nextParamsForEngagement, nextParamsForSource } from "../index.js";
+
+function paramsOf(search: string): URLSearchParams {
+  return new URLSearchParams(search);
+}
+
+describe("nextParamsForSource", () => {
+  it("clears the chat selection so the right pane can't receive misrouted input", () => {
+    // Regression: issue 388 — switching the source tag bar previously left
+    // `?c=` pointing at a chat from the old tag, leaving the right pane on
+    // the wrong conversation while the rail showed a different list.
+    const result = nextParamsForSource(paramsOf("c=abc-123&source=manual"), "github_pull_request");
+    expect(result.has("c")).toBe(false);
+    expect(result.get("source")).toBe("github_pull_request");
+  });
+
+  it("drops the source key for the default `manual` tab to keep `/` canonical", () => {
+    const result = nextParamsForSource(paramsOf("source=feishu&c=xyz"), "manual");
+    expect(result.has("source")).toBe(false);
+    expect(result.has("c")).toBe(false);
+  });
+
+  it("clears any doc-preview overlay along with the chat selection", () => {
+    const result = nextParamsForSource(
+      paramsOf("c=abc&source=manual&docChat=a&docAgent=b&docPath=p&docBase=base"),
+      "github_issue",
+    );
+    expect(result.has("docChat")).toBe(false);
+    expect(result.has("docAgent")).toBe(false);
+    expect(result.has("docPath")).toBe(false);
+    expect(result.has("docBase")).toBe(false);
+  });
+
+  it("preserves unrelated params (engagement, filter, etc.)", () => {
+    const result = nextParamsForSource(paramsOf("c=x&source=manual&engagement=archived"), "github_pull_request");
+    expect(result.get("engagement")).toBe("archived");
+  });
+});
+
+describe("nextParamsForEngagement", () => {
+  it("clears the chat selection when switching engagement tabs", () => {
+    // Same misrouted-input risk as the source tab: an active chat is hidden
+    // when you flip to Archived, so the right pane must reset too.
+    const result = nextParamsForEngagement(paramsOf("c=abc&engagement=active"), "archived");
+    expect(result.has("c")).toBe(false);
+    expect(result.get("engagement")).toBe("archived");
+  });
+
+  it("drops the engagement key for the default `active` tab", () => {
+    const result = nextParamsForEngagement(paramsOf("engagement=all&c=abc"), "active");
+    expect(result.has("engagement")).toBe(false);
+    expect(result.has("c")).toBe(false);
+  });
+
+  it("clears any doc-preview overlay", () => {
+    const result = nextParamsForEngagement(
+      paramsOf("c=abc&engagement=active&docChat=a&docAgent=b&docPath=p&docBase=base"),
+      "all",
+    );
+    expect(result.has("docChat")).toBe(false);
+    expect(result.has("docAgent")).toBe(false);
+    expect(result.has("docPath")).toBe(false);
+    expect(result.has("docBase")).toBe(false);
+  });
+
+  it("preserves unrelated params (source, etc.)", () => {
+    const result = nextParamsForEngagement(paramsOf("c=x&source=feishu&engagement=active"), "archived");
+    expect(result.get("source")).toBe("feishu");
+  });
+});

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -75,23 +75,14 @@ export function WorkspacePage() {
 
   const setEngagement = useCallback(
     (view: ChatEngagementView) => {
-      const next = new URLSearchParams(searchParams);
-      // Default value omitted from URL so the canonical home page stays `/`.
-      if (view === "active") next.delete("engagement");
-      else next.set("engagement", view);
-      setSearchParams(next, { replace: true });
+      setSearchParams(nextParamsForEngagement(searchParams, view), { replace: true });
     },
     [searchParams, setSearchParams],
   );
 
   const setSource = useCallback(
     (next: ChatSource) => {
-      const params = new URLSearchParams(searchParams);
-      // Default `manual` is the implicit value — keep it out of the URL so
-      // `/` stays the canonical workspace entrypoint.
-      if (next === "manual") params.delete("source");
-      else params.set("source", next);
-      setSearchParams(params, { replace: true });
+      setSearchParams(nextParamsForSource(searchParams, next), { replace: true });
     },
     [searchParams, setSearchParams],
   );
@@ -125,4 +116,40 @@ function clearDocPreviewParams(params: URLSearchParams): void {
   params.delete("docAgent");
   params.delete("docPath");
   params.delete("docBase");
+}
+
+/**
+ * Pure URL transition for the engagement tab. Exported for unit tests.
+ *
+ * Switching engagement can hide the currently-selected chat (e.g. flipping
+ * Active → Archived while viewing an active chat). Leaving `?c=` set would
+ * keep the previously-selected chat on the right pane and invite misrouted
+ * input, so we drop the selection (and any doc-preview overlay) here.
+ */
+export function nextParamsForEngagement(current: URLSearchParams, view: ChatEngagementView): URLSearchParams {
+  const next = new URLSearchParams(current);
+  // Default value omitted from URL so the canonical home page stays `/`.
+  if (view === "active") next.delete("engagement");
+  else next.set("engagement", view);
+  next.delete("c");
+  clearDocPreviewParams(next);
+  return next;
+}
+
+/**
+ * Pure URL transition for the source tab. Exported for unit tests.
+ *
+ * A chat belongs to exactly one source, so switching source always hides
+ * the currently-selected chat from the rail — clear `?c=` so the right
+ * pane mirrors the new tab and can't receive misrouted input.
+ */
+export function nextParamsForSource(current: URLSearchParams, source: ChatSource): URLSearchParams {
+  const next = new URLSearchParams(current);
+  // Default `manual` is the implicit value — keep it out of the URL so
+  // `/` stays the canonical workspace entrypoint.
+  if (source === "manual") next.delete("source");
+  else next.set("source", source);
+  next.delete("c");
+  clearDocPreviewParams(next);
+  return next;
 }


### PR DESCRIPTION
## Summary
- Source / engagement tab callbacks now drop `?c=` and any doc-preview overlay so the right pane resets to `NoChatView` instead of stranding the user on the previously selected chat.
- Extracted the URL transitions to pure helpers (`nextParamsForEngagement`, `nextParamsForSource`) and added unit coverage in `packages/web/src/pages/workspace/__tests__/url-transitions.test.ts` (8 cases).

Fixes #388 — the previous behavior caused misrouted input because the rail re-listed under the new tab while the right pane kept the old chat.

## Test plan
- [x] `pnpm --filter @first-tree-hub/web test` — 143/143 (added 8 new cases)
- [x] `pnpm --filter @first-tree-hub/web typecheck`
- [x] `pnpm check` (biome)
- [x] `pnpm --filter @first-tree-hub/web build`
- [ ] Visual click test on `vite dev`:
  - [ ] Source: select Manual chat → click PR/Issue/Feishu → right pane resets, URL drops `c`
  - [ ] Engagement: select Active chat → click Archived/All → right pane resets, URL drops `c`
  - [ ] Default tabs (`source=manual`, `engagement=active`) keep their keys out of the URL
  - [ ] Deep link `?c=<id>&source=feishu` still loads the chat (URL-only path bypasses these callbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)