### PR TITLE
[codex] Linkify generated markdown document paths

### DIFF
--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -139,7 +139,7 @@ export function DocPreviewDrawer() {
           ) {
             return;
           }
-          const nextDocPath = docPreviewPathFromHref(href, resolvedDocPath);
+          const nextDocPath = docPreviewPathFromHref(href, { currentDocPath: resolvedDocPath, basePath: docBasePath });
           if (!nextDocPath) return;
           event.preventDefault();
           openDocPath(nextDocPath);
@@ -152,7 +152,7 @@ export function DocPreviewDrawer() {
         );
       },
     }),
-    [openDocPath, resolvedDocPath],
+    [docBasePath, openDocPath, resolvedDocPath],
   );
 
   const startResize = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {

--- a/packages/web/src/lib/__tests__/doc-preview-links.test.ts
+++ b/packages/web/src/lib/__tests__/doc-preview-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { docPreviewPathFromHref } from "../doc-preview-links.js";
+import { docPreviewPathFromHref, linkifyMarkdownDocPaths } from "../doc-preview-links.js";
 
 describe("docPreviewPathFromHref", () => {
   it("accepts markdown paths and strips query/hash fragments", () => {
@@ -42,5 +42,58 @@ describe("docPreviewPathFromHref", () => {
     expect(docPreviewPathFromHref("//example.com/readme.md")).toBeNull();
     expect(docPreviewPathFromHref("#heading")).toBeNull();
     expect(docPreviewPathFromHref("docs/readme.txt")).toBeNull();
+  });
+});
+
+describe("linkifyMarkdownDocPaths", () => {
+  it("links plain markdown document paths in chat text", () => {
+    expect(linkifyMarkdownDocPaths("Created docs/intro.md, README.md:12, and docs/api.md:42:13.")).toBe(
+      "Created [docs/intro.md](docs/intro.md), [README.md:12](README.md:12), and [docs/api.md:42:13](docs/api.md:42:13).",
+    );
+  });
+
+  it("links repo-local absolute paths when a base path is available", () => {
+    const path = "/Users/gandy/.first-tree/hub/data/workspaces/coder/chat-1/first-tree-hub/docs/intro.md:7";
+    expect(linkifyMarkdownDocPaths(`Created ${path}`, { basePath: "first-tree-hub" })).toBe(
+      `Created [${path}](${path})`,
+    );
+  });
+
+  it("does not rewrite existing links, inline code, fenced code, external urls, or non-markdown paths", () => {
+    expect(
+      linkifyMarkdownDocPaths(
+        [
+          "Already [intro](docs/intro.md)",
+          "Inline `docs/code.md`",
+          'HTML <a href="docs/html.md">link</a>',
+          '[ref]: docs/reference.md "Reference"',
+          "    docs/indented.md",
+          "```",
+          "docs/fenced.md",
+          "```",
+          "External https://example.com/readme.md",
+          "Text docs/readme.txt",
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        "Already [intro](docs/intro.md)",
+        "Inline `docs/code.md`",
+        'HTML <a href="docs/html.md">link</a>',
+        '[ref]: docs/reference.md "Reference"',
+        "    docs/indented.md",
+        "```",
+        "docs/fenced.md",
+        "```",
+        "External https://example.com/readme.md",
+        "Text docs/readme.txt",
+      ].join("\n"),
+    );
+  });
+
+  it("does not treat markdown-named directories as domains", () => {
+    expect(linkifyMarkdownDocPaths("See notes.md/follow-up.md")).toBe(
+      "See [notes.md/follow-up.md](notes.md/follow-up.md)",
+    );
   });
 });

--- a/packages/web/src/lib/__tests__/doc-preview-links.test.ts
+++ b/packages/web/src/lib/__tests__/doc-preview-links.test.ts
@@ -8,10 +8,27 @@ describe("docPreviewPathFromHref", () => {
 
   it("resolves relative links against the current document path", () => {
     expect(docPreviewPathFromHref("../api.md", "docs/design/overview.md")).toBe("docs/api.md");
+    expect(docPreviewPathFromHref("../api.md:12", { currentDocPath: "docs/design/overview.md" })).toBe("docs/api.md");
   });
 
   it("normalizes root-relative markdown paths inside the preview root", () => {
     expect(docPreviewPathFromHref("/docs/intro.md")).toBe("docs/intro.md");
+  });
+
+  it("accepts generated markdown file links with line suffixes", () => {
+    expect(docPreviewPathFromHref("README.md:12")).toBe("README.md");
+    expect(docPreviewPathFromHref("docs/intro.md:12:4")).toBe("docs/intro.md");
+  });
+
+  it("strips repo-local base path from absolute workspace links", () => {
+    expect(
+      docPreviewPathFromHref(
+        "/Users/gandy/.first-tree/hub/data/workspaces/coder/chat-1/first-tree-hub/docs/intro.md:7",
+        {
+          basePath: "first-tree-hub",
+        },
+      ),
+    ).toBe("docs/intro.md");
   });
 
   it("rejects paths that escape above the preview root", () => {

--- a/packages/web/src/lib/doc-preview-links.ts
+++ b/packages/web/src/lib/doc-preview-links.ts
@@ -1,5 +1,11 @@
 const SCHEME_RE = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
 const MARKDOWN_PATH_RE = /^(?<path>.*?\.md)(?::\d+(?::\d+)?)?$/i;
+const DOC_PATH_TOKEN_RE =
+  /(^|[\s([{"'])(?<path>(?:\.{1,2}\/|\/)?(?:[A-Za-z0-9_.~+@%-]+\/)*[A-Za-z0-9_.~+@%-]+\.md(?::\d+(?::\d+)?)?)(?=$|[\s)\]}"',.;!?])/g;
+const DOMAIN_LIKE_PATH_RE = /^[a-z][a-z0-9.-]*\.[a-z]{2,}\//i;
+const HTML_TAG_RE = /<\/?[A-Za-z][^>\n]*>/g;
+const INLINE_MARKDOWN_LINK_RE = /\[[^\]\n]*\]\([^)\n]*\)/g;
+const REFERENCE_LINK_DEFINITION_RE = /^\s*\[[^\]\n]+\]:\s*\S+/;
 
 export type DocPreviewPathOptions = {
   currentDocPath?: string | null;
@@ -35,6 +41,75 @@ export function docPreviewPathFromHref(
   }
 
   return normalizeDocPath(candidate);
+}
+
+export function linkifyMarkdownDocPaths(markdown: string, options: DocPreviewPathOptions = {}): string {
+  const lines = markdown.split(/(\r?\n)/);
+  let inFence = false;
+
+  return lines
+    .map((line) => {
+      if (line === "\n" || line === "\r\n") return line;
+
+      if (/^\s*(```|~~~)/.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+      if (inFence) return line;
+      if (/^(?: {4}|\t)/.test(line) || REFERENCE_LINK_DEFINITION_RE.test(line)) return line;
+
+      return linkifyMarkdownDocPathsInLine(line, options);
+    })
+    .join("");
+}
+
+function linkifyMarkdownDocPathsInLine(line: string, options: DocPreviewPathOptions): string {
+  const skipRanges = findInlineSkipRanges(line);
+  return line.replace(DOC_PATH_TOKEN_RE, (match, boundary: string, path: string, offset: number) => {
+    const pathStart = offset + boundary.length;
+    if (isInsideAnyRange(pathStart, skipRanges) || !isLikelyPreviewableDocPath(path, options)) {
+      return match;
+    }
+    return `${boundary}[${path}](${path})`;
+  });
+}
+
+function findInlineSkipRanges(line: string): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = [];
+
+  for (const match of line.matchAll(INLINE_MARKDOWN_LINK_RE)) {
+    if (match.index !== undefined) ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+
+  for (const match of line.matchAll(HTML_TAG_RE)) {
+    if (match.index !== undefined) ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+
+  for (let idx = 0; idx < line.length; ) {
+    if (line[idx] !== "`") {
+      idx += 1;
+      continue;
+    }
+    const start = idx;
+    while (line[idx] === "`") idx += 1;
+    const ticks = line.slice(start, idx);
+    const end = line.indexOf(ticks, idx);
+    if (end === -1) continue;
+    ranges.push({ start, end: end + ticks.length });
+    idx = end + ticks.length;
+  }
+
+  return ranges;
+}
+
+function isInsideAnyRange(index: number, ranges: Array<{ start: number; end: number }>): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function isLikelyPreviewableDocPath(path: string, options: DocPreviewPathOptions): boolean {
+  const firstSegment = path.split("/", 1).at(0) ?? "";
+  if (!firstSegment.endsWith(".md") && DOMAIN_LIKE_PATH_RE.test(path)) return false;
+  return docPreviewPathFromHref(path, options) !== null;
 }
 
 function stripBasePathPrefix(path: string, basePath: string): string {

--- a/packages/web/src/lib/doc-preview-links.ts
+++ b/packages/web/src/lib/doc-preview-links.ts
@@ -1,22 +1,52 @@
-const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:(?!\d)/i;
+const MARKDOWN_PATH_RE = /^(?<path>.*?\.md)(?::\d+(?::\d+)?)?$/i;
 
-export function docPreviewPathFromHref(href: string, currentDocPath?: string | null): string | null {
+export type DocPreviewPathOptions = {
+  currentDocPath?: string | null;
+  basePath?: string | null;
+};
+
+export function docPreviewPathFromHref(
+  href: string,
+  currentDocPathOrOptions?: string | null | DocPreviewPathOptions,
+): string | null {
+  const options =
+    typeof currentDocPathOrOptions === "object" && currentDocPathOrOptions !== null
+      ? currentDocPathOrOptions
+      : { currentDocPath: currentDocPathOrOptions };
   const trimmed = href.trim();
   if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//") || SCHEME_RE.test(trimmed)) {
     return null;
   }
 
   const pathPart = trimmed.split(/[?#]/, 1).at(0) ?? "";
-  if (!pathPart.toLowerCase().endsWith(".md")) return null;
+  const markdownMatch = MARKDOWN_PATH_RE.exec(pathPart);
+  const markdownPath = markdownMatch?.groups?.path;
+  if (!markdownPath) return null;
 
-  let candidate = pathPart.startsWith("/") ? pathPart.slice(1) : pathPart;
-  if (currentDocPath && !pathPart.startsWith("/")) {
-    const slash = currentDocPath.lastIndexOf("/");
-    const base = slash >= 0 ? currentDocPath.slice(0, slash + 1) : "";
-    candidate = `${base}${pathPart}`;
+  let candidate = markdownPath.startsWith("/") ? markdownPath.slice(1) : markdownPath;
+  if (options.basePath) {
+    candidate = stripBasePathPrefix(candidate, options.basePath);
+  }
+  if (options.currentDocPath && !markdownPath.startsWith("/")) {
+    const slash = options.currentDocPath.lastIndexOf("/");
+    const base = slash >= 0 ? options.currentDocPath.slice(0, slash + 1) : "";
+    candidate = `${base}${markdownPath}`;
   }
 
   return normalizeDocPath(candidate);
+}
+
+function stripBasePathPrefix(path: string, basePath: string): string {
+  const normalizedBase = normalizeDocPath(basePath);
+  if (!normalizedBase) return path;
+  const pathParts = path.split("/").filter(Boolean);
+  const baseParts = normalizedBase.split("/");
+  for (let idx = 0; idx <= pathParts.length - baseParts.length; idx++) {
+    const matches = baseParts.every((part, offset) => pathParts[idx + offset] === part);
+    if (matches) return pathParts.slice(idx + baseParts.length).join("/");
+  }
+  return path;
 }
 
 function normalizeDocPath(path: string): string | null {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -52,7 +52,7 @@ import {
 } from "../../../components/mention-autocomplete.js";
 import { Button } from "../../../components/ui/button.js";
 import { Markdown } from "../../../components/ui/markdown.js";
-import { docPreviewPathFromHref } from "../../../lib/doc-preview-links.js";
+import { docPreviewPathFromHref, linkifyMarkdownDocPaths } from "../../../lib/doc-preview-links.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { cn } from "../../../lib/utils.js";
@@ -335,6 +335,17 @@ function TextRow({
   const senderName = agentNameFn(msg.senderId);
   const isSelf = myAgentId === msg.senderId;
   const docBasePath = documentBasePathFromMetadata(msg.metadata);
+  const shouldLinkifyDocPaths = msg.source !== "hub_ui";
+  const rawTextContent =
+    msg.format === "text" || msg.format === "markdown"
+      ? typeof msg.content === "string"
+        ? msg.content
+        : JSON.stringify(msg.content)
+      : null;
+  const textContent =
+    rawTextContent && shouldLinkifyDocPaths
+      ? linkifyMarkdownDocPaths(rawTextContent, { basePath: docBasePath })
+      : rawTextContent;
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ href, children, ...props }) {
@@ -420,9 +431,7 @@ function TextRow({
           ) : msg.format === "file" && isImageRefContent(msg.content) ? (
             <ImageFromRef content={msg.content} />
           ) : msg.format === "text" || msg.format === "markdown" ? (
-            <Markdown components={markdownComponents}>
-              {typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}
-            </Markdown>
+            <Markdown components={markdownComponents}>{textContent ?? ""}</Markdown>
           ) : (
             <pre
               className="mono text-label"

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -351,7 +351,7 @@ function TextRow({
             return;
           }
 
-          const docPath = docPreviewPathFromHref(href);
+          const docPath = docPreviewPathFromHref(href, { basePath: docBasePath });
           if (!docPath) return;
 
           event.preventDefault();


### PR DESCRIPTION
## Summary

- Auto-link plain Markdown document paths in non-`hub_ui` chat messages so generated docs can open in the existing right-side preview drawer.
- Reuse the existing document preview path normalization instead of scanning workspaces or introducing an artifact registry.
- Avoid rewriting existing links, inline/fenced/indented code, HTML tags, reference-link definitions, external URLs, and non-Markdown paths.

## Context Tree

- Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/280

## Validation

- `pnpm --dir packages/web exec vitest run src/lib/__tests__/doc-preview-links.test.ts --passWithNoTests`
- `pnpm --filter @first-tree-hub/web test`
- `pnpm --filter @first-tree-hub/web typecheck`
- `pnpm check`
- `pnpm --filter @first-tree-hub/web build`

Note: the build still reports the existing large chunk warning.
