### PR TITLE
refactor(server): mint per-org GitHub App installation token for Context Tree snapshot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,12 +16,6 @@ FIRST_TREE_HUB_DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:543
 # Bind address — MUST be 0.0.0.0 for Docker; default 127.0.0.1 for local
 FIRST_TREE_HUB_HOST=0.0.0.0
 
-# Optional deployment-level read token for private Context Tree repos configured
-# in Team Settings. Requires repository contents read access only. The token is
-# only applied to repos listed in FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS.
-# FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN=
-# FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS=agent-team-foundation/first-tree-context
-
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Server — Optional (have defaults or are auto-generated)                  │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -366,8 +366,6 @@ Most environment variables use the `FIRST_TREE_HUB_` prefix. `onboard` also acce
 | `FIRST_TREE_HUB_HOST` | Bind address | `127.0.0.1` |
 | `FIRST_TREE_HUB_JWT_SECRET` | JWT signing key | auto: random generated |
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | Adapter credential encryption key | auto: random generated |
-| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | Optional deployment-level read token for private Context Tree repos configured in Team Settings. Only used by the server-managed Context Tree mirror for allowlisted `https://github.com/...` repos. | — |
-| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` | Comma-separated GitHub repo allowlist (`owner/repo`) that may use `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN`. Required before the token is applied to any org-configured repo. | — |
 | `FIRST_TREE_HUB_WEB_DIST_PATH` | Web static files path | auto-discovered |
 | `FIRST_TREE_HUB_PUBLIC_URL` | Public-facing hub URL. Stamped as the `iss` claim on connect tokens (so `connect <token>` derives the hub URL with no extra arg) and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | request `Host` (dev only) |
 | `FIRST_TREE_HUB_GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App client ID. Enables `/signup` + `/auth/github/start`. Both client id AND secret must be set together. | — |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -36,8 +36,6 @@ These must be set for Docker / CI / `--no-interactive` deployments. Interactive 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` | — | Optional deployment-level read token for private Context Tree repos configured in Team Settings |
-| `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` | — | Comma-separated GitHub repo allowlist (`owner/repo`) that may use the Context Tree read token |
 | `FIRST_TREE_HUB_PORT` | `8000` | Server port |
 | `FIRST_TREE_HUB_JWT_SECRET` | auto-generated | JWT signing secret |
 | `FIRST_TREE_HUB_ENCRYPTION_KEY` | auto-generated | Adapter credential encryption key |

--- a/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
+++ b/docs/user-facing-context-tree-ui-technical-plan.zh-CN.md
@@ -157,7 +157,7 @@ ContextTreeStatus
 - 用短 TTL in-memory cache 缓解同一 `repo + branch + headCommit + window` 的重复请求。
 - 返回 active / stale / unavailable 状态;refresh 失败但已有 managed checkout 时返回 stale snapshot,只有没有可读 snapshot 时才返回 unavailable。
 
-当前实现支持 remote repo 自动 materialize:当组织的 Context Tree repo 是 HTTPS remote URL 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。私有 GitHub repo 通过 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` 提供部署级只读 token;token 只用于 server-side git sync,不暴露给 Web,且只会应用到 `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS` 显式 allowlist 中的 GitHub repos。
+当前实现支持 remote repo 自动 materialize:当组织的 Context Tree repo 是 HTTPS remote URL 时,Hub Server 会 clone/fetch 到 `$FIRST_TREE_HUB_HOME/data/context-tree-repos/<hash>` 并从该 managed checkout 生成 snapshot。私有 GitHub repo 通过该组织已绑定的 GitHub App installation 在 snapshot 请求时按需 mint 短期 installation token(`services/github-app-token.ts`);token 只用于 server-side git sync,不暴露给 Web,组织没有装 App 时回退到无凭证拉取(私有 repo 此时返回 unavailable + 引导文案)。
 
 ### 性能和复用边界
 

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -6,7 +6,6 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import type { ContextTreeChange, ContextTreeNode } from "@agent-team-foundation/first-tree-hub-shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { contextTreeGithubTokenForRepo } from "../api/context-tree-snapshot.js";
 import { contextTreeSnapshotTestInternals, getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
 
 const execFileAsync = promisify(execFile);
@@ -54,20 +53,6 @@ async function commitAllAt(cwd: string, message: string): Promise<string> {
 }
 
 describe("Context Tree snapshot service", () => {
-  it("only applies the deployment GitHub token to allowlisted repos", () => {
-    const syncConfig = {
-      githubToken: "ghp_secret",
-      githubTokenRepos: "agent-team-foundation/first-tree-context, Example/Other.git",
-    };
-
-    expect(
-      contextTreeGithubTokenForRepo("https://github.com/agent-team-foundation/first-tree-context.git", syncConfig),
-    ).toBe("ghp_secret");
-    expect(contextTreeGithubTokenForRepo("https://github.com/example/other", syncConfig)).toBe("ghp_secret");
-    expect(contextTreeGithubTokenForRepo("https://github.com/example/not-allowed", syncConfig)).toBeUndefined();
-    expect(contextTreeGithubTokenForRepo("https://user:secret@github.com/example/other", syncConfig)).toBeUndefined();
-  });
-
   it("parses fallback frontmatter lists", () => {
     const parsed = contextTreeSnapshotTestInternals.parseMarkdownFallback(`---
 title: "Client Runtime"
@@ -338,9 +323,11 @@ Body`);
         "fatal: could not read from https://user:secret@github.com/example/private.git",
       ),
     ).toBe("fatal: could not read from https://[redacted]@github.com/example/private.git");
-    expect(contextTreeSnapshotTestInternals.redactSecret("fatal: token ghp_secret123 failed")).toBe(
-      "fatal: token [redacted] failed",
-    );
+    for (const prefix of ["ghp", "ghs", "ghu", "gho", "ghr"] as const) {
+      expect(contextTreeSnapshotTestInternals.redactSecret(`fatal: token ${prefix}_secret123 failed`)).toBe(
+        "fatal: token [redacted] failed",
+      );
+    }
     expect(contextTreeSnapshotTestInternals.redactSecret("fatal: token github_pat_secret123 failed")).toBe(
       "fatal: token [redacted] failed",
     );

--- a/packages/server/src/__tests__/github-app-token.test.ts
+++ b/packages/server/src/__tests__/github-app-token.test.ts
@@ -1,0 +1,196 @@
+import { generateKeyPairSync } from "node:crypto";
+import type { ContextTreeSnapshot } from "@agent-team-foundation/first-tree-hub-shared";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { ContextTreeBinding } from "../services/context-tree-snapshot.js";
+import type { InstallationRow } from "../services/github-app-installations.js";
+import {
+  type ContextTreeInstallationTokenResult,
+  decorateSnapshotWithMintGuidance,
+  mintContextTreeInstallationToken,
+} from "../services/github-app-token.js";
+
+/**
+ * `mintContextTreeInstallationToken` is a pure transform: given an
+ * installation row + App credentials, decide whether to mint and ship
+ * a token. No DB access — route handlers do the `findInstallationByOrg`
+ * lookup and pass the row in. Tests construct fixtures directly and
+ * inject a `fetcher` for the GitHub round-trip.
+ */
+describe("services/github-app-token", () => {
+  let appId: string;
+  let privateKeyPem: string;
+
+  beforeAll(() => {
+    appId = "424242";
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    privateKeyPem = privateKey;
+  });
+
+  describe("mintContextTreeInstallationToken", () => {
+    it("returns no-app-config when the deployment has no GitHub App configured", async () => {
+      const result = await mintContextTreeInstallationToken(installationFixture(), undefined);
+      expect(result).toEqual({ ok: false, reason: "no-app-config" });
+    });
+
+    it("returns no-installation when the caller passes no installation row", async () => {
+      const result = await mintContextTreeInstallationToken(null, { appId, privateKeyPem });
+      expect(result).toEqual({ ok: false, reason: "no-installation" });
+    });
+
+    it("returns suspended when the installation is suspended upstream", async () => {
+      const installation = installationFixture({ suspendedAt: new Date() });
+      const result = await mintContextTreeInstallationToken(installation, { appId, privateKeyPem });
+      expect(result).toEqual({ ok: false, reason: "suspended" });
+    });
+
+    it("returns mint-failed with a GitHub status when GitHub rejects the mint", async () => {
+      const installation = installationFixture({ installationId: 7777 });
+      const fetcher: typeof fetch = async () =>
+        new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+      const result = await mintContextTreeInstallationToken(installation, { appId, privateKeyPem }, { fetcher });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected mint to fail");
+      expect(result.reason).toBe("mint-failed");
+      expect(result.detail).toContain("401");
+    });
+
+    it("returns the minted installation token on success", async () => {
+      const installation = installationFixture({ installationId: 7777 });
+      const calls: string[] = [];
+      const fetcher: typeof fetch = async (url) => {
+        calls.push(String(url));
+        return new Response(
+          JSON.stringify({
+            token: "ghs_installation_token",
+            expires_at: "2026-05-15T01:00:00Z",
+            permissions: { contents: "read" },
+            repository_selection: "selected",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        );
+      };
+      const result = await mintContextTreeInstallationToken(installation, { appId, privateKeyPem }, { fetcher });
+      expect(result).toEqual({ ok: true, token: "ghs_installation_token" });
+      expect(calls).toEqual(["https://api.github.com/app/installations/7777/access_tokens"]);
+    });
+  });
+
+  describe("decorateSnapshotWithMintGuidance", () => {
+    const githubBinding: ContextTreeBinding = { repo: "agent-team-foundation/first-tree-context", branch: "main" };
+
+    it("returns the snapshot unchanged when the mint succeeded", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, { ok: true, token: "ghs_t" });
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("returns the snapshot unchanged when it is not unavailable", () => {
+      const snapshot: ContextTreeSnapshot = { ...unavailableSnapshot("ok"), snapshotStatus: "active" };
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, {
+        ok: false,
+        reason: "no-installation",
+      });
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("leaves no-app-config snapshots untouched (public-repo path)", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, {
+        ok: false,
+        reason: "no-app-config",
+      });
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("does not append App guidance when no repo is configured", () => {
+      const snapshot = unavailableSnapshot("Context Tree is not configured.");
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, {}, { ok: false, reason: "no-installation" });
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("does not append App guidance when binding uses a localPath", () => {
+      const snapshot = unavailableSnapshot("Context Tree checkout not found at /tmp/tree.");
+      const decorated = decorateSnapshotWithMintGuidance(
+        snapshot,
+        { repo: "agent-team-foundation/first-tree-context", localPath: "/tmp/tree" },
+        { ok: false, reason: "no-installation" },
+      );
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("does not append App guidance for a non-GitHub remote", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const decorated = decorateSnapshotWithMintGuidance(
+        snapshot,
+        { repo: "https://gitlab.com/example/tree", branch: "main" },
+        { ok: false, reason: "no-installation" },
+      );
+      expect(decorated).toBe(snapshot);
+    });
+
+    it("appends install-guidance for no-installation", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, {
+        ok: false,
+        reason: "no-installation",
+      });
+      expect(decorated.contextStatus.detail).toContain("Install the First Tree GitHub App from Team Settings");
+    });
+
+    it("appends unsuspend-guidance for suspended", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, { ok: false, reason: "suspended" });
+      expect(decorated.contextStatus.detail).toContain("suspended");
+    });
+
+    it("appends mint-failed detail when GitHub rejected the mint", () => {
+      const snapshot = unavailableSnapshot("Hub could not sync the configured Context Tree repo.");
+      const failure: ContextTreeInstallationTokenResult = {
+        ok: false,
+        reason: "mint-failed",
+        detail: "GitHub returned 403 when minting an installation token.",
+      };
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, failure);
+      expect(decorated.contextStatus.detail).toContain("GitHub returned 403");
+    });
+  });
+});
+
+function installationFixture(overrides: Partial<InstallationRow> = {}): InstallationRow {
+  const now = new Date();
+  return {
+    id: "01000000-0000-7000-8000-000000000000",
+    installationId: 1,
+    accountType: "Organization",
+    accountLogin: "acme",
+    accountGithubId: 999,
+    hubOrganizationId: "org-1",
+    permissions: { contents: "read" },
+    events: ["push"],
+    suspendedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function unavailableSnapshot(detail: string): ContextTreeSnapshot {
+  return {
+    repo: "agent-team-foundation/first-tree-context",
+    branch: "main",
+    headCommit: null,
+    syncedAt: null,
+    snapshotStatus: "unavailable",
+    contextStatus: { label: "Team context unavailable", detail, severity: "error" },
+    summary: { addedCount: 0, editedCount: 0, removedCount: 0, changedNodeCount: 0 },
+    usage: { windowDays: 7, agentCount: 0, usageCount: 0 },
+    updates: [],
+    nodes: [],
+    edges: [],
+    changes: [],
+  };
+}

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -1,5 +1,4 @@
 import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
-import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireUser } from "../scope/require-user.js";
@@ -7,7 +6,14 @@ import {
   type ContextTreeBinding,
   contextTreeSnapshotWindowDays,
   getContextTreeSnapshot,
+  isGithubRemoteBinding,
 } from "../services/context-tree-snapshot.js";
+import { findInstallationByOrg } from "../services/github-app-installations.js";
+import {
+  type ContextTreeInstallationTokenResult,
+  decorateSnapshotWithMintGuidance,
+  mintContextTreeInstallationToken,
+} from "../services/github-app-token.js";
 import { getOrgContextTree, resolveUserPrimaryOrgId } from "../services/org-settings.js";
 import { summarizeContextTreeUsage } from "../services/session-event.js";
 
@@ -34,55 +40,19 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
       const { userId } = requireUser(request);
       const orgId = await resolveUserPrimaryOrgId(app.db, userId);
       const binding: ContextTreeBinding = orgId ? await getOrgContextTree(app.db, orgId) : {};
-      const githubToken = contextTreeGithubTokenForRepo(binding.repo, app.config.contextTreeSync);
+      let mintResult: ContextTreeInstallationTokenResult | null = null;
+      if (orgId && isGithubRemoteBinding(binding)) {
+        const installation = await findInstallationByOrg(app.db, orgId);
+        mintResult = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      }
+      const githubToken = mintResult?.ok ? mintResult.token : undefined;
       const window = query.window ?? "7d";
-      const snapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+      const rawSnapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+      const snapshot = mintResult ? decorateSnapshotWithMintGuidance(rawSnapshot, binding, mintResult) : rawSnapshot;
       const usage = orgId
         ? await summarizeContextTreeUsage(app.db, orgId, contextTreeSnapshotWindowDays(window))
         : snapshot.usage;
       return contextTreeSnapshotSchema.parse({ ...snapshot, usage });
     },
   );
-}
-
-type ContextTreeSyncConfig = NonNullable<ServerConfig["contextTreeSync"]>;
-
-export function contextTreeGithubTokenForRepo(
-  repo: string | null | undefined,
-  syncConfig: ContextTreeSyncConfig | undefined,
-): string | undefined {
-  if (!repo || !syncConfig?.githubToken) return undefined;
-  const repoKey = githubRepoKey(repo);
-  if (!repoKey) return undefined;
-  const allowedRepos = new Set(
-    (syncConfig.githubTokenRepos ?? "")
-      .split(",")
-      .map((entry) => normalizeGithubRepoKey(entry))
-      .filter((entry): entry is string => entry !== null),
-  );
-  return allowedRepos.has(repoKey) ? syncConfig.githubToken : undefined;
-}
-
-function githubRepoKey(value: string): string | null {
-  const shorthand = normalizeGithubRepoKey(value);
-  if (shorthand) return shorthand;
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return null;
-  }
-  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") return null;
-  if (url.username || url.password) return null;
-  return normalizeGithubRepoKey(url.pathname.replace(/^\/+/, ""));
-}
-
-function normalizeGithubRepoKey(value: string): string | null {
-  const trimmed = value
-    .trim()
-    .replace(/^\/+/, "")
-    .replace(/\.git$/i, "");
-  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(trimmed);
-  if (!match) return null;
-  return `${match[1]?.toLowerCase()}/${match[2]?.toLowerCase()}`;
 }

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -1,5 +1,4 @@
 import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
-import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/config";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireOrgMembership } from "../../scope/require-org.js";
@@ -7,18 +6,22 @@ import {
   type ContextTreeBinding,
   contextTreeSnapshotWindowDays,
   getContextTreeSnapshot,
+  isGithubRemoteBinding,
 } from "../../services/context-tree-snapshot.js";
+import { findInstallationByOrg } from "../../services/github-app-installations.js";
+import {
+  type ContextTreeInstallationTokenResult,
+  decorateSnapshotWithMintGuidance,
+  mintContextTreeInstallationToken,
+} from "../../services/github-app-token.js";
 import { getOrgContextTree } from "../../services/org-settings.js";
 import { summarizeContextTreeUsage } from "../../services/session-event.js";
-import { contextTreeGithubTokenForRepo } from "../context-tree-snapshot.js";
 
 const querySchema = z
   .object({
     window: z.enum(["1d", "7d", "30d"]).optional(),
   })
   .strict();
-
-type ContextTreeSyncConfig = NonNullable<ServerConfig["contextTreeSync"]>;
 
 export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>(
@@ -37,12 +40,15 @@ export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promis
       const query = querySchema.parse(request.query);
       const scope = await requireOrgMembership(request, app.db);
       const binding: ContextTreeBinding = await getOrgContextTree(app.db, scope.organizationId);
-      const githubToken = contextTreeGithubTokenForRepo(
-        binding.repo,
-        app.config.contextTreeSync as ContextTreeSyncConfig | undefined,
-      );
+      let mintResult: ContextTreeInstallationTokenResult | null = null;
+      if (isGithubRemoteBinding(binding)) {
+        const installation = await findInstallationByOrg(app.db, scope.organizationId);
+        mintResult = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      }
+      const githubToken = mintResult?.ok ? mintResult.token : undefined;
       const window = query.window ?? "7d";
-      const snapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+      const rawSnapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+      const snapshot = mintResult ? decorateSnapshotWithMintGuidance(rawSnapshot, binding, mintResult) : rawSnapshot;
       const usage = await summarizeContextTreeUsage(
         app.db,
         scope.organizationId,

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -283,6 +283,27 @@ function normalizeRemoteRepoUrl(value: string): string {
   return value;
 }
 
+/**
+ * Whether this binding actually drives a GitHub-hosted remote fetch — the
+ * only case where minting a GitHub App installation token is meaningful.
+ *
+ * Returns false when:
+ *  - `localPath` is set (sync code short-circuits to the local checkout
+ *    before ever looking at `repo`)
+ *  - `repo` is missing
+ *  - `repo` is a file:// URL, a non-GitHub HTTPS URL, or otherwise
+ *    unparseable
+ *
+ * Used by the snapshot routes to gate the "install the GitHub App"
+ * guidance — without this gate, every unavailable snapshot (missing repo,
+ * bad branch, …) gets a misleading App-install hint appended.
+ */
+export function isGithubRemoteBinding(binding: { repo?: string; localPath?: string }): boolean {
+  if (binding.localPath && binding.localPath.trim().length > 0) return false;
+  if (!binding.repo) return false;
+  return isGithubHttpsRepo(normalizeRemoteRepoUrl(binding.repo));
+}
+
 function managedContextTreeCacheRoot(): string {
   return join(DEFAULT_DATA_DIR, "context-tree-repos");
 }
@@ -478,7 +499,7 @@ function errorMessage(error: unknown): string {
 function redactSecret(message: string): string {
   return message
     .replace(/(https?:\/\/)[^/@\s]+@/g, "$1[redacted]@")
-    .replace(/\bghp_[A-Za-z0-9_]+/g, "[redacted]")
+    .replace(/\b(?:ghp|ghs|ghu|gho|ghr)_[A-Za-z0-9_]+/g, "[redacted]")
     .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, "[redacted]");
 }
 

--- a/packages/server/src/services/github-app-token.ts
+++ b/packages/server/src/services/github-app-token.ts
@@ -1,0 +1,111 @@
+import type { ContextTreeSnapshot } from "@agent-team-foundation/first-tree-hub-shared";
+import { type ContextTreeBinding, isGithubRemoteBinding } from "./context-tree-snapshot.js";
+import { createAppJwt, GithubAppApiError, type GithubAppCredentials, mintInstallationToken } from "./github-app.js";
+import type { InstallationRow } from "./github-app-installations.js";
+
+/**
+ * Outcome of minting a Context Tree installation token for an org.
+ *
+ * - `ok: true`  — caller passes `token` as the git basic-auth password
+ *                 (username `x-access-token`).
+ * - `ok: false` — caller falls back to unauthenticated git fetch. Public
+ *                 repos still resolve; private repos surface as an
+ *                 unavailable snapshot. The route layer uses `reason` to
+ *                 pick a user-facing remediation message.
+ */
+export type ContextTreeInstallationTokenResult =
+  | { ok: true; token: string }
+  | { ok: false; reason: "no-app-config" | "no-installation" | "suspended" | "mint-failed"; detail?: string };
+
+export type MintContextTreeInstallationTokenOptions = {
+  /** Test seam — injected `fetch` for `mintInstallationToken`. */
+  fetcher?: typeof fetch;
+};
+
+/**
+ * Mint a short-lived GitHub App installation token for the given installation.
+ * Returns `ok: false` (with a precise reason) when the org has no App
+ * configured, no installation row, the installation is suspended, or GitHub
+ * rejects the mint — callers fall back to unauthenticated git fetch (public
+ * repos still resolve; private repos surface as an unavailable snapshot
+ * with a remediation message).
+ *
+ * Takes the `installation` row directly so the helper has no DB dependency
+ * — route handlers do the `findInstallationByOrg` lookup themselves. Keeps
+ * this module a pure transform that's trivial to unit-test.
+ *
+ * Credentials use the narrow `GithubAppCredentials` shape so the helper
+ * isn't coupled to the broader OAuth config surface; callers pass
+ * `config.oauth?.githubApp`, which structurally satisfies it.
+ */
+export async function mintContextTreeInstallationToken(
+  installation: InstallationRow | null,
+  appCredentials: GithubAppCredentials | undefined,
+  options: MintContextTreeInstallationTokenOptions = {},
+): Promise<ContextTreeInstallationTokenResult> {
+  if (!appCredentials) {
+    return { ok: false, reason: "no-app-config" };
+  }
+  if (!installation) {
+    return { ok: false, reason: "no-installation" };
+  }
+  if (installation.suspendedAt) {
+    return { ok: false, reason: "suspended" };
+  }
+
+  try {
+    const appJwt = await createAppJwt({
+      appId: appCredentials.appId,
+      privateKeyPem: appCredentials.privateKeyPem,
+    });
+    const minted = await mintInstallationToken(appJwt, installation.installationId, { fetcher: options.fetcher });
+    return { ok: true, token: minted.token };
+  } catch (error) {
+    const detail =
+      error instanceof GithubAppApiError
+        ? `GitHub returned ${error.status} when minting an installation token.`
+        : "Hub could not mint a GitHub App installation token.";
+    return { ok: false, reason: "mint-failed", detail };
+  }
+}
+
+/**
+ * Append a remediation hint to an unavailable snapshot's `contextStatus.detail`
+ * when the underlying cause is a missing / suspended / failed GitHub App token
+ * mint. Public-repo snapshots (mint reason `no-app-config`) are left untouched
+ * — the deployment may legitimately have no App configured.
+ *
+ * Gated on `isGithubRemoteBinding(binding)` so unrelated unavailable
+ * reasons (no repo configured, localPath missing, illegal branch name,
+ * public-repo fetch error) don't get a misleading "install the GitHub
+ * App" hint appended.
+ *
+ * Lives next to `mintContextTreeInstallationToken` so the two routes that
+ * call mint share one shaping function; the snapshot service itself stays
+ * token-agnostic.
+ */
+export function decorateSnapshotWithMintGuidance(
+  snapshot: ContextTreeSnapshot,
+  binding: ContextTreeBinding,
+  mintResult: ContextTreeInstallationTokenResult,
+): ContextTreeSnapshot {
+  if (mintResult.ok) return snapshot;
+  if (snapshot.snapshotStatus !== "unavailable") return snapshot;
+  if (mintResult.reason === "no-app-config") return snapshot;
+  if (!isGithubRemoteBinding(binding)) return snapshot;
+
+  const guidance =
+    mintResult.reason === "no-installation"
+      ? "Install the First Tree GitHub App from Team Settings and grant it access to this repo."
+      : mintResult.reason === "suspended"
+        ? "The GitHub App installation is suspended — unsuspend it from your GitHub account settings."
+        : `Hub could not mint a GitHub App installation token.${mintResult.detail ? ` ${mintResult.detail}` : ""}`;
+
+  return {
+    ...snapshot,
+    contextStatus: {
+      ...snapshot.contextStatus,
+      detail: `${snapshot.contextStatus.detail} ${guidance}`,
+    },
+  };
+}

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -72,19 +72,9 @@ export const serverConfigSchema = defineConfig({
   // (webhook secret / allowed org) used to live here as global config.
   // They are now per-org settings in the `organization_settings` table —
   // admins configure them through Team Settings. See issue #255.
-  contextTreeSync: optional({
-    /**
-     * Deployment-level read credential used only by the server-managed Context
-     * Tree mirror. Repo and branch remain per-org settings.
-     */
-    githubToken: field(z.string(), {
-      env: "FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN",
-      secret: true,
-    }),
-    githubTokenRepos: field(z.string().optional(), {
-      env: "FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN_REPOS",
-    }),
-  }),
+  // The server-managed Context Tree mirror mints a per-org GitHub App
+  // installation token at request time (see `services/github-app-token.ts`);
+  // no global token belongs here.
   oauth: optional({
     /**
      * GitHub App credentials — the sign-in surface introduced by PR 2/3 of


### PR DESCRIPTION
## Summary

- Replace deployment-level `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` PAT with per-org GitHub App installation tokens for the server-managed Context Tree snapshot mirror — fixes the single-PAT multi-tenant isolation hole (one ops-managed PAT held cross-org access to every customer's tree, gated only by a startup-time allowlist).
- Routes now mint a short-lived (~1h) installation token from the org's bound GitHub App installation at request time. The new helper is gated on `isGithubRemoteBinding(binding)` — non-GitHub bindings (no repo / `localPath` / GitLab / `file://`) skip installation lookup, mint, and decoration entirely, so snapshot endpoint latency no longer ties to GitHub reachability for local / non-GitHub / unconfigured trees.
- Hardens secret redaction: surfaced git error messages now redact all GitHub token prefixes (`ghp` / `ghs` / `ghu` / `gho` / `ghr` + `github_pat_`). Installation tokens (`ghs_`) and user-to-server tokens (`ghu_`) were not covered by the old regex.

### Migration

⚠️ **Breaking for any deployment relying on `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` to pull a private Context Tree.** Before merging, every affected org must install the First Tree GitHub App from Team Settings and grant it access to the configured tree repo. After merge, ops should remove the `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN(_REPOS)` env vars (config zod schema ignores unknown env, so leaving them set will not crash boot — just dead weight).

### Architectural notes

- **Helper is a pure transform.** `mintContextTreeInstallationToken(installation, appCredentials, options?)` takes the installation row + creds and returns a tagged result (`ok:true|false` with `no-app-config` / `no-installation` / `suspended` / `mint-failed`). DB lookup (`findInstallationByOrg`) lives in the route layer so the helper has no DB dependency and unit-tests need zero `vi.mock` — sidesteps the worker-cache pollution that vitest's `isolate: false` config can trigger.
- **`decorateSnapshotWithMintGuidance` is double-gated.** Route layer only calls it when `isGithubRemoteBinding(binding)`. The decorator itself also re-checks the binding as a defensive net so future callers can't accidentally append "install the GitHub App" hints to unrelated unavailable reasons (missing repo, illegal branch name, public-repo fetch error, …).
- **Token caching deliberately omitted.** GitHub's per-installation 5000/hr budget is far above the snapshot rate-limit (6/min). Eager mint at route time gives the cleanest error classification; if profiling ever shows mint as a hotspot, switch to a lazy `tokenProvider` callback then.

### Reviewers

@codex-reviewer already reviewed twice — flagged (a) decorator gate (now in place) and (b) route gate (now in place). Two follow-ups deferred to separate PRs per their recommendation:

1. Tree PR updating `agent-hub/context-tab.md` + `agent-hub/github-app.md` (in progress).
2. Cleanup of stale `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN` references in `agent-hub/{deployment,context-tree-sync}.md` of the tree repo.

## Test plan

- [x] `pnpm check` (Biome) — 722 files clean
- [x] `pnpm typecheck` — 9/9 packages
- [x] `pnpm test` — 124 files / 995 tests pass; new file `github-app-token.test.ts` covers all 4 mint reasons + success path + 9 decorator branches (including 3 gate cases: no repo, localPath, non-GitHub remote)
- [ ] **Staging**: org with App installed + private tree repo → `/orgs/:orgId/context-tree/snapshot` returns `active` and `headCommit` matches GitHub
- [ ] **Staging**: org without App + same private repo → `unavailable` with detail text guiding to Team Settings
- [ ] **Staging**: clear `FIRST_TREE_HUB_CONTEXT_TREE_GITHUB_TOKEN(_REPOS)` envs → server starts cleanly, previously-public-repo orgs still `active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)