### PR TITLE
fix(chat): preview absolute-in-root .md paths via runtime relative rewrite (Option R / Case A)

### DIFF
--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -1,0 +1,119 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildMessageDocumentSnapshots } from "../runtime/doc-snapshots.js";
+
+/**
+ * Unit tests for the runtime snapshot builder, focused on Option R (Case A):
+ * an absolute `.md` path that lands inside the workspace root is snapshotted
+ * AND rewritten in the outbound text to its canonical workspace-relative path,
+ * so web's unchanged re-scan can match it. Relative mentions and out-of-root /
+ * hidden / escaping paths must behave exactly as before.
+ */
+describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R / Case A)", () => {
+  let root: string;
+  let outside: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "doc-snap-root-"));
+    await writeFile(join(root, "design.md"), "# design\n", "utf8");
+    await mkdir(join(root, "docs"), { recursive: true });
+    await writeFile(join(root, "docs", "intro.md"), "# intro\n", "utf8");
+    // Symlink escape fixture: public.md → .agent/secret.md (hidden segment).
+    await mkdir(join(root, ".agent"), { recursive: true });
+    await writeFile(join(root, ".agent", "secret.md"), "# secret\n", "utf8");
+    await symlink(join(root, ".agent", "secret.md"), join(root, "public.md"));
+
+    // A real .md file that EXISTS but lives OUTSIDE the workspace root, so the
+    // rejection is proven by containment, not a missing-file shortcut.
+    outside = await mkdtemp(join(tmpdir(), "doc-snap-outside-"));
+    await writeFile(join(outside, "external.md"), "# external\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it("rewrites a bare absolute-in-root token to its relative path + snapshots it", async () => {
+    const abs = join(root, "design.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`wrote ${abs} just now`, root);
+
+    expect(docs.map((d) => d.path)).toEqual(["design.md"]);
+    expect(docs[0]?.content).toBe("# design\n");
+    expect(rewrittenText).toBe("wrote design.md just now");
+  });
+
+  it("rewrites an absolute target inside an inline markdown link in place", async () => {
+    const abs = join(root, "docs", "intro.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see [intro](${abs}) for setup`, root);
+
+    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
+    expect(rewrittenText).toBe("see [intro](docs/intro.md) for setup");
+  });
+
+  it("preserves the :line[:col] suffix when rewriting an absolute token, keys the snapshot de-suffixed", async () => {
+    const abs = join(root, "docs", "intro.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:42:7 here`, root);
+
+    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
+    expect(rewrittenText).toBe("open docs/intro.md:42:7 here");
+  });
+
+  it("leaves an out-of-root absolute path untouched — no snapshot, no rewrite", async () => {
+    const abs = join(outside, "external.md");
+    const text = `external doc at ${abs} here`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("leaves relative tokens completely unchanged (regression)", async () => {
+    const text = "see docs/intro.md and [d](design.md)";
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    expect(docs.map((d) => d.path).sort()).toEqual(["design.md", "docs/intro.md"]);
+    // Text is byte-for-byte identical: relative mentions are never rewritten.
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("does not rewrite a non-canonical RELATIVE token (web canonicalises it on re-scan)", async () => {
+    const text = "see [d](./docs/intro.md)";
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("rejects a symlink whose realpath crosses into a hidden dir — relative AND absolute forms", async () => {
+    const rel = "see [p](public.md)";
+    const relOut = await buildMessageDocumentSnapshots(rel, root);
+    expect(relOut.docs).toEqual([]);
+    expect(relOut.rewrittenText).toBe(rel);
+
+    const abs = join(root, "public.md");
+    const absText = `see ${abs}`;
+    const absOut = await buildMessageDocumentSnapshots(absText, root);
+    expect(absOut.docs).toEqual([]);
+    expect(absOut.rewrittenText).toBe(absText);
+  });
+
+  it("rejects a hidden-segment mention and leaves the text verbatim", async () => {
+    const text = "secret [s](.agent/secret.md)";
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("rewrites every occurrence of the same absolute path, snapshotting it once", async () => {
+    const abs = join(root, "design.md");
+    const text = `first ${abs} then again ${abs}`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    expect(docs.map((d) => d.path)).toEqual(["design.md"]);
+    expect(rewrittenText).toBe("first design.md then again design.md");
+  });
+});

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -322,6 +322,26 @@ describe("createResultSink — forwardResult enrichment", () => {
       // → no documentContext (no legacy kind:"path" fallback).
       expect(body.metadata?.documentContext).toBeUndefined();
     });
+
+    it("sends content with absolute-in-root paths rewritten to relative (Option R wiring)", async () => {
+      // The sink must forward `rewrittenText`, not the agent's original body, so
+      // web's unchanged re-scan sees a relative token and matches the snapshot.
+      const { sink, sendMessage } = buildSink({
+        trigger: { messageId: "m1", senderId: "agent-peer" },
+        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+      });
+
+      const abs = join(worktree, "design.md");
+      await sink(`done — wrote ${abs} for review`);
+
+      const [, body] = sendMessage.mock.calls[0] ?? [];
+      const sent = body as {
+        content?: string;
+        metadata?: { documentContext?: { docs?: Array<{ path: string }> } };
+      };
+      expect(sent.content).toBe("done — wrote design.md for review");
+      expect(sent.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+    });
   });
 
   it("case 3: inReplyTo is set from the current trigger (InReplyTo-required)", async () => {

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -12,67 +12,87 @@ import {
 } from "@agent-team-foundation/first-tree-hub-shared";
 
 /**
- * Scan an outbound agent message for inline markdown links of the form
- * `[text](path.md)` and turn each safely-resolvable target into a
- * snapshot of the file's contents at send time.
+ * Scan an outbound agent message for `.md` path mentions (inline markdown
+ * links `[text](path.md)` AND bare `path.md` tokens) and turn each
+ * safely-resolvable target into a snapshot of the file's contents at send
+ * time.
  *
- * Only inline `[text](path.md)` is recognised — reference-style links,
- * autolinks, HTML `<a>`, escaped `\[ ... \]`, and image markdown
- * `![alt](...)` are deliberately out of scope (see proposal §非目标).
- * The shared schema enforces canonical path form and the server
- * re-validates byte budgets + sha256 so a misbehaving runtime cannot
- * lodge mismatched data.
+ * Resolution is constrained to `root`. A path resolves when its real target
+ * is a regular `.md` file physically inside the worktree with no hidden
+ * segment. Two written forms resolve:
+ *   - workspace-relative (`docs/foo.md`, `./docs/foo.md`); and
+ *   - **absolute paths that land inside `root`** (`<root>/docs/foo.md`).
+ *     Web cannot map an absolute path back to a snapshot key (it does not
+ *     know `root`), so for every resolved token whose written form is not
+ *     already the canonical relative path, we **rewrite that span in the
+ *     outbound text** to the canonical relative path (preserving any
+ *     `:line[:col]` suffix). The caller sends `rewrittenText`, and web's
+ *     unchanged re-scan then sees a relative token, matches the snapshot,
+ *     and renders the preview link. This keeps web/server/schema untouched
+ *     and is immune to server-side body rewrites (e.g. `@mention` prepend)
+ *     because web re-scans rather than trusting byte offsets.
  *
- * Resolution is constrained to `root`. Anything that escapes the worktree
- * (absolute path, `..` traversal, symlink pointing to a hidden segment
- * inside or outside root), hides (`.dotfile` / `.dotdir`, `.agent/`), or
- * is missing is dropped — the caller's message still goes through, the
- * offending link simply downgrades to a plain link in the UI.
+ * Anything that escapes the worktree (absolute path resolving OUTSIDE root,
+ * `..` traversal, symlink pointing to a hidden segment inside or outside
+ * root), hides (`.dotfile` / `.dotdir`, `.agent/`), or is missing is dropped
+ * — the caller's message still goes through, the offending mention simply
+ * stays plain text in the UI (and is left untouched in `rewrittenText`).
+ *
+ * The shared schema enforces canonical path form and the server re-validates
+ * byte budgets + sha256 so a misbehaving runtime cannot lodge mismatched
+ * data.
  */
 export async function buildMessageDocumentSnapshots(
   text: string,
   root: string,
-): Promise<{ docs: SnapshotDoc[]; skipped: number }> {
-  // Inline links are scanned first so a path that appears both as
-  // `[label](docs/foo.md)` AND as a bare mention later in the text is
-  // recorded once, keyed by the same canonical path the web cache lookup
-  // will produce when the user clicks either occurrence.
-  const inline = scanInlineMarkdownLinks(text);
-  const bare = scanBareDocPathTokens(text).map((m) => stripDocPathLineSuffix(m.raw));
-  const candidates = [...inline, ...bare];
-  if (candidates.length === 0) return { docs: [], skipped: 0 };
+): Promise<{ docs: SnapshotDoc[]; skipped: number; rewrittenText: string }> {
+  const occurrences = collectDocPathOccurrences(text);
+  if (occurrences.length === 0) return { docs: [], skipped: 0, rewrittenText: text };
 
   const rootReal = await safeRealpath(root);
-  if (!rootReal) return { docs: [], skipped: candidates.length };
+  if (!rootReal) return { docs: [], skipped: occurrences.length, rewrittenText: text };
 
+  // Pass 1 — resolve every occurrence to its canonical workspace-relative key
+  // (or null). Absolute-in-root paths canonicalise to the same relative key
+  // web derives once the text is rewritten, so a click hits the snapshot.
+  const resolved = await Promise.all(
+    occurrences.map(async (occ) => ({
+      ...occ,
+      canonical: await canonicalizeWorkspacePath(rootReal, occ.writtenPath),
+    })),
+  );
+
+  // Pass 2 — build snapshots. De-dupe by canonical path so the same file
+  // mentioned twice is read once; the on-wire key is the canonical path the
+  // web cache lookup produces from a clicked href.
   const docs: SnapshotDoc[] = [];
   let totalBytes = 0;
   let skipped = 0;
-  const seenCanonical = new Set<string>();
+  const seen = new Set<string>();
+  const snapshotted = new Set<string>();
 
-  for (const rawPath of candidates) {
-    if (docs.length >= MAX_DOC_SNAPSHOTS_PER_MESSAGE) {
-      skipped += 1;
-      continue;
-    }
-    // Canonicalise the link path BEFORE resolution so on-wire storage
-    // matches what the web cache lookup will produce from clicked hrefs.
-    const canonical = normalizeDocLinkPath(rawPath);
+  for (const occ of resolved) {
+    const canonical = occ.canonical;
     if (!canonical || !canonical.toLowerCase().endsWith(".md")) {
       skipped += 1;
       continue;
     }
-    if (seenCanonical.has(canonical)) continue;
-    seenCanonical.add(canonical);
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
 
-    const resolved = await resolveWorkspaceFile(rootReal, canonical);
-    if (!resolved) {
+    if (docs.length >= MAX_DOC_SNAPSHOTS_PER_MESSAGE) {
+      skipped += 1;
+      continue;
+    }
+
+    const file = await resolveWorkspaceFile(rootReal, canonical);
+    if (!file) {
       skipped += 1;
       continue;
     }
 
     try {
-      const buf = await readFile(resolved);
+      const buf = await readFile(file);
       // Pre-flight raw-byte cap so a multi-MB file doesn't waste a full UTF-8
       // round-trip just to be rejected below.
       if (buf.byteLength > MAX_DOC_SNAPSHOT_BYTES) {
@@ -102,13 +122,75 @@ export async function buildMessageDocumentSnapshots(
       const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
       docs.push({ path: canonical, sha256, size, content });
       totalBytes += size;
+      snapshotted.add(canonical);
     } catch {
       skipped += 1;
     }
   }
 
-  return { docs, skipped };
+  // Pass 3 — rewrite the text spans of resolved ABSOLUTE-in-root tokens to
+  // their canonical relative path (web can't map an absolute path to a
+  // snapshot key without knowing `root`). The rewrite surface is kept minimal:
+  // relative mentions — canonical or not (`./docs/foo.md`) — are left verbatim
+  // because web already canonicalises them during its re-scan match. Only
+  // tokens that actually produced a snapshot are rewritten, so "rewritten ⇔
+  // previewable" holds and an unsnapshot-able mention is never mutated.
+  const rewrites: Array<{ start: number; end: number; replacement: string }> = [];
+  for (const occ of resolved) {
+    if (occ.canonical && isAbsolute(occ.writtenPath) && snapshotted.has(occ.canonical)) {
+      rewrites.push({ start: occ.start, end: occ.end, replacement: `${occ.canonical}${occ.lineSuffix}` });
+    }
+  }
+
+  return { docs, skipped, rewrittenText: applyRewrites(text, rewrites) };
 }
+
+/**
+ * One `.md` path mention found in the outbound text, with the exact text span
+ * to replace if the path resolves to a workspace file.
+ *
+ * - `writtenPath` is the path as authored, minus any `:line[:col]` suffix.
+ * - `lineSuffix` is that suffix verbatim ("" when absent) so a rewrite can
+ *   preserve `foo.md:12`.
+ * - `[start, end)` is the slice to replace: the whole bare token (incl. the
+ *   line suffix) for bare mentions, or just the `(target)` for inline links.
+ */
+type DocPathOccurrence = {
+  writtenPath: string;
+  lineSuffix: string;
+  start: number;
+  end: number;
+};
+
+function collectDocPathOccurrences(text: string): DocPathOccurrence[] {
+  const out: DocPathOccurrence[] = [];
+  for (const link of scanInlineMarkdownLinks(text)) {
+    out.push({ writtenPath: link.target, lineSuffix: "", start: link.start, end: link.end });
+  }
+  for (const m of scanBareDocPathTokens(text)) {
+    const writtenPath = stripDocPathLineSuffix(m.raw);
+    out.push({ writtenPath, lineSuffix: m.raw.slice(writtenPath.length), start: m.start, end: m.end });
+  }
+  return out;
+}
+
+/** Apply non-overlapping `[start, end) → replacement` edits to `text`. */
+function applyRewrites(text: string, rewrites: Array<{ start: number; end: number; replacement: string }>): string {
+  if (rewrites.length === 0) return text;
+  const ordered = [...rewrites].sort((a, b) => a.start - b.start);
+  let out = "";
+  let cursor = 0;
+  for (const edit of ordered) {
+    if (edit.start < cursor) continue; // defensive: bare/inline spans never overlap
+    out += text.slice(cursor, edit.start);
+    out += edit.replacement;
+    cursor = edit.end;
+  }
+  out += text.slice(cursor);
+  return out;
+}
+
+type InlineLinkMatch = { target: string; start: number; end: number };
 
 /**
  * Inline markdown link scanner. Conservative: requires a literal `[ ... ](path.md)`
@@ -116,25 +198,54 @@ export async function buildMessageDocumentSnapshots(
  * first whitespace or `)`. Reference-style / autolink / HTML / escaped /
  * image forms are deliberately not matched (proposal §非目标).
  *
+ * The leading `[ ... ](` is captured as group 1 so the target's start offset
+ * is `match.index + group1.length` — used to rewrite an absolute-in-root
+ * target in place without re-searching the string.
+ *
  * Two forms are excluded by inspecting the byte preceding the opening `[`:
  *   - `\[text](path.md)` — markdown-escaped bracket
  *   - `![alt](path.md)` — image, not a click target
  */
-function scanInlineMarkdownLinks(text: string): string[] {
-  const out: string[] = [];
-  // [\s\S] inside the link text class so multi-line text is tolerated.
-  const re = /\[(?:[^\]\\]|\\.)*\]\((\S+?\.md)(?:\s+"[^"]*")?\)/g;
+function scanInlineMarkdownLinks(text: string): InlineLinkMatch[] {
+  const out: InlineLinkMatch[] = [];
+  const re = /(\[(?:[^\]\\]|\\.)*\]\()(\S+?\.md)(?:\s+"[^"]*")?\)/g;
   let match: RegExpExecArray | null = re.exec(text);
   while (match !== null) {
-    const start = match.index;
-    const prev = start > 0 ? text[start - 1] : "";
-    if (prev !== "\\" && prev !== "!") {
-      const raw = match[1];
-      if (raw) out.push(raw);
+    const linkStart = match.index;
+    const prev = linkStart > 0 ? text[linkStart - 1] : "";
+    const prefix = match[1];
+    const target = match[2];
+    if (prev !== "\\" && prev !== "!" && prefix !== undefined && target) {
+      const start = linkStart + prefix.length;
+      out.push({ target, start, end: start + target.length });
     }
     match = re.exec(text);
   }
   return out;
+}
+
+/**
+ * Resolve the canonical workspace-relative key for a written `.md` path,
+ * accepting BOTH relative paths and absolute paths that land inside the
+ * workspace root.
+ *
+ * Absolute paths are `realpath`'d FIRST, then checked for containment — so an
+ * ancestor symlink cannot be used to claim a path is "inside" the root when
+ * its real target is not. The relative result is run back through
+ * `normalizeDocLinkPath` so the key is POSIX-canonical and any hidden segment
+ * exposed by the realpath (`<root>/.agent/x.md` reached via a symlink) is
+ * rejected — matching what web's re-scan derives from the rewritten relative
+ * token. Returns null when the path escapes the root, hides, or cannot be
+ * realpath'd; the caller then leaves the text untouched and embeds no snapshot.
+ */
+async function canonicalizeWorkspacePath(rootReal: string, writtenPath: string): Promise<string | null> {
+  if (!isAbsolute(writtenPath)) return normalizeDocLinkPath(writtenPath);
+
+  const real = await safeRealpath(writtenPath);
+  if (!real) return null;
+  const prefix = rootReal.endsWith(sep) ? rootReal : rootReal + sep;
+  if (real !== rootReal && !real.startsWith(prefix)) return null;
+  return normalizeDocLinkPath(relative(rootReal, real));
 }
 
 /**

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -56,8 +56,14 @@ export type ResultSinkDeps = {
 export type ResultSink = (text: string) => Promise<void>;
 
 export function createResultSink(deps: ResultSinkDeps): ResultSink {
-  async function buildMetadata(text: string): Promise<Record<string, unknown> | undefined> {
+  // Build the outbound payload: the (possibly rewritten) content + metadata.
+  // The content may differ from `text` when a referenced doc was written as an
+  // absolute-in-root path: `buildMessageDocumentSnapshots` rewrites that span
+  // to the canonical workspace-relative path so web's unchanged re-scan can
+  // match the snapshot. Relative mentions are returned verbatim.
+  async function prepareOutbound(text: string): Promise<{ content: string; metadata?: Record<string, unknown> }> {
     const metadata: Record<string, unknown> = {};
+    let content = text;
     const documentBasePath = await deps.getDocumentBasePath?.();
     if (documentBasePath) {
       // Embed the inline-snapshot variant only. This is the cloud-friendly
@@ -74,7 +80,8 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
       // messages may still hold `kind:"path"`; the web reader keeps handling
       // them for back-compat — this only stops emitting new ones.)
       try {
-        const { docs, skipped } = await buildMessageDocumentSnapshots(text, documentBasePath);
+        const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, documentBasePath);
+        content = rewrittenText;
         if (docs.length > 0) {
           metadata.documentContext = documentContextSchema.parse({ kind: "snapshot", docs });
         }
@@ -83,7 +90,7 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
         }
       } catch (err) {
         // Snapshot build failure must never block message delivery — log and
-        // attach no documentContext so the message still goes out.
+        // attach no documentContext so the message still goes out (verbatim).
         deps.log(`doc snapshot: build failed, no documentContext attached: ${(err as Error).message}`);
       }
     }
@@ -93,7 +100,7 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
     // text reaches the chat for human observers only; agent-to-agent
     // wake-ups now require an explicit `first-tree-hub chat send <name>`.
 
-    return Object.keys(metadata).length > 0 ? metadata : undefined;
+    return { content, metadata: Object.keys(metadata).length > 0 ? metadata : undefined };
   }
 
   return async function forwardResult(text: string): Promise<void> {
@@ -113,11 +120,11 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
     // isn't accidentally attached to this outbound reply.
     deps.clearTrigger();
 
-    const metadata = await buildMetadata(text);
+    const { content, metadata } = await prepareOutbound(text);
 
     await deps.sdk.sendMessage(deps.chatId, {
       format: "text",
-      content: text,
+      content,
       // `purpose: "agent-final-text"` tells the server to skip the
       // group-chat `@mention required` guard and force every fan-out row
       // to `notify=false`. final text lands in chat history so human

--- a/packages/shared/src/lib/doc-link-scan.ts
+++ b/packages/shared/src/lib/doc-link-scan.ts
@@ -30,11 +30,14 @@
 /**
  * v1 limitation — the path-segment character class is intentionally ASCII
  * only. Unicode filenames and Windows backslash-separated paths are NOT
- * linkified. Workspaces in practice use POSIX-style ASCII paths, and the
- * runtime's `normalizeDocLinkPath` also rejects absolute paths, so this
- * matches the rest of the pipeline. Loosening the character class later
- * is straightforward but requires re-validating that we don't accidentally
- * absorb adjacent punctuation as part of a "filename".
+ * linkified. Workspaces in practice use POSIX-style ASCII paths. The regex
+ * does accept a leading "/", so absolute tokens are scanned; the runtime
+ * (`buildMessageDocumentSnapshots`) resolves an absolute path that lands
+ * inside the workspace root and rewrites it to its canonical relative form,
+ * while `normalizeDocLinkPath` strips a leading "/" and treats the rest as
+ * root-relative. Loosening the character class later is straightforward but
+ * requires re-validating that we don't accidentally absorb adjacent
+ * punctuation as part of a "filename".
  */
 const BARE_PATH_RE =
   /(^|[\s([{"'])(?<path>(?:\.{1,2}\/|\/)?(?:[A-Za-z0-9_.~+@%-]+\/)*[A-Za-z0-9_.~+@%-]+\.md(?::\d+(?::\d+)?)?)(?=$|[\s)\]}"',.;!?])/g;


### PR DESCRIPTION
## Problem

When an agent writes an **absolute `.md` path that lands inside its workspace root** (e.g. `/Users/.../<chatId>/docs/foo.md`), the chat doc-preview link did not render. Web can't map an absolute path back to a snapshot key because **it doesn't know the workspace root** — only the runtime does. (Inline `[label](/abs/foo.md)` was broken for the same reason.)

This is **Case A** of the doc-preview work (follows #474 / #476). Scope is deliberately narrow: only absolute paths inside the workspace root. Context Tree docs (Case B) and any out-of-workspace path remain out of scope.

## Why this approach (Option R), not authoritative link spans

The alternative considered was carrying runtime-authored `links: [{start,end,...}]` byte spans and retiring web's re-scan. That was rejected after reading the code:

- The agent message route (`packages/server/src/api/agent/messages.ts`) sends with **`normalizeMentionsInContent: true`**. When mentions are declared but absent from the body, step 2c in `services/message.ts` **prepends `@name ` to the front of the content**, shifting every byte offset. `purpose: "agent-final-text"` only bypasses the group-mention *enforcement* guards, not this rewrite. So offset-anchored spans would silently break the moment a snapshot rides a send that declares mentions.
- Web's current **re-scan is the source of robustness** — it re-scans the stored (post-rewrite) body and matches tokens by canonical-path-set membership, so it's immune to body mutation. Retiring it would be a regression.

**Option R** keeps that robustness: the runtime — which already reads the file to snapshot it, in a single chokepoint (`result-sink` → `buildMessageDocumentSnapshots`) — rewrites the absolute token to its canonical workspace-relative path **in the outbound text**. Same process, same string, so the rewrite is reliable. Web then sees a relative token and matches the snapshot with **no web / server / schema changes**, and relative display comes for free.

## Changes (runtime only)

- `packages/client/src/runtime/doc-snapshots.ts`
  - `buildMessageDocumentSnapshots` now returns `{ docs, skipped, rewrittenText }`.
  - New `canonicalizeWorkspacePath`: accepts relative paths (as before) **and** absolute paths inside root. Absolute paths are `realpath`'d **before** the containment check, so an ancestor symlink can't fake "inside root"; the relative result is run back through `normalizeDocLinkPath` so hidden segments exposed via symlink are rejected.
  - Inline-link scanner now reports the target's offset (leading `[...](` captured as a group) so an absolute inline target can be rewritten in place.
  - Rewrite is gated on **"actually snapshotted"** (`rewritten ⇔ previewable`) and applied to **every** occurrence of the path; the `:line[:col]` suffix is preserved (`/abs/foo.md:12` → `foo.md:12`). **Only absolute** tokens are rewritten — relative mentions (canonical or not, e.g. `./docs/foo.md`) are left verbatim since web already canonicalises them on match. Out-of-root / hidden / escaping / missing paths are left verbatim with no snapshot.
- `packages/client/src/runtime/result-sink.ts`: forwards `rewrittenText` instead of the original body.
- `packages/shared/src/lib/doc-link-scan.ts`: fixed a stale comment that claimed `normalizeDocLinkPath` "rejects" absolute paths (it strips the leading `/`). **Comment only — no behavior change.**

**Not touched:** web, server, schema. Snapshot gating, the README.md:12 display/href split, and #476's "no `documentContext` when zero snapshots" all live on the web/server side and are unchanged.

## Tests

- New `packages/client/src/__tests__/doc-snapshots.test.ts`: abs bare token rewrite, abs inline-target rewrite, abs `:line[:col]` preservation, out-of-root absolute left untouched (proven with a real file outside root, not a missing-file shortcut), relative regression (byte-for-byte identical), non-canonical relative not rewritten, symlink-into-hidden rejection (relative + absolute), hidden-segment rejection, multi-occurrence rewrite + single snapshot.
- `result-sink.test.ts`: added a wiring test asserting the sink forwards the rewritten content.

Results: **client 405/405**, **shared 251/251**, **web 201/201** (untouched), **server doc-snapshots 11/11**. `client + shared typecheck` clean, biome clean on changed files.

## Context Tree

Implementation-only bug fix — no decisions / constraints / architecture / ownership changes. No tree PR needed.