### PR TITLE
fix: unwrap double-encoded agent message content

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -76,18 +76,22 @@ describe("bootstrapWorkspace", () => {
     expect(existsSync(toolsPath)).toBe(true);
 
     const content = readFileSync(toolsPath, "utf-8");
-    expect(content).toContain("FIRST_TREE_HUB_SERVER_URL");
-    expect(content).toContain("FIRST_TREE_HUB_ACCESS_TOKEN");
-    expect(content).toContain("How You Communicate");
     expect(content).toContain("Agent Hub");
     expect(content).toContain("[From: <agent-name>]");
-    expect(content).toContain("Use your judgment about when to respond");
+    expect(content).toContain("first-tree-hub chat send");
     // L4 silent-turn protocol: the prompt directive that pairs with the
     // result-sink empty-output guard. Tells the agent that silence is the
     // correct response when it has nothing new — drops courtesy fillers
     // that would otherwise sustain agent↔agent loops.
-    expect(content).toContain("if you have nothing new for the recipient, output nothing");
-    expect(content).toContain("the runtime will end the turn silently");
+    expect(content).toContain("Stay silent when you have nothing to add");
+    expect(content).toContain("If you have nothing new for the recipient, output nothing");
+    expect(content).toContain("the runtime ends the turn");
+    // Issue #389: pin the anti-double-encode directive so future prompt edits
+    // don't accidentally drop it. The CLI passes content as-is; agents that
+    // JSON.stringify before sending produce a literal `"@x ...\n..."` row
+    // that the UI cannot render as markdown.
+    expect(content).toContain("Content rules");
+    expect(content).toContain("JSON.stringify");
   });
 
   it("does not write self.md (per PRD D7 — prompt lives in agent_configs)", () => {

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -331,67 +331,43 @@ export function installFirstTreeIntegration(options: InstallFirstTreeIntegration
 function generateToolsDoc(): string {
   return `# Agent Hub SDK
 
-## How You Communicate
-
 You are running inside **Agent Hub**, a messaging platform for agent teams.
 
-- Messages from other team members arrive as your prompt input
-- Each message includes a \`[From: <agent-name>]\` header — that name is also
-  what you pass back to \`chat send\` to reply to or address that agent
-- **Your final text response is automatically delivered** to the chat — just respond normally
-- For **proactive communication** (sending to other agents, other chats, or structured data),
-  use the \`first-tree-hub\` CLI below
-- **Use your judgment about when to respond.** Not every message requires
-  a reply — if you have nothing new for the recipient, output nothing and
-  the runtime will end the turn silently.
-  Your role and responsibilities are injected via the Hub-managed system prompt.
-
-## Environment Variables
-
-These are injected automatically when the agent process starts:
-
-| Variable | Description |
-|----------|-------------|
-| \`FIRST_TREE_HUB_SERVER_URL\` | Server address for API calls |
-| \`FIRST_TREE_HUB_ACCESS_TOKEN\` | User member access JWT (short-lived) |
-| \`FIRST_TREE_HUB_AGENT_ID\` | YOUR own agent UUID. The CLI reads it to identify you as the sender — never pass it as a \`send\` target. |
-| \`FIRST_TREE_HUB_CHAT_ID\` | The chat this session is currently bound to. The CLI uses it to route messages — you don't need to pass it manually. |
-
-The \`first-tree-hub\` CLI reads these automatically — no extra setup needed.
+- Messages from other team members arrive as your prompt input. Each message has a
+  \`[From: <agent-name>]\` header — that name is what you pass back to \`chat send\`.
+- **Your final text response is automatically delivered** to the chat — just respond normally.
+- **Stay silent when you have nothing to add.** Not every message needs a reply.
+  If you have nothing new for the recipient, output nothing and the runtime ends the turn.
+- For **proactive communication** (other agents, other chats, or different format),
+  use the \`first-tree-hub\` CLI below.
 
 ## Sending Messages
 
-Use the \`first-tree-hub chat send\` CLI — it reads the env vars above and
-attaches the \`Authorization\` + \`X-Agent-Id\` headers automatically:
+The CLI auto-reads its config from env — no setup needed.
 
 \`\`\`bash
-# Send to another agent — first positional argument is the recipient's NAME
-# (NOT a uuid; uuids in chat history / participant lists are not accepted).
-# Run \`first-tree-hub agent list\` to see available names.
-#
-# Routing: if the recipient is a participant of your current chat (typically
-# the case in a group chat where someone @-mentioned you to talk to them),
-# the message stays in that chat. Otherwise it falls back to a direct chat
-# between you and the recipient. You don't need to think about which.
+# Send to an agent by NAME (uuids are NOT accepted — run \`first-tree-hub agent list\` for names)
 first-tree-hub chat send <agentName> "your message"
 
-# Send into a specific chat by id — use this only when you explicitly want
-# to address a chat your current session is NOT bound to.
+# Address a specific chat (only when not your current chat)
 first-tree-hub chat send --chat <chatId> "your message"
 
-# Send markdown (default format is text)
-first-tree-hub chat send <agentName> -f markdown "**bold** message"
+# Markdown format (default is text)
+first-tree-hub chat send <agentName> -f markdown "**bold**"
 
-# Reply to a specific message
-first-tree-hub chat send <agentName> --reply-to <messageId> "reply content"
+# Reply to a message
+first-tree-hub chat send <agentName> --reply-to <messageId> "reply"
 
-# Pipe long content via stdin (recommended for special characters)
-echo "long message body" | first-tree-hub chat send <agentName>
+# Pipe long / multiline content via stdin
+echo "long body" | first-tree-hub chat send <agentName>
 \`\`\`
 
-> Agent uuids appear in \`chat list\`, chat history, and participant lists,
-> but they are NOT accepted by \`chat send\` — always use the name.
+**Content rules (important):**
 
-For content with quotes, \`$\`, backticks, or newlines, prefer stdin to avoid shell escaping issues.
+- Pass content as a **raw string** — never \`JSON.stringify\` it first. Wrapping in
+  outer quotes + \`\\n\` escapes produces a literal \`"@x ...\\n..."\` that the UI
+  cannot render as markdown.
+- For multi-line / markdown / special chars (quotes, \`$\`, backticks, newlines),
+  use **stdin** with real newlines, plus \`-f markdown\`.
 `;
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/__tests__/maybe-unwrap-double-encoded.test.ts
+++ b/packages/server/src/__tests__/maybe-unwrap-double-encoded.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { maybeUnwrapDoubleEncoded } from "../services/message.js";
+
+/**
+ * Pins the issue-#389 defensive unwrap. Agents occasionally `JSON.stringify`
+ * a string before passing it to `chat send` (a leftover from function-calling
+ * habits where tool arguments are JSON-encoded). The result is a literal
+ * `"@x ...\n..."` row in the DB that the UI renders as a quoted line with
+ * literal `\n` instead of markdown.
+ *
+ * The unwrap is intentionally STRICT: it only triggers on the exact shape an
+ * accidental double-encode produces, so quoted phrases written by humans —
+ * or any string that merely starts with `"` — are left alone. The caller in
+ * `sendMessage` further restricts this to non-human senders; these cases
+ * exercise only the structural matcher.
+ */
+describe("maybeUnwrapDoubleEncoded", () => {
+  it("unwraps a JSON-encoded string with interior \\n escapes", () => {
+    const wrapped = JSON.stringify("@bob hello\n\nline two");
+    expect(maybeUnwrapDoubleEncoded(wrapped)).toBe("@bob hello\n\nline two");
+  });
+
+  it('unwraps a JSON-encoded string with interior \\" escapes', () => {
+    const wrapped = JSON.stringify('she said "hi"\nthen left');
+    expect(maybeUnwrapDoubleEncoded(wrapped)).toBe('she said "hi"\nthen left');
+  });
+
+  it("leaves human quoted phrases alone — no escape sequences inside", () => {
+    expect(maybeUnwrapDoubleEncoded('"this is a quote"')).toBeNull();
+    expect(maybeUnwrapDoubleEncoded('"hello"')).toBeNull();
+  });
+
+  it("leaves plain text alone", () => {
+    expect(maybeUnwrapDoubleEncoded("hello world")).toBeNull();
+    expect(maybeUnwrapDoubleEncoded("@bob\nthis is fine")).toBeNull();
+  });
+
+  it("leaves single-quoted-looking but not JSON content alone", () => {
+    // missing trailing quote
+    expect(maybeUnwrapDoubleEncoded('"unterminated\\n')).toBeNull();
+    // outer single quotes, not double
+    expect(maybeUnwrapDoubleEncoded("'@bob\\nhi'")).toBeNull();
+  });
+
+  it("leaves JSON-encoded non-strings alone (objects, arrays, numbers)", () => {
+    expect(maybeUnwrapDoubleEncoded('{"key":"value"}')).toBeNull();
+    expect(maybeUnwrapDoubleEncoded("[1,2,3]")).toBeNull();
+    expect(maybeUnwrapDoubleEncoded("42")).toBeNull();
+  });
+
+  it("rejects too-short inputs", () => {
+    expect(maybeUnwrapDoubleEncoded("")).toBeNull();
+    expect(maybeUnwrapDoubleEncoded('""')).toBeNull();
+    expect(maybeUnwrapDoubleEncoded('"a"')).toBeNull();
+  });
+
+  it("handles realistic agent double-encode from the issue", () => {
+    // The exact shape called out in issue #389: outer quotes + literal \n
+    // between markdown paragraphs.
+    const wrapped = '"@somebody ✅ Task done — https://...\\n\\nfollow-up...\\n\\n1. step\\n2. step\\n"';
+    const out = maybeUnwrapDoubleEncoded(wrapped);
+    expect(out).not.toBeNull();
+    expect(out).toContain("@somebody");
+    expect(out).toContain("\n\n");
+    expect(out).not.toContain("\\n");
+  });
+});

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -94,7 +94,7 @@ async function sendMessageInner(
         .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker"))),
       tx.select({ type: chats.type }).from(chats).where(eq(chats.id, chatId)).limit(1),
       tx
-        .select({ inboxId: agents.inboxId, organizationId: agents.organizationId })
+        .select({ inboxId: agents.inboxId, organizationId: agents.organizationId, type: agents.type })
         .from(agents)
         .where(eq(agents.uuid, senderId))
         .limit(1),
@@ -102,6 +102,26 @@ async function sendMessageInner(
     const chatType = chatRow?.type ?? null;
     if (!senderRow) {
       throw new NotFoundError(`Sender agent "${senderId}" not found`);
+    }
+
+    // 1b. Defensive: unwrap content that was JSON.stringify-ed once before the
+    //     agent passed it to the CLI / API. The bad shape is an outer `"..."`
+    //     wrapper + interior `\n` / `\"` escape sequences; the UI renders it
+    //     as a raw quoted line instead of markdown. See issue #389.
+    //
+    //     Guarded by sender type (human-typed quoted phrases never touched)
+    //     and by a strict structural match (see `maybeUnwrapDoubleEncoded`).
+    //     Non-string content (e.g. structured question payloads) is bypassed.
+    let effectiveContent: SendMessage["content"] = data.content;
+    if (senderRow.type !== "human" && typeof effectiveContent === "string") {
+      const unwrapped = maybeUnwrapDoubleEncoded(effectiveContent);
+      if (unwrapped !== null) {
+        log.warn(
+          { metric: "double_encoded_content_unwrapped_total", chatId, senderId },
+          "agent sent JSON-encoded string content — unwrapping to restore markdown rendering",
+        );
+        effectiveContent = unwrapped;
+      }
     }
 
     // `replyTo` is a sender-declared routing promise — the sender is saying
@@ -129,7 +149,7 @@ async function sendMessageInner(
     const explicitMentions = Array.isArray(explicitMentionsRaw)
       ? explicitMentionsRaw.filter((m): m is string => typeof m === "string")
       : [];
-    const contentText = typeof data.content === "string" ? data.content : "";
+    const contentText = typeof effectiveContent === "string" ? effectiveContent : "";
     const resolved = contentText ? extractMentions(contentText, participants) : [];
     const mergedMentions = [...new Set([...explicitMentions, ...resolved])];
     const metadataToStore = mergedMentions.length > 0 ? { ...incomingMeta, mentions: mergedMentions } : incomingMeta;
@@ -180,7 +200,7 @@ async function sendMessageInner(
     //
     //     Driven by its own opt-in flag (separate from enforceGroupMention) so
     //     admin/web and adapter paths can validate without mutating content.
-    let outboundContent = data.content;
+    let outboundContent = effectiveContent;
     if (options.normalizeMentionsInContent && typeof outboundContent === "string") {
       const present = new Set(scanMentionTokens(outboundContent));
       const missingNames: string[] = [];
@@ -418,6 +438,36 @@ async function sendMessageInner(
   });
 
   return { message: txResult.message, recipients: txResult.recipients };
+}
+
+/**
+ * Detect agent-sent content that was JSON.stringify-ed once before reaching
+ * the CLI / API. The bad shape is an outer `"..."` wrapper + interior `\n` /
+ * `\"` escape sequences, which the UI renders as a quoted literal instead of
+ * markdown (issue #389). Returns the unwrapped inner string on a confident
+ * match, or `null` to leave the content alone.
+ *
+ * Match conditions (all required) — kept strict so legitimate human content
+ * that happens to look like a quoted phrase is never touched. The caller is
+ * additionally responsible for restricting this to non-human senders.
+ *
+ *   - first and last char are `"`
+ *   - body contains at least one typical JSON escape sequence
+ *     (`\n`, `\r`, `\t`, `\"`, or `\\`)
+ *   - `JSON.parse` succeeds
+ *   - the parse result is a `string` (excludes `{...}`, `[...]`, numbers)
+ */
+export function maybeUnwrapDoubleEncoded(content: string): string | null {
+  if (content.length < 4) return null;
+  if (content.charCodeAt(0) !== 0x22 /* " */) return null;
+  if (content.charCodeAt(content.length - 1) !== 0x22 /* " */) return null;
+  if (!/\\[nrt"\\]/.test(content)) return null;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 export const LOOP_OBSERVATION_WINDOW = 4;


### PR DESCRIPTION
## Summary

Fixes #389 — agent-sent `chat send` content occasionally arrives JSON-stringified once (literal `"@x ...\n..."`), which the UI renders as a quoted line with literal `\n` instead of markdown.

Two-layer defense:

- **Server (`message.ts`)** — strict structural detect-and-unwrap on agent-sourced string content (outer `"..."` + interior JSON escapes + `JSON.parse` returns a string). Gated by `sender.type !== "human"` so quoted phrases typed by people are never touched. Emits a `metric: double_encoded_content_unwrapped_total` warn log so the trend is observable.
- **Client (`bootstrap.ts`)** — trim the agent SDK prompt in `generateToolsDoc` (~65 → ~40 lines) by dropping low-value sections (env-vars table, code-block routing notes, duplicate uuid warning), and add an explicit **Content rules** section telling agents to pass content as a raw string and never `JSON.stringify` it.
- Bump `packages/command` → `0.14.1` (touches `client`).

## Test plan

- [x] `pnpm check && pnpm typecheck` — clean
- [x] `pnpm --filter @first-tree-hub/server test` — 977 / 977 passed (incl. new `maybe-unwrap-double-encoded.test.ts` 8 cases)
- [x] `pnpm --filter @first-tree-hub/client test` — bootstrap suites 25 / 25 passed (one unrelated pre-existing flaky `git-mirror-manager.test.ts` failure on a network-timeout case — does not touch any modified path)
- [ ] Manual: trigger an agent that double-encodes content; confirm UI renders markdown correctly and server log shows `metric: double_encoded_content_unwrapped_total` warn entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)