### PR TITLE
fix(update): server polls npm for command version + decouple from build time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,11 +45,26 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
+      # Pass the in-tree Command-package version as a Docker build-arg.
+      # Server uses it as the bootstrap value for `serverCommandVersion`
+      # before the npm-registry poller starts — see Dockerfile's
+      # `ARG COMMAND_VERSION` block. Reading from `packages/command/package.json`
+      # keeps the image's bootstrap version in lockstep with whichever
+      # stable CLI commit the image was built from.
+      - name: Resolve Command-package version
+        id: command-version
+        run: |
+          VERSION=$(node -p "require('./packages/command/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved Command version: $VERSION"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            COMMAND_VERSION=${{ steps.command-version.outputs.version }}
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,8 +41,22 @@ jobs:
             exit 1
           fi
 
-          ALPHA_VERSION="${BASE_VERSION}-alpha.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          # Bump base to the next patch BEFORE attaching the alpha pre-release
+          # tag. SemVer ranks `X.Y.Z-alpha.*` *lower* than `X.Y.Z`, so naming
+          # an alpha after the same base as the last stable would publish
+          # versions that auto-update treats as older than what's already
+          # installed (the "Server advertises 0.14.7-alpha.X, running 0.14.7
+          # (ahead)" symptom). Aligning the base with next-patch makes
+          # `0.14.8-alpha.X > 0.14.7` and gives alpha its intended "preview
+          # of the upcoming release" semantics. The split into MAJOR/MINOR/
+          # PATCH is safe because the regex above already guaranteed three
+          # numeric components.
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          ALPHA_VERSION="${NEXT_VERSION}-alpha.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "alpha_version=$ALPHA_VERSION" >> "$GITHUB_OUTPUT"
 
           VIEW_ERROR=$(mktemp)
@@ -150,8 +164,22 @@ jobs:
             exit 1
           fi
 
-          ALPHA_VERSION="${BASE_VERSION}-alpha.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          # Bump base to the next patch BEFORE attaching the alpha pre-release
+          # tag. SemVer ranks `X.Y.Z-alpha.*` *lower* than `X.Y.Z`, so naming
+          # an alpha after the same base as the last stable would publish
+          # versions that auto-update treats as older than what's already
+          # installed (the "Server advertises 0.14.7-alpha.X, running 0.14.7
+          # (ahead)" symptom). Aligning the base with next-patch makes
+          # `0.14.8-alpha.X > 0.14.7` and gives alpha its intended "preview
+          # of the upcoming release" semantics. The split into MAJOR/MINOR/
+          # PATCH is safe because the regex above already guaranteed three
+          # numeric components.
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          ALPHA_VERSION="${NEXT_VERSION}-alpha.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "alpha_version=$ALPHA_VERSION" >> "$GITHUB_OUTPUT"
 
           IS_PRIVATE=$(node -p "require('./package.json').private === true ? 'true' : 'false'")

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,16 @@ RUN pnpm install --frozen-lockfile --prod \
 FROM node:24-alpine
 WORKDIR /app
 
+# Bootstrap Command-package version baked into the image. CI passes this as
+# `--build-arg COMMAND_VERSION=$(node -p "require('./packages/command/package.json').version")`,
+# so a freshly-built image always advertises the in-tree CLI version BEFORE
+# the npm-registry poller takes over at runtime. Default `0.0.0` keeps local
+# `docker build` (without the build-arg) from crashing — it's SemVer-valid so
+# the welcome frame stays well-formed, and the poller overwrites it within a
+# poll interval anyway.
+ARG COMMAND_VERSION=0.0.0
+ENV FIRST_TREE_HUB_COMMAND_VERSION=$COMMAND_VERSION
+
 # Production node_modules (includes compiled bcrypt, workspace links)
 COPY --from=prod-deps /app ./
 

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "type": "module",
   "description": "First Tree Hub — unified CLI for client and agent management",
   "exports": {

--- a/packages/command/src/__tests__/install-global-spec.test.ts
+++ b/packages/command/src/__tests__/install-global-spec.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { installGlobalSpec } from "../core/update.js";
+
+/**
+ * `installGlobalSpec` short-circuits invalid specs *before* spawning npm —
+ * the rejection path returns `{ ok: false, mode: "global", reason: ... }`
+ * without touching `child_process`, so we can exercise it in unit tests
+ * without mocking spawn. We deliberately do NOT cover the happy path here
+ * because that would require a real npm + global install context.
+ */
+describe("installGlobalSpec — pre-spawn validation", () => {
+  it.each([
+    ["empty string", ""],
+    ["leading dash (npm flag smuggle)", "-g"],
+    ["leading dash with version-like body", "-0.14.7"],
+    ["whitespace", "0.14.7 latest"],
+    ["semicolon shell metachar", "0.14.7;rm"],
+    ["pipe shell metachar", "latest|rm"],
+    ["at sign (would split package@spec twice)", "alpha@evil"],
+    ["slash (would let attacker switch package)", "../other/pkg"],
+    ["equals sign (would smuggle as npm flag)", "--registry=evil"],
+    ["overlong spec", "a".repeat(200)],
+  ])("rejects %s", async (_label, spec) => {
+    const result = await installGlobalSpec(spec);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.mode).toBe("global");
+      expect(result.reason).toMatch(/invalid npm spec/i);
+    }
+  });
+
+  it.each([
+    ["dist-tag latest", "latest"],
+    ["dist-tag alpha", "alpha"],
+    ["exact stable version", "0.14.7"],
+    ["exact alpha version", "0.14.8-alpha.286.1"],
+    ["build metadata variant", "0.14.7+build.123"],
+  ])("would pass validation for %s (spec stays intact)", (_label, spec) => {
+    // We only assert the regex layer accepts it — we don't await the
+    // npm spawn (no global npm available in CI sandbox). The test exists
+    // to catch accidental regressions to the allow-list (a tighter regex
+    // that, say, drops `+` would break SemVer build-metadata callers).
+    // Re-using the same regex check by calling installGlobalSpec would
+    // shell out; instead just assert the format by re-applying the rule:
+    expect(spec).toMatch(/^[A-Za-z0-9.+-]+$/);
+    expect(spec.startsWith("-")).toBe(false);
+  });
+});

--- a/packages/command/src/core/index.ts
+++ b/packages/command/src/core/index.ts
@@ -72,7 +72,13 @@ export {
 export type { ExecuteUpdateResult, InstallMode } from "./update.js";
 // Self-update glue — exported so both `client start` and `connect <token>`
 // can pass identical prompt / install callbacks to the ClientRuntime.
-export { detectInstallMode, fetchLatestVersion, installGlobalLatest, PACKAGE_NAME } from "./update.js";
+export {
+  detectInstallMode,
+  fetchLatestVersion,
+  installGlobalLatest,
+  installGlobalSpec,
+  PACKAGE_NAME,
+} from "./update.js";
 export { createExecuteUpdate, declineUpdate, promptUpdate, SELF_RESTART_EXIT_CODE } from "./update-glue.js";
 // Command package version (bundle self-identification)
 export { CLI_USER_AGENT, COMMAND_VERSION } from "./version.js";

--- a/packages/command/src/core/update-glue.ts
+++ b/packages/command/src/core/update-glue.ts
@@ -8,7 +8,12 @@ export const SELF_RESTART_EXIT_CODE = 75;
 
 /** Interactive update prompt. Defaults to N on timeout. */
 export const promptUpdate: UpdatePromptFn = async ({ currentVersion, targetVersion, timeoutSeconds }) => {
-  const message = `A newer First Tree Hub client is available.\n  You: ${currentVersion}\n  Server bundled with: ${targetVersion}\n  Will install: latest on npm (>= ${targetVersion})\n  Updating will restart the client and briefly interrupt any active sessions.\n  Update now?`;
+  // Phrasing matches the post-poller install path: we install the exact
+  // version the server advertised, not whatever `@latest` happens to point
+  // at. "Server recommends" (rather than "bundled with") because the version
+  // now comes from the server's npm-registry poll for the configured
+  // channel, not from the server image build.
+  const message = `A newer First Tree Hub client is available.\n  You: ${currentVersion}\n  Server recommends: ${targetVersion}\n  Will install: ${targetVersion}\n  Updating will restart the client and briefly interrupt any active sessions.\n  Update now?`;
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutSeconds * 1000);

--- a/packages/command/src/core/update-glue.ts
+++ b/packages/command/src/core/update-glue.ts
@@ -1,7 +1,7 @@
 import type { ExecuteUpdateFn, UpdatePromptFn } from "@first-tree-hub/client";
 import { confirm } from "@inquirer/prompts";
 import { print } from "./output.js";
-import { detectInstallMode, installGlobalLatest } from "./update.js";
+import { detectInstallMode, installGlobalSpec } from "./update.js";
 
 /** Reserved exit code that means "clean self-restart, service manager please bring me back". */
 export const SELF_RESTART_EXIT_CODE = 75;
@@ -46,7 +46,7 @@ export const declineUpdate: UpdatePromptFn = async () => false;
  * operator restarts manually.
  */
 export function createExecuteUpdate({ managed }: { managed: boolean }): ExecuteUpdateFn {
-  return async () => {
+  return async ({ targetVersion }) => {
     const mode = detectInstallMode();
     if (mode === "source") {
       print.line("  [update] Running from source checkout — self-update skipped. Use `git pull` instead.\n");
@@ -59,14 +59,20 @@ export function createExecuteUpdate({ managed }: { managed: boolean }): ExecuteU
       return { installed: false };
     }
 
-    print.line("  [update] Running `npm install -g @agent-team-foundation/first-tree-hub@latest`...\n");
-    const result = await installGlobalLatest();
+    // Auto-update installs the *exact* version the server advertised in
+    // `server:welcome.serverCommandVersion`. Using `@latest` here would
+    // mis-resolve once the server starts advertising alpha builds (alpha
+    // lives on a different dist-tag), and even on the stable track it could
+    // race to a different version than the one drift-check approved. The
+    // server is the authoritative source of "what should this client run".
+    print.line(`  [update] Running \`npm install -g @agent-team-foundation/first-tree-hub@${targetVersion}\`...\n`);
+    const result = await installGlobalSpec(targetVersion);
     if (!result.ok) {
       print.line(`  [update] Install failed: ${result.reason}\n`);
       return { installed: false };
     }
 
-    const installed = result.installedVersion ?? "latest";
+    const installed = result.installedVersion ?? targetVersion;
     if (managed) {
       print.line(`  [update] Installed ${installed}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).\n`);
       process.exit(SELF_RESTART_EXIT_CODE);

--- a/packages/command/src/core/update.ts
+++ b/packages/command/src/core/update.ts
@@ -117,15 +117,51 @@ export type ExecuteUpdateResult =
   | { ok: false; mode: InstallMode; reason: string };
 
 /**
- * Install `<pkg>@latest` globally. Returns after the child exits. Does not
- * exit the parent process — callers are expected to handle that (so the
- * UpdateManager can attempt the restart itself while this function remains
- * side-effect-scoped).
+ * Validate an npm install spec (the part after `@` in `<pkg>@<spec>`). We
+ * accept either a known dist-tag string (`latest`, `alpha`, …) or an exact
+ * SemVer version (`0.14.7`, `0.14.8-alpha.286.1`). The intent is purely
+ * defensive: the spec is concatenated into the npm CLI args, and we never
+ * want to forward an attacker-controlled shell metacharacter from a
+ * (compromised) server welcome frame straight into `spawn`. spawn() already
+ * argv-escapes, but a `--registry=...` style spec would still be
+ * interpreted as an npm flag — refusing leading dashes and whitespace
+ * collapses the surface unambiguously.
  */
-export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
+function isSafeInstallSpec(spec: string): boolean {
+  if (typeof spec !== "string" || spec.length === 0 || spec.length > 128) return false;
+  // Allow letters, digits, dot, plus, hyphen — covers every legal SemVer +
+  // dist-tag. Crucially excludes whitespace, `@`, `/`, `=`, shell quotes.
+  // Hyphens inside the body are fine (`0.14.8-alpha.286.1`), but a leading
+  // hyphen would let the spec smuggle in as an npm flag.
+  if (spec.startsWith("-")) return false;
+  return /^[A-Za-z0-9.+-]+$/.test(spec);
+}
+
+/**
+ * Install `<pkg>@<spec>` globally. `spec` is either a dist-tag (e.g. `latest`)
+ * or an exact version (e.g. `0.14.7-alpha.286.1`). Returns after the child
+ * exits. Does not exit the parent process — callers are expected to handle
+ * that (so the UpdateManager can attempt the restart itself while this
+ * function remains side-effect-scoped).
+ *
+ * Why both shapes exist: the auto-update path receives `targetVersion` from
+ * the server `welcome` frame and MUST install that exact version — using
+ * `@latest` from auto-update would silently mis-resolve once the server
+ * starts advertising alpha builds (alpha lives on a different dist-tag).
+ * The manual `first-tree-hub update` CLI keeps the dist-tag form so users
+ * who type the command without args still get "newest stable on npm".
+ */
+export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResult> {
+  if (!isSafeInstallSpec(spec)) {
+    return {
+      ok: false,
+      mode: "global",
+      reason: `Refusing to install: invalid npm spec ${JSON.stringify(spec)}`,
+    };
+  }
   return new Promise((resolvePromise) => {
     const npmCmd = resolveNpmCommand();
-    const npmArgs = ["install", "-g", `${PACKAGE_NAME}@latest`];
+    const npmArgs = ["install", "-g", `${PACKAGE_NAME}@${spec}`];
     const child = spawn(npmCmd, npmArgs, { stdio: ["ignore", "pipe", "pipe"] });
 
     const stdoutChunks: Buffer[] = [];
@@ -154,6 +190,16 @@ export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
       }
     });
   });
+}
+
+/**
+ * Back-compat shim: install `<pkg>@latest`. The manual `first-tree-hub
+ * update` CLI uses this so an operator-typed `update` keeps the
+ * "newest stable on npm" behaviour. Auto-update prefers `installGlobalSpec`
+ * with the welcome frame's `targetVersion`.
+ */
+export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
+  return installGlobalSpec("latest");
 }
 
 /**

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -29,6 +29,12 @@ const baseConfig: Config = {
     presenceCleanupSeconds: 60,
     notificationWebhookUrl: undefined,
   },
+  update: {
+    channel: "latest",
+    commandVersion: "test.version",
+    pollIntervalMinutes: 1440,
+    registryUrl: "https://localhost.invalid",
+  },
   instanceId: "test-instance",
 };
 

--- a/packages/server/src/__tests__/command-version-poller.test.ts
+++ b/packages/server/src/__tests__/command-version-poller.test.ts
@@ -1,0 +1,170 @@
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it } from "vitest";
+import { createCommandVersionPoller } from "../services/command-version-poller.js";
+
+/**
+ * Stub logger that swallows everything. Keeps test output clean — the
+ * poller intentionally logs at `warn` on every failed fetch and at `info`
+ * on every version change, neither of which we want in the test runner.
+ */
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+  level: "info",
+  silent: () => {},
+} as unknown as FastifyBaseLogger;
+
+/** Build a `fetch`-shaped stub that responds with the given packument body. */
+function stubFetchWithBody(body: unknown, status = 200) {
+  const impl: typeof fetch = async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  return impl;
+}
+
+describe("createCommandVersionPoller", () => {
+  it("starts with the supplied bootstrap version", () => {
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.14.6",
+      fetchImpl: stubFetchWithBody({ "dist-tags": {} }),
+    });
+
+    expect(poller.get()).toBe("0.14.6");
+  });
+
+  it("updates the cached version when refresh finds a different dist-tag", async () => {
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.14.6",
+      fetchImpl: stubFetchWithBody({ "dist-tags": { latest: "0.14.8", alpha: "0.14.9-alpha.1.1" } }),
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.8");
+  });
+
+  it("reads the alpha tag when channel=alpha", async () => {
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "alpha",
+      intervalMs: 60_000,
+      initialVersion: "0.14.7",
+      fetchImpl: stubFetchWithBody({ "dist-tags": { latest: "0.14.7", alpha: "0.14.8-alpha.286.1" } }),
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.8-alpha.286.1");
+  });
+
+  it("keeps the previous version when the registry returns a non-OK response", async () => {
+    const failingFetch: typeof fetch = async () => new Response("server error", { status: 500 });
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.14.6",
+      fetchImpl: failingFetch,
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.6");
+  });
+
+  it("keeps the previous version when the requested dist-tag is missing", async () => {
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "alpha",
+      intervalMs: 60_000,
+      initialVersion: "0.14.7",
+      fetchImpl: stubFetchWithBody({ "dist-tags": { latest: "0.14.7" } }),
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.7");
+  });
+
+  it("keeps the previous version when fetch throws", async () => {
+    const throwingFetch: typeof fetch = async () => {
+      throw new Error("ENETUNREACH");
+    };
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.14.6",
+      fetchImpl: throwingFetch,
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.6");
+  });
+
+  it("builds the registry URL with the scope's slash preserved", async () => {
+    const calls: string[] = [];
+    const recordingFetch: typeof fetch = async (input) => {
+      calls.push(typeof input === "string" ? input : (input as URL).toString());
+      return new Response(JSON.stringify({ "dist-tags": { latest: "1.0.0" } }), { status: 200 });
+    };
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test/",
+      packageName: "@agent-team-foundation/first-tree-hub",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.0.0",
+      fetchImpl: recordingFetch,
+    });
+
+    await poller.refresh();
+    expect(calls).toHaveLength(1);
+    // Trailing slash on registryUrl must be stripped; `@scope/name` must
+    // survive encoding so npm registry can resolve the packument.
+    expect(calls[0]).toBe("https://example.test/@agent-team-foundation/first-tree-hub");
+  });
+
+  it("stop() prevents further refreshes from mutating state", async () => {
+    let body = { "dist-tags": { latest: "0.14.6" } };
+    const dynamicFetch: typeof fetch = async () => new Response(JSON.stringify(body), { status: 200 });
+    const poller = createCommandVersionPoller({
+      logger: silentLogger,
+      registryUrl: "https://example.test",
+      packageName: "@scope/pkg",
+      channel: "latest",
+      intervalMs: 60_000,
+      initialVersion: "0.14.5",
+      fetchImpl: dynamicFetch,
+    });
+
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.6");
+
+    poller.stop();
+    body = { "dist-tags": { latest: "9.9.9" } };
+    await poller.refresh();
+    expect(poller.get()).toBe("0.14.6");
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -135,6 +135,18 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       presenceCleanupSeconds: 60,
       notificationWebhookUrl: undefined,
     },
+    update: {
+      // Pin a deterministic version so welcome-frame tests can assert
+      // exact equality without coupling to the in-tree package.json.
+      channel: "latest",
+      commandVersion: "test.version",
+      // Long enough that the timer never fires inside a test run — we
+      // call `refresh()` manually when a test needs a forced poll.
+      pollIntervalMinutes: 1440,
+      // Point at an unreachable host so a stray refresh during tests
+      // logs-and-skips instead of hitting the real npm registry.
+      registryUrl: "https://localhost.invalid",
+    },
     instanceId: "test-instance",
   };
   const app = await buildApp(config);

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -412,7 +412,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             socket.send(
               JSON.stringify({
                 type: "server:welcome",
-                serverCommandVersion: app.commandVersion,
+                serverCommandVersion: app.commandVersion(),
                 serverTimeMs: Date.now(),
                 capabilities: { wsInboxDeliver: true },
               }),

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -80,6 +80,7 @@ import { broadcastToAdmins } from "./services/admin-broadcast.js";
 import { expiryToSeconds } from "./services/auth.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
+import { COMMAND_PACKAGE_NAME, createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
 import { createKaelRuntime, type KaelRuntime } from "./services/kael-runtime.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
@@ -97,13 +98,24 @@ export type AppContext = {
 };
 
 /**
- * Resolve the Command-package version advertised to clients. Prefers the
- * value the Command CLI explicitly injected; otherwise falls back to the
- * server workspace's own package.json (dev mode, `pnpm --filter … dev`).
- * Returning a string (rather than undefined) keeps the welcome frame well-
- * formed — the client treats the value advisorily.
+ * Resolve the bootstrap Command-package version advertised before the first
+ * successful npm-registry poll lands. Priority order:
+ *
+ *  1. `config.update.commandVersion` — explicit injection. Set by the
+ *     Dockerfile at build time (via `COMMAND_VERSION` build-arg, which CI
+ *     reads from `packages/command/package.json.version`), so a fresh image
+ *     boots with a sane version even when the npm registry is unreachable
+ *     at startup.
+ *  2. Server workspace's own `package.json` — kept only for `pnpm --filter
+ *     … dev` runs where no build-arg path exists. Server's package.json
+ *     never bumps (it's `private: true`), so this is intentionally a weak
+ *     fallback — at runtime the poller will overwrite it within minutes.
+ *  3. `"0.0.0"` — last-resort sentinel that keeps the welcome frame
+ *     well-formed. SemVer-valid; clients drop into the "ahead" branch and
+ *     skip update, which is the right failure mode (better than crashing
+ *     clients with an invalid version string).
  */
-function resolveCommandVersion(injected: string | undefined): string {
+function resolveBootstrapCommandVersion(injected: string | undefined): string {
   if (injected && injected.trim().length > 0) return injected;
   try {
     const req = createRequire(import.meta.url);
@@ -276,10 +288,29 @@ export async function buildApp(config: Config) {
   app.decorate("config", config);
 
   // Advisory Command-package version broadcast to every Client via the
-  // `server:welcome` WS frame — lets clients detect version drift.
-  const commandVersion = resolveCommandVersion(config.commandVersion);
-  app.decorate("commandVersion", commandVersion);
-  app.log.info({ commandVersion }, "Hub server advertising command version");
+  // `server:welcome` WS frame. The poller refreshes the advertised value
+  // from the npm registry on `config.update.pollIntervalMinutes`, so the
+  // server's deploy cadence no longer gates client auto-update. Bootstrap
+  // value is the build-arg-injected version; the poller takes over on
+  // `onReady`.
+  const bootstrapCommandVersion = resolveBootstrapCommandVersion(config.update.commandVersion);
+  const commandVersionPoller = createCommandVersionPoller({
+    logger: app.log,
+    registryUrl: config.update.registryUrl,
+    packageName: COMMAND_PACKAGE_NAME,
+    channel: config.update.channel,
+    intervalMs: config.update.pollIntervalMinutes * 60_000,
+    initialVersion: bootstrapCommandVersion,
+  });
+  app.decorate("commandVersion", () => commandVersionPoller.get());
+  app.log.info(
+    {
+      bootstrapCommandVersion,
+      channel: config.update.channel,
+      pollIntervalMinutes: config.update.pollIntervalMinutes,
+    },
+    "Hub server advertising command version (poller bootstrap)",
+  );
 
   // Notifier: dedicated PG connection for LISTEN/NOTIFY
   const listenClient = postgres(config.database.url, { max: 1, ...sslOptions(config.database.url) });
@@ -626,10 +657,12 @@ export async function buildApp(config: Config) {
     await notifier.start();
     backgroundTasks.start();
     pulseAggregator.start();
+    commandVersionPoller.start();
   });
 
   // Cleanup on close
   app.addHook("onClose", async () => {
+    commandVersionPoller.stop();
     pulseAggregator.stop();
     backgroundTasks.stop();
     adapterManager.shutdown();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -3,19 +3,14 @@ import type { ServerConfig } from "@agent-team-foundation/first-tree-hub-shared/
 /**
  * Server runtime config extends the shared ServerConfig with
  * fields that are generated per-process (not persisted to YAML).
+ *
+ * `commandVersion` and the rest of the version-advertisement knobs now live
+ * under `serverConfig.update.*` (see `shared/src/config/server-config.ts`),
+ * so the runtime extension stays focused on per-process generated fields.
  */
 export type Config = ServerConfig & {
   /** Unique ID for this server instance — generated at startup */
   instanceId: string;
   /** Web static files dist path — resolved by CLI startup */
   webDistPath?: string;
-  /**
-   * Command package version this server was bundled with. Injected by the
-   * Command CLI at startup (which reads its own `package.json`). Advertised
-   * to every connecting client via the `server:welcome` WS frame so clients
-   * can detect version drift and self-update. Optional because the server
-   * can also be launched standalone via `pnpm --filter … dev`, in which case
-   * the bootstrap falls back to the server workspace's own package.json.
-   */
-  commandVersion?: string;
 };

--- a/packages/server/src/services/command-version-poller.ts
+++ b/packages/server/src/services/command-version-poller.ts
@@ -1,0 +1,150 @@
+import type { FastifyBaseLogger } from "fastify";
+
+/**
+ * npm name of the consumer-facing CLI tarball. Kept here (rather than
+ * imported from `packages/command`) because the server Docker image
+ * deliberately does NOT copy the Command package — see the May 2026
+ * "decouple Docker entry from CLI" refactor — so a runtime import would
+ * fail. The string is part of npm's public API; renaming it would break
+ * every installed client anyway.
+ */
+export const COMMAND_PACKAGE_NAME = "@agent-team-foundation/first-tree-hub";
+
+/**
+ * Tracks the Command-package version the server should advertise to every
+ * connected Client via `server:welcome.serverCommandVersion`.
+ *
+ * Why this exists: hard-coding the broadcasted version to the server's own
+ * `package.json` (or to the Command package.json baked into the image at
+ * build time) couples auto-update to the server's deploy cadence — clients
+ * never see a fresh CLI release until the server image is also rebuilt and
+ * rolled. The poller instead asks the npm registry for the configured
+ * channel's current `dist-tag` value, so:
+ *
+ *   - Staging deployments running `channel=alpha` follow CI's preview
+ *     publishes within `pollIntervalMinutes` of upload.
+ *   - Prod deployments running `channel=latest` follow stable releases the
+ *     same way.
+ *   - Server build cadence and Command publish cadence decouple cleanly.
+ *
+ * Fault tolerance: a failing fetch never tears down the in-memory value —
+ * the previously-seen version (or the bootstrap fallback if no poll has
+ * ever succeeded) stays advertised. This keeps welcome frames well-formed
+ * during a registry outage; clients simply continue running their current
+ * version until the next successful poll.
+ */
+export type CommandVersionPoller = {
+  /** Current cached version. Cheap; safe to call on the hot WS path. */
+  get(): string;
+  /** Begin periodic refreshes. Fires an immediate refresh in the background. */
+  start(): void;
+  /** Stop the timer and ignore in-flight responses. Idempotent. */
+  stop(): void;
+  /** Force a refresh now. Exposed for tests; production code calls `start()`. */
+  refresh(): Promise<void>;
+};
+
+export type CommandVersionPollerOptions = {
+  logger: FastifyBaseLogger;
+  registryUrl: string;
+  packageName: string;
+  channel: string;
+  intervalMs: number;
+  /** Bootstrap value used until the first successful poll lands. */
+  initialVersion: string;
+  /**
+   * Override for tests. Production uses global `fetch`. Returning `null`
+   * (rather than throwing) lets tests model "registry unreachable" without
+   * tripping the catch-all.
+   */
+  fetchImpl?: typeof fetch;
+};
+
+/** Shape of the trimmed packument response we read. */
+type Packument = { "dist-tags"?: Record<string, string> };
+
+export function createCommandVersionPoller(opts: CommandVersionPollerOptions): CommandVersionPoller {
+  const fetchFn = opts.fetchImpl ?? fetch;
+  let current = opts.initialVersion;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  async function fetchOnce(): Promise<string | null> {
+    // npm registry packument URL. We append the package name *unencoded*
+    // because the npm registry expects literal `@` and `/` for scoped
+    // packages (`@scope/name`) — both are reserved chars URL-wise but
+    // sub-delims that registries treat as path segments. The package name
+    // never comes from user input on this code path (it's hard-coded by
+    // the server build), so there's no injection vector to encode away.
+    const url = `${opts.registryUrl.replace(/\/$/, "")}/${opts.packageName}`;
+    try {
+      const res = await fetchFn(url, {
+        headers: {
+          // Asking for the abbreviated packument cuts the payload from
+          // megabytes (full per-version metadata) to ~tens of kilobytes —
+          // dist-tags is all we need.
+          Accept: "application/vnd.npm.install-v1+json",
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        opts.logger.warn(
+          { status: res.status, url, channel: opts.channel },
+          "command-version-poller: npm registry returned non-OK",
+        );
+        return null;
+      }
+      const body = (await res.json()) as Packument;
+      const tag = body["dist-tags"]?.[opts.channel];
+      if (typeof tag !== "string" || tag.length === 0) {
+        opts.logger.warn(
+          { channel: opts.channel, tags: Object.keys(body["dist-tags"] ?? {}) },
+          "command-version-poller: dist-tag missing from packument",
+        );
+        return null;
+      }
+      return tag;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      opts.logger.warn({ err: message, url }, "command-version-poller: fetch failed");
+      return null;
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    const next = await fetchOnce();
+    if (stopped || next === null) return;
+    if (next !== current) {
+      opts.logger.info(
+        { from: current, to: next, channel: opts.channel },
+        "command-version-poller: advertised version changed",
+      );
+      current = next;
+    }
+  }
+
+  return {
+    get: () => current,
+    start: () => {
+      if (timer) return;
+      // Kick the first refresh in the background — we do NOT await it here
+      // so server boot stays unblocked when the registry is slow.
+      void refresh();
+      timer = setInterval(() => {
+        void refresh();
+      }, opts.intervalMs);
+      // `unref` so the timer alone doesn't keep the process alive across
+      // graceful shutdown. The `onClose` hook clears it explicitly anyway,
+      // but this is a safety net for crash paths.
+      if (typeof timer.unref === "function") timer.unref();
+    },
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    refresh,
+  };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -18,8 +18,13 @@ declare module "fastify" {
     adapterManager: AdapterManager;
     notifier: Notifier;
     configService: ConfigService;
-    /** Command-package version advertised via the `server:welcome` WS frame. */
-    commandVersion: string;
+    /**
+     * Command-package version advertised via the `server:welcome` WS frame.
+     * Exposed as a getter so the npm-registry poller can refresh the value
+     * without re-decorating the Fastify instance. Call it on the hot WS path
+     * — it's a synchronous in-memory read.
+     */
+    commandVersion: () => string;
   }
   interface FastifyRequest {
     agent?: AgentIdentity;

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -282,6 +282,43 @@ export const serverConfigSchema = defineConfig({
     }),
   },
   /**
+   * Command-package version advertisement. The server broadcasts a version
+   * string to every Client via `server:welcome` so clients can detect drift
+   * and self-update. We resolve the value at runtime by polling the npm
+   * registry for the configured channel's current `dist-tag` —
+   * decoupling "what version clients should run" from the server's own
+   * build/deploy cadence (otherwise prod auto-update silently stalls
+   * whenever the server image lags behind a fresh CLI publish).
+   *
+   * - `channel`: which npm `dist-tag` to track. Staging deployments set
+   *   `alpha` so clients automatically follow CI's preview builds; prod stays
+   *   on `latest`.
+   * - `commandVersion`: bootstrap fallback used until the first successful
+   *   poll, and the cache value when the registry is unreachable.
+   *   Docker images inject `packages/command/package.json.version` at build
+   *   time via the `COMMAND_VERSION` build-arg.
+   * - `pollIntervalMinutes`: refresh cadence. 60 minutes is the safe default
+   *   for both prod (slow stable cadence) and staging (frequent alpha
+   *   publishes still get picked up within an hour). Tune lower on staging
+   *   for tighter alpha rollout.
+   * - `registryUrl`: lets corp deployments point at a Verdaccio/Artifactory
+   *   mirror with the same dist-tags.
+   */
+  update: {
+    channel: field(z.enum(["latest", "alpha"]).default("latest"), {
+      env: "FIRST_TREE_HUB_UPDATE_CHANNEL",
+    }),
+    commandVersion: field(z.string().optional(), {
+      env: "FIRST_TREE_HUB_COMMAND_VERSION",
+    }),
+    pollIntervalMinutes: field(z.coerce.number().int().min(1).max(1440).default(60), {
+      env: "FIRST_TREE_HUB_UPDATE_POLL_INTERVAL_MINUTES",
+    }),
+    registryUrl: field(z.string().url().default("https://registry.npmjs.org"), {
+      env: "FIRST_TREE_HUB_UPDATE_REGISTRY_URL",
+    }),
+  },
+  /**
    * Runtime tunables. Replaced the deleted `/admin/system/config` HTTP
    * surface (proposal hub-strip-jwt-ambient-scope §3.5) — these knobs are
    * deployment-level, not customer-tunable, and get baked in via the


### PR DESCRIPTION
## Summary

Repairs the broken auto-update broadcast and decouples it from server deploy cadence; aligns CI alpha versioning with SemVer.

- **Server (Step 1 + 2)**: New `update.{channel,commandVersion,pollIntervalMinutes,registryUrl}` config + `command-version-poller` that reads `dist-tags[channel]` from the npm registry. `app.commandVersion` is a getter so the poller can refresh without re-decorating.
- **Client (Step 3a)**: Auto-update installs `targetVersion` from the welcome frame (not `@latest`) so the channel knob actually works end-to-end. New `installGlobalSpec` with an allow-list regex blocks npm-flag smuggling.
- **CI (Step 4)**: Alpha version base is next-patch (`0.14.7` → `0.14.8-alpha.<run>.<attempt>`) — fixes the SemVer-reversal where alpha builds compared older than the last stable.

## Background

Auto-update across all clients has been silently broken since fe88360 (May 15, 2026 — `refactor: drop self-host support; decouple Docker entry from CLI`). That refactor dropped the CLI-bootstraps-server path which injected \`commandVersion\` into the server config; the new direct \`node packages/server/dist/index.mjs\` entry left the injection unwired. Server fell back to \`packages/server/package.json.version\` = \`0.1.0\`; every welcome frame broadcasts \`0.1.0\`; every client (running 0.14.x) hits the \`semver.lt(target, current)\` "ahead" branch in \`UpdateManager.decide\`; auto-update never fires.

This PR also unblocks the staging-publishes-alpha goal: server-side \`channel=alpha\` config + alpha versioning that ranks newer than stable per SemVer.

## What changed

| Area | File | Note |
|---|---|---|
| Shared schema | \`packages/shared/src/config/server-config.ts\` | new \`update\` group |
| Server runtime | \`packages/server/src/services/command-version-poller.ts\` | new |
| Server wiring | \`packages/server/src/app.ts\`, \`types.ts\`, \`config.ts\`, \`api/agent/ws-client.ts\` | \`commandVersion\` becomes a getter, poller in onReady/onClose |
| Docker | \`Dockerfile\`, \`.github/workflows/docker.yml\` | \`COMMAND_VERSION\` build-arg → ENV, fallback for offline registries |
| Client install | \`packages/command/src/core/update.ts\`, \`update-glue.ts\` | \`installGlobalSpec\` + auto-update uses \`targetVersion\` |
| CI alpha versioning | \`.github/workflows/npm-publish.yml\` | next-patch base for alpha pre-release |
| Tests | command + server \`__tests__/\` | new poller + install-spec tests |
| Version bump | \`packages/command/package.json\` | 0.14.7 → 0.14.8 |

## Staging rollout

Set on the staging server deployment:
\`\`\`
FIRST_TREE_HUB_UPDATE_CHANNEL=alpha
FIRST_TREE_HUB_UPDATE_POLL_INTERVAL_MINUTES=15   # optional, tighter alpha cadence
\`\`\`
Restart the container — client side needs zero config.

## Test plan

- [x] \`pnpm check\` clean (Biome)
- [x] \`pnpm typecheck\` 11/11 tasks
- [x] shared tests 251/251
- [x] command tests 121/121
- [x] server tests 1127/1127 (against local Postgres)
- [ ] Stage deploy → verify a staging client at \`0.14.6\` auto-updates to the latest \`0.14.8-alpha.X\` after CI publishes
- [ ] Prod deploy → verify a prod client at \`0.14.6\` auto-updates to \`0.14.8\` once the npm-release workflow ships it
- [ ] Inspect server boot log for the new \`Hub server advertising command version (poller bootstrap)\` line + a follow-up \`command-version-poller: advertised version changed\` info on the first successful poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)