### PR TITLE
refactor(web): unify admin canvas to 960 and contain wide cells

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -134,7 +134,18 @@ export function Layout() {
         <Outlet />
       ) : (
         <main className="flex-1 overflow-auto">
-          <div className="p-6 mx-auto" style={{ maxWidth: 1280 }}>
+          {/* Canvas width 960 is the single shared content width across
+              Context / Team / Settings / Agent Detail. Chosen as the
+              comfortable upper bound for configuration- and editing-heavy
+              admin pages (GitHub uses ~896, Vercel ~880, Linear ~960). Below
+              the lg breakpoint padding tightens so 960 + p-6 = 1008 logical
+              units doesn't force a horizontal scrollbar on smaller viewports.
+              The Team table's column widths sum to ~870 — at viewports
+              narrower than ~810 the table overflows into main's own scroll;
+              that's the standard "wide table → local horizontal scroll"
+              pattern (GitHub, Stripe both do this), and the page chrome
+              never scrolls horizontally. */}
+          <div className="p-4 lg:p-6 mx-auto" style={{ maxWidth: 960 }}>
             <Outlet />
           </div>
         </main>

--- a/packages/web/src/pages/agent-detail/git-section.tsx
+++ b/packages/web/src/pages/agent-detail/git-section.tsx
@@ -53,9 +53,21 @@ export function GitSection(props: GitSectionProps) {
                 onUndo={() => props.onUndoDelete(item.key)}
                 disabled={props.disabled}
               >
-                <span className="font-mono text-caption">{item.value.url}</span>
-                {item.value.ref && <span className="text-caption text-muted-foreground">@ {item.value.ref}</span>}
-                <span className="text-caption text-muted-foreground">→ {path || "./"}</span>
+                {/* URL is the primary long token (GitHub URLs run 60-120
+                    chars); flex-1 + min-w-0 + truncate keeps it contained
+                    inside the row instead of pushing past the page canvas. */}
+                <span className="font-mono text-caption truncate min-w-0 flex-1" title={item.value.url}>
+                  {item.value.url}
+                </span>
+                {item.value.ref && (
+                  <span className="text-caption text-muted-foreground shrink-0">@ {item.value.ref}</span>
+                )}
+                <span
+                  className="text-caption text-muted-foreground truncate min-w-0 max-w-xs"
+                  title={`→ ${path || "./"}`}
+                >
+                  → {path || "./"}
+                </span>
               </ListRow>
             );
           })

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -75,10 +75,21 @@ export function McpSection(props: McpSectionProps) {
                 onUndo={() => props.onUndoDelete(item.key)}
                 disabled={props.disabled}
               >
-                <span className="text-caption rounded bg-muted px-1.5 py-0.5 font-mono">{item.value.transport}</span>
-                <span className="font-medium font-mono">{item.value.name}</span>
+                <span className="text-caption rounded bg-muted px-1.5 py-0.5 font-mono shrink-0">
+                  {item.value.transport}
+                </span>
+                <span className="font-medium font-mono shrink-0">{item.value.name}</span>
                 {health && <DenseBadge tone={toolHealthBadgeTone(health)}>{health}</DenseBadge>}
-                <span className="text-caption text-muted-foreground truncate">{describeMcp(item.value)}</span>
+                {/* Long URLs / commands must truncate inside their flex slot;
+                    without flex-1 + min-w-0 the span hugs its content width
+                    and pushes the row past its parent. title surfaces the
+                    full value on hover. */}
+                <span
+                  className="text-caption text-muted-foreground truncate flex-1 min-w-0"
+                  title={describeMcp(item.value)}
+                >
+                  {describeMcp(item.value)}
+                </span>
               </ListRow>
             );
           })

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -89,12 +89,12 @@ type Props = {
 };
 
 const COLUMNS = [
-  // Name (220) holds displayName + @handle. The internal NameCell already
-  // truncates both lines with a `title` tooltip on overflow, so 220 covers
-  // the realistic 90th-percentile name pair and longer names degrade
-  // gracefully. Down from 260 — the freed width is redistributed to
-  // Delegate / Manager which were causing 2-line wraps at 160.
-  { key: "name", label: "Name", width: 220 },
+  // Column widths sum to ~870 so the table renders without horizontal
+  // compression inside the shared 960 page canvas (960 − 48 layout padding
+  // − 40 page padding ≈ 872 content width). Every populated cell already
+  // truncates with a `title` tooltip, so realistic long names degrade
+  // gracefully without forcing the column wider.
+  { key: "name", label: "Name", width: 200 },
   // Delegate and Manager are split into separate columns so each header
   // carries exactly one meaning. Human rows fill Delegate (the assistant
   // acting on their behalf) and leave Manager as `—`; agent rows fill
@@ -105,30 +105,15 @@ const COLUMNS = [
   // one column and leaves the other empty — the half-blank pattern reads
   // as section structure, not missing data, and neither column has to
   // mean two things at once.
-  //
-  // 180 (up from 160): the cell renders an AgentChip ("Display Name
-  // @handle") which at 160 wrapped onto two lines for typical agent names
-  // — the bump keeps it on one line and the inner truncate handles the
-  // long tail, mirroring Runs on.
-  { key: "delegate", label: "Delegate", width: 180 },
-  { key: "manager", label: "Manager", width: 180 },
-  // The cell renders `<runtime-provider> @ <host>` in one line — covers
-  // both framework and host together (plain "Runtime" only described the
-  // framework half). Wider than the other middle columns because the
-  // combined `claude-code @ alice-macbook` form runs roughly 25-30 chars;
-  // this wider column fits most everyday cases, and longer corporate
-  // FQDNs gracefully truncate with the `title` tooltip showing full value.
-  // Status (live operational state) is the orthogonal axis and stays in
-  // its own column so config and live state don't share a cell. Both
-  // blank for human rows.
-  { key: "runtime", label: "Runs on", width: 220 },
-  { key: "status", label: "Status", width: 160 },
-  { key: "created", label: "Created", width: 160 },
-  // Middle columns mostly pin to 160-180 for grid rhythm. Runs on opts out
-  // at 220 because its content (provider + host) is denser than the
-  // others. Name stays wider (variable display-name + @handle) and Actions
-  // stays narrow (single kebab icon) — those sit at the content-density
-  // extremes.
+  { key: "delegate", label: "Delegate", width: 140 },
+  { key: "manager", label: "Manager", width: 140 },
+  // Runtime cell renders `<runtime-provider> @ <host>` truncated with a
+  // tooltip — 170 fits the typical `claude-code @ alice-macbook` form on
+  // one line and longer FQDNs ellipsize cleanly. Status (live operational
+  // state) is the orthogonal axis and stays in its own column.
+  { key: "runtime", label: "Runs on", width: 170 },
+  { key: "status", label: "Status", width: 88 },
+  { key: "created", label: "Created", width: 88 },
   { key: "actions", label: "", width: 44 },
 ] as const;
 


### PR DESCRIPTION
## Summary

- Replace the legacy 1280 max-width applied to every non-Workspace page with a single 960 canvas shared by Context, Team, Settings, and Agent Detail — the comfortable upper bound for configuration- and editing-heavy admin pages (GitHub uses ~896, Vercel ~880, Linear ~960). Workspace keeps its full-width multi-panel layout.
- 1280 was chosen to fit the widest table (Team) and then forced on every other page, which pushed Settings input fields past 80 characters per line and left Context's 920 SVG floating in ~360 logical units of empty space. Pulling the canvas in to 960 brings the editing-focused pages into their natural prose width while leaving Team enough room to render natively.
- Trim Team table column widths from a 1164 sum to ~870 so the table renders at its native size inside the 960 canvas. table-fixed + per-cell truncate were already in place — column widths were the gap. Status / Created collapse to their content width; Name / Delegate / Manager / Runs-on reclaim the freed space.
- MCP server rows move the describeMcp text into a flex-1 + min-w-0 slot with a title tooltip so long URLs / stdio commands truncate cleanly instead of pushing the row past its parent.
- Git repository rows get the same treatment for the repo URL and a max-w-xs cap on the derived local path. The cells previously had no truncate at all — a typical GitHub URL would push the row well past the 1280 canvas, never mind 960.
- Layout padding tightens (p-4 → p-6 at the lg breakpoint) so the 960 canvas plus padding doesn't force horizontal scroll on viewports below the desktop target.

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm --filter @first-tree-hub/web typecheck` — tsc + design-token guardrails clean
- [x] `pnpm --filter @first-tree-hub/web test` — 167 tests pass
- [x] Browser-checked at viewport 1440 / 1023 / 768 across Workspace, Context, Team, Settings, and the five agent-detail tabs (Profile / Setup / Prompt / Tools / Resources) — no document-level horizontal scroll on any of them.
- [ ] Review by an owner of the admin pages — column-width / canvas decisions are visual taste calls worth a second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)