### PR TITLE
fix(web): require @mention by membership shape, not chats.type (1-on-1 DM regression)

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -71,6 +71,7 @@ import { docPreviewPathFromHref, linkifyMarkdownDocPaths } from "../../../lib/do
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { cn } from "../../../lib/utils.js";
+import { computeRequiresMention } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 import { ChatRightSidebar } from "../right-sidebar/index.js";
 
@@ -1269,17 +1270,27 @@ export function ChatView({
   }, [chatDetail?.participants, activity?.agents, agentId, chatScopedAgentIdentity, myAgentId, managedByMeMap]);
 
   /**
-   * "Needs explicit @mention" guard: a real group, OR a direct chat where the
-   * current user isn't yet a participant (their first send promotes it to a
-   * 3-person group). In both cases an unaddressed message would be silently
-   * dropped by `mention_only` peers and the server now rejects it with 400.
-   * See proposals/group-chat-ux-improvements §2.
+   * "Needs explicit @mention" guard: a real group (3+ speakers), OR a 1-on-1
+   * where the current user isn't yet a participant (their first send promotes
+   * it to a 3-person group). In both cases an unaddressed message would be
+   * silently dropped by `mention_only` peers and the server rejects it with
+   * 400. See proposals/group-chat-ux-improvements §2.
+   *
+   * Keyed on **membership shape**, not `chats.type`. Since the group-chat
+   * convergence (first-tree-hub #465 / first-tree-context #281) every chat is
+   * created with `type='group'`, so the old `chatDetail.type === "group"`
+   * check fired for 1-on-1 DMs too and forced an @mention there — breaking the
+   * "DM doesn't need an explicit @mention" UX. The server already keys on
+   * shape (`services/message.ts` `isOneOnOne = participants.length === 2`,
+   * speakers only); this mirrors it. `chatDetail.participants` is also
+   * speakers-only (`getChatDetail` filters `accessMode = 'speaker'`).
    */
   const requiresMention = useMemo(() => {
     if (!chatDetail) return false;
-    if (chatDetail.type === "group") return true;
-    const meIn = chatDetail.participants.some((p) => p.agentId === myAgentId);
-    return chatDetail.type === "direct" && !meIn && chatDetail.participants.length >= 2;
+    return computeRequiresMention(
+      chatDetail.participants.map((p) => p.agentId),
+      myAgentId,
+    );
   }, [chatDetail, myAgentId]);
 
   // First-message pre-fill: when the user lands on a brand-new empty chat

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1277,8 +1277,8 @@ export function ChatView({
    * 400. See proposals/group-chat-ux-improvements §2.
    *
    * Keyed on **membership shape**, not `chats.type`. Since the group-chat
-   * convergence (first-tree-hub #465 / first-tree-context #281) every chat is
-   * created with `type='group'`, so the old `chatDetail.type === "group"`
+   * convergence (first-tree-hub PR 465 / first-tree-context PR 281) every chat
+   * is created with `type='group'`, so the old `chatDetail.type === "group"`
    * check fired for 1-on-1 DMs too and forced an @mention there — breaking the
    * "DM doesn't need an explicit @mention" UX. The server already keys on
    * shape (`services/message.ts` `isOneOnOne = participants.length === 2`,

--- a/packages/web/src/utils/__tests__/requires-mention.test.ts
+++ b/packages/web/src/utils/__tests__/requires-mention.test.ts
@@ -6,10 +6,10 @@ const A = "agent-a";
 const B = "agent-b";
 
 describe("computeRequiresMention", () => {
-  // ── 1-on-1 (the regression first-tree-hub #465 introduced) ────────────────
+  // ── 1-on-1 (the regression first-tree-hub PR 465 introduced) ──────────────
   it("does NOT require a mention in a 1-on-1 where the user is a speaker", () => {
-    // human + their assistant: 2 speakers, user is in. Post-#465 every chat is
-    // type='group', but a 1-on-1 must still send without an explicit @mention.
+    // human + their assistant: 2 speakers, user is in. After PR 465 every chat
+    // is type='group', but a 1-on-1 must still send without an explicit @mention.
     expect(computeRequiresMention([ME, A], ME)).toBe(false);
   });
 

--- a/packages/web/src/utils/__tests__/requires-mention.test.ts
+++ b/packages/web/src/utils/__tests__/requires-mention.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { computeRequiresMention } from "../requires-mention.js";
+
+const ME = "me-agent";
+const A = "agent-a";
+const B = "agent-b";
+
+describe("computeRequiresMention", () => {
+  // ── 1-on-1 (the regression first-tree-hub #465 introduced) ────────────────
+  it("does NOT require a mention in a 1-on-1 where the user is a speaker", () => {
+    // human + their assistant: 2 speakers, user is in. Post-#465 every chat is
+    // type='group', but a 1-on-1 must still send without an explicit @mention.
+    expect(computeRequiresMention([ME, A], ME)).toBe(false);
+  });
+
+  it("does NOT require a mention in a 1-on-1 between two agents the user is in", () => {
+    expect(computeRequiresMention([ME, A], ME)).toBe(false);
+  });
+
+  // ── real groups (3+ speakers) ─────────────────────────────────────────────
+  it("requires a mention in a 3-speaker group the user is in", () => {
+    expect(computeRequiresMention([ME, A, B], ME)).toBe(true);
+  });
+
+  it("requires a mention in a larger group", () => {
+    expect(computeRequiresMention([ME, A, B, "agent-c"], ME)).toBe(true);
+  });
+
+  // ── prospective seat: user not yet a speaker ──────────────────────────────
+  it("requires a mention when watching a 2-speaker chat (first send makes it 3)", () => {
+    // User isn't a member yet; sending promotes them to a 3rd speaker → group.
+    expect(computeRequiresMention([A, B], ME)).toBe(true);
+  });
+
+  it("does NOT require a mention when joining a single-speaker chat (becomes 1-on-1)", () => {
+    expect(computeRequiresMention([A], ME)).toBe(false);
+  });
+
+  // ── degenerate / guard cases ──────────────────────────────────────────────
+  it("does NOT require a mention in a solo chat the user is in", () => {
+    expect(computeRequiresMention([ME], ME)).toBe(false);
+  });
+
+  it("treats a null/undefined self as not-yet-a-member (counts the send seat)", () => {
+    expect(computeRequiresMention([A, B], null)).toBe(true);
+    expect(computeRequiresMention([A], undefined)).toBe(false);
+  });
+
+  it("handles an empty participant list", () => {
+    expect(computeRequiresMention([], ME)).toBe(false);
+  });
+});

--- a/packages/web/src/utils/__tests__/requires-mention.test.ts
+++ b/packages/web/src/utils/__tests__/requires-mention.test.ts
@@ -13,8 +13,11 @@ describe("computeRequiresMention", () => {
     expect(computeRequiresMention([ME, A], ME)).toBe(false);
   });
 
-  it("does NOT require a mention in a 1-on-1 between two agents the user is in", () => {
-    expect(computeRequiresMention([ME, A], ME)).toBe(false);
+  it("does NOT require a mention in a 1-on-1 where the user is one of two agents", () => {
+    // The current user's own agent id is one of the two speakers (here `A`,
+    // not the `ME` constant) — confirms the predicate keys on actual
+    // membership, not a hardcoded notion of self.
+    expect(computeRequiresMention([A, B], A)).toBe(false);
   });
 
   // ── real groups (3+ speakers) ─────────────────────────────────────────────

--- a/packages/web/src/utils/requires-mention.ts
+++ b/packages/web/src/utils/requires-mention.ts
@@ -1,0 +1,31 @@
+/**
+ * Whether the chat composer must carry an explicit `@mention` before a send is
+ * allowed.
+ *
+ * Mirrors the server's membership-shape rule (`services/message.ts`
+ * `isOneOnOne = participants.length === 2`, speakers only): a 1-on-1 never
+ * needs an explicit mention; a real group (3+ speakers) does.
+ *
+ * Keyed on **speaker count**, NOT `chats.type`. Since the group-chat
+ * convergence (first-tree-hub #465 / first-tree-context #281) every chat is
+ * created with `type='group'`, so a `type === "group"` check forced an
+ * `@mention` in 1-on-1 DMs too — breaking the "DM doesn't need an explicit
+ * @mention" UX. This predicate keys on shape instead, matching the server.
+ *
+ * `participantAgentIds` must be the chat's **speakers**. `getChatDetail`
+ * returns `accessMode = 'speaker'` rows only, and the server's `isOneOnOne`
+ * uses the same speaker-filtered list — so the two stay in lockstep.
+ *
+ * If the current user isn't yet a speaker, their first send promotes them to
+ * one, so that prospective seat is counted (a send into a 2-speaker chat the
+ * user is only watching makes it a real 3-speaker group).
+ */
+export function computeRequiresMention(
+  participantAgentIds: readonly string[],
+  myAgentId: string | null | undefined,
+): boolean {
+  const meIn = myAgentId != null && participantAgentIds.includes(myAgentId);
+  // Effective speaker count once this send lands.
+  const speakersAfterSend = participantAgentIds.length + (meIn ? 0 : 1);
+  return speakersAfterSend >= 3;
+}

--- a/packages/web/src/utils/requires-mention.ts
+++ b/packages/web/src/utils/requires-mention.ts
@@ -7,8 +7,8 @@
  * needs an explicit mention; a real group (3+ speakers) does.
  *
  * Keyed on **speaker count**, NOT `chats.type`. Since the group-chat
- * convergence (first-tree-hub #465 / first-tree-context #281) every chat is
- * created with `type='group'`, so a `type === "group"` check forced an
+ * convergence (first-tree-hub PR 465 / first-tree-context PR 281) every chat
+ * is created with `type='group'`, so a `type === "group"` check forced an
  * `@mention` in 1-on-1 DMs too — breaking the "DM doesn't need an explicit
  * @mention" UX. This predicate keys on shape instead, matching the server.
  *


### PR DESCRIPTION
## Symptom

In a **1-on-1 chat** (e.g. a human and their assistant) the web composer now forces you to `@mention` the agent before the **Send** button enables. Sending a plain message no longer works. This started today — yesterday DMs sent fine without a mention. Group chats correctly still require a mention.

## Root cause

The group-chat convergence in **#465** (`refactor(chat): phase 1 — … group-chat-only convergence`, merged 2026-05-20) made **every new chat `type: "group"`** (`createChatSchema.type` is locked to `z.literal("group")`; the legacy `type='direct'` column is now decision-inert scaffolding).

The **server** was correctly migrated to key its mention enforcement on *membership shape* rather than the type column:

```ts
// packages/server/src/services/message.ts
const isOneOnOne = participants.length === 2; // speakers only
if (options.enforceGroupMention && chatType === "group" && !isOneOnOne && !isAgentFinalText) { … }
```

…so the backend happily accepts an unmentioned 1-on-1 send.

But the **web client** was left keying on the now-always-`"group"` type column (`packages/web/src/pages/workspace/center/chat-view.tsx`, originally added 2026-04-27, before the convergence):

```ts
const requiresMention = useMemo(() => {
  if (!chatDetail) return false;
  if (chatDetail.type === "group") return true;   // ← always true post-#465
  const meIn = chatDetail.participants.some((p) => p.agentId === myAgentId);
  return chatDetail.type === "direct" && !meIn && chatDetail.participants.length >= 2;
}, [chatDetail, myAgentId]);
```

`requiresMention` gates the Send button (`chat-view.tsx` send-guard + `disabled`), so 1-on-1 DMs got stuck behind a mandatory `@mention`.

## Fix

Key the client guard on **speaker count**, mirroring the server's `isOneOnOne`. Extracted into a pure, tested helper `computeRequiresMention(participantAgentIds, myAgentId)`:

- ≤2 speakers → 1-on-1 → **no** mention required.
- 3+ speakers → real group → mention required.
- User not yet a speaker → their first send promotes them, so the prospective seat is counted (sending into a 2-speaker chat you're only watching makes it a real 3-speaker group — preserves the old `!meIn` behavior).

`chatDetail.participants` is speakers-only (`getChatDetail` filters `accessMode='speaker'`), the same source the server's `isOneOnOne` uses, so the counts stay in lockstep.

## Tests

- New `packages/web/src/utils/__tests__/requires-mention.test.ts` (9 cases: 1-on-1, groups, prospective-seat, degenerate/null).
- `pnpm --filter @first-tree-hub/web test` → 22 files / 201 tests pass.
- `tsc --noEmit` and `biome check` clean.

## Note / follow-up (out of scope)

`chat-view.tsx:1665` still has a cosmetic `WorkingBubble defaultOpen={chatDetail?.type === "direct"}` — also stale post-#465 (always `false` now). Not the reported bug; flagging for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
