### PR TITLE
fix(client): Context Tree SSH fallback + tolerate inbox enum drift

### DIFF
--- a/packages/client/src/__tests__/client-connection-inbox-malformed.test.ts
+++ b/packages/client/src/__tests__/client-connection-inbox-malformed.test.ts
@@ -1,0 +1,150 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { ClientConnection } from "../client-connection.js";
+
+/**
+ * Regression: when an `inbox:deliver` frame fails schema validation, the
+ * client must still ack the surviving top-level `entryId` so the server's
+ * 300s reaper doesn't re-deliver a frame this build is guaranteed to keep
+ * dropping. Without the ack, the entry round-trips through the reaper
+ * `delivered → pending → delivered → drop` loop up to `maxRetries`, then
+ * is silently lost. With the ack, the message is still lost (this build
+ * cannot parse it), but the server state is clean and there's no spam.
+ *
+ * We exercise the malformed path by sending a frame whose nested `message`
+ * is invalid (missing required `id` field) — `entryId` is a top-level
+ * field and stays valid, which mirrors the real-world failure mode where
+ * server-side enum drift breaks `message.source` but the envelope shape
+ * is fine.
+ */
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+type ServerSetup = {
+  /** Frame to push to the client right after handshake completes. */
+  malformedFrame: Record<string, unknown>;
+  /** Collects entryIds the client subsequently acks via `inbox:ack`. */
+  ackedEntryIds: number[];
+};
+
+function attachWss(wss: WebSocketServer, setup: ServerSetup): void {
+  wss.on("connection", (ws: WebSocket) => {
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw)) as { type: string; entryId?: unknown };
+      if (msg.type === "auth") {
+        ws.send(JSON.stringify({ type: "auth:ok" }));
+        return;
+      }
+      if (msg.type === "client:register") {
+        ws.send(JSON.stringify({ type: "client:registered" }));
+        // Push the malformed frame on the same socket immediately after
+        // the registration ack — WS preserves frame order, so the client
+        // is guaranteed to process `registered` first.
+        ws.send(JSON.stringify(setup.malformedFrame));
+        return;
+      }
+      if (msg.type === "inbox:ack" && typeof msg.entryId === "number") {
+        setup.ackedEntryIds.push(msg.entryId);
+      }
+    });
+  });
+}
+
+describe("ClientConnection — malformed inbox:deliver frame", () => {
+  let httpServer: HttpServer;
+  let wss: WebSocketServer;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    httpServer = createServer();
+    wss = new WebSocketServer({ server: httpServer, path: "/api/v1/agent/ws/client" });
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") throw new Error("no server address");
+    serverUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("best-effort acks the entryId so the server reaper doesn't retry-loop", async () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const setup: ServerSetup = {
+      ackedEntryIds: [],
+      malformedFrame: {
+        type: "inbox:deliver",
+        entryId: 9999,
+        inboxId: "inbox_abc",
+        chatId: "chat_1",
+        // `message` lacks the required `id` field — inner clientMessageSchema
+        // rejects, but the outer envelope is OK.
+        message: { not: "a valid message" },
+      },
+    };
+    attachWss(wss, setup);
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_malformed",
+      getAccessToken: async () => token,
+    });
+    connection.on("error", () => {});
+
+    await connection.connect();
+    expect(connection.isConnected).toBe(true);
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("ack not received within 2s")), 2_000);
+      const check = (): void => {
+        if (setup.ackedEntryIds.includes(9999)) {
+          clearTimeout(timer);
+          resolve();
+          return;
+        }
+        setTimeout(check, 25);
+      };
+      check();
+    });
+
+    expect(setup.ackedEntryIds).toEqual([9999]);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("does not ack when the frame lacks a usable entryId", async () => {
+    // If `entryId` is absent or not a non-negative integer, there's nothing
+    // safe to ack — we'd rather let the reaper repeat than ack the wrong row.
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    const setup: ServerSetup = {
+      ackedEntryIds: [],
+      malformedFrame: {
+        type: "inbox:deliver",
+        entryId: "not-a-number",
+        inboxId: "inbox_abc",
+        chatId: "chat_1",
+        message: { not: "a valid message" },
+      },
+    };
+    attachWss(wss, setup);
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_malformed_no_entry",
+      getAccessToken: async () => token,
+    });
+    connection.on("error", () => {});
+
+    await connection.connect();
+    // Wait long enough that any erroneous ack would have arrived.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(setup.ackedEntryIds).toEqual([]);
+
+    await connection.disconnect();
+  }, 10_000);
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -854,6 +854,18 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     if (type === "inbox:deliver") {
       const parsed = inboxDeliverFrameSchema.safeParse(msg);
       if (!parsed.success) {
+        // Best-effort ack: without it the server's reaper rolls the entry
+        // back to `pending` 300s later and re-pushes the same frame, which
+        // this build is guaranteed to drop again. The retry loop runs up
+        // to maxRetries before the entry is abandoned — pure spam in both
+        // directions. `entryId` is a top-level field and usually survives
+        // when inner `message` validation is what failed (see frameKeys).
+        // Logged separately as `entryIdAcked` so operators can correlate.
+        const rawEntryId = msg.entryId;
+        const entryIdAcked = typeof rawEntryId === "number" ? rawEntryId : null;
+        if (entryIdAcked !== null) {
+          this.sendInboxAck(entryIdAcked);
+        }
         // Per-issue path/message + the receiving frame keys so we can pinpoint
         // shape drift between server build and client schema during gradual
         // rollouts. Frame body intentionally not logged in full — message
@@ -868,6 +880,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
             })),
             frameKeys: Object.keys(msg),
             messageKeys: msg.message && typeof msg.message === "object" ? Object.keys(msg.message) : null,
+            entryIdAcked,
           },
           "malformed inbox:deliver frame — dropping",
         );

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -862,7 +862,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         // when inner `message` validation is what failed (see frameKeys).
         // Logged separately as `entryIdAcked` so operators can correlate.
         const rawEntryId = msg.entryId;
-        const entryIdAcked = typeof rawEntryId === "number" ? rawEntryId : null;
+        // Match `inboxAckFrameSchema`: non-negative integer. A `typeof "number"`
+        // check alone would let NaN / Infinity / floats slip through and ack
+        // would silently no-op on the server side (rejected by its own schema).
+        const entryIdAcked =
+          typeof rawEntryId === "number" && Number.isInteger(rawEntryId) && rawEntryId >= 0 ? rawEntryId : null;
         if (entryIdAcked !== null) {
           this.sendInboxAck(entryIdAcked);
         }

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -6,6 +6,7 @@ import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/c
 import type { ContextTreeConfig } from "../sdk.js";
 import { type AccessTokenProvider, FirstTreeHubSDK } from "../sdk.js";
 import type { ChatContext } from "./chat-context.js";
+import { httpsToSshBaseRewrite } from "./git-mirror-manager.js";
 import type { AgentIdentity } from "./handler.js";
 
 const CONTEXT_TREE_REPOS_DIR = join(DEFAULT_DATA_DIR, "context-tree-repos");
@@ -29,17 +30,19 @@ export function contextTreeCloneDir(repo: string, branch: string): string {
 }
 
 /**
- * Convert a plain HTTPS git URL to its SSH counterpart so we can fall back
- * to key-based auth when the HTTPS clone fails. Headless service envs
- * (systemd / launchd unit) have no TTY for git's credential prompt, so any
- * unconfigured HTTPS access exits with "could not read Username". URLs not
- * matching `https://<host>/<path>` (already SSH, ssh://, git://, file paths)
- * return null — no rewrite possible / needed.
+ * Convert a plain HTTPS git URL to its scp-like SSH counterpart for fallback
+ * cloning. Delegates the host parsing + safety rules (reject embedded
+ * credentials, reject non-default ports) to `httpsToSshBaseRewrite` in
+ * git-mirror-manager — keeps a single source of truth for URL rewriting.
+ * Returns null when no portable mapping exists.
  */
 function toSshGitUrl(httpsRepo: string): string | null {
-  const m = httpsRepo.match(/^https:\/\/([^/]+)\/(.+)$/);
-  if (!m) return null;
-  return `git@${m[1]}:${m[2]}`;
+  const rewrite = httpsToSshBaseRewrite(httpsRepo);
+  if (!rewrite) return null;
+  // `rewrite.httpsBase` is the `https://<host>/` prefix; replace it with the
+  // matching `git@<host>:` to produce a full SSH URL for the same path.
+  if (!httpsRepo.startsWith(rewrite.httpsBase)) return null;
+  return rewrite.sshBase + httpsRepo.slice(rewrite.httpsBase.length);
 }
 
 function withContextTreeSyncLock(
@@ -156,7 +159,11 @@ async function syncContextTreeRepo(
           timeout: 60_000,
         });
         log("Context Tree cloned via SSH fallback");
-        return { path: cloneDir, repoUrl: repo, branch };
+        // Report the SSH URL as ground truth — `git remote get-url origin`
+        // on this checkout will be the SSH form, and downstream consumers
+        // (`first-tree tree integrate --tree-url`, telemetry) should match
+        // the actual remote rather than the configured-but-unusable HTTPS.
+        return { path: cloneDir, repoUrl: sshRepo, branch };
       } catch (sshErr) {
         const sshMsg = sshErr instanceof Error ? sshErr.message : String(sshErr);
         log(`Context Tree SSH fallback also failed: ${sshMsg}`);

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -28,6 +28,20 @@ export function contextTreeCloneDir(repo: string, branch: string): string {
   return join(CONTEXT_TREE_REPOS_DIR, digest);
 }
 
+/**
+ * Convert a plain HTTPS git URL to its SSH counterpart so we can fall back
+ * to key-based auth when the HTTPS clone fails. Headless service envs
+ * (systemd / launchd unit) have no TTY for git's credential prompt, so any
+ * unconfigured HTTPS access exits with "could not read Username". URLs not
+ * matching `https://<host>/<path>` (already SSH, ssh://, git://, file paths)
+ * return null — no rewrite possible / needed.
+ */
+function toSshGitUrl(httpsRepo: string): string | null {
+  const m = httpsRepo.match(/^https:\/\/([^/]+)\/(.+)$/);
+  if (!m) return null;
+  return `git@${m[1]}:${m[2]}`;
+}
+
 function withContextTreeSyncLock(
   key: string,
   fn: () => Promise<ContextTreeBinding | null>,
@@ -122,6 +136,32 @@ async function syncContextTreeRepo(
     const msg = err instanceof Error ? err.message : String(err);
     log(`Context Tree sync failed: ${msg}`);
     log("Check that git credentials (SSH key or credential helper) are configured for this repo");
+
+    // First-time HTTPS clone is the common failure case in headless service
+    // envs (systemd / launchd) — no TTY for git's credential prompt, so HTTPS
+    // auth exits with "could not read Username". If the configured URL is
+    // HTTPS, retry once with the SSH counterpart before giving up. Many
+    // operators have SSH keys configured even when credential helpers aren't.
+    // Pull failures (existing .git present) skip this — the existing remote
+    // is whatever clone last succeeded; switching it mid-flight is messier
+    // than letting the "use existing clone" fallback below take over.
+    const sshRepo = !existsSync(join(cloneDir, ".git")) ? toSshGitUrl(repo) : null;
+    if (sshRepo) {
+      log(`Retrying Context Tree clone via SSH: ${sshRepo}`);
+      try {
+        rmSync(cloneDir, { recursive: true, force: true });
+        mkdirSync(cloneDir, { recursive: true });
+        execFileSync("git", ["clone", "--branch", branch, "--single-branch", sshRepo, cloneDir], {
+          stdio: "pipe",
+          timeout: 60_000,
+        });
+        log("Context Tree cloned via SSH fallback");
+        return { path: cloneDir, repoUrl: repo, branch };
+      } catch (sshErr) {
+        const sshMsg = sshErr instanceof Error ? sshErr.message : String(sshErr);
+        log(`Context Tree SSH fallback also failed: ${sshMsg}`);
+      }
+    }
 
     // If pull failed due to diverged history, try re-clone.
     // Only re-clone when the error indicates a non-recoverable git state.

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -75,6 +75,70 @@ describe("inboxDeliverFrameSchema", () => {
       expect((res.data as { hint?: string }).hint).toBe("future-only-field");
     }
   });
+
+  it("degrades an unknown message.source to null instead of rejecting the frame", () => {
+    // Forward-roll defence: a server that adds a new source value (e.g.
+    // PR #481 renaming `hub_ui` → `web`) would otherwise force older clients
+    // to drop the entire frame, lose the message after retryCount exhausts,
+    // and spam the reaper every 300s in the meantime.
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: { ...baseClientMessage, source: "some-future-source" },
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.message.source).toBeNull();
+    }
+  });
+
+  it("preserves a known message.source value through parse", () => {
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: { ...baseClientMessage, source: "cli" },
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.message.source).toBe("cli");
+    }
+  });
+
+  it("degrades a wrong-type message.source (e.g. number) to null", () => {
+    // `.catch` is field-scoped, not enum-specific — anything that doesn't
+    // match the nullable enum (wrong primitive type, missing field, etc.)
+    // also degrades to null. Confirmed here so future maintainers don't
+    // mistake the override for "tolerate unknown strings only".
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: { ...baseClientMessage, source: 12345 },
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.message.source).toBeNull();
+    }
+  });
+
+  it("still rejects the frame when a required field outside `source` is invalid", () => {
+    // Defence-in-depth check: the `source` catch must not mask other parse
+    // errors. If `message.id` were missing, the frame should still fail —
+    // otherwise we'd silently accept truly broken frames.
+    const res = inboxDeliverFrameSchema.safeParse({
+      type: "inbox:deliver",
+      entryId: 1,
+      inboxId: "inbox_abc",
+      chatId: "chat_1",
+      message: { ...baseClientMessage, id: undefined },
+    });
+    expect(res.success).toBe(false);
+  });
 });
 
 describe("inboxAckFrameSchema", () => {

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -165,6 +165,16 @@ export type PrecedingMessage = z.infer<typeof precedingMessageSchema>;
  */
 export const clientMessageSchema = messageSchema.extend({
   configVersion: z.number().int().positive(),
+  // Forward-roll defence: the server may push new source values before the
+  // client ships the matching enum update (e.g. a new adapter is added).
+  // Without `.catch`, the strict enum rejects the whole inbox frame, which
+  // forces a 300s reaper round-trip before re-delivery — and that retry
+  // hits the same schema mismatch, so the entry exhausts retryCount and
+  // is effectively lost. Degrading unknown values to `null` keeps the
+  // frame parseable so the handler still receives the message body; only
+  // the audit-trail `source` label is lost. Mirrors the
+  // inboxDeliverFrameSchema `.passthrough()` policy for top-level fields.
+  source: messageSourceSchema.nullable().catch(null),
   recipientMode: participantModeSchema.default("full"),
   precedingMessages: z.array(precedingMessageSchema).default([]),
 });

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -174,6 +174,13 @@ export const clientMessageSchema = messageSchema.extend({
   // frame parseable so the handler still receives the message body; only
   // the audit-trail `source` label is lost. Mirrors the
   // inboxDeliverFrameSchema `.passthrough()` policy for top-level fields.
+  //
+  // Scope: `.catch` is field-scoped — it fires for ANY shape mismatch on
+  // `source` (unknown enum value, wrong type like `12345`, missing /
+  // undefined), not just enum drift. Acceptable because `source` is a
+  // pure audit label that handlers never branch on. Other fields' parse
+  // errors still bubble up to the parent `safeParse`, so required-shape
+  // drift on id / chatId / format is NOT silently swallowed.
   source: messageSourceSchema.nullable().catch(null),
   recipientMode: participantModeSchema.default("full"),
   precedingMessages: z.array(precedingMessageSchema).default([]),


### PR DESCRIPTION
## Summary

Two robustness fixes surfaced in the same incident — agent slot startup logging `Context Tree sync failed` every restart, and a `malformed inbox:deliver frame — dropping` warning that silently lost a user message until they re-sent it.

### 1. Context Tree clone — HTTPS → SSH fallback

`bootstrap.ts:syncContextTreeRepo` clones over HTTPS. Headless service envs (systemd / launchd) have no TTY for git's credential prompt, so first-time clone exits with `fatal: could not read Username for 'https://github.com'`. Result: every agent slot starts without organizational context, and since the clone dir is never created the failure repeats on every restart.

Now retries once with the scp-like SSH counterpart (`git@host:path`) when the original URL is HTTPS and no local `.git` exists. SSH keys are commonly configured even when credential helpers aren't. Pull failures (existing clone) are unchanged — they continue to fall through to "use existing clone" / diverged-history re-clone.

### 2. Inbox frame — tolerate `source` enum drift + ack unparseable frames

`inboxDeliverFrameSchema` declares `.passthrough()` to survive forward-rolling server fields, but its inner `clientMessageSchema` keeps `messageSourceSchema` as a strict enum. When the server pushed a `source` value the client didn't recognise (schema drift between deploys), the whole frame was rejected. The server's 300s reaper rolled the entry back to `pending` and re-pushed, this client dropped it again, until `retryCount` exhausted — silently losing the message.

- **shared:** override `source` in `clientMessageSchema` with `.catch(null)` so unknown values degrade gracefully. Inbound direction (`messageSchema`, `sendMessageSchema`) stays strict.
- **client:** when a frame still fails parsing for any other reason, best-effort ack via the top-level `entryId` (which usually survives nested-message validation errors). The frame is dropped either way, but acking prevents a 300s reaper retry loop that this build is guaranteed to keep dropping. Logged as `entryIdAcked` for operator correlation.

## Test plan

- [x] `pnpm typecheck` — all 11 tasks pass
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` — 251/251 pass (incl. existing `inbox-frames-schema.test.ts`)
- [x] `pnpm --filter @first-tree-hub/client test` — 391/391 pass; one pre-existing flaky test in `git-mirror-manager.test.ts` (5s timeout against an unreachable HTTPS URL, fails on `main` too — unrelated)
- [ ] Manual: restart `first-tree-hub` client on a machine with SSH key configured but no HTTPS credential helper, verify Context Tree clone succeeds via SSH fallback
- [ ] Manual: push a message with a new `source` value not in the client's enum, verify the frame is processed normally and `source` lands as `null`