### PR TITLE
chore: default group to Source + tidy LRU eviction comment

### DIFF
--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -655,11 +655,13 @@ export class SessionManager {
         this._activeCount--;
         candidate.session.handler.shutdown().catch(() => {});
       }
-      // LRU eviction is a local memory-management concern, not operator intent
-      // — do NOT emit a wire state. The server row stays as last reported;
-      // the local `evictedMappings` entry keeps resume-on-next-message working.
-      // (`suspended` here would accumulate rows in agent_chat_sessions forever
-      // since the cleanup cron is out of scope for this redesign.)
+      // LRU eviction is local memory-management, not operator intent — do
+      // NOT emit a wire state here. The chat now lives in `evictedMappings`
+      // and the next `agent:bound` (initial bind or reconnect) will pick it
+      // up via `getEvictedChatIds()` in `agent-slot.fullStateSync` and
+      // advertise it as `suspended`, so the server's `agent_chat_sessions.state`
+      // converges to "handler is gone" on the next sync without churn on
+      // every eviction.
       this.sessions.delete(candidate.key);
       this.sessionRuntimeStates.delete(candidate.key);
       // Drop the trigger alongside the session — the next message routed to

--- a/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
@@ -224,19 +224,20 @@ describe("nextParamsForClearFilters", () => {
 });
 
 describe("nextParamsForGroup", () => {
-  it("drops the param for the default `recency` mode", () => {
+  it("drops the param for the default `source` mode", () => {
     // Default omitted from URL so the canonical home page stays `/`.
-    const result = nextParamsForGroup(paramsOf("group=source"), "recency");
+    const result = nextParamsForGroup(paramsOf("group=recency"), "source");
     expect(result.has("group")).toBe(false);
   });
 
   it("sets non-default modes", () => {
-    expect(nextParamsForGroup(paramsOf(""), "source").get("group")).toBe("source");
+    expect(nextParamsForGroup(paramsOf(""), "recency").get("group")).toBe("recency");
+    expect(nextParamsForGroup(paramsOf(""), "type").get("group")).toBe("type");
     expect(nextParamsForGroup(paramsOf(""), "none").get("group")).toBe("none");
   });
 
   it("preserves the chat selection (grouping is purely visual)", () => {
-    const result = nextParamsForGroup(paramsOf("c=abc"), "source");
+    const result = nextParamsForGroup(paramsOf("c=abc"), "recency");
     expect(result.get("c")).toBe("abc");
   });
 });

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -4,13 +4,13 @@ export type GroupMode = "recency" | "source" | "type" | "none";
 
 /**
  * Parse a `?group=` URL value into a `GroupMode`. Unknown / missing
- * values fall back to `recency` (the default). Exported so both the
+ * values fall back to `source` (the default). Exported so both the
  * URL-state side (`WorkspacePage`) and the headless dropdown
  * (`ConversationList`) share one canonical parser.
  */
 export function parseGroupMode(raw: string | null): GroupMode {
-  if (raw === "source" || raw === "type" || raw === "none") return raw;
-  return "recency";
+  if (raw === "recency" || raw === "type" || raw === "none") return raw;
+  return "source";
 }
 
 export type GroupBucket = {

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -23,7 +23,7 @@ import { ConversationList, DRAFT_CHAT_ID } from "./conversations/index.js";
  *   - `?watching=1` (default off) — chats where the caller is a watcher
  *   - `?origin=manual,pr,issue,…` (default empty = unfiltered) — multi-select
  *   - `?with=agent-x,agent-y` (default empty = unfiltered) — participants
- *   - `?group=recency|source|none` (default `recency`) — list grouping
+ *   - `?group=recency|source|type|none` (default `source`) — list grouping
  *
  * Phase B replaces the Phase A single-value `?source=` with the multi-select
  * `?origin=`; the legacy key is still accepted on first load and upgraded
@@ -346,7 +346,7 @@ export function nextParamsForParticipants(current: URLSearchParams, agents: Read
  */
 export function nextParamsForGroup(current: URLSearchParams, mode: GroupMode): URLSearchParams {
   const next = new URLSearchParams(current);
-  if (mode === "recency") next.delete("group");
+  if (mode === "source") next.delete("group");
   else next.set("group", mode);
   return next;
 }


### PR DESCRIPTION
Two small follow-ups bundled together:

## 1. `chore(web)`: default conversation grouping → Source

Workspace left-rail's `?group=` default was `recency`; flip it to `source` so the rail buckets by where a conversation came from (Manual / GitHub / Feishu) out of the box. Dropdown still exposes all four modes — only the URL fallback changes, and `nextParamsForGroup` now drops `group=` from the URL when Source is selected so the canonical home stays `/`.

- `packages/web/src/pages/workspace/conversations/group-rows.ts` — `parseGroupMode` default flipped
- `packages/web/src/pages/workspace/index.tsx` — JSDoc + `nextParamsForGroup`
- `packages/web/src/pages/workspace/__tests__/url-transitions.test.ts` — adjusted to match new default

## 2. `docs(session-manager)`: update LRU eviction comment

Follow-up from reviewer nit on #477. The old comment said `evictIfNeeded` does NOT emit a wire state full stop, but #477 made `fullStateSync` pick these chats up via `getEvictedChatIds()` on the next `agent:bound`. Runtime behavior unchanged — only the explanation needed updating.

## Test plan

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @first-tree-hub/web test` (192 pass)
- [x] `url-transitions.test.ts` updated for new default
- [ ] Manual: load `/` and verify the left rail buckets by Source by default; switching to Recency via dropdown adds `?group=recency` to URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)