### PR TITLE
chore(test): alias intra-monorepo imports to source, skip ^build for test

### DIFF
--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+export default defineConfig({
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/packages/command/vitest.config.ts
+++ b/packages/command/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+export default defineConfig({
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { MAX_FORKS } from "./src/__tests__/test-config.js";
 
 export default defineConfig({
@@ -19,5 +20,8 @@ export default defineConfig({
         minForks: 1,
       },
     },
+  },
+  resolve: {
+    alias: monorepoSourceAliases,
   },
 });

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
+
+// Web tests don't render React, but many of them import `.tsx` modules
+// (e.g. `pages/team/index.tsx` for its non-component helpers) — the React
+// plugin is needed at transform time to strip the JSX.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: monorepoSourceAliases,
+  },
+});

--- a/scripts/vitest-aliases.ts
+++ b/scripts/vitest-aliases.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Re-point intra-monorepo imports to the source `.ts` entry instead of the
+// built `./dist/*.mjs`. Without this, vitest must resolve cross-package
+// imports through each package.json's `import` condition, which forces
+// `turbo test` to declare `dependsOn: ["^build"]` and `tsdown`-builds every
+// dependency before tests can run. With these aliases, vite/vitest compile
+// the .ts source on the fly via its own transform, so the `^build` step
+// (5-15s on a cold CI run) drops out entirely.
+//
+// The runtime / publish paths (the `import` condition consumed by Node, by
+// `tsdown` when it inlines `client`/`shared` into the published `command`
+// tarball, and by Vite's prod build for `web`) are untouched.
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+// Array form (not object) so each alias matches exactly with an anchored
+// RegExp. An unanchored prefix like `@first-tree-hub/client` would
+// otherwise swallow `@first-tree-hub/client/observability` and rewrite it
+// to a bogus path with `/observability` appended to the file.
+export const monorepoSourceAliases: { find: RegExp; replacement: string }[] = [
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared\/config$/,
+    replacement: resolve(root, "packages/shared/src/config/index.ts"),
+  },
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared\/observability$/,
+    replacement: resolve(root, "packages/shared/src/observability/index.ts"),
+  },
+  {
+    find: /^@agent-team-foundation\/first-tree-hub-shared$/,
+    replacement: resolve(root, "packages/shared/src/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/client\/observability$/,
+    replacement: resolve(root, "packages/client/src/observability/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/client$/,
+    replacement: resolve(root, "packages/client/src/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server\/observability$/,
+    replacement: resolve(root, "packages/server/src/observability/index.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server\/config$/,
+    replacement: resolve(root, "packages/server/src/config.ts"),
+  },
+  {
+    find: /^@first-tree-hub\/server$/,
+    replacement: resolve(root, "packages/server/src/app.ts"),
+  },
+];

--- a/turbo.json
+++ b/turbo.json
@@ -12,8 +12,6 @@
     "typecheck": {
       "dependsOn": ["^build"]
     },
-    "test": {
-      "dependsOn": ["^build"]
-    }
+    "test": {}
   }
 }


### PR DESCRIPTION
## Summary
- Vitest now resolves intra-monorepo imports (`@first-tree-hub/*`, `@agent-team-foundation/first-tree-hub-shared/*`) to each package's `src/*.ts` via `resolve.alias`, instead of routing through `exports.import` → `./dist/*.mjs`.
- Because vitest can now consume source directly, `turbo test` no longer needs `dependsOn: ["^build"]`. The `tsdown` step (5-15s on a cold CI run) drops out of the test critical path.
- Aliases are centralized in `scripts/vitest-aliases.ts` and re-imported by each package's vitest config. The `web` package gets a new `vitest.config.ts` so its `vite.config.ts` (used by vite dev / prod build) is untouched — JSX transform stays available under vitest via `@vitejs/plugin-react`.

## Why this is safe
- Runtime / publish paths are unchanged: Node still resolves through `exports.import` → `./dist/*.mjs`, `tsdown` still inlines `client`/`shared` into the published `command` tarball, and Vite's prod `web` build still walks the same module graph it did before.
- Aliases match with anchored RegExps so `@first-tree-hub/client` does NOT accidentally swallow `@first-tree-hub/client/observability`.

Stacks on top of #419 (which moves the CI test job onto a `services: postgres` sidecar). The two PRs are independent — either can land first; together they remove both the `docker pull postgres:17` cost and the `tsdown` cost from the CI test critical path.

## Test plan
- [ ] CI: lint / typecheck / test all green on this PR.
- [ ] Compare `test` job wall time vs runs immediately before this PR (and ideally vs #419 alone) to confirm the additional ~5-15s reduction.
- [ ] Local: `pnpm test` still passes without first running `pnpm build`.
- [ ] Local: `pnpm --filter @first-tree-hub/web dev` and `pnpm --filter @first-tree-hub/web build` are unchanged (this PR adds a new `vitest.config.ts`; the existing `vite.config.ts` is not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)