### PR TITLE
feat(web): collapsible WorkingBubble for inline tool_call / thinking events

### DIFF
--- a/packages/web/src/components/chat/working-bubble.tsx
+++ b/packages/web/src/components/chat/working-bubble.tsx
@@ -1,0 +1,250 @@
+/**
+ * WorkingBubble — collapsible group of in-progress tool_call / thinking
+ * events from one agent's active turn, rendered inline in the chat
+ * timeline.
+ *
+ * Folded (group-chat default): a single mono row indistinguishable from
+ * the legacy in-line ToolCallStatusRow / ThinkingRow, plus a trailing
+ * chevron.
+ *
+ * Expanded (direct-chat default): the same head row, the full event
+ * history underneath, and a compact meta line with counts + elapsed.
+ *
+ * No border / background / radius — state is conveyed solely through
+ * the leading status dot. The bubble doesn't model "done" itself; when
+ * `filterEventsForTimeline` drops the events after `turn_end`, the
+ * parent omits the workgroup entry and the bubble simply unmounts.
+ */
+
+import { useState } from "react";
+import { asToolCallPayload, type SessionEventRow } from "../../api/sessions.js";
+
+type WorkingBubbleProps = {
+  /**
+   * tool_call and thinking events for one active turn, in seq-ascending
+   * order. Errors are intentionally excluded — they're rendered as
+   * their own ErrorRow upstream so failures stay visible regardless of
+   * this bubble's open/closed state.
+   */
+  events: SessionEventRow[];
+  /**
+   * Direct chats pass `true` (single-agent context — show everything),
+   * group chats pass `false` (quiet by default).
+   */
+  defaultOpen: boolean;
+};
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${ms}ms`;
+}
+
+function formatElapsedSec(totalSeconds: number): string {
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}m${s.toString().padStart(2, "0")}s`;
+}
+
+function previewArgs(args: unknown): string {
+  if (args === undefined || args === null) return "";
+  if (typeof args === "string") return args;
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return "…";
+  }
+}
+
+function ToolCallLine({ event }: { event: SessionEventRow }) {
+  const payload = asToolCallPayload(event.payload);
+  if (!payload) return null;
+  const isErr = payload.status === "error";
+  const isPending = payload.status === "pending";
+  const color = isErr ? "var(--state-error)" : isPending ? "var(--state-blocked)" : "var(--fg-3)";
+  const verb = isErr ? "failed" : isPending ? "using" : "used";
+  return (
+    <div
+      className="mono flex items-center text-label"
+      style={{
+        gap: 8,
+        padding: "var(--sp-0_5) var(--sp-2)",
+        color: "var(--fg-3)",
+      }}
+    >
+      {isPending ? (
+        <span
+          aria-hidden
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: color,
+            animation: "heartbeat-pulse 1.2s ease-in-out infinite",
+            flexShrink: 0,
+            marginTop: 5,
+          }}
+        />
+      ) : (
+        <span aria-hidden style={{ color, flexShrink: 0 }}>
+          {isErr ? "⚠" : "↳"}
+        </span>
+      )}
+      <span
+        className="flex items-baseline"
+        style={{ color: "var(--fg-3)", minWidth: 0, flex: 1 }}
+        title={payload.args !== undefined && payload.args !== null ? previewArgs(payload.args) : undefined}
+      >
+        <span style={{ whiteSpace: "nowrap", flexShrink: 0 }}>
+          {verb} <span style={{ color: "var(--fg-2)" }}>{payload.name}</span>
+        </span>
+        {payload.args !== undefined && payload.args !== null ? (
+          <span className="truncate" style={{ color: "var(--fg-4)", minWidth: 0, flex: 1 }}>
+            ({previewArgs(payload.args)})
+          </span>
+        ) : null}
+        {payload.durationMs !== undefined && !isPending ? (
+          <span
+            className="text-caption"
+            style={{
+              color: "var(--fg-4)",
+              marginLeft: 6,
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            · {formatDuration(payload.durationMs)}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function formatClockTime(iso: string): string {
+  const d = new Date(iso);
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("month")}/${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
+function ThinkingLine({ event }: { event: SessionEventRow }) {
+  return (
+    <div
+      className="mono flex items-center text-label"
+      style={{
+        gap: 8,
+        padding: "var(--sp-0_5) var(--sp-2)",
+        color: "var(--fg-3)",
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: "var(--accent)",
+          animation: "heartbeat-pulse 1.2s ease-in-out infinite",
+          flexShrink: 0,
+        }}
+      />
+      <span style={{ color: "var(--fg-3)" }}>thinking…</span>
+      <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+        {formatClockTime(event.createdAt)}
+      </span>
+    </div>
+  );
+}
+
+function renderLine(event: SessionEventRow): React.ReactNode {
+  if (event.kind === "tool_call") return <ToolCallLine event={event} />;
+  if (event.kind === "thinking") return <ThinkingLine event={event} />;
+  return null;
+}
+
+function summarize(events: SessionEventRow[]): { toolCalls: number; thinkings: number; elapsedSec: number } {
+  let toolCalls = 0;
+  let thinkings = 0;
+  for (const e of events) {
+    if (e.kind === "tool_call") toolCalls += 1;
+    if (e.kind === "thinking") thinkings += 1;
+  }
+  const first = events[0];
+  const elapsedSec = first ? Math.max(0, Math.round((Date.now() - new Date(first.createdAt).getTime()) / 1000)) : 0;
+  return { toolCalls, thinkings, elapsedSec };
+}
+
+export function WorkingBubble({ events, defaultOpen }: WorkingBubbleProps) {
+  // `open` is local state so the user's manual toggle survives incoming
+  // events. Resetting only happens on remount, which the parent triggers
+  // when `turn_end` arrives and the workgroup entry disappears.
+  const [open, setOpen] = useState<boolean>(defaultOpen);
+
+  // Head row = the latest event in the turn. Folded chats see only this
+  // row, which matches the legacy in-line presentation pixel-for-pixel.
+  const latest = events[events.length - 1];
+  if (!latest) return null;
+  const { toolCalls, thinkings, elapsedSec } = summarize(events);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full text-left"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          cursor: "pointer",
+          minWidth: 0,
+        }}
+        aria-expanded={open}
+        aria-label={open ? "Collapse working details" : "Expand working details"}
+      >
+        <span style={{ flex: 1, minWidth: 0 }}>{renderLine(latest)}</span>
+        <span
+          aria-hidden
+          className="text-caption"
+          style={{
+            color: "var(--fg-4)",
+            transform: open ? "rotate(180deg)" : "none",
+            transition: "transform 150ms ease",
+            marginRight: "var(--sp-1_5)",
+            flexShrink: 0,
+            lineHeight: 1,
+          }}
+        >
+          ▾
+        </span>
+      </button>
+
+      {open ? (
+        <div>
+          {events.map((e) => (
+            <div key={e.id}>{renderLine(e)}</div>
+          ))}
+          <div
+            className="mono text-caption"
+            style={{
+              color: "var(--fg-4)",
+              padding: "var(--sp-0_5) var(--sp-2) 0 var(--sp-4)",
+            }}
+          >
+            {toolCalls} {toolCalls === 1 ? "tool" : "tools"} · {thinkings} thinking · {formatElapsedSec(elapsedSec)}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -30,7 +30,6 @@ import {
   agentSessionsQueryKey,
   asAssistantTextPayload,
   asErrorPayload,
-  asToolCallPayload,
   listSessionEvents,
   type SessionEventRow,
 } from "../../../api/sessions.js";
@@ -41,6 +40,7 @@ import {
   QuestionMessage,
   type QuestionStatus,
 } from "../../../components/chat/question-message.js";
+import { WorkingBubble } from "../../../components/chat/working-bubble.js";
 import { FirstTreeLogo } from "../../../components/first-tree-logo.js";
 import {
   ambiguousDisplayNames,
@@ -71,21 +71,6 @@ function formatClockTime(iso: string): string {
   return `${get("month")}/${get("day")} ${get("hour")}:${get("minute")}`;
 }
 
-function formatDuration(ms: number): string {
-  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
-  return `${ms}ms`;
-}
-
-function previewArgs(args: unknown): string {
-  if (args === undefined || args === null) return "";
-  if (typeof args === "string") return args;
-  try {
-    return JSON.stringify(args);
-  } catch {
-    return "…";
-  }
-}
-
 function ReadReceipt({ msg, myAgentId }: { msg: MessageWithDelivery; myAgentId: string | null }) {
   if (!myAgentId || msg.senderId !== myAgentId) return null;
   const status = msg.deliveryStatus ?? "sent";
@@ -107,77 +92,6 @@ function ReadReceipt({ msg, myAgentId }: { msg: MessageWithDelivery; myAgentId: 
     <span className="mono text-caption" style={{ color: "var(--fg-4)" }} title="Sent">
       ✓ sent
     </span>
-  );
-}
-
-/**
- * Compact, single-line "status indicator" for a tool call. Per the chat-view
- * design, we don't show the tool's full args/result — only a "Using <name>…"
- * pulse while the turn is in progress. When the turn ends, the whole row is
- * hidden by the turn-grouping filter (see `activeSince` below).
- */
-function ToolCallStatusRow({ event }: { event: SessionEventRow }) {
-  const payload = asToolCallPayload(event.payload);
-  if (!payload) return null;
-  const isErr = payload.status === "error";
-  const isPending = payload.status === "pending";
-  const color = isErr ? "var(--state-error)" : isPending ? "var(--state-blocked)" : "var(--fg-3)";
-  const verb = isErr ? "failed" : isPending ? "using" : "used";
-  return (
-    <div
-      className="mono flex items-center text-label"
-      style={{
-        gap: 8,
-        padding: "var(--sp-0_5) var(--sp-2)",
-        color: "var(--fg-3)",
-      }}
-    >
-      {isPending ? (
-        <span
-          aria-hidden
-          style={{
-            width: 6,
-            height: 6,
-            borderRadius: "50%",
-            background: color,
-            animation: "heartbeat-pulse 1.2s ease-in-out infinite",
-            flexShrink: 0,
-            marginTop: 5,
-          }}
-        />
-      ) : (
-        <span aria-hidden style={{ color, flexShrink: 0 }}>
-          {isErr ? "⚠" : "↳"}
-        </span>
-      )}
-      <span
-        className="flex items-baseline"
-        style={{ color: "var(--fg-3)", minWidth: 0, flex: 1 }}
-        title={payload.args !== undefined && payload.args !== null ? previewArgs(payload.args) : undefined}
-      >
-        <span style={{ whiteSpace: "nowrap", flexShrink: 0 }}>
-          {verb} <span style={{ color: "var(--fg-2)" }}>{payload.name}</span>
-        </span>
-        {payload.args !== undefined && payload.args !== null ? (
-          <span className="truncate" style={{ color: "var(--fg-4)", minWidth: 0, flex: 1 }}>
-            ({previewArgs(payload.args)})
-          </span>
-        ) : null}
-        {payload.durationMs !== undefined && !isPending ? (
-          <span
-            className="text-caption"
-            style={{
-              color: "var(--fg-4)",
-              marginLeft: 6,
-              whiteSpace: "nowrap",
-              flexShrink: 0,
-            }}
-          >
-            · {formatDuration(payload.durationMs)}
-          </span>
-        ) : null}
-      </span>
-    </div>
   );
 }
 
@@ -232,40 +146,6 @@ function AssistantTextRow({
           {payload.text}
         </div>
       </div>
-    </div>
-  );
-}
-
-/**
- * Lightweight "Thinking…" pulse. The actual thinking content is never
- * transmitted — the backend emits a bare marker and we surface it as a
- * single-line status. Hidden once the turn ends.
- */
-function ThinkingRow({ event }: { event: SessionEventRow }) {
-  return (
-    <div
-      className="mono flex items-center text-label"
-      style={{
-        gap: 8,
-        padding: "var(--sp-0_5) var(--sp-2)",
-        color: "var(--fg-3)",
-      }}
-    >
-      <span
-        aria-hidden
-        style={{
-          width: 6,
-          height: 6,
-          borderRadius: "50%",
-          background: "var(--accent)",
-          animation: "heartbeat-pulse 1.2s ease-in-out infinite",
-          flexShrink: 0,
-        }}
-      />
-      <span style={{ color: "var(--fg-3)" }}>thinking…</span>
-      <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-        {formatClockTime(event.createdAt)}
-      </span>
     </div>
   );
 }
@@ -601,7 +481,8 @@ type PendingImage = {
 
 type TimelineItem =
   | { kind: "message"; at: string; key: string; data: MessageWithDelivery }
-  | { kind: "event"; at: string; key: string; data: SessionEventRow };
+  | { kind: "event"; at: string; key: string; data: SessionEventRow }
+  | { kind: "workgroup"; at: string; key: string; events: SessionEventRow[] };
 
 /**
  * Renders a small "↗ View on GitHub" link beside the chat title when the chat
@@ -891,17 +772,41 @@ export function ChatView({
    * final result) are always visible; transient events go through the
    * turn-grouping filter so completed turns collapse to just their result
    * message. See `filterEventsForTimeline` for the full rules.
+   *
+   * Second pass collapses adjacent `tool_call` + `thinking` rows into a
+   * single `workgroup` entry — these become the inline WorkingBubble. Any
+   * non-bubble item (message, assistant_text, error) flushes the current
+   * bucket, so intermediate streamed text stays visible as its own row
+   * even when surrounded by tool calls.
    */
   const items: TimelineItem[] = useMemo(() => {
     const msgs = messagesData?.items ?? [];
     const visibleEvents = filterEventsForTimeline(eventsData?.items ?? []);
 
-    const out: TimelineItem[] = [
+    const flat: TimelineItem[] = [
       ...msgs.map((m) => ({ kind: "message" as const, at: m.createdAt, key: `m-${m.id}`, data: m })),
       ...visibleEvents.map((e) => ({ kind: "event" as const, at: e.createdAt, key: `e-${e.id}`, data: e })),
     ];
-    out.sort((a, b) => a.at.localeCompare(b.at));
-    return out;
+    flat.sort((a, b) => a.at.localeCompare(b.at));
+
+    const grouped: TimelineItem[] = [];
+    let bucket: SessionEventRow[] = [];
+    const flushBucket = () => {
+      const first = bucket[0];
+      if (!first) return;
+      grouped.push({ kind: "workgroup", at: first.createdAt, key: `wg-${first.id}`, events: bucket });
+      bucket = [];
+    };
+    for (const item of flat) {
+      if (item.kind === "event" && (item.data.kind === "tool_call" || item.data.kind === "thinking")) {
+        bucket.push(item.data);
+        continue;
+      }
+      flushBucket();
+      grouped.push(item);
+    }
+    flushBucket();
+    return grouped;
   }, [messagesData, eventsData]);
 
   /**
@@ -1313,19 +1218,19 @@ export function ChatView({
           )}
           <div className="flex flex-col" style={{ gap: 4 }}>
             {items.map((item) => {
+              if (item.kind === "workgroup") {
+                return <WorkingBubble key={item.key} events={item.events} defaultOpen={chatDetail?.type !== "group"} />;
+              }
               if (item.kind === "event") {
                 const ev = item.data;
                 switch (ev.kind) {
-                  case "tool_call":
-                    return <ToolCallStatusRow key={item.key} event={ev} />;
                   case "assistant_text":
                     return <AssistantTextRow key={item.key} event={ev} agentId={agentId} agentNameFn={agentName} />;
-                  case "thinking":
-                    return <ThinkingRow key={item.key} event={ev} />;
                   case "error":
                     return <ErrorRow key={item.key} event={ev} />;
                   default:
-                    // turn_end is filtered upstream; any unknown kind is dropped.
+                    // tool_call / thinking are folded into the workgroup above;
+                    // turn_end is filtered upstream; anything else is dropped.
                     return null;
                 }
               }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -781,7 +781,20 @@ export function ChatView({
    */
   const items: TimelineItem[] = useMemo(() => {
     const msgs = messagesData?.items ?? [];
-    const visibleEvents = filterEventsForTimeline(eventsData?.items ?? []);
+    const rawEvents = eventsData?.items ?? [];
+    const visibleEvents = filterEventsForTimeline(rawEvents);
+
+    // Turn id = the seq of the last turn_end seen across all events, including
+    // ones filterEventsForTimeline dropped. Every visible transient event has
+    // seq > lastTurnEndSeq, so each turn gets a unique stable anchor that
+    // survives toolUseId dedupe (where individual event ids change as
+    // pending → final updates flow in). Used to build remount-safe bubble
+    // keys so the user's manual open/closed toggle isn't reset when a single
+    // tool call's pending row gets replaced by its final-status row.
+    let lastTurnEndSeq = -1;
+    for (const e of rawEvents) {
+      if (e.kind === "turn_end" && e.seq > lastTurnEndSeq) lastTurnEndSeq = e.seq;
+    }
 
     const flat: TimelineItem[] = [
       ...msgs.map((m) => ({ kind: "message" as const, at: m.createdAt, key: `m-${m.id}`, data: m })),
@@ -791,10 +804,17 @@ export function ChatView({
 
     const grouped: TimelineItem[] = [];
     let bucket: SessionEventRow[] = [];
+    let bucketIndex = 0;
     const flushBucket = () => {
       const first = bucket[0];
       if (!first) return;
-      grouped.push({ kind: "workgroup", at: first.createdAt, key: `wg-${first.id}`, events: bucket });
+      grouped.push({
+        kind: "workgroup",
+        at: first.createdAt,
+        key: `wg-${lastTurnEndSeq}-${bucketIndex}`,
+        events: bucket,
+      });
+      bucketIndex += 1;
       bucket = [];
     };
     for (const item of flat) {
@@ -1219,7 +1239,13 @@ export function ChatView({
           <div className="flex flex-col" style={{ gap: 4 }}>
             {items.map((item) => {
               if (item.kind === "workgroup") {
-                return <WorkingBubble key={item.key} events={item.events} defaultOpen={chatDetail?.type !== "group"} />;
+                // Default to folded while chatDetail is still loading — opening
+                // a group chat's bubble for one frame and then folding it after
+                // chatDetail resolves is worse than under-opening direct chats
+                // by the same one-frame window.
+                return (
+                  <WorkingBubble key={item.key} events={item.events} defaultOpen={chatDetail?.type === "direct"} />
+                );
               }
               if (item.kind === "event") {
                 const ev = item.data;


### PR DESCRIPTION
## Summary

Inline working-events get grouped per agent turn into a collapsible bubble.

- **Folded head row** mirrors the existing `ToolCallStatusRow` / `ThinkingRow` pixel-for-pixel — direct chat users see no visual change, just an added chevron at the end. No border, no background, no radius: state is conveyed solely by the leading 6px status dot.
- **Direct chats default to expanded** (single-agent context; keep current experience). **Group chats default to collapsed** (quiet by default to suppress noise across concurrent agents). Local toggle state survives incoming events.
- **Intermediate `assistant_text` stays an independent row** — streamed mid-turn replies are never folded into the bubble.
- **No "done" state to render**: existing `filterEventsForTimeline` already drops transient events after `turn_end`, so the bubble simply unmounts when a turn completes.

## Implementation

- New component `packages/web/src/components/chat/working-bubble.tsx` — internalises the legacy `ToolCallStatusRow` / `ThinkingRow` visuals as private line renderers.
- `chat-view.tsx`: timeline `useMemo` runs a second pass that collapses adjacent `tool_call` + `thinking` items into a `workgroup` timeline entry. Any other item (message, `assistant_text`, `error`) flushes the bucket, so intermediate text and errors remain in their original positions.
- `defaultOpen` is wired from `chatDetail.type !== "group"`.

**Protocol unchanged.** No new event kinds, no new endpoints, no backend changes — the existing `turn_end` event already provides the boundary the grouping relies on.

## Test plan

- [x] `pnpm check` (biome) — 0 errors
- [x] `pnpm typecheck` — no new errors in changed files (pre-existing `d3-hierarchy` / `dompurify` issues unchanged)
- [x] `pnpm test session-timeline` — 11/11 pass; turn-grouping contract preserved
- [x] Full `pnpm test` — same fail count as main (8 pre-existing failures unrelated to this change), zero regressions
- [x] Visual end-to-end verification via a dev-only preview page (now removed) — confirmed: folded/expanded states, direct vs group defaults, toggle persistence across events, intermediate `assistant_text` independence, error-state inline rendering

## Diff

`+285 / −130`, 2 files: 1 new component (~245 lines), `chat-view.tsx` net −95 lines (removed `ToolCallStatusRow`, `ThinkingRow`, `formatDuration`, `previewArgs` — now internalised in WorkingBubble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)