### PR TITLE
fix(server): let watcher rows pass requireChatAccess for chat-scoped reads

### DIFF
--- a/packages/server/src/__tests__/chat-read-watcher.test.ts
+++ b/packages/server/src/__tests__/chat-read-watcher.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression coverage for issue #394 — watcher rows on chat_membership
+ * must be able to clear their own unread state via POST /chats/:id/read.
+ *
+ * Before the fix, `requireChatAccess` only let a "direct speaker" pass on
+ * the membership branch. Watchers had to rely on the supervisor branch
+ * (`agents.managerId = caller.memberId` for some speaker in the chat).
+ * When the supervisor anchor was stale — the managed speaker had left
+ * the chat but `recomputeChatWatchers` had not run yet — the watcher
+ * row outlived the supervisor link, and mark-read 404'd with no way for
+ * the user to dismiss the unread badge surfaced by `listMeChats`.
+ *
+ * Two scenarios pinned here:
+ *   1. Healthy supervisor-watcher — mark-read works (was already fine).
+ *   2. Stale watcher (no managed speaker anymore) — mark-read works
+ *      after the fix; was 404 before.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chatUserState } from "../db/schema/chat-user-state.js";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { recomputeChatWatchers } from "../services/watcher.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+describe("issue #394 — watcher mark-read", () => {
+  const getApp = useTestApp();
+
+  it("healthy supervisor-watcher can mark-read", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const managed = await createAgent(app.db, {
+      name: `mng-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Mng",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId: undefined,
+    });
+    const peer = await createTestAgent(app, { name: "peer-h" });
+    const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+    await recomputeChatWatchers(app.db, chatId);
+
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: admin.humanAgentUuid,
+      unreadMentionCount: 1,
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/read`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [state] = await app.db
+      .select({ unread: chatUserState.unreadMentionCount })
+      .from(chatUserState)
+      .where(and(eq(chatUserState.chatId, chatId), eq(chatUserState.agentId, admin.humanAgentUuid)))
+      .limit(1);
+    expect(state?.unread).toBe(0);
+  });
+
+  it("stale watcher (no managed speaker anymore) can still mark-read", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const managed = await createAgent(app.db, {
+      name: `mng-stale-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "Mng-Stale",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId: undefined,
+    });
+    const peer = await createTestAgent(app, { name: "peer-s" });
+    const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+    await recomputeChatWatchers(app.db, chatId);
+
+    // Sever the supervisor anchor: remove the managed speaker without
+    // re-running `recomputeChatWatchers`. The admin's watcher row stays,
+    // and `listMeChats` still surfaces the chat — the same shape as the
+    // production stale-watcher state #394 reports.
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, managed.uuid)));
+
+    const [stillWatcher] = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, admin.humanAgentUuid)))
+      .limit(1);
+    expect(stillWatcher?.accessMode).toBe("watcher");
+
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: admin.humanAgentUuid,
+      unreadMentionCount: 1,
+    });
+
+    // Chat still surfaces with unread (red badge would show on the
+    // sidebar) — the user needs a way to dismiss it.
+    const meChats = (await app.db.execute(sql`
+      SELECT COALESCE(cus.unread_mention_count, 0) AS unread
+        FROM chats c
+        JOIN chat_membership cm ON cm.chat_id = c.id AND cm.agent_id = ${admin.humanAgentUuid}
+        LEFT JOIN chat_user_state cus ON cus.chat_id = c.id AND cus.agent_id = ${admin.humanAgentUuid}
+       WHERE c.id = ${chatId}
+    `)) as unknown as Array<{ unread: number }>;
+    expect(meChats[0]?.unread).toBe(1);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/read`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [state] = await app.db
+      .select({ unread: chatUserState.unreadMentionCount })
+      .from(chatUserState)
+      .where(and(eq(chatUserState.chatId, chatId), eq(chatUserState.agentId, admin.humanAgentUuid)))
+      .limit(1);
+    expect(state?.unread).toBe(0);
+  });
+});

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -121,10 +121,23 @@ type ChatRow = {
 };
 
 /**
- * Gate access to a chat. Allowed if the caller's HUMAN agent is a
- * participant, OR any agent the caller manages (via members.id) is a
- * participant. Admin role does NOT auto-grant chat access — chat content
- * remains private to participants and supervisors (their managers).
+ * Gate access to a chat. Allowed if the caller's HUMAN agent has any
+ * `chat_membership` row (speaker OR watcher), OR any agent the caller
+ * manages (via members.id) is a speaker. Admin role does NOT auto-grant
+ * chat access — chat content remains private to members and supervisors
+ * (their managers).
+ *
+ * Watchers are allowed on the direct-membership branch because they
+ * surface in `listMeChats` with their own unread badge and engagement
+ * state; chat-scoped per-user operations like read-cursor and
+ * watcher→speaker upgrade must be reachable from that surface. Write
+ * endpoints that need to refuse watchers rely on `ensureParticipant`
+ * or service-layer checks, not on this guard.
+ *
+ * The supervisor branch is a fallback for callers whose human agent
+ * has no direct row but who manage a speaker — e.g. before
+ * `recomputeChatWatchers` has materialised the watcher row, or when a
+ * member's human agent and managed agent diverge in cross-org chats.
  *
  * The Params type is generic so routes that mount on a path with extra
  * params (e.g. `/agents/:uuid/sessions/:chatId/...` for compound checks)
@@ -154,17 +167,15 @@ export async function requireChatAccess<P extends { chatId: string }>(
     humanAgentId: caller.humanAgentId,
   };
 
-  // Direct speaker?
+  // Direct membership — speaker or watcher. A watcher row grants
+  // chat-level access even if the supervisor anchor that produced it
+  // is no longer live; pruning stale watcher rows is a separate
+  // concern from gating callers who can already see the chat in their
+  // own workspace list.
   const [direct] = await db
     .select({ chatId: chatMembership.chatId })
     .from(chatMembership)
-    .where(
-      and(
-        eq(chatMembership.chatId, chatId),
-        eq(chatMembership.agentId, caller.humanAgentId),
-        eq(chatMembership.accessMode, "speaker"),
-      ),
-    )
+    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, caller.humanAgentId)))
     .limit(1);
   if (direct) {
     stampOrgScope(request, scope);


### PR DESCRIPTION
Fixes #394.

## Summary
- Relax `requireChatAccess`'s direct-membership branch to accept both `speaker` and `watcher` rows. Previously only speakers passed; watchers had to rely on the supervisor fallback (caller manages a speaker in the chat).
- When the supervisor anchor went stale — managed speaker removed from a chat without `recomputeChatWatchers` being re-run — the watcher row outlived its supervisor link, so `POST /chats/:id/read` 404'd while `listMeChats` kept surfacing the chat with its unread counter. Users saw a stuck red badge they couldn't dismiss.
- Watcher access here mirrors what `listMeChats` already exposes (the chat is in the user's workspace list). Write endpoints continue to enforce speaker-only semantics via `ensureParticipant` or service-layer checks, so this is not a new write surface.
- Regression test pins both paths: healthy supervisor-watcher and stale-watcher mark-read.

## Test plan
- [x] `pnpm --filter @first-tree-hub/server test src/__tests__/chat-read-watcher.test.ts` — 2/2 pass
- [x] `pnpm --filter @first-tree-hub/server test` — 979/979 pass, no regression
- [x] `pnpm check` (biome) clean
- [x] `pnpm typecheck` clean across workspace
- [x] Live TCP HTTP verification against a real `app.listen()` instance: stale watcher receives `200` + `unreadMentionCount: 0` (script kept out of the diff)

## Follow-up
- Root cause for *how* stale watcher rows are produced in production is not addressed here. Worth a follow-up to audit the lifecycle paths that delete speaker rows or change `agents.managerId` without dispatching `recomputeChatWatchers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)