### PR TITLE
chore(ci, test): speed up CI test — services postgres + vitest source alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,27 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Sidecar Postgres started by the runner in parallel with checkout / install,
+    # so the test process never pays a `docker pull postgres:17` cost on its
+    # critical path. `global-setup.ts` reads `CI_DATABASE_URL` and skips the
+    # testcontainers spin-up; locally that env is unset and the original
+    # testcontainers path stays intact.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      CI_DATABASE_URL: postgres://test:test@localhost:5432/test
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+export default defineConfig({
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/packages/command/vitest.config.ts
+++ b/packages/command/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+export default defineConfig({
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/packages/server/src/__tests__/global-setup.ts
+++ b/packages/server/src/__tests__/global-setup.ts
@@ -6,9 +6,19 @@ import { MAX_FORKS, TEMPLATE_DB, WORKER_DB_PREFIX } from "./test-config.js";
 let container: Awaited<ReturnType<PostgreSqlContainer["start"]>> | undefined;
 
 export async function setup() {
-  container = await new PostgreSqlContainer("postgres:17").start();
-
-  const baseUrl = container.getConnectionUri();
+  // CI fast path: a sidecar Postgres is already running (GitHub Actions
+  // `services:`), URL injected via env. Skip the testcontainers spin-up — on
+  // ubuntu-latest runners the image pull + container start costs 10-25s on
+  // the test critical path. Locally `CI_DATABASE_URL` is unset and we fall
+  // back to testcontainers as before.
+  const ciUrl = process.env.CI_DATABASE_URL;
+  let baseUrl: string;
+  if (ciUrl) {
+    baseUrl = ciUrl;
+  } else {
+    container = await new PostgreSqlContainer("postgres:17").start();
+    baseUrl = container.getConnectionUri();
+  }
   process.env.JWT_SECRET_KEY = "test-jwt-secret-key-for-vitest";
 
   // Create a migrated template database. Each worker (see setup.ts) gets its

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { MAX_FORKS } from "./src/__tests__/test-config.js";
 
 export default defineConfig({
@@ -19,5 +20,8 @@ export default defineConfig({
         minForks: 1,
       },
     },
+  },
+  resolve: {
+    alias: monorepoSourceAliases,
   },
 });

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+// Web tests don't render React, but many of them import `.tsx` modules
+// (e.g. `pages/team/index.tsx` for its non-component helpers) — the React
+// plugin is needed at transform time to strip the JSX.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/scripts/vitest-aliases.ts
+++ b/scripts/vitest-aliases.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Re-point intra-monorepo imports to the source `.ts` entry instead of the
+// built `./dist/*.mjs`. Without this, vitest must resolve cross-package
+// imports through each package.json's `import` condition, which forces
+// `turbo test` to declare `dependsOn: ["^build"]` and `tsdown`-builds every
+// dependency before tests can run. With these aliases, vite/vitest compile
+// the .ts source on the fly via its own transform, so the `^build` step
+// (5-15s on a cold CI run) drops out entirely.
+//
+// The runtime / publish paths (the `import` condition consumed by Node, by
+// `tsdown` when it inlines `client`/`shared` into the published `command`
+// tarball, and by Vite's prod build for `web`) are untouched.
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+// Array form (not object) so each alias matches exactly with an anchored
+// RegExp. An unanchored prefix like `@first-tree-hub/client` would
+// otherwise swallow `@first-tree-hub/client/observability` and rewrite it
+// to a bogus path with `/observability` appended to the file.
+export const monorepoSourceAliases: { find: RegExp; replacement: string }[] = [
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared\/config$/,
+    replacement: resolve(root, "packages/shared/src/config/index.ts"),
+  },
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared\/observability$/,
+    replacement: resolve(root, "packages/shared/src/observability/index.ts"),
+  },
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared$/,
+    replacement: resolve(root, "packages/shared/src/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/client\/observability$/,
+    replacement: resolve(root, "packages/client/src/observability/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/client$/,
+    replacement: resolve(root, "packages/client/src/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server\/observability$/,
+    replacement: resolve(root, "packages/server/src/observability/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server\/config$/,
+    replacement: resolve(root, "packages/server/src/config.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server$/,
+    replacement: resolve(root, "packages/server/src/app.ts"),
+  },
+];

--- a/turbo.json
+++ b/turbo.json
@@ -12,8 +12,6 @@
     "typecheck": {
       "dependsOn": ["^build"]
     },
-    "test": {
-      "dependsOn": ["^build"]
-    }
+    "test": {}
   }
 }


### PR DESCRIPTION
Two independent optimizations to the CI \`test\` job that together cut **~15-40s** off the critical path. Either commit can be cherry-picked / reverted alone if needed.

## Commits

### 1. \`chore(ci)\` — services Postgres on the CI runner

The previous flow span \`new PostgreSqlContainer("postgres:17").start()\` from inside \`globalSetup\`, so the image pull + container start (~10-25s on a cold ubuntu-latest runner) sat directly on the test critical path.

This commit moves Postgres onto a runner sidecar via GitHub Actions \`services:\`, which boots in parallel with \`actions/checkout\` and \`pnpm install\`. By the time \`pnpm test\` runs, the DB is already \`pg_isready\`-healthy. \`globalSetup\` prefers \`CI_DATABASE_URL\` when present and falls back to testcontainers, so local \`pnpm test\` behavior is unchanged.

### 2. \`chore(test)\` — vitest resolves intra-monorepo imports to source

Each internal package's \`exports.import\` points at \`./dist/*.mjs\`, so vitest had to import built artifacts → \`turbo test\` declared \`dependsOn: ["^build"]\` and ran \`tsdown\` (5-15s on a cold CI run) before tests could start.

This commit centralizes a small alias map in \`scripts/vitest-aliases.ts\` and wires it into every package's \`vitest.config.ts\` (a couple are newly added, including \`packages/web/vitest.config.ts\` so \`web/vite.config.ts\` stays untouched). Vitest now compiles \`.ts\` sources directly via vite's transform, so \`^build\` is dropped from \`turbo.json\`'s \`test\` task.

Runtime / publish paths are untouched: Node still resolves through \`exports.import\` → \`./dist/*.mjs\`, \`tsdown\` still inlines \`client\`/\`shared\` into the published \`command\` tarball, and the prod \`web\` build still walks the same module graph. Aliases use anchored RegExps so \`@first-tree-hub/client\` does NOT swallow \`@first-tree-hub/client/observability\`.

## Expected wall-time impact

| Source of cost (CI) | Before | After |
|---|---|---|
| \`docker pull postgres:17\` + container start | 10-25s on critical path | hidden behind \`pnpm install\` |
| \`tsdown\` shared/client/server | 5-15s on critical path | not run |
| Postgres readiness wait | ~0-5s | ~0-5s |

Together: ~15-40s off the \`test\` job.

## Test plan
- [ ] CI \`test\` job goes green (sidecar PG health-gated; vitest resolves aliases correctly).
- [ ] Compare \`test\` job wall time vs the immediately preceding main runs to confirm the reduction.
- [ ] Local sanity: \`pnpm test\` from a clean tree without first running \`pnpm build\` still passes (verifies both the \`CI_DATABASE_URL\`-unset fallback and the alias path).
- [ ] Local sanity: \`pnpm --filter @first-tree-hub/web dev\` and \`pnpm --filter @first-tree-hub/web build\` are unchanged — this PR adds a new \`vitest.config.ts\` next to the existing \`vite.config.ts\`, which is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)