### PR TITLE
[codex] Simplify agent config tab layouts

### DIFF
--- a/packages/web/src/pages/agent-detail/appearance-section.tsx
+++ b/packages/web/src/pages/agent-detail/appearance-section.tsx
@@ -11,7 +11,7 @@ import { resolveAvatarHue } from "../../components/chat/chat-row-avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Label } from "../../components/ui/label.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigRow, ConfigSection } from "./flat-section.js";
 
 /**
  * Appearance — manager-configurable avatar color + image.
@@ -81,38 +81,33 @@ export function AppearanceSection({ agent, canEdit = true, onSave, onRefresh }: 
   const colorLabel =
     typeof agent.avatarColorToken === "string" && agent.avatarColorToken.length > 0 ? agent.avatarColorToken : "auto";
 
+  const action =
+    canEdit && agent.status === "active" ? (
+      <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+        <Pencil className="h-3 w-3" /> Edit
+      </Button>
+    ) : null;
+
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Appearance</PanelTitle>
-        {canEdit && agent.status === "active" && (
-          <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
-            <Pencil className="h-3 w-3" /> Edit
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="text-body">
-        <div className="flex items-center gap-3">
-          <AvatarPreview agent={agent} size={48} />
-          <div className="flex flex-col">
-            <div className="flex items-baseline gap-2">
-              <span className="text-body">Color</span>
-              <span className="mono text-caption text-muted-foreground">{colorLabel}</span>
-            </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-body">Image</span>
-              <span className="mono text-caption text-muted-foreground">
-                {agent.avatarImageUrl ? "custom" : "none"}
-              </span>
-            </div>
-          </div>
-        </div>
-      </PanelBody>
+    <ConfigSection eyebrow="profile" title="Appearance" action={action}>
+      <ConfigRow
+        label="Avatar"
+        value={
+          <span className="inline-flex items-center gap-3">
+            <AvatarPreview agent={agent} size={40} />
+            <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+              {agent.avatarImageUrl ? "custom image" : `color ${colorLabel}`}
+            </span>
+          </span>
+        }
+      />
+      <ConfigRow label="Image" value={agent.avatarImageUrl ? "custom" : "none"} />
+      <ConfigRow label="Color" value={<span className="font-mono">{colorLabel}</span>} />
 
       {canEdit && (
         <AppearanceEditDialog agent={agent} open={open} onOpenChange={setOpen} onSave={onSave} onRefresh={onRefresh} />
       )}
-    </Panel>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -5,7 +5,7 @@ import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigSection } from "./flat-section.js";
 import { ListRow } from "./list-row.js";
 import type { DraftListItem } from "./use-config-draft.js";
 
@@ -41,19 +41,19 @@ export function EnvSection(props: EnvSectionProps) {
     });
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
+  const action = !props.disabled ? (
+    <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+      <Plus className="h-3 w-3" /> Add
+    </Button>
+  ) : null;
+
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Environment variables ({activeCount})</PanelTitle>
-        {!props.disabled && (
-          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3 w-3" /> Add
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="space-y-2">
+    <ConfigSection eyebrow="resources" title="Environment variables" count={activeCount} action={action}>
+      <div>
         {props.items.length === 0 ? (
-          <p className="text-body text-muted-foreground">No environment variables.</p>
+          <p className="text-body text-muted-foreground" style={{ padding: "var(--sp-3) 0" }}>
+            No environment variables.
+          </p>
         ) : (
           props.items.map((item) => {
             const isSensitive = item.value.sensitive;
@@ -103,7 +103,7 @@ export function EnvSection(props: EnvSectionProps) {
             );
           })
         )}
-      </PanelBody>
+      </div>
       {dialog && (
         <EnvDialog
           open={!!dialog}
@@ -121,7 +121,7 @@ export function EnvSection(props: EnvSectionProps) {
           }}
         />
       )}
-    </Panel>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/flat-section.tsx
+++ b/packages/web/src/pages/agent-detail/flat-section.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+type ConfigSectionProps = {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  count?: ReactNode;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+export function ConfigSection({ eyebrow, title, count, action, children, className }: ConfigSectionProps) {
+  return (
+    <section className={cn("space-y-2", className)}>
+      <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end sm:gap-3">
+        <div className="min-w-0">
+          {eyebrow && (
+            <div className="mono uppercase text-eyebrow" style={{ color: "var(--fg-4)", marginBottom: "var(--sp-1)" }}>
+              {eyebrow}
+            </div>
+          )}
+          <div className="flex items-baseline gap-2">
+            <h2 className="text-subtitle" style={{ color: "var(--fg)" }}>
+              {title}
+            </h2>
+            {count != null && (
+              <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+                {count}
+              </span>
+            )}
+          </div>
+        </div>
+        {action}
+      </div>
+      <div style={{ borderTop: "var(--hairline) solid var(--border)" }}>{children}</div>
+    </section>
+  );
+}
+
+type ConfigRowProps = {
+  label: ReactNode;
+  value?: ReactNode;
+  description?: ReactNode;
+  meta?: ReactNode;
+  action?: ReactNode;
+  icon?: ReactNode;
+  danger?: boolean;
+  children?: ReactNode;
+};
+
+export function ConfigRow({ label, value, description, meta, action, icon, danger = false, children }: ConfigRowProps) {
+  return (
+    <div
+      className="grid grid-cols-1 gap-2 text-body md:gap-3 md:[grid-template-columns:minmax(10rem,0.7fr)_minmax(0,1.7fr)_auto_auto] md:items-center"
+      style={{
+        padding: "var(--sp-2_5) 0",
+        borderBottom: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {icon}
+        <span className="font-medium truncate" style={{ color: danger ? "var(--state-error)" : "var(--fg)" }}>
+          {label}
+        </span>
+      </div>
+      <div className="min-w-0 break-words">
+        {children ?? (
+          <>
+            {value != null && <div style={{ color: "var(--fg-2)" }}>{value}</div>}
+            {description && (
+              <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+                {description}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      {meta && <div className="shrink-0 md:justify-self-end">{meta}</div>}
+      {action && <div className="shrink-0 md:col-start-4 md:justify-self-end">{action}</div>}
+    </div>
+  );
+}
+
+type TableHeaderProps = {
+  columns: string[];
+  template: string;
+};
+
+export function ConfigTableHeader({ columns, template }: TableHeaderProps) {
+  return (
+    <div
+      className="grid gap-3 mono uppercase text-eyebrow"
+      style={{
+        gridTemplateColumns: template,
+        padding: "var(--sp-2) 0",
+        color: "var(--fg-4)",
+        borderBottom: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      {columns.map((c) => (
+        <div key={c}>{c}</div>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/pages/agent-detail/git-section.tsx
+++ b/packages/web/src/pages/agent-detail/git-section.tsx
@@ -5,7 +5,7 @@ import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigSection } from "./flat-section.js";
 import { ListRow } from "./list-row.js";
 import type { DraftListItem } from "./use-config-draft.js";
 
@@ -28,19 +28,19 @@ export function GitSection(props: GitSectionProps) {
   const [dialog, setDialog] = useState<{ mode: "add" } | { mode: "edit"; key: string; initial: GitRepo } | null>(null);
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
+  const action = !props.disabled ? (
+    <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+      <Plus className="h-3 w-3" /> Add
+    </Button>
+  ) : null;
+
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Git repositories ({activeCount})</PanelTitle>
-        {!props.disabled && (
-          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3 w-3" /> Add
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="space-y-2">
+    <ConfigSection eyebrow="resources" title="Git repositories" count={activeCount} action={action}>
+      <div>
         {props.items.length === 0 ? (
-          <p className="text-body text-muted-foreground">No Git repositories.</p>
+          <p className="text-body text-muted-foreground" style={{ padding: "var(--sp-3) 0" }}>
+            No Git repositories.
+          </p>
         ) : (
           props.items.map((item) => {
             const path = item.value.localPath ?? deriveRepoLocalPath(item.value.url);
@@ -60,7 +60,7 @@ export function GitSection(props: GitSectionProps) {
             );
           })
         )}
-      </PanelBody>
+      </div>
       {dialog && (
         <GitDialog
           open={!!dialog}
@@ -74,7 +74,7 @@ export function GitSection(props: GitSectionProps) {
           }}
         />
       )}
-    </Panel>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -10,9 +10,9 @@ import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
 import { useAgentIdentityMap } from "../../lib/use-agent-name-map.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
+import { ConfigRow, ConfigSection } from "./flat-section.js";
 
 /**
  * Redesign §5.3 Identity — a compact two-line summary plus a dedicated
@@ -40,64 +40,52 @@ export function IdentitySection({ agent, canEdit = true, onSave }: IdentitySecti
   const ownerName = agent.managerId ? resolveMember(agent.managerId) : null;
   const delegateIdentity = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
 
+  const action =
+    canEdit && agent.status === "active" ? (
+      <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+        <Pencil className="h-3 w-3" /> Edit
+      </Button>
+    ) : null;
+
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Profile</PanelTitle>
-        {canEdit && agent.status === "active" && (
-          <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
-            <Pencil className="h-3 w-3" /> Edit
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="text-body space-y-1">
-        <div>
-          <span className="font-semibold">{agent.displayName}</span>
-          {agent.name && <span className="ml-2 font-mono text-caption text-muted-foreground">@{agent.name}</span>}
-          {delegateIdentity && (
-            <>
-              <span className="mx-2 text-muted-foreground">·</span>
-              <span className="text-muted-foreground">
-                delegate <AgentChip name={delegateIdentity.name} displayName={delegateIdentity.displayName} />
-              </span>
-            </>
-          )}
-        </div>
-        <div className="text-caption text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span>
-            owner <span className="text-foreground">{ownerName ?? "—"}</span>
-          </span>
-          {role && (
-            <span>
-              role <span className="text-foreground">{role}</span>
+    <ConfigSection eyebrow="profile" title="Identity" action={action}>
+      <ConfigRow label="Display name" value={<span className="font-semibold">{agent.displayName}</span>} />
+      <ConfigRow label="Handle" value={agent.name ? <span className="font-mono">@{agent.name}</span> : "—"} />
+      {delegateIdentity && (
+        <ConfigRow
+          label="Delegate"
+          value={<AgentChip name={delegateIdentity.name} displayName={delegateIdentity.displayName} />}
+        />
+      )}
+      <ConfigRow label="Owner" value={ownerName ?? "—"} />
+      {role && <ConfigRow label="Role" value={role} />}
+      <ConfigRow
+        label="Type"
+        value={<DenseBadge tone={agent.type === "autonomous_agent" ? "accent" : "neutral"}>{agent.type}</DenseBadge>}
+      />
+      <ConfigRow
+        label="Visibility"
+        value={
+          <DenseBadge tone={agent.visibility === "organization" ? "accent" : "outline"}>{agent.visibility}</DenseBadge>
+        }
+      />
+      {domains.length > 0 && (
+        <ConfigRow
+          label="Domains"
+          value={
+            <span className="inline-flex flex-wrap gap-1 align-middle">
+              {domains.map((d) => (
+                <DenseBadge key={d} tone="outline">
+                  {d}
+                </DenseBadge>
+              ))}
             </span>
-          )}
-          <span>
-            type <DenseBadge tone={agent.type === "autonomous_agent" ? "accent" : "neutral"}>{agent.type}</DenseBadge>
-          </span>
-          <span>
-            visibility{" "}
-            <DenseBadge tone={agent.visibility === "organization" ? "accent" : "outline"}>
-              {agent.visibility}
-            </DenseBadge>
-          </span>
-          {domains.length > 0 && (
-            <span>
-              domains{" "}
-              <span className="inline-flex flex-wrap gap-1 align-middle">
-                {domains.map((d) => (
-                  <DenseBadge key={d} tone="outline">
-                    {d}
-                  </DenseBadge>
-                ))}
-              </span>
-            </span>
-          )}
-        </div>
-      </PanelBody>
+          }
+        />
+      )}
 
       {canEdit && <IdentityEditDialog agent={agent} open={open} onOpenChange={setOpen} onSave={onSave} />}
-    </Panel>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/list-row.tsx
+++ b/packages/web/src/pages/agent-detail/list-row.tsx
@@ -37,9 +37,13 @@ export function ListRow({ status, onEdit, onDelete, onUndo, children, disabled }
   return (
     <div
       className={cn(
-        "flex items-center gap-2 rounded border px-3 py-2 text-body",
-        isDeleted ? "bg-error-soft border-error text-error line-through decoration-error" : "bg-card",
+        "flex items-center gap-2 text-body transition-colors",
+        isDeleted ? "text-error line-through decoration-error" : "hover:bg-accent",
       )}
+      style={{
+        padding: "var(--sp-2_5) 0",
+        borderBottom: "var(--hairline) solid var(--border-faint)",
+      }}
     >
       <div className="flex-1 min-w-0 flex items-center gap-2">{children}</div>
       {badge.label && (

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -6,7 +6,7 @@ import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigSection } from "./flat-section.js";
 import { ListRow } from "./list-row.js";
 import type { DraftListItem } from "./use-config-draft.js";
 
@@ -46,19 +46,19 @@ export function McpSection(props: McpSectionProps) {
   );
   const activeCount = props.items.filter((i) => i.status !== "deleted").length;
 
+  const action = !props.disabled ? (
+    <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
+      <Plus className="h-3 w-3" /> Add
+    </Button>
+  ) : null;
+
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>MCP servers ({activeCount})</PanelTitle>
-        {!props.disabled && (
-          <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-            <Plus className="h-3 w-3" /> Add
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="space-y-2">
+    <ConfigSection eyebrow="tools" title="MCP servers" count={activeCount} action={action}>
+      <div>
         {props.items.length === 0 ? (
-          <p className="text-body text-muted-foreground">No MCP servers. Add one to extend the agent's tools.</p>
+          <p className="text-body text-muted-foreground" style={{ padding: "var(--sp-3) 0" }}>
+            No MCP servers. Add one to extend the agent's tools.
+          </p>
         ) : (
           props.items.map((item) => {
             const health: McpToolHealth | null = props.toolHealth
@@ -83,7 +83,7 @@ export function McpSection(props: McpSectionProps) {
             );
           })
         )}
-      </PanelBody>
+      </div>
 
       {dialog && (
         <McpDialog
@@ -98,7 +98,7 @@ export function McpSection(props: McpSectionProps) {
           }}
         />
       )}
-    </Panel>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -3,7 +3,7 @@ import { Check, ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "../../components/ui/button.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigRow } from "./flat-section.js";
 
 /**
  * Model — an inline dropdown with a "changed" hint and Revert. No inline save:
@@ -77,39 +77,38 @@ export function ModelSection({
   }, [presetOptions, value]);
 
   return (
-    <Panel
-      style={{
-        borderColor: dirty ? "color-mix(in oklch, var(--state-blocked) 70%, transparent)" : undefined,
-      }}
-    >
-      <PanelHeader>
-        <PanelTitle>
-          Model
-          {dirty && (
-            <span
-              className="mono uppercase text-caption"
-              style={{
-                padding: "var(--hairline) var(--sp-1_5)",
-                borderRadius: "var(--radius-chip)",
-                background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
-                color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
-              }}
-            >
-              changed
-            </span>
-          )}
-        </PanelTitle>
-        {dirty && (
+    <ConfigRow
+      label="Model"
+      meta={dirty ? <ChangedChip /> : null}
+      action={
+        dirty ? (
           <Button size="xs" variant="ghost" onClick={onRevert} disabled={disabled}>
             Revert
           </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="space-y-2">
+        ) : null
+      }
+    >
+      <div className="space-y-2">
         <ModelDropdown items={items} value={value} onChange={onChange} disabled={disabled} />
         <p className="text-caption text-muted-foreground">{MODEL_HELP_BY_PROVIDER[provider]}</p>
-      </PanelBody>
-    </Panel>
+      </div>
+    </ConfigRow>
+  );
+}
+
+function ChangedChip() {
+  return (
+    <span
+      className="mono uppercase text-caption"
+      style={{
+        padding: "var(--hairline) var(--sp-1_5)",
+        borderRadius: "var(--radius-chip)",
+        background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+        color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
+      }}
+    >
+      changed
+    </span>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/profile-tab.tsx
+++ b/packages/web/src/pages/agent-detail/profile-tab.tsx
@@ -2,6 +2,7 @@ import { Link2 } from "lucide-react";
 import { useNavigate } from "react-router";
 import { Button } from "../../components/ui/button.js";
 import { AppearanceSection } from "./appearance-section.js";
+import { ConfigRow, ConfigSection } from "./flat-section.js";
 import { IdentitySection } from "./identity-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
@@ -18,17 +19,23 @@ export function ProfileTab() {
         onRefresh={ctx.refreshAgent}
       />
       {ctx.canManageAgent && (
-        <div className="flex justify-end">
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={() => navigate(`/settings/integrations?agent=${ctx.agent.uuid}`)}
-            title="Manage platform bindings in Integrations"
-          >
-            <Link2 className="h-3 w-3" />
-            Manage platform bindings
-          </Button>
-        </div>
+        <ConfigSection
+          eyebrow="profile"
+          title="Platform bindings"
+          action={
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => navigate(`/settings/integrations?agent=${ctx.agent.uuid}`)}
+              title="Manage platform bindings in Integrations"
+            >
+              <Link2 className="h-3 w-3" />
+              Manage
+            </Button>
+          }
+        >
+          <ConfigRow label="Integrations" value="Manage external platform bindings for this agent." />
+        </ConfigSection>
       )}
     </>
   );

--- a/packages/web/src/pages/agent-detail/prompt-section.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-section.tsx
@@ -2,7 +2,7 @@ import { Pencil } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "../../components/ui/button.js";
 import { Markdown } from "../../components/ui/markdown.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigSection } from "./flat-section.js";
 
 /**
  * System Prompt Append — inline editor, no dialog. `Done` collapses the editor
@@ -27,25 +27,25 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
     if (editing) taRef.current?.focus();
   }, [editing]);
 
+  const action =
+    !editing && !disabled ? (
+      <Button size="xs" variant="outline" onClick={() => setEditing(true)}>
+        <Pencil className="h-3 w-3" /> Edit
+      </Button>
+    ) : null;
+
   return (
-    <Panel
-      style={{
-        borderColor: dirty ? "color-mix(in oklch, var(--state-blocked) 70%, transparent)" : undefined,
-      }}
-    >
-      <PanelHeader>
-        <PanelTitle>
+    <ConfigSection
+      eyebrow="prompt"
+      title={
+        <span className="inline-flex items-center gap-2">
           System prompt append
           {dirty && <ChangedChip />}
-        </PanelTitle>
-        {!editing && !disabled && (
-          <Button size="xs" variant="outline" onClick={() => setEditing(true)}>
-            <Pencil className="h-3 w-3" /> Edit
-          </Button>
-        )}
-      </PanelHeader>
-
-      <PanelBody>
+        </span>
+      }
+      action={action}
+    >
+      <div style={{ padding: "var(--sp-3) 0" }}>
         {editing ? (
           <div className="space-y-2">
             <textarea
@@ -80,13 +80,10 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
                 Done
               </Button>
             </div>
-            <p className="text-caption text-muted-foreground">
-              `Done` collapses this editor. The change is saved only when you click Save in the bar at the bottom of the
-              page.
-            </p>
+            <p className="text-caption text-muted-foreground">Use Save below to apply this prompt change.</p>
           </div>
         ) : (
-          <div className="rounded bg-muted p-3 text-body max-h-64 overflow-auto min-h-8">
+          <div className="text-body max-h-64 overflow-auto min-h-8">
             {value ? (
               <Markdown>{value}</Markdown>
             ) : (
@@ -94,8 +91,8 @@ export function PromptSection({ value, baseline, onChange, onRevert, disabled }:
             )}
           </div>
         )}
-      </PanelBody>
-    </Panel>
+      </div>
+    </ConfigSection>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/setup-section.tsx
+++ b/packages/web/src/pages/agent-detail/setup-section.tsx
@@ -2,7 +2,7 @@ import type { RuntimeProvider } from "@agent-team-foundation/first-tree-hub-shar
 import { Link2, Lock, Play } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "../../components/ui/button.js";
-import { Panel, PanelBody, PanelHeader, PanelTitle } from "../../components/ui/panel.js";
+import { ConfigRow, ConfigSection } from "./flat-section.js";
 
 /**
  * Setup section — "where it runs" pick (locked here, re-bindable via the
@@ -42,10 +42,9 @@ const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> =
 export function SetupSection(props: SetupSectionProps) {
   const copy = RUNTIME_COPY[props.runtimeProvider];
   return (
-    <div className="space-y-3">
-      <RuntimeCard name={copy.name} caption={copy.caption} locked />
-
-      <ComputerCard
+    <ConfigSection eyebrow="setup" title="Runtime">
+      <RuntimeRow name={copy.name} caption={copy.caption} locked />
+      <ComputerRow
         computerLabel={props.computerLabel}
         statusLoading={props.computerStatusLoading ?? false}
         statusError={props.computerStatusError ?? null}
@@ -54,42 +53,30 @@ export function SetupSection(props: SetupSectionProps) {
         onBindComputer={props.onBindComputer}
         onRebind={props.onRebind}
       />
-
       {props.modelSlot}
-    </div>
+    </ConfigSection>
   );
 }
 
-function RuntimeCard({ name, caption, locked }: { name: string; caption: string; locked: boolean }) {
+function RuntimeRow({ name, caption, locked }: { name: string; caption: string; locked: boolean }) {
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>
-          Where it runs
-          {locked && (
-            <span
-              className="mono uppercase text-caption inline-flex items-center gap-1"
-              style={{ color: "var(--fg-4)" }}
-            >
-              <Lock className="h-3 w-3" aria-hidden /> locked
-            </span>
-          )}
-        </PanelTitle>
-      </PanelHeader>
-      <PanelBody className="space-y-1 text-body">
-        <div className="inline-flex items-center gap-2">
-          <Play className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--accent)" }} />
-          <span className="font-medium">{name}</span>
-        </div>
-        <p className="text-caption" style={{ color: "var(--fg-3)" }}>
-          {caption}
-        </p>
-      </PanelBody>
-    </Panel>
+    <ConfigRow
+      label="Provider"
+      icon={<Play className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--accent)" }} />}
+      value={name}
+      description={caption}
+      meta={
+        locked ? (
+          <span className="mono uppercase text-caption inline-flex items-center gap-1" style={{ color: "var(--fg-4)" }}>
+            <Lock className="h-3 w-3" aria-hidden /> locked
+          </span>
+        ) : null
+      }
+    />
   );
 }
 
-function ComputerCard(props: {
+function ComputerRow(props: {
   computerLabel: string | null;
   statusLoading: boolean;
   statusError: string | null;
@@ -100,49 +87,37 @@ function ComputerCard(props: {
 }) {
   const bound = !!props.computerLabel;
   const canShowActions = !props.statusLoading && !props.statusError;
-  return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Bound computer</PanelTitle>
-        {canShowActions && props.canBindComputer && props.onBindComputer && !bound && (
-          <Button
-            size="xs"
-            variant="outline"
-            onClick={props.onBindComputer}
-            disabled={props.bindPending}
-            title={props.bindPending ? "Binding computer…" : "Pick a connected computer for this agent"}
-          >
-            <Link2 className="h-3 w-3" />
-            {props.bindPending ? "Binding…" : "Bind computer"}
-          </Button>
-        )}
-        {canShowActions && bound && props.onRebind && (
-          <Button size="xs" variant="outline" onClick={props.onRebind} title="Move this agent to another computer">
-            <Link2 className="h-3 w-3" />
-            Re-bind
-          </Button>
-        )}
-      </PanelHeader>
-      <PanelBody className="text-body">
-        {props.statusLoading ? (
-          <p className="text-caption" style={{ color: "var(--fg-3)" }}>
-            Checking computer binding…
-          </p>
-        ) : props.statusError ? (
-          <p className="text-caption" style={{ color: "var(--state-error)" }}>
-            Could not verify computer binding: {props.statusError}
-          </p>
-        ) : bound ? (
-          <div className="mono" style={{ color: "var(--fg-2)" }}>
-            {props.computerLabel}
-          </div>
-        ) : (
-          <p className="text-caption" style={{ color: "var(--fg-3)" }}>
-            No computer bound. A computer claims this agent on its first WebSocket connect, or you can pick one manually
-            via the button above.
-          </p>
-        )}
-      </PanelBody>
-    </Panel>
-  );
+  const action =
+    canShowActions && props.canBindComputer && props.onBindComputer && !bound ? (
+      <Button
+        size="xs"
+        variant="outline"
+        onClick={props.onBindComputer}
+        disabled={props.bindPending}
+        title={props.bindPending ? "Binding computer…" : "Pick a connected computer for this agent"}
+      >
+        <Link2 className="h-3 w-3" />
+        {props.bindPending ? "Binding…" : "Bind computer"}
+      </Button>
+    ) : canShowActions && bound && props.onRebind ? (
+      <Button size="xs" variant="outline" onClick={props.onRebind} title="Move this agent to another computer">
+        <Link2 className="h-3 w-3" />
+        Re-bind
+      </Button>
+    ) : null;
+
+  let value: ReactNode = props.computerLabel;
+  let description: ReactNode = "The computer environment and tool access for this agent.";
+  if (props.statusLoading) {
+    value = "Checking computer binding…";
+    description = null;
+  } else if (props.statusError) {
+    value = <span style={{ color: "var(--state-error)" }}>Could not verify computer binding: {props.statusError}</span>;
+    description = null;
+  } else if (!bound) {
+    value = "No computer bound";
+    description = "A computer claims this agent on first WebSocket connect, or you can pick one manually.";
+  }
+
+  return <ConfigRow label="Computer" value={value} description={description} action={action} />;
 }


### PR DESCRIPTION
## Summary

- Replace heavy card-style panels inside agent configuration tabs with lightweight `ConfigSection` / `ConfigRow` layouts.
- Flatten Profile, Setup, Prompt, Tools, and Resources tab internals into hairline-separated rows while preserving existing edit dialogs and actions.
- Lighten list rows for env vars, MCP servers, and Git repos so the page keeps the minimal top-tab style.

## Why

The agent configuration page had already moved to top tabs, but each tab still used many bordered cards. This made the internal layout feel heavier than the rest of the page. The new row-based structure keeps module boundaries clear with less visual weight.

## Validation

- `pnpm exec biome check packages/web/src/pages/agent-detail`
- `pnpm --filter @first-tree-hub/web typecheck`
- `pnpm --dir packages/web exec vitest run src/pages/agent-detail`
- `pnpm --filter @agent-team-foundation/first-tree-hub-shared build`
- `pnpm --filter @first-tree-hub/web build`

Note: web build passes with the existing Vite chunk-size warning.
