### PR TITLE
chore(chat): stop emitting kind:"path" documentContext (drop local-path leak)

### DIFF
--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -93,15 +93,13 @@ describe("createResultSink — forwardResult enrichment", () => {
     expect(body.purpose).toBe("agent-final-text");
   });
 
-  it("case 1.5 (documentContext regression): writes path-variant metadata.documentContext + omits metadata.mentions", async () => {
-    // v1.5 regression guard — PR #356's documentContext injection must
-    // survive改造 4 surgery. Verifying the branch is still wired AND that
-    // it is NOT accompanied by an automatic mentions array.
-    //
+  it("case 1.5: a base path that resolves no docs attaches NO documentContext (no kind:path leak)", async () => {
     // The basePath here is a relative string that won't resolve to a real
-    // worktree on disk, so the snapshot scan returns no docs and the sink
-    // falls back to the legacy path variant — exactly what we want for
-    // single-host / shared-fs deployments.
+    // worktree on disk, so the snapshot scan returns no docs. We no longer
+    // fall back to the legacy `kind:"path"` variant — it would embed the
+    // agent host's local absolute path in immutable history and is dead in
+    // the cloud topology. A message with no resolvable doc carries no
+    // documentContext at all (and still no auto-mentions array).
     const { sink, sendMessage } = buildSink({
       trigger: { messageId: "m1", senderId: "agent-peer" },
       getDocumentBasePath: vi.fn().mockResolvedValue("first-tree-hub"),
@@ -110,9 +108,9 @@ describe("createResultSink — forwardResult enrichment", () => {
     await sink("see [design](docs/design.md)");
 
     const body = sendMessage.mock.calls[0]?.[1] as {
-      metadata?: { documentContext?: { kind?: string; basePath?: string }; mentions?: unknown };
+      metadata?: { documentContext?: unknown; mentions?: unknown };
     };
-    expect(body.metadata?.documentContext).toEqual({ kind: "path", basePath: "first-tree-hub" });
+    expect(body.metadata?.documentContext).toBeUndefined();
     expect(body.metadata?.mentions).toBeUndefined();
   });
 
@@ -193,7 +191,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       expect(body.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["docs/intro.md"]);
     });
 
-    it("rejects dotfiles / hidden dirs and falls back to path variant when no docs survive", async () => {
+    it("rejects dotfiles / hidden dirs and attaches NO documentContext when no docs survive", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
@@ -202,10 +200,12 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("hidden: [secret](.agent/secret.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; basePath?: string } };
+        metadata?: { documentContext?: unknown };
       };
-      expect(body.metadata?.documentContext?.kind).toBe("path");
-      expect(body.metadata?.documentContext?.basePath).toBe(worktree);
+      // The hidden path is rejected, leaving zero snapshots — and we no longer
+      // emit the legacy `kind:"path"` fallback (which would leak the worktree
+      // absolute path into history), so there is no documentContext at all.
+      expect(body.metadata?.documentContext).toBeUndefined();
     });
 
     it("stores canonical workspace-relative paths so web cache lookup matches", async () => {
@@ -240,10 +240,11 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("see [public](public.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; basePath?: string } };
+        metadata?: { documentContext?: unknown };
       };
-      expect(body.metadata?.documentContext?.kind).toBe("path");
-      expect(body.metadata?.documentContext?.basePath).toBe(worktree);
+      // Symlink target is rejected → zero snapshots → no documentContext (the
+      // legacy kind:"path" fallback that leaked the worktree path is gone).
+      expect(body.metadata?.documentContext).toBeUndefined();
     });
 
     it("stores size that matches Buffer.byteLength(content, utf8) so server validation never rejects a malformed-UTF-8 file", async () => {
@@ -299,12 +300,11 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("see [evil](https://x.com/api.md) and [also](//x.com/a.md) and [mail](mailto:a@b.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; basePath?: string } };
+        metadata?: { documentContext?: unknown };
       };
-      // None of the three hrefs is a workspace path, so the sink falls back
-      // to the path variant rather than emitting any snapshot.
-      expect(body.metadata?.documentContext?.kind).toBe("path");
-      expect(body.metadata?.documentContext?.basePath).toBe(worktree);
+      // None of the three hrefs is a workspace path → zero snapshots → no
+      // documentContext (no legacy kind:"path" fallback).
+      expect(body.metadata?.documentContext).toBeUndefined();
     });
 
     it("ignores escaped link `\\[...](path.md)` and image link `![alt](path.md)`", async () => {
@@ -316,12 +316,11 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("escaped: \\[design](design.md) and image: ![diagram](api.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; basePath?: string } };
+        metadata?: { documentContext?: unknown };
       };
-      // Neither escaped nor image triggers snapshot emission, so the sink
-      // falls back to the path variant.
-      expect(body.metadata?.documentContext?.kind).toBe("path");
-      expect(body.metadata?.documentContext?.basePath).toBe(worktree);
+      // Neither escaped nor image triggers snapshot emission → zero snapshots
+      // → no documentContext (no legacy kind:"path" fallback).
+      expect(body.metadata?.documentContext).toBeUndefined();
     });
   });
 

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -60,33 +60,31 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
     const metadata: Record<string, unknown> = {};
     const documentBasePath = await deps.getDocumentBasePath?.();
     if (documentBasePath) {
-      // Prefer the inline-snapshot variant when the text actually references
-      // markdown docs we can resolve. This is the cloud-friendly form: web
-      // gets the bytes straight from the message, no second server round-trip
-      // and no dependency on the server having access to the agent's local
-      // workspace filesystem (see proposal §核心设计).
+      // Embed the inline-snapshot variant only. This is the cloud-friendly
+      // form: web gets the bytes straight from the message, no second server
+      // round-trip and no dependency on the server having access to the
+      // agent's local workspace filesystem (see proposal §核心设计).
       //
-      // When no resolvable links exist (or all of them are rejected), fall
-      // back to the path-based variant so single-host deployments where
-      // server + runtime share the workspace can still preview via the
-      // legacy `/docs/preview` endpoint.
-      let snapshotsWritten = false;
+      // We deliberately do NOT fall back to the legacy `kind:"path"` variant.
+      // It carries the agent host's local absolute workspace path into
+      // immutable chat history (a cloud-topology leak), and is dead in the
+      // cloud anyway since the server can't read the agent's disk. Any real,
+      // referenced `.md` is already captured as a snapshot above; a message
+      // with no resolvable doc simply carries no documentContext. (Historical
+      // messages may still hold `kind:"path"`; the web reader keeps handling
+      // them for back-compat — this only stops emitting new ones.)
       try {
         const { docs, skipped } = await buildMessageDocumentSnapshots(text, documentBasePath);
         if (docs.length > 0) {
           metadata.documentContext = documentContextSchema.parse({ kind: "snapshot", docs });
-          snapshotsWritten = true;
         }
         if (skipped > 0) {
           deps.log(`doc snapshot: skipped ${skipped} unresolvable link(s)`);
         }
       } catch (err) {
-        // Snapshot build failure must never block message delivery — degrade
-        // to the path-based fallback below and log so it's debuggable.
-        deps.log(`doc snapshot: build failed, falling back to path variant: ${(err as Error).message}`);
-      }
-      if (!snapshotsWritten) {
-        metadata.documentContext = documentContextSchema.parse({ kind: "path", basePath: documentBasePath });
+        // Snapshot build failure must never block message delivery — log and
+        // attach no documentContext so the message still goes out.
+        deps.log(`doc snapshot: build failed, no documentContext attached: ${(err as Error).message}`);
       }
     }
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -790,7 +790,7 @@ export class SessionManager {
     };
   }
 
-  private async resolveDocumentBasePath(log: (msg: string) => void, chatId: string): Promise<string | null> {
+  private async resolveDocumentBasePath(log: (msg: string) => void, chatId: string): Promise<string> {
     // Per-chat workspace root: the same dir the handler hands the agent as cwd
     // (`acquireWorkspace(workspaceRoot, chatId)` returns `<workspaceRoot>/<chatId>`).
     // Computed with a pure `join` — NOT `acquireWorkspace`, whose mkdir/rmSync


### PR DESCRIPTION
Closes #475. Follow-up to #474.

## Why
#474 made the doc-preview base path resolve for every workspace shape. A side effect: **every** agent message with no resolvable `.md` now fell back to `kind:"path"` and embedded the agent host's local **absolute** workspace path (`<dataDir>/workspaces/<agentName>/<chatId>`) into immutable chat history.

That path is:
- a cloud-topology smell — it leaks the runtime host's directory layout / agent name to every chat participant, permanently;
- functionally dead in cloud — the server can't read the agent's local disk, so the legacy `/me/docs/preview` path variant can't resolve it anyway.

Since #474, any real, *referenced* `.md` (inline link or bare mention) that exists is already captured as a **snapshot**, so the `kind:"path"` fallback only ever applied to docs that can't be previewed regardless (non-existent / hidden / oversized).

## Change
`result-sink` now embeds **only** the inline-snapshot variant. A message with no resolvable doc carries **no** `documentContext`.

Back-compat preserved: historical messages may still hold `kind:"path"`, and both the web reader (`documentBasePathFromMetadata`) and the server schema/endpoint keep handling them — this only stops *emitting* new ones.

Also tightens `resolveDocumentBasePath` to `Promise<string>` (it is total after #474 — never returns null), per @yuezengwu's review note on #474.

## Test plan
- [x] `pnpm --filter client test` — 389/389. The result-sink "no resolvable doc" cases (relative base, hidden/dotfile, symlink-escape, external-href, escaped/image link) now assert **no** `documentContext` instead of a `kind:"path"` fallback.
- [x] Server `kind:"path"` schema + `/me/docs/preview` tests unchanged (reading old messages still works).
- [x] `pnpm --filter client typecheck` clean
- [x] biome check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)