### PR TITLE
fix(client): protect working sessions + sync state after restart

### DIFF
--- a/packages/client/src/__tests__/session-manager-question-answer.test.ts
+++ b/packages/client/src/__tests__/session-manager-question-answer.test.ts
@@ -46,7 +46,7 @@ function createSessionManager(
 ) {
   const factory: HandlerFactory = () => handler;
   return new SessionManager({
-    session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     concurrency: 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -117,7 +117,7 @@ describe("SessionManager.evictIdle — askuser-in-flight guard (#418)", () => {
       const factory: HandlerFactory = () => handler;
       const sm = new SessionManager({
         // 1-second idle timeout so a single 10s evictIdle tick is plenty.
-        session: { idle_timeout: 1, max_sessions: 10, reconcile_interval_seconds: 300 },
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
         concurrency: 5,
         handlerFactory: factory,
         handlerConfig: { workspaceRoot: "/tmp/test" },

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -36,7 +36,12 @@ function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
   ackEntry?: (entryId: number) => Promise<void>;
-  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
+  session?: {
+    idle_timeout: number;
+    max_sessions: number;
+    working_grace_seconds: number;
+    reconcile_interval_seconds: number;
+  };
   concurrency?: number;
   log?: pino.Logger;
 }) {
@@ -45,7 +50,12 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    session: opts.session ?? {
+      idle_timeout: 300,
+      max_sessions: 10,
+      working_grace_seconds: 3600,
+      reconcile_interval_seconds: 300,
+    },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -116,7 +126,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -183,7 +193,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -270,7 +280,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -315,7 +325,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -369,7 +379,7 @@ describe("SessionManager", () => {
 
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 2,
       handlerFactory: factory,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -444,7 +454,7 @@ describe("SessionManager ackEntry callback", () => {
     const h = handler ?? createMockHandler();
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 5,
       handlerFactory: () => h,
       handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -496,7 +506,7 @@ describe("SessionManager ackEntry callback", () => {
     const handler = createMockHandler();
     const sdk = mockSdk();
     const sm = new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 1, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 1, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 1,
       handlerFactory: () => handler,
       handlerConfig: { workspaceRoot: "/tmp/test" },

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -50,7 +50,12 @@ function createSessionManager(opts: {
   handler?: AgentHandler;
   handlerFactory?: HandlerFactory;
   ackEntry?: (entryId: number) => Promise<void>;
-  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
+  session?: {
+    idle_timeout: number;
+    max_sessions: number;
+    working_grace_seconds: number;
+    reconcile_interval_seconds: number;
+  };
   concurrency?: number;
   log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
@@ -60,7 +65,12 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    session: opts.session ?? {
+      idle_timeout: 300,
+      max_sessions: 10,
+      working_grace_seconds: 3600,
+      reconcile_interval_seconds: 300,
+    },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -234,7 +244,7 @@ describe("SessionManager: runtime state cleanup on eviction", () => {
       });
 
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       handlerFactory: factory,
       onRuntimeStateChange: (state) => runtimeChanges.push(state),
     });
@@ -346,5 +356,127 @@ describe("SessionManager: ackEntry handles entryId correctly", () => {
     expect(ackEntry).toHaveBeenCalledWith(2);
 
     await sm.shutdown();
+  });
+});
+
+describe("SessionManager.evictIdle — working-state grace window", () => {
+  // A long thinking turn or one giant SDK message produces no inbound events
+  // for minutes at a time, so `lastActivity` (refreshed only by handler
+  // `touch()`) drifts past `idle_timeout` even though the handler is still
+  // working. Without this grace window the runtime suspends the SDK
+  // mid-thought; with it, the slot survives until either work resumes or the
+  // upper bound `idle_timeout + working_grace_seconds` is exceeded.
+  it("does NOT suspend a session whose runtimeState is 'working' inside the grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      let capturedCtx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, ctx) {
+          capturedCtx = ctx;
+          return "s-working";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        // 1s idle window + 60s grace — picked so a single 20s tick lands
+        // inside the grace window.
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
+      defined(capturedCtx, "ctx").setRuntimeState("working");
+
+      // 20s ≫ idle_timeout (1s) but ≪ idle_timeout + grace (61s).
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(handler.suspend).not.toHaveBeenCalled();
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("DOES suspend once inactiveMs exceeds idle_timeout + working_grace_seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      let capturedCtx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, ctx) {
+          capturedCtx = ctx;
+          return "s-stuck";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        // 1s idle + 5s grace — the timer below blows past the 6s cap so
+        // the runtime should give up and reclaim the slot.
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 5, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-stuck" }));
+      defined(capturedCtx, "ctx").setRuntimeState("working");
+
+      // 30s ≫ idle_timeout + grace (6s). evictIdle ticks every 10s.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(handler.suspend).toHaveBeenCalledTimes(1);
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("also exempts 'blocked' (the state evictIdle itself flips 'working' into after 2 minutes)", async () => {
+    vi.useFakeTimers();
+    try {
+      let capturedCtx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, ctx) {
+          capturedCtx = ctx;
+          return "s-blocked";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-blocked" }));
+      defined(capturedCtx, "ctx").setRuntimeState("blocked");
+
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(handler.suspend).not.toHaveBeenCalled();
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("'idle' runtimeState still suspends at idle_timeout (regression)", async () => {
+    vi.useFakeTimers();
+    try {
+      let capturedCtx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, ctx) {
+          capturedCtx = ctx;
+          return "s-idle";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-idle" }));
+      defined(capturedCtx, "ctx").setRuntimeState("idle");
+
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      expect(handler.suspend).toHaveBeenCalledTimes(1);
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -53,7 +53,7 @@ function makeSessionManager(opts: {
     return next;
   };
   return new SessionManager({
-    session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     concurrency: 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -183,7 +183,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
   }) {
     const queue = [...opts.handlerQueue];
     return new SessionManager({
-      session: { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       concurrency: 1,
       handlerFactory: () => queue.shift() ?? workingHandler(),
       handlerConfig: { workspaceRoot: "/tmp/test" },

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -35,7 +35,12 @@ function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
   handlerFactory?: HandlerFactory;
-  session?: { idle_timeout: number; max_sessions: number; reconcile_interval_seconds: number };
+  session?: {
+    idle_timeout: number;
+    max_sessions: number;
+    working_grace_seconds: number;
+    reconcile_interval_seconds: number;
+  };
   concurrency?: number;
   log?: pino.Logger;
   onStateChange?: (chatId: string, state: SessionState) => void;
@@ -45,7 +50,12 @@ function createSessionManager(opts: {
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
-    session: opts.session ?? { idle_timeout: 300, max_sessions: 10, reconcile_interval_seconds: 300 },
+    session: opts.session ?? {
+      idle_timeout: 300,
+      max_sessions: 10,
+      working_grace_seconds: 3600,
+      reconcile_interval_seconds: 300,
+    },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
     handlerConfig: { workspaceRoot: "/tmp/test" },
@@ -110,7 +120,7 @@ describe("SessionManager: state notifications", () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const handlers: AgentHandler[] = [];
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       handlerFactory: () => {
         const h = createMockHandler();
         handlers.push(h);
@@ -221,6 +231,36 @@ describe("SessionManager: getSessionStates()", () => {
   });
 });
 
+describe("SessionManager: getEvictedChatIds()", () => {
+  // After a process restart, SessionRegistry hydrates every persisted
+  // (chatId → claudeSessionId) row into `evictedMappings` — `sessions` is
+  // empty. The agent-slot full-state-sync uses these chatIds to advertise
+  // them as "suspended" on the wire so the server's
+  // `agent_chat_sessions.state` isn't stuck on a pre-restart snapshot.
+  it("returns evictedMappings keys (LRU-evicted chats included)", async () => {
+    const sm = createSessionManager({
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    // chat-c forces LRU eviction of the older chat (chat-a is suspended-then-evicted
+    // out of `sessions` into `evictedMappings`).
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
+
+    const evicted = new Set(sm.getEvictedChatIds());
+    expect(evicted.has("chat-a")).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("returns empty array when nothing has been evicted", async () => {
+    const sm = createSessionManager({});
+    expect(sm.getEvictedChatIds()).toEqual([]);
+    await sm.shutdown();
+  });
+});
+
 describe("SessionManager: shutdown state reporting", () => {
   it("reports active sessions as 'suspended' on shutdown", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
@@ -287,7 +327,7 @@ describe("SessionManager: terminate + reconcile", () => {
 
   it("getHeldChatIds() unions active sessions and evicted mappings", async () => {
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
@@ -305,7 +345,7 @@ describe("SessionManager: terminate + reconcile", () => {
   it("applyStaleChatIds() cleans up both live sessions and evicted mappings", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, reconcile_interval_seconds: 300 },
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
     });
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -809,6 +809,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             respawnQuery(claudeSessionId, sessionCtx);
           } catch (resumeErr) {
             sessionCtx.log(`Auto-resume failed: ${resumeErr instanceof Error ? resumeErr.message : String(resumeErr)}`);
+            // Mirror the MAX_RETRIES branch above: leaving runtimeState at
+            // `working` would block the SessionManager's idle-suspend grace
+            // window from ever firing on this session, so the slot would
+            // never be reclaimed.
+            sessionCtx.setRuntimeState("error");
             return;
           }
         }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -237,10 +237,22 @@ export class AgentSlot {
     for (const { chatId, state } of this.sessionManager.getSessionStates()) {
       this.clientConnection.reportSessionState(this.config.agentId, chatId, state);
     }
-    const runtimeState = this.sessionManager.getAggregateRuntimeState();
-    if (runtimeState) {
-      this.clientConnection.reportRuntimeState(this.config.agentId, runtimeState);
+    // After a process restart `sessions` is empty but SessionRegistry just
+    // hydrated every persisted (chatId → claudeSessionId) row into
+    // `evictedMappings`. Without this loop, the server's
+    // `agent_chat_sessions.state` would stay on the pre-restart snapshot
+    // (commonly `active`) forever — the next inbound message would only
+    // refresh that one row, leaving the rest stale. "suspended" is the
+    // closest in-schema state for "handler is gone but resumable".
+    for (const chatId of this.sessionManager.getEvictedChatIds()) {
+      this.clientConnection.reportSessionState(this.config.agentId, chatId, "suspended");
     }
+    // Explicit "idle" clears any stale `working`/`blocked` on the server:
+    // any in-flight work owned by the previous process died with its SDK
+    // transport. The first inbound message will flip it back to `working`
+    // through the normal session-runtime-state path.
+    const runtimeState = this.sessionManager.getAggregateRuntimeState();
+    this.clientConnection.reportRuntimeState(this.config.agentId, runtimeState ?? "idle");
   }
 
   /**

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-import { CONCURRENCY, IDLE_TIMEOUT_MS, MAX_SESSIONS } from "./constants.js";
+import { CONCURRENCY, IDLE_TIMEOUT_MS, MAX_SESSIONS, WORKING_GRACE_SECONDS } from "./constants.js";
 
 /**
  * Minimal `agent.yaml` schema.
@@ -26,6 +26,13 @@ const sessionConfigSchema = z
       .positive()
       .default(IDLE_TIMEOUT_MS / 1000),
     max_sessions: z.number().int().positive().default(MAX_SESSIONS),
+    /**
+     * Upper bound on how long `working`/`blocked` may keep a session alive
+     * past `idle_timeout` before force-suspend. Matches the field of the
+     * same name in the admin-managed runtime config; this default applies
+     * only when the legacy local `agent.yaml` path is in use.
+     */
+    working_grace_seconds: z.number().int().positive().default(WORKING_GRACE_SECONDS),
     /** How often the client reconciles its local chatIds with the server. */
     reconcile_interval_seconds: z.number().int().min(30).max(3600).default(300),
   })

--- a/packages/client/src/runtime/constants.ts
+++ b/packages/client/src/runtime/constants.ts
@@ -20,3 +20,11 @@ export const CONCURRENCY = 16;
 
 /** How often the session manager scans for idle sessions to reclaim. */
 export const IDLE_SCAN_INTERVAL_MS = 60_000;
+
+/**
+ * Grace window above `idle_timeout` during which a `working` or `blocked`
+ * session is exempted from idle suspend. Bounds the worst case where a
+ * handler bug leaves `runtimeState` stuck at `working` so a slot can't be
+ * leaked forever.
+ */
+export const WORKING_GRACE_SECONDS = 60 * 60;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -361,6 +361,18 @@ export class SessionManager {
     }));
   }
 
+  /**
+   * ChatIds the client still holds in `evictedMappings` — i.e. either
+   * hydrated from disk on startup or dropped from `sessions` by LRU. Used
+   * by the agent-slot full-state-sync to advertise these as "suspended" on
+   * the wire, so the server's `agent_chat_sessions.state` doesn't get
+   * stuck on a pre-restart "active" snapshot when the in-memory handler is
+   * actually gone.
+   */
+  getEvictedChatIds(): string[] {
+    return [...this.evictedMappings.keys()];
+  }
+
   // ---- Internal -----------------------------------------------------------
 
   private async routeMessage(chatId: string, message: SessionMessage, entryId?: number): Promise<void> {
@@ -663,6 +675,7 @@ export class SessionManager {
 
   private evictIdle(): void {
     const timeoutMs = this.config.session.idle_timeout * 1000;
+    const workingGraceMs = this.config.session.working_grace_seconds * 1000;
     // Blocked detection — 2 minutes without activity while session is active
     const blockedThresholdMs = 120_000;
     const now = Date.now();
@@ -688,8 +701,35 @@ export class SessionManager {
           );
           continue;
         }
+
+        // `lastActivity` is bumped per inbound SDK message/event (handler
+        // `touch()`), so a long thinking turn or a single very large message
+        // looks identical to "session has been idle" here. Without this
+        // exemption the runtime suspends the SDK transport mid-thinking and
+        // the work is lost. `working_grace_seconds` bounds the worst case:
+        // if a handler bug strands the state at `working`/`blocked`, the
+        // slot is reclaimed after the grace window expires.
+        const currentState = this.sessionRuntimeStates.get(session.chatId);
+        const stillProgressing = currentState === "working" || currentState === "blocked";
+        if (stillProgressing && inactiveMs < timeoutMs + workingGraceMs) {
+          this.config.log.info(
+            {
+              chatId: session.chatId,
+              runtimeState: currentState,
+              inactiveSec: Math.round(inactiveMs / 1000),
+              graceSec: this.config.session.working_grace_seconds,
+            },
+            "session idle threshold reached but still working — skipping suspend",
+          );
+          continue;
+        }
+
         this.config.log.info(
-          { chatId: session.chatId, idleTimeoutSec: this.config.session.idle_timeout },
+          {
+            chatId: session.chatId,
+            idleTimeoutSec: this.config.session.idle_timeout,
+            runtimeState: currentState ?? "idle",
+          },
           "session idle, suspending",
         );
         this.suspendSession(session);

--- a/packages/command/src/__tests__/client-runtime-context-tree.test.ts
+++ b/packages/command/src/__tests__/client-runtime-context-tree.test.ts
@@ -104,7 +104,7 @@ describe("ClientRuntime context-tree wiring", () => {
     rt.addAgent("alpha", {
       agentId: "agent-alpha",
       runtime: "claude-code",
-      session: { idle_timeout: 300, max_sessions: 4 },
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
       concurrency: 1,
     } as unknown as Parameters<typeof rt.addAgent>[1]);
 

--- a/packages/command/src/core/client-runtime.ts
+++ b/packages/command/src/core/client-runtime.ts
@@ -149,6 +149,7 @@ export class ClientRuntime {
       session: {
         idle_timeout: config.session.idle_timeout,
         max_sessions: config.session.max_sessions,
+        working_grace_seconds: config.session.working_grace_seconds,
         // Admin-managed runtime config doesn't carry this field yet; local
         // `agent.yaml` users can override via the client YAML schema.
         reconcile_interval_seconds: 300,

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -20,6 +20,11 @@ export const agentConfigSchema = defineConfig({
   session: {
     idle_timeout: field(z.number().int().positive().default(300)),
     max_sessions: field(z.number().int().positive().default(10)),
+    // Upper bound on how long a session may stay `working`/`blocked` past
+    // `idle_timeout` before the runtime force-suspends it. Protects long
+    // thinking / large message generation from idle eviction while still
+    // bounding stuck-state slot leaks. See evictIdle in session-manager.ts.
+    working_grace_seconds: field(z.number().int().positive().default(3600)),
   },
 });
 


### PR DESCRIPTION
## Summary

Fixes two related bugs that make sessions / agent state look broken to the server while the client is actually healthy.

**Bug A — long thinking trips idle suspend.** `lastActivity` is only refreshed when an inbound SDK event hits `touch()` ([handlers/claude-code.ts:724](https://github.com/agent-team-foundation/first-tree-hub/blob/main/packages/client/src/handlers/claude-code.ts#L724), [handlers/codex.ts:366](https://github.com/agent-team-foundation/first-tree-hub/blob/main/packages/client/src/handlers/codex.ts#L366)), so a 5-minute reasoning block or a single very large message looks identical to an idle session and `evictIdle` tears down the SDK transport mid-thought. `evictIdle` now exempts sessions whose runtime state is `working` or `blocked` up to `idle_timeout + working_grace_seconds`, then force-suspends — so a handler bug stranding the state cannot leak a slot forever.

**Bug B — server state stays stale after client restart.** When the client restarts (auto-update / SIGTERM / OOM / boot), `SessionRegistry` hydrates persisted chats into `evictedMappings`, leaving the in-memory `sessions` map empty. The previous `fullStateSync` walked only `sessions`, so the server's `agent_chat_sessions.state` and `agent_presence.runtime_state` stayed pinned to the pre-restart snapshot (commonly `active` / `working`) until the next inbound message touched each chat. `fullStateSync` now also walks `evictedMappings` reporting `suspended`, and always reports an aggregate `runtime_state`, defaulting to `idle`.

**Bonus fix.** `claude-code` `respawnQuery` failure now flips runtime state to `error` (mirroring the `MAX_RETRIES` branch), so a permanently stuck `working` cannot outlive the grace window.

### New config field

`session.working_grace_seconds` on the admin-managed runtime config (default `3600`). Same hot-reload path as `idle_timeout`, so the upper bound can be retuned from admin without shipping a new client.

## Test plan

- [x] `pnpm check` (biome)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @first-tree-hub/client test` (391 pass — the one `git-mirror-manager` failure is a pre-existing 5s-timeout flake, passes with `--testTimeout=30000`)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` (251 pass)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` (125 pass)
- New cases:
  - [x] `working`/`blocked` exempt from idle suspend within grace window
  - [x] `working` force-suspended once past `idle_timeout + working_grace_seconds`
  - [x] `idle` runtime state still suspends at `idle_timeout` (regression)
  - [x] `getEvictedChatIds` returns LRU/restored chats; empty otherwise
- [ ] Manual: restart client mid-thinking and verify the chat keeps running through the grace window
- [ ] Manual: restart client and verify server-side `agent_presence.runtime_state` flips to `idle` instead of staying on the pre-restart `working`

🤖 Generated with [Claude Code](https://claude.com/claude-code)