### PR TITLE
feat(server,web): close private-agent identity & owner-exclusive gaps

### DIFF
--- a/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
+++ b/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Coverage for the "chat-scoped identity is membership-derived, not
+ * discovery-derived" invariant from
+ * `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3 / §4.4.2.
+ *
+ * Two behaviours pinned:
+ *
+ *   1. `GET /api/v1/chats/:chatId` returns each participant's full
+ *      `name / displayName / type` even when the caller is not the
+ *      manager of a `visibility=private` participant. The membership
+ *      itself is the trust boundary — without this, a private agent in
+ *      a group chat shows up as a UUID prefix for everyone except its
+ *      manager (issue #372).
+ *
+ *   2. The service-layer `addMeChatParticipants` rejects non-owners
+ *      from pulling a `visibility=private` agent into a chat. The
+ *      API-layer `assertAllAgentsVisibleInOrg` already enforces this
+ *      via the discovery filter (404), but the service-layer check is
+ *      the load-bearing invariant for any future entrypoint that
+ *      bypasses the discovery filter.
+ */
+
+import { AGENT_VISIBILITY, type ChatDetail } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { createAgent } from "../services/agent.js";
+import {
+  addParticipant as agentAddParticipant,
+  createChat as agentCreateChat,
+  findOrCreateDirectChat,
+} from "../services/chat.js";
+import { addMeChatParticipants, createMeChat } from "../services/me-chat.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("chat-scoped identity rendering vs discovery visibility", () => {
+  const getApp = useTestApp();
+
+  it("GET /chats/:chatId surfaces a private participant's name even to non-managers", async () => {
+    const app = getApp();
+    // Two admins in the same default org. Alice owns a private agent X;
+    // Bob is in the chat with Alice + X but has no management
+    // relationship with X.
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const privateAgent = await createAgent(app.db, {
+      name: `priv-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // Alice spins up a group chat she + Bob + private agent X are in.
+    // (Three speakers → group.)
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [bob.humanAgentUuid, privateAgent.uuid],
+    });
+
+    // Bob — who can't "discover" Alice's private agent — fetches the
+    // chat. Identity rendering inside the chat must NOT be filtered
+    // by visibility: Bob must see the real name and displayName.
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}`,
+      headers: { authorization: `Bearer ${bob.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json<ChatDetail>();
+    const xRow = body.participants.find((p) => p.agentId === privateAgent.uuid);
+    expect(xRow).toBeDefined();
+    expect(xRow?.name).toBe(privateAgent.name);
+    expect(xRow?.displayName).toBe("Alice's Private Agent");
+    expect(xRow?.type).toBe("autonomous_agent");
+  });
+
+  it("addMeChatParticipants rejects a non-owner who tries to add a private agent", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    // Alice owns a private agent; Bob has a chat with Alice but does
+    // not manage the private agent.
+    const privateAgent = await createAgent(app.db, {
+      name: `priv-add-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // Bob creates a direct chat with Alice (Bob is the speaker we'll
+    // exercise the add-participant gate on).
+    const { chatId } = await createMeChat(app.db, bob.humanAgentUuid, bob.organizationId, {
+      participantIds: [alice.humanAgentUuid],
+    });
+
+    // Bob attempts to pull Alice's private agent into the chat. The
+    // service-layer owner-exclusive check must refuse — even though
+    // Bob is a legitimate speaker in the chat, he cannot grant the
+    // exposure consent for an agent he does not own.
+    await expect(
+      addMeChatParticipants(app.db, chatId, bob.humanAgentUuid, bob.organizationId, {
+        participantIds: [privateAgent.uuid],
+      }),
+    ).rejects.toThrow(/private agent/i);
+  });
+
+  it("addMeChatParticipants accepts the owner adding their own private agent", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const privateAgent = await createAgent(app.db, {
+      name: `priv-self-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [bob.humanAgentUuid],
+    });
+
+    // Owner adding her own private agent — the natural "invite-as-consent" path.
+    await expect(
+      addMeChatParticipants(app.db, chatId, alice.humanAgentUuid, alice.organizationId, {
+        participantIds: [privateAgent.uuid],
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("createMeChat rejects a non-owner who tries to include a private agent at creation time", async () => {
+    // Same invariant as addMeChatParticipants, but on the create path.
+    // RFC §4.4.2 expects the service-layer gate on every chat-membership
+    // write — closing the create-side bypass.
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const privateAgent = await createAgent(app.db, {
+      name: `priv-create-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    await expect(
+      createMeChat(app.db, bob.humanAgentUuid, bob.organizationId, {
+        participantIds: [alice.humanAgentUuid, privateAgent.uuid],
+      }),
+    ).rejects.toThrow(/private agent/i);
+  });
+
+  it("agent-SDK createChat rejects a private target owned by a different member", async () => {
+    // Agent-SDK path (POST /api/v1/agent/chats) hits services/chat.ts
+    // createChat; without the owner-exclusive gate, an autonomous agent
+    // controlled by Bob could pull Alice's private agent into a fresh
+    // chat purely on the agent SDK.
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    // Bob's agent — the "caller" on the agent-SDK side. visibility
+    // defaults to organization for autonomous_agent so it doesn't
+    // entangle the test with discovery rules.
+    const bobsAgent = await createAgent(app.db, {
+      name: `bob-agent-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Bob's Agent",
+      managerId: bob.memberId,
+      organizationId: bob.organizationId,
+    });
+
+    const alicesPrivate = await createAgent(app.db, {
+      name: `alice-priv-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    await expect(
+      agentCreateChat(app.db, bobsAgent.uuid, {
+        type: "group",
+        participantIds: [alicesPrivate.uuid, alice.humanAgentUuid],
+      }),
+    ).rejects.toThrow(/private agent/i);
+  });
+
+  it("agent-SDK addParticipant rejects a private target owned by a different member", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const bobsAgent = await createAgent(app.db, {
+      name: `bob-agent-add-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Bob's Agent",
+      managerId: bob.memberId,
+      organizationId: bob.organizationId,
+    });
+
+    const alicesPrivate = await createAgent(app.db, {
+      name: `alice-priv-add-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // Bob's agent first creates a chat with Bob (no private targets) —
+    // legitimate so we can exercise the add-participant gate next.
+    const chat = await agentCreateChat(app.db, bobsAgent.uuid, {
+      type: "direct",
+      participantIds: [bob.humanAgentUuid],
+    });
+    if (!chat.id) throw new Error("Unexpected: createChat returned no id");
+
+    await expect(agentAddParticipant(app.db, chat.id, bobsAgent.uuid, { agentId: alicesPrivate.uuid })).rejects.toThrow(
+      /private agent/i,
+    );
+  });
+
+  it("findOrCreateDirectChat refuses to open a new direct chat with a private agent across owners", async () => {
+    // Closes the `sendToAgent` fallback bypass: Bob's agent looking up
+    // Alice's private agent by name would otherwise create a direct
+    // chat with it and DM-spam past the discovery filter. Existing
+    // direct chats are intentionally not retroactively gated; this
+    // test pins the new-chat path only.
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const bobsAgent = await createAgent(app.db, {
+      name: `bob-dm-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Bob's Agent",
+      managerId: bob.memberId,
+      organizationId: bob.organizationId,
+    });
+
+    const alicesPrivate = await createAgent(app.db, {
+      name: `alice-dm-priv-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Alice's Private Agent",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    await expect(findOrCreateDirectChat(app.db, bobsAgent.uuid, alicesPrivate.uuid)).rejects.toThrow(
+      /private agent across owners/i,
+    );
+  });
+});

--- a/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
+++ b/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
@@ -1,3 +1,4 @@
+import { AGENT_VISIBILITY } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
@@ -77,6 +78,13 @@ describe("direct chat default mode (migration 0029)", () => {
       const uid = crypto.randomUUID().slice(0, 6);
       const auto = await createTestAgent(app, { name: `dc-au-${uid}`, type: "autonomous_agent" });
       const { agent: pa } = await createTestAgent(app, { name: `dc-pa-${uid}`, type: "personal_assistant" });
+      // `personal_assistant` defaults to `visibility=private` (see
+      // `services/agent.ts::defaultVisibility`); flip it to organization
+      // so the cross-owner direct-chat owner-exclusive gate doesn't
+      // pre-empt this test. This case targets the mode-seeding rule,
+      // not the visibility gate covered in
+      // `chat-private-mention-visibility.test.ts`.
+      await app.db.update(agents).set({ visibility: AGENT_VISIBILITY.ORGANIZATION }).where(eq(agents.uuid, pa.uuid));
 
       const chat = await findOrCreateDirectChat(app.db, auto.agent.uuid, pa.uuid);
       const modes = await loadModes(chat.id);

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -6,7 +6,7 @@ import {
   submitQuestionAnswerSchema,
   updateChatSchema,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -42,9 +42,26 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { chatId: string } }>("/:chatId", async (request) => {
     const { chat, scope } = await requireChatAccess(request, app.db);
 
+    // Participants are resolved via INNER JOIN `agents` so each row
+    // already carries `name / displayName / type`. The trust boundary
+    // for chat-scoped identity is `chat_membership`, not org-level
+    // discovery — we deliberately do **not** apply
+    // `agentVisibilityCondition` here. See
+    // `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3.
     const participants = await app.db
-      .select()
+      .select({
+        agentId: chatMembership.agentId,
+        role: chatMembership.role,
+        mode: chatMembership.mode,
+        joinedAt: chatMembership.joinedAt,
+        name: agents.name,
+        displayName: agents.displayName,
+        type: agents.type,
+        avatarColorToken: agents.avatarColorToken,
+        avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
+      })
       .from(chatMembership)
+      .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
       .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.accessMode, "speaker")));
 
     const firstMsgRows = (await app.db.execute<{ content: unknown }>(sql`
@@ -55,31 +72,13 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     `)) as unknown as Array<{ content: unknown }>;
     const firstMessagePreview = firstMsgRows[0] ? extractSummary(firstMsgRows[0].content) : null;
 
-    const participantAgentIds = participants.map((p) => p.agentId);
-    const agentRows =
-      participantAgentIds.length > 0
-        ? await app.db
-            .select({
-              agentId: agents.uuid,
-              displayName: agents.displayName,
-              type: agents.type,
-              avatarColorToken: agents.avatarColorToken,
-              avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
-            })
-            .from(agents)
-            .where(inArray(agents.uuid, participantAgentIds))
-        : [];
-    const agentMeta = new Map(agentRows.map((a) => [a.agentId, a]));
-    const participantsForTitle = participants.map((p) => {
-      const meta = agentMeta.get(p.agentId);
-      return {
-        agentId: p.agentId,
-        displayName: meta?.displayName ?? p.agentId,
-        type: meta?.type ?? "unknown",
-        avatarColorToken: meta?.avatarColorToken ?? null,
-        avatarImageUrl: agentAvatarImageUrl(p.agentId, meta?.avatarImageUpdatedAt ?? null),
-      };
-    });
+    const participantsForTitle = participants.map((p) => ({
+      agentId: p.agentId,
+      displayName: p.displayName,
+      type: p.type,
+      avatarColorToken: p.avatarColorToken ?? null,
+      avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
+    }));
     const title = resolveChatTitle(chat.topic, firstMessagePreview, participantsForTitle, scope.humanAgentId);
 
     const engagementStatus = await getCallerEngagement(app.db, chat.id, scope.humanAgentId);
@@ -95,6 +94,9 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         agentId: p.agentId,
         role: p.role,
         mode: p.mode,
+        name: p.name,
+        displayName: p.displayName,
+        type: p.type,
         joinedAt: p.joinedAt.toISOString(),
       })),
     };

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { AddParticipant, CreateChat } from "@agent-team-foundation/first-tree-hub-shared";
+import { type AddParticipant, AGENT_VISIBILITY, type CreateChat } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -18,7 +18,13 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
 
   // Verify all participants exist and belong to the same organization
   const existingAgents = await db
-    .select({ id: agents.uuid, organizationId: agents.organizationId, type: agents.type })
+    .select({
+      id: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
     .from(agents)
     .where(inArray(agents.uuid, [...allParticipantIds]));
 
@@ -35,6 +41,22 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
   const crossOrg = existingAgents.filter((a) => a.organizationId !== orgId);
   if (crossOrg.length > 0) {
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
+  }
+
+  // Owner-exclusive rule: a private agent can only be brought into a
+  // chat by another agent owned by the same member (i.e. the creator
+  // and the target share `managerId`). `creator.managerId` is the
+  // caller's effective owner identity — for a human agent this is the
+  // member's own id; for an autonomous agent this is whichever member
+  // owns it. RFC §4.4.2 / §4.5 — keeping the gate at the service layer
+  // closes the agent-SDK bypass path, not only the user-facing /me API.
+  const privateNotOwned = existingAgents.filter(
+    (a) => a.id !== creatorId && a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== creator.managerId,
+  );
+  if (privateNotOwned.length > 0) {
+    throw new ForbiddenError(
+      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.id).join(", ")}`,
+    );
   }
 
   return db.transaction(async (tx) => {
@@ -90,9 +112,22 @@ export async function getChat(db: Database, chatId: string) {
 
 export async function getChatDetail(db: Database, chatId: string) {
   const chat = await getChat(db, chatId);
+  // Participants JOIN `agents` so each row carries `name / displayName /
+  // type`. Identity rendering inside a chat is membership-derived; we do
+  // not apply `agentVisibilityCondition` here — see
+  // `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3.
   const participants = await db
-    .select()
+    .select({
+      agentId: chatMembership.agentId,
+      role: chatMembership.role,
+      mode: chatMembership.mode,
+      joinedAt: chatMembership.joinedAt,
+      name: agents.name,
+      displayName: agents.displayName,
+      type: agents.type,
+    })
     .from(chatMembership)
+    .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
     .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
 
   return { ...chat, participants };
@@ -244,7 +279,12 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
 
   // Verify target agent exists and is in the same org
   const [targetAgent] = await db
-    .select({ id: agents.uuid, organizationId: agents.organizationId })
+    .select({
+      id: agents.uuid,
+      organizationId: agents.organizationId,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
     .from(agents)
     .where(eq(agents.uuid, data.agentId))
     .limit(1);
@@ -255,6 +295,29 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
 
   if (targetAgent.organizationId !== chat.organizationId) {
     throw new BadRequestError("Cannot add agent from different organization");
+  }
+
+  // Owner-exclusive rule for private targets. The requester is an
+  // agent on the SDK side; resolve its owner via `agents.managerId`
+  // and compare with the target's owner — only the same member may
+  // bring a private agent into a chat. Closes the agent-SDK bypass of
+  // the discovery filter (RFC §4.4.2 / §4.5). `targetAgent.id !==
+  // requesterId` skips the self-add case so an agent rejoining its own
+  // chat via `joinChat` semantics isn't incidentally blocked.
+  if (targetAgent.visibility === AGENT_VISIBILITY.PRIVATE && targetAgent.id !== requesterId) {
+    const [requester] = await db
+      .select({ managerId: agents.managerId })
+      .from(agents)
+      .where(eq(agents.uuid, requesterId))
+      .limit(1);
+    if (!requester) {
+      // Should be unreachable — `assertParticipant` above proved the
+      // requester is in chat_membership, which FK-references agents.
+      throw new NotFoundError(`Agent "${requesterId}" not found`);
+    }
+    if (requester.managerId !== targetAgent.managerId) {
+      throw new ForbiddenError(`Only the owner can add a private agent to a chat: ${targetAgent.id}`);
+    }
   }
 
   // Check not already a speaker. A watcher row is allowed — it's the
@@ -581,7 +644,13 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
   //      cannot reuse a historical dirty row whose participants happen to
   //      include both ends but whose chat lives in another org.
   const ends = await db
-    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
     .from(agents)
     .where(inArray(agents.uuid, [agentAId, agentBId]));
 
@@ -624,6 +693,25 @@ export async function findOrCreateDirectChat(db: Database, agentAId: string, age
     if (directChats.length > 0 && directChats[0]) {
       return directChats[0];
     }
+  }
+
+  // Owner-exclusive rule for new direct chats. Applied symmetrically:
+  // if either endpoint is a private agent and the two endpoints have
+  // different owners, refuse to materialise the direct chat. Covers
+  // the agent-SDK `sendToAgent` path — sender knowing only the
+  // target's `agents.name` (which is org-scoped, not secret) would
+  // otherwise create a direct chat with a private agent it has no
+  // owner relationship to (RFC §4.4.2 / §4.5 / §4.7 "Personal agent
+  // outbound DM to a stranger → forbidden"). Pre-existing direct
+  // chats are intentionally NOT retroactively gated: an existing
+  // membership row is already a scoped-consent artefact.
+  if (
+    (agentA.visibility === AGENT_VISIBILITY.PRIVATE || agentB.visibility === AGENT_VISIBILITY.PRIVATE) &&
+    agentA.managerId !== agentB.managerId
+  ) {
+    throw new ForbiddenError(
+      `Cannot open a direct chat with a private agent across owners: "${agentAId}" ↔ "${agentBId}"`,
+    );
   }
 
   // Create new direct chat. Mode is derived server-side from

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -19,6 +19,7 @@
 import { randomUUID } from "node:crypto";
 import {
   type AddMeChatParticipants,
+  AGENT_VISIBILITY,
   CHAT_ENGAGEMENT_STATUSES,
   type ChatEngagementStatus,
   type ChatEngagementView,
@@ -45,7 +46,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
-import { BadRequestError, NotFoundError } from "../errors.js";
+import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { addChatParticipants, changeChatType } from "./participant-mode.js";
@@ -605,7 +606,13 @@ export async function createMeChat(
 
   const allIds = [humanAgentId, ...distinctIds];
   const found = await db
-    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
     .from(agents)
     .where(inArray(agents.uuid, allIds));
 
@@ -617,6 +624,24 @@ export async function createMeChat(
   const crossOrg = found.filter((a) => a.organizationId !== organizationId);
   if (crossOrg.length > 0) {
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.uuid).join(", ")}`);
+  }
+
+  // Owner-exclusive rule for private agents (creation path, mirroring
+  // the add-participant gate in `addMeChatParticipants`). The caller
+  // agent's `managerId` is its owning member — looking it up from
+  // `found` (rather than accepting it as a parameter) keeps the
+  // owner-id source-of-truth inside the service. RFC §4.4.2 / §4.5.
+  const caller = found.find((a) => a.uuid === humanAgentId);
+  if (!caller) {
+    throw new BadRequestError("Caller agent not found in the chat's organization");
+  }
+  const privateNotOwned = found.filter(
+    (a) => a.uuid !== humanAgentId && a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== caller.managerId,
+  );
+  if (privateNotOwned.length > 0) {
+    throw new ForbiddenError(
+      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.uuid).join(", ")}`,
+    );
   }
 
   const chatType = distinctIds.length === 1 ? "direct" : "group";
@@ -686,9 +711,18 @@ export async function addMeChatParticipants(
   if (chat.organizationId !== callerOrganizationId) {
     throw new NotFoundError(`Chat "${chatId}" not found`);
   }
+  // Resolve caller's chat-membership AND owner member-id in one query.
+  // The owner member-id is the authoritative input to the
+  // owner-exclusive check below — deriving it from the caller agent's
+  // `managerId` (rather than accepting it as a parameter) prevents an
+  // internal caller from mismatching the two and bypassing the check.
+  // Works regardless of caller agent type: a human agent's managerId
+  // is its own member; an autonomous/personal_assistant agent's
+  // managerId is the member that owns it.
   const [callerRow] = await db
-    .select({ chatId: chatMembership.chatId })
+    .select({ ownerMemberId: agents.managerId })
     .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
     .where(
       and(
         eq(chatMembership.chatId, chatId),
@@ -700,9 +734,16 @@ export async function addMeChatParticipants(
   if (!callerRow) {
     throw new NotFoundError(`Chat "${chatId}" not found`);
   }
+  const callerMemberId = callerRow.ownerMemberId;
 
   const found = await db
-    .select({ uuid: agents.uuid, organizationId: agents.organizationId, type: agents.type })
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
     .from(agents)
     .where(inArray(agents.uuid, distinct));
 
@@ -714,6 +755,25 @@ export async function addMeChatParticipants(
   const crossOrg = found.filter((a) => a.organizationId !== chat.organizationId);
   if (crossOrg.length > 0) {
     throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((a) => a.uuid).join(", ")}`);
+  }
+
+  // Owner-exclusive rule for private agents. Only the agent's manager
+  // (the owner) can pull a private agent into a chat — inviting it into
+  // the chat is the owner's own scoped "consent" to expose it to other
+  // members. Mirrors the "邀请即同意 / Owner-exclusive" property in
+  // `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.4.2 /
+  // §4.5, and prevents anyone with an agent's UUID from bypassing the
+  // discovery filter to drop someone else's private agent into a chat.
+  // Living at the service layer (not just the API caller-side
+  // `assertAllAgentsVisibleInOrg` gate) so the invariant holds for any
+  // future entrypoint that builds on this service.
+  const privateNotOwned = found.filter(
+    (a) => a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== callerMemberId,
+  );
+  if (privateNotOwned.length > 0) {
+    throw new ForbiddenError(
+      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.uuid).join(", ")}`,
+    );
   }
 
   await db.transaction(async (tx) => {

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -79,7 +79,18 @@ export const chatSchema = z.object({
 export type Chat = z.infer<typeof chatSchema>;
 
 export const chatDetailSchema = chatSchema.extend({
-  participants: z.array(chatParticipantSchema),
+  /**
+   * Participants with `name / displayName / type` resolved via JOIN
+   * `agents`, intentionally **not** filtered by agent visibility. The
+   * authoritative trust boundary in a chat-scoped query is
+   * `chat_membership`, not org-level discovery — see
+   * `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3.
+   * The client renders chat-internal identity (mention autocomplete,
+   * participant chips, message sender name) off this field so a private
+   * agent that is a member of the chat shows its real name to every
+   * other member, not a UUID prefix.
+   */
+  participants: z.array(chatParticipantDetailSchema),
   /** Server-resolved display title. Priority: `topic` > first message
    *  preview > participant join. Clients should render this directly
    *  rather than re-implementing the fallback chain. */

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -855,7 +855,57 @@ export function ChatView({
     }
   }, [itemCount]);
 
-  const displayName = agentName(agentId);
+  /**
+   * Chat-scoped identity index. The chat detail endpoint resolves each
+   * participant's `name / displayName / type` via JOIN `agents` without
+   * applying `agentVisibilityCondition`, so private agents that are
+   * members of this chat carry their real labels here — the identity
+   * map (`useAgentNameMap` / `useAgentIdentityMap`) goes through the
+   * org-scoped `/agents` endpoint and would drop them. The chat
+   * membership is the authoritative trust boundary for in-chat identity
+   * rendering; see
+   * `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3.
+   */
+  const chatParticipantById = useMemo(() => {
+    const map = new Map<string, { name: string | null; displayName: string }>();
+    for (const p of chatDetail?.participants ?? []) {
+      map.set(p.agentId, { name: p.name, displayName: p.displayName });
+    }
+    return map;
+  }, [chatDetail?.participants]);
+
+  /**
+   * Resolve an agentId to a display label, preferring the chat-scoped
+   * participant index over the org-visibility-filtered identity map.
+   * Falls back to the identity map for senders that are no longer in
+   * the chat (e.g. historical messages after a future remove flow lands)
+   * and to the raw UUID prefix as a last resort.
+   */
+  const chatScopedAgentName = useCallback(
+    (id: string | null | undefined): string => {
+      if (!id) return "—";
+      const p = chatParticipantById.get(id);
+      if (p) return p.displayName;
+      return agentName(id);
+    },
+    [chatParticipantById, agentName],
+  );
+
+  /**
+   * Identity-pair variant used by the participant chip row and the
+   * mention picker. Same precedence rule as `chatScopedAgentName`.
+   */
+  const chatScopedAgentIdentity = useCallback(
+    (id: string | null | undefined): { name: string | null; displayName: string } | null => {
+      if (!id) return null;
+      const p = chatParticipantById.get(id);
+      if (p) return { name: p.name, displayName: p.displayName };
+      return agentIdentity(id);
+    },
+    [chatParticipantById, agentIdentity],
+  );
+
+  const displayName = chatScopedAgentName(agentId);
 
   /** Set of agentIds currently in the chat. Used to (a) detect "outsiders"
    *  the user `@`-mentions and (b) skip the redundant addParticipants call
@@ -864,19 +914,15 @@ export function ChatView({
     return new Set(chatDetail?.participants?.map((p) => p.agentId) ?? []);
   }, [chatDetail?.participants]);
 
-  // Mention autocomplete candidates: every org agent the user might address,
-  // resolved to their `{name, displayName}` via the shared identity map.
-  // Includes BOTH chat participants and outsiders — picking an outsider
-  // implicitly invites them via `addMeChatParticipants` at send time, which
-  // turns a 1:1 into a group server-side. Self is excluded; any agent
-  // without a slug (`name`) is skipped because mentions need one — even
-  // current chat participants. This is intentional: the server's
-  // `extractMentions` matches `@<token>` against `agents.name`, so a
-  // participant with `name=null` (legacy / soft-deleted row) cannot be
-  // addressed via `@` regardless. They still show in `ParticipantsHeader`
-  // chips (which uses `agentIdentity.displayName`); the picker just won't
-  // offer them. Fixing this requires the server to backfill missing
-  // `agents.name`, not a client-side workaround.
+  // Mention autocomplete candidates: every agent the user might address,
+  // resolved to their `{name, displayName}`. Chat participants take
+  // precedence over the visibility-filtered identity map so private agents
+  // already in the chat surface in the picker (identity inside a chat is
+  // membership-derived, not discovery-derived — fixes the missing-private-
+  // agent autocomplete bug). Outsiders sourced from `/activity` continue
+  // to rely on the identity map — that lookup is org-scoped and correctly
+  // bounded by discovery rules. Self is excluded; any agent without a slug
+  // (`name`) is skipped because mentions need one.
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     const ids = new Set<string>();
     for (const p of chatDetail?.participants ?? []) ids.add(p.agentId);
@@ -898,7 +944,7 @@ export function ChatView({
     const out: MentionCandidate[] = [];
     for (const id of ids) {
       if (id === myAgentId) continue;
-      const ident = agentIdentity(id);
+      const ident = chatScopedAgentIdentity(id);
       if (!ident || !ident.name) continue;
       out.push({
         agentId: id,
@@ -908,7 +954,7 @@ export function ChatView({
       });
     }
     return out;
-  }, [chatDetail?.participants, activity?.agents, agentId, agentIdentity, myAgentId]);
+  }, [chatDetail?.participants, activity?.agents, agentId, chatScopedAgentIdentity, myAgentId]);
 
   /**
    * "Needs explicit @mention" guard: a real group, OR a direct chat where the
@@ -1178,7 +1224,7 @@ export function ChatView({
             chatId={chatId}
             participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
             candidates={mentionCandidates}
-            agentIdentity={agentIdentity}
+            agentIdentity={chatScopedAgentIdentity}
             onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
             readOnly={readOnly}
           />
@@ -1251,7 +1297,9 @@ export function ChatView({
                 const ev = item.data;
                 switch (ev.kind) {
                   case "assistant_text":
-                    return <AssistantTextRow key={item.key} event={ev} agentId={agentId} agentNameFn={agentName} />;
+                    return (
+                      <AssistantTextRow key={item.key} event={ev} agentId={agentId} agentNameFn={chatScopedAgentName} />
+                    );
                   case "error":
                     return <ErrorRow key={item.key} event={ev} />;
                   default:
@@ -1272,14 +1320,14 @@ export function ChatView({
                     content={msg.content}
                     answer={answer}
                     status={status}
-                    agentNameFn={agentName}
+                    agentNameFn={chatScopedAgentName}
                   />
                 );
               }
               if (msg.format === "question_answer") {
-                return <QuestionAnswerRow key={item.key} msg={msg} agentNameFn={agentName} />;
+                return <QuestionAnswerRow key={item.key} msg={msg} agentNameFn={chatScopedAgentName} />;
               }
-              return <TextRow key={item.key} msg={msg} myAgentId={myAgentId} agentNameFn={agentName} />;
+              return <TextRow key={item.key} msg={msg} myAgentId={myAgentId} agentNameFn={chatScopedAgentName} />;
             })}
           </div>
           <div ref={messagesEndRef} />
@@ -1746,6 +1794,29 @@ function ParticipantsHeader({
                 borderColor: "var(--border)",
               }}
             >
+              {/* V1 one-way-door notice. Chat membership has no remove
+                  flow yet (`docs/agent-space-and-mention-visibility-
+                  design.zh-CN.md` §4.4.3 / §4.5 — "Revocable" deferred
+                  to V2), so the user can't undo an add. Surface this
+                  before they pick rather than after — especially load-
+                  bearing when an owner adds their own private agent,
+                  because that is the moment the agent's existence is
+                  exposed to other chat members (the "邀请即同意" /
+                  invite-as-consent boundary). */}
+              <div
+                role="note"
+                className="text-caption"
+                style={{
+                  padding: "var(--sp-1) var(--sp-3)",
+                  color: "var(--fg-3)",
+                  borderBottom: "var(--hairline) solid var(--border-faint)",
+                  background: "var(--bg-sunken)",
+                  whiteSpace: "normal",
+                  lineHeight: 1.4,
+                }}
+              >
+                Adding is final in V1 — participants can't be removed yet.
+              </div>
               {(() => {
                 const ambiguous = ambiguousDisplayNames(outsideCandidates);
                 // Same grouping contract as the new-chat picker: mine


### PR DESCRIPTION
## Summary

Closes two long-standing invariants that previously fell through the cracks (fixes #372).

### 1. Identity rendering inside a chat = f(Membership), not f(Discoverability)

Pre-fix, `chatDetail.participants` only carried `{agentId, role, mode, joinedAt}`; the web client resolved names via the visibility-filtered `/agents` endpoint, so a private agent in a chat surfaced as a UUID prefix to every other member who didn't manage it.

- `GET /chats/:id` and `chat.service::getChatDetail` JOIN `agents` directly (without applying `agentVisibilityCondition`)
- Web client prefers `chatDetail.participants[i].{name, displayName}` for `@`-autocomplete, participant chips, and message sender labels; the identity map is now a fallback only

### 2. Only the owner can pull a private agent into a chat

Service-layer owner-exclusive checks on **every** speaker write path — caller's owner member id is derived from the DB, never accepted as a parameter:

| Path | Service |
|---|---|
| `POST /chats/:id/participants` | `me-chat.ts::addMeChatParticipants` |
| `POST /orgs/:org/chats` | `me-chat.ts::createMeChat` |
| `POST /agent/chats` | `chat.ts::createChat` |
| `POST /agent/chats/:id/participants` | `chat.ts::addParticipant` |
| Agent-SDK `chat send <name>` fallback | `chat.ts::findOrCreateDirectChat` (symmetric: refuses new chat if either endpoint is private and the two ends have different owners) |

Pre-existing direct chats are **intentionally not retroactively gated** in `findOrCreateDirectChat` — an existing membership row is already a past consent artefact.

### 3. V1 one-way-door UI notice

Add-participant dropdown shows _"Adding is final in V1 — participants can't be removed yet"_, since V1 has no membership remove flow.

## Out of scope (explicit)

- **`visibility → space` field rename + DB migration.** Naming clarity vs migration cost; the rename can ship later without changing the rules above.
- **Adapter-managed chat path** (`adapter-mapping.ts::findOrCreateChatForChannel` / `ensureParticipant`). Adapter binding is a separate consent boundary — the IM admin's invite into a Feishu/Slack channel IS the consent. A future RFC should decide whether to fold this into the same owner-exclusive rule or document the alternative trust model.
- **Chat membership remove flow** — V2. Tracked in the source RFC.
- **chatDetail loading-window UI gating** — short visual flicker possible while the chat fetch is in flight; falls back to the identity map. UX polish, not a correctness issue.

## References

- **Source RFC** (full derivation, edge cases): `docs/agent-space-and-mention-visibility-design.zh-CN.md` — PR #386
- **Context Tree PR** (cross-repo architectural decision record): https://github.com/agent-team-foundation/first-tree-context/pull/274

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes (incl. `lint:tokens`)
- [x] `pnpm test` — 976/976 tests pass
- [x] New test file `packages/server/src/__tests__/chat-private-mention-visibility.test.ts` — 7 cases covering GET visibility leak, all 5 write-path owner-exclusive gates
- [x] Regression test in `direct-chat-mention-mode.test.ts:81` adjusted (cross-owner personal_assistant case explicitly opts out of the new visibility gate)
- [ ] Manual: open a chat that contains a private agent owned by another user — autocomplete and chips show real names
- [ ] Manual: try to add another user's private agent via the [+] picker — should not appear; via raw API call — should return 403
- [ ] Manual: agent-SDK `chat send <other-user-private-agent-name>` should be refused with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)