### PR TITLE
fix(chat): doc-preview works for all workspaces + snapshot-gated timeline links

### DIFF
--- a/packages/client/src/__tests__/document-base-path.test.ts
+++ b/packages/client/src/__tests__/document-base-path.test.ts
@@ -1,0 +1,43 @@
+import type { AgentRuntimeConfigPayload } from "@agent-team-foundation/first-tree-hub-shared";
+import { describe, expect, it } from "vitest";
+import { documentBasePathFromRuntimeConfig } from "../runtime/session-manager.js";
+
+function payload(gitRepos: AgentRuntimeConfigPayload["gitRepos"]): AgentRuntimeConfigPayload {
+  return { kind: "claude-code", prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos };
+}
+
+const PER_CHAT = "/data/workspaces/agent/chat-123";
+
+describe("documentBasePathFromRuntimeConfig", () => {
+  it("returns the per-chat workspace root when there are zero repos", () => {
+    expect(documentBasePathFromRuntimeConfig(payload([]), PER_CHAT)).toBe(PER_CHAT);
+  });
+
+  it("returns the per-chat workspace root when there are multiple repos", () => {
+    const result = documentBasePathFromRuntimeConfig(
+      payload([{ url: "https://github.com/a/one.git" }, { url: "https://github.com/a/two.git" }]),
+      PER_CHAT,
+    );
+    expect(result).toBe(PER_CHAT);
+  });
+
+  it("returns an ABSOLUTE repo worktree path (perChatRoot + derived localPath) for a single repo", () => {
+    // Regression: the old code returned a bare relative localPath
+    // ("first-tree-hub"), which the runtime resolved against its own
+    // process.cwd() (the launch dir, not the per-chat workspace) and failed to
+    // find any doc — leaving single-repo cloud preview dead.
+    expect(
+      documentBasePathFromRuntimeConfig(payload([{ url: "https://github.com/a/first-tree-hub.git" }]), PER_CHAT),
+    ).toBe(`${PER_CHAT}/first-tree-hub`);
+  });
+
+  it("honours an explicit localPath for a single repo", () => {
+    expect(
+      documentBasePathFromRuntimeConfig(payload([{ url: "https://x/y.git", localPath: "nested/repo" }]), PER_CHAT),
+    ).toBe(`${PER_CHAT}/nested/repo`);
+  });
+
+  it("falls back to the per-chat root when a single repo's localPath is blank", () => {
+    expect(documentBasePathFromRuntimeConfig(payload([{ url: "", localPath: "   " }]), PER_CHAT)).toBe(PER_CHAT);
+  });
+});

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type {
   AgentRuntimeConfigPayload,
   GitRepo,
@@ -41,14 +42,32 @@ type PendingMessage = {
   entryId: number;
 };
 
-function documentBasePathFromRuntimeConfig(payload: AgentRuntimeConfigPayload): string | null {
-  // A single repo has an unambiguous markdown-link root. Multi-repo workspaces
-  // need path-prefix matching before we can safely choose a base path.
-  if (payload.gitRepos.length !== 1) return null;
-  const repo = payload.gitRepos[0];
-  if (!repo) return null;
-  const localPath = repoLocalPath(repo).trim();
-  return localPath.length > 0 ? localPath : null;
+/**
+ * Resolve the base path the runtime reads markdown doc snapshots against.
+ *
+ * NEVER returns null — every chat has a workspace, and the snapshot scanner
+ * existence-checks each candidate inside the returned root, so a bare mention
+ * that doesn't physically exist simply stays plain text rather than
+ * mis-resolving. Previously this returned null for zero/multi-repo
+ * workspaces, which left those messages with no `documentContext` at all, so
+ * a doc the agent wrote in the workspace could never be previewed.
+ *
+ * Resolution:
+ *  - exactly one repo → that repo's worktree, the unambiguous markdown-link
+ *    root. The worktree is materialised at `<perChatRoot>/<localPath>`, so the
+ *    base MUST be that ABSOLUTE path. Returning a bare relative `localPath`
+ *    (the old behaviour) made the runtime resolve it against its own
+ *    `process.cwd()` — the launch dir, not the per-chat workspace — so it
+ *    silently failed to find any doc and cloud preview was dead.
+ *  - zero or multiple repos → the per-chat workspace root.
+ */
+export function documentBasePathFromRuntimeConfig(payload: AgentRuntimeConfigPayload, perChatRoot: string): string {
+  if (payload.gitRepos.length === 1) {
+    const repo = payload.gitRepos[0];
+    const localPath = repo ? repoLocalPath(repo).trim() : "";
+    if (localPath.length > 0) return join(perChatRoot, localPath);
+  }
+  return perChatRoot;
 }
 
 function repoLocalPath(repo: GitRepo): string {
@@ -742,7 +761,7 @@ export class SessionManager {
         this.currentTrigger.delete(chatId);
       },
       log,
-      getDocumentBasePath: () => this.resolveDocumentBasePath(log),
+      getDocumentBasePath: () => this.resolveDocumentBasePath(log, chatId),
     });
 
     const envCtx = { sdk: this.config.sdk, agent: this.config.agentIdentity, chatId };
@@ -771,14 +790,21 @@ export class SessionManager {
     };
   }
 
-  private async resolveDocumentBasePath(log: (msg: string) => void): Promise<string | null> {
-    if (!this.config.agentConfigCache) return null;
+  private async resolveDocumentBasePath(log: (msg: string) => void, chatId: string): Promise<string | null> {
+    // Per-chat workspace root: the same dir the handler hands the agent as cwd
+    // (`acquireWorkspace(workspaceRoot, chatId)` returns `<workspaceRoot>/<chatId>`).
+    // Computed with a pure `join` — NOT `acquireWorkspace`, whose mkdir/rmSync
+    // side effects must not run on every outbound message.
+    const perChatRoot = join(this.config.handlerConfig.workspaceRoot, chatId);
+    if (!this.config.agentConfigCache) return perChatRoot;
     try {
       const { payload } = await this.config.agentConfigCache.refreshIfNewer(this.config.agentIdentity.agentId, 0);
-      return documentBasePathFromRuntimeConfig(payload);
+      return documentBasePathFromRuntimeConfig(payload, perChatRoot);
     } catch (err) {
-      log(`document preview base path unavailable: ${err instanceof Error ? err.message : String(err)}`);
-      return null;
+      log(
+        `document preview base path: config unavailable, using workspace root: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return perChatRoot;
     }
   }
 

--- a/packages/web/src/lib/__tests__/doc-preview-links.test.ts
+++ b/packages/web/src/lib/__tests__/doc-preview-links.test.ts
@@ -40,9 +40,23 @@ describe("docPreviewPathFromHref", () => {
 });
 
 describe("linkifyMarkdownDocPaths", () => {
-  it("wraps plain markdown document paths into inline markdown links", () => {
-    expect(linkifyMarkdownDocPaths("Created docs/intro.md and README.md:12.")).toBe(
-      "Created [docs/intro.md](docs/intro.md) and [README.md:12](README.md:12).",
+  it("wraps only snapshotted paths, linking to the canonical (de-suffixed) target", () => {
+    // `README.md:12` keeps its `:12` in the visible text but links to the
+    // canonical `README.md` — an href with a `:` before any `/` would be
+    // stripped to "" by react-markdown's defaultUrlTransform and reload the page.
+    expect(
+      linkifyMarkdownDocPaths("Created docs/intro.md and README.md:12.", new Set(["docs/intro.md", "README.md"])),
+    ).toBe("Created [docs/intro.md](docs/intro.md) and [README.md:12](README.md).");
+  });
+
+  it("leaves a mentioned-but-not-snapshotted path as plain text (no dead links)", () => {
+    // The agent only *talks about* README.md:12 (e.g. describing a bug); there
+    // is no snapshot for it, so it must NOT become a clickable (dead) link.
+    expect(linkifyMarkdownDocPaths("the README.md:12 bug is annoying", new Set())).toBe(
+      "the README.md:12 bug is annoying",
+    );
+    expect(linkifyMarkdownDocPaths("see docs/intro.md for details", new Set(["docs/other.md"]))).toBe(
+      "see docs/intro.md for details",
     );
   });
 
@@ -57,25 +71,27 @@ describe("linkifyMarkdownDocPaths", () => {
       "External https://example.com/readme.md",
       "Text docs/readme.txt",
     ].join("\n");
-    expect(linkifyMarkdownDocPaths(input)).toBe(input);
+    // Even when the snapshot set contains these paths, the scanner skips
+    // links / code / HTML, so the source is returned unchanged.
+    expect(
+      linkifyMarkdownDocPaths(input, new Set(["docs/intro.md", "docs/code.md", "docs/fenced.md", "docs/html.md"])),
+    ).toBe(input);
   });
 
   it("returns the source unchanged when no plain markdown paths are present", () => {
     const text = "hello world";
-    expect(linkifyMarkdownDocPaths(text)).toBe(text);
+    expect(linkifyMarkdownDocPaths(text, new Set(["docs/intro.md"]))).toBe(text);
   });
 
   it("leaves tokens that would canonicalise to null as plain text (hidden segments, escapes)", () => {
-    // These all match the surface-level bare-path regex but
-    // `normalizeDocLinkPath` rejects them — wrapping them anyway would
-    // produce an anchor whose onClick declines to intercept, letting
-    // the browser navigate away from the chat as a same-origin nav.
+    // These match the surface-level regex but `normalizeDocLinkPath` rejects
+    // them, so they can never be in the snapshot set and stay plain text.
     const input = "see .agent/secret.md and ../outside.md and docs/.git/HEAD.md";
-    expect(linkifyMarkdownDocPaths(input)).toBe(input);
+    expect(linkifyMarkdownDocPaths(input, new Set([".agent/secret.md", "outside.md"]))).toBe(input);
   });
 
-  it("linkifies the resolvable token in a line that also contains an unresolvable one", () => {
-    expect(linkifyMarkdownDocPaths("ok docs/intro.md but not .agent/secret.md")).toBe(
+  it("linkifies the snapshotted token in a line that also contains an unresolvable one", () => {
+    expect(linkifyMarkdownDocPaths("ok docs/intro.md but not .agent/secret.md", new Set(["docs/intro.md"]))).toBe(
       "ok [docs/intro.md](docs/intro.md) but not .agent/secret.md",
     );
   });

--- a/packages/web/src/lib/doc-preview-links.ts
+++ b/packages/web/src/lib/doc-preview-links.ts
@@ -42,23 +42,29 @@ export function docPreviewPathFromHref(href: string, currentDocPath?: string | n
 
 /**
  * Rewrite plain `.md` path mentions in chat text into inline markdown links
- * `[path](path)` so react-markdown renders them as clickable previews. The
- * scan rules are shared with the runtime snapshot scanner (`scanBareDocPathTokens`)
- * — both sides must agree token-for-token, otherwise the web side would
- * render a link whose canonical key has no snapshot in metadata and the
- * click would silently fall back to the legacy server `/me/docs/preview`
- * endpoint that cannot read the agent's local workspace.
+ * so react-markdown renders them as clickable previews.
  *
- * Each match is also canonicalised through `normalizeDocLinkPath` before it
- * becomes a link — tokens like `.agent/secret.md` or `../outside.md` pass
- * the surface-level regex but `normalizeDocLinkPath` rejects them as
- * hidden / out-of-root, so wrapping them anyway would produce a dead link
- * that `docPreviewPathFromHref` re-rejects on click and the browser then
- * follows as a same-origin nav (404 / navigation away from chat). Filtering
- * here keeps the invariant "every wrapped token has a matching snapshot or
- * is at least resolvable inside the workspace".
+ * A token is linkified ONLY when its canonical path is present in
+ * `snapshotPaths` — the set of `.md` docs the runtime actually embedded as
+ * snapshots in this message's `metadata.documentContext`. This is the single
+ * invariant that keeps the feature honest:
+ *
+ *   - No dead / false-positive links. A path the agent merely *mentions*
+ *     conversationally (an example like `README.md:12`, a file that doesn't
+ *     exist, or a doc that was too large to snapshot) has no snapshot, so it
+ *     stays plain text instead of rendering a link that opens an empty preview
+ *     or — worse — an unrelated workspace file that happens to share the name.
+ *   - Every rendered link is guaranteed to open from the React Query cache
+ *     with no server round-trip (load-bearing on the cloud topology).
+ *
+ * The link target is the CANONICAL (de-suffixed) path, while the visible text
+ * keeps the raw token. So `README.md:12` renders `[README.md:12](README.md)`:
+ * the user still sees the line number, but the href has no `:` before a `/`,
+ * so react-markdown's `defaultUrlTransform` keeps it instead of stripping it
+ * to `""` (an empty href made the anchor reload the whole page on click).
  */
-export function linkifyMarkdownDocPaths(markdown: string): string {
+export function linkifyMarkdownDocPaths(markdown: string, snapshotPaths: ReadonlySet<string>): string {
+  if (snapshotPaths.size === 0) return markdown;
   const matches = scanBareDocPathTokens(markdown);
   if (matches.length === 0) return markdown;
 
@@ -69,14 +75,13 @@ export function linkifyMarkdownDocPaths(markdown: string): string {
   let cursor = 0;
   for (const match of matches) {
     if (match.start < cursor) continue;
-    // Canonicalise BEFORE wrapping. If the token would not resolve to a
-    // workspace-safe canonical path we leave the original text alone —
-    // rendering an anchor whose onClick declines to intercept produces a
-    // same-origin navigation, which is far worse UX than plain text.
+    // Canonicalise BEFORE wrapping, then require a matching snapshot. Tokens
+    // like `.agent/secret.md` / `../outside.md` canonicalise to null; tokens
+    // with no embedded snapshot are conversational mentions, not previews.
     const canonical = normalizeDocLinkPath(stripDocPathLineSuffix(match.raw));
-    if (!canonical) continue;
+    if (!canonical || !snapshotPaths.has(canonical)) continue;
     out += markdown.slice(cursor, match.start);
-    out += `[${match.raw}](${match.raw})`;
+    out += `[${match.raw}](${canonical})`;
     cursor = match.end;
   }
   out += markdown.slice(cursor);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -284,15 +284,18 @@ function TextRow({
   // Linkify plain `.md` mentions only on agent-sourced messages. Anything the
   // user typed in the web composer (`source === "hub_ui"`) is left untouched
   // so paths that humans write — code-fence walkthroughs, quoted snippets,
-  // intentional bare references — render exactly as authored. The scan rules
-  // mirror the runtime snapshot scanner, so every link this rewrites has a
-  // matching `documentContext.docs[]` entry to power the preview drawer
-  // without a server round-trip.
+  // intentional bare references — render exactly as authored. Only paths that
+  // this message actually carries a snapshot for get linkified, so a filename
+  // the agent only *mentions* in prose stays plain text instead of becoming a
+  // dead link — and every link that does render opens from cache without a
+  // server round-trip.
   const textContent = useMemo<string | null>(() => {
     if (msg.format !== "text" && msg.format !== "markdown") return null;
     if (typeof msg.content !== "string") return JSON.stringify(msg.content);
-    return msg.source === "hub_ui" ? msg.content : linkifyMarkdownDocPaths(msg.content);
-  }, [msg.format, msg.content, msg.source]);
+    if (msg.source === "hub_ui") return msg.content;
+    const snapshotPaths = new Set(docSnapshots?.keys() ?? []);
+    return linkifyMarkdownDocPaths(msg.content, snapshotPaths);
+  }, [msg.format, msg.content, msg.source, docSnapshots]);
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ href, children, ...props }) {


### PR DESCRIPTION
## Summary

Follow-up to #458. The clickable-doc-path / doc-preview feature only worked when a chat's workspace had **exactly one git repo**, and even then was **broken in the cloud topology**. This fixes both the root cause and a related timeline-link UX bug, so any `.md` an agent actually generates in its workspace renders as a clickable inline link that opens the preview rail — for **every** workspace shape, cloud included.

## Root causes & fixes

### 1. Base-path resolution never covered most workspaces (runtime)
`documentBasePathFromRuntimeConfig` returned `null` when `gitRepos.length !== 1`. With a null base, `result-sink` attaches **no `documentContext` at all** → no snapshot → a doc written in the workspace can never be previewed. That's every 0-repo or multi-repo workspace.

And the single-repo branch returned a bare **relative** `localPath` (e.g. `"first-tree-hub"`). The runtime resolves that against its own `process.cwd()` (the long-lived client launch dir, **not** the per-chat workspace — the runtime never `chdir`s per chat), so the file isn't found → snapshot skipped → falls back to `kind:"path"`, which only works on single-host where the **server** can read the path. ⇒ **single-repo cloud preview was dead.** (Verified by exercising the real `buildMessageDocumentSnapshots`: relative base resolves only when `process.cwd()` happens to be the per-chat workspace; absolute base always resolves.)

**Fix:** `resolveDocumentBasePath(log, chatId)` now computes the per-chat root as `join(handlerConfig.workspaceRoot, chatId)` — a **pure `join`**, deliberately *not* `acquireWorkspace` (whose `mkdir`/`rmSync` side effects must not run on every outbound message). `documentBasePathFromRuntimeConfig(payload, perChatRoot)` **never returns null**:
- exactly one repo → **absolute** `<perChatRoot>/<localPath>` (the worktree is materialised there)
- zero / multiple repos → the per-chat workspace root

Resolution stays safe: `resolveWorkspaceFile` existence-checks each candidate inside the root, so a bare mention that doesn't physically exist just stays plain text instead of mis-resolving.

### 2. Timeline links were over-eager + a top-level `:line` href bug (web)
`linkifyMarkdownDocPaths` linkified **any** bare `.md`-looking token in agent prose. Two problems:
- **False-positive / dead links.** An agent merely *talking about* a filename (e.g. "the `README.md:12` bug") got turned into a clickable link with no backing doc — opening an empty preview, or worse an unrelated workspace file with the same name.
- **`README.md:12` reloaded the page.** The link target was the raw token, so `README.md:12` (no `/` before the `:`) hit react-markdown's `defaultUrlTransform`, which treats `README.md:` as an unknown URL scheme and strips the href to `""`. Clicking an `<a href="">` navigated to the current page = full reload.

**Fix:** linkify now takes the set of snapshot paths the message actually carries and **only linkifies a token whose canonical path has a matching snapshot**, with the link target set to the **canonical (de-suffixed)** path. So:
- a mention with no snapshot stays plain text (no dead links),
- `README.md:12` renders `[README.md:12](README.md)` — visible text keeps the line number, href is clean and survives `defaultUrlTransform`.

`chat-view` passes `new Set(docSnapshots?.keys())` into linkify (snapshots are already memoized from `msg.metadata`).

## Resulting UX

An agent generates `hub-end-to-end-architecture.md` (or any `.md`) in its workspace and mentions it → the filename renders as an inline link in the timeline → click slides out the side-by-side preview rail with the content, **no page reload, no server round-trip, cloud-friendly**. Works for top-level and subdir files, with or without `:line[:col]` suffixes, across single-repo / multi-repo / no-repo workspaces. Filenames the agent only *mentions* (no real doc) stay plain text.

## Test plan
- [x] `pnpm --filter client test` — 389/389 (incl. new `documentBasePathFromRuntimeConfig` cases: zero/multi/single-repo **absolute** path, blank localPath fallback)
- [x] `pnpm --filter web test` — 192/192 (linkify snapshot-gating: dead-mention stays plain text; `README.md:12` → canonical href; existing skip rules)
- [x] `pnpm --filter client --filter web typecheck` clean
- [x] biome check clean on changed files

## Known follow-up (separate PR)
With the base path now always set, every agent message carries `documentContext` — `kind:"path"` (with the local absolute path) when no doc resolves. Snapshot-gating already removes its effect on timeline links; tightening or omitting `kind:"path"` in the cloud topology (to avoid embedding a local absolute path in immutable history) is left to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)