### PR TITLE
[codex] Align settings layout with top config tabs

### DIFF
--- a/packages/web/src/components/ui/settings-section.tsx
+++ b/packages/web/src/components/ui/settings-section.tsx
@@ -1,40 +1,34 @@
 import type { ReactNode } from "react";
 
 /**
- * Section frame for Settings master-detail pages. The first section in a
- * page renders without a top divider (it sits flush against the page
- * header); every subsequent section gets a hairline rule above so the
- * page reads as a clean vertical stack of related-but-distinct
- * configuration groups, not a jumble of forms.
+ * Section frame for Settings pages. Mirrors the agent configuration
+ * sections: compact heading, optional metadata at the right, then a single
+ * hairline before the fields/list rows. The page reads as a clean stack
+ * without card frames or sidebar-era visual weight.
  *
  * Title sits as a normal H2 with optional one-line description below;
  * the optional `right` slot is for inline metadata (e.g. count badge).
- * Form-style sections put their Save button at the *bottom* of the
- * children, not in the right slot — see the existing Settings panels
- * for the pattern.
+ * Form-style sections put their Save button next to the relevant field,
+ * not in the right slot — see the existing Settings panels for the pattern.
  */
 export function SettingsSection({
   title,
   description,
   right,
   children,
-  isFirst = false,
 }: {
   title: string;
   description?: string;
   right?: ReactNode;
   children: ReactNode;
-  /** Pass `true` to suppress the top divider — the first section in a stack. */
-  isFirst?: boolean;
 }) {
   return (
     <section
       style={{
-        padding: "var(--sp-6) 0",
-        borderTop: isFirst ? undefined : "var(--hairline) solid var(--border-faint)",
+        padding: "var(--sp-4) 0",
       }}
     >
-      <div className="flex items-baseline justify-between" style={{ gap: "var(--sp-3)" }}>
+      <div className="flex items-end justify-between" style={{ gap: "var(--sp-3)" }}>
         <div style={{ minWidth: 0 }}>
           <h2 className="text-subtitle font-medium m-0" style={{ color: "var(--fg)" }}>
             {title}
@@ -47,7 +41,15 @@ export function SettingsSection({
         </div>
         {right}
       </div>
-      <div style={{ marginTop: "var(--sp-4)" }}>{children}</div>
+      <div
+        style={{
+          marginTop: "var(--sp-2)",
+          paddingTop: "var(--sp-3)",
+          borderTop: "var(--hairline) solid var(--border)",
+        }}
+      >
+        {children}
+      </div>
     </section>
   );
 }

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -14,7 +14,7 @@ import { SettingsSection } from "../components/ui/settings-section.js";
  * binding at startup, existing sessions keep the value they were spun up
  * with. Admins should advise members to restart agents after editing.
  */
-export function ContextTreeSettingsPanel({ isFirst = false }: { isFirst?: boolean }) {
+export function ContextTreeSettingsPanel() {
   const { organizationId } = useAuth();
   const queryClient = useQueryClient();
 
@@ -58,7 +58,6 @@ export function ContextTreeSettingsPanel({ isFirst = false }: { isFirst?: boolea
     <SettingsSection
       title="Context tree"
       description="Changes apply to new agent sessions. Members should restart agents to pick up updated tree contents."
-      isFirst={isFirst}
     >
       {settingQuery.isLoading ? (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -23,7 +23,7 @@ import { SettingsSection } from "../components/ui/settings-section.js";
  * webhook delivery is paused on GitHub's side and the binding is
  * effectively inactive until unsuspended.
  */
-export function GithubAppInstallationPanel({ isFirst = false }: { isFirst?: boolean }) {
+export function GithubAppInstallationPanel() {
   const { organizationId } = useAuth();
 
   const installationQuery = useQuery({
@@ -36,7 +36,6 @@ export function GithubAppInstallationPanel({ isFirst = false }: { isFirst?: bool
     <SettingsSection
       title="GitHub App"
       description="One installation unlocks user sign-in, webhook ingestion, and (later) server-side write access."
-      isFirst={isFirst}
     >
       {installationQuery.isLoading ? (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>

--- a/packages/web/src/pages/org-settings.tsx
+++ b/packages/web/src/pages/org-settings.tsx
@@ -33,9 +33,9 @@ export function OrgSettingsPage() {
 
   return (
     <div>
-      {isAdmin && <TeamIdentityPanel isFirst />}
+      {isAdmin && <TeamIdentityPanel />}
       {isAdmin && <ContextTreeSettingsPanel />}
-      <SourceReposSettingsPanel isFirst={!isAdmin} />
+      <SourceReposSettingsPanel />
     </div>
   );
 }

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -3,8 +3,9 @@ import { useAuth } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
 
 /**
- * Settings is a master-detail container. Flat aesthetic — no borders, no
- * contrasting sidebar bg; active state is a soft pill.
+ * Settings is a top-tab container. It follows the same flat rhythm as
+ * the agent configuration page: no secondary sidebar, one thin tab rule,
+ * and each sub-route owns its compact page header + sections.
  *
  * Sub-tabs:
  *   Team           — org-scoped Identity / Context Tree / Source repos
@@ -16,12 +17,20 @@ import { cn } from "../lib/utils.js";
  *   Messaging      — IM bridges (Feishu / Slack adapter CRUD)
  *   Onboarding     — guided-setup stepper enable / disable
  *
- * `GitHub` is hidden from the member sidebar because both reads and writes
+ * `GitHub` is hidden from the member tab bar because both reads and writes
  * are admin-gated server-side — surfacing the entry would just lead to a
  * 403 inside.
  */
 export function SettingsLayout() {
-  const { role, onboardingCompletedAt } = useAuth();
+  const { role, onboardingCompletedAt, meLoaded } = useAuth();
+  // Wait for `/me` to resolve before rendering the nav — otherwise a fresh
+  // direct hit on /settings/github would briefly paint the member-view tab
+  // set (no GitHub, plus Onboarding) before `role` flips to "admin". The
+  // sidebar-era variant tolerated that flash visually; the top-tab variant
+  // makes it obvious.
+  if (!meLoaded) {
+    return null;
+  }
   const isAdmin = role === "admin";
   // Once Step 3 succeeds (`onboarding_completed_at` stamped), the wizard
   // is a terminal — subsequent tree / source-repo edits live in Settings →
@@ -31,12 +40,19 @@ export function SettingsLayout() {
   const hasCompletedOnboarding = onboardingCompletedAt !== null;
 
   return (
-    <div className="-m-6 flex" style={{ minHeight: "calc(100vh - var(--sp-10))" }}>
-      <aside
-        className="shrink-0 overflow-auto"
+    <div className="-m-6 flex flex-col" style={{ minHeight: "calc(100vh - var(--sp-10))" }}>
+      <nav
+        aria-label="Settings"
+        className="flex items-end overflow-x-auto"
         style={{
-          width: 200,
-          padding: "var(--sp-4) var(--sp-2)",
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
+          gap: 2,
+          height: 34,
+          padding: "0 var(--sp-5)",
+          background: "var(--bg-raised)",
+          borderBottom: "var(--hairline) solid var(--border)",
         }}
       >
         <SubNavLink to="/settings/team" label="Team" />
@@ -44,9 +60,9 @@ export function SettingsLayout() {
         {isAdmin && <SubNavLink to="/settings/github" label="GitHub" />}
         <SubNavLink to="/settings/integrations" label="Messaging" />
         {!hasCompletedOnboarding && <SubNavLink to="/settings/onboarding" label="Onboarding" />}
-      </aside>
+      </nav>
 
-      <div className="flex-1 min-w-0 overflow-auto">
+      <div className="flex-1 min-w-0">
         <Outlet />
       </div>
     </div>
@@ -57,29 +73,24 @@ function SubNavLink({ to, label }: { to: string; label: string }) {
   return (
     <NavLink
       to={to}
-      className={({ isActive }) =>
-        cn(
-          "block w-full text-left bg-transparent text-body transition-colors",
-          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-          !isActive && "hover:bg-accent",
-        )
-      }
-      style={{
-        borderRadius: "var(--radius-input)",
-      }}
+      className={cn(
+        "inline-flex items-center bg-transparent text-body font-medium",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      )}
     >
       {({ isActive }) => (
         <span
-          className="flex items-center"
+          className={cn(
+            "inline-flex items-center whitespace-nowrap transition-colors",
+            isActive ? "text-[var(--fg)]" : "text-[var(--fg-3)] hover:text-[var(--fg)]",
+          )}
           style={{
-            padding: "var(--sp-1_25) var(--sp-2_5)",
-            background: isActive ? "var(--bg-active)" : "transparent",
-            color: isActive ? "var(--fg)" : "var(--fg-3)",
-            fontWeight: isActive ? 500 : 400,
-            borderRadius: "var(--radius-input)",
+            padding: "var(--sp-1_75) var(--sp-3)",
+            marginBottom: -1,
+            borderBottom: `var(--hairline-bold) solid ${isActive ? "var(--accent)" : "transparent"}`,
           }}
         >
-          <span className="flex-1 truncate">{label}</span>
+          {label}
         </span>
       )}
     </NavLink>

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -32,7 +32,7 @@ export function SettingsGithubPage() {
     <>
       <PageHeader title="GitHub" subtitle="Connected GitHub App and granted permissions" />
       <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
-        <GithubAppInstallationPanel isFirst />
+        <GithubAppInstallationPanel />
       </div>
     </>
   );

--- a/packages/web/src/pages/settings/onboarding.tsx
+++ b/packages/web/src/pages/settings/onboarding.tsx
@@ -45,7 +45,6 @@ export function SettingsOnboardingPage() {
               : "The stepper is shown above your workspace. You can hide it any time once your agent is set up."
           }
           right={isDismissed ? null : <ActiveBadge />}
-          isFirst
         >
           {isDismissed ? (
             <Button type="button" size="sm" onClick={() => void restoreOnboarding()}>

--- a/packages/web/src/pages/source-repos-settings-panel.tsx
+++ b/packages/web/src/pages/source-repos-settings-panel.tsx
@@ -20,7 +20,7 @@ import { SettingsSection } from "../components/ui/settings-section.js";
  * GitHub picker and that lives in the onboarding flow today. A second
  * pass will extract the picker into a reusable component.
  */
-export function SourceReposSettingsPanel({ isFirst = false }: { isFirst?: boolean }) {
+export function SourceReposSettingsPanel() {
   const { organizationId, role } = useAuth();
   const isAdmin = role === "admin";
   const queryClient = useQueryClient();
@@ -61,7 +61,6 @@ export function SourceReposSettingsPanel({ isFirst = false }: { isFirst?: boolea
           : "Repos your team's agents are bound to. Read-only — only admins can edit."
       }
       right={countBadge}
-      isFirst={isFirst}
     >
       {settingQuery.isLoading ? (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>

--- a/packages/web/src/pages/team-identity-panel.tsx
+++ b/packages/web/src/pages/team-identity-panel.tsx
@@ -12,7 +12,7 @@ import { SettingsSection } from "../components/ui/settings-section.js";
  * (display name) — already a friendly default — so there's no separate
  * "rename hint" surface; admins who want to customize just edit the form.
  */
-export function TeamIdentityPanel({ isFirst = false }: { isFirst?: boolean }) {
+export function TeamIdentityPanel() {
   const { organizationId } = useAuth();
   const queryClient = useQueryClient();
 
@@ -53,7 +53,7 @@ export function TeamIdentityPanel({ isFirst = false }: { isFirst?: boolean }) {
   };
 
   return (
-    <SettingsSection title="Identity" isFirst={isFirst}>
+    <SettingsSection title="Identity">
       {orgQuery.isLoading ? (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>
           Loading…


### PR DESCRIPTION
## Summary
- Move Settings navigation into a top secondary nav under a Settings page header.
- Keep settings subpages minimal by tightening SettingsSection spacing and separators.
- Address review feedback by using normal nav/link semantics instead of partial ARIA tabs, using NavLink active state, and keeping the secondary nav sticky during long-page scroll.

## Review Follow-up
- Removed the outer Settings PageHeader so child routes keep the only page header.
- Removed the extra SettingsSection top divider.
- Aligned the settings nav visual tokens with the existing TabBar.
- Changed the /me loading gate to return null.
- Removed the dead `isFirst` prop and all call sites.
- Replaced span mouse handlers with CSS hover styling to satisfy biome a11y.

## Validation
- pnpm check
- pnpm --filter @first-tree-hub/web typecheck
- pnpm --filter @first-tree-hub/web test
- pnpm --filter @first-tree-hub/web build