### PR TITLE
fix(web,server): project agent avatar color & image into chat-detail surfaces

### DIFF
--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -20,6 +20,8 @@ function mkParticipant(agentId: string, name: string | null, displayName?: strin
     // back to a synthetic label when the caller doesn't provide one.
     displayName: displayName ?? `agent-${agentId}`,
     type: "autonomous_agent",
+    avatarColorToken: null,
+    avatarImageUrl: null,
   };
 }
 

--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -12,6 +12,8 @@ function mkParticipant(extras: Partial<ChatParticipantDetail>): ChatParticipantD
     name: extras.name ?? "default-name",
     displayName: extras.displayName ?? "Default Name",
     type: extras.type ?? "autonomous_agent",
+    avatarColorToken: extras.avatarColorToken ?? null,
+    avatarImageUrl: extras.avatarImageUrl ?? null,
   };
 }
 

--- a/packages/server/src/__tests__/chat-detail-avatar-fields.test.ts
+++ b/packages/server/src/__tests__/chat-detail-avatar-fields.test.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { createChat } from "../services/chat.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Regression: the chat-detail surface used to drop the manager-configured
+ * `avatarColorToken` / `avatarImageUrl` from the wire shape of every
+ * `/chats/:chatId` route (admin and agent), even though the SELECT pulled
+ * them out of the agents JOIN. The web client (header chips + right-sidebar
+ * agent rows) then fell back to the deterministic djb2-hash hue, so a hue
+ * the manager set in Appearance never showed on those surfaces.
+ *
+ * Pin: every chat-participant payload exposes both fields, mirroring
+ * `meChatParticipantSchema` so the chat-detail and left-rail renders agree.
+ */
+describe("chat-detail wire shape — participant avatar fields", () => {
+  const getApp = useTestApp();
+
+  it("admin GET /chats/:chatId returns avatarColorToken + avatarImageUrl for every participant", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human", displayName: "Caller" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent", displayName: "Peer Bot" });
+    await app.db.update(agents).set({ avatarColorToken: "hue-3" }).where(eq(agents.uuid, peer.agent.uuid));
+
+    const chat = await createChat(app.db, caller.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${chat.id}`,
+      headers: { authorization: `Bearer ${caller.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      participants: Array<{
+        agentId: string;
+        avatarColorToken: string | null;
+        avatarImageUrl: string | null;
+      }>;
+    };
+    const peerRow = body.participants.find((p) => p.agentId === peer.agent.uuid);
+    expect(peerRow).toBeDefined();
+    expect(peerRow?.avatarColorToken).toBe("hue-3");
+    // No image uploaded — synthesizer returns null.
+    expect(peerRow?.avatarImageUrl).toBeNull();
+    const callerRow = body.participants.find((p) => p.agentId === caller.agent.uuid);
+    expect(callerRow?.avatarColorToken).toBeNull();
+  });
+
+  it("agent GET /agent/chats/:chatId returns avatarColorToken + avatarImageUrl", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "autonomous_agent", displayName: "Caller Bot" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent", displayName: "Peer Bot" });
+    await app.db.update(agents).set({ avatarColorToken: "hue-5" }).where(eq(agents.uuid, peer.agent.uuid));
+
+    const chatRes = await caller.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    const chatId = chatRes.json().id as string;
+
+    const res = await caller.request("GET", `/api/v1/agent/chats/${chatId}`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      participants: Array<{
+        agentId: string;
+        avatarColorToken: string | null;
+        avatarImageUrl: string | null;
+      }>;
+    };
+    const peerRow = body.participants.find((p) => p.agentId === peer.agent.uuid);
+    expect(peerRow?.avatarColorToken).toBe("hue-5");
+    expect(peerRow?.avatarImageUrl).toBeNull();
+  });
+
+  it("agent GET /agent/chats/:chatId/participants returns avatarColorToken + avatarImageUrl", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "autonomous_agent", displayName: "Caller Bot" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent", displayName: "Peer Bot" });
+    await app.db.update(agents).set({ avatarColorToken: "hue-1" }).where(eq(agents.uuid, peer.agent.uuid));
+
+    const chatRes = await caller.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    const chatId = chatRes.json().id as string;
+
+    const res = await caller.request("GET", `/api/v1/agent/chats/${chatId}/participants`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{
+      agentId: string;
+      avatarColorToken: string | null;
+      avatarImageUrl: string | null;
+    }>;
+    const peerRow = body.find((p) => p.agentId === peer.agent.uuid);
+    expect(peerRow?.avatarColorToken).toBe("hue-1");
+    expect(peerRow?.avatarImageUrl).toBeNull();
+  });
+});

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -6,6 +6,7 @@ import {
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
+import { agentAvatarImageUrl } from "../../services/agent.js";
 import * as chatService from "../../services/chat.js";
 
 const log = createLogger("AgentChatsRoute");
@@ -72,6 +73,8 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       displayName: r.displayName,
       type: r.type,
       joinedAt: r.joinedAt.toISOString(),
+      avatarColorToken: r.avatarColorToken ?? null,
+      avatarImageUrl: agentAvatarImageUrl(r.agentId, r.avatarImageUpdatedAt ?? null),
     }));
   });
 

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -120,6 +120,8 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         displayName: p.displayName,
         type: p.type,
         joinedAt: p.joinedAt.toISOString(),
+        avatarColorToken: p.avatarColorToken ?? null,
+        avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
       })),
     };
   });

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -7,6 +7,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { agentAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { backfillSilentContextForNewParticipants } from "./inbox.js";
 import { resolveChatTitle } from "./me-chat.js";
@@ -142,6 +143,8 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
       name: agents.name,
       displayName: agents.displayName,
       type: agents.type,
+      avatarColorToken: agents.avatarColorToken,
+      avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
@@ -160,9 +163,10 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
   const firstMessagePreview = firstMessageRow ? extractSummary(firstMessageRow.content) : null;
   const title = resolveChatTitle(chat.topic, firstMessagePreview, participantRows, selfAgentId ?? "");
 
-  // Preserve the resolved name / displayName / type fields on the wire
-  // (PR #402 identity-rendering contract). Earlier wire consumers also
-  // continue to see chatId / agentId / role / mode / joinedAt.
+  // Preserve the resolved name / displayName / type / avatar fields on
+  // the wire (PR #402 identity-rendering contract; avatar fields added
+  // so the chat-detail surface renders manager-configured hue + image
+  // — see `meChatParticipantSchema` for the matching field on the rail).
   const participants = participantRows.map((p) => ({
     chatId,
     agentId: p.agentId,
@@ -172,6 +176,8 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
     name: p.name,
     displayName: p.displayName,
     type: p.type,
+    avatarColorToken: p.avatarColorToken ?? null,
+    avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
   }));
 
   // Match the chatDetailSchema wire contract — the chat-first workspace
@@ -250,6 +256,8 @@ export async function listChatParticipantsWithNames(db: Database, chatId: string
       name: agents.name,
       displayName: agents.displayName,
       type: agents.type,
+      avatarColorToken: agents.avatarColorToken,
+      avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))

--- a/packages/shared/src/__tests__/mentions.test.ts
+++ b/packages/shared/src/__tests__/mentions.test.ts
@@ -24,6 +24,8 @@ function mkParticipant(
     // back to a synthetic label when the extras don't provide one.
     displayName: extras.displayName ?? `agent-${agentId}`,
     type: extras.type ?? "autonomous_agent",
+    avatarColorToken: extras.avatarColorToken ?? null,
+    avatarImageUrl: extras.avatarImageUrl ?? null,
   };
 }
 

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -63,6 +63,21 @@ export const chatParticipantDetailSchema = chatParticipantSchema.extend({
    */
   displayName: z.string(),
   type: z.string(),
+  /**
+   * Manager-selected avatar color token (one of `AVATAR_COLOR_TOKENS`).
+   * NULL = auto — renderer falls back to the deterministic djb2 hash of
+   * `agentId`. Kept as a loose string here (matching `type`) so DB rows
+   * with legacy / unrecognised values flow through harmlessly. Mirrors
+   * `meChatParticipantSchema` so the chat detail surface (header chips,
+   * right-sidebar agent rows) renders the same color the left rail does.
+   */
+  avatarColorToken: z.string().nullable(),
+  /**
+   * Synthesized URL for the manager-uploaded avatar image, or NULL when
+   * the agent has no image and the renderer should fall back to
+   * color + initial.
+   */
+  avatarImageUrl: z.string().nullable(),
 });
 export type ChatParticipantDetail = z.infer<typeof chatParticipantDetailSchema>;
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1016,9 +1016,22 @@ export function ChatView({
    * `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.3.3.
    */
   const chatParticipantById = useMemo(() => {
-    const map = new Map<string, { name: string | null; displayName: string }>();
+    const map = new Map<
+      string,
+      {
+        name: string | null;
+        displayName: string;
+        avatarImageUrl: string | null;
+        avatarColorToken: string | null;
+      }
+    >();
     for (const p of chatDetail?.participants ?? []) {
-      map.set(p.agentId, { name: p.name, displayName: p.displayName });
+      map.set(p.agentId, {
+        name: p.name,
+        displayName: p.displayName,
+        avatarImageUrl: p.avatarImageUrl ?? null,
+        avatarColorToken: p.avatarColorToken ?? null,
+      });
     }
     return map;
   }, [chatDetail?.participants]);
@@ -1047,16 +1060,27 @@ export function ChatView({
   const chatScopedAgentIdentity = useCallback(
     (
       id: string | null | undefined,
-    ): { name: string | null; displayName: string; avatarImageUrl: string | null } | null => {
+    ): {
+      name: string | null;
+      displayName: string;
+      avatarImageUrl: string | null;
+      avatarColorToken: string | null;
+    } | null => {
       if (!id) return null;
       const p = chatParticipantById.get(id);
       if (p) {
-        // Labels come from the chat-membership-authoritative source, but
-        // the avatar URL is org-scoped — pull it from the identity map
-        // when present. A private agent visible only through chat
-        // membership won't have an `agentIdentity` entry; we surface a
-        // null URL so the chip falls back to color + initial.
-        return { name: p.name, displayName: p.displayName, avatarImageUrl: agentIdentity(id)?.avatarImageUrl ?? null };
+        // Labels come from the chat-membership-authoritative source. The
+        // avatar fields are now projected onto `ChatParticipantDetail`
+        // too (server JOIN on agents), so prefer the chat-scoped value
+        // and only fall back to the org-scoped identity map when the
+        // chat row is missing them (older server build, version skew).
+        const ident = agentIdentity(id);
+        return {
+          name: p.name,
+          displayName: p.displayName,
+          avatarImageUrl: p.avatarImageUrl ?? ident?.avatarImageUrl ?? null,
+          avatarColorToken: p.avatarColorToken ?? ident?.avatarColorToken ?? null,
+        };
       }
       return agentIdentity(id);
     },
@@ -1897,10 +1921,15 @@ function ParticipantsHeader({
   /** Identity resolver covering ALL agents (incl. the viewer's own,
    *  which `mentionCandidates` excludes). Lets the chip row label
    *  self correctly instead of falling back to a UUID prefix. The
-   *  `avatarImageUrl` field is consumed for the chip's leading avatar. */
-  agentIdentity: (
-    uuid: string | null | undefined,
-  ) => { name: string | null; displayName: string; avatarImageUrl: string | null } | null;
+   *  `avatarImageUrl` and `avatarColorToken` fields are threaded into
+   *  the chip's leading avatar so a manager-configured image / hue
+   *  shows up here as well as on the left-rail row. */
+  agentIdentity: (uuid: string | null | undefined) => {
+    name: string | null;
+    displayName: string;
+    avatarImageUrl: string | null;
+    avatarColorToken: string | null;
+  } | null;
   onAdded: () => void;
   readOnly?: boolean;
 }) {
@@ -1952,7 +1981,13 @@ function ParticipantsHeader({
               gap: 6,
             }}
           >
-            <RealAvatar src={ident?.avatarImageUrl ?? null} name={label} seed={id} size={16} />
+            <RealAvatar
+              src={ident?.avatarImageUrl ?? null}
+              name={label}
+              seed={id}
+              colorToken={ident?.avatarColorToken ?? null}
+              size={16}
+            />
             {label}
           </span>
         );

--- a/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
@@ -2,7 +2,7 @@ import type { ChatParticipantDetail } from "@agent-team-foundation/first-tree-hu
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Pause } from "lucide-react";
 import { agentSessionsQueryKey, getSession, type SessionListItem, suspendSession } from "../../../api/sessions.js";
-import { pickAvatarHue } from "../../../components/chat/chat-row-avatar.js";
+import { Avatar } from "../../../components/avatar.js";
 import { DenseBadge } from "../../../components/ui/dense-badge.js";
 
 /**
@@ -68,8 +68,6 @@ export function AgentRow({
   // actively in, that first-render flash is misleading.
   const state = sessionQuery.isPending ? "loading" : (session?.state ?? "none");
   const view = describeState(state);
-  const hue = pickAvatarHue(participant.agentId);
-  const initial = (participant.displayName.trim()[0] ?? participant.name?.trim()[0] ?? "?").toUpperCase();
   // Suspend button is gated by: (a) caller permission and (b) the session
   // being in `active` — the server rejects any other transition, so
   // surfacing the button would just produce a 409 on click.
@@ -85,21 +83,14 @@ export function AgentRow({
         borderRadius: "var(--radius-input)",
       }}
     >
-      <div className="relative shrink-0">
-        <span
-          aria-hidden="true"
-          className="inline-flex items-center justify-center font-semibold"
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 999,
-            background: hue,
-            color: "var(--fg-on-vivid)",
-            fontSize: 11,
-          }}
-        >
-          {initial}
-        </span>
+      <div className="relative shrink-0" style={{ width: 28, height: 28 }}>
+        <Avatar
+          src={participant.avatarImageUrl}
+          name={participant.displayName}
+          seed={participant.agentId}
+          colorToken={participant.avatarColorToken}
+          size={28}
+        />
         <span
           aria-hidden="true"
           style={{


### PR DESCRIPTION
## Summary

- The admin `GET /chats/:chatId` and both agent-scoped chat endpoints already JOIN-loaded `avatarColorToken` / `avatarImageUpdatedAt` from `agents` but **dropped them when shaping the `participants` payload**. As a result, the chat header chips and right-sidebar Agent rows fell back to the deterministic djb2-hash hue and never showed the manager-uploaded image — while the left-rail conversation row (driven by `/me/chats`) rendered both correctly.
- Project the two avatar fields onto every chat-detail / participants endpoint so the wire shape mirrors `meChatParticipantSchema`. Web consumes the new fields in `chatParticipantById` → `chatScopedAgentIdentity` → `ParticipantsHeader`, and `AgentRow` drops its hand-rolled `<span>` avatar in favour of the shared `<Avatar>` component so an uploaded image actually appears in the right sidebar.
- New contract-level regression test pins all three server routes against the new shape with a manager-set hue token.

## Files

| Layer | Path | Change |
|---|---|---|
| server | `api/chats.ts` | admin `/chats/:chatId` response includes `avatarColorToken` + `avatarImageUrl` |
| server | `api/agent/chats.ts` | agent `/chats/:chatId/participants` response includes the same; `getChatDetail` auto-flows through the existing spread |
| server | `services/chat.ts` | `getChatDetail` + `listChatParticipantsWithNames` SELECT/map carry the new fields |
| server | `__tests__/chat-detail-avatar-fields.test.ts` | **new** — 3 cases asserting wire shape on admin / agent-detail / agent-participants routes with `hue-3 / hue-5 / hue-1` |
| shared | `schemas/chat.ts` | `chatParticipantDetailSchema` extended with `avatarColorToken` + `avatarImageUrl` (both nullable, mirrors `meChatParticipantSchema`) |
| shared / client | 3 test fixtures | schema tightening required `null` defaults in mock participant factories |
| web | `pages/workspace/center/chat-view.tsx` | chip-row + header identity resolver thread `colorToken` through to `<Avatar>` |
| web | `pages/workspace/right-sidebar/agent-row.tsx` | replace hand-rolled colored `<span>` with shared `<Avatar>` so image + manager hue both render; status dot overlay preserved |

## Test plan

- [x] `pnpm check && pnpm typecheck` — biome 748 files clean, all 9 packages typecheck
- [x] `pnpm test` — server 137 file / 1098 tests pass (incl. the 3 new regression cases), client 48 file / 388 tests pass
- [ ] Local visual QA against an isolated dev hub: configure `avatarColorToken` + upload image on an agent, open a chat, verify the title-bar chip and right-sidebar Agents row both render the configured hue / image (matches left-rail row)

## Notes

- Wire-shape change is **additive** (two new nullable fields on `ChatParticipantDetail`); back-compat-safe for any older consumer that doesn't read them.
- `createChat` response shape is pre-existing tech debt (returns raw `chat_membership` rows without `name/displayName/type`); deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)