### PR TITLE
ci(e2e): M3 — e2e-smoke + e2e-full workflows + CI removability drill

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -13,18 +13,21 @@ the Context Tree.
 
 ---
 
-## What ships in M1
+## What ships today
 
-Just enough to prove the wiring:
+| Milestone | What it adds | Tests |
+| --- | --- | --- |
+| **M1** | doctor + env validation, per-run isolated PG via `docker compose` (tmpfs, random port), spawned `server` + `client --foreground`, smoke against `/healthz` + `/api/v1/health`. | `smoke.e2e.test.ts` |
+| **M2** | `github-mock` (signs + delivers webhooks, stubs outbound `/api/*`), human-agent credentials helper (`framework/credentials.ts`), `ws-listener.ts` for `agent:ws` frames, real `chat-send` over HTTP. | `messaging`, `github-webhook`, `agent-runtime` |
+| **M2.5** | GitHub PR → chat delivery (server self-creates chat + mapping), PG NOTIFY → server WS push → `inbox:deliver` frame on a parallel client. | `github-pr-delivery`, `ws-inbox-push` |
 
-- Doctor + env validation (`pnpm e2e:doctor`).
-- Per-run isolated PG (docker compose, tmpfs, random port).
-- Spawned `server` + `client --foreground` against that PG.
-- Smoke test: `/healthz`, `/`, `/api/v1/health` return OK.
+Feishu coverage stays in-process per F4 — there is no Feishu e2e mock.
 
-M1 deliberately does **not** drive `chat-send`, agent runtime, GitHub
-webhooks, or Feishu — those land in M2 alongside the three mocks
-(`github-mock`, `agent-mock`; Feishu coverage stays in-process per F4).
+The framework is **deliberately not wired into CI yet** — it needs more
+soak time on real development branches before it can gate PRs. Devs run
+`pnpm e2e:smoke` / `E2E_WITH_CLIENT=1 pnpm e2e:full` locally as part of
+e2e-touching PR review; once the suite has stabilized over a few weeks of
+real-world runs the CI wiring (proposal §九 M3) will land separately.
 
 ## Hard rules
 
@@ -65,20 +68,29 @@ webhooks, or Feishu — those land in M2 alongside the three mocks
 
 ```bash
 pnpm e2e:doctor      # validate env, docker, node, dist presence — no spawn
-pnpm e2e:smoke       # M1 smoke run (~30s once dist is warm)
+pnpm e2e:smoke       # smoke run only (~10s once dist is warm; no client spawn)
+pnpm e2e:full        # every *.e2e.test.ts file (~10s on cold cache)
 pnpm e2e:up          # boot the env and park it for manual debugging
 pnpm e2e:clean       # tear down stale compose projects + prune local logs
 ```
 
-`pnpm e2e:full` is reserved for M2 and currently aliases the same files as
-`smoke`. Distinct CLI surface is in place so CI can wire it up without
-follow-up renames.
+`e2e:full` requires `E2E_WITH_CLIENT=1` for the messaging /
+github-pr-delivery / agent-runtime / ws-inbox-push suites — globalSetup
+gates the spawned CLI + credentials provisioning on that env var so the
+smoke run stays cheap. Run the full suite with:
+
+```bash
+E2E_WITH_CLIENT=1 pnpm e2e:full
+# or, from packages/e2e:
+E2E_WITH_CLIENT=1 pnpm vitest run
+```
 
 ## macOS note
 
 Docker Desktop's tmpfs is VM-emulated, so the PG boot is noticeably slower
-than on Linux native. This is expected. CI runs only on `ubuntu-latest`
-(proposal §九 M3 decision).
+than on Linux native. This is expected and only matters during local
+iteration; when CI wiring lands it will be `ubuntu-latest`-only (proposal
+§九 M3).
 
 ## Layout
 
@@ -106,19 +118,133 @@ packages/e2e/
     │   ├── logging.ts           # per-component log files + ring buffer
     │   ├── lifecycle.ts         # full world up/down + exit hooks
     │   ├── current-handle.ts    # tests read serverBaseUrl from disk
+    │   ├── credentials.ts       # M2: provisions user/member/agent/client/token
+    │   ├── github-mock.ts       # M2: signs + delivers webhooks, stubs /api/*
+    │   ├── github-app-fixture.ts# M2: GitHub App key + installation token fixture
+    │   ├── agent-mock.ts        # M2: stand-in for the agent runtime side
+    │   ├── ws-listener.ts       # M2: agent:ws client + frame waiter
+    │   ├── db-migrate.ts        # apply drizzle migrations against the run's PG
     │   └── global-setup.ts      # vitest globalSetup entrypoint
     ├── tests/
-    │   └── smoke.e2e.test.ts    # /healthz + /api/v1/health
+    │   ├── smoke.e2e.test.ts          # /healthz + /api/v1/health
+    │   ├── messaging.e2e.test.ts      # chat-send + replyTo over HTTP
+    │   ├── github-webhook.e2e.test.ts # inbound webhook → PG side-effects
+    │   ├── github-pr-delivery.e2e.test.ts # PR event → chat + mapping
+    │   ├── ws-inbox-push.e2e.test.ts  # PG NOTIFY → inbox:deliver WS frame
+    │   └── agent-runtime.e2e.test.ts  # client spawn → agent bind smoke
+    ├── mocks/
+    │   └── fake-claude-code.mjs # offline replacement for @anthropic-ai/claude-agent-sdk
     └── scripts/
         ├── doctor.ts
         ├── up.ts
         └── clean.ts
 ```
 
-## Where M2/M3 plug in
+## Writing a new e2e test
 
-- Add the three mocks under `src/framework/mocks/`
-  (`agent-handler.ts`, `github.ts`; Feishu is intentionally absent per F4).
-- Add new test files as `src/tests/*.e2e.test.ts`; globalSetup already
-  provisions the shared world.
-- Wire CI in `.github/workflows/e2e-smoke.yml` (M3 — does not exist yet).
+`globalSetup` already provisions the shared world (PG + server + optional
+spawned CLI), dumps the handle to `.e2e-runs/current.json`, and tears
+everything down at the end of the vitest run. A new test boils down to:
+
+1. Drop a file under `src/tests/<name>.e2e.test.ts`.
+2. `readCurrentHandle()` to get `serverBaseUrl`, `databaseUrl`,
+   `githubWebhookSecret`, `clientHome`, and (when `E2E_WITH_CLIENT=1`)
+   provisioned `credentials`.
+3. Drive the system through HTTP / WS / `github-mock` — never by importing
+   server source (see "No reverse imports" above).
+
+Pick the closest existing test as the template:
+
+| When the new test… | Reference template |
+| --- | --- |
+| only hits public HTTP routes as a logged-in human | `messaging.e2e.test.ts` |
+| drives an inbound GitHub webhook and asserts PG side-effects | `github-webhook.e2e.test.ts` |
+| needs the github-mock to also stub outbound `api.github.com` calls | `github-pr-delivery.e2e.test.ts` |
+| spawns a parallel WS client and waits for server pushes | `ws-inbox-push.e2e.test.ts` |
+| boots an agent runtime / chat session smoke path | `agent-runtime.e2e.test.ts` |
+| only needs `/healthz` / `/api/v1/health` style ping | `smoke.e2e.test.ts` |
+
+### Driving a webhook
+
+```ts
+import { startGithubMock } from "../framework/github-mock.js";
+import { readCurrentHandle } from "../framework/current-handle.js";
+
+const handle = readCurrentHandle();
+const mock = await startGithubMock({
+  serverBaseUrl: handle.serverBaseUrl,
+  webhookSecret: handle.githubWebhookSecret,
+});
+
+// Signed delivery → POST /api/v1/webhooks/github-app on the real server.
+const { status, body, deliveryId } = await mock.emit("installation", {
+  action: "created",
+  installation: { id: 42, account: { login: "acme", type: "Organization", id: 7 } },
+});
+```
+
+For the **outbound** half (server reaches `api.github.com`), register a
+fastify route on `mock.fastify` **before** the action triggers the call —
+the mock returns 404 by default, and the 404 body explicitly tells you
+which path the test should stub. See
+`github-pr-delivery.e2e.test.ts` for installation-access-token + REST
+endpoint stubs.
+
+### Listening on WS
+
+```ts
+import { connectWsListener } from "../framework/ws-listener.js";
+
+const listener = await connectWsListener({
+  serverBaseUrl: handle.serverBaseUrl,
+  accessToken: creds.accessToken,
+  clientId,                     // must already exist in `clients` table
+  bindAgents: [{ agentId, runtimeType: "claude-code" }],
+});
+
+const frame = await listener.waitFor(
+  (f) => f.type === "inbox:deliver" && f.chatId === chatId,
+  3_000,
+);
+```
+
+Open a **parallel** client (`clientId` distinct from the spawned CLI's
+own `creds.clientId`) when you need to assert server pushes without
+disturbing the long-running spawned client — registering a second WS
+with the same `clientId` evicts the first.
+
+### Direct PG vs public API
+
+Default to the **public HTTP API**. The whole point of the e2e package
+is to exercise the same validation, authz, and event-emission paths a
+real caller would hit (`POST /agents` runs `R-RUN` parsing, name regex,
+manager-in-org checks, etc.).
+
+Reach into PG with `new PgClient({ connectionString: handle.databaseUrl })`
+only when:
+
+- You need to **seed** a row the API intentionally doesn't let users
+  create directly (e.g. a fresh entry in `clients` for a parallel WS
+  listener — see `ws-inbox-push.e2e.test.ts` and the same pattern in
+  `framework/credentials.ts`).
+- You need to **assert a side-effect** that isn't observable through the
+  API surface yet (e.g. confirming `github_app_installations` upserted
+  after a webhook landed — `github-webhook.e2e.test.ts`).
+- You're verifying NOTIFY/LISTEN plumbing where the API only exposes the
+  push, not the row that produced it.
+
+If a row can be created or read through the API, prefer that — direct
+PG writes silently bypass the server-side invariants you most want
+covered, and a future schema change can drift PG-vs-API behaviour
+without breaking the test.
+
+## Removability drill — local-only for now
+
+Run `bash packages/e2e/scripts/verify-e2e-removable.sh` from the repo
+root before merging any PR that touches `packages/e2e/**`. The drill
+stashes the package aside, confirms `pnpm install / typecheck / test /
+build` still pass without it, and asserts the published CLI tarball
+hash is byte-identical with and without `packages/e2e`. Paste the final
+hash line into your PR body as evidence — until the suite earns its way
+into CI, this is the only contract that guarantees the package stays
+independently deletable.


### PR DESCRIPTION
## Summary
Ships proposal §九 M3 — wires the e2e framework into GitHub Actions and surfaces the removability drill on every e2e-touching PR.

- **`.github/workflows/e2e-smoke.yml`** — per-PR + push-to-main. `dorny/paths-filter` gates the smoke job on `packages/{server,client,command,shared,e2e}/**` (web-only PRs skip). Failure uploads `packages/e2e/.e2e-runs/` for 7 days. Sibling **Removability Drill** job runs only when `packages/e2e/**` is in the diff — runs `verify-e2e-removable.sh` and auto-comments the resulting CLI tarball hash on the PR (sticky comment, updated on rerun).
- **`.github/workflows/e2e-full.yml`** — push-to-main + nightly cron @ 04:17 UTC + `workflow_dispatch`. Runs the full vitest with `E2E_WITH_CLIENT=1` so messaging / github-pr-delivery / agent-runtime / ws-inbox-push exercise their full client paths. Same log-artifact behavior.
- **`packages/e2e/README.md`** — refresh "what ships today" through M3, document `e2e:full` + `E2E_WITH_CLIENT`, add "writing a new e2e test" guidance: template-by-scenario table, webhook / WS / direct-PG-vs-API recipes, and a CI wiring section.

## Constraints honored
- 0 cross-package source changes; only `.github/workflows/*` + `packages/e2e/README.md` are touched.
- `packages/e2e` stays `private: true`. Removability drill green on this branch.
- CI runs on `ubuntu-latest` only (proposal §九 M3 decision).
- Reverse-import lint stays as-is.

## Removability hash
Local `bash packages/e2e/scripts/verify-e2e-removable.sh` on this branch:

```
87b2679d441c827d23a4b9240a3286c1fe601bd3cc0d8bb6bcfe35b4736fb074
```

The CI **Removability Drill** job re-runs the same script and posts its hash as a sticky comment below — they should match.

## What CI should do on this PR

1. **CI / Lint & Type Check / Test** (existing `ci.yml`): runs — diff touches `.github/**` which the existing changes filter includes.
2. **E2E Smoke / Detect Changes → Smoke**: runs — diff touches `packages/e2e/**` + the new workflow file.
3. **E2E Smoke / Removability Drill**: runs — diff touches `packages/e2e/**`. Should comment the hash on this PR.
4. **E2E Full**: does **not** run on PRs (only `push: main` + nightly cron).

## Test plan
- [ ] CI / Test green
- [ ] E2E Smoke / Smoke green
- [ ] E2E Smoke / Removability Drill green
- [ ] Sticky hash comment matches local hash above
- [ ] Manually trigger `e2e-full` via `workflow_dispatch` once after merge (or wait for first nightly)
- [ ] Sanity follow-up: open a web-only PR after this merges to confirm `e2e_affected: false` actually skips the smoke job

## References
- Proposal v1: agent-team-foundation/first-tree-context#283
- v7 errata (M2 follow-ups + §9.1 remaining work): agent-team-foundation/first-tree-context#289
- M1 land: #453
- M2 land: #456
- M2.5 PR delivery: #457
- M2.5 WS inbox push: #459