### PR TITLE
refactor(web): sentence-case badges and friendlier sidebar copy

### DIFF
--- a/packages/web/src/components/ui/dense-badge.tsx
+++ b/packages/web/src/components/ui/dense-badge.tsx
@@ -13,10 +13,12 @@ type DenseBadgeProps = HTMLAttributes<HTMLSpanElement> & {
 };
 
 // Mirrors the Badge atom in design-canvas/atoms.jsx:
-//   mono / var(--sp-2_5) / uppercase / padding var(--hairline) var(--sp-1_75) / radius 3 / var(--hairline) border.
+//   mono / var(--sp-2_5) / padding var(--hairline) var(--sp-1_75) / radius 3 / var(--hairline) border.
 // shadcn Badge is var(--sp-3) + rounded-md and reads as "chunky" in dense panels.
 // Typography is bound to the `text-caption` token from index.css; tones are
 // resolved via the shared tones map so chips stay in sync with state chips.
+// Casing is the caller's responsibility — pass sentence-case labels for
+// reading flow ("Working", "Open"), uppercase only for true codes.
 export function DenseBadge({ tone = "neutral", className, style, ...rest }: DenseBadgeProps) {
   const t = TONE_STYLES[tone];
   const merged: CSSProperties = {
@@ -27,7 +29,7 @@ export function DenseBadge({ tone = "neutral", className, style, ...rest }: Dens
   };
   return (
     <span
-      className={cn("mono inline-flex items-center uppercase text-caption leading-[1.6]", className)}
+      className={cn("mono inline-flex items-center text-caption leading-[1.6]", className)}
       style={{
         padding: "var(--hairline) var(--sp-1_75)",
         borderRadius: "var(--radius-chip)",

--- a/packages/web/src/components/ui/state-chip.tsx
+++ b/packages/web/src/components/ui/state-chip.tsx
@@ -10,15 +10,28 @@ function isAgentState(state: string): state is AgentState {
   return state === "idle" || state === "working" || state === "blocked" || state === "error" || state === "offline";
 }
 
+// Wire-level state values are lowercase enum tokens; the chip displays a
+// sentence-case label so the surface reads naturally. `error` becomes
+// `Failed` to match the AgentRow session-state vocabulary in the chat
+// right sidebar — two surfaces calling the same condition by different
+// names would force the user to translate.
+const STATE_LABELS: Record<AgentState, string> = {
+  idle: "Idle",
+  working: "Working",
+  blocked: "Blocked",
+  error: "Failed",
+  offline: "Offline",
+};
+
 export function StateChip({ state, className }: StateChipProps) {
   const normalized: AgentState = state !== null && isAgentState(state) ? state : "offline";
   const color = normalized === "offline" ? "var(--fg-3)" : `var(--state-${normalized})`;
   // Typography (size / weight / letter-spacing) comes from the `text-caption`
   // token — shared with DenseBadge so state and neutral chips stay aligned.
   return (
-    <span className={cn("mono inline-flex items-center gap-1.5 uppercase text-caption", className)} style={{ color }}>
+    <span className={cn("mono inline-flex items-center gap-1.5 text-caption", className)} style={{ color }}>
       <StateDot state={normalized} size={7} />
-      {normalized}
+      {STATE_LABELS[normalized]}
     </span>
   );
 }

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -70,7 +70,7 @@ export function IdentitySection({ agent, canEdit = true, onSave }: IdentitySecti
             <span className="inline-flex flex-wrap gap-1 align-middle">
               {domains.map((d) => (
                 <DenseBadge key={d} tone="outline">
-                  {d}
+                  {humanizeDomain(d)}
                 </DenseBadge>
               ))}
             </span>
@@ -223,4 +223,19 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
       </DialogContent>
     </Dialog>
   );
+}
+
+/**
+ * Domain tags come from `metadata.tree.domains` and mirror the Context
+ * Tree's top-level directory names (`kael`, `agent-hub`, `first-tree-skill-cli`,
+ * …). They're free-form strings, not a closed enum, so we lean on a
+ * lightweight transform instead of a hard-coded map: kebab/snake → spaces,
+ * then capitalize the first letter so the chip reads as sentence-case
+ * ("Agent hub", "First tree skill cli") rather than as a code token.
+ */
+function humanizeDomain(domain: string): string {
+  if (!domain) return domain;
+  const spaced = domain.replace(/[-_]+/g, " ").trim();
+  if (!spaced) return domain;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -40,6 +40,17 @@ function toolHealthBadgeTone(h: McpToolHealth): "accent" | "error" | "outline" {
   return "outline";
 }
 
+function toolHealthLabel(h: McpToolHealth): string {
+  switch (h) {
+    case "working":
+      return "Working";
+    case "error":
+      return "Error";
+    case "unknown":
+      return "Unknown";
+  }
+}
+
 export function McpSection(props: McpSectionProps) {
   const [dialog, setDialog] = useState<{ mode: "add" } | { mode: "edit"; key: string; initial: McpServer } | null>(
     null,
@@ -79,7 +90,7 @@ export function McpSection(props: McpSectionProps) {
                   {item.value.transport}
                 </span>
                 <span className="font-medium font-mono shrink-0">{item.value.name}</span>
-                {health && <DenseBadge tone={toolHealthBadgeTone(health)}>{health}</DenseBadge>}
+                {health && <DenseBadge tone={toolHealthBadgeTone(health)}>{toolHealthLabel(health)}</DenseBadge>}
                 {/* Long URLs / commands must truncate inside their flex slot;
                     without flex-1 + min-w-0 the span hugs its content width
                     and pushes the row past its parent. title surfaces the

--- a/packages/web/src/pages/bindings.tsx
+++ b/packages/web/src/pages/bindings.tsx
@@ -303,10 +303,12 @@ export function BindingsPage() {
                       <span className="mono font-medium">{resolveAgentName(a.agentId)}</span>
                     </DenseTableCell>
                     <DenseTableCell>
-                      <DenseBadge>{a.platform}</DenseBadge>
+                      <DenseBadge>{humanizePlatform(a.platform)}</DenseBadge>
                     </DenseTableCell>
                     <DenseTableCell>
-                      <DenseBadge tone={a.status === "active" ? "accent" : "outline"}>{a.status}</DenseBadge>
+                      <DenseBadge tone={a.status === "active" ? "accent" : "outline"}>
+                        {humanizeAdapterStatus(a.status)}
+                      </DenseBadge>
                     </DenseTableCell>
                     <DenseTableCell>
                       <span className="inline-flex items-center gap-1.5 text-label">
@@ -390,7 +392,7 @@ export function BindingsPage() {
                     </span>
                   </DenseTableCell>
                   <DenseTableCell>
-                    <DenseBadge>{m.platform}</DenseBadge>
+                    <DenseBadge>{humanizePlatform(m.platform)}</DenseBadge>
                   </DenseTableCell>
                   <DenseTableCell>
                     <span className="mono text-label" style={{ color: "var(--fg-2)" }}>
@@ -399,7 +401,7 @@ export function BindingsPage() {
                   </DenseTableCell>
                   <DenseTableCell style={{ color: "var(--fg-2)" }}>{m.displayName ?? "—"}</DenseTableCell>
                   <DenseTableCell>
-                    <DenseBadge tone="outline">{m.boundVia ?? "—"}</DenseBadge>
+                    <DenseBadge tone="outline">{humanizeBoundVia(m.boundVia)}</DenseBadge>
                   </DenseTableCell>
                   <DenseTableCell className="mono text-caption" style={{ color: "var(--fg-4)" }}>
                     {formatDate(m.createdAt)}
@@ -514,6 +516,58 @@ function narrowPlatform(p: string): "feishu" | "slack" | "kael" {
 }
 function narrowStatus(s: string): "active" | "inactive" {
   return s === "inactive" ? "inactive" : "active";
+}
+
+/**
+ * Display label for the wire-level platform enum (`feishu` / `slack` /
+ * `kael`). Falls back to the raw value so any forward-compat platform the
+ * server emits still renders something, just unstyled.
+ */
+function humanizePlatform(platform: string): string {
+  switch (platform) {
+    case "feishu":
+      return "Feishu";
+    case "slack":
+      return "Slack";
+    case "kael":
+      return "Kael";
+    default:
+      return platform;
+  }
+}
+
+function humanizeAdapterStatus(status: string): string {
+  switch (status) {
+    case "active":
+      return "Active";
+    case "inactive":
+      return "Inactive";
+    default:
+      return status;
+  }
+}
+
+/**
+ * Map the wire-level adapter `bound_via` enum (`code` / `reverse_token` /
+ * `oauth` / `manual`) to a sentence-case phrase. Note: this is a DIFFERENT
+ * enum from the GitHub-entity `boundVia` used in the chat right sidebar —
+ * adapter mappings track how an IM user got bound, not how a PR/issue got
+ * linked, so we deliberately do NOT share the helper.
+ */
+function humanizeBoundVia(boundVia: string | null): string {
+  if (!boundVia) return "—";
+  switch (boundVia) {
+    case "code":
+      return "Code";
+    case "reverse_token":
+      return "Reverse token";
+    case "oauth":
+      return "OAuth";
+    case "manual":
+      return "Manual";
+    default:
+      return boundVia;
+  }
 }
 
 function EmptyRow({ children }: { children: ReactNode }) {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2370,20 +2370,6 @@ function AddParticipantQuickButton({
             borderColor: "var(--border)",
           }}
         >
-          <div
-            role="note"
-            className="text-caption"
-            style={{
-              padding: "var(--sp-1) var(--sp-3)",
-              color: "var(--fg-3)",
-              borderBottom: "var(--hairline) solid var(--border-faint)",
-              background: "var(--bg-sunken)",
-              whiteSpace: "normal",
-              lineHeight: 1.4,
-            }}
-          >
-            Adding is final in V1 — participants can't be removed yet.
-          </div>
           {(() => {
             const ambiguous = ambiguousDisplayNames(outsideCandidates);
             return groupAndSortCandidates(outsideCandidates).map((item) => {

--- a/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/agent-row.tsx
@@ -13,7 +13,7 @@ import { DenseBadge } from "../../../components/ui/dense-badge.js";
  * — a Suspend button that flips an active session to `suspended`.
  *
  * Session data comes from `GET /agents/:uuid/sessions/:chatId`. A 404
- * (no row) collapses to `noSession` and renders an em-dash style row.
+ * (no row) collapses to the "none" state and renders an "Idle" caption.
  */
 export function AgentRow({
   participant,
@@ -64,7 +64,7 @@ export function AgentRow({
   const session = sessionQuery.data;
   // While the first fetch is in flight `data` is `undefined`. Distinguish
   // "loading" from "fetched but no row" so the row doesn't briefly flash
-  // "no session" before the real state lands — for a chat the user is
+  // "Idle" before the real state lands — for a chat the user is
   // actively in, that first-render flash is misleading.
   const state = sessionQuery.isPending ? "loading" : (session?.state ?? "none");
   const view = describeState(state);
@@ -113,11 +113,11 @@ export function AgentRow({
         <div className="truncate text-subtitle">{participant.displayName}</div>
         {state === "none" ? (
           <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-            no session
+            Idle
           </div>
         ) : state === "loading" ? (
           <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-            loading…
+            Loading…
           </div>
         ) : (
           <div className="mono flex items-center text-caption" style={{ color: "var(--fg-3)" }}>
@@ -139,40 +139,35 @@ function describeState(state: string): {
   tone: "accent" | "neutral" | "warn" | "error" | "outline";
   dotBg: string;
   dotBorder: string;
-  subText: string | null;
 } {
   switch (state) {
     case "active":
       return {
-        label: "ACTIVE",
+        label: "Working",
         tone: "accent",
         dotBg: "var(--state-idle)",
         dotBorder: "none",
-        subText: "running",
       };
     case "suspended":
       return {
-        label: "SUSPENDED",
+        label: "Paused",
         tone: "neutral",
         dotBg: "var(--bg-raised)",
         dotBorder: "var(--hairline-bold) solid var(--fg-4)",
-        subText: "idle",
       };
     case "errored":
       return {
-        label: "ERRORED",
+        label: "Failed",
         tone: "error",
         dotBg: "var(--state-error)",
         dotBorder: "none",
-        subText: null,
       };
     case "evicted":
       return {
-        label: "EVICTED",
+        label: "Offline",
         tone: "outline",
         dotBg: "var(--state-offline)",
         dotBorder: "none",
-        subText: null,
       };
     case "loading":
       return {
@@ -180,7 +175,6 @@ function describeState(state: string): {
         tone: "outline",
         dotBg: "transparent",
         dotBorder: "var(--hairline-bold) solid var(--fg-4)",
-        subText: null,
       };
     default:
       return {
@@ -188,7 +182,6 @@ function describeState(state: string): {
         tone: "outline",
         dotBg: "transparent",
         dotBorder: "var(--hairline-bold) solid var(--fg-4)",
-        subText: "no session",
       };
   }
 }
@@ -206,7 +199,7 @@ function SuspendButton({ onClick, isPending }: { onClick: () => void; isPending:
       <button
         type="button"
         disabled
-        aria-label="Suspending agent session"
+        aria-label="Pausing agent"
         className="text-label inline-flex shrink-0 items-center"
         style={{
           gap: "var(--sp-1)",
@@ -218,7 +211,7 @@ function SuspendButton({ onClick, isPending }: { onClick: () => void; isPending:
         }}
       >
         <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
-        Suspending
+        Pausing
       </button>
     );
   }
@@ -227,7 +220,7 @@ function SuspendButton({ onClick, isPending }: { onClick: () => void; isPending:
     <button
       type="button"
       onClick={onClick}
-      aria-label="Suspend agent session"
+      aria-label="Pause agent"
       className="text-label inline-flex shrink-0 items-center transition-colors hover:bg-[var(--bg-warn-soft)] hover:text-[var(--fg-warn-strong)] hover:border-[var(--fg-warn-strong)]"
       style={{
         gap: "var(--sp-1)",
@@ -237,10 +230,10 @@ function SuspendButton({ onClick, isPending }: { onClick: () => void; isPending:
         background: "transparent",
         color: "var(--fg-3)",
       }}
-      title="Suspend this agent's session in this chat"
+      title="Pause this agent in this chat"
     >
       <Pause className="h-3 w-3" aria-hidden="true" fill="currentColor" strokeWidth={0} />
-      Suspend
+      Pause
     </button>
   );
 }

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -98,7 +98,7 @@ function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
           </div>
         ) : null}
         <div className="text-caption" style={{ color: "var(--fg-4)" }}>
-          via {humanizeBoundVia(entity.boundVia)}
+          {humanizeBoundVia(entity.boundVia)}
         </div>
       </div>
       <ExternalLink
@@ -135,18 +135,20 @@ function iconColor(state: GithubEntityLiveState | null): string {
 
 /**
  * Map the wire-level `bound_via` enum (`direct` / `fixes_link` /
- * `agent_created`) to a phrase users can read at a glance. Falling back
- * to the raw key preserves forward-compatibility for any new boundVia
- * value the server might emit before this map catches up.
+ * `agent_created`) to a self-contained sentence — the row doesn't
+ * prepend "via " anymore, so each label has to read as a complete
+ * provenance hint on its own. Falling back to the raw key preserves
+ * forward-compatibility for any new boundVia value the server might
+ * emit before this map catches up.
  */
 function humanizeBoundVia(boundVia: string): string {
   switch (boundVia) {
     case "direct":
-      return "Direct mention";
+      return "Mentioned in chat";
     case "fixes_link":
-      return "Fixes link";
+      return "Auto-linked from \"Fixes #…\"";
     case "agent_created":
-      return "Agent created";
+      return "Created by an agent";
     default:
       return boundVia;
   }
@@ -156,16 +158,16 @@ function viewForState(state: GithubEntityLiveState | null): { label: string; ton
   if (!state) return null;
   switch (state) {
     case "open":
-      return { label: "OPEN", tone: "accent" };
+      return { label: "Open", tone: "accent" };
     case "closed":
-      return { label: "CLOSED", tone: "neutral" };
+      return { label: "Closed", tone: "neutral" };
     case "merged":
       // Mapped to `outline` since the DenseBadge palette doesn't carry a
       // purple/merged tone; the icon swap to GitMerge does the heavy
       // lifting for the visual signal.
-      return { label: "MERGED", tone: "outline" };
+      return { label: "Merged", tone: "outline" };
     case "draft":
-      return { label: "DRAFT", tone: "outline" };
+      return { label: "Draft", tone: "outline" };
     default:
       return null;
   }

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -146,7 +146,7 @@ function humanizeBoundVia(boundVia: string): string {
     case "direct":
       return "Mentioned in chat";
     case "fixes_link":
-      return "Auto-linked from \"Fixes #…\"";
+      return 'Auto-linked from "Fixes #…"';
     case "agent_created":
       return "Created by an agent";
     default:

--- a/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
@@ -12,7 +12,6 @@ import {
   type MentionCandidate,
   MentionLabel,
 } from "../../../components/mention-autocomplete.js";
-import { DenseBadge } from "../../../components/ui/dense-badge.js";
 import { AgentRow } from "./agent-row.js";
 
 /**
@@ -24,12 +23,10 @@ import { AgentRow } from "./agent-row.js";
  *
  * The bottom "Add" affordance mirrors the header quick-add icon —
  * both go through the same `addMeChatParticipants` mutation.
- * Membership is currently non-revocable; only the header dropdown
- * still surfaces the one-way-door notice inline (see chat-view.tsx
- * ParticipantsHeader for the canonical copy and the design-doc
- * reference). The sidebar dropdown drops the notice — users opening
- * the sidebar are already in management mode and the repeated banner
- * was visual noise.
+ * Membership is currently non-revocable, but neither surface shows an
+ * inline notice — the banner read as noise once users were already
+ * in the picker, and the irreversibility lives in product docs / FAQs
+ * instead.
  */
 export function ParticipantsSection({
   chatId,
@@ -143,14 +140,6 @@ function HumanRow({ participant }: { participant: ChatParticipantDetail }) {
       />
       <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 2 }}>
         <div className="truncate text-subtitle">{participant.displayName}</div>
-        {/* Same DenseBadge slot as AgentRow's state badge — keeps the
-            two row variants visually symmetric so the eye doesn't have
-            to context-switch between "agent row" and "human row" styling
-            mid-list. Humans don't have runtime state, so the badge just
-            labels the kind. */}
-        <div className="mono flex items-center text-caption" style={{ color: "var(--fg-3)" }}>
-          <DenseBadge tone="outline">HUMAN</DenseBadge>
-        </div>
       </div>
     </div>
   );
@@ -275,7 +264,7 @@ function AddParticipantInlineButton({
           aria-label="Add participant"
           className="absolute z-20 max-h-72 overflow-auto border shadow-lg"
           style={{
-            bottom: "calc(100% + var(--sp-1))",
+            top: "calc(100% + var(--sp-1))",
             left: 0,
             right: 0,
             background: "var(--bg-raised)",


### PR DESCRIPTION
## Summary

- Stop forcing every `DenseBadge` / `StateChip` label into ALL CAPS at the component level; let callers pass sentence-case labels and humanize wire-level enums (`active`/`errored`/`fixes_link`/...) into reading-flow copy ("Working" / "Failed" / "Auto-linked from \"Fixes #…\"").
- Polish the chat **right sidebar**: flip the inline "+ Add" picker dropdown to grow downward; drop the `HUMAN` badge from HumanRow; rename `Suspend` to `Pause` (UI only — backend mutation stays `suspendSession`); replace `no session` with `Idle`; remove a `describeState` `subText` field that was defined but never rendered; correct two stale UI-reference comments.
- Drop the chat header quick-add picker's `"Adding is final in V1 — participants can't be removed yet."` banner — the version reference leaked an internal milestone and the warning was noise.
- Same sentence-case treatment for `/bindings` (platform / status / adapter boundVia), `/agents/:id` MCP tool health and Identity domain tags.

Out of scope: `SectionHeader` / `DenseTable` column heads / `Tile` eyebrows keep the design-system caps treatment — those are layout-language labels, not state badges.

## Files

```
packages/web/src/components/ui/dense-badge.tsx          (drop `uppercase`)
packages/web/src/components/ui/state-chip.tsx           (drop `uppercase`, add STATE_LABELS)
packages/web/src/pages/workspace/right-sidebar/         (3 files — see Summary)
packages/web/src/pages/workspace/center/chat-view.tsx   (remove banner)
packages/web/src/pages/bindings.tsx                     (humanize platform/status/boundVia)
packages/web/src/pages/agent-detail/mcp-section.tsx     (humanize tool health)
packages/web/src/pages/agent-detail/identity-section.tsx (humanize domain tags)
```

## Notes

- `aria-label` / `title` on the Pause button are updated alongside the visible label so screen-readers stay in sync.
- `bindings.tsx`'s `boundVia` enum (`code/reverse_token/oauth/manual`, adapter bind method) is a **different** enum from `right-sidebar/github-section.tsx`'s `boundVia` (`direct/fixes_link/agent_created`, chat ↔ GitHub entity binding). Humanize helpers stay local on purpose; the bindings.tsx one has a comment explaining why.
- No wire-level enum values were changed — only their display labels.

## Test plan

- [ ] `pnpm --filter @first-tree-hub/web typecheck` clean (verified locally)
- [ ] Chat right sidebar visual: human row no HUMAN badge; agent row shows `Working / Paused / Failed / Offline / Idle`; inline "+ Add" picker grows downward; GitHub section captions read `Mentioned in chat` / `Auto-linked from "Fixes #…"` / `Created by an agent` and the status badges (when GitHub app is wired up) show `Open / Closed / Merged / Draft`
- [ ] Chat header quick-add picker no longer shows the "V1" banner; picker itself still works
- [ ] `/bindings`: platform, status, and bound-via columns are sentence case
- [ ] `/agents/:id` MCP section: tool health badge sentence case; Identity domain tags sentence case
- [ ] `SectionHeader` / table column heads / `Tile` eyebrows still appear in caps (regression check — we deliberately did NOT touch these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)