### PR TITLE
fix(web): ask-user free-text input — focus loss + UX refactor

### DIFF
--- a/packages/server/scripts/seed-askuser-demo.mjs
+++ b/packages/server/scripts/seed-askuser-demo.mjs
@@ -26,13 +26,14 @@ const { ensureDefaultOrganization } = await import("../src/services/organization
 const { findOrCreateUserFromGithub } = await import("../src/services/auth-identity.ts");
 const { createPersonalTeam } = await import("../src/services/membership.ts");
 const sharedDbSchema = await import("../src/db/schema/index.ts");
-const { sql: drizzleSql, eq } = await import("drizzle-orm");
+const { eq } = await import("drizzle-orm");
 
 const JWT_SECRET = process.env.JWT_SECRET_KEY ?? process.env.JWT_SECRET ?? "demo-jwt-secret";
 
 const config = {
   database: { url: DB_URL, provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
+  workspace: { root: "/tmp/fth-seed-demo-workspaces" },
   secrets: {
     jwtSecret: JWT_SECRET,
     encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -62,20 +63,10 @@ const config = {
 const app = await buildApp(config);
 await app.ready();
 
-await app.db.execute(
-  drizzleSql.raw(`
-  TRUNCATE TABLE pending_questions, inbox_entries, messages,
-    agent_chat_sessions, agent_presence, chat_participants,
-    chat_subscriptions, chats, agents, members, clients,
-    users, organizations, auth_identities, agent_configs,
-    notifications, invitation_redemptions, invitations,
-    adapter_chat_mappings, adapter_agent_mappings,
-    adapter_message_references, adapter_configs,
-    session_events, server_instances, processed_events,
-    tasks, task_chats
-  RESTART IDENTITY CASCADE
-`),
-);
+// TRUNCATE block removed: schema has drifted since this seed was written
+// (chat_participants → chat_membership, tasks/task_chats gone). On a fresh
+// DB (up.sh just migrated) there's nothing to clear anyway; for repeated
+// seeds, run `./reset.sh` to drop the DB.
 await ensureDefaultOrganization(app.db);
 
 // Match the hardcoded login.tsx dev-callback href:
@@ -95,6 +86,7 @@ const { userId } = await findOrCreateUserFromGithub(app.db, githubProfile);
 const team = await createPersonalTeam(app.db, {
   userId,
   loginSeed: githubProfile.login,
+  teamDisplayName: `${githubProfile.displayName}'s team`,
   userDisplayName: githubProfile.displayName,
 });
 const orgId = team.organizationId;

--- a/packages/web/src/components/chat/question-message.tsx
+++ b/packages/web/src/components/chat/question-message.tsx
@@ -9,6 +9,7 @@ import {
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { submitQuestionAnswer } from "../../api/questions.js";
+import { useAutoResizeTextarea } from "../../lib/use-autoresize-textarea.js";
 import { cn } from "../../lib/utils.js";
 import { Button } from "../ui/button.js";
 import { OptionCard } from "./option-card.js";
@@ -29,12 +30,10 @@ import { OptionCard } from "./option-card.js";
  */
 export type QuestionStatus = "pending" | "answered" | "superseded";
 
-const FREE_TEXT_SENTINEL = "__free_text__";
-
 type AnswerSelection = {
-  /** For multiSelect: ordered set of selected labels. For single-select: at most one entry. */
+  /** Selected option labels. Never contains a free-text marker — the textarea is the source of truth for free text. */
   picked: string[];
-  /** When the "Other..." sentinel is selected, this is the user's typed answer. */
+  /** User's typed answer. Non-empty means free-text overrides any picked options. */
   freeText: string;
 };
 
@@ -43,11 +42,10 @@ function emptySelection(): AnswerSelection {
 }
 
 function selectionToAnswer(question: QuestionItem, sel: AnswerSelection): string | null {
-  // "Other..." takes precedence — typed text is the literal answer.
-  if (sel.picked.includes(FREE_TEXT_SENTINEL)) {
-    const trimmed = sel.freeText.trim();
-    return trimmed.length === 0 ? null : trimmed;
-  }
+  // Typing into the free-text field is the user's implicit "use my own
+  // answer" signal — it always overrides picked options.
+  const trimmed = sel.freeText.trim();
+  if (trimmed.length > 0) return trimmed;
   if (sel.picked.length === 0) return null;
   if (!question.multiSelect) return sel.picked[0] ?? null;
   return sel.picked.join(", ");
@@ -106,8 +104,7 @@ export function QuestionMessage({
       if (matched.length === tokens.length && matched.length > 0) {
         next[q.question] = { picked: matched, freeText: "" };
       } else {
-        // Free-text path — no matching option label.
-        next[q.question] = { picked: [FREE_TEXT_SENTINEL], freeText: recorded };
+        next[q.question] = { picked: [], freeText: recorded };
       }
     }
     setSelections(next);
@@ -130,6 +127,11 @@ export function QuestionMessage({
   });
 
   const onSubmit = useCallback(() => {
+    // Guard against duplicate submissions from any trigger path — the submit
+    // button is `disabled` while pending, but the Cmd/Ctrl+Enter shortcut
+    // inside the free-text field reaches us directly and would otherwise fire
+    // concurrent POSTs before the answered refetch lands.
+    if (mutation.isPending) return;
     setSubmitError(null);
     const answers: Record<string, string> = {};
     for (const q of content.questions) {
@@ -196,6 +198,7 @@ export function QuestionMessage({
                 [q.question]: next,
               }))
             }
+            onSubmit={onSubmit}
           />
         ))}
       </div>
@@ -224,6 +227,7 @@ function QuestionBlock({
   disabled,
   showAnsweredCheck,
   onChange,
+  onSubmit,
 }: {
   question: QuestionItem;
   previewFormat: QuestionPreviewFormat;
@@ -232,27 +236,36 @@ function QuestionBlock({
   disabled: boolean;
   showAnsweredCheck: boolean;
   onChange: (next: AnswerSelection) => void;
+  onSubmit: () => void;
 }) {
-  // Programmatic focus is user-initiated (revealed only after they click
-  // "Other…"), so it's accessible — biome's `noAutofocus` rule blocks the
-  // declarative `autoFocus` attribute, this useEffect+ref achieves the
-  // same intent without tripping it.
-  const freeTextRef = useRef<HTMLTextAreaElement>(null);
-  const isFreeTextPicked = selection.picked.includes(FREE_TEXT_SENTINEL);
-  useEffect(() => {
-    if (isFreeTextPicked && !disabled) freeTextRef.current?.focus();
-  }, [isFreeTextPicked, disabled]);
-
   const togglePick = useCallback(
     (label: string) => {
       const isPicked = selection.picked.includes(label);
-      let nextPicked: string[];
       if (question.multiSelect) {
-        nextPicked = isPicked ? selection.picked.filter((l) => l !== label) : [...selection.picked, label];
+        // Toggle just this label. Any free-text draft is preserved — in
+        // multi-select mode, free-text and picked options coexist (free-text
+        // wins at submit time).
+        const nextPicked = isPicked ? selection.picked.filter((l) => l !== label) : [...selection.picked, label];
+        onChange({ ...selection, picked: nextPicked });
       } else {
-        nextPicked = isPicked ? [] : [label];
+        // Picking an option is the user's explicit "use this answer" — discard
+        // any free-text draft so the picked option becomes the real submission.
+        const nextPicked = isPicked ? [] : [label];
+        onChange({ picked: nextPicked, freeText: "" });
       }
-      onChange({ ...selection, picked: nextPicked });
+    },
+    [question.multiSelect, selection, onChange],
+  );
+
+  const onFreeTextChange = useCallback(
+    (value: string) => {
+      if (question.multiSelect) {
+        onChange({ ...selection, freeText: value });
+      } else {
+        // Typing custom text means "I want a custom answer instead" — drop
+        // any previously picked option so the UI matches what we'll submit.
+        onChange({ picked: [], freeText: value });
+      }
     },
     [question.multiSelect, selection, onChange],
   );
@@ -285,75 +298,100 @@ function QuestionBlock({
           />
         ))}
         {allowFreeText ? (
-          <button
-            type="button"
+          <FreeTextField
+            value={selection.freeText}
             disabled={disabled}
-            onClick={
-              disabled
-                ? undefined
-                : () =>
-                    onChange({
-                      picked: question.multiSelect
-                        ? isFreeTextPicked
-                          ? selection.picked.filter((l) => l !== FREE_TEXT_SENTINEL)
-                          : [...selection.picked, FREE_TEXT_SENTINEL]
-                        : isFreeTextPicked
-                          ? []
-                          : [FREE_TEXT_SENTINEL],
-                      freeText: selection.freeText,
-                    })
-            }
-            className={cn(
-              "w-full text-left rounded-[var(--radius-input)] border transition-colors",
-              "flex flex-col",
-              disabled ? "cursor-default opacity-70" : "cursor-pointer hover:bg-[color:var(--bg-hover)]",
-            )}
-            style={{
-              padding: "var(--sp-2_5) var(--sp-3)",
-              gap: "var(--sp-1_5)",
-              borderColor: isFreeTextPicked ? "var(--accent)" : "var(--border)",
-              background: isFreeTextPicked ? "var(--bg-active)" : "var(--bg-raised)",
-            }}
-          >
-            <span
-              className="mono text-body font-semibold"
-              style={{ color: isFreeTextPicked ? "var(--accent)" : "var(--fg-3)" }}
-            >
-              Other…
-            </span>
-            <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-              Type a free-text answer.
-            </span>
-            {isFreeTextPicked ? (
-              <textarea
-                ref={freeTextRef}
-                value={selection.freeText}
-                disabled={disabled}
-                onChange={(e) => onChange({ ...selection, freeText: e.target.value })}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={(e) => {
-                  // Enter inserts a newline; Cmd/Ctrl-Enter is reserved for the
-                  // submit button so the user can't accidentally submit a
-                  // half-typed answer by pressing Enter once.
-                  if (e.key === "Enter" && !e.metaKey && !e.ctrlKey) {
-                    // Default behaviour (newline) — but stop click bubbling.
-                    e.stopPropagation();
-                  }
-                }}
-                rows={2}
-                className="rounded-[var(--radius-input)] border text-body"
-                style={{
-                  padding: "var(--sp-2)",
-                  borderColor: "var(--border)",
-                  background: "var(--bg-sunken)",
-                  color: "var(--fg)",
-                  resize: "vertical",
-                }}
-              />
-            ) : null}
-          </button>
+            isMultiSelect={question.multiSelect}
+            hasPickedOptions={selection.picked.length > 0}
+            questionText={question.question}
+            onChange={onFreeTextChange}
+            onSubmit={onSubmit}
+            showAnsweredCheck={showAnsweredCheck}
+          />
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function FreeTextField({
+  value,
+  disabled,
+  isMultiSelect,
+  hasPickedOptions,
+  questionText,
+  onChange,
+  onSubmit,
+  showAnsweredCheck,
+}: {
+  value: string;
+  disabled: boolean;
+  isMultiSelect: boolean;
+  hasPickedOptions: boolean;
+  /** The question this textarea answers — used for the accessible name so screen readers can tell which question a free-text field belongs to. */
+  questionText: string;
+  onChange: (next: string) => void;
+  onSubmit: () => void;
+  showAnsweredCheck: boolean;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  useAutoResizeTextarea(textareaRef, value);
+
+  const isActive = value.trim().length > 0;
+
+  return (
+    <div
+      className="rounded-[var(--radius-input)] border flex flex-col"
+      style={{
+        padding: "var(--sp-2_5) var(--sp-3)",
+        gap: "var(--sp-1_5)",
+        borderColor: isActive ? "var(--accent)" : "var(--border)",
+        background: isActive ? "var(--bg-active)" : "var(--bg-raised)",
+        opacity: disabled ? 0.7 : 1,
+      }}
+    >
+      <div className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
+        <span className="mono text-body font-semibold" style={{ color: isActive ? "var(--accent)" : "var(--fg-3)" }}>
+          Write your own
+        </span>
+        {showAnsweredCheck && isActive ? (
+          <span className="mono text-caption" style={{ color: "var(--accent)" }} title="Selected">
+            ✓
+          </span>
+        ) : null}
+        {isMultiSelect && isActive && hasPickedOptions ? (
+          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+            (overrides picked options)
+          </span>
+        ) : null}
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        disabled={disabled}
+        placeholder="Type your own answer…"
+        aria-label={`Write your own answer for: ${questionText}`}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          // Cmd/Ctrl+Enter submits — plain Enter inserts a newline so users
+          // can write multi-line answers without accidentally firing the form.
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            onSubmit();
+          }
+        }}
+        rows={2}
+        className="rounded-[var(--radius-input)] border text-body w-full"
+        style={{
+          padding: "var(--sp-2)",
+          borderColor: "var(--border)",
+          background: "var(--bg-sunken)",
+          color: "var(--fg)",
+          resize: "none",
+          maxHeight: "15rem",
+          overflowY: "auto",
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

User report:
> 输入框输入有很多问题，输完一个字后，点击空格或其他键好像总是容易失去焦点。

The free-text "Other…" input on agent question cards (`AskUserQuestion` tool) dropped focus and lost characters when the user pressed Space (or any key that triggered the surrounding `<button>`'s implicit click). The textarea was nested inside a `<button>` (invalid HTML — interactive descendant), so Space-as-click toggled the option off and unmounted the textarea mid-typing.

Two commits:

1. **`fix(web)`** — Repair the focus-loss bug and reshape the input to be always-visible and predictable.
2. **`chore(server)`** — Drive-by: unstick `seed-askuser-demo.mjs` from schema/service drift surfaced while validating the UX path on the local dev stack.

### Web changes (`packages/web/src/components/chat/question-message.tsx`)

- Replace nested `<button>` + `<textarea>` with a sibling layout — no more interactive descendant.
- `FREE_TEXT_SENTINEL` removed; non-empty `freeText` is the implicit "use my own answer" signal. `selectionToAnswer` returns trimmed `freeText` when present, otherwise falls back to picked options.
- **Single-select**: typing into the textarea clears `picked`; picking an option clears `freeText`. Mutually exclusive answers, "last interaction wins".
- **Multi-select**: `picked` and `freeText` coexist with free-text taking precedence at submit; UI surfaces `(overrides picked options)` so the override is visible.
- `aria-label` on the textarea includes the question text so screen readers can disambiguate multiple question cards in a chat.
- Guard `onSubmit` against `mutation.isPending` — Cmd/Ctrl+Enter shortcut from inside the textarea would otherwise bypass the disabled submit button and fire duplicate POSTs.
- Reuse the shared `useAutoResizeTextarea` hook with `maxHeight: 15rem`, matching the chat composer / new-chat draft.
- `"Other…"` → `"Write your own"` (more action-oriented label).

### Seed script (`packages/server/scripts/seed-askuser-demo.mjs`)

Three single-line contract updates so the demo seed can run again on a current schema:

- Add missing `workspace: { root: ... }` to the boot config (`app.ts` now requires `config.workspace.root`).
- Drop the stale `TRUNCATE` — `chat_participants` was renamed to `chat_membership`; `chat_subscriptions`, `tasks`, `task_chats` no longer exist. Fresh DBs need no clearing; for repeated seeds use `dev-stack/reset.sh`.
- Pass both `teamDisplayName` and `userDisplayName` to `createPersonalTeam` — the service uses the former for the org label and the latter for the member's display name.
- Remove now-unused `drizzleSql` import.

## Test plan

- [x] `pnpm exec biome check` on changed files
- [x] `pnpm --filter @first-tree-hub/web typecheck` (incl. `lint:tokens`)
- [x] `pnpm --filter @first-tree-hub/web test --run` — 21 test files / 185 tests pass
- [x] Local dev stack via `~/.first-tree/dev-stack/up.sh` + `seed-askuser-demo.mjs` — login as `devuser`, two demo question cards render
- [x] Manual: focus textarea, hammer Space / arbitrary keys — no focus loss, no dropped characters
- [x] Manual: single-select → typing into free-text clears prior `picked`, and picking an option clears free-text draft
- [x] Manual: Cmd/Ctrl+Enter from inside textarea submits without firing twice while pending
- [x] Manual: auto-grow up to 15rem then internal scroll
- [x] Reviewed by codex (two rounds: blocking duplicate-submit guard + a11y `aria-label`; then blocking `userDisplayName` contract fix) — final verdict pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)