### PR TITLE
feat: chat right sidebar (agents + suspend + GitHub bindings) + float doc-preview

### DIFF
--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -11,11 +11,15 @@ import type { FastifyInstance } from "fastify";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { assertAllAgentsVisibleInOrg, requireChatAccess } from "../scope/require-resource.js";
 import { agentAvatarImageUrl } from "../services/agent.js";
 import { ensureParticipant, joinChat, leaveChat } from "../services/chat.js";
+import { findInstallationByOrg } from "../services/github-app-installations.js";
+import { mintContextTreeInstallationToken } from "../services/github-app-token.js";
+import { resolveChatGithubEntity } from "../services/github-entity-live.js";
 import { prepareImageOutbound } from "../services/image-broadcast.js";
 import {
   addMeChatParticipants,
@@ -118,6 +122,67 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         joinedAt: p.joinedAt.toISOString(),
       })),
     };
+  });
+
+  /**
+   * List GitHub entities bound to this chat. Reads the binding rows from
+   * `github_entity_chat_mappings`, then fetches the live `title` / `state`
+   * for each from the GitHub REST API at request time — nothing is
+   * persisted. Per the right-sidebar plan, we deliberately did NOT add
+   * cached columns; freshness wins over a low-cost cache.
+   *
+   * Returns an empty list when the chat has no bindings. When the org
+   * has no GitHub App installation (or token mint fails), rows are
+   * still returned with `title: null` and `state: null` so the row
+   * remains a working link to GitHub.
+   */
+  app.get<{ Params: { chatId: string } }>("/:chatId/github-entities", async (request) => {
+    const { chat, scope } = await requireChatAccess(request, app.db);
+
+    // Pull every mapping row that points at this chat. A given chat can
+    // be the target of multiple bindings — e.g. the direct PR binding
+    // plus the `Fixes #N` linker pointing at the related Issue — so we
+    // expect 1..N rows here. Dedup by (entityType, entityKey) on the way
+    // out: the (humanAgent, delegateAgent) axes are an audit detail the
+    // sidebar doesn't surface, and they would otherwise produce visible
+    // duplicates when more than one delegate agent acts on the same
+    // entity in the same chat.
+    const rows = await app.db
+      .select({
+        entityType: githubEntityChatMappings.entityType,
+        entityKey: githubEntityChatMappings.entityKey,
+        boundVia: githubEntityChatMappings.boundVia,
+        boundAt: githubEntityChatMappings.boundAt,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chat.id))
+      .orderBy(desc(githubEntityChatMappings.boundAt));
+
+    if (rows.length === 0) return { items: [] };
+
+    const dedup = new Map<string, (typeof rows)[number]>();
+    for (const r of rows) {
+      const key = `${r.entityType}::${r.entityKey}`;
+      // Earliest-encountered row wins: rows arrive newest-first so the
+      // dedup keeps the **most recent** binding, which carries the
+      // `boundVia` the user actually triggered last.
+      if (!dedup.has(key)) dedup.set(key, r);
+    }
+
+    // Mint an installation token once and reuse it for every entity
+    // fetch. The token TTL is ~1h — well outside the request window —
+    // and minting per-entity would inflate latency proportional to
+    // mapping count.
+    const installation = await findInstallationByOrg(app.db, scope.organizationId);
+    const mintResult = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+    const token = mintResult.ok ? mintResult.token : null;
+
+    const items = await Promise.all(
+      Array.from(dedup.values()).map((r) =>
+        resolveChatGithubEntity({ entityType: r.entityType, entityKey: r.entityKey, boundVia: r.boundVia }, token),
+      ),
+    );
+    return { items: items.filter((x): x is NonNullable<typeof x> => x !== null) };
   });
 
   app.post<{ Params: { chatId: string } }>(

--- a/packages/server/src/services/github-entity-live.ts
+++ b/packages/server/src/services/github-entity-live.ts
@@ -1,0 +1,200 @@
+import {
+  type ChatGithubEntity,
+  GITHUB_ENTITY_TYPES,
+  type GithubEntityBoundVia,
+  type GithubEntityLiveState,
+  type GithubEntityType,
+  githubEntityBoundViaSchema,
+} from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Per-entity GitHub fetch timeout. GitHub's `api.github.com` is typically
+ * < 500ms but the right sidebar must not block on a stuck connection — a
+ * 4-second cap keeps the worst-case `chat-detail` request bounded.
+ */
+const GITHUB_FETCH_TIMEOUT_MS = 4_000;
+
+const GITHUB_ENTITY_TYPE_SET = new Set<string>(GITHUB_ENTITY_TYPES);
+
+/**
+ * Parsed `entityKey`. Two shapes:
+ *
+ *   - `owner/repo#42`      — issue / pull_request / discussion
+ *   - `owner/repo@<sha>`   — commit
+ */
+type ParsedEntityKey =
+  | { kind: "numeric"; owner: string; repo: string; number: number }
+  | { kind: "sha"; owner: string; repo: string; sha: string }
+  | null;
+
+const NUMERIC_ENTITY_KEY = /^([^/\s]+)\/([^/\s#@]+)#(\d+)$/;
+const SHA_ENTITY_KEY = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-f]{6,40})$/;
+
+function parseEntityKey(entityType: GithubEntityType, entityKey: string): ParsedEntityKey {
+  if (entityType === "commit") {
+    const m = SHA_ENTITY_KEY.exec(entityKey);
+    if (!m) return null;
+    const [, owner, repo, sha] = m;
+    if (!owner || !repo || !sha) return null;
+    return { kind: "sha", owner, repo, sha };
+  }
+  const m = NUMERIC_ENTITY_KEY.exec(entityKey);
+  if (!m) return null;
+  const [, owner, repo, numberStr] = m;
+  if (!owner || !repo || !numberStr) return null;
+  return { kind: "numeric", owner, repo, number: Number(numberStr) };
+}
+
+/**
+ * Build the canonical `https://github.com/...` URL for an entity. Pure
+ * derivation from `(entityType, entityKey)` so the link is always present
+ * even when the live API fetch fails.
+ */
+function buildHtmlUrl(entityType: GithubEntityType, parsed: NonNullable<ParsedEntityKey>): string {
+  const repoBase = `https://github.com/${parsed.owner}/${parsed.repo}`;
+  if (parsed.kind === "sha") return `${repoBase}/commit/${parsed.sha}`;
+  switch (entityType) {
+    case "pull_request":
+      return `${repoBase}/pull/${parsed.number}`;
+    case "issue":
+      return `${repoBase}/issues/${parsed.number}`;
+    case "discussion":
+      return `${repoBase}/discussions/${parsed.number}`;
+    default:
+      // Numeric entity that isn't pr/issue/discussion shouldn't happen with
+      // the current schema, but fall back to the bare repo so the UI still
+      // has a useful link instead of an empty `href`.
+      return repoBase;
+  }
+}
+
+export type FetchedEntityLiveFields = {
+  title: string | null;
+  state: GithubEntityLiveState | null;
+};
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+/**
+ * Fetch the live title + state for one entity. Returns `{ title: null,
+ * state: null }` on any failure — the caller threads these straight to
+ * the wire so the row still renders with just the entityKey + link.
+ *
+ * Discussions need the GraphQL API to resolve title/state and are out
+ * of scope for this iteration; we return nulls so the row stays a
+ * link-only chip.
+ */
+async function fetchEntityLiveFields(
+  entityType: GithubEntityType,
+  parsed: NonNullable<ParsedEntityKey>,
+  token: string,
+  fetcher: typeof fetch,
+): Promise<FetchedEntityLiveFields> {
+  const headers = {
+    Authorization: `token ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  // AbortController caps every per-entity round-trip at
+  // GITHUB_FETCH_TIMEOUT_MS. Without it a stuck connection would block
+  // the entire `/chats/:id/github-entities` response (Promise.all on the
+  // call site amplifies the worst case).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_FETCH_TIMEOUT_MS);
+  const fetchOpts = { headers, signal: controller.signal } as const;
+  try {
+    if (entityType === "pull_request" && parsed.kind === "numeric") {
+      const res = await fetcher(
+        `${GITHUB_API_BASE}/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}`,
+        fetchOpts,
+      );
+      if (!res.ok) return { title: null, state: null };
+      const body = (await res.json()) as { title?: string; state?: string; merged?: boolean; draft?: boolean };
+      // Collapse PR's three boolean axes into the unified enum: a merged
+      // PR is always merged regardless of state; an open draft is `draft`;
+      // anything else maps directly from `state`.
+      let state: GithubEntityLiveState | null = null;
+      if (body.merged) state = "merged";
+      else if (body.draft && body.state === "open") state = "draft";
+      else if (body.state === "open" || body.state === "closed") state = body.state;
+      return { title: body.title ?? null, state };
+    }
+    if (entityType === "issue" && parsed.kind === "numeric") {
+      const res = await fetcher(
+        `${GITHUB_API_BASE}/repos/${parsed.owner}/${parsed.repo}/issues/${parsed.number}`,
+        fetchOpts,
+      );
+      if (!res.ok) return { title: null, state: null };
+      const body = (await res.json()) as { title?: string; state?: string };
+      const state: GithubEntityLiveState | null = body.state === "open" || body.state === "closed" ? body.state : null;
+      return { title: body.title ?? null, state };
+    }
+    if (entityType === "commit" && parsed.kind === "sha") {
+      const res = await fetcher(
+        `${GITHUB_API_BASE}/repos/${parsed.owner}/${parsed.repo}/commits/${parsed.sha}`,
+        fetchOpts,
+      );
+      if (!res.ok) return { title: null, state: null };
+      const body = (await res.json()) as { commit?: { message?: string } };
+      // First line of the commit message is its de-facto title.
+      const title = body.commit?.message?.split("\n", 1)[0]?.trim() ?? null;
+      return { title, state: null };
+    }
+    return { title: null, state: null };
+  } catch {
+    // Network errors, AbortController timeouts, and JSON parse errors all
+    // collapse to "unavailable"; the row still renders with the link.
+    return { title: null, state: null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type MappingRow = {
+  entityType: string;
+  entityKey: string;
+  boundVia: string;
+};
+
+/**
+ * Materialise the wire-shape `ChatGithubEntity` for a single mapping row.
+ *
+ * `parsed` may be null when `entityKey` doesn't match the expected
+ * `owner/repo#N` or `owner/repo@<sha>` shape; in that case the
+ * `htmlUrl` falls back to a search URL keyed on the raw `entityKey`
+ * (still better than dropping the row silently). Live fields are null.
+ */
+export async function resolveChatGithubEntity(
+  row: MappingRow,
+  token: string | null,
+  fetcher: typeof fetch = fetch,
+): Promise<ChatGithubEntity | null> {
+  // Defend against unknown enum values landing here — schema drift between
+  // shared and server would otherwise propagate to the wire. Both axes are
+  // narrowed via the canonical Zod schema (boundVia) and the exported
+  // tuple-derived Set (entityType) so any future enum entry needs at most
+  // a touch on `shared/`, never this file.
+  if (!GITHUB_ENTITY_TYPE_SET.has(row.entityType)) return null;
+  const entityType: GithubEntityType = row.entityType as GithubEntityType; // safe: set membership just narrowed it
+  const boundViaParsed = githubEntityBoundViaSchema.safeParse(row.boundVia);
+  if (!boundViaParsed.success) return null;
+  const boundVia: GithubEntityBoundVia = boundViaParsed.data;
+  const parsed = parseEntityKey(entityType, row.entityKey);
+  if (!parsed) return null;
+  const live = token ? await fetchEntityLiveFields(entityType, parsed, token, fetcher) : { title: null, state: null };
+  return {
+    entityType,
+    entityKey: row.entityKey,
+    boundVia,
+    htmlUrl: buildHtmlUrl(entityType, parsed),
+    title: live.title,
+    state: live.state,
+    number: parsed.kind === "numeric" ? parsed.number : null,
+  };
+}
+
+export const __testing = {
+  parseEntityKey,
+  buildHtmlUrl,
+  fetchEntityLiveFields,
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -142,6 +142,16 @@ export {
   updateChatSchema,
 } from "./schemas/chat.js";
 export {
+  type ChatGithubEntity,
+  type ChatGithubEntityListResponse,
+  chatGithubEntityListResponseSchema,
+  chatGithubEntitySchema,
+  type GithubEntityBoundVia,
+  type GithubEntityLiveState,
+  githubEntityBoundViaSchema,
+  githubEntityLiveStateSchema,
+} from "./schemas/chat-github-entities.js";
+export {
   CHAT_SOURCES,
   type ChatMetadata,
   type ChatSource,

--- a/packages/shared/src/schemas/chat-github-entities.ts
+++ b/packages/shared/src/schemas/chat-github-entities.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { githubEntityTypeSchema } from "./chat-metadata.js";
+
+/**
+ * Schema for `GET /api/v1/chats/:chatId/github-entities`.
+ *
+ * Each item describes one entity bound to the chat via
+ * `github_entity_chat_mappings`. Live state (`title`, `state`) is fetched
+ * per-request from the GitHub REST API at request time and NEVER
+ * persisted to the database — the user explicitly opted for the
+ * fresh-on-every-open model rather than a webhook-synced column.
+ *
+ * Live fields may be `null` when the GitHub call failed (token unavailable,
+ * rate-limited, 404 on a deleted entity, etc.). The client falls back to
+ * rendering `entityKey + htmlUrl` so the row is still a working link.
+ */
+
+export const githubEntityBoundViaSchema = z.enum(["direct", "fixes_link", "agent_created"]);
+export type GithubEntityBoundVia = z.infer<typeof githubEntityBoundViaSchema>;
+
+/**
+ * Coarse live state. PR-specific values (`merged`, `draft`) are folded
+ * into the same enum as the issue's `open` / `closed` so the UI can
+ * switch on a single field. `null` means we couldn't reach GitHub for
+ * this entity in this request — the row still renders, just without
+ * the state badge.
+ */
+export const githubEntityLiveStateSchema = z.enum(["open", "closed", "merged", "draft"]);
+export type GithubEntityLiveState = z.infer<typeof githubEntityLiveStateSchema>;
+
+export const chatGithubEntitySchema = z.object({
+  entityType: githubEntityTypeSchema,
+  /** Stable cluster key, e.g. "owner/repo#42" or "owner/repo@<sha>". */
+  entityKey: z.string().min(1),
+  /** How the binding was first created — audit-only, surfaced by the UI as a small caption. */
+  boundVia: githubEntityBoundViaSchema,
+  /**
+   * Canonical GitHub URL derived purely from `entityKey` + `entityType`.
+   * Always present so the row remains a working link even when GitHub is
+   * unreachable for the live fields.
+   */
+  htmlUrl: z.string().url(),
+  /** Live title from GitHub. `null` when the fetch failed / no token. */
+  title: z.string().nullable(),
+  /** Live state from GitHub. `null` when the fetch failed / no token. */
+  state: githubEntityLiveStateSchema.nullable(),
+  /** Issue / PR / Discussion number when applicable. */
+  number: z.number().int().nullable(),
+});
+export type ChatGithubEntity = z.infer<typeof chatGithubEntitySchema>;
+
+export const chatGithubEntityListResponseSchema = z.object({
+  items: z.array(chatGithubEntitySchema),
+});
+export type ChatGithubEntityListResponse = z.infer<typeof chatGithubEntityListResponseSchema>;

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -1,4 +1,10 @@
-import type { Chat, ChatDetail, ChatEngagementStatus, Message } from "@agent-team-foundation/first-tree-hub-shared";
+import type {
+  Chat,
+  ChatDetail,
+  ChatEngagementStatus,
+  ChatGithubEntityListResponse,
+  Message,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import { api, withOrg } from "./client.js";
 
 type PaginatedChats = {
@@ -25,6 +31,15 @@ export function listChats(params?: { limit?: number; cursor?: string }): Promise
 
 export function getChat(chatId: string): Promise<ChatDetail> {
   return api.get<ChatDetail>(`/chats/${encodeURIComponent(chatId)}`);
+}
+
+/**
+ * List the GitHub entities bound to this chat. Server fetches live state
+ * from GitHub on every request — nothing is cached server-side — so the
+ * client should rely on React Query's `staleTime` to keep this gentle.
+ */
+export function listChatGithubEntities(chatId: string): Promise<ChatGithubEntityListResponse> {
+  return api.get<ChatGithubEntityListResponse>(`/chats/${encodeURIComponent(chatId)}/github-entities`);
 }
 
 export function renameChat(chatId: string, topic: string | null): Promise<Chat> {

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, X } from "lucide-react";
+import { GripHorizontal, Loader2, X } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
@@ -21,8 +21,14 @@ import { Markdown } from "./ui/markdown.js";
 const DEFAULT_MAX_WIDTH = 720;
 const DEFAULT_VIEWPORT_RATIO = 0.45;
 const MIN_DRAWER_WIDTH = 360;
-const RESERVED_MAIN_WIDTH = 320;
+const MIN_DRAWER_HEIGHT = 280;
+const DEFAULT_TOP = 80;
+const DEFAULT_RIGHT_GAP = 24;
 const RESIZE_KEY_STEP = 24;
+const SCREEN_PADDING = 8;
+const RECT_STORAGE_KEY = "first-tree-hub:doc-preview-drawer:v1";
+
+type FloatingRect = { top: number; left: number; width: number; height: number };
 
 function defaultDrawerWidth(): number {
   if (typeof window === "undefined") return DEFAULT_MAX_WIDTH;
@@ -32,9 +38,54 @@ function defaultDrawerWidth(): number {
   );
 }
 
-function clampDrawerWidth(width: number): number {
-  const maxWidth = Math.max(MIN_DRAWER_WIDTH, window.innerWidth - RESERVED_MAIN_WIDTH);
-  return Math.min(Math.max(width, MIN_DRAWER_WIDTH), maxWidth);
+function defaultRect(): FloatingRect {
+  const width = defaultDrawerWidth();
+  if (typeof window === "undefined") {
+    return { top: DEFAULT_TOP, left: 320, width, height: 540 };
+  }
+  const height = Math.min(640, Math.max(MIN_DRAWER_HEIGHT, Math.round(window.innerHeight * 0.72)));
+  const left = Math.max(SCREEN_PADDING, window.innerWidth - width - DEFAULT_RIGHT_GAP);
+  return { top: DEFAULT_TOP, left, width, height };
+}
+
+function clampRect(rect: FloatingRect): FloatingRect {
+  if (typeof window === "undefined") return rect;
+  const maxAvailableWidth = Math.max(MIN_DRAWER_WIDTH, window.innerWidth - SCREEN_PADDING * 2);
+  const maxAvailableHeight = Math.max(MIN_DRAWER_HEIGHT, window.innerHeight - SCREEN_PADDING * 2);
+  const width = Math.max(MIN_DRAWER_WIDTH, Math.min(maxAvailableWidth, rect.width));
+  const height = Math.max(MIN_DRAWER_HEIGHT, Math.min(maxAvailableHeight, rect.height));
+  const left = Math.max(SCREEN_PADDING, Math.min(window.innerWidth - width - SCREEN_PADDING, rect.left));
+  const top = Math.max(SCREEN_PADDING, Math.min(window.innerHeight - height - SCREEN_PADDING, rect.top));
+  return { top, left, width, height };
+}
+
+function loadPersistedRect(): FloatingRect | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(RECT_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<FloatingRect>;
+    if (
+      typeof parsed.top !== "number" ||
+      typeof parsed.left !== "number" ||
+      typeof parsed.width !== "number" ||
+      typeof parsed.height !== "number"
+    ) {
+      return null;
+    }
+    return { top: parsed.top, left: parsed.left, width: parsed.width, height: parsed.height };
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedRect(rect: FloatingRect): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RECT_STORAGE_KEY, JSON.stringify(rect));
+  } catch {
+    // localStorage may be unavailable (private mode, disk quota); silently ignore.
+  }
 }
 
 function useIsMobileDocPreview(): boolean {
@@ -71,10 +122,31 @@ export function DocPreviewDrawer() {
       ? queryClient.getQueryData<DocSnapshotEntry>(docSnapshotQueryKey(docChatId, docMsgId, docPath))
       : undefined;
   const isMobile = useIsMobileDocPreview();
-  const [drawerWidth, setDrawerWidth] = useState(defaultDrawerWidth);
+  // Persisted floating rectangle (top/left/width/height). Loaded once from
+  // localStorage so the drawer reopens in the same spot the user left it.
+  // Mobile mode ignores this — it always renders fixed inset-0.
+  const [rect, setRect] = useState<FloatingRect>(() => clampRect(loadPersistedRect() ?? defaultRect()));
   const drawerRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Persist rect changes (debounced via React's batching). Skip mobile —
+  // the rect state isn't used there and we don't want a fullscreen modal
+  // session to overwrite a previously-saved desktop position.
+  useEffect(() => {
+    if (isMobile) return;
+    savePersistedRect(rect);
+  }, [isMobile, rect]);
+
+  // Re-clamp when the viewport shrinks below the saved rect (e.g. window
+  // resize, devtools open). Without this the drawer could be parked
+  // off-screen with no way to drag it back.
+  useEffect(() => {
+    if (isMobile) return;
+    const onResize = () => setRect((current) => clampRect(current));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [isMobile]);
 
   const close = useCallback(() => {
     const next = new URLSearchParams(searchParams);
@@ -169,35 +241,95 @@ export function DocPreviewDrawer() {
     [openDocPath, resolvedDocPath],
   );
 
-  const startResize = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+  // Drag the floating drawer by its header. The header element opts into
+  // dragging via this handler; interactive children (close button, etc.)
+  // short-circuit on mousedown so they retain their own click semantics.
+  const startDrag = useCallback((event: ReactMouseEvent<HTMLElement>) => {
+    if (event.button !== 0) return;
+    if (event.target instanceof Element && event.target.closest("button, a, input, textarea, select")) {
+      return;
+    }
     event.preventDefault();
-    const previousCursor = document.body.style.cursor;
+    const startX = event.clientX;
+    const startY = event.clientY;
     const previousUserSelect = document.body.style.userSelect;
-    document.body.style.cursor = "col-resize";
+    const previousCursor = document.body.style.cursor;
     document.body.style.userSelect = "none";
+    document.body.style.cursor = "grabbing";
 
+    let startRect: FloatingRect | null = null;
     const onMouseMove = (moveEvent: MouseEvent) => {
-      setDrawerWidth(clampDrawerWidth(window.innerWidth - moveEvent.clientX));
+      setRect((current) => {
+        if (!startRect) startRect = current;
+        return clampRect({
+          ...current,
+          top: startRect.top + (moveEvent.clientY - startY),
+          left: startRect.left + (moveEvent.clientX - startX),
+        });
+      });
     };
     const onMouseUp = () => {
-      document.body.style.cursor = previousCursor;
       document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("mouseup", onMouseUp);
     };
-
     window.addEventListener("mousemove", onMouseMove);
     window.addEventListener("mouseup", onMouseUp);
   }, []);
 
+  // Resize via the bottom-right corner grip. Tracks the initial rect at
+  // drag-start so cumulative drag deltas stay stable across React state
+  // updates (avoids the classic "rect drifts" bug from reading stale state).
+  const startResize = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "nwse-resize";
+
+    let startRect: FloatingRect | null = null;
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      setRect((current) => {
+        if (!startRect) startRect = current;
+        return clampRect({
+          ...current,
+          width: startRect.width + (moveEvent.clientX - startX),
+          height: startRect.height + (moveEvent.clientY - startY),
+        });
+      });
+    };
+    const onMouseUp = () => {
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  }, []);
+
+  // Keyboard a11y for resize: ArrowLeft / Right adjust width, ArrowUp /
+  // Down adjust height. The previous left-edge resize affordance went
+  // away with the float, so the grip in the bottom-right corner takes
+  // over its keyboard role.
   const resizeWithKeyboard = useCallback((event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    const step = RESIZE_KEY_STEP;
     if (event.key === "ArrowLeft") {
       event.preventDefault();
-      setDrawerWidth((current) => clampDrawerWidth(current + RESIZE_KEY_STEP));
-    }
-    if (event.key === "ArrowRight") {
+      setRect((current) => clampRect({ ...current, width: current.width - step }));
+    } else if (event.key === "ArrowRight") {
       event.preventDefault();
-      setDrawerWidth((current) => clampDrawerWidth(current - RESIZE_KEY_STEP));
+      setRect((current) => clampRect({ ...current, width: current.width + step }));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setRect((current) => clampRect({ ...current, height: current.height - step }));
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setRect((current) => clampRect({ ...current, height: current.height + step }));
     }
   }, []);
 
@@ -237,29 +369,31 @@ export function DocPreviewDrawer() {
       data-doc-preview-drawer=""
       className={cn(
         "z-40 flex flex-col bg-surface-raised text-text-primary shadow-2xl",
-        "animate-in slide-in-from-right duration-200",
+        "animate-in fade-in duration-150",
         isMobile
           ? "fixed inset-0 w-full border-l border-border"
-          : "relative my-3 mr-3 h-auto shrink-0 overflow-hidden rounded-[var(--radius-panel)] border border-border-faint max-w-[calc(100vw-var(--sp-8))]",
+          : "fixed overflow-hidden rounded-[var(--radius-dialog)] border border-border",
       )}
       onKeyDown={trapMobileFocus}
       ref={drawerRef}
       role="dialog"
-      style={isMobile ? undefined : { width: drawerWidth }}
+      style={isMobile ? undefined : { top: rect.top, left: rect.left, width: rect.width, height: rect.height }}
     >
-      {isMobile ? null : (
-        <button
-          aria-label="Resize document preview"
-          className="group absolute top-0 left-0 h-full w-3 -translate-x-1/2 cursor-col-resize"
-          onMouseDown={startResize}
-          onKeyDown={resizeWithKeyboard}
-          type="button"
-        >
-          <div className="mx-auto h-full w-1 bg-accent opacity-0 transition-opacity group-hover:opacity-100" />
-        </button>
-      )}
-
-      <header className="flex min-h-12 items-center gap-3 px-4 pt-3 pb-2">
+      {/* Drag handle. The whole header opts into pointer-drag so the user
+         can grab anywhere in the title strip, not just the grip glyph.
+         Mouse-only by design: dragging a panel with the keyboard is an
+         unusual pattern and would compete with the existing
+         keyboard-resize handle in the bottom-right corner; keyboard
+         users can rely on the persisted-rect default position instead. */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: keyboard-equivalent provided by the bottom-right resize handle + persisted default position */}
+      <header
+        className={cn(
+          "flex min-h-12 items-center gap-3 px-4 pt-3 pb-2",
+          !isMobile && "cursor-grab select-none active:cursor-grabbing",
+        )}
+        onMouseDown={isMobile ? undefined : startDrag}
+      >
+        {isMobile ? null : <GripHorizontal aria-hidden="true" className="h-4 w-4 shrink-0 text-text-tertiary" />}
         <div className="min-w-0 flex-1">
           <div className="truncate text-body font-medium">{title}</div>
           {subtitle ? <div className="truncate text-caption text-text-tertiary">{subtitle}</div> : null}
@@ -300,6 +434,27 @@ export function DocPreviewDrawer() {
           </>
         )}
       </div>
+
+      {isMobile ? null : (
+        <button
+          aria-label="Resize document preview"
+          className="absolute right-0 bottom-0 z-10 flex h-4 w-4 cursor-nwse-resize items-end justify-end p-0.5 text-text-tertiary hover:text-text-primary"
+          onKeyDown={resizeWithKeyboard}
+          onMouseDown={startResize}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="h-2.5 w-2.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.25"
+            viewBox="0 0 10 10"
+          >
+            <path d="M0 9 L9 0 M3.5 9 L9 3.5 M7 9 L9 7" />
+          </svg>
+        </button>
+      )}
     </aside>
   );
 }

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -7,6 +7,7 @@ import { CenterPanel } from "./center/index.js";
 import { OnboardingStepper } from "./center/onboarding-stepper.js";
 import { type GroupMode, parseGroupMode } from "./conversations/group-rows.js";
 import { ConversationList, DRAFT_CHAT_ID } from "./conversations/index.js";
+import { ChatRightSidebar } from "./right-sidebar/index.js";
 
 /**
  * Workspace shell — chat-first. The left rail is `ConversationList`; the
@@ -152,6 +153,7 @@ export function WorkspacePage() {
         <OnboardingStepper />
         <CenterPanel selectedChatId={selectedChatId} onSelectChat={selectChat} />
       </main>
+      <ChatRightSidebar selectedChatId={selectedChatId === DRAFT_CHAT_ID ? null : selectedChatId} />
       <DocPreviewDrawer />
     </div>
   );

--- a/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
@@ -1,0 +1,244 @@
+import type { ChatParticipantDetail } from "@agent-team-foundation/first-tree-hub-shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Pause } from "lucide-react";
+import { agentSessionsQueryKey, getSession, type SessionListItem, suspendSession } from "../../../api/sessions.js";
+import { pickAvatarHue } from "../../../components/chat/chat-row-avatar.js";
+import { DenseBadge } from "../../../components/ui/dense-badge.js";
+
+/**
+ * Per-agent row inside the right sidebar Agents section.
+ *
+ * Shows the agent's per-(agent, chat) session state and — when the
+ * caller has `agent:manage` access (org admin OR the agent's manager)
+ * — a Suspend button that flips an active session to `suspended`.
+ *
+ * Session data comes from `GET /agents/:uuid/sessions/:chatId`. A 404
+ * (no row) collapses to `noSession` and renders an em-dash style row.
+ */
+export function AgentRow({
+  participant,
+  chatId,
+  canSuspend,
+}: {
+  participant: ChatParticipantDetail;
+  chatId: string;
+  canSuspend: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery<SessionListItem | null>({
+    queryKey: ["chat-right-sidebar", "session", participant.agentId, chatId],
+    queryFn: async () => {
+      try {
+        return await getSession(participant.agentId, chatId);
+      } catch (err) {
+        // No session row yet → present the agent as idle / no-session.
+        // The 404 is the normal "agent in chat but never spoke" state,
+        // not an error worth surfacing on the row.
+        if (err instanceof Error && err.message.toLowerCase().includes("not found")) {
+          return null;
+        }
+        throw err;
+      }
+    },
+    // The admin WebSocket `session:state` push invalidates `["sessions"]`
+    // and `["activity"]` but NOT our new query key, so fall back to a
+    // gentle poll for now. P6 (aggregate endpoint) will let us drop this.
+    refetchInterval: 10_000,
+  });
+
+  const suspendMut = useMutation({
+    mutationFn: () => suspendSession(participant.agentId, chatId),
+    onSuccess: () => {
+      // Eager refresh: refetch our own session row + every shared key the
+      // admin WS push usually fans out to. The actual state-flip will be
+      // confirmed by the next refetch / WebSocket frame.
+      queryClient.invalidateQueries({
+        queryKey: ["chat-right-sidebar", "session", participant.agentId, chatId],
+      });
+      queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(participant.agentId) });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+    },
+  });
+
+  const session = sessionQuery.data;
+  // While the first fetch is in flight `data` is `undefined`. Distinguish
+  // "loading" from "fetched but no row" so the row doesn't briefly flash
+  // "no session" before the real state lands — for a chat the user is
+  // actively in, that first-render flash is misleading.
+  const state = sessionQuery.isPending ? "loading" : (session?.state ?? "none");
+  const view = describeState(state);
+  const hue = pickAvatarHue(participant.agentId);
+  const initial = (participant.displayName.trim()[0] ?? participant.name?.trim()[0] ?? "?").toUpperCase();
+  // Suspend button is gated by: (a) caller permission and (b) the session
+  // being in `active` — the server rejects any other transition, so
+  // surfacing the button would just produce a 409 on click.
+  const showSuspend = canSuspend && state === "active";
+  const isSuspending = suspendMut.isPending;
+
+  return (
+    <div
+      className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+      style={{
+        gap: "var(--sp-2_5)",
+        padding: "var(--sp-1_75) var(--sp-2)",
+        borderRadius: "var(--radius-input)",
+      }}
+    >
+      <div className="relative shrink-0">
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center justify-center font-semibold"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 999,
+            background: hue,
+            color: "var(--fg-on-vivid)",
+            fontSize: 11,
+          }}
+        >
+          {initial}
+        </span>
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            right: -1,
+            bottom: -1,
+            width: 9,
+            height: 9,
+            borderRadius: 999,
+            background: view.dotBg,
+            border: view.dotBorder,
+            boxShadow: "0 0 0 var(--hairline-bold) var(--bg-raised)",
+          }}
+        />
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 2 }}>
+        <div className="truncate text-subtitle">{participant.displayName}</div>
+        <div className="mono flex items-center text-caption" style={{ gap: "var(--sp-1)", color: "var(--fg-3)" }}>
+          <DenseBadge tone={view.tone}>{view.label}</DenseBadge>
+          {view.subText ? <span>{view.subText}</span> : null}
+        </div>
+      </div>
+
+      {showSuspend ? <SuspendButton onClick={() => suspendMut.mutate()} isPending={isSuspending} /> : null}
+    </div>
+  );
+}
+
+/** State view-model. Centralised so the badge tone, status-dot color,
+ * and label text stay in sync — three places drifting apart is how the
+ * sidebar starts lying to the user. */
+function describeState(state: string): {
+  label: string;
+  tone: "accent" | "neutral" | "warn" | "error" | "outline";
+  dotBg: string;
+  dotBorder: string;
+  subText: string | null;
+} {
+  switch (state) {
+    case "active":
+      return {
+        label: "ACTIVE",
+        tone: "accent",
+        dotBg: "var(--state-idle)",
+        dotBorder: "none",
+        subText: "running",
+      };
+    case "suspended":
+      return {
+        label: "SUSPENDED",
+        tone: "neutral",
+        dotBg: "var(--bg-raised)",
+        dotBorder: "var(--hairline-bold) solid var(--fg-4)",
+        subText: "idle",
+      };
+    case "errored":
+      return {
+        label: "ERRORED",
+        tone: "error",
+        dotBg: "var(--state-error)",
+        dotBorder: "none",
+        subText: null,
+      };
+    case "evicted":
+      return {
+        label: "EVICTED",
+        tone: "outline",
+        dotBg: "var(--state-offline)",
+        dotBorder: "none",
+        subText: null,
+      };
+    case "loading":
+      return {
+        label: "…",
+        tone: "outline",
+        dotBg: "transparent",
+        dotBorder: "var(--hairline-bold) solid var(--fg-4)",
+        subText: null,
+      };
+    default:
+      return {
+        label: "—",
+        tone: "outline",
+        dotBg: "transparent",
+        dotBorder: "var(--hairline-bold) solid var(--fg-4)",
+        subText: "no session",
+      };
+  }
+}
+
+/**
+ * One-click Suspend button. No confirm step: the operation is reversible
+ * (the next message in the chat upserts the session back to `active`),
+ * so the inline confirm we used to render added friction without buying
+ * real safety. A warning-tinted Pause glyph keeps the action visually
+ * distinct from neutral chips on the row.
+ */
+function SuspendButton({ onClick, isPending }: { onClick: () => void; isPending: boolean }) {
+  if (isPending) {
+    return (
+      <button
+        type="button"
+        disabled
+        aria-label="Suspending agent session"
+        className="text-label inline-flex shrink-0 items-center"
+        style={{
+          gap: "var(--sp-1)",
+          padding: "var(--sp-0_5) var(--sp-2_25)",
+          borderRadius: "var(--radius-input)",
+          border: "var(--hairline) solid var(--border)",
+          background: "var(--bg-sunken)",
+          color: "var(--fg-3)",
+        }}
+      >
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Suspending
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Suspend agent session"
+      className="text-label inline-flex shrink-0 items-center transition-colors hover:bg-[var(--bg-warn-soft)] hover:text-[var(--fg-warn-strong)] hover:border-[var(--fg-warn-strong)]"
+      style={{
+        gap: "var(--sp-1)",
+        padding: "var(--sp-0_5) var(--sp-2_25)",
+        borderRadius: "var(--radius-input)",
+        border: "var(--hairline) solid var(--border)",
+        background: "var(--bg-raised)",
+        color: "var(--fg-warn-strong)",
+      }}
+      title="Suspend this agent's session in this chat"
+    >
+      <Pause className="h-3 w-3" aria-hidden="true" fill="currentColor" strokeWidth={0} />
+      Suspend
+    </button>
+  );
+}

--- a/packages/web/src/pages/workspace/right-sidebar/agents-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/agents-section.tsx
@@ -1,0 +1,86 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { getActivityOverview } from "../../../api/activity.js";
+import { getChat } from "../../../api/chats.js";
+import { useAuth } from "../../../auth/auth-context.js";
+import { AgentRow } from "./agent-row.js";
+
+/**
+ * Agents section — lists every agent participating in the current chat
+ * plus a per-row session status indicator and an admin-gated Suspend
+ * button. Humans (chat members who aren't agents) are not surfaced
+ * here; the chat header already names them.
+ */
+export function AgentsSection({ chatId }: { chatId: string }) {
+  const { role } = useAuth();
+  // Shares the React-Query key with chat-view's own `getChat` call so we
+  // get cache reuse for free — opening a chat with the right sidebar
+  // open does not fire two parallel `/chats/:id` requests.
+  const chatQuery = useQuery({
+    queryKey: ["chat-detail", chatId],
+    queryFn: () => getChat(chatId),
+    enabled: !!chatId,
+  });
+  // `/activity` tells us which agents the current user manages —
+  // combined with the org-admin role check below, this is the front-end
+  // mirror of the server's `requireAgentAccess(..., "manage")` rule.
+  // Hiding the button when the user lacks permission keeps unauthorised
+  // clicks from ever reaching a 403.
+  const activityQuery = useQuery({
+    queryKey: ["activity"],
+    queryFn: getActivityOverview,
+    refetchInterval: 15_000,
+  });
+
+  const managedByMe = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const a of activityQuery.data?.agents ?? []) m.set(a.agentId, a.managedByMe);
+    return m;
+  }, [activityQuery.data?.agents]);
+
+  const agents = useMemo(
+    // Two non-human variants land here: `personal_assistant` and
+    // `autonomous_agent` (per `AGENT_TYPES` in shared/agent.ts). Listing
+    // them by exclusion of `human` future-proofs the filter against new
+    // agent variants — the sidebar should surface any non-human
+    // participant regardless of subtype.
+    () => (chatQuery.data?.participants ?? []).filter((p) => p.type !== "human"),
+    [chatQuery.data?.participants],
+  );
+
+  const isAdmin = role === "admin";
+
+  return (
+    <section style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}>
+      <div className="flex items-center justify-between" style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-1)" }}>
+        <div className="text-eyebrow" style={{ color: "var(--fg-4)" }}>
+          Agents
+        </div>
+        <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+          {agents.length}
+        </div>
+      </div>
+
+      <div className="flex flex-col" style={{ padding: "0 var(--sp-2) var(--sp-2)", gap: 2 }}>
+        {chatQuery.isLoading ? (
+          <div className="text-body" style={{ padding: "var(--sp-2) var(--sp-2)", color: "var(--fg-3)" }}>
+            Loading…
+          </div>
+        ) : agents.length === 0 ? (
+          <div className="text-body" style={{ padding: "var(--sp-2) var(--sp-2)", color: "var(--fg-3)" }}>
+            No agents in this chat.
+          </div>
+        ) : (
+          agents.map((p) => (
+            <AgentRow
+              key={p.agentId}
+              chatId={chatId}
+              participant={p}
+              canSuspend={isAdmin || (managedByMe.get(p.agentId) ?? false)}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -1,0 +1,158 @@
+import type {
+  ChatGithubEntity,
+  GithubEntityLiveState,
+  GithubEntityType,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { useQuery } from "@tanstack/react-query";
+import { CircleDot, ExternalLink, GitCommit, GitMerge, GitPullRequest, MessageCircle } from "lucide-react";
+import { listChatGithubEntities } from "../../../api/chats.js";
+import { DenseBadge, type DenseBadgeTone } from "../../../components/ui/dense-badge.js";
+
+/**
+ * GitHub section — lists every PR / Issue / Discussion / Commit bound to
+ * the current chat via `github_entity_chat_mappings`. Live title + state
+ * are fetched per-request by the server from the GitHub REST API and are
+ * NOT persisted; rows degrade gracefully (link only) when the GitHub
+ * round-trip fails or the org has no installation.
+ *
+ * Hidden entirely when the chat has no bindings — empty rails would
+ * waste vertical space on chats that aren't sourced from GitHub.
+ */
+export function GitHubSection({ chatId }: { chatId: string }) {
+  const query = useQuery({
+    queryKey: ["chat-right-sidebar", "github-entities", chatId],
+    queryFn: () => listChatGithubEntities(chatId),
+    // GitHub live state can drift between sessions; refresh every 60s when
+    // the panel is open, and treat the data as fresh for ~30s so quick
+    // panel toggles do not refetch.
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  const items = query.data?.items ?? [];
+
+  if (query.isLoading || items.length === 0) {
+    // Loading / empty: render nothing. The Agents section already covered
+    // the "right rail has content" cue; an extra spinner would just churn
+    // the layout.
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between" style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-1)" }}>
+        <div className="text-eyebrow" style={{ color: "var(--fg-4)" }}>
+          GitHub
+        </div>
+        <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+          {items.length}
+        </div>
+      </div>
+
+      <div className="flex flex-col" style={{ padding: "0 var(--sp-2) var(--sp-2)", gap: 2 }}>
+        {items.map((entity) => (
+          <GitHubRow key={`${entity.entityType}::${entity.entityKey}`} entity={entity} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
+  const Icon = iconForType(entity.entityType, entity.state);
+  const view = viewForState(entity.state);
+
+  return (
+    <a
+      href={entity.htmlUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-start transition-colors hover:bg-[var(--bg-hover)]"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-2)",
+        borderRadius: "var(--radius-input)",
+        color: "inherit",
+        textDecoration: "none",
+      }}
+    >
+      <Icon
+        aria-hidden="true"
+        className="shrink-0"
+        size={16}
+        strokeWidth={1.75}
+        style={{ marginTop: 2, color: iconColor(entity.state) }}
+      />
+      <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 3 }}>
+        <div className="mono text-label flex items-center" style={{ gap: "var(--sp-1_5)", color: "var(--fg-2)" }}>
+          <span>{entity.entityKey}</span>
+          {view ? <DenseBadge tone={view.tone}>{view.label}</DenseBadge> : null}
+        </div>
+        {entity.title ? (
+          <div
+            className="text-body"
+            style={{
+              color: "var(--fg)",
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+            }}
+          >
+            {entity.title}
+          </div>
+        ) : null}
+        <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+          via {entity.boundVia}
+        </div>
+      </div>
+      <ExternalLink
+        aria-hidden="true"
+        size={12}
+        className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+        style={{ marginTop: 4, color: "var(--fg-3)" }}
+      />
+    </a>
+  );
+}
+
+function iconForType(type: GithubEntityType, state: GithubEntityLiveState | null) {
+  if (type === "pull_request") return state === "merged" ? GitMerge : GitPullRequest;
+  if (type === "issue") return CircleDot;
+  if (type === "discussion") return MessageCircle;
+  return GitCommit;
+}
+
+function iconColor(state: GithubEntityLiveState | null): string {
+  switch (state) {
+    case "merged":
+      return "oklch(0.42 0.18 295)";
+    case "closed":
+      return "var(--fg-3)";
+    case "draft":
+      return "var(--fg-4)";
+    case "open":
+      return "var(--fg-success-strong)";
+    default:
+      return "var(--fg-3)";
+  }
+}
+
+function viewForState(state: GithubEntityLiveState | null): { label: string; tone: DenseBadgeTone } | null {
+  if (!state) return null;
+  switch (state) {
+    case "open":
+      return { label: "OPEN", tone: "accent" };
+    case "closed":
+      return { label: "CLOSED", tone: "neutral" };
+    case "merged":
+      // Mapped to `outline` since the DenseBadge palette doesn't carry a
+      // purple/merged tone; the icon swap to GitMerge does the heavy
+      // lifting for the visual signal.
+      return { label: "MERGED", tone: "outline" };
+    case "draft":
+      return { label: "DRAFT", tone: "outline" };
+    default:
+      return null;
+  }
+}

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -1,0 +1,124 @@
+import { ChevronsLeft, ChevronsRight, Users } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "../../../lib/utils.js";
+import { AgentsSection } from "./agents-section.js";
+import { GitHubSection } from "./github-section.js";
+
+const COLLAPSE_STORAGE_KEY = "first-tree-hub:chat-right-sidebar:collapsed:v1";
+
+function loadCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(COLLAPSE_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(COLLAPSE_STORAGE_KEY, collapsed ? "1" : "0");
+  } catch {
+    // localStorage may be unavailable (private mode); ignore quietly.
+  }
+}
+
+/**
+ * ChatRightSidebar — workspace right rail. Renders chat-scoped detail
+ * panels (Agents, GitHub bindings) for the currently selected chat.
+ *
+ * Persists its collapsed state in `localStorage` rather than the URL so
+ * a refresh keeps the user's preference without polluting deep-link
+ * URLs (the URL already owns chat selection + doc-preview overlay).
+ *
+ * Returns `null` when no chat is selected — the rail is meaningless on
+ * the draft/empty workspace state and an empty column would just
+ * compress the main area.
+ */
+export function ChatRightSidebar({ selectedChatId }: { selectedChatId: string | null }) {
+  const [collapsed, setCollapsed] = useState<boolean>(loadCollapsed);
+
+  useEffect(() => {
+    saveCollapsed(collapsed);
+  }, [collapsed]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+
+  if (!selectedChatId) return null;
+
+  return (
+    <aside
+      aria-label="Chat details"
+      className={cn("flex shrink-0 flex-col overflow-hidden transition-[width] duration-150")}
+      style={{
+        width: collapsed ? 44 : 320,
+        background: "var(--bg-raised)",
+        borderLeft: "var(--hairline) solid var(--border)",
+      }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-between"
+        style={{
+          height: 52,
+          padding: collapsed ? "0" : "0 var(--sp-2_5) 0 var(--sp-3)",
+          borderBottom: "var(--hairline) solid var(--border-faint)",
+        }}
+      >
+        {collapsed ? null : (
+          <div className="text-subtitle" style={{ color: "var(--fg)" }}>
+            Chat details
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={collapsed ? "Expand chat details" : "Collapse chat details"}
+          aria-expanded={!collapsed}
+          className={cn(
+            "inline-flex items-center justify-center transition-colors hover:bg-[var(--bg-hover)]",
+            collapsed && "mx-auto",
+          )}
+          style={{
+            width: 30,
+            height: 30,
+            border: 0,
+            background: "transparent",
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg-2)",
+            cursor: "pointer",
+          }}
+        >
+          {collapsed ? <ChevronsLeft size={16} /> : <ChevronsRight size={16} />}
+        </button>
+      </div>
+
+      {collapsed ? (
+        <div className="flex flex-1 flex-col items-center" style={{ paddingTop: "var(--sp-2)", gap: "var(--sp-1)" }}>
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label="Open Agents section"
+            className="inline-flex items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+            style={{
+              width: 32,
+              height: 32,
+              border: 0,
+              background: "transparent",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg-2)",
+              cursor: "pointer",
+            }}
+          >
+            <Users size={16} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          <AgentsSection chatId={selectedChatId} />
+          <GitHubSection chatId={selectedChatId} />
+        </div>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a chat-scoped right rail to the workspace that surfaces the two things you most need while reading a chat: **which agents are active here** and **which GitHub PR/Issue this conversation is about**. Also turns the doc-preview drawer into a true floating panel so the two rails stop competing for layout space.

### Right sidebar

- **Agents section**: per-(agent, chat) session state for every non-human participant (status dot + DenseBadge covering `active` / `suspended` / `errored` / `evicted` / `loading` / `no-session`). A warning-tinted **Pause + "Suspend"** button appears only when the caller has `agent:manage` permission (`role === "admin" || managedByMe`) AND the session is currently `active`. **One click, no confirm** — the operation is reversible (next message in the chat upserts the session back to `active`), so inline confirm was friction without real safety value.
- **GitHub section**: every entity bound to the chat via `github_entity_chat_mappings` (PR / Issue / Discussion / Commit), with live `title` + `state` (open / closed / merged / draft) fetched per-request from the GitHub REST API. **Nothing is persisted** — freshness on every open beats a webhook-synced column for this use case. Rows degrade gracefully (link only) when GitHub is unreachable or the org has no installation.
- **Container**: 320 px ↔ 44 px collapsible, state persisted in `localStorage` (not URL — the URL already owns chat selection + doc-preview overlay). Hidden entirely when no chat is selected.

### Doc-preview drawer → floating overlay

- **Desktop**: `fixed` rather than a flex sibling. Drag the header to move, bottom-right grip to resize (mouse + keyboard `Arrow*` a11y). Position + size persist to `localStorage` and re-clamp on viewport resize so the panel can't escape the screen.
- **Mobile**: unchanged, still `fixed inset-0` modal with focus trap.
- The previous `relative` flex placement competed with the new right sidebar; floating decouples both rails.

### New endpoint

`GET /api/v1/chats/:chatId/github-entities` — reads `github_entity_chat_mappings` for the chat (dedup by `(entityType, entityKey)`, keep most-recent `boundVia`), mints one installation token, fetches each entity's live state in parallel from `api.github.com` with a 4 s `AbortController` cap, returns `ChatGithubEntityListResponse`. Schema lives in `shared/src/schemas/chat-github-entities.ts`.

### What was NOT changed

- **No DB migrations.** No new columns, no new tables. The only DB read is `github_entity_chat_mappings` which already exists.
- **No webhook changes.** Live state stays out of the DB by design.

## Self code review

See thread on the [last commit](de1ab39) — I caught two medium items in review and fixed them before requesting review: the GitHub fetch was missing a timeout (now 4 s AbortController per entity), and two `as` assertions violated the "no `as`" convention (now narrowed via `GITHUB_ENTITY_TYPE_SET.has(...)` and `githubEntityBoundViaSchema.safeParse(...)`).

Known follow-ups (not blockers, intentionally deferred):
- **N+1 session query**: each agent runs its own `getSession`. Acceptable for short chats; long-term a `GET /chats/:chatId/agent-sessions` aggregate endpoint would let us drop the 10 s poll.
- `agent-row.tsx` uses `err.message.includes("not found")` for 404 detection — fragile, should ride a future `ApiError(status)` refactor.
- `merged` purple uses a hex `oklch(...)` literal — token guardrail doesn't flag it but a `--state-merged` token in `index.css` would be cleaner.

## Test plan

- [x] `pnpm check` (biome)
- [x] `pnpm typecheck` (9 packages, including web design-token guardrail)
- [x] `pnpm --filter @first-tree-hub/server test` — 135 files / 1088 tests pass
- [x] Manual end-to-end against `dev.cloud.first-tree.ai`:
  - [x] Right sidebar appears for every selected chat, hidden on draft
  - [x] Agents section reflects real ACTIVE / SUSPENDED state and updates on WS push + 10 s poll
  - [x] Suspend button: click → "Suspending…" spinner → SUSPENDED + button disappears (real state change in DB confirmed)
  - [x] Suspend button hidden for users without `agent:manage` (front-end gate)
  - [x] Collapse/expand persists across reload via localStorage
  - [x] doc-preview floats above the rail, keyboard resize hits MIN_DRAWER_WIDTH 360
  - [x] Empty GitHub section is hidden (no churn for non-GitHub chats)

Screenshots in the testing notes (Finder bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)