### PR TITLE
fix(web,server): reduce GET /chats refetch storm under WebSocket push

### DIFF
--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -29,6 +29,7 @@ function mkChatDetail(overrides?: Partial<ChatDetail>): ChatDetail {
     title: "v1 ship",
     firstMessagePreview: null,
     engagementStatus: "active",
+    viewerMembershipKind: "participant",
     ...overrides,
   };
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "type": "module",
   "description": "First Tree Hub — unified CLI for server, client, and agent management",
   "exports": {

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -83,11 +83,29 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
 
     const engagementStatus = await getCallerEngagement(app.db, chat.id, scope.humanAgentId);
 
+    // Caller's own membership row — drives speaker-vs-watcher UI on the
+    // chat detail page without forcing the client to round-trip through
+    // `/orgs/:orgId/chats`. `null` when the caller reaches the chat via
+    // supervision (managed agent is a speaker) rather than direct
+    // membership; that's the same null-shape `MeChatRow` carries when
+    // listChats filters to supervised-only rows.
+    const [callerMembership] = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.agentId, scope.humanAgentId)))
+      .limit(1);
+    const viewerMembershipKind: "participant" | "watching" | null = callerMembership
+      ? callerMembership.accessMode === "speaker"
+        ? "participant"
+        : "watching"
+      : null;
+
     return {
       ...chat,
       title,
       firstMessagePreview,
       engagementStatus,
+      viewerMembershipKind,
       createdAt: chat.createdAt.toISOString(),
       updatedAt: chat.updatedAt.toISOString(),
       participants: participants.map((p) => ({

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -174,7 +174,31 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
     type: p.type,
   }));
 
-  return { ...chat, participants, title, firstMessagePreview };
+  // Match the chatDetailSchema wire contract — the chat-first workspace
+  // reads this field instead of round-tripping `/orgs/:orgId/chats` just to
+  // distinguish speaker vs watcher view. Agent-SDK callers always reach
+  // this code with their own uuid as `selfAgentId`, and the SDK only sees
+  // chats it is a speaker in, so the lookup is cheap and almost always
+  // resolves to `"participant"`; the admin / supervisor `null` shape still
+  // matters for the alternate route (`api/chats.ts`).
+  const viewerMembershipKind = await resolveViewerMembershipKind(db, chatId, selfAgentId);
+
+  return { ...chat, participants, title, firstMessagePreview, viewerMembershipKind };
+}
+
+async function resolveViewerMembershipKind(
+  db: Database,
+  chatId: string,
+  viewerAgentId: string | null,
+): Promise<"participant" | "watching" | null> {
+  if (!viewerAgentId) return null;
+  const [row] = await db
+    .select({ accessMode: chatMembership.accessMode })
+    .from(chatMembership)
+    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, viewerAgentId)))
+    .limit(1);
+  if (!row) return null;
+  return row.accessMode === "speaker" ? "participant" : "watching";
 }
 
 export async function listChats(db: Database, agentId: string, limit: number, cursor?: string) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-team-foundation/first-tree-hub-shared",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "First Tree Hub shared schemas, types, and configuration (internal to the monorepo)",
   "license": "MIT",

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -104,6 +104,13 @@ export const chatDetailSchema = chatSchema.extend({
    *  the lazy-materialised `chat_user_state` row so the value is always
    *  defined (defaults to `active`); the schema is non-nullable on purpose. */
   engagementStatus: chatEngagementStatusSchema,
+  /** Caller's chat-membership view: `"participant"` (speaker), `"watching"`
+   *  (watcher), or `null` for supervisor / admin views where the caller has
+   *  no direct row in `chat_membership` (access granted via managed agents).
+   *  Mirrors the value `services/me-chat.ts` puts on `MeChatRow.membershipKind`
+   *  so the chat-detail page can decide between speaker UI and watcher UI
+   *  without round-tripping through the conversation-list query. */
+  viewerMembershipKind: z.enum(["participant", "watching"]).nullable(),
 });
 export type ChatDetail = z.infer<typeof chatDetailSchema>;
 

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -29,14 +29,20 @@ const subscribers = new Set<Subscriber>();
 let latestQc: QC | null = null;
 let refCount = 0;
 
-// `session:state` frames can burst when an agent ticks through tool
-// calls — every frame would otherwise force a `me/chats` refetch and the
-// React-Query default (`staleTime: 0`) wouldn't dedupe. Leading-edge fire
-// keeps the working ring snappy; a 500ms trailing window collapses the
-// burst into at most one extra round-trip after it ends. Tuned to be
-// shorter than typical observed gaps between tool calls (~1s) but long
-// enough to fold a 10+ frame storm into a single follow-up.
-const ME_CHATS_INVALIDATE_THROTTLE_MS = 500;
+// `session:state` and `session:event` frames burst when an agent ticks
+// through tool calls — every frame would otherwise force a `me/chats`
+// refetch and the React-Query default (`staleTime: 0`) wouldn't dedupe.
+// Leading-edge fire keeps the working ring / WorkingChip snappy; the
+// trailing window collapses the burst into at most one extra round-trip
+// after it ends.
+//
+// 1s is the long-enough-to-fold-a-burst, short-enough-to-feel-live
+// trade-off — `engagedAgentIds` (avatar ring) and `liveActivity`
+// (WorkingChip) update with at most ~1s lag, well inside the 60s
+// server-side `liveActivity` window. Also applied to `chat:message`
+// to fold storm-of-messages flurries (formerly invalidated every frame
+// without a throttle).
+const ME_CHATS_INVALIDATE_THROTTLE_MS = 1000;
 let meChatsLastInvalidatedAt = 0;
 let meChatsTrailingTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -84,17 +90,20 @@ function broadcast(msg: WsMessage) {
       // by tool_call / thinking / assistant_text / turn_end fans out
       // through this socket; invalidate the conversation-list so the
       // WorkingChip in the time slot updates within the throttle window.
-      // Re-uses the same 500ms leading + trailing helper as `session:state`.
+      // Re-uses the same leading + trailing throttle helper as
+      // `session:state` (window defined by `ME_CHATS_INVALIDATE_THROTTLE_MS`).
       invalidateMeChatsThrottled(latestQc);
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
       // carries `{ type, chatId }` (see shared/me-chat.ts:chatMessageFrameSchema);
-      // we invalidate the chat list, the chat's message timeline, and the
-      // chat's detail panel. Failures are swallowed — the parent broadcast
-      // wraps each subscriber in try/catch and the user-facing fallback is
-      // the 5s polling refetch already wired into ChatView.
+      // we invalidate the chat list (throttled — bulk arrivals like a
+      // backfill or a chatty agent don't need one HTTP per frame), the
+      // chat's message timeline, and the chat's detail panel. Failures
+      // are swallowed — the parent broadcast wraps each subscriber in
+      // try/catch and the user-facing fallback is the 5s polling refetch
+      // already wired into ChatView.
       const chatId = typeof msg.chatId === "string" ? msg.chatId : null;
-      latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
+      invalidateMeChatsThrottled(latestQc);
       if (chatId) {
         latestQc.invalidateQueries({ queryKey: ["chat-messages", chatId] });
         latestQc.invalidateQueries({ queryKey: ["chat-detail", chatId] });
@@ -135,6 +144,11 @@ function connect() {
   };
   socket.onopen = () => {
     if (socket !== ws) return;
+    // Capture before reset — drives the `ws:reconnect` sentinel below so we
+    // only fire it for genuine reconnects, not the first handshake of a
+    // fresh mount (where subscribers' own mount-effects already cover the
+    // catch-up work).
+    const isReconnect = reconnectAttempt > 0;
     reconnectAttempt = 0;
     // Catch up on every (re)open — including initial connect after a
     // sleep / network partition. Without this, push-only consumers like
@@ -147,7 +161,25 @@ function connect() {
       latestQc.invalidateQueries({ queryKey: ["activity"] });
       latestQc.invalidateQueries({ queryKey: ["sessions"] });
       latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
+      // The chat-first workspace reads `viewerMembershipKind` (and other
+      // viewer-scoped fields) off `["chat-detail", chatId]`. Without this,
+      // a frame that fired while the WS was down (e.g. the caller was
+      // added to / removed from a chat) wouldn't refresh the open chat's
+      // membership view until the next push or a manual refresh. Prefix
+      // invalidate so every cached chat-detail row catches up.
+      latestQc.invalidateQueries({ queryKey: ["chat-detail"] });
     }
+    // Synthetic sentinel — lets subscribers (e.g. chat-by-id's markRead)
+    // re-run side effects that depend on data freshness after a WS gap.
+    // The query-cache invalidations above cover anything that re-derives
+    // off React-Query state, but `chat:message` frames the WS missed
+    // during the gap can leave the open chat's unread badge stale.
+    // Subscribers identify this frame by its `ws:reconnect` type — it's
+    // not a server-emitted shape and won't collide with any wire frame.
+    // Routed through `broadcast` so the parent try/catch contains
+    // subscriber errors. Gated on `isReconnect` so mount-time effects
+    // aren't double-fired on the very first handshake.
+    if (isReconnect) broadcast({ type: "ws:reconnect" });
   };
   socket.onclose = (ev) => {
     // Only the current (latest) socket's close triggers reconnect.

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -646,6 +646,11 @@ export function AgentDetailPage() {
                 await queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
                 await queryClient.invalidateQueries({ queryKey: ["agents"] });
                 await queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
+                // chat-detail caches participant `displayName / name / type`
+                // (per-chat join against agents); editing an agent's identity
+                // must invalidate every cached chat-detail row, otherwise the
+                // open chat view shows stale labels until the next push.
+                await queryClient.invalidateQueries({ queryKey: ["chat-detail"] });
               }}
             />
           </SectionShell>

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -1,9 +1,9 @@
-import type { MeChatRow } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 import { getChat } from "../../../api/chats.js";
-import { joinMeChat, listMeChats, markMeChatRead } from "../../../api/me-chats.js";
+import { joinMeChat, markMeChatRead } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import { useAdminWs } from "../../../hooks/use-admin-ws.js";
 import { ChatView } from "./chat-view.js";
 
 /**
@@ -16,18 +16,22 @@ import { ChatView } from "./chat-view.js";
  *      autonomous/personal agent).
  *   2. Fallback: the first non-self participant.
  *
- * Mark-read fires once per chat on mount. Watching chats render the
- * timeline only — composer is replaced with `Join to reply`.
+ * Reads everything off `chatDetail` — speaker/watcher distinction comes
+ * from `chatDetail.viewerMembershipKind`, participant `type` comes from
+ * the wire schema. The earlier implementation also pulled two filter
+ * variants of `/orgs/:orgId/chats` just to find this one row, which
+ * compounded every `["me","chats"]` invalidate into 3 concurrent
+ * list fetches.
+ *
+ * Mark-read fires on mount and on every incoming `chat:message` frame
+ * for this chatId (the server-side write is a single idempotent UPSERT,
+ * so re-firing is cheap and lets the conversation-list's unread badge
+ * drop without the user having to leave + return).
  */
 
-function findRowAcrossFilters(qcRows: MeChatRow[] | undefined, chatId: string): MeChatRow | null {
-  if (!qcRows) return null;
-  return qcRows.find((r) => r.chatId === chatId) ?? null;
-}
-
-function pickPrimaryAgent(participants: { agentId: string; type?: string }[], myAgentId: string | null): string | null {
+function pickPrimaryAgent(participants: { agentId: string; type: string }[], myAgentId: string | null): string | null {
   const nonSelf = participants.filter((p) => p.agentId !== myAgentId);
-  const nonHuman = nonSelf.find((p) => p.type !== undefined && p.type !== "human");
+  const nonHuman = nonSelf.find((p) => p.type !== "human");
   if (nonHuman) return nonHuman.agentId;
   return nonSelf[0]?.agentId ?? null;
 }
@@ -35,54 +39,20 @@ function pickPrimaryAgent(participants: { agentId: string; type?: string }[], my
 export function ChatByIdView({ chatId }: { chatId: string }) {
   const queryClient = useQueryClient();
   const { agentId: myAgentId } = useAuth();
-  /**
-   * Track the (chatId, lastMessageAt) pair we've already mark-read'd in this
-   * mount. Re-marking on chat re-entry is necessary when new mentions
-   * arrived between A → B → A, otherwise the unread dot stays. We key on
-   * the row's `lastMessageAt` so a fresh message bumps the entry and the
-   * next mount of this chat fires mark-read again.
-   */
-  const markedRef = useRef<Map<string, string>>(new Map());
 
-  // Load the canonical chat detail for participant membership. ChatDetail
-  // doesn't include `type`, so we cross-reference with `/me/chats` rows to
-  // find a non-human primary.
   const { data: chatDetail } = useQuery({
     queryKey: ["chat-detail", chatId],
     queryFn: () => getChat(chatId),
     enabled: !!chatId,
   });
 
-  // Pull the user's chat list to (a) decide membership (participant vs
-  // watching) and (b) read participant `type` annotations the admin chat
-  // detail doesn't expose. We try the `all` filter first since it is the
-  // hot-list the conversation list also uses.
-  const { data: allChats } = useQuery({
-    queryKey: ["me", "chats", "all"] as const,
-    queryFn: () => listMeChats({ filter: "all" }),
-    refetchInterval: 30_000,
-  });
-
-  const { data: watchingChats } = useQuery({
-    queryKey: ["me", "chats", "watching"] as const,
-    queryFn: () => listMeChats({ filter: "watching" }),
-    refetchInterval: 30_000,
-  });
-
-  const meRow: MeChatRow | null = useMemo(() => {
-    return findRowAcrossFilters(allChats?.rows, chatId) ?? findRowAcrossFilters(watchingChats?.rows, chatId) ?? null;
-  }, [allChats, watchingChats, chatId]);
-
-  const participantsForPrimary = useMemo(() => {
-    if (meRow) return meRow.participants.map((p) => ({ agentId: p.agentId, type: p.type }));
-    if (chatDetail) return chatDetail.participants.map((p) => ({ agentId: p.agentId, type: undefined }));
-    return [];
-  }, [meRow, chatDetail]);
-
-  const primaryAgent = useMemo(
-    () => pickPrimaryAgent(participantsForPrimary, myAgentId),
-    [participantsForPrimary, myAgentId],
-  );
+  const primaryAgent = useMemo(() => {
+    if (!chatDetail) return null;
+    return pickPrimaryAgent(
+      chatDetail.participants.map((p) => ({ agentId: p.agentId, type: p.type })),
+      myAgentId,
+    );
+  }, [chatDetail, myAgentId]);
 
   const markReadMut = useMutation({
     mutationFn: () => markMeChatRead(chatId),
@@ -93,20 +63,47 @@ export function ChatByIdView({ chatId }: { chatId: string }) {
     },
   });
 
-  // Fire mark-read whenever (chatId, lastMessageAt) is new for this mount.
-  // The lastMessageAt key means: if a new message arrives while the user is
-  // looking at chat B (admin WS invalidates `["me","chats"]` → meRow refreshes
-  // → lastMessageAt advances), navigating back to A and on to a different
-  // chat-with-new-mentions still triggers mark-read on re-entry.
+  // Track whether we've already fired mark-read for the current chatId so a
+  // strict-mode double-mount or a `chatDetail` refetch doesn't pile up redundant
+  // POSTs. Incoming `chat:message` and `ws:reconnect` frames still re-fire below.
   const markReadFn = markReadMut.mutate;
-  const meRowLastMessageAt = meRow?.lastMessageAt ?? "";
+  const markedChatIdRef = useRef<string | null>(null);
+  // Whether the caller has a chat_membership row (speaker or watcher).
+  // Supervisor / admin views reach this page via managed agents and have
+  // no row of their own — firing markRead would `INSERT INTO chat_user_state`
+  // a row the conversation-list query (INNER JOIN `chat_membership`) never
+  // reads, leaving permanent dead rows in the table. Wait for chatDetail to
+  // load before deciding; once known, all three trigger points (mount,
+  // chat:message, ws:reconnect) share the same gate.
+  const canMarkRead = chatDetail != null && chatDetail.viewerMembershipKind !== null;
   useEffect(() => {
-    if (!meRow) return; // wait for the row to load before firing mark-read
-    const seen = markedRef.current.get(chatId);
-    if (seen === meRowLastMessageAt) return;
-    markedRef.current.set(chatId, meRowLastMessageAt);
+    if (!canMarkRead) return;
+    if (markedChatIdRef.current === chatId) return;
+    markedChatIdRef.current = chatId;
     markReadFn();
-  }, [chatId, meRow, meRowLastMessageAt, markReadFn]);
+  }, [chatId, canMarkRead, markReadFn]);
+
+  // Re-fire on every incoming message for this chat — the user has the
+  // composer open and is reading in real time, so the unread state on the
+  // list rail should follow. `ws:reconnect` is a synthetic frame emitted
+  // by `use-admin-ws` after a WS gap closes, covering the case where
+  // chat:message frames fired while the socket was down (the chat-detail
+  // and chat-messages caches catch up via the reconnect-block invalidate,
+  // but the unread badge needs an explicit markRead because nothing else
+  // observes "we are looking at this chat right now").
+  useAdminWs({
+    onMessage: (msg) => {
+      if (!canMarkRead) return;
+      if (msg.type === "ws:reconnect") {
+        markReadFn();
+        return;
+      }
+      if (msg.type !== "chat:message") return;
+      const incomingChatId = typeof msg.chatId === "string" ? msg.chatId : null;
+      if (incomingChatId !== chatId) return;
+      markReadFn();
+    },
+  });
 
   const joinMut = useMutation({
     mutationFn: () => joinMeChat(chatId),
@@ -116,7 +113,7 @@ export function ChatByIdView({ chatId }: { chatId: string }) {
     },
   });
 
-  const isWatching = meRow?.membershipKind === "watching";
+  const isWatching = chatDetail?.viewerMembershipKind === "watching";
 
   if (!primaryAgent) {
     return (
@@ -137,7 +134,7 @@ export function ChatByIdView({ chatId }: { chatId: string }) {
         agentId={primaryAgent}
         chatId={chatId}
         readOnly
-        titleFallback={meRow?.title ?? null}
+        titleFallback={chatDetail?.title ?? null}
         joinAction={{
           onJoin: () => joinMut.mutate(),
           joining: joinMut.isPending,


### PR DESCRIPTION
## Summary

- One `["me", "chats"]` invalidate was fanning out into **three concurrent** `GET /chats` requests because the chat-detail page kept two redundant `listMeChats` queries just to read `participant.type` and `membershipKind`. Both are now available on `ChatDetail` (the former via the existing wire schema, the latter via the new `viewerMembershipKind` field added in this PR).
- Combined with sub-500ms WS frame storms (`session:event` / `session:state` / `chat:message`), this drove **~9-12 `GET /chats`/s** under a single agent burst. Expected after this change: **~1-2/s**.
- Throttle window raised 500ms → 1s; `chat:message` now goes through the same leading + trailing throttle helper (was firing one invalidate per frame). `ws:reconnect` synthetic frame closes the markRead gap that would otherwise be re-introduced by removing the list-query dependency.

## What changed

**Shared / Server (wire contract)**
- `packages/shared/src/schemas/chat.ts`: `chatDetailSchema` gains `viewerMembershipKind: "participant" | "watching" | null`. `null` = supervisor / admin view (caller reaches the chat through a managed agent without a direct `chat_membership` row).
- `packages/server/src/api/chats.ts` (admin class-C `GET /chats/:chatId`) and `packages/server/src/services/chat.ts` (`getChatDetail`, used by the agent SDK) both compute and return the field.

**Web — drop the redundant list queries**
- `packages/web/src/pages/workspace/center/chat-by-id.tsx`: stop fetching `listMeChats({ filter: "all" })` and `listMeChats({ filter: "watching" })`; `pickPrimaryAgent` and `isWatching` now derive from `chatDetail.participants` and `chatDetail.viewerMembershipKind`.

**Web — WS-driven invalidate**
- `packages/web/src/hooks/use-admin-ws.ts`:
  - `ME_CHATS_INVALIDATE_THROTTLE_MS` 500 → 1000.
  - `chat:message` now routes through `invalidateMeChatsThrottled` instead of firing an invalidate per frame.
  - The catch-up invalidate on `(re)open` now also touches `["chat-detail"]` so chats the caller was added to / removed from while the socket was down refresh on reconnect.
  - On a genuine reconnect (`reconnectAttempt > 0`, captured before the reset), `broadcast({ type: "ws:reconnect" })` so subscribers can re-run freshness side effects.
- `packages/web/src/pages/workspace/center/chat-by-id.tsx`: subscribe to `ws:reconnect` to re-fire markRead. All three triggers (mount, `chat:message`, `ws:reconnect`) share a `canMarkRead` guard (`chatDetail` loaded && `viewerMembershipKind !== null`) to keep supervisor views from writing orphan `chat_user_state` rows.

**Drive-by fix**
- `packages/web/src/pages/agent-detail.tsx`: `onRefresh` now also invalidates `["chat-detail"]`. Pre-existing bug surfaced during the audit — editing an agent's `displayName` left stale labels in the open chat-detail panel because that cache joins `agents`.

**Test**
- `packages/client/src/__tests__/chat-context.test.ts`: extend `mkChatDetail` mock with `viewerMembershipKind: "participant"` for the schema change.

**Version bumps** (per [`docs/versioning-and-publishing.md`](docs/versioning-and-publishing.md))
- `packages/command` 0.14.3 → 0.14.4 (client imports `ChatDetail`).
- `packages/shared` 0.2.2 → 0.2.3 (`chatDetailSchema` is an externally-importable surface).

## Why the throttle bump is safe

`MeChatRow.liveActivity` (the WorkingChip) becomes stale after `LIVE_ACTIVITY_STALE_MS = 60_000` server-side (`packages/shared/src/schemas/me-chat.ts:88`). 1s / 60s = 1.7% slack — well below any perceptual threshold. The avatar engaged ring (`engagedAgentIds`) is driven by the same throttle and degrades the same way.

## Test plan

- [ ] **Frequency baseline**: open a chat, DevTools → Network → filter `/chats` → observe an agent burst. Expect ~1-2 `GET /chats`/s (was ~9-12).
- [ ] **WS reconnect re-fires markRead**: open chat A → DevTools → Throttling → Offline 30s → Online → expect chat A's unread badge in the conversation list to clear (driven by the `ws:reconnect` sentinel).
- [ ] **Supervisor view doesn't write orphans**: as admin, open a chat you reach via a managed agent (no direct `chat_membership` row) → confirm `chat_user_state` does not gain a new row for your `humanAgentId`. If the path is hard to reproduce, the code-level guard (`canMarkRead`) is sufficient.
- [ ] **Stale displayName fix**: in the chat-detail panel, edit a participant agent's `displayName` from `agent-detail.tsx` → confirm the open chat-detail panel updates immediately (no manual refresh needed).
- [ ] **Speaker vs watcher UI** continues to render correctly with the new `viewerMembershipKind` source.

## Known follow-up (non-blocking)

If a caller is kicked out of a chat while the WS is down, the `ws:reconnect` sentinel fires before `chat-detail` refetches → one redundant `POST /read` returns 404. Safe (idempotent, no dirty write, doesn't block UI), but cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)