### PR TITLE
refactor: drop stale legacy GitHub webhook refs from comments

### DIFF
--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -457,7 +457,7 @@ async function completeOauthFlow(
   // `/user/installations` check enforced when the row was first written),
   // and auto-claim if there's exactly one. Multiple → leave them for the
   // manual `POST /claim` endpoint to disambiguate (the Settings "Claim install"
-  // UI that drives that endpoint is tracked in #318 and not in PR 2/3 yet).
+  // UI that drives that endpoint is tracked in #318).
   if (resolvedOrganizationId) {
     try {
       const orphans = await findUnboundInstallationsByAccount(app.db, Number(profile.githubId));

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -46,8 +46,6 @@ const POST_INSTALL_NEXT = "/settings/github";
  *
  * Admin-only: the installation block exposes account-level metadata
  * (login, permissions, events) that a regular member doesn't need.
- * Mirrors the readPolicy="admin" choice for `github_integration` in the
- * legacy settings.
  */
 export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
@@ -146,11 +144,10 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   // an org account, where "the user is an org admin" isn't a strong enough
   // basis to auto-claim).
   //
-  // ⚠ This endpoint is **API-only** in PR 2/3 — there is no Settings UI
-  // that calls it yet. The orphan-list endpoint and the `Claim install`
-  // button per orphan are tracked in #318 and intentionally deferred to
-  // keep PR 2/3 focused. Until #318 ships, multi-orphan recovery requires
-  // the operator to POST to this endpoint directly.
+  // ⚠ This endpoint is **API-only** — there is no Settings UI that calls
+  // it yet. The orphan-list endpoint and the `Claim install` button per
+  // orphan are tracked in #318. Until #318 ships, multi-orphan recovery
+  // requires the operator to POST to this endpoint directly.
   //
   // Authorization mirrors the OAuth callback's `installation_id` check:
   // being an admin of the target Hub org isn't sufficient — installation

--- a/packages/server/src/db/schema/organization-settings.ts
+++ b/packages/server/src/db/schema/organization-settings.ts
@@ -15,9 +15,9 @@ import { users } from "./users.js";
  * and is currently set unconditionally. We keep it on the table from day
  * one so tightening to compare-and-swap later is a code-only change.
  *
- * Sensitive fields inside `value` (e.g. `github_integration.webhookSecret`)
- * are AES-256-GCM-encrypted at the service layer using `crypto.ts`'s
- * `encryptValue` / `decryptValue` — same pattern as `adapter_configs`.
+ * Sensitive fields inside `value` are AES-256-GCM-encrypted at the service
+ * layer using `crypto.ts`'s `encryptValue` / `decryptValue` — same pattern
+ * as `adapter_configs`.
  */
 export const organizationSettings = pgTable(
   "organization_settings",
@@ -25,7 +25,7 @@ export const organizationSettings = pgTable(
     organizationId: text("organization_id")
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
-    /** e.g. "context_tree" | "github_integration"; validated by shared registry. */
+    /** e.g. "context_tree" | "source_repos"; validated by shared registry. */
     namespace: text("namespace").notNull(),
     /** Whole-group config JSON; schema-validated by namespace at the service layer. */
     value: jsonb("value").$type<Record<string, unknown>>().notNull().default({}),

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -25,8 +25,7 @@ import { pickDefaultMembership } from "./auth.js";
  *
  * The generic getter returns the masked output. Per-namespace plaintext
  * accessors live alongside this module when a secret needs to leave the
- * encrypted-at-rest boundary (none today after the github_integration
- * webhook secret was retired — DP12).
+ * encrypted-at-rest boundary (none today).
  */
 
 function assertNamespace(ns: string): asserts ns is OrgSettingNamespace {

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -77,9 +77,8 @@ export const serverConfigSchema = defineConfig({
   // no global token belongs here.
   oauth: optional({
     /**
-     * GitHub App credentials — the sign-in surface introduced by PR 2/3 of
-     * the GitHub App migration split. A single App installation simultaneously
-     * unlocks user-OAuth, the webhook stream (PR 3/3), and installation-token
+     * GitHub App credentials. A single App installation simultaneously
+     * unlocks user-OAuth, the webhook stream, and installation-token
      * minting. All five required fields must be set together; partial
      * configuration is rejected at boot for the same reason as the legacy
      * block — a half-wired App is worse than no App.

--- a/packages/shared/src/schemas/github-app.ts
+++ b/packages/shared/src/schemas/github-app.ts
@@ -72,8 +72,7 @@ export type GithubAppInstallationEvents = z.infer<typeof githubAppInstallationEv
  * and treat absence of expiry fields as "still on legacy OAuth token".
  *
  * The token strings themselves are AES-256-GCM ciphertext — same pattern as
- * `adapter_configs` / `organization_settings.github_integration`. Plaintext
- * never touches the row.
+ * `adapter_configs`. Plaintext never touches the row.
  */
 export const githubAppUserTokenMetadataSchema = z.object({
   login: z.string().optional(),

--- a/packages/shared/src/schemas/org-settings.ts
+++ b/packages/shared/src/schemas/org-settings.ts
@@ -6,8 +6,8 @@ import { z } from "zod";
  *
  * Each namespace has three schemas:
  *   - `storage` — what is persisted in `organization_settings.value`. For
- *     namespaces with secrets, the storage schema names the *cipher* field
- *     (e.g. `webhookSecretCipher`); plaintext never touches the row.
+ *     namespaces with secrets, the storage schema names the *cipher* field;
+ *     plaintext never touches the row.
  *   - `input`   — what the admin API accepts in PUT bodies. For namespaces
  *     with secrets, `webhookSecret` is plaintext; the service layer
  *     encrypts it before merging into storage.
@@ -129,12 +129,6 @@ export const orgContextTreeOutputSchema = z.object({
   repo: z.string().optional(),
   branch: z.string().optional(),
 });
-
-// `github_integration` (per-org webhook secret cipher) was retired with the
-// GitHub App ingestion cutover — webhook secrets now live in server env, and
-// installations bind via `github_app_installations` instead. The JSONB key
-// `webhookSecretCipher` is left untouched on legacy rows; a follow-up release
-// drops the orphan rows in a separate migration (DP12).
 
 // -- source_repos --
 

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -7,13 +7,6 @@ import { GithubAppInstallationPanel } from "../github-app-installation-panel.js"
  * Settings → GitHub. Admin-only — the App installation admin API is
  * admin-gated server-side, so a member landing here would just see a
  * 403 in the panel. Redirect them out instead.
- *
- * The legacy `GithubIntegrationPanel` (per-org webhook secret config)
- * was deleted in this PR (PR 2/3 of the GitHub App split). The matching
- * server-side cleanup — per-org webhook endpoint + `github_integration`
- * settings namespace + migration `0038` — lands in PR 3/3 alongside the
- * App webhook switch. Until that lands, the legacy webhook route still
- * accepts deliveries; the namespace just has no Settings UI to write to.
  */
 export function SettingsGithubPage() {
   const { role } = useAuth();


### PR DESCRIPTION
## Summary

Comment-only cleanup of stale references to the retired per-org GitHub webhook flow.

- Per-org webhook (`organization_settings.github_integration` + `/webhooks/github/:orgId`) was replaced by the GitHub App webhook (`github_app_installations` + `/webhooks/github-app`); code cutover landed earlier.
- Removed now-misleading comment refs in 8 files: `github_integration` / `webhookSecretCipher` examples (no counterpart in `ORG_SETTINGS_NAMESPACES` registry today) and `PR 2/3` / `PR 3/3` / `DP12` milestone notes that no longer anchor to anything in-tree.
- Zero runtime behavior change. Service-layer `assertNamespace` already rejects any `github_integration` writes; this PR does not change that path.

## Retained on purpose

- `packages/server/src/db/schema/github-app-installations.ts:13` — *new table replaces old mechanism* architectural narrative; valuable for future schema-evolution reviewers.
- `packages/server/drizzle/0032_*.sql`, `drizzle/0037_*.sql` — immutable SQL migration history.

## Out-of-band follow-up

The orphan row in `organization_settings` (namespace=`github_integration`) is dropped manually post-merge:

```sql
DELETE FROM organization_settings WHERE namespace = 'github_integration';
```

No migration written — SaaS-only deployment, no self-hosted users; service layer already gates writes, so the row is unreachable from code.

## Test plan

- [x] `pnpm check` — biome clean
- [x] `pnpm typecheck` — 9 / 9 tasks green
- [x] `pnpm --filter @first-tree-hub/server test` — 1119 / 1119 passing
- [x] Independent reviewer pass (two rounds, both approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)