### PR TITLE
fix(server,client): keep AskUserQuestion answers reachable across chat upgrades and idle suspends

### DIFF
--- a/packages/client/src/__tests__/ask-user-bridge.test.ts
+++ b/packages/client/src/__tests__/ask-user-bridge.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearAllPendingQuestionsForTest,
+  clearPendingForChat,
   hasPendingForChat,
   pendingQuestionCount,
   registerPendingQuestion,
-  rejectPendingForAgent,
+  rejectPendingForChat,
   tryResolveQuestionAnswer,
 } from "../handlers/ask-user-bridge.js";
 
@@ -55,13 +56,13 @@ describe("ask-user-bridge", () => {
     expect(tryResolveQuestionAnswer("string")).toBe(false);
   });
 
-  it("rejectPendingForAgent rejects only that agent's entries and returns the count", async () => {
+  it("rejectPendingForChat rejects only that (agent, chat) handler's entries and returns the count", async () => {
     const a1 = registerPendingQuestion({ correlationId: "tu_a1", agentId: "agent_a", chatId: "chat_a" });
     const a2 = registerPendingQuestion({ correlationId: "tu_a2", agentId: "agent_a", chatId: "chat_a" });
     const b1 = registerPendingQuestion({ correlationId: "tu_b1", agentId: "agent_b", chatId: "chat_b" });
     expect(pendingQuestionCount()).toBe(3);
 
-    const dropped = rejectPendingForAgent("agent_a", "Session shutting down.");
+    const dropped = rejectPendingForChat("agent_a", "chat_a", "Session shutting down.");
     expect(dropped).toBe(2);
     expect(pendingQuestionCount()).toBe(1);
 
@@ -72,6 +73,59 @@ describe("ask-user-bridge", () => {
     const matched = tryResolveQuestionAnswer({ correlationId: "tu_b1", answers: { q: "v" } });
     expect(matched).toBe(true);
     await expect(b1).resolves.toEqual({ status: "answered", answers: { q: "v" } });
+  });
+
+  it("rejectPendingForChat does NOT touch other chats of the same agent (#418)", async () => {
+    // The regression that motivated this scope key: one chat shutting down
+    // used to nuke another chat's pending askuser waiters because the
+    // bridge cleanup was per-agent, but handlers (and SDK transports) are
+    // per-(agent, chat). With per-chat scoping, tearing down chat_a leaves
+    // chat_b's awaiter alive so the user can still answer.
+    const a1 = registerPendingQuestion({ correlationId: "tu_a1", agentId: "agent_shared", chatId: "chat_a" });
+    const b1 = registerPendingQuestion({ correlationId: "tu_b1", agentId: "agent_shared", chatId: "chat_b" });
+    expect(pendingQuestionCount()).toBe(2);
+
+    const dropped = rejectPendingForChat("agent_shared", "chat_a", "Session shutting down.");
+    expect(dropped).toBe(1);
+    expect(pendingQuestionCount()).toBe(1);
+
+    await expect(a1).resolves.toEqual({ status: "denied", reason: "Session shutting down." });
+
+    // chat_b's awaiter survives the chat_a shutdown.
+    expect(hasPendingForChat("agent_shared", "chat_b")).toBe(true);
+    const matched = tryResolveQuestionAnswer({ correlationId: "tu_b1", answers: { q: "still alive" } });
+    expect(matched).toBe(true);
+    await expect(b1).resolves.toEqual({ status: "answered", answers: { q: "still alive" } });
+  });
+
+  it("clearPendingForChat silently removes only the matching (agent, chat) entries (#418)", async () => {
+    // suspend-path cleanup: removes without resolving (the SDK transport is
+    // being torn down). Per-chat scoping prevents one chat's suspend from
+    // wiping another chat's still-live waiter on the same agent.
+    const a1 = registerPendingQuestion({ correlationId: "tu_a1", agentId: "agent_shared", chatId: "chat_a" });
+    const b1 = registerPendingQuestion({ correlationId: "tu_b1", agentId: "agent_shared", chatId: "chat_b" });
+    expect(pendingQuestionCount()).toBe(2);
+
+    let a1Settled = false;
+    void a1.then(() => {
+      a1Settled = true;
+    });
+
+    const dropped = clearPendingForChat("agent_shared", "chat_a");
+    expect(dropped).toBe(1);
+    expect(pendingQuestionCount()).toBe(1);
+
+    // clearPendingForChat does NOT resolve the Promise — it's a silent
+    // cleanup. Give the microtask queue a tick to prove the Promise stays
+    // pending.
+    await Promise.resolve();
+    expect(a1Settled).toBe(false);
+
+    // chat_b's awaiter is untouched and still resolves on answer.
+    expect(hasPendingForChat("agent_shared", "chat_b")).toBe(true);
+    const matched = tryResolveQuestionAnswer({ correlationId: "tu_b1", answers: { q: "ok" } });
+    expect(matched).toBe(true);
+    await expect(b1).resolves.toEqual({ status: "answered", answers: { q: "ok" } });
   });
 
   it("hasPendingForChat reports true only for the matching (agent, chat) pair", () => {

--- a/packages/client/src/__tests__/session-manager-question-answer.test.ts
+++ b/packages/client/src/__tests__/session-manager-question-answer.test.ts
@@ -104,6 +104,94 @@ afterEach(() => {
   clearAllPendingQuestionsForTest();
 });
 
+describe("SessionManager.evictIdle — askuser-in-flight guard (#418)", () => {
+  it("does NOT suspend a chat that has a pending AskUserQuestion when its idle_timeout elapses", async () => {
+    // Reproduces the #418 client-side root cause 2: idle_timeout fires
+    // while the asker is still waiting on a `canUseTool` Promise, the
+    // handler.suspend tears down the SDK transport, and the bridge entry
+    // is silently dropped — making the eventual answer arrive at a chat
+    // with no live waiter. With the `hasPendingForChat` guard in
+    // `evictIdle`, suspend is skipped for as long as the awaiter is alive.
+    vi.useFakeTimers();
+    try {
+      const handler = createMockHandler();
+      const sdk = mockSdk();
+      const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+      const factory: HandlerFactory = () => handler;
+      const sm = new SessionManager({
+        // 1-second idle timeout so a single 10s evictIdle tick is plenty.
+        session: { idle_timeout: 1, max_sessions: 10, reconcile_interval_seconds: 300 },
+        concurrency: 5,
+        handlerFactory: factory,
+        handlerConfig: { workspaceRoot: "/tmp/test" },
+        agentIdentity: {
+          agentId: "agent-1",
+          inboxId: "inbox-agent-1",
+          displayName: "Agent",
+          type: "autonomous_agent",
+          delegateMention: null,
+          metadata: {},
+        },
+        sdk,
+        log: silentLogger(),
+        ackEntry,
+      });
+
+      // Build an active session for chat-pending, then register a pending
+      // AskUserQuestion against it.
+      await sm.dispatch({
+        id: 1,
+        inboxId: "inbox-test",
+        messageId: "msg-trigger",
+        chatId: "chat-pending",
+        status: "delivered",
+        retryCount: 0,
+        createdAt: new Date().toISOString(),
+        deliveredAt: new Date().toISOString(),
+        ackedAt: null,
+        message: {
+          id: "msg-trigger",
+          chatId: "chat-pending",
+          senderId: "sender-human",
+          format: "text",
+          content: "Please ask me something",
+          metadata: {},
+          replyToInbox: null,
+          replyToChat: null,
+          inReplyTo: null,
+          source: null,
+          createdAt: new Date().toISOString(),
+          configVersion: 1,
+          recipientMode: "full",
+          inReplyToSnapshot: null,
+          precedingMessages: [],
+        },
+      });
+      void registerPendingQuestion({
+        correlationId: "tu_idle_guard",
+        agentId: "agent-1",
+        chatId: "chat-pending",
+      });
+
+      // Advance well past idle_timeout — the 10s evictIdle interval will
+      // fire at least once. Without the guard, handler.suspend would have
+      // been invoked.
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(handler.suspend).not.toHaveBeenCalled();
+
+      // Once the awaiter is gone (e.g. the answer landed), the next tick
+      // suspends as usual.
+      clearAllPendingQuestionsForTest();
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(handler.suspend).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("SessionManager.dispatch — question_answer short-circuit", () => {
   it("resolves the bridge waiter and acks the entry without invoking the handler", async () => {
     const handler = createMockHandler();

--- a/packages/client/src/handlers/ask-user-bridge.ts
+++ b/packages/client/src/handlers/ask-user-bridge.ts
@@ -18,8 +18,12 @@ import { questionAnswerMessageContentSchema } from "@agent-team-foundation/first
  *      user had typed those answers directly.
  *
  * The Map is process-wide so a session that suspends/resumes during the wait
- * window keeps the same correlation key working — `agentId` is only used to
- * scope the {@link rejectPendingForAgent} cleanup on full handler shutdown.
+ * window keeps the same correlation key working — `(agentId, chatId)` is the
+ * scope key used by {@link rejectPendingForChat} on full handler shutdown
+ * and {@link clearPendingForChat} on idle suspend. Scoping by `agentId`
+ * alone caused issue #418: one chat suspending wiped out another chat's
+ * pending askuser entries for the same agent (handlers are per-(agent,
+ * chat), but the bridge cleanup was per-agent).
  *
  * The Promise contract is `{ status: "answered", answers }` for a normal
  * answer or `{ status: "denied", reason }` when the question has been
@@ -97,11 +101,17 @@ export function hasPendingForChat(agentId: string, chatId: string): boolean {
   return false;
 }
 
-/** Cleanup hook used by handler.shutdown() to fail-fast every in-flight question. */
-export function rejectPendingForAgent(agentId: string, reason: string): number {
+/**
+ * Cleanup hook used by `handler.shutdown()` to fail-fast every in-flight
+ * question for THIS (agent, chat) handler. Scoping by chatId as well as
+ * agentId matters when the same agent is bound to multiple concurrent chats
+ * (each chat has its own handler): tearing down one handler must not nuke
+ * the other handler's still-live askuser awaiters (#418).
+ */
+export function rejectPendingForChat(agentId: string, chatId: string, reason: string): number {
   let count = 0;
   for (const [correlationId, entry] of pending) {
-    if (entry.agentId !== agentId) continue;
+    if (entry.agentId !== agentId || entry.chatId !== chatId) continue;
     pending.delete(correlationId);
     entry.resolve({ status: "denied", reason });
     count++;
@@ -110,20 +120,25 @@ export function rejectPendingForAgent(agentId: string, reason: string): number {
 }
 
 /**
- * Silent cleanup for `handler.suspend()`. Removes pending entries WITHOUT
- * resolving the Promise — the SDK process is being torn down anyway, and
- * resolving would unblock the canUseTool callback whose return value the
- * SDK then writes to a now-closed transport (the symptom: 'ProcessTransport
- * is not ready for writing' uncaught). The orphaned Promise stack frame is
- * GC'd alongside the SDK process exit. When the user eventually answers,
- * SessionManager.dispatch sees no matching waiter (`tryResolveQuestionAnswer`
- * returns false) and routes the answer message through the normal dispatch
- * path so the suspended session resumes with the answer as fresh input.
+ * Silent cleanup for `handler.suspend()`. Removes pending entries for this
+ * (agent, chat) handler WITHOUT resolving the Promise — the SDK process is
+ * being torn down anyway, and resolving would unblock the canUseTool
+ * callback whose return value the SDK then writes to a now-closed transport
+ * (the symptom: 'ProcessTransport is not ready for writing' uncaught). The
+ * orphaned Promise stack frame is GC'd alongside the SDK process exit. When
+ * the user eventually answers, SessionManager.dispatch sees no matching
+ * waiter (`tryResolveQuestionAnswer` returns false) and routes the answer
+ * message through the normal dispatch path so the suspended session resumes
+ * with the answer as fresh input.
+ *
+ * Per-chat scoping (#418): suspend of chat B must not clear chat A's
+ * pending entries — both belong to the same agentId but have independent
+ * lifecycles.
  */
-export function clearPendingForAgent(agentId: string): number {
+export function clearPendingForChat(agentId: string, chatId: string): number {
   let count = 0;
   for (const [correlationId, entry] of pending) {
-    if (entry.agentId !== agentId) continue;
+    if (entry.agentId !== agentId || entry.chatId !== chatId) continue;
     pending.delete(correlationId);
     count++;
   }

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -41,7 +41,7 @@ import type {
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { acquireWorkspace, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
-import { clearPendingForAgent, registerPendingQuestion, rejectPendingForAgent } from "./ask-user-bridge.js";
+import { clearPendingForChat, registerPendingQuestion, rejectPendingForChat } from "./ask-user-bridge.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 
 const MAX_RETRIES = 2;
@@ -571,7 +571,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       if (options.signal.aborted) {
         // The query was aborted while we were waiting (eviction, restart,
         // hot-switch). The bridge entry has already been removed by
-        // `rejectPendingForAgent`; just return a deny so the SDK unwinds.
+        // `rejectPendingForChat`; just return a deny so the SDK unwinds.
         return {
           behavior: "deny",
           message: "AskUserQuestion aborted before an answer arrived.",
@@ -1079,7 +1079,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // (the answer becomes regular input on the next turn).
       const sessionCtx = ctx;
       if (sessionCtx) {
-        const dropped = clearPendingForAgent(sessionCtx.agent.agentId);
+        const dropped = clearPendingForChat(sessionCtx.agent.agentId, sessionCtx.chatId);
         if (dropped > 0) sessionCtx.log(`Cleared ${dropped} pending AskUserQuestion entries on suspend`);
       }
 
@@ -1110,7 +1110,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // resolve. The supersede happens server-side via archiveSession /
       // claimClient (commit 2); this is the local-process counterpart.
       if (sessionCtx) {
-        const dropped = rejectPendingForAgent(sessionCtx.agent.agentId, "Session shutting down.");
+        const dropped = rejectPendingForChat(sessionCtx.agent.agentId, sessionCtx.chatId, "Session shutting down.");
         if (dropped > 0) sessionCtx.log(`Rejected ${dropped} pending AskUserQuestion entries during shutdown`);
       }
       // PRD §7.5: shutdown is session termination (explicit terminate,

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -7,7 +7,7 @@ import type {
   SessionState,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { deriveRepoLocalPath } from "@agent-team-foundation/first-tree-hub-shared";
-import { tryResolveQuestionAnswer } from "../handlers/ask-user-bridge.js";
+import { hasPendingForChat, tryResolveQuestionAnswer } from "../handlers/ask-user-bridge.js";
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
@@ -663,12 +663,28 @@ export class SessionManager {
     // Blocked detection — 2 minutes without activity while session is active
     const blockedThresholdMs = 120_000;
     const now = Date.now();
+    const agentId = this.config.agentIdentity.agentId;
 
     for (const [, session] of this.sessions) {
       if (session.status !== "active") continue;
       const inactiveMs = now - session.lastActivity;
 
       if (inactiveMs > timeoutMs) {
+        // #418: when an AskUserQuestion is in flight, suspending tears down
+        // the SDK transport and silently drops the bridge entry — the
+        // eventual answer then arrives with no live waiter and the asker
+        // session is permanently stuck. Skip the suspend so the awaiter
+        // can resolve through the live-bridge path. `lastActivity` still
+        // ticks forward on inject, so a runaway pending entry is bounded
+        // by the supersede paths (chat archive / client claim) rather
+        // than by idle eviction.
+        if (hasPendingForChat(agentId, session.chatId)) {
+          this.config.log.info(
+            { chatId: session.chatId, inactiveSec: Math.round(inactiveMs / 1000) },
+            "session idle but AskUserQuestion in flight — skipping suspend",
+          );
+          continue;
+        }
         this.config.log.info(
           { chatId: session.chatId, idleTimeoutSec: this.config.session.idle_timeout },
           "session idle, suspending",

--- a/packages/server/src/__tests__/questions.test.ts
+++ b/packages/server/src/__tests__/questions.test.ts
@@ -2,10 +2,13 @@ import type {
   QuestionAnswerMessageContent,
   QuestionMessageContent,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { pendingQuestions } from "../db/schema/pending-questions.js";
 import { createAgent } from "../services/agent.js";
@@ -339,5 +342,259 @@ describe("supersede hooks", () => {
     const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
     expect(row?.status).toBe("superseded");
     expect(row?.supersededReason).toBe("client_claimed");
+  });
+});
+
+/**
+ * Regression: github.com/agent-team-foundation/first-tree-hub#404 — when a
+ * `direct → group` upgrade re-grades the asker to `mention_only` AFTER the
+ * question is posted, the `format=question_answer` fan-out used to set
+ * `notify=false` for the asker (structured content carries no @<name>
+ * tokens), leaving the SDK's `canUseTool` Promise dangling forever. The
+ * fix forces notify=true for the asker via `addressedToAgentIds`.
+ */
+describe("submitAnswer — group chat with mention_only asker (#404)", () => {
+  const getApp = useTestApp();
+
+  async function setMode(app: FastifyInstance, chatId: string, agentUuid: string, mode: "full" | "mention_only") {
+    await app.db
+      .update(chatMembership)
+      .set({ mode })
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, agentUuid)));
+  }
+
+  async function inboxIdOf(app: FastifyInstance, agentUuid: string): Promise<string> {
+    const [row] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, agentUuid))
+      .limit(1);
+    if (!row?.inboxId) throw new Error(`No inbox for agent ${agentUuid}`);
+    return row.inboxId;
+  }
+
+  it("forces notify=true on the asker's inbox row even when their mode is mention_only", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `q-grp-${crypto.randomUUID().slice(0, 8)}` });
+    const asker = await createAgent(
+      app.db,
+      {
+        name: `q-asker-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: "Asker",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+        runtimeProvider: "claude-code",
+      },
+      { force: true },
+    );
+    const bystander = await createAgent(
+      app.db,
+      {
+        name: `q-bystander-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: "Bystander",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+        runtimeProvider: "claude-code",
+      },
+      { force: true },
+    );
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [asker.uuid, bystander.uuid],
+    });
+
+    // Mirror the production state that produced the bug: a `direct → group`
+    // upgrade demoted the asker to `mention_only` between question publish
+    // and answer. Force both non-human speakers to `mention_only` here.
+    await setMode(app, chat.id, asker.uuid, "mention_only");
+    await setMode(app, chat.id, bystander.uuid, "mention_only");
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chat.id, asker.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chat.id}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "Yes" } },
+    });
+    expect(res.statusCode).toBe(201);
+    const answerMessageId = res.json<{ messageId: string }>().messageId;
+
+    // Asker MUST receive notify=true so their client's WS push wakes the
+    // SDK's `canUseTool` waiter — this is the regression the fix targets.
+    const askerInboxId = await inboxIdOf(app, asker.uuid);
+    const [askerEntry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, askerInboxId), eq(inboxEntries.messageId, answerMessageId)))
+      .limit(1);
+    expect(askerEntry?.notify).toBe(true);
+
+    // Uninvolved mention_only bystanders must stay silent — the answer is
+    // directed at the asker, not a group broadcast. notify=true here would
+    // re-introduce the old "agent courtesy loop" wake (migration 0029).
+    const bystanderInboxId = await inboxIdOf(app, bystander.uuid);
+    const [bystanderEntry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, bystanderInboxId), eq(inboxEntries.messageId, answerMessageId)))
+      .limit(1);
+    expect(bystanderEntry?.notify).toBe(false);
+  });
+});
+
+/**
+ * Regression: #416 — the asker must still be a speaker of the chat at
+ * answer time. fan-out is gated on `chat_membership.accessMode = 'speaker'`;
+ * if the asker has been moved out between question publish and answer the
+ * `addressedToAgentIds` widening can't bring them back, so we short-circuit
+ * upstream in `submitAnswer` and convert to a supersede.
+ */
+describe("submitAnswer — asker left chat between publish and answer (#416)", () => {
+  const getApp = useTestApp();
+
+  it("flips the pending row to superseded(asker_left_chat) and returns ConflictError", async () => {
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const correlationId = `tu_${crypto.randomUUID().slice(0, 12)}`;
+    await sendMessage(app.db, chatId, peerAgent.uuid, {
+      format: "question",
+      content: buildQuestionContent(correlationId),
+    });
+
+    // Simulate the asker (peerAgent) being moved out of the chat after the
+    // question was posted but before the human submits the answer. Use a
+    // direct DELETE on chat_membership to model any path that removes a
+    // speaker — leaveChat, role demotion, admin removal, etc.
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, peerAgent.uuid)));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/questions/${correlationId}/answer`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { answers: { "Should I proceed?": "Yes" } },
+    });
+    expect(res.statusCode).toBe(409);
+
+    const [row] = await app.db.select().from(pendingQuestions).where(eq(pendingQuestions.id, correlationId)).limit(1);
+    expect(row?.status).toBe("superseded");
+    expect(row?.supersededReason).toBe("asker_left_chat");
+
+    // No answer message was emitted — chat history stays consistent with
+    // the supersede semantics used elsewhere.
+    const answerRows = await app.db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.chatId, chatId), eq(messages.format, "question_answer")));
+    expect(answerRows).toHaveLength(0);
+  });
+});
+
+/**
+ * Direct unit-level coverage of the `addressedToAgentIds` option on
+ * `sendMessage`. The #404 case above verifies the end-to-end path through
+ * `submitAnswer`; these tests pin the option's own contract so future
+ * refactors of `sendMessage` cannot quietly invert the short-circuit order.
+ */
+describe("sendMessage — addressedToAgentIds option", () => {
+  const getApp = useTestApp();
+
+  async function inboxIdOf(app: FastifyInstance, agentUuid: string): Promise<string> {
+    const [row] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, agentUuid))
+      .limit(1);
+    if (!row?.inboxId) throw new Error(`No inbox for agent ${agentUuid}`);
+    return row.inboxId;
+  }
+
+  it("isSilentSend wins over addressedToAgentIds — silence contract is unconditional", async () => {
+    // The silent-send guard (`message.ts` step 2e: content empty after
+    // stripping `@<name>` tokens) is a chat-wide silence contract that must
+    // not be overridable by per-recipient routing intent. Otherwise an
+    // empty-content addressed message would wake the addressee, breaking
+    // the L4 form guard that migration 0029 was built on top of.
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    const result = await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { format: "text", content: "" },
+      { addressedToAgentIds: [peerAgent.uuid] },
+    );
+
+    // No notify=true recipients despite the explicit address.
+    expect(result.recipients).toEqual([]);
+
+    const inboxId = await inboxIdOf(app, peerAgent.uuid);
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.messageId, result.message.id)))
+      .limit(1);
+    // Row is still written for history replay, but notify=false.
+    expect(entry?.notify).toBe(false);
+  });
+
+  it("addressedToAgentIds containing a non-participant is a silent no-op", async () => {
+    // Defensive: forwarding a stale or wrong-chat agentId must not crash
+    // sendMessage and must not somehow promote any unrelated row to
+    // notify=true. The participants query already filters by chat
+    // membership, so a non-participant id falls out at the fan-out stage.
+    const app = getApp();
+    const { admin, peerAgent, chatId } = await setupQuestionScenario(app);
+
+    // Build an agent that is NOT a participant of this chat.
+    const outsider = await createAgent(
+      app.db,
+      {
+        name: `q-outsider-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: "Outsider",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+        runtimeProvider: "claude-code",
+      },
+      { force: true },
+    );
+
+    const result = await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { format: "text", content: "hello" },
+      { addressedToAgentIds: [outsider.uuid] },
+    );
+
+    // The chat's actual peer (peerAgent, mode=full in a direct chat) still
+    // got notified — `addressedToAgentIds` only adds, never subtracts.
+    const peerInboxId = await inboxIdOf(app, peerAgent.uuid);
+    const [peerEntry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, peerInboxId), eq(inboxEntries.messageId, result.message.id)))
+      .limit(1);
+    expect(peerEntry?.notify).toBe(true);
+
+    // The outsider has no inbox row for this message at all — they're not
+    // a chat participant, so fan-out skips them entirely.
+    const outsiderInboxId = await inboxIdOf(app, outsider.uuid);
+    const outsiderEntries = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, outsiderInboxId), eq(inboxEntries.messageId, result.message.id)));
+    expect(outsiderEntries).toHaveLength(0);
   });
 });

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -51,6 +51,27 @@ export type SendMessageOptions = {
    * human-typed content.
    */
   normalizeMentionsInContent?: boolean;
+  /**
+   * Agent IDs that this message is **addressed to** by construction — used
+   * for system-routed messages whose recipient is fixed at write time and
+   * not derivable from `@<name>` tokens in the content. Within the
+   * non-silenced fan-out branch, addressed agents always receive
+   * `notify=true` regardless of their chat membership mode (`mention_only`)
+   * or `metadata.mentions`.
+   *
+   * Canonical use: a `question_answer` from a human submitter is addressed
+   * to the original asker. Without this override, a chat that upgraded
+   * `direct → group` after the question was posted would silently re-grade
+   * the asker to `mention_only`, and the answer's structured content (an
+   * object, not a string with `@<name>`) would produce no mentions and
+   * therefore no notify=true row — leaving the asker's `canUseTool` Promise
+   * dangling forever.
+   *
+   * `isSilentSend` and `isAgentFinalText` still take precedence (they force
+   * notify=false for everyone); this only widens the notify set within the
+   * non-silenced branch.
+   */
+  addressedToAgentIds?: readonly string[];
 };
 
 export async function sendMessage(
@@ -354,6 +375,7 @@ async function sendMessageInner(
     //    so a `mention_only` agent that gets @mentioned later can still see
     //    the chat history it missed — see proposals/group-chat-ux-improvements §1.
     const mentionSet = new Set(mergedMentions);
+    const addressedSet = new Set(options.addressedToAgentIds ?? []);
     // Build a single fan-out structure that carries agentId alongside the
     // inbox row. agentId is needed by the post-tx session-activation step
     // (Step 1b) but is not part of the inbox_entries schema — it's stripped
@@ -367,7 +389,12 @@ async function sendMessageInner(
         // force every fan-out row to notify=false regardless of mode /
         // mentions. Inbox entries are still written so history replay still
         // works; nobody is woken.
-        notify: !isSilentSend && !isAgentFinalText && (p.mode !== "mention_only" || mentionSet.has(p.agentId)),
+        // `addressedToAgentIds` widens the notify set within the non-silenced
+        // branch — see option doc on `SendMessageOptions`.
+        notify:
+          !isSilentSend &&
+          !isAgentFinalText &&
+          (addressedSet.has(p.agentId) || p.mode !== "mention_only" || mentionSet.has(p.agentId)),
       }));
 
     if (fanout.length > 0) {

--- a/packages/server/src/services/questions.ts
+++ b/packages/server/src/services/questions.ts
@@ -8,6 +8,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { messages } from "../db/schema/messages.js";
 import { pendingQuestions } from "../db/schema/pending-questions.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
@@ -124,7 +125,7 @@ export async function submitAnswer(
   // here, both submitters could pass the status=pending check, both could
   // commit, both could call sendMessage outside the tx, and the inbox would
   // see two answer messages — a bug we hit in field testing.
-  const questionRow = await db.transaction(async (tx) => {
+  const txResult = await db.transaction(async (tx) => {
     const [row] = await tx
       .select({
         id: pendingQuestions.id,
@@ -149,6 +150,33 @@ export async function submitAnswer(
       throw new ConflictError(`Question "${args.correlationId}" is no longer pending`, {
         "question.status": row.status,
       });
+    }
+
+    // #416: the asker must still be a speaker of this chat. Fan-out is gated
+    // on `chat_membership.accessMode = 'speaker'`, so if the asker has been
+    // moved out between question publish and answer (manager unjoined, role
+    // changed, etc.) the answer would land at no inbox and the SDK's
+    // `canUseTool` Promise would hang forever. Flip to `superseded` inside
+    // the lock-tx so the terminal state is persisted alongside the row lock;
+    // throwing from inside the tx would roll the flip back, so we return a
+    // sentinel and let the caller throw outside.
+    const [askerMembership] = await tx
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, row.chatId),
+          eq(chatMembership.agentId, row.agentId),
+          eq(chatMembership.accessMode, "speaker"),
+        ),
+      )
+      .limit(1);
+    if (!askerMembership) {
+      await tx
+        .update(pendingQuestions)
+        .set({ status: "superseded", supersededAt: new Date(), supersededReason: "asker_left_chat" })
+        .where(eq(pendingQuestions.id, args.correlationId));
+      return { askerLeft: true as const };
     }
 
     // Cross-check the answers' keys against the original question texts so a
@@ -190,8 +218,16 @@ export async function submitAnswer(
       .set({ status: "answered", answeredAt: new Date() })
       .where(eq(pendingQuestions.id, args.correlationId));
 
-    return row;
+    return { askerLeft: false as const, row };
   });
+
+  if (txResult.askerLeft) {
+    throw new ConflictError(`Question "${args.correlationId}" is no longer pending`, {
+      "question.status": "superseded",
+      "question.supersede_reason": "asker_left_chat",
+    });
+  }
+  const questionRow = txResult.row;
 
   // Step 5: send the answer message. By the time we get here we hold an
   // exclusive claim on the row (any concurrent submitter is now seeing
@@ -206,12 +242,25 @@ export async function submitAnswer(
 
   let result: Awaited<ReturnType<typeof sendMessage>>;
   try {
-    result = await sendMessage(db, args.chatId, args.submitterAgentId, {
-      format: "question_answer",
-      content: answerContent,
-      inReplyTo: questionRow.messageId,
-      source: "hub_ui",
-    });
+    result = await sendMessage(
+      db,
+      args.chatId,
+      args.submitterAgentId,
+      {
+        format: "question_answer",
+        content: answerContent,
+        inReplyTo: questionRow.messageId,
+        source: "hub_ui",
+      },
+      // This `question_answer` is addressed to the asker by construction —
+      // the answer's structured content carries no `@<name>` tokens, so
+      // without an explicit recipient hint the default fan-out rule would
+      // set notify=false for the asker if the chat upgraded `direct → group`
+      // between question publish and answer (which re-grades non-human
+      // speakers to `mention_only`), leaving the SDK's `canUseTool` Promise
+      // dangling forever. See issue #404.
+      { addressedToAgentIds: [questionRow.agentId] },
+    );
   } catch (err) {
     // Best-effort revert: status was flipped to 'answered' but we never
     // emitted the answer message, so the agent would never see the answer


### PR DESCRIPTION
## Summary

Three independent root causes were hanging the asker session forever after `AskUserQuestion`:

- **#404 — server fan-out silenced the answer.** A `direct → group` upgrade re-grades non-human speakers to `mention_only`; `submitAnswer`'s structured `question_answer` content carries no `@<name>` tokens, so the default fan-out rule sets `notify=false` for the asker. New `addressedToAgentIds` option on `sendMessage` widens the non-silenced notify set so system-routed answers always wake their addressee. `isSilentSend` / `isAgentFinalText` still win.
- **#418 — client bridge wiped the wrong chat's awaiter.** `clearPendingForAgent` / `rejectPendingForAgent` were per-agent but handlers are per-(agent, chat); a sibling chat's suspend nuked another chat's live askuser awaiter. Renamed to `clearPendingForChat` / `rejectPendingForChat`. Also: `SessionManager.evictIdle` now wires the `hasPendingForChat` guard its docstring already promised, so a single chat's own idle eviction stops tearing down its SDK transport mid-await.
- **#416 — asker left chat between publish and answer.** `submitAnswer`'s lock-tx pre-checks asker membership; missing → flip to `superseded(asker_left_chat)` (sentinel return so the rollback doesn't undo the supersede) and 409 outside the tx.

Closes #404, #416, #418. Follow-ups: #417 (chat-first unread badge for askuser), #422 (server should push a session signal on supersede so the asker client clears its bridge entry — surfaced by the #416 + #418 interaction).

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — 9/9 tasks
- [x] `pnpm --filter @first-tree-hub/server test` — 1042 / 1042 (including 4 new `questions.test.ts` cases: #404 group-chat asker, #416 asker-left-chat, two `addressedToAgentIds` unit guards)
- [x] `pnpm --filter @first-tree-hub/client exec vitest run ask-user-bridge session-manager-question-answer` — 11 / 11 (including 3 cross-chat isolation cases + `evictIdle` askuser-in-flight guard with fake timers)
- [x] Two reviewer rounds on this branch (#404 first pass + #416/#418 expansion): both passed, no blocking issues
- [ ] Manual dogfood: post-merge, retry the original repro from issue #404 — group chat, agent askuser, answer via web UI, confirm the agent resumes within seconds rather than hanging until idle suspend

🤖 Generated with [Claude Code](https://claude.com/claude-code)