### PR TITLE
fix(server): bootstrap resilience — non-blocking adapter init, /readyz, migration-lock preflight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV NODE_ENV=production
 ENV FIRST_TREE_HUB_WEB_DIST_PATH=/app/packages/server/web-dist
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD wget -qO- http://localhost:8000/healthz || exit 1
 
 CMD ["node", "packages/server/dist/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV NODE_ENV=production
 ENV FIRST_TREE_HUB_WEB_DIST_PATH=/app/packages/server/web-dist
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD wget -qO- http://localhost:8000/healthz || exit 1
 
 CMD ["node", "packages/server/dist/index.mjs"]

--- a/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
+++ b/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
@@ -1,0 +1,53 @@
+import postgres from "postgres";
+import { afterEach, describe, expect, it } from "vitest";
+import { sslOptions } from "../db/connection.js";
+import { runMigrations } from "../db/migrate.js";
+
+/**
+ * Pins the `hashtext('drizzle_migrations')` key used by
+ * `preflightMigrationLock`. If a future drizzle bump changes the lock key,
+ * this test stays green only as long as the preflight constant matches the
+ * one we hold here — meaning the preflight and the holder both speak to the
+ * same advisory-lock slot.
+ *
+ * See `packages/server/src/db/migrate.ts` `MIGRATION_LOCK_KEY_SQL` comment
+ * for the verification path through drizzle-orm.
+ */
+describe("preflightMigrationLock (T10)", () => {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    // No shared state between cases — each opens / closes its own postgres
+    // client, and the lock is session-scoped so it goes away on .end().
+  });
+
+  it("throws migration lock contention when another session holds hashtext('drizzle_migrations')", async () => {
+    expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
+    const url = databaseUrl ?? "";
+
+    // Hold the advisory lock from a separate session for the duration of
+    // the test. `pg_advisory_lock` blocks if contested, but we're the only
+    // contender so it returns immediately.
+    const holder = postgres(url, { max: 1, ...sslOptions(url) });
+    try {
+      await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
+
+      // Use a tight 2s preflight timeout so the contention path completes
+      // fast. The 30s production default is the right answer for boot, not
+      // for a unit test that just needs to assert the error path.
+      await expect(runMigrations(url, { lockTimeoutMs: 2_000 })).rejects.toThrow(/migration lock contention/);
+    } finally {
+      // Release the lock so subsequent test runs (and other test files in
+      // the same worker process) aren't blocked.
+      await holder`SELECT pg_advisory_unlock(hashtext('drizzle_migrations'))`;
+      await holder.end();
+    }
+  });
+
+  it("succeeds when the advisory lock is free", async () => {
+    expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
+    // Sanity case: with no holder, preflight returns fast and migrate runs.
+    const tableCount = await runMigrations(databaseUrl ?? "");
+    expect(tableCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { bootstrapState, markReady, markStage } from "../bootstrap-state.js";
+import { runStage, withTimeout } from "../bootstrap-utils.js";
 import { runMigrations } from "../db/migrate.js";
 import { useTestApp } from "./helpers.js";
+
+/**
+ * Bootstrap state is process-scoped and persists across `it`s (vitest reuses
+ * worker processes via `isolate: false`). Clear the stage map between tests
+ * so a write in one case doesn't leak into another suite's readyz check.
+ */
+function resetBootstrapState(): void {
+  for (const key of Object.keys(bootstrapState.stages)) {
+    delete bootstrapState.stages[key];
+  }
+  bootstrapState.readyAt = null;
+}
 
 describe("server bootstrap", () => {
   it("runMigrations resolves the drizzle folder and applies migrations idempotently", async () => {
@@ -16,6 +30,83 @@ describe("server bootstrap", () => {
     it("returns 200 from a built app", async () => {
       const res = await getApp().inject({ method: "GET", url: "/healthz" });
       expect(res.statusCode).toBe(200);
+    });
+  });
+
+  afterEach(() => {
+    resetBootstrapState();
+  });
+
+  describe("withTimeout", () => {
+    it("resolves when the inner promise resolves first", async () => {
+      const result = await withTimeout(Promise.resolve(42), 1_000, "fast");
+      expect(result).toBe(42);
+    });
+
+    it("rejects with a stage-tagged message when the inner promise hangs", async () => {
+      const neverResolves = new Promise<number>(() => {});
+      await expect(withTimeout(neverResolves, 50, "stuck")).rejects.toThrow(
+        /bootstrap stage "stuck" timed out after 50ms/,
+      );
+    });
+
+    it("clears the timer when the inner promise rejects fast", async () => {
+      // Regression guard: a leaked setTimeout would keep the event loop alive.
+      // We don't directly observe the timer, but the rejection must propagate
+      // without waiting for the timeout fire.
+      const t0 = Date.now();
+      await expect(withTimeout(Promise.reject(new Error("boom")), 5_000, "early-fail")).rejects.toThrow("boom");
+      expect(Date.now() - t0).toBeLessThan(500);
+    });
+  });
+
+  describe("runStage", () => {
+    it("records done status with duration on success", async () => {
+      const result = await runStage("test-success", async () => "ok", 1_000);
+      expect(result).toBe("ok");
+      const stage = bootstrapState.stages["test-success"];
+      expect(stage?.status).toBe("done");
+      expect(stage?.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("records failed status with error message on throw", async () => {
+      await expect(
+        runStage(
+          "test-throw",
+          async () => {
+            throw new Error("boom");
+          },
+          1_000,
+        ),
+      ).rejects.toThrow("boom");
+      const stage = bootstrapState.stages["test-throw"];
+      expect(stage?.status).toBe("failed");
+      expect(stage?.error).toBe("boom");
+    });
+
+    it("records failed status with timeout error when stage hangs", async () => {
+      await expect(runStage("test-hang", () => new Promise(() => {}), 30)).rejects.toThrow(
+        /bootstrap stage "test-hang" timed out after 30ms/,
+      );
+      const stage = bootstrapState.stages["test-hang"];
+      expect(stage?.status).toBe("failed");
+      expect(stage?.error).toMatch(/timed out/);
+    });
+  });
+
+  describe("bootstrap-state", () => {
+    it("markStage merges patches onto existing entries", () => {
+      markStage("merge-test", { status: "in_progress" });
+      markStage("merge-test", { durationMs: 12 });
+      const stage = bootstrapState.stages["merge-test"];
+      expect(stage?.status).toBe("in_progress");
+      expect(stage?.durationMs).toBe(12);
+    });
+
+    it("markReady sets readyAt", () => {
+      bootstrapState.readyAt = null;
+      markReady();
+      expect(bootstrapState.readyAt).toBeInstanceOf(Date);
     });
   });
 });

--- a/packages/server/src/__tests__/readyz.test.ts
+++ b/packages/server/src/__tests__/readyz.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapState, markReady, markStage } from "../bootstrap-state.js";
+import type { BotStatus } from "../services/adapter-manager.js";
+import { useTestApp } from "./helpers.js";
+
+/**
+ * `/readyz` reads the process-scoped `bootstrapState`. Tests must reset the
+ * relevant slice so order-independent runs see a clean baseline — the test
+ * runner re-uses worker processes (vitest `isolate: false`).
+ */
+function resetState() {
+  for (const key of Object.keys(bootstrapState.stages)) {
+    delete bootstrapState.stages[key];
+  }
+  bootstrapState.readyAt = null;
+}
+
+function markAllStagesDone() {
+  markStage("initTelemetry", { status: "done", durationMs: 1 });
+  markStage("runMigrations", { status: "done", durationMs: 1 });
+  markStage("buildApp", { status: "done", durationMs: 1 });
+  markStage("appListen", { status: "done", durationMs: 1 });
+}
+
+describe("/readyz", () => {
+  const getApp = useTestApp();
+
+  beforeEach(() => {
+    resetState();
+  });
+  afterEach(() => {
+    resetState();
+  });
+
+  it("returns 503 with stage detail when stages have not been marked done", async () => {
+    const res = await getApp().inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.readyAt).toBeNull();
+    expect(body.stages).toEqual({});
+    expect(Array.isArray(body.adapters)).toBe(true);
+  });
+
+  it("returns 200 when all stages done, readyAt set, and no adapter bots active", async () => {
+    markAllStagesDone();
+    markReady();
+
+    const res = await getApp().inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ready).toBe(true);
+    expect(body.readyAt).toBeTruthy();
+    expect(body.stages.appListen?.status).toBe("done");
+  });
+
+  it("returns 503 when any required stage failed", async () => {
+    markAllStagesDone();
+    markStage("runMigrations", { status: "failed", error: "boom" });
+    markReady();
+
+    const res = await getApp().inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    const body = res.json();
+    expect(body.ready).toBe(false);
+    expect(body.stages.runMigrations?.status).toBe("failed");
+    expect(body.stages.runMigrations?.error).toBe("boom");
+  });
+
+  it("returns 503 when stages done but markReady has not been called", async () => {
+    markAllStagesDone();
+    // readyAt left null on purpose
+
+    const res = await getApp().inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    expect(res.json().ready).toBe(false);
+  });
+
+  describe("adapter connectivity gating", () => {
+    function stubBotStatuses(statuses: BotStatus[]) {
+      // Replace the live getBotStatuses with a stub; restore between cases
+      // so other adapter behavior isn't affected.
+      return vi.spyOn(getApp().adapterManager, "getBotStatuses").mockReturnValue(statuses);
+    }
+
+    it("returns 503 when all required stages done but some adapter bot is disconnected", async () => {
+      markAllStagesDone();
+      markReady();
+      const spy = stubBotStatuses([
+        {
+          configId: 1,
+          platform: "feishu",
+          agentId: "agent-a",
+          appId: "cli_a",
+          connected: true,
+          lastError: null,
+          lastActiveAt: null,
+        },
+        {
+          configId: 2,
+          platform: "feishu",
+          agentId: "agent-b",
+          appId: "cli_b",
+          connected: false,
+          lastError: "feishu ws.start timeout after 8000ms for cli_b",
+          lastActiveAt: null,
+        },
+      ]);
+
+      try {
+        const res = await getApp().inject({ method: "GET", url: "/readyz" });
+        expect(res.statusCode).toBe(503);
+        const body = res.json();
+        expect(body.ready).toBe(false);
+        expect(body.adapters).toHaveLength(2);
+        expect(body.adapters[1].connected).toBe(false);
+        expect(body.adapters[1].lastError).toMatch(/timeout/);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("returns 503 when every adapter bot is disconnected even with stages done", async () => {
+      markAllStagesDone();
+      markReady();
+      const spy = stubBotStatuses([
+        {
+          configId: 1,
+          platform: "feishu",
+          agentId: "agent-a",
+          appId: "cli_a",
+          connected: false,
+          lastError: "boom",
+          lastActiveAt: null,
+        },
+      ]);
+
+      try {
+        const res = await getApp().inject({ method: "GET", url: "/readyz" });
+        expect(res.statusCode).toBe(503);
+        const body = res.json();
+        expect(body.ready).toBe(false);
+        expect(body.adapters[0].connected).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it("returns 200 when stages done, readyAt set, and every adapter bot is connected", async () => {
+      markAllStagesDone();
+      markReady();
+      const spy = stubBotStatuses([
+        {
+          configId: 1,
+          platform: "feishu",
+          agentId: "agent-a",
+          appId: "cli_a",
+          connected: true,
+          lastError: null,
+          lastActiveAt: new Date().toISOString(),
+        },
+      ]);
+
+      try {
+        const res = await getApp().inject({ method: "GET", url: "/readyz" });
+        expect(res.statusCode).toBe(200);
+        expect(res.json().ready).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/server/src/api/readyz.ts
+++ b/packages/server/src/api/readyz.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from "fastify";
+import { bootstrapState } from "../bootstrap-state.js";
+
+/**
+ * Required bootstrap stages for readiness. `appListen` is the last stage and
+ * the one that flips `bootstrapState.readyAt`; the others must be `done` too
+ * so a partial-failure boot (e.g. migrations finished but listen timed out)
+ * still reports the offending stage in the body.
+ */
+const REQUIRED_STAGES = ["initTelemetry", "runMigrations", "buildApp", "appListen"] as const;
+
+/**
+ * Readiness endpoint — distinct from `/healthz` (liveness). Returns 200 only
+ * when every bootstrap stage is done AND every managed adapter bot is
+ * connected. The body always carries stage + adapter detail so operators can
+ * see which stage stalled or which bot is offline. See
+ * docs/server-bootstrap-resilience-design.md §3 (T6).
+ */
+export async function readyzRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/readyz", { config: { rateLimit: false } }, async (_request, reply) => {
+    const allStagesDone = REQUIRED_STAGES.every((s) => bootstrapState.stages[s]?.status === "done");
+    const adapters = app.adapterManager.getBotStatuses();
+    const allAdaptersConnected = adapters.every((b) => b.connected);
+    const ready = allStagesDone && allAdaptersConnected && bootstrapState.readyAt !== null;
+
+    const body = {
+      ready,
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: bootstrapState.readyAt?.toISOString() ?? null,
+      stages: bootstrapState.stages,
+      adapters,
+    };
+    return reply.status(ready ? 200 : 503).send(body);
+  });
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -54,6 +54,7 @@ import { orgOverviewRoutes } from "./api/orgs/overview.js";
 import { orgSessionRoutes } from "./api/orgs/sessions.js";
 import { orgSettingsRoutes } from "./api/orgs/settings.js";
 import { orgWsRoutes } from "./api/orgs/ws.js";
+import { readyzRoutes } from "./api/readyz.js";
 import { sessionRoutes } from "./api/sessions.js";
 // Public agent discovery removed — visibility is now handled via agent.visibility field
 import { githubAppWebhookRoutes } from "./api/webhooks/github-app.js";
@@ -410,8 +411,12 @@ export async function buildApp(config: Config) {
     return reply.status(500).send({ error: "Internal server error", ...traceField });
   });
 
-  // Root-level health check for container orchestration (outside /api/v1)
+  // Root-level health checks for container orchestration (outside /api/v1).
+  // `/healthz` checks process + DB reachability (used by Docker HEALTHCHECK).
+  // `/readyz` checks full readiness — all bootstrap stages done + all adapter
+  // bots connected. See docs/server-bootstrap-resilience-design.md §3 (T6).
   await app.register(healthzRoutes);
+  await app.register(readyzRoutes);
 
   // All API routes under /api/v1 prefix
   await app.register(
@@ -611,15 +616,16 @@ export async function buildApp(config: Config) {
       .catch((err) => createLogger("chat-message-kick").warn({ err, chatId, messageId }, "chat:message kick failed"));
   });
 
-  // Start notifier and background tasks on server start
+  // Start notifier and background tasks on server start.
+  // Adapter / kael initial reload happens inside backgroundTasks.start() as a
+  // fire-and-forget task so app.listen() is not blocked by remote handshakes —
+  // see docs/server-bootstrap-resilience-design.md (T1/T2).
   app.addHook("onReady", async () => {
     // Ensure the default organization exists (idempotent)
     await ensureDefaultOrganization(db);
     await notifier.start();
     backgroundTasks.start();
     pulseAggregator.start();
-    await adapterManager.reload();
-    await kaelRuntime?.reload();
   });
 
   // Cleanup on close

--- a/packages/server/src/bootstrap-state.ts
+++ b/packages/server/src/bootstrap-state.ts
@@ -1,0 +1,34 @@
+/**
+ * In-memory boot progress mirror used by /readyz and structured stage logs.
+ * Process-scoped — there is exactly one bootstrap per process. See
+ * docs/server-bootstrap-resilience-design.md §3 (T5/T6).
+ */
+
+export type StageStatus = "pending" | "in_progress" | "done" | "failed";
+
+export type StageInfo = {
+  status: StageStatus;
+  durationMs?: number;
+  error?: string;
+};
+
+export type BootstrapState = {
+  startedAt: Date;
+  stages: Record<string, StageInfo>;
+  readyAt: Date | null;
+};
+
+export const bootstrapState: BootstrapState = {
+  startedAt: new Date(),
+  stages: {},
+  readyAt: null,
+};
+
+export function markStage(name: string, patch: Partial<StageInfo>): void {
+  const existing = bootstrapState.stages[name] ?? { status: "pending" as StageStatus };
+  bootstrapState.stages[name] = { ...existing, ...patch };
+}
+
+export function markReady(): void {
+  bootstrapState.readyAt = new Date();
+}

--- a/packages/server/src/bootstrap-utils.ts
+++ b/packages/server/src/bootstrap-utils.ts
@@ -1,0 +1,48 @@
+import { performance } from "node:perf_hooks";
+import { markStage } from "./bootstrap-state.js";
+import { createLogger } from "./observability/index.js";
+
+const log = createLogger("Bootstrap");
+
+/**
+ * Race a promise against a timeout. Rejects with a stage-tagged Error so the
+ * stderr message identifies which boot phase stalled. See
+ * docs/server-bootstrap-resilience-design.md §3 (T4).
+ */
+export async function withTimeout<T>(p: Promise<T>, ms: number, stage: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`bootstrap stage "${stage}" timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a bootstrap stage with structured `bootstrap.stage.{start,done,failed}`
+ * logs, a stage-tagged timeout, and side-effect updates to the shared
+ * `bootstrapState` (consumed by /readyz).
+ */
+export async function runStage<T>(name: string, fn: () => Promise<T>, timeoutMs: number): Promise<T> {
+  log.info({ stage: name }, "bootstrap.stage.start");
+  markStage(name, { status: "in_progress" });
+  const t0 = performance.now();
+  try {
+    const result = await withTimeout(fn(), timeoutMs, name);
+    const stageMs = Math.round(performance.now() - t0);
+    markStage(name, { status: "done", durationMs: stageMs });
+    log.info({ stage: name, stageMs }, "bootstrap.stage.done");
+    return result;
+  } catch (err) {
+    const stageMs = Math.round(performance.now() - t0);
+    const message = err instanceof Error ? err.message : String(err);
+    markStage(name, { status: "failed", durationMs: stageMs, error: message });
+    log.error({ stage: name, stageMs, err }, "bootstrap.stage.failed");
+    throw err;
+  }
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -53,13 +53,77 @@ function validateJournalOrder(migrationsFolder: string): void {
 }
 
 /**
+ * Advisory-lock key used by the preflight check.
+ *
+ * Verified against `drizzle-orm@0.44.7`:
+ *   - `node_modules/drizzle-orm/postgres-js/migrator.js` → delegates to
+ *     `node_modules/drizzle-orm/pg-core/dialect.js::migrate()`, which
+ *     **does NOT acquire any advisory lock** in this version; it only wraps
+ *     `INSERT INTO drizzle.__drizzle_migrations` in a transaction.
+ *   - So this preflight is **purely defensive**: it surfaces *external*
+ *     holders (an operator's `SELECT pg_advisory_lock(...)`, a stale
+ *     prior-replica session that exited mid-migration with the lock held,
+ *     or a future drizzle release that re-introduces locking) within the
+ *     timeout window instead of letting drizzle hang silently.
+ *
+ * If you bump `drizzle-orm`, re-read `pg-core/dialect.js::migrate()` and
+ * update this key (and `MIGRATION_LOCK_TIMEOUT_MS`) accordingly. The
+ * integration test `bootstrap-migration-lock.test.ts` pins the contention
+ * behavior using the same key.
+ */
+const MIGRATION_LOCK_KEY_SQL = "hashtext('drizzle_migrations')";
+const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 30_000;
+const MIGRATION_LOCK_POLL_INTERVAL_MS = 1_000;
+
+export type RunMigrationsOptions = {
+  /** Override the preflight advisory-lock timeout. Default 30s. */
+  lockTimeoutMs?: number;
+};
+
+/**
+ * Probe the advisory-lock key drizzle would use for migrations. If another
+ * session holds it, fail with a clear message instead of letting drizzle's
+ * `migrate()` hang forever. We don't keep the lock — see the key constant
+ * above for the full rationale. See server-bootstrap-resilience-design.md §3 (T10).
+ */
+async function preflightMigrationLock(databaseUrl: string, timeoutMs: number): Promise<void> {
+  const ssl = sslOptions(databaseUrl);
+  const client = postgres(databaseUrl, { max: 1, ...ssl });
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (true) {
+      const rows = (await client.unsafe(
+        `SELECT pg_try_advisory_lock(${MIGRATION_LOCK_KEY_SQL}) AS acquired`,
+      )) as Array<{
+        acquired: boolean;
+      }>;
+      if (rows[0]?.acquired) {
+        await client.unsafe(`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY_SQL})`);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `migration lock contention — another process holds drizzle migration lock (${MIGRATION_LOCK_KEY_SQL}) ` +
+            `after ${timeoutMs}ms`,
+        );
+      }
+      await new Promise((r) => setTimeout(r, MIGRATION_LOCK_POLL_INTERVAL_MS));
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+/**
  * Run Drizzle database migrations. Returns the count of public tables after
  * migration, used as a rough indicator that the schema landed.
  */
-export async function runMigrations(databaseUrl: string): Promise<number> {
+export async function runMigrations(databaseUrl: string, options: RunMigrationsOptions = {}): Promise<number> {
   const migrationsFolder = resolveMigrationsFolder();
 
   validateJournalOrder(migrationsFolder);
+
+  await preflightMigrationLock(databaseUrl, options.lockTimeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS);
 
   const ssl = sslOptions(databaseUrl);
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -72,11 +72,15 @@ function validateJournalOrder(migrationsFolder: string): void {
  * behavior using the same key.
  */
 const MIGRATION_LOCK_KEY_SQL = "hashtext('drizzle_migrations')";
-const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 30_000;
+// Sits inside the 20s `runMigrations` stage budget set in `index.ts`; 15s
+// preflight + ≥5s for the actual drizzle migrate call. If you raise either,
+// raise the other in lockstep (and re-evaluate the Dockerfile HEALTHCHECK
+// `--start-period`).
+const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 15_000;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 1_000;
 
 export type RunMigrationsOptions = {
-  /** Override the preflight advisory-lock timeout. Default 30s. */
+  /** Override the preflight advisory-lock timeout. Default 15s. */
   lockTimeoutMs?: number;
 };
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,8 +45,13 @@ async function main() {
   const app = await withSpan("server.bootstrap", { "service.instance.id": config.instanceId }, async () => {
     // Run Drizzle migrations before the app comes up. Idempotent under
     // multi-replica startup (Drizzle journal table); cold-start cost is
-    // a few hundred ms when there's nothing new to apply.
-    const tableCount = await runStage("runMigrations", () => runMigrations(serverConfig.database.url), 60_000);
+    // a few hundred ms when there's nothing new to apply. The 20s budget
+    // matches the Dockerfile HEALTHCHECK start-period so a migration that
+    // truly exceeds it fails the boot fast rather than letting docker
+    // judge unhealthy mid-migration. If a future migration is known to
+    // run longer, raise both this and the HEALTHCHECK start-period
+    // together.
+    const tableCount = await runStage("runMigrations", () => runMigrations(serverConfig.database.url), 20_000);
     log.info({ tableCount }, "migrations applied");
 
     const built = await runStage("buildApp", () => buildApp(config), 30_000);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { initConfig, serverConfigSchema } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { buildApp } from "./app.js";
+import { markReady } from "./bootstrap-state.js";
+import { runStage } from "./bootstrap-utils.js";
 import type { Config } from "./config.js";
 import { runMigrations } from "./db/migrate.js";
-import { applyLoggerConfig, createLogger, initTelemetry, shutdownTelemetry } from "./observability/index.js";
+import { applyLoggerConfig, createLogger, initTelemetry, shutdownTelemetry, withSpan } from "./observability/index.js";
 
 const log = createLogger("Bootstrap");
 
@@ -34,16 +36,24 @@ async function main() {
   // bootstrap (e.g. notifier.start) will then be captured. instanceId is
   // carried as service.instance.id so replicas are distinguishable in the
   // trace backend.
-  await initTelemetry(serverConfig.observability.tracing, config.instanceId);
+  await runStage("initTelemetry", () => initTelemetry(serverConfig.observability.tracing, config.instanceId), 10_000);
 
-  // Run Drizzle migrations before the app comes up. Idempotent under
-  // multi-replica startup (Drizzle journal table); cold-start cost is
-  // a few hundred ms when there's nothing new to apply.
-  const tableCount = await runMigrations(serverConfig.database.url);
-  log.info({ tableCount }, "migrations applied");
+  // Wrap post-telemetry stages in a `server.bootstrap` root span so Logfire
+  // shows a single bootstrap flamegraph. `initTelemetry` itself can't be
+  // traced — it's the call that wires up the tracer — and is covered by the
+  // stage logs instead. See server-bootstrap-resilience-design.md §3 (T8).
+  const app = await withSpan("server.bootstrap", { "service.instance.id": config.instanceId }, async () => {
+    // Run Drizzle migrations before the app comes up. Idempotent under
+    // multi-replica startup (Drizzle journal table); cold-start cost is
+    // a few hundred ms when there's nothing new to apply.
+    const tableCount = await runStage("runMigrations", () => runMigrations(serverConfig.database.url), 60_000);
+    log.info({ tableCount }, "migrations applied");
 
-  const app = await buildApp(config);
-  await app.listen({ host: config.server.host, port: config.server.port });
+    const built = await runStage("buildApp", () => buildApp(config), 30_000);
+    await runStage("appListen", () => built.listen({ host: config.server.host, port: config.server.port }), 10_000);
+    return built;
+  });
+  markReady();
   log.info(`server listening on http://${config.server.host}:${config.server.port}`);
 
   const shutdown = async (signal: string) => {

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -3,6 +3,7 @@ import { Client, EventDispatcher, LoggerLevel, WSClient } from "@larksuiteoapi/n
 import { trace } from "@opentelemetry/api";
 import { and, eq, ne, sql } from "drizzle-orm";
 import type { FastifyBaseLogger } from "fastify";
+import { withTimeout } from "../bootstrap-utils.js";
 import type { Database } from "../db/connection.js";
 import { adapterConfigs } from "../db/schema/adapter-configs.js";
 import { agents } from "../db/schema/agents.js";
@@ -17,26 +18,40 @@ import { type Notifier, notifyRecipients } from "./notifier.js";
 
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy"];
 
+const FEISHU_WS_START_TIMEOUT_MS = 8_000;
+
 /**
- * Temporarily clear proxy env vars while running a callback.
- * The Lark SDK's internal HTTP client (axios) reads proxy env vars
- * but does not respect NO_PROXY, causing connection failures behind proxies.
- * Other code that needs the proxy is unaffected — vars are restored immediately.
+ * Reentrant proxy-env bypass for the Lark SDK (axios reads proxy env but
+ * ignores NO_PROXY). Concurrent reloads share a single bypass window — the
+ * first caller snapshots and unsets env, last caller restores. Without the
+ * counter, parallel callers would race and either leak a deleted state or
+ * corrupt the saved snapshot. See server-bootstrap-resilience-design.md §5.
  */
+let proxyBypassDepth = 0;
+let proxyBypassSaved: Record<string, string> | null = null;
+
 async function withoutProxy<T>(fn: () => Promise<T>): Promise<T> {
-  const saved: Record<string, string> = {};
-  for (const key of PROXY_ENV_KEYS) {
-    const val = process.env[key];
-    if (val !== undefined) {
-      saved[key] = val;
-      delete process.env[key];
+  if (proxyBypassDepth === 0) {
+    const saved: Record<string, string> = {};
+    for (const key of PROXY_ENV_KEYS) {
+      const val = process.env[key];
+      if (val !== undefined) {
+        saved[key] = val;
+        delete process.env[key];
+      }
     }
+    proxyBypassSaved = saved;
   }
+  proxyBypassDepth++;
   try {
     return await fn();
   } finally {
-    for (const [key, val] of Object.entries(saved)) {
-      process.env[key] = val;
+    proxyBypassDepth--;
+    if (proxyBypassDepth === 0 && proxyBypassSaved) {
+      for (const [key, val] of Object.entries(proxyBypassSaved)) {
+        process.env[key] = val;
+      }
+      proxyBypassSaved = null;
     }
   }
 }
@@ -52,14 +67,37 @@ type ManagedBot = {
   agentId: string;
   /** Whether to clear proxy env vars for SDK API calls (Lark SDK ignores NO_PROXY). */
   bypassProxy: boolean;
-  client: InstanceType<typeof Client>;
-  wsClient: WSClient;
+  /**
+   * Whether the WS handshake completed during the last reload attempt.
+   * `false` rows are kept in the map so /readyz can report them as
+   * disconnected; their `client`/`wsClient` are undefined. The SDK's
+   * `autoReconnect` does NOT resurrect a failed start — we only retry on
+   * the next `reload()` (PG NOTIFY or admin-triggered).
+   */
+  connected: boolean;
+  /** Last error message if the start handshake failed. */
+  lastError: string | null;
+  /** Undefined for bots whose start handshake failed. */
+  client: InstanceType<typeof Client> | undefined;
+  /** Undefined for bots whose start handshake failed. */
+  wsClient: WSClient | undefined;
   /** Timestamp of the last successful inbound or outbound activity. */
   lastActiveAt: Date | null;
 };
 
+/** A `ManagedBot` narrowed to the connected state, so SDK calls are type-safe. */
+type ConnectedBot = ManagedBot & {
+  connected: true;
+  client: InstanceType<typeof Client>;
+  wsClient: WSClient;
+};
+
+function isConnected(bot: ManagedBot): bot is ConnectedBot {
+  return bot.connected && bot.client !== undefined && bot.wsClient !== undefined;
+}
+
 /** Wrap an SDK API call with proxy bypass if needed. */
-function botApiCall<T>(bot: ManagedBot, fn: () => Promise<T>): Promise<T> {
+function botApiCall<T>(bot: ConnectedBot, fn: () => Promise<T>): Promise<T> {
   return bot.bypassProxy ? withoutProxy(fn) : fn();
 }
 
@@ -69,6 +107,7 @@ export type BotStatus = {
   agentId: string;
   appId: string;
   connected: boolean;
+  lastError: string | null;
   lastActiveAt: string | null;
 };
 
@@ -100,10 +139,13 @@ export function createAdapterManager(
 ): AdapterManager {
   const bots = new Map<string, ManagedBot>();
 
-  /** Find a managed bot by its bound agentId. */
-  function findBotByAgentId(agentId: string): ManagedBot | undefined {
+  /**
+   * Find a managed bot by its bound agentId. Only returns connected bots —
+   * callers (outbound send, edit) need a live `client`/`wsClient`.
+   */
+  function findBotByAgentId(agentId: string): ConnectedBot | undefined {
     for (const bot of bots.values()) {
-      if (bot.agentId === agentId) return bot;
+      if (bot.agentId === agentId && isConnected(bot)) return bot;
     }
     return undefined;
   }
@@ -122,7 +164,7 @@ export function createAdapterManager(
       if (event.senderType === "bot") return;
 
       const bot = bots.get(appId);
-      if (!bot) return;
+      if (!bot || !isConnected(bot)) return;
 
       try {
         await withSpan(
@@ -155,15 +197,15 @@ export function createAdapterManager(
       const configs = await db.select().from(adapterConfigs).where(eq(adapterConfigs.status, "active"));
       const seen = new Set<string>();
 
-      for (const config of configs) {
-        if (config.platform !== "feishu" || !config.credentials) continue;
+      const startTasks = configs.map(async (config) => {
+        if (config.platform !== "feishu" || !config.credentials) return;
 
         let creds: FeishuBotCredentials;
         try {
           creds = decryptCredentials(config.credentials as string, encryptionKey) as FeishuBotCredentials;
         } catch (err) {
           log.error({ configId: config.id, err }, "Failed to decrypt adapter credentials");
-          continue;
+          return;
         }
 
         const appId = creds.app_id;
@@ -172,11 +214,11 @@ export function createAdapterManager(
         // Skip if already running with same config version (detect credential changes)
         const configVersion = config.updatedAt.toISOString();
         const existing = bots.get(appId);
-        if (existing && existing.configId === config.id && existing.configUpdatedAt === configVersion) continue;
+        if (existing && existing.configId === config.id && existing.configUpdatedAt === configVersion) return;
 
         // Stop old connection if config changed
         if (existing) {
-          existing.wsClient.close({ force: true });
+          existing.wsClient?.close({ force: true });
           log.info({ appId }, "Stopped old Feishu WS connection (config changed)");
         }
 
@@ -184,45 +226,90 @@ export function createAdapterManager(
         const bypassProxy = creds.bypass_proxy !== false;
         const wrap = bypassProxy ? withoutProxy : <T>(fn: () => Promise<T>) => fn();
 
-        // Create SDK client for outbound API calls
-        const client = await wrap(() => Promise.resolve(new Client({ appId, appSecret: creds.app_secret })));
+        // `ws` is hoisted so the catch block can force-close it on timeout —
+        // otherwise the SDK's `autoReconnect: true` keeps a background timer
+        // alive against a dangling reference. The construction itself doesn't
+        // touch the network; only `ws.start()` does.
+        let ws: WSClient | undefined;
+        try {
+          // Create SDK client for outbound API calls
+          const client = await wrap(() => Promise.resolve(new Client({ appId, appSecret: creds.app_secret })));
 
-        // Create WSClient for inbound events
-        const eventDispatcher = new EventDispatcher({}).register({
-          "im.message.receive_v1": async (data: Record<string, unknown>) => {
-            await handleInboundEvent(appId, data);
-          },
-        });
-
-        const wsClient = await wrap(async () => {
-          const ws = new WSClient({
-            appId,
-            appSecret: creds.app_secret,
-            loggerLevel: LoggerLevel.warn,
-            autoReconnect: true,
+          // Create WSClient for inbound events
+          const eventDispatcher = new EventDispatcher({}).register({
+            "im.message.receive_v1": async (data: Record<string, unknown>) => {
+              await handleInboundEvent(appId, data);
+            },
           });
-          await ws.start({ eventDispatcher });
-          return ws;
-        });
 
-        bots.set(appId, {
-          configId: config.id,
-          configUpdatedAt: configVersion,
-          appId,
-          agentId: config.agentId,
-          bypassProxy,
-          client,
-          wsClient,
-          lastActiveAt: null,
-        });
+          await wrap(async () => {
+            ws = new WSClient({
+              appId,
+              appSecret: creds.app_secret,
+              loggerLevel: LoggerLevel.warn,
+              autoReconnect: true,
+            });
+            // Per-bot timeout: a single slow remote handshake must not stall
+            // server startup. A timed-out bot is recorded as disconnected
+            // (see catch); the next reload() retries.
+            await withTimeout(ws.start({ eventDispatcher }), FEISHU_WS_START_TIMEOUT_MS, `feishu.ws.start:${appId}`);
+          });
 
-        log.info({ appId, configId: config.id, agentId: config.agentId }, "Started Feishu adapter bot (WebSocket)");
-      }
+          bots.set(appId, {
+            configId: config.id,
+            configUpdatedAt: configVersion,
+            appId,
+            agentId: config.agentId,
+            bypassProxy,
+            connected: true,
+            lastError: null,
+            client,
+            // Non-null here: ws is assigned by the wrap() callback before
+            // start() resolves; if start() rejected we would be in catch.
+            wsClient: ws,
+            lastActiveAt: null,
+          });
+
+          log.info({ appId, configId: config.id, agentId: config.agentId }, "Started Feishu adapter bot (WebSocket)");
+        } catch (err) {
+          // S1: tear down the half-started WSClient so the SDK's autoReconnect
+          // timer doesn't keep firing in the background against a dropped ref.
+          if (ws) {
+            try {
+              ws.close({ force: true });
+            } catch (closeErr) {
+              log.warn({ appId, err: closeErr }, "ws.close after failed start raised");
+            }
+          }
+
+          // B1: keep a disconnected stub in the map so /readyz can report
+          // "bot exists, not connected" instead of silently hiding it.
+          bots.set(appId, {
+            configId: config.id,
+            configUpdatedAt: configVersion,
+            appId,
+            agentId: config.agentId,
+            bypassProxy,
+            connected: false,
+            lastError: err instanceof Error ? err.message : String(err),
+            client: undefined,
+            wsClient: undefined,
+            lastActiveAt: null,
+          });
+
+          log.error(
+            { appId, configId: config.id, err },
+            "Failed to start Feishu adapter bot — recorded as disconnected (other bots unaffected)",
+          );
+        }
+      });
+
+      await Promise.allSettled(startTasks);
 
       // Stop bots that are no longer active
       for (const [appId, bot] of bots) {
         if (!seen.has(appId)) {
-          bot.wsClient.close({ force: true });
+          bot.wsClient?.close({ force: true });
           bots.delete(appId);
           log.info({ appId }, "Stopped inactive Feishu adapter bot");
         }
@@ -282,7 +369,8 @@ export function createAdapterManager(
           platform: "feishu",
           agentId: bot.agentId,
           appId: bot.appId,
-          connected: bots.has(bot.appId),
+          connected: bot.connected,
+          lastError: bot.lastError,
           lastActiveAt: bot.lastActiveAt?.toISOString() ?? null,
         });
       }
@@ -291,8 +379,10 @@ export function createAdapterManager(
 
     shutdown() {
       for (const [appId, bot] of bots) {
-        bot.wsClient.close({ force: true });
-        log.info({ appId }, "Shut down Feishu WS connection");
+        if (bot.wsClient) {
+          bot.wsClient.close({ force: true });
+          log.info({ appId }, "Shut down Feishu WS connection");
+        }
       }
       bots.clear();
     },
@@ -355,7 +445,7 @@ function parseEventData(appId: string, data: Record<string, unknown>): InboundEv
 async function processInboundMessage(
   db: Database,
   event: InboundEvent,
-  bot: ManagedBot,
+  bot: ConnectedBot,
   log: FastifyBaseLogger,
   inboxNotifier?: Notifier,
 ): Promise<void> {
@@ -422,7 +512,7 @@ async function processInboundMessage(
 }
 
 /** Reply to unknown (unbound) user with binding instructions. */
-async function replyUnknownUser(bot: ManagedBot, event: InboundEvent, log: FastifyBaseLogger): Promise<void> {
+async function replyUnknownUser(bot: ConnectedBot, event: InboundEvent, log: FastifyBaseLogger): Promise<void> {
   const text = [
     "Your account is not linked to First Tree Hub yet.",
     "To bind, send:  /bind <your-agent-id>",
@@ -460,7 +550,7 @@ function extractTextContent(event: InboundEvent): string {
  */
 async function handleBindCommand(
   db: Database,
-  bot: ManagedBot,
+  bot: ConnectedBot,
   event: InboundEvent,
   agentName: string,
   log: FastifyBaseLogger,
@@ -553,7 +643,7 @@ async function handleBindCommand(
  */
 async function processFeishuOutbound(
   db: Database,
-  findBotByAgentId: (agentId: string) => ManagedBot | undefined,
+  findBotByAgentId: (agentId: string) => ConnectedBot | undefined,
   log: FastifyBaseLogger,
 ): Promise<{ sent: number; errors: number }> {
   // Claim pending inbox entries for feishu-bound human agents
@@ -595,7 +685,7 @@ async function processFeishuOutbound(
 
 async function processFeishuOutboundClaimed(
   db: Database,
-  findBotByAgentId: (agentId: string) => ManagedBot | undefined,
+  findBotByAgentId: (agentId: string) => ConnectedBot | undefined,
   log: FastifyBaseLogger,
   claimed: ReadonlyArray<{ id: number; inbox_id: string; message_id: string; chat_id: string | null }>,
 ): Promise<{ sent: number; errors: number }> {

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -96,6 +96,16 @@ export function createBackgroundTasks(
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
         log.error({ err }, "failed initial heartbeat");
       });
+
+      // Initial adapter / kael reload — fire-and-forget so server.listen() is not
+      // blocked by remote handshakes. Subsequent reloads come from PG NOTIFY
+      // (hot reload path). See docs/server-bootstrap-resilience-design.md.
+      adapterManager.reload().catch((err) => {
+        log.error({ err }, "initial adapter reload failed");
+      });
+      kaelRuntime?.reload().catch((err) => {
+        log.error({ err }, "initial kael reload failed");
+      });
     },
 
     stop() {


### PR DESCRIPTION
## Background

2026-05-15 staging 7h outage ([#431](https://github.com/agent-team-foundation/first-tree-hub/issues/431) / [#427](https://github.com/agent-team-foundation/first-tree-hub/pull/427)). The feishu adapter manager awaited 5 `WSClient.start()` handshakes serially inside the `onReady` hook (10–25s real-time), exceeding CapRover's `deploymentTimeoutSeconds` → SIGKILL → exit 255. Swarm reconcile-looped 792 times in 5h, pinning the host at 33% CPU.

## Key decisions

### `/healthz` vs `/readyz` separation

- **`/healthz`** = liveness (process alive + DB reachable). Semantics unchanged so Docker `HEALTHCHECK` and CapRover/swarm probes keep working.
- **`/readyz`** = full readiness. Returns `200` only when **every** bootstrap stage is `done`, `readyAt` is set, and **every** managed adapter bot is `connected`.

### Failed bots stay in the `bots` map as `disconnected` stubs

Previously `getBotStatuses()` did `bots.has(appId)` (always `true` because it iterates `bots.values()`), so a permanently-down bot was invisible to readiness probes. Now a failed `ws.start` writes a `{ connected: false, lastError, client: undefined, wsClient: undefined }` entry, and `/readyz` reports "bot exists, not connected → 503" with the error string. A new `ConnectedBot` type guard narrows inbound/outbound paths to compile-time-safe SDK access.

> **Known limitation.** After `ws.start` times out the SDK's `autoReconnect` is forcibly stopped via `ws.close({force: true})` to prevent a dangling background timer. The bot stays `connected: false` in the `bots` map until the next `reload()` — either a PG NOTIFY config change or a process restart. We do not currently observe SDK-internal reconnect success to auto-flip readiness. P2 follow-up if needed.

### Tight, aligned migration / healthcheck budgets

- Dockerfile `HEALTHCHECK --start-period`: **20s** (was 10s before this PR; original draft used 60s "as margin"). Plenty for the new fast-listen path; surfaces a stuck boot ~40s earlier than 60s.
- `runMigrations` runStage timeout: **20s** (was 60s in original draft). Matches the HEALTHCHECK start-period so a migration that truly exceeds it fails the boot fast (`bootstrap stage "runMigrations" timed out after 20000ms`) rather than letting docker judge unhealthy mid-migration.
- `preflightMigrationLock` default: **15s** (was 30s). Sits inside the 20s stage budget so the inner preflight always fires its own `migration lock contention` error first instead of being swallowed by the outer stage timeout. Leaves ≥5s headroom for the actual drizzle migrate call.

If a future migration is known to run longer, raise these three numbers in lockstep.

## Changes

### P0 — root-cause fix + readiness signal

- `services/background-tasks.ts` — `start()` fires `adapterManager.reload()` / `kaelRuntime?.reload()` as fire-and-forget tasks (initial pass; hot reload still arrives via PG NOTIFY).
- `app.ts` — drop the synchronous reload from the `onReady` hook; register `/readyz` alongside `/healthz`.
- `services/adapter-manager.ts`:
  - `withoutProxy()` reentrant (depth counter + saved snapshot); parallel callers share one bypass window without racing on `process.env`.
  - `reload()` walks configs in parallel via `Promise.allSettled` with a per-bot 8s timeout on `ws.start`.
  - On start failure, `ws.close({force: true})` in `catch` stops the SDK autoReconnect timer.
  - `ManagedBot` carries `connected` + `lastError`; new `ConnectedBot` type guard narrows inbound/outbound paths.
- `bootstrap-utils.ts` (new) — `withTimeout(p, ms, stage)` + `runStage(name, fn, timeoutMs)` (start/done/failed structured logs + state side effects).
- `bootstrap-state.ts` (new) — process-scoped state + `markStage` / `markReady`.
- `index.ts` — `runStage`-wrapped `initTelemetry` (10s), `runMigrations` (20s), `buildApp` (30s), `appListen` (10s); `markReady()` after listen.
- `api/readyz.ts` (new) — aggregates stage status + `getBotStatuses()`; `200` / `503` with full body.
- `Dockerfile` — HEALTHCHECK `--start-period` 10s → 20s.

### P1 — observability + defensive preflight

- `index.ts` — `server.bootstrap` OTel root span around the post-telemetry stages (Logfire flame chart). `initTelemetry` is the call that wires up the tracer, so it stays outside; stage logs cover it.
- `db/migrate.ts` — `preflightMigrationLock` probes `pg_try_advisory_lock(hashtext('drizzle_migrations'))` with a configurable timeout (15s default) before invoking `drizzle.migrate(...)`. Defensive only — verified that `drizzle-orm@0.44.7` `postgres-js` dialect does **not** itself acquire this lock (see in-source comment). The preflight surfaces *external* holders (operator manual locks, stale prior-replica sessions, or a future drizzle release reintroducing locking).

## Tests

**138 files / 1112 tests green.** 17 new cases (baseline 1095 → 1112):

- `bootstrap.test.ts` (8 new) — `withTimeout` resolve / timeout / no-timer-leak, `runStage` done / failed / timeout, `markStage` / `markReady`.
- `readyz.test.ts` (7, new file) — stage gating (4) + adapter connectivity gating with `vi.spyOn`-stubbed `BotStatus` (3: mixed / all-disconnected / all-connected).
- `bootstrap-migration-lock.test.ts` (2, new file) — contention with `{lockTimeoutMs: 2000}` override + sanity case with no holder.

## Follow-ups (from PR review, non-blocking)

1. **`/readyz` cold-start non-monotonic readiness.** Between `markReady()` and the first `bots.set(...)` from the fire-and-forget initial `adapterManager.reload()`, `bots` is empty so `[].every(b => b.connected)` returns `true`, briefly serving `/readyz 200` even if an active feishu config will later fail to connect. Window is short and `/readyz` is not yet wired into docker / swarm probes, but flagged for follow-up — likely fix is to add an `initialAdapterReloadDone` stage to `REQUIRED_STAGES`.
2. **`withoutProxy` bypass window widened.** Parallel `ws.start` across 5 bots shares one bypass window for up to 8s, and now also overlaps with `app.listen()` already serving traffic. Any concurrent outbound that reads `process.env.HTTPS_PROXY` lazily during this window may go direct. Verify on staging with `tcpdump`; long-term fix is SDK-instance-level proxy config rather than `process.env`.

## Risk & rollback

- No DB migration. No npm version bump (server-only changes).
- `onReady → backgroundTasks` timing change is the structural one: any test or business code that assumed "`buildApp` returns ⇒ adapter already connected" needs to wait on `/readyz` instead. Existing suite verified; autoReconnect-aware paths already tolerate disconnected state.
- `git revert` of the two commits in this PR restores prior behavior.

## Test plan

- [x] `pnpm format` / `pnpm check` clean
- [x] `pnpm --filter @first-tree-hub/server typecheck` clean
- [x] `pnpm --filter @first-tree-hub/server test` — 1112/1112 green
- [ ] `docker build .` succeeds; `docker run` reaches `/healthz 200` ≤ 5s and `/readyz 200` within 30s on a clean DB
- [ ] Set `FIRST_TREE_HUB_DATABASE_URL=postgresql://bad-host:5432/x` → server stderr reports `bootstrap stage "runMigrations" timed out after 20000ms`
- [ ] Misconfigure one adapter's `app_secret` → other bots still start, `/readyz` returns 503 with `body.adapters[bad].connected === false` and `lastError` populated

## Design doc

Local-only reference (architect workspace, not committed):

```
/home/bai/.first-tree/hub/data/workspaces/architect/913fa788-e893-4c82-8b68-43edc197aa63/docs/server-bootstrap-resilience-design.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)