### PR TITLE
feat(server): bind GitHub PR/issue to agent's chat on tool_call

### DIFF
--- a/docs/github-entity-chat-binding-design.md
+++ b/docs/github-entity-chat-binding-design.md
@@ -1,0 +1,129 @@
+# GitHub Entity ↔ Chat Binding — Design
+
+Source of truth for how a Hub chat learns to "own" the GitHub PRs and
+Issues that flow through it. Touches `github_entity_chat_mappings` and the
+webhook → audience → delivery pipeline.
+
+## Problem framing
+
+Stripped down, the problem is generic:
+
+> A write to a GitHub entity happened from inside chat C. How do future
+> webhooks for that entity get routed back to C instead of forking a new
+> chat?
+
+The framing matters: "agent ran `gh pr create`" is *one* way the write can
+happen, not the only one. The long-term design space has four families:
+
+| Family | Where the binding signal comes from | Coverage | Cost | Robustness |
+|---|---|---|---|---|
+| **A. Explicit declaration** | Agent calls a Hub-provided `bind_chat_to_github_entity(url)` API after the write | Whatever agents are taught to call | Medium (teach the agent) | Strong (structured input) |
+| **B. Outbound proxy** | All agent → GitHub traffic flows through Hub's installation token / proxy; binding is a side-effect of the outbound write | Near-total | High (forcing traffic shape) | Strong |
+| **C. Webhook backfill** | When `*.opened` arrives, reverse-look-up recent chat activity in a time window | Generic, no per-tool work | Medium (heuristic + indexes) | Fuzzy (may misbind) |
+| **D. Tool-call stdout extraction** | Regex against `resultPreview` of a whitelisted tool | Whatever extractors get written | Low | Brittle (string-level coupling) |
+
+**Target shape**: A is the main path, B is the audit floor, C is the
+safety net, D demotes to a fallback for tools we can't influence.
+
+## What ships today (Phase 1)
+
+Pure family **D**, scoped tight: only `Bash gh pr create` and `Bash gh
+issue create` are recognised. Both emit a single-line URL on stdout which
+fits the 400-char `resultPreview` cap with no information loss.
+
+Pipeline:
+
+1. **Client** (AgentRuntime) — runs the tool, reports `session:event`
+   with `kind="tool_call"`, `status="ok"`, `resultPreview="<url>"` over
+   the existing WebSocket frame. No client-side parsing.
+2. **Server** — `sessionEventService.appendEvent` writes the event row
+   and, on `kind="tool_call" && status="ok"`, fires
+   `maybeBindGithubEntityFromToolCall` fire-and-forget:
+   - `extractGithubEntity` (whitelist parser) → `(entityType, entityKey)`
+   - `resolveBindingPair` → `(org, representative_human, delegate)`
+   - `insertMappingIfAbsent` with `boundVia="agent_created"`
+3. **Webhook arrives** — `pull_request.opened` from `<app-slug>[bot]`.
+   `resolveAudience` finds the existing mapping in the subscribed path
+   and routes the card to the same chat.
+
+Schema unchanged. `bound_via` is `text` with no CHECK, so the new
+`"agent_created"` literal is an application-layer extension only.
+
+### Defensive scaffolding
+
+Even though family D ships first, the data model is set up so future
+families can plug in without rewrites:
+
+- **`bound_via` open-ended** — adding `agent_declared` (family A) or
+  `outbound_proxy` (family B) is a string literal change. No migration.
+- **`resolveBindingPair` is entry-point-agnostic** — any new caller
+  (HTTP endpoint for family A, proxy hook for family B) reuses it.
+- **`insertMappingIfAbsent` + composite PK** — multiple binding sources
+  can coexist without dedup logic; the loser of a race re-reads the
+  winner's row.
+- **`resolveTargetChat` creation-event guard** — opened webhooks with no
+  mapping + no mention return `null`. `isMentionMatched` is required (not
+  optional) so any future caller has to make an explicit fail-closed
+  decision.
+- **`our-app-bot` echo branch** — keeps `kind: "existing"` so Hub's own
+  outbound writes still route through the subscription path; drops
+  `kind: "new"` so they don't mint a chat to echo themselves.
+
+## Why D is acceptable as the Phase 1 entry point
+
+- Zero client work — every existing AgentRuntime already reports
+  `session:event` frames over WS. No SDK version bump.
+- Covers the 80% case (`gh pr create`) on day one.
+- Failure mode is "binding doesn't happen" — the legacy
+  fresh-chat-on-opened path still works, so the worst case is the
+  pre-PR behaviour, not a regression.
+- The whitelist is honest about its limits — anything not on it falls
+  through without misbinding.
+
+## What's explicitly *not* the long-term plan
+
+Adding more extractors (curl, GitHub MCP, …) layers stdout-parsing on
+top of stdout-parsing. The brittleness compounds rather than cancels.
+Phase 2 deliberately does *not* commit to "extend D forever"; it
+delineates the boundary where family A starts paying off.
+
+## Phase 2 candidates (data-driven)
+
+Driven by what telemetry shows once Phase 1 is in staging:
+
+1. **`webhook_arrived_without_mapping` counter**, scoped to
+   `(eventType, action) ∈ {(pull_request, opened), (issues, opened)}` and
+   sender = our App bot. Quantifies the family-A gap — high count means
+   agents are creating entities through paths D doesn't cover.
+2. **`resultPreview` cap bump** to ~2 KB *or* a `resultFull` field for
+   whitelisted tool kinds. Unblocks curl + MCP without forcing every
+   session event payload to bloat.
+3. **Family A intro**: a small `POST /api/agents/me/github-entity-binding`
+   endpoint the agent can call right after a non-`gh` GitHub write. Agent
+   prompt nudge in parallel.
+4. **Async GitHub API verification** to garbage-collect "ghost mappings"
+   where the agent wrote a syntactically valid but non-existent URL into
+   `resultPreview`.
+
+## Open questions
+
+- **Race window**: tool_call ok → DB insert is sub-ms, GitHub webhook
+  delivery is ~100ms+. The mapping should win deterministically, but
+  Phase 1 doesn't measure it. If the counter above shows non-trivial
+  loss, a `pending_creation` short-TTL table (B-flavoured pre-occupy)
+  comes back as an option.
+- **Group chat ergonomics**: the representative-human pick is
+  deterministic (delegateMention-linked first, id-sorted fallback). If
+  product wants the card to surface "PR opened by <X>" with X = actual
+  GitHub author, that lives in the card builder, not the mapping row.
+
+## File map
+
+| Concern | File |
+|---|---|
+| Whitelist parser | `packages/server/src/services/github-entity-extractor.ts` |
+| Binding service + guard | `packages/server/src/services/github-entity-chat.ts` |
+| Session-event hook | `packages/server/src/services/session-event.ts` |
+| Audience echo branch | `packages/server/src/services/github-audience.ts` |
+| Delivery null handling | `packages/server/src/services/github-delivery.ts` |
+| Mapping schema | `packages/server/src/db/schema/github-entity-chat-mappings.ts` |

--- a/packages/server/src/__tests__/agent-created-binding.test.ts
+++ b/packages/server/src/__tests__/agent-created-binding.test.ts
@@ -1,0 +1,501 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import type { ToolCallEventPayload } from "@agent-team-foundation/first-tree-hub-shared";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import type { GithubEntity } from "../api/webhooks/github-entity.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { maybeBindGithubEntityFromToolCall, resolveTargetChat } from "../services/github-entity-chat.js";
+import { appendEvent } from "../services/session-event.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+type App = ReturnType<ReturnType<typeof useTestApp>>;
+
+async function seedAgent(
+  app: App,
+  opts: {
+    orgId: string;
+    memberId: string;
+    name: string;
+    type: "human" | "autonomous_agent";
+    status?: "active" | "suspended";
+  },
+): Promise<string> {
+  const uuid = randomUUID();
+  await app.db.insert(agents).values({
+    uuid,
+    name: opts.name,
+    organizationId: opts.orgId,
+    type: opts.type,
+    displayName: opts.name,
+    inboxId: `inbox_${uuid}`,
+    managerId: opts.memberId,
+    status: opts.status ?? "active",
+  });
+  return uuid;
+}
+
+async function seedChat(app: App, orgId: string, type: "direct" | "group", participants: string[]): Promise<string> {
+  const id = `chat_${randomUUID()}`;
+  await app.db.insert(chats).values({ id, organizationId: orgId, type, metadata: {} });
+  await app.db.insert(chatMembership).values(
+    participants.map((agentId, idx) => ({
+      chatId: id,
+      agentId,
+      role: idx === 0 ? "owner" : "member",
+      accessMode: "speaker" as const,
+    })),
+  );
+  return id;
+}
+
+function prCreatePayload(url: string): ToolCallEventPayload {
+  return {
+    toolUseId: `tu-${randomUUID()}`,
+    name: "Bash",
+    args: { command: 'gh pr create --title "x" --body "y"' },
+    status: "ok",
+    resultPreview: url,
+  };
+}
+
+describe("maybeBindGithubEntityFromToolCall", () => {
+  const getApp = useTestApp();
+
+  it("writes a single agent_created mapping for a direct chat (1 human + 1 delegate)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      delegate,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/501"),
+    );
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.boundVia).toBe("agent_created");
+    expect(rows[0]?.entityType).toBe("pull_request");
+    expect(rows[0]?.entityKey).toBe("owner/repo#501");
+    expect(rows[0]?.humanAgentId).toBe(admin.humanAgentUuid);
+    expect(rows[0]?.delegateAgentId).toBe(delegate);
+  });
+
+  it("writes exactly ONE mapping in a group chat (representative human, no fan-out)", async () => {
+    // Without the representative-pick logic, a group with N humans would
+    // produce N mapping rows -> N subscribed audience targets on the next
+    // webhook -> N duplicate cards delivered to the same chat. The
+    // representative-pick keeps that to exactly one row.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const human2 = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `h2-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "group", [admin.humanAgentUuid, human2, delegate]);
+
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      delegate,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/502"),
+    );
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(1);
+    // Representative is the id-sorted-first active human in the chat.
+    const expectedHuman = [admin.humanAgentUuid, human2].sort()[0];
+    expect(rows[0]?.humanAgentId).toBe(expectedHuman);
+    expect(rows[0]?.delegateAgentId).toBe(delegate);
+  });
+
+  it("is idempotent: a repeated tool_call ok event produces no second row", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    const payload = prCreatePayload("https://github.com/owner/repo/pull/503");
+    await maybeBindGithubEntityFromToolCall(app.db, delegate, chatId, payload);
+    await maybeBindGithubEntityFromToolCall(app.db, delegate, chatId, payload);
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("skips when the reporter is not a member of the chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const outsider = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `out-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      outsider,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/504"),
+    );
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("skips when the chat has no human members (delegate-only)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `a-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `b-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [delegateA, delegateB]);
+
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      delegateA,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/505"),
+    );
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("no-op when extractor returns null (unrecognised tool / non-creation command)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    await maybeBindGithubEntityFromToolCall(app.db, delegate, chatId, {
+      toolUseId: "tu",
+      name: "Bash",
+      args: { command: "gh pr list" },
+      status: "ok",
+      resultPreview: "PR #1 https://github.com/owner/repo/pull/1",
+    });
+
+    const rows = await app.db.select().from(githubEntityChatMappings);
+    expect(rows.filter((r) => r.chatId === chatId)).toHaveLength(0);
+  });
+});
+
+describe("resolveTargetChat creation-event guard", () => {
+  const getApp = useTestApp();
+
+  function entity(): GithubEntity {
+    return {
+      type: "pull_request",
+      key: `owner/repo#${Math.floor(Math.random() * 100000)}`,
+      title: "Guard test",
+      url: "https://github.com/owner/repo/pull/0",
+    };
+  }
+
+  it("returns null on an opened PR webhook when no mapping exists and target is not mention-driven", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+
+    const result = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: entity(),
+      relatedEntities: [],
+      eventType: "pull_request",
+      action: "opened",
+      isMentionMatched: false,
+    });
+
+    expect(result).toBeNull();
+    // No mapping row was written, no chat invented.
+    const mappings = await app.db.select().from(githubEntityChatMappings);
+    expect(
+      mappings.filter((m) => m.humanAgentId === admin.humanAgentUuid && m.delegateAgentId === delegate),
+    ).toHaveLength(0);
+  });
+
+  it("still creates the chat when target IS mention-driven (default behaviour preserved)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+
+    const ent = entity();
+    const result = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: ent,
+      relatedEntities: [],
+      eventType: "pull_request",
+      action: "opened",
+      isMentionMatched: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.created).toBe(true);
+    expect(result?.boundVia).toBe("direct");
+  });
+
+  it("non-creation events (e.g. issue_comment.created) never trigger the guard", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+
+    const result = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: entity(),
+      relatedEntities: [],
+      eventType: "issue_comment",
+      action: "created",
+      isMentionMatched: false,
+    });
+
+    // Guard didn't fire because the event isn't a creation event — falls
+    // through to (c) which mints the chat.
+    expect(result).not.toBeNull();
+    expect(result?.created).toBe(true);
+  });
+
+  it("PR comments on an agent_created entity route back to the original chat (end-to-end)", async () => {
+    // The whole point of the agent_created mapping. We pre-write the mapping
+    // (as `maybeBindGithubEntityFromToolCall` would on tool_call ok) and
+    // assert resolveTargetChat returns the same chat for a downstream comment.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      delegate,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/707"),
+    );
+
+    const result = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: {
+        type: "pull_request",
+        key: "owner/repo#707",
+        url: "https://github.com/owner/repo/pull/707",
+      },
+      relatedEntities: [],
+      eventType: "issue_comment",
+      action: "created",
+      isMentionMatched: false,
+    });
+
+    expect(result?.chatId).toBe(chatId);
+    expect(result?.created).toBe(false);
+    expect(result?.boundVia).toBe("agent_created");
+
+    // Same mapping is reused; no extra rows.
+    const all = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.entityType, "pull_request"),
+          eq(githubEntityChatMappings.entityKey, "owner/repo#707"),
+        ),
+      );
+    expect(all).toHaveLength(1);
+  });
+});
+
+describe("appendEvent → agent_created binding hook", () => {
+  const getApp = useTestApp();
+
+  async function waitForMapping(
+    app: ReturnType<ReturnType<typeof useTestApp>>,
+    chatId: string,
+    timeoutMs = 2000,
+  ): Promise<Array<{ boundVia: string; entityKey: string }>> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const rows = await app.db
+        .select({
+          boundVia: githubEntityChatMappings.boundVia,
+          entityKey: githubEntityChatMappings.entityKey,
+        })
+        .from(githubEntityChatMappings)
+        .where(eq(githubEntityChatMappings.chatId, chatId));
+      if (rows.length > 0) return rows;
+      await sleep(25);
+    }
+    return [];
+  }
+
+  it("writes a mapping when a tool_call ok event flows through appendEvent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    await appendEvent(app.db, delegate, chatId, {
+      kind: "tool_call",
+      payload: prCreatePayload("https://github.com/owner/repo/pull/801"),
+    });
+
+    const rows = await waitForMapping(app, chatId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.boundVia).toBe("agent_created");
+    expect(rows[0]?.entityKey).toBe("owner/repo#801");
+  });
+
+  it("does NOT trigger the binding hook for pending tool_call events", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const chatId = await seedChat(app, admin.organizationId, "direct", [admin.humanAgentUuid, delegate]);
+
+    await appendEvent(app.db, delegate, chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-pending",
+        name: "Bash",
+        args: { command: "gh pr create" },
+        status: "pending",
+      },
+    });
+
+    // Give any (incorrectly fired) side-effect a chance to land.
+    await sleep(150);
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("appendEvent succeeds even if the binding side-effect fails (fire-and-forget isolation)", async () => {
+    // Simulate the chat going away between INSERT session_events and the
+    // bookkeeping side-effect by using a chatId with no membership rows. The
+    // side-effect's resolveBindingPair returns null and logs at debug; the
+    // main appendEvent return value must still reflect a successful insert.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+    const orphanChatId = `chat_${randomUUID()}`;
+    await app.db
+      .insert(chats)
+      .values({ id: orphanChatId, organizationId: admin.organizationId, type: "direct", metadata: {} });
+
+    const persisted = await appendEvent(app.db, delegate, orphanChatId, {
+      kind: "tool_call",
+      payload: prCreatePayload("https://github.com/owner/repo/pull/802"),
+    });
+
+    expect(persisted.seq).toBe(1);
+    expect(persisted.kind).toBe("tool_call");
+    await sleep(150);
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, orphanChatId));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/__tests__/agent-created-binding.test.ts
+++ b/packages/server/src/__tests__/agent-created-binding.test.ts
@@ -95,6 +95,57 @@ describe("maybeBindGithubEntityFromToolCall", () => {
     expect(rows[0]?.delegateAgentId).toBe(delegate);
   });
 
+  it("prefers a human whose delegateMention points at the reporter over id-sorted-first", async () => {
+    // Selection order is "delegateMention-linked first, id-sorted fallback".
+    // Force the id ordering to disagree with the delegate link: create the
+    // linked human AFTER the unlinked one so id-sorted-first would pick the
+    // unlinked one. The representative pick must override that with the
+    // linked human regardless.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+    });
+
+    // Build two extra humans, then pick whichever sorts smaller as the
+    // unlinked one and the other as the linked one. Guarantees the linked
+    // human is NOT id-sorted-first against the unlinked extra.
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `hA-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `hB-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const [smallerHuman, largerHuman] = humanA < humanB ? [humanA, humanB] : [humanB, humanA];
+    // Point the larger-id human at the reporter via delegateMention.
+    await app.db.update(agents).set({ delegateMention: delegate }).where(eq(agents.uuid, largerHuman));
+
+    const chatId = await seedChat(app, admin.organizationId, "group", [smallerHuman, largerHuman, delegate]);
+
+    await maybeBindGithubEntityFromToolCall(
+      app.db,
+      delegate,
+      chatId,
+      prCreatePayload("https://github.com/owner/repo/pull/506"),
+    );
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.humanAgentId).toBe(largerHuman);
+  });
+
   it("writes exactly ONE mapping in a group chat (representative human, no fan-out)", async () => {
     // Without the representative-pick logic, a group with N humans would
     // produce N mapping rows -> N subscribed audience targets on the next

--- a/packages/server/src/__tests__/agent-created-webhook-e2e.test.ts
+++ b/packages/server/src/__tests__/agent-created-webhook-e2e.test.ts
@@ -1,0 +1,313 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { messages } from "../db/schema/messages.js";
+import { maybeBindGithubEntityFromToolCall } from "../services/github-entity-chat.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * End-to-end "agent main path" webhook simulation. Walks the full pipeline
+ * exactly like a real GitHub delivery would: HMAC-signed POST → normalize →
+ * audience → resolveTargetChat → delivery. No mocks; only the GitHub side
+ * is faked (a static signed JSON body).
+ *
+ * Three scenarios cover the contract of the agent_created feature:
+ *
+ *   1. Happy path. Agent's `gh pr create` wrote an `agent_created` mapping.
+ *      The subsequent `pull_request.opened` webhook arrives with sender =
+ *      `<app-slug>[bot]` (because the agent used Hub's installation token).
+ *      Expectation: existing chat receives the card; the App-bot echo
+ *      suppression branch keeps subscribed targets.
+ *
+ *   2. PR comment after agent creation. Same `agent_created` mapping, but
+ *      now a `issue_comment.created` event from an external commenter.
+ *      Expectation: routes to the same chat (subscribed path), no new chat.
+ *
+ *   3. Negative: opened webhook with no mapping and no mention. Expectation:
+ *      audience is empty, no chat invented, no mapping row, no message.
+ */
+
+const APP_WEBHOOK_SECRET = "test-app-webhook-secret";
+
+function signBody(secret: string, body: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+type App = ReturnType<ReturnType<typeof useTestApp>>;
+
+async function postWebhook(app: App, eventType: string, payload: object) {
+  const body = JSON.stringify(payload);
+  return app.inject({
+    method: "POST",
+    url: "/api/v1/webhooks/github-app",
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": eventType,
+      "x-github-delivery": randomUUID(),
+      "x-hub-signature-256": signBody(APP_WEBHOOK_SECRET, body),
+    },
+    payload: body,
+  });
+}
+
+async function seedDelegateAgent(app: App, opts: { orgId: string; memberId: string; name: string }): Promise<string> {
+  const uuid = randomUUID();
+  await app.db.insert(agents).values({
+    uuid,
+    name: opts.name,
+    organizationId: opts.orgId,
+    type: "autonomous_agent",
+    displayName: opts.name,
+    inboxId: `inbox_${uuid}`,
+    managerId: opts.memberId,
+  });
+  return uuid;
+}
+
+async function seedInstallation(app: App, opts: { installationId: number; orgId: string }): Promise<void> {
+  await app.db.insert(githubAppInstallations).values({
+    id: uuidv7(),
+    installationId: opts.installationId,
+    accountType: "Organization",
+    accountLogin: "owner",
+    accountGithubId: 1000 + opts.installationId,
+    hubOrganizationId: opts.orgId,
+    permissions: { contents: "read" },
+    events: ["pull_request", "issues", "issue_comment"],
+  });
+}
+
+async function seedDirectChat(app: App, orgId: string, humanId: string, delegateId: string): Promise<string> {
+  const chatId = `chat_${randomUUID()}`;
+  await app.db.insert(chats).values({ id: chatId, organizationId: orgId, type: "direct", metadata: {} });
+  await app.db.insert(chatMembership).values([
+    { chatId, agentId: humanId, role: "owner", accessMode: "speaker" },
+    { chatId, agentId: delegateId, role: "member", accessMode: "speaker" },
+  ]);
+  return chatId;
+}
+
+describe("Agent-created → real webhook end-to-end", () => {
+  const getApp = useTestApp();
+
+  it("opened webhook from <slug>[bot] routes to the agent_created chat (no new chat invented)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 200001;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedDelegateAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const chatId = await seedDirectChat(app, admin.organizationId, admin.humanAgentUuid, delegate);
+
+    // Stage 1: the agent's gh pr create tool_call lands → mapping written.
+    // Driven through the service directly to avoid the fire-and-forget timing
+    // of the appendEvent path (covered separately in
+    // agent-created-binding.test.ts).
+    await maybeBindGithubEntityFromToolCall(app.db, delegate, chatId, {
+      toolUseId: "tu-e2e-1",
+      name: "Bash",
+      args: { command: 'gh pr create --title "wire X" --body "fixes Y"' },
+      status: "ok",
+      resultPreview: "https://github.com/owner/repo/pull/901",
+    });
+    const beforeMapping = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#901"));
+    expect(beforeMapping).toHaveLength(1);
+    expect(beforeMapping[0]?.boundVia).toBe("agent_created");
+    expect(beforeMapping[0]?.chatId).toBe(chatId);
+
+    // Stage 2: real `pull_request.opened` webhook fires. Sender = our App
+    // bot (because the agent used Hub's installation token to open the PR).
+    const beforeChatCount = (await app.db.select().from(chats)).length;
+    const res = await postWebhook(app, "pull_request", {
+      action: "opened",
+      pull_request: {
+        number: 901,
+        title: "wire X",
+        html_url: "https://github.com/owner/repo/pull/901",
+        body: "fixes Y",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "test-app-slug[bot]", type: "Bot" },
+      installation: { id: installationId },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.delivered).toBe(1);
+    expect(body.newChats).toBe(0);
+
+    // Same chat, exactly one card delivered, no extra chats minted.
+    const sent = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(sent).toHaveLength(1);
+    const afterChatCount = (await app.db.select().from(chats)).length;
+    expect(afterChatCount).toBe(beforeChatCount);
+    const allMappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#901"));
+    expect(allMappings).toHaveLength(1);
+  });
+
+  it("issue_comment.created after agent_created routes to the original chat (PR follow-up flow)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 200002;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedDelegateAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const chatId = await seedDirectChat(app, admin.organizationId, admin.humanAgentUuid, delegate);
+
+    await maybeBindGithubEntityFromToolCall(app.db, delegate, chatId, {
+      toolUseId: "tu-e2e-2",
+      name: "Bash",
+      args: { command: "gh pr create --title x --body y" },
+      status: "ok",
+      resultPreview: "https://github.com/owner/repo/pull/902",
+    });
+
+    // PR comment from an external reviewer — sender is NOT a bot, NOT mentioning us.
+    const res = await postWebhook(app, "issue_comment", {
+      action: "created",
+      issue: {
+        number: 902,
+        title: "wire X",
+        html_url: "https://github.com/owner/repo/issues/902",
+        pull_request: { html_url: "https://github.com/owner/repo/pull/902" },
+      },
+      comment: {
+        body: "Looks good.",
+        html_url: "https://github.com/owner/repo/pull/902#issuecomment-1",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "reviewer-bob", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().delivered).toBe(1);
+
+    const sent = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.metadata).toMatchObject({
+      source: "github",
+      event: "issue_comment",
+      action: "created",
+      entityType: "pull_request",
+      entityKey: "owner/repo#902",
+    });
+  });
+
+  it("opened webhook with no mapping and no mention does NOT mint a chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 200003;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const beforeChats = (await app.db.select().from(chats)).length;
+    const beforeMappings = (await app.db.select().from(githubEntityChatMappings)).length;
+
+    const res = await postWebhook(app, "pull_request", {
+      action: "opened",
+      pull_request: {
+        number: 903,
+        title: "external work",
+        html_url: "https://github.com/owner/repo/pull/903",
+        body: "no @mentions here",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external-author", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(res.statusCode).toBe(200);
+    // Empty audience short-circuits before the delivery stage — the webhook
+    // route returns `{audience: 0}` in that branch, not `{delivered, newChats}`.
+    expect(res.json().audience).toBe(0);
+
+    const afterChats = (await app.db.select().from(chats)).length;
+    const afterMappings = (await app.db.select().from(githubEntityChatMappings)).length;
+    expect(afterChats).toBe(beforeChats);
+    expect(afterMappings).toBe(beforeMappings);
+    const sentToOrg = await app.db
+      .select()
+      .from(messages)
+      .innerJoin(chats, eq(messages.chatId, chats.id))
+      .where(eq(chats.organizationId, admin.organizationId));
+    expect(sentToOrg).toHaveLength(0);
+  });
+
+  it("opened webhook with body @mention still creates a chat (mention exemption preserved)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 200004;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedDelegateAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    const humanAgent = await app.db
+      .insert(agents)
+      .values({
+        uuid: randomUUID(),
+        name: humanName,
+        organizationId: admin.organizationId,
+        type: "human",
+        displayName: humanName,
+        inboxId: `inbox_${randomUUID()}`,
+        managerId: admin.memberId,
+        delegateMention: delegate,
+      })
+      .returning({ uuid: agents.uuid });
+    expect(humanAgent[0]?.uuid).toBeTruthy();
+
+    const beforeChats = (await app.db.select().from(chats)).length;
+
+    const res = await postWebhook(app, "pull_request", {
+      action: "opened",
+      pull_request: {
+        number: 904,
+        title: "ping the agent",
+        html_url: "https://github.com/owner/repo/pull/904",
+        body: `cc @${humanName}`,
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external-author", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().delivered).toBe(1);
+    expect(res.json().newChats).toBe(1);
+
+    const afterChats = (await app.db.select().from(chats)).length;
+    expect(afterChats).toBe(beforeChats + 1);
+
+    const mapping = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.entityType, "pull_request"),
+          eq(githubEntityChatMappings.entityKey, "owner/repo#904"),
+        ),
+      );
+    expect(mapping).toHaveLength(1);
+    expect(mapping[0]?.boundVia).toBe("direct");
+  });
+});

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -309,7 +309,15 @@ describe("resolveAudience", () => {
     expect(audience[0]?.chatId).toBe(chatId);
   });
 
-  it("returns [] when actor is our-app-bot (DP13 silences whole audience)", async () => {
+  it("keeps subscribed targets when actor is our-app-bot (route Hub's own writes back to existing chats)", async () => {
+    // Background: when an agent creates a PR via Hub's GitHub App token, the
+    // resulting `pull_request.opened` webhook arrives with `sender = <app>[bot]`.
+    // Pre-agent-binding behaviour silenced the whole audience here, which
+    // meant PR comments / CI changes on bot-authored entities never reached
+    // the chat the agent worked in. The new behaviour keeps `kind: "existing"`
+    // rows so subscribed chats still get the event; `kind: "new"` rows are
+    // dropped because minting a fresh chat just to echo our own write is
+    // never useful.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -342,6 +350,41 @@ describe("resolveAudience", () => {
         actorLogin: "first-tree-hub[bot]",
         actorIsBot: true,
         kind: "synchronized",
+      }),
+      "first-tree-hub",
+    );
+
+    expect(audience).toHaveLength(1);
+    expect(audience[0]?.kind).toBe("existing");
+    expect(audience[0]?.chatId).toBe(chatId);
+  });
+
+  it("drops mention-only targets when actor is our-app-bot (no fresh chat for our own write)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#104",
+        actorLogin: "first-tree-hub[bot]",
+        actorIsBot: true,
+        involves: [{ githubLogin: humanName, reason: "mentioned" }],
+        kind: "opened",
       }),
       "first-tree-hub",
     );

--- a/packages/server/src/__tests__/github-entity-extractor.test.ts
+++ b/packages/server/src/__tests__/github-entity-extractor.test.ts
@@ -1,0 +1,125 @@
+import type { ToolCallEventPayload } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { extractGithubEntity } from "../services/github-entity-extractor.js";
+
+function basePayload(overrides: Partial<ToolCallEventPayload> = {}): ToolCallEventPayload {
+  return {
+    toolUseId: "tool_use_1",
+    name: "Bash",
+    args: { command: "" },
+    status: "ok",
+    resultPreview: "",
+    ...overrides,
+  };
+}
+
+describe("extractGithubEntity", () => {
+  it("extracts a pull_request entity from `gh pr create` output", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        args: { command: 'gh pr create --title "Refactor inbox" --body "Fixes #42"' },
+        resultPreview: "https://github.com/agent-team-foundation/first-tree-hub/pull/123\n",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "pull_request",
+      entityKey: "agent-team-foundation/first-tree-hub#123",
+      entityUrl: "https://github.com/agent-team-foundation/first-tree-hub/pull/123",
+      source: "bash-gh-pr",
+    });
+  });
+
+  it("extracts an issue entity from `gh issue create` output", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        args: { command: "gh issue create --title bug --body details" },
+        resultPreview: "https://github.com/owner/repo/issues/77",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "issue",
+      entityKey: "owner/repo#77",
+      entityUrl: "https://github.com/owner/repo/issues/77",
+      source: "bash-gh-issue",
+    });
+  });
+
+  it("returns null when status is not ok (in-flight pending event)", () => {
+    expect(
+      extractGithubEntity(
+        basePayload({
+          status: "pending",
+          args: { command: "gh pr create" },
+          resultPreview: "https://github.com/owner/repo/pull/1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when status is error", () => {
+    expect(
+      extractGithubEntity(
+        basePayload({
+          status: "error",
+          args: { command: "gh pr create" },
+          resultPreview: "auth failed",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when tool name is not Bash", () => {
+    expect(
+      extractGithubEntity(
+        basePayload({
+          name: "Read",
+          args: { command: "gh pr create" },
+          resultPreview: "https://github.com/owner/repo/pull/1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores non-create gh commands even when their output contains a PR URL", () => {
+    // `gh pr list` shows PR URLs but we MUST NOT bind them — those PRs were
+    // not created by this tool call.
+    expect(
+      extractGithubEntity(
+        basePayload({
+          args: { command: "gh pr list" },
+          resultPreview: "#1 fix bug https://github.com/owner/repo/pull/1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when args is not an object with a command string", () => {
+    expect(extractGithubEntity(basePayload({ args: null }))).toBeNull();
+    expect(extractGithubEntity(basePayload({ args: { command: 123 } }))).toBeNull();
+    expect(extractGithubEntity(basePayload({ args: "gh pr create" }))).toBeNull();
+  });
+
+  it("returns null when resultPreview has no GitHub URL", () => {
+    expect(
+      extractGithubEntity(
+        basePayload({
+          args: { command: "gh pr create" },
+          resultPreview: "ok",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("picks the issue URL when both `gh issue create` and an unrelated PR URL appear", () => {
+    // The command discriminates intent, not the URL match — the issue regex
+    // only matches /issues/N, so a stray /pull/N in the output is ignored.
+    const result = extractGithubEntity(
+      basePayload({
+        args: { command: "gh issue create --title x" },
+        resultPreview: "see also https://github.com/foo/bar/pull/9 — https://github.com/owner/repo/issues/77",
+      }),
+    );
+    expect(result?.entityType).toBe("issue");
+    expect(result?.entityKey).toBe("owner/repo#77");
+  });
+});

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -9,15 +9,22 @@ import { resolveTargetChat as resolveTargetChatRaw } from "../services/github-en
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
- * Test-only thin wrapper: every existing case in this file expects a
- * non-null resolution (none of them exercise the creation-event guard's
- * `null` branch). Wrap the service so the existing assertions still
- * compile after the signature change.
+ * Test-only thin wrapper: every existing case in this file simulates the
+ * mention path (none of them exercise the creation-event guard's null
+ * branch). The wrapper defaults `isMentionMatched: true` so the legacy
+ * assertions still compile after `isMentionMatched` became required, and
+ * throws on null because that would be a real regression for these cases.
  */
 async function resolveTargetChat(
-  ...args: Parameters<typeof resolveTargetChatRaw>
+  db: Parameters<typeof resolveTargetChatRaw>[0],
+  params: Omit<Parameters<typeof resolveTargetChatRaw>[1], "isMentionMatched"> & {
+    isMentionMatched?: boolean;
+  },
 ): Promise<NonNullable<Awaited<ReturnType<typeof resolveTargetChatRaw>>>> {
-  const result = await resolveTargetChatRaw(...args);
+  const result = await resolveTargetChatRaw(db, {
+    ...params,
+    isMentionMatched: params.isMentionMatched ?? true,
+  });
   if (!result) throw new Error("resolveTargetChat returned null in legacy test path");
   return result;
 }

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -5,8 +5,22 @@ import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
-import { resolveTargetChat } from "../services/github-entity-chat.js";
+import { resolveTargetChat as resolveTargetChatRaw } from "../services/github-entity-chat.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Test-only thin wrapper: every existing case in this file expects a
+ * non-null resolution (none of them exercise the creation-event guard's
+ * `null` branch). Wrap the service so the existing assertions still
+ * compile after the signature change.
+ */
+async function resolveTargetChat(
+  ...args: Parameters<typeof resolveTargetChatRaw>
+): Promise<NonNullable<Awaited<ReturnType<typeof resolveTargetChatRaw>>>> {
+  const result = await resolveTargetChatRaw(...args);
+  if (!result) throw new Error("resolveTargetChat returned null in legacy test path");
+  return result;
+}
 
 async function seedDelegate(
   app: ReturnType<ReturnType<typeof useTestApp>>,

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -202,7 +202,15 @@ export async function resolveAudience(
   if (audience.length === 0) return audience;
 
   const actor = await identifyActor(db, organizationId, event.actor, appSlug);
-  if (actor.kind === "our-app-bot") return [];
+  if (actor.kind === "our-app-bot") {
+    // The App bot is on the wire because Hub itself wrote to GitHub — the
+    // user already saw their own action client-side. We still need to fan
+    // out to *existing* subscriptions so PR comments / CI changes reach
+    // the chat the agent worked in; mention-driven `kind: "new"` rows are
+    // dropped because creating a fresh chat just to echo our own write is
+    // never useful.
+    return audience.filter((a) => a.kind === "existing");
+  }
   if (actor.kind === "agent") {
     // Echo suppression applies to subscribed rows only: a row where the
     // actor is on either side of an existing mapping shouldn't fan back

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -36,9 +36,13 @@ export function evaluateDelegateTarget(
  *   - `agent`         — actor.login maps to one of this org's agents. Used
  *                       for echo suppression: the agent's own actions don't
  *                       fan back into their own chat.
- *   - `our-app-bot`   — actor is `<app-slug>[bot]`. Audience is forced empty
- *                       because the event is a downstream effect of Hub's own
- *                       outbound write, not a human/agent intent.
+ *   - `our-app-bot`   — actor is `<app-slug>[bot]`. The event is a downstream
+ *                       effect of Hub's own outbound write. `kind: "existing"`
+ *                       targets are kept (so PRs the agent opens via Hub's
+ *                       installation token still surface their comments / CI
+ *                       back to the agent's chat via the subscription path);
+ *                       `kind: "new"` mention rows are dropped — minting a
+ *                       fresh chat for our own write is never useful.
  *   - `external`      — anyone else (other humans, third-party bots like
  *                       dependabot, …). No echo filter applied.
  */
@@ -99,10 +103,14 @@ export type AudienceTarget = {
  * `delegate_mention`-configured agent whose target is eligible AND isn't
  * already subscribed, appends a `new` row.
  *
- * Echo filtering runs after the union: when the actor maps to an agent in
- * this org, rows where the actor is either the human or the delegate side
- * are dropped so the agent's own action doesn't bounce back. When the actor
- * is our App's bot user (DP13), the whole audience is suppressed.
+ * Echo filtering runs after the union:
+ *   - actor = `agent`: rows where the actor sits on either the human or
+ *     delegate side of an `existing` mapping are dropped. `kind: "new"`
+ *     mention rows are kept (explicit involves are intentional routing).
+ *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
+ *     events on entities the agent opened still reach the chat through the
+ *     subscription path; `kind: "new"` rows are dropped to avoid forking a
+ *     fresh chat just to echo Hub's own outbound write. See `ActorIdentity`.
  */
 export async function resolveAudience(
   db: Database,

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -40,6 +40,25 @@ export async function deliverNormalizedEvent(
   for (const target of audience) {
     try {
       const resolved = await resolveChatFor(app, event, target);
+      if (!resolved) {
+        // Creation-event guard fired: opened webhook had no existing mapping
+        // and no explicit mention for this target, so we drop the event for
+        // this target rather than inventing a chat. Other targets in the
+        // audience may still receive the card.
+        log.info(
+          {
+            humanAgent: target.humanAgentId,
+            delegateAgent: target.delegateAgentId,
+            entityType: event.entity.type,
+            entityKey: event.entity.key,
+            eventType: event.rawEventType,
+            action: event.rawAction,
+            reason: "creation_event_no_mapping_no_mention",
+          },
+          "webhook_dropped_creation",
+        );
+        continue;
+      }
       if (resolved.created) stats.newChats += 1;
 
       const card = buildCard(event, target);
@@ -82,7 +101,7 @@ async function resolveChatFor(
   app: FastifyInstance,
   event: NormalizedEvent,
   target: AudienceTarget,
-): Promise<ResolvedChat> {
+): Promise<ResolvedChat | null> {
   if (target.kind === "existing") {
     if (!target.chatId) {
       throw new Error("audience target kind=existing must carry chatId");
@@ -107,7 +126,14 @@ async function resolveChatFor(
     relatedEntities,
     eventType: event.rawEventType,
     action: event.rawAction ?? "",
+    // `kind: "new"` audience targets come from explicit mentions / involves
+    // in the event payload — these are the only path allowed to mint a fresh
+    // chat for an opened creation event. Subscription targets never reach
+    // resolveTargetChat (`kind: "existing"` short-circuits above), but the
+    // guard is still wired so any future caller is safe by default.
+    isMentionMatched: true,
   });
+  if (!resolved) return null;
   return { chatId: resolved.chatId, created: resolved.created };
 }
 

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -78,14 +78,25 @@ export async function resolveTargetChat(
      * mention-driven targets are allowed to create a fresh chat from a
      * creation webhook (`pull_request.opened` / `issues.opened`); subscription
      * fall-through is rejected so opened events can't proliferate chats.
-     * Defaults to `true` to preserve legacy behaviour for callers that don't
-     * carry the flag.
+     *
+     * Required, not optional: the guard is fail-closed by design so any
+     * future caller that forgets to plumb the signal lands in the safer
+     * "drop, don't invent" branch instead of silently re-enabling the old
+     * chat-proliferation behaviour.
      */
-    isMentionMatched?: boolean;
+    isMentionMatched: boolean;
   },
 ): Promise<{ chatId: string; created: boolean; boundVia: BoundVia } | null> {
-  const { organizationId, humanAgentId, delegateAgentId, entity, relatedEntities, eventType, action } = params;
-  const isMentionMatched = params.isMentionMatched ?? true;
+  const {
+    organizationId,
+    humanAgentId,
+    delegateAgentId,
+    entity,
+    relatedEntities,
+    eventType,
+    action,
+    isMentionMatched,
+  } = params;
 
   // (a) Direct hit.
   const direct = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, entity);
@@ -258,10 +269,15 @@ async function createEntityChat(
  * Pick the (org, human, delegate) tuple to bind a tool_call-driven entity to.
  *
  * The reporting agent is the delegate side. The human side is the
- * representative human member of the chat — id-sorted to keep the choice
- * deterministic across concurrent webhooks. Picking one representative
- * (rather than fan-out to every human) keeps subscription-driven webhook
- * delivery from duplicating the same card N times in a group chat.
+ * representative human member of the chat — exactly one row is written so
+ * group chats don't fan out into N duplicate cards on the next webhook.
+ *
+ * Selection order (deterministic across concurrent calls):
+ *   1. Active humans whose `delegateMention` already points at the reporter
+ *      —— these humans are the natural "owner" of the reporter's work; any
+ *      downstream code that reads `mapping.humanAgentId` (notification
+ *      recipient, card signatures, audit) sees a meaningful pairing.
+ *   2. Fallback: id-sorted-first among the remaining active humans.
  *
  * Returns null when:
  *   - the reporter isn't a member of the chat
@@ -283,6 +299,7 @@ async function resolveBindingPair(
       agentId: chatMembership.agentId,
       agentType: agents.type,
       agentStatus: agents.status,
+      delegateMention: agents.delegateMention,
     })
     .from(chatMembership)
     .innerJoin(chats, eq(chatMembership.chatId, chats.id))
@@ -299,7 +316,8 @@ async function resolveBindingPair(
   const humans = rows.filter((r) => r.agentType === "human" && r.agentStatus === "active");
   if (humans.length === 0) return null;
 
-  const representative = humans[0];
+  const linkedHuman = humans.find((h) => h.delegateMention === reporterAgentId);
+  const representative = linkedHuman ?? humans[0];
   if (!representative) return null;
   return {
     organizationId: representative.chatOrganizationId,

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -1,10 +1,46 @@
+import type { ToolCallEventPayload } from "@agent-team-foundation/first-tree-hub-shared";
 import { chatMetadataSchema } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { formatEntityTitle } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { createLogger } from "../observability/index.js";
 import { createChat } from "./chat.js";
+import { extractGithubEntity } from "./github-entity-extractor.js";
+
+const log = createLogger("GithubEntityChat");
+
+/**
+ * `bound_via` audit values:
+ *   - "direct"        — first-touch row created in `resolveTargetChat` step (c)
+ *   - "fixes_link"    — secondary row written by the `Fixes #N` linker
+ *   - "agent_created" — proactively written when an agent's tool_call creates
+ *                       a PR/Issue, before the corresponding `*.opened` webhook
+ *                       arrives. See `maybeBindGithubEntityFromToolCall`.
+ *
+ * Routing logic ignores the distinction; this column is purely for audit /
+ * future strategy tweaks.
+ */
+export type BoundVia = "direct" | "fixes_link" | "agent_created";
+
+function asBoundVia(value: string): BoundVia {
+  if (value === "fixes_link") return "fixes_link";
+  if (value === "agent_created") return "agent_created";
+  return "direct";
+}
+
+/**
+ * `(eventType, action)` pairs that represent the creation of a brand-new
+ * GitHub entity. Reserved for the "creation webhooks must not invent new
+ * chats" guard — see `resolveTargetChat`.
+ */
+export function isCreationEvent(eventType: string, action: string): boolean {
+  return (eventType === "pull_request" && action === "opened") || (eventType === "issues" && action === "opened");
+}
 
 /**
  * Resolve which chat a GitHub event for (human, delegate, entity) belongs to.
@@ -36,9 +72,20 @@ export async function resolveTargetChat(
     eventType: string;
     /** GitHub action on `eventType`. Same scope as `eventType`. */
     action: string;
+    /**
+     * Whether the calling audience target came from an explicit mention /
+     * involve in the event payload (vs. a pre-existing subscription). Only
+     * mention-driven targets are allowed to create a fresh chat from a
+     * creation webhook (`pull_request.opened` / `issues.opened`); subscription
+     * fall-through is rejected so opened events can't proliferate chats.
+     * Defaults to `true` to preserve legacy behaviour for callers that don't
+     * carry the flag.
+     */
+    isMentionMatched?: boolean;
   },
-): Promise<{ chatId: string; created: boolean; boundVia: "direct" | "fixes_link" }> {
+): Promise<{ chatId: string; created: boolean; boundVia: BoundVia } | null> {
   const { organizationId, humanAgentId, delegateAgentId, entity, relatedEntities, eventType, action } = params;
+  const isMentionMatched = params.isMentionMatched ?? true;
 
   // (a) Direct hit.
   const direct = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, entity);
@@ -60,6 +107,18 @@ export async function resolveTargetChat(
     });
     // If the insert lost a race, our re-read returns the winner's row.
     return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
+  }
+
+  // (b.5) Creation-event guard. `pull_request.opened` / `issues.opened` must
+  // never invent a chat for a target that didn't explicitly @-mention an
+  // agent. By the time we get here, (a) miss + (b) miss already proves the
+  // entity is brand-new from the mapping's perspective; the only legitimate
+  // reason to enter (c) is an explicit mention/involve. Subscription
+  // fall-through (or any future caller that forgets to set the flag) gets
+  // rejected with `null` so the delivery loop drops the event instead of
+  // proliferating chats. See proposals discussion: opened-webhook intercept.
+  if (isCreationEvent(eventType, action) && !isMentionMatched) {
+    return null;
   }
 
   // (c) Miss — create a fresh chat. Two concurrent (c)-path callers for the
@@ -86,7 +145,7 @@ async function lookupMapping(
   humanAgentId: string,
   delegateAgentId: string,
   entity: GithubEntity,
-): Promise<{ chatId: string; boundVia: "direct" | "fixes_link" } | null> {
+): Promise<{ chatId: string; boundVia: BoundVia } | null> {
   const [row] = await db
     .select({ chatId: githubEntityChatMappings.chatId, boundVia: githubEntityChatMappings.boundVia })
     .from(githubEntityChatMappings)
@@ -101,7 +160,7 @@ async function lookupMapping(
     )
     .limit(1);
   if (!row) return null;
-  return { chatId: row.chatId, boundVia: row.boundVia === "fixes_link" ? "fixes_link" : "direct" };
+  return { chatId: row.chatId, boundVia: asBoundVia(row.boundVia) };
 }
 
 async function insertMappingIfAbsent(
@@ -112,9 +171,9 @@ async function insertMappingIfAbsent(
     delegateAgentId: string;
     entity: GithubEntity;
     chatId: string;
-    boundVia: "direct" | "fixes_link";
+    boundVia: BoundVia;
   },
-): Promise<{ chatId: string; boundVia: "direct" | "fixes_link" }> {
+): Promise<{ chatId: string; boundVia: BoundVia }> {
   const [inserted] = await db
     .insert(githubEntityChatMappings)
     .values({
@@ -140,7 +199,7 @@ async function insertMappingIfAbsent(
       boundVia: githubEntityChatMappings.boundVia,
     });
   if (inserted) {
-    return { chatId: inserted.chatId, boundVia: inserted.boundVia === "fixes_link" ? "fixes_link" : "direct" };
+    return { chatId: inserted.chatId, boundVia: asBoundVia(inserted.boundVia) };
   }
   // Lost the race — read the winning row.
   const winner = await lookupMapping(
@@ -193,4 +252,113 @@ async function createEntityChat(
     metadata,
   });
   return { id: chat.id };
+}
+
+/**
+ * Pick the (org, human, delegate) tuple to bind a tool_call-driven entity to.
+ *
+ * The reporting agent is the delegate side. The human side is the
+ * representative human member of the chat — id-sorted to keep the choice
+ * deterministic across concurrent webhooks. Picking one representative
+ * (rather than fan-out to every human) keeps subscription-driven webhook
+ * delivery from duplicating the same card N times in a group chat.
+ *
+ * Returns null when:
+ *   - the reporter isn't a member of the chat
+ *   - the reporter is itself a human agent (humans don't emit tool_calls)
+ *   - the chat has no active human member
+ */
+async function resolveBindingPair(
+  db: Database,
+  chatId: string,
+  reporterAgentId: string,
+): Promise<{
+  organizationId: string;
+  humanAgentId: string;
+  delegateAgentId: string;
+} | null> {
+  const rows = await db
+    .select({
+      chatOrganizationId: chats.organizationId,
+      agentId: chatMembership.agentId,
+      agentType: agents.type,
+      agentStatus: agents.status,
+    })
+    .from(chatMembership)
+    .innerJoin(chats, eq(chatMembership.chatId, chats.id))
+    .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+    .where(eq(chatMembership.chatId, chatId))
+    .orderBy(asc(chatMembership.agentId));
+
+  if (rows.length === 0) return null;
+
+  const reporter = rows.find((r) => r.agentId === reporterAgentId);
+  if (!reporter) return null;
+  if (reporter.agentType === "human") return null;
+
+  const humans = rows.filter((r) => r.agentType === "human" && r.agentStatus === "active");
+  if (humans.length === 0) return null;
+
+  const representative = humans[0];
+  if (!representative) return null;
+  return {
+    organizationId: representative.chatOrganizationId,
+    humanAgentId: representative.agentId,
+    delegateAgentId: reporterAgentId,
+  };
+}
+
+/**
+ * Side-effect of a `tool_call` session event: when the agent has just created
+ * a PR/Issue via a recognised tool (`gh pr create` / `gh issue create`), pin
+ * the resulting entity to the current chat so the upcoming `*.opened` webhook
+ * routes back instead of fanning out a new chat.
+ *
+ * Failures are swallowed — the caller (sessionEventService.appendEvent) must
+ * not let mapping bookkeeping break the main tool_call write.
+ */
+export async function maybeBindGithubEntityFromToolCall(
+  db: Database,
+  reporterAgentId: string,
+  chatId: string,
+  payload: ToolCallEventPayload,
+): Promise<void> {
+  const entity = extractGithubEntity(payload);
+  if (!entity) return;
+
+  const pair = await resolveBindingPair(db, chatId, reporterAgentId);
+  if (!pair) {
+    log.debug(
+      { chatId, reporterAgentId, entityKey: entity.entityKey },
+      "agent_binding skipped: no eligible (human, delegate) pair",
+    );
+    return;
+  }
+
+  const githubEntity: GithubEntity = {
+    type: entity.entityType,
+    key: entity.entityKey,
+    url: entity.entityUrl,
+  };
+
+  await insertMappingIfAbsent(db, {
+    organizationId: pair.organizationId,
+    humanAgentId: pair.humanAgentId,
+    delegateAgentId: pair.delegateAgentId,
+    entity: githubEntity,
+    chatId,
+    boundVia: "agent_created",
+  });
+
+  log.info(
+    {
+      chatId,
+      reporterAgentId,
+      humanAgentId: pair.humanAgentId,
+      entityType: entity.entityType,
+      entityKey: entity.entityKey,
+      source: entity.source,
+    },
+    "agent_binding inserted",
+  );
 }

--- a/packages/server/src/services/github-entity-extractor.ts
+++ b/packages/server/src/services/github-entity-extractor.ts
@@ -1,0 +1,63 @@
+import type { ToolCallEventPayload } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Detect "the agent just created a PR or Issue" from a tool_call session event.
+ *
+ * Phase 1 allowlist only — `Bash gh pr create` / `Bash gh issue create`. These
+ * two tools emit a single-line URL on stdout (well under the 400-char
+ * `resultPreview` cap), so detection is lossless. curl / GitHub MCP tools are
+ * out of scope until Phase 2 (their JSON responses can overflow the preview).
+ *
+ * Returning a value tells `maybeBindGithubEntityFromToolCall` to write an
+ * `agent_created` mapping row so the upcoming `pull_request.opened` /
+ * `issues.opened` webhook routes back to the agent's current chat instead of
+ * fanning out a fresh one.
+ */
+export type ExtractedEntity = {
+  entityType: "pull_request" | "issue";
+  /** Stable cluster key, e.g. `"owner/repo#123"`. */
+  entityKey: string;
+  entityUrl: string;
+  source: "bash-gh-pr" | "bash-gh-issue";
+};
+
+const PR_COMMAND_RE = /\bgh\s+pr\s+create\b/;
+const ISSUE_COMMAND_RE = /\bgh\s+issue\s+create\b/;
+const PR_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/;
+const ISSUE_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/;
+
+export function extractGithubEntity(payload: ToolCallEventPayload): ExtractedEntity | null {
+  if (payload.status !== "ok") return null;
+  if (payload.name !== "Bash") return null;
+
+  const args = payload.args;
+  if (typeof args !== "object" || args === null) return null;
+  const command = (args as { command?: unknown }).command;
+  if (typeof command !== "string") return null;
+
+  const preview = payload.resultPreview ?? "";
+
+  if (PR_COMMAND_RE.test(command)) {
+    const m = preview.match(PR_URL_RE);
+    if (!m) return null;
+    return {
+      entityType: "pull_request",
+      entityKey: `${m[1]}/${m[2]}#${m[3]}`,
+      entityUrl: m[0],
+      source: "bash-gh-pr",
+    };
+  }
+
+  if (ISSUE_COMMAND_RE.test(command)) {
+    const m = preview.match(ISSUE_URL_RE);
+    if (!m) return null;
+    return {
+      entityType: "issue",
+      entityKey: `${m[1]}/${m[2]}#${m[3]}`,
+      entityUrl: m[0],
+      source: "bash-gh-issue",
+    };
+  }
+
+  return null;
+}

--- a/packages/server/src/services/github-entity-extractor.ts
+++ b/packages/server/src/services/github-entity-extractor.ts
@@ -1,17 +1,26 @@
 import type { ToolCallEventPayload } from "@agent-team-foundation/first-tree-hub-shared";
 
 /**
- * Detect "the agent just created a PR or Issue" from a tool_call session event.
+ * Phase 1 fallback path for chat ↔ GitHub entity binding.
  *
- * Phase 1 allowlist only — `Bash gh pr create` / `Bash gh issue create`. These
- * two tools emit a single-line URL on stdout (well under the 400-char
- * `resultPreview` cap), so detection is lossless. curl / GitHub MCP tools are
- * out of scope until Phase 2 (their JSON responses can overflow the preview).
+ * The long-term direction is *not* to extend this whitelist indefinitely —
+ * see `docs/github-entity-chat-binding-design.md` for the four-family
+ * framing (declaration / outbound proxy / webhook backfill / stdout
+ * extraction). Stdout extraction is the cheapest first cut, not the
+ * canonical entry point; once an explicit `bind_chat_to_github_entity`
+ * API lands, prefer adding callers there over expanding this file.
  *
- * Returning a value tells `maybeBindGithubEntityFromToolCall` to write an
- * `agent_created` mapping row so the upcoming `pull_request.opened` /
- * `issues.opened` webhook routes back to the agent's current chat instead of
- * fanning out a fresh one.
+ * Detect "the agent just created a PR or Issue" from a tool_call session
+ * event. Phase 1 allowlist only — `Bash gh pr create` / `Bash gh issue
+ * create`. These two tools emit a single-line URL on stdout (well under
+ * the 400-char `resultPreview` cap), so detection is lossless. curl /
+ * GitHub MCP tools are out of scope until Phase 2 (their JSON responses
+ * can overflow the preview).
+ *
+ * Returning a value tells `maybeBindGithubEntityFromToolCall` to write
+ * an `agent_created` mapping row so the upcoming `pull_request.opened`
+ * / `issues.opened` webhook routes back to the agent's current chat
+ * instead of fanning out a fresh one.
  */
 export type ExtractedEntity = {
   entityType: "pull_request" | "issue";

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -8,7 +8,11 @@ import { and, asc, desc, eq, gt, gte, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { sessionEvents } from "../db/schema/session-events.js";
+import { createLogger } from "../observability/index.js";
 import { uuidv7 } from "../uuid.js";
+import { maybeBindGithubEntityFromToolCall } from "./github-entity-chat.js";
+
+const log = createLogger("SessionEvent");
 
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 1000;
@@ -76,7 +80,7 @@ export async function appendEvent(
 
     const row = result[0];
     if (row) {
-      return rowToEvent({
+      const persisted = rowToEvent({
         id: row.id,
         agentId: row.agent_id,
         chatId: row.chat_id,
@@ -85,6 +89,21 @@ export async function appendEvent(
         payload: row.payload,
         createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
       });
+
+      // Side-effect: when a tool_call event reports the agent just created a
+      // GitHub PR/Issue, write the chat ↔ entity mapping eagerly so the
+      // incoming `*.opened` webhook routes back to this chat instead of
+      // forking a fresh one. Fire-and-forget — the main session-event write
+      // has already succeeded and must not be unwound on bookkeeping
+      // failures. Status filter avoids spurious DB queries: only `ok` events
+      // carry a stdout preview worth extracting from.
+      if (validated.kind === "tool_call" && validated.payload.status === "ok") {
+        maybeBindGithubEntityFromToolCall(db, agentId, chatId, validated.payload).catch((err) => {
+          log.warn({ err, agentId, chatId }, "agent_binding side-effect failed");
+        });
+      }
+
+      return persisted;
     }
   }
 


### PR DESCRIPTION
## Summary

When an agent runs `gh pr create` / `gh issue create`, eagerly bind the resulting PR / Issue to the agent's current chat so the upcoming `*.opened` webhook (and every comment / review / CI event after it) routes back to that chat instead of forking a fresh one. Solves the delegate-misrouting issue where agent work in `chat C1` produced GitHub events that landed in a new `chat C2`.

### Pipeline

| File | Role |
|---|---|
| `services/github-entity-extractor.ts` | Whitelist parser. Phase 1 covers `Bash gh pr create` / `gh issue create` (single-line URL stdout fits the 400-char `resultPreview` cap, zero loss). |
| `services/github-entity-chat.ts` | `maybeBindGithubEntityFromToolCall` writes a `boundVia="agent_created"` mapping row. `resolveBindingPair` picks an id-sorted representative human so group chats produce **one** mapping row, not one per human. `resolveTargetChat` gains an `isMentionMatched` flag + creation-event guard: opened-style webhooks with no mapping / no mention now return `null` (defensive — `kind: "new"` audience rows already imply mention; the guard keeps future audience refactors safe). |
| `services/session-event.ts` | `appendEvent` hook fires fire-and-forget when `kind: "tool_call" && status: "ok"`. Failures only `log.warn`; the main session-event write is never unwound. |
| `services/github-delivery.ts` | Drops `null` resolutions with a structured `webhook_dropped_creation` log; passes `isMentionMatched: true` for `kind: "new"` audience targets. |
| `services/github-audience.ts` | `our-app-bot` echo branch keeps `kind: "existing"` targets so PRs the agent opens via Hub's installation token still surface their comments / CI back to the original chat. Mention-only targets are still dropped (no fresh chat for our own write). |

### Schema / migration

**No DB schema change.** `github_entity_chat_mappings.bound_via` is `text` with no CHECK constraint; the new `"agent_created"` literal is a pure application-layer extension. No drizzle migration needed.

### Behaviour matrix

| Scenario | Outcome |
|---|---|
| Agent `gh pr create` → tool_call ok | Mapping written immediately; subsequent `pull_request.opened` from `<slug>[bot]` reuses the same chat |
| Agent in group chat | One mapping row (representative human), no N× duplicate cards |
| PR comment after agent_created | Routes to original chat via subscribed path |
| External user opens PR with no mention | `audience: 0`, no chat invented, no mapping |
| External user opens PR with `@<agent>` body | Mention exemption preserved — new chat + `direct` mapping |
| Repeated tool_call event (pending then ok, or duplicate ok) | Idempotent — `ON CONFLICT DO NOTHING` |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm check` (biome) — clean
- [x] `pnpm --filter @first-tree-hub/server test` — **1009 / 1009 passing** (+22 new)
  - `github-entity-extractor.test.ts` — 9 unit tests (pure function parser)
  - `agent-created-binding.test.ts` — 13 integration tests (direct chat, group representative, idempotency, non-member skip, no-human skip, hook isolation, `appendEvent` → mapping plumbing, `resolveTargetChat` guard branches)
  - `agent-created-webhook-e2e.test.ts` — 4 HMAC-signed real webhook simulations covering opened-from-bot reuse, PR comment follow-up routing, the negative no-mention drop, and the mention exemption
- [ ] Staging soak with a real GitHub App installation (out of this PR's scope — Phase 2 task)

## Out of scope (Phase 2+)

- curl / GitHub MCP tool extractors — needs `resultPreview` cap bump or a dedicated `resultFull` field
- Async GitHub API verification of mapping entities (defends against agents writing junk URLs)
- `pending_creation` short-TTL table if telemetry shows the webhook-arrives-before-tool_call race is non-trivial

🤖 Generated with [Claude Code](https://claude.com/claude-code)