### PR TITLE
feat(context-tree): emit usage signal only on actual tree-file reads, carry node path

### DIFF
--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent } from "@agent-team-foundation/first-tree-hub-shared";
 import { describe, expect, it, vi } from "vitest";
-import { createToolCallProcessor } from "../handlers/claude-code.js";
+import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude-code.js";
 
 /**
  * S11 (NC2 client handler) — tool-call processor fixtures.
@@ -284,5 +284,180 @@ describe("createToolCallProcessor", () => {
     if (!ev || ev.kind !== "thinking") throw new Error("expected thinking event");
     // Payload is intentionally empty — thinking content is never persisted.
     expect(ev.payload).toEqual({});
+  });
+});
+
+/**
+ * P0 Context Tree usage signal. The processor emits `context_tree_usage` only
+ * when a view tool SUCCESSFULLY reads a file under the configured tree root,
+ * carrying the tree-root-relative node path — replacing the old
+ * per-inbound-message vanity emit. The emit fires on the successful
+ * tool_result (not the tool_use request), so failed/aborted reads never count.
+ * When no tree binding is configured, it emits nothing.
+ */
+describe("createToolCallProcessor — Context Tree usage signal", () => {
+  const TREE = "/home/op/.first-tree/tree";
+  const binding = { path: TREE, repoUrl: "https://github.com/example/tree" } as const;
+
+  function usageEvents(emit: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>) {
+    return emit.mock.calls.map((c) => c[0]).filter((ev) => ev.kind === "context_tree_usage");
+  }
+
+  it("emits context_tree_usage with the node path when a tree Read succeeds", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r1", "Read", { file_path: `${TREE}/members/Gandy2025/NODE.md` }));
+    // No usage on the tool_use request — only after the read succeeds.
+    expect(usageEvents(emit)).toHaveLength(0);
+    processor.onMessage(userToolResult("r1", "file contents"));
+
+    const usage = usageEvents(emit);
+    expect(usage).toHaveLength(1);
+    const ev = usage[0];
+    if (!ev || ev.kind !== "context_tree_usage") throw new Error("expected context_tree_usage");
+    expect(ev.payload.nodePath).toBe("members/Gandy2025/NODE.md");
+    expect(ev.payload.treeRepoUrl).toBe("https://github.com/example/tree");
+    expect(ev.payload.purpose).toBe("design_decision");
+  });
+
+  it("emits for NotebookRead under the tree as well", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r2", "NotebookRead", { file_path: `${TREE}/designs/spike.md` }));
+    processor.onMessage(userToolResult("r2", "cells"));
+
+    const usage = usageEvents(emit);
+    expect(usage).toHaveLength(1);
+    expect(usage[0]?.kind === "context_tree_usage" && usage[0].payload.nodePath).toBe("designs/spike.md");
+  });
+
+  it("does NOT emit when a tree Read FAILS (is_error)", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r3", "Read", { file_path: `${TREE}/missing/NODE.md` }));
+    processor.onMessage(userToolResult("r3", "ENOENT: no such file", true));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("does NOT emit for an aborted tree Read that never returns a result", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r4", "Read", { file_path: `${TREE}/NODE.md` }));
+    // Turn aborted before the tool_result arrives.
+    processor.flush();
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("does NOT emit when Read targets a file outside the tree", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r5", "Read", { file_path: "/home/op/project/src/index.ts" }));
+    processor.onMessage(userToolResult("r5", "code"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("does NOT match a sibling dir that shares the tree-root prefix", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    // `/home/op/.first-tree/tree-other/...` must not count as inside the tree.
+    processor.onMessage(assistantToolUse("r6", "Read", { file_path: "/home/op/.first-tree/tree-other/NODE.md" }));
+    processor.onMessage(userToolResult("r6", "x"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("does NOT emit for a non-view tool even if an arg path is under the tree", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(
+      assistantToolUse("r7", "Bash", { command: `cat ${TREE}/NODE.md`, file_path: `${TREE}/NODE.md` }),
+    );
+    processor.onMessage(userToolResult("r7", "contents"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("emits nothing when no Context Tree binding is configured", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit); // no binding
+
+    processor.onMessage(assistantToolUse("r8", "Read", { file_path: `${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r8", "x"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("emits nothing when the binding path is null", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, { path: null, repoUrl: null });
+
+    processor.onMessage(assistantToolUse("r9", "Read", { file_path: `${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r9", "x"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+
+  it("carries a null treeRepoUrl through when the binding has no repo url", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, { path: TREE, repoUrl: null });
+
+    processor.onMessage(assistantToolUse("r10", "Read", { file_path: `${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r10", "x"));
+
+    const usage = usageEvents(emit);
+    expect(usage).toHaveLength(1);
+    const ev = usage[0];
+    if (!ev || ev.kind !== "context_tree_usage") throw new Error("expected context_tree_usage");
+    expect(ev.payload.treeRepoUrl).toBeNull();
+    expect(ev.payload.nodePath).toBe("NODE.md");
+  });
+
+  it("does NOT emit when Read input has no string file_path", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r11", "Read", { offset: 0 }));
+    processor.onMessage(userToolResult("r11", "x"));
+
+    expect(usageEvents(emit)).toHaveLength(0);
+  });
+});
+
+describe("treeNodePathOf", () => {
+  const TREE = "/home/op/.first-tree/tree";
+
+  it("relativizes a file under the tree root", () => {
+    expect(treeNodePathOf(`${TREE}/members/x/NODE.md`, TREE)).toBe("members/x/NODE.md");
+  });
+
+  it("tolerates a trailing slash on the tree root", () => {
+    expect(treeNodePathOf(`${TREE}/NODE.md`, `${TREE}/`)).toBe("NODE.md");
+  });
+
+  it("returns null for a path outside the tree", () => {
+    expect(treeNodePathOf("/home/op/project/x.ts", TREE)).toBeNull();
+  });
+
+  it("returns null for a sibling dir sharing the prefix", () => {
+    expect(treeNodePathOf("/home/op/.first-tree/tree-other/NODE.md", TREE)).toBeNull();
+  });
+
+  it("returns null for the tree root itself (no node path)", () => {
+    expect(treeNodePathOf(TREE, TREE)).toBeNull();
+  });
+
+  it("returns null on empty inputs", () => {
+    expect(treeNodePathOf("", TREE)).toBeNull();
+    expect(treeNodePathOf(`${TREE}/NODE.md`, "")).toBeNull();
   });
 });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -209,6 +209,10 @@ function readFilePathArg(input: unknown): string | null {
  * tree files by absolute path (CLAUDE.md points it at the full tree at
  * `contextTreePath`), so a prefix match on the normalised root is the filter.
  * The trailing-slash trim keeps `/a/tree` from matching `/a/tree-other/x`.
+ *
+ * Invariant: both `filePath` and `contextTreePath` are expected to be
+ * absolute. A relative `filePath` will not match the absolute root and returns
+ * null — i.e. it silently under-counts (fails safe) rather than mis-attributing.
  */
 export function treeNodePathOf(filePath: string, contextTreePath: string): string | null {
   if (!filePath || !contextTreePath) return null;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -189,15 +189,68 @@ function extractToolResultText(content: unknown): string {
 }
 
 /**
+ * View tools whose `file_path` argument names a single file the model is
+ * reading. A read of a file under the Context Tree root is the honest
+ * "agent consulted the tree" signal (see `treeNodePathOf`). Search tools
+ * (Grep/Glob) are excluded — they scan, they don't read a specific node.
+ */
+const TREE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["Read", "NotebookRead"]);
+
+/** Extract a string `file_path` argument from a tool_use input, if present. */
+function readFilePathArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const fp = (input as { file_path?: unknown }).file_path;
+  return typeof fp === "string" ? fp : null;
+}
+
+/**
+ * If `filePath` lives under `contextTreePath`, return its tree-root-relative
+ * path (e.g. `members/Gandy2025/NODE.md`); otherwise null. The agent reads
+ * tree files by absolute path (CLAUDE.md points it at the full tree at
+ * `contextTreePath`), so a prefix match on the normalised root is the filter.
+ * The trailing-slash trim keeps `/a/tree` from matching `/a/tree-other/x`.
+ */
+export function treeNodePathOf(filePath: string, contextTreePath: string): string | null {
+  if (!filePath || !contextTreePath) return null;
+  const root = contextTreePath.endsWith("/") ? contextTreePath.slice(0, -1) : contextTreePath;
+  if (!filePath.startsWith(`${root}/`)) return null;
+  const rel = filePath.slice(root.length + 1);
+  return rel.length > 0 ? rel : null;
+}
+
+/**
+ * If a tool with this name + input is a tree-file read, return the node path
+ * it read; else null.
+ */
+function treeReadNodePath(toolName: string, input: unknown, contextTreePath: string): string | null {
+  if (!TREE_READ_TOOL_NAMES.has(toolName)) return null;
+  const filePath = readFilePathArg(input);
+  if (filePath === null) return null;
+  return treeNodePathOf(filePath, contextTreePath);
+}
+
+/** Context Tree binding the tool-call processor needs to emit usage signals. */
+export type ContextTreeBinding = { path: string | null; repoUrl: string | null };
+
+/**
  * Pair `tool_use` (assistant) with `tool_result` (user) blocks and emit a
  * `tool_call` event per pair. Unpaired entries are flushed as `status: "pending"`.
+ *
+ * When a `contextTree` binding is supplied, a view tool whose read of a file
+ * under the tree root SUCCEEDS ALSO emits a `context_tree_usage` event carrying
+ * the node path — the honest replacement for the old per-inbound-message emit.
+ * Emitting on the successful tool_result (not the tool_use request) means
+ * failed/aborted reads never inflate the signal.
  */
 export type ToolCallProcessor = {
   onMessage(message: unknown): void;
   flush(): void;
 };
 
-export function createToolCallProcessor(emit: (event: SessionEvent) => void): ToolCallProcessor {
+export function createToolCallProcessor(
+  emit: (event: SessionEvent) => void,
+  contextTree?: ContextTreeBinding,
+): ToolCallProcessor {
   type Pending = { toolUseId: string; name: string; args: unknown; startedAt: number };
   const pending = new Map<string, Pending>();
 
@@ -219,6 +272,23 @@ export function createToolCallProcessor(emit: (event: SessionEvent) => void): To
         ...(resultPreview !== undefined ? { resultPreview } : {}),
       },
     });
+
+    // Honest Context Tree usage: a view tool that successfully read a file
+    // under the tree root means the agent actually consulted that node. Emit
+    // here (on the successful tool_result), not on the tool_use request, so
+    // failed reads (is_error) and aborted/unanswered reads never count.
+    // Carries the node path so the web feed can show which node was read.
+    // Replaces the old unconditional per-inbound-message emit (the vanity metric).
+    if (status === "ok" && contextTree?.path) {
+      const nodePath = treeReadNodePath(entry.name, entry.args, contextTree.path);
+      if (nodePath !== null) {
+        emit({
+          kind: "context_tree_usage",
+          payload: { purpose: "design_decision", treeRepoUrl: contextTree.repoUrl, nodePath },
+        });
+      }
+    }
+
     pending.delete(block.tool_use_id);
   }
 
@@ -351,8 +421,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     sessionCtx: SessionContext,
     sessionId: string,
   ): Promise<SDKUserMessage> {
-    emitContextTreeUsage(sessionCtx);
-
     // Image messages — two supported shapes:
     //   1. imageRef: `{imageId, mimeType, filename, size}` — new path. Bytes
     //      live on local disk, delivered via the `image_payload` WS push.
@@ -427,14 +495,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       parent_tool_use_id: null,
       session_id: sessionId,
     };
-  }
-
-  function emitContextTreeUsage(sessionCtx: SessionContext): void {
-    if (!contextTreePath) return;
-    sessionCtx.emitEvent({
-      kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: contextTreeRepoUrl },
-    });
   }
 
   /**
@@ -712,7 +772,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   async function consumeOutput(sessionCtx: SessionContext): Promise<void> {
-    const toolCallProcessor = createToolCallProcessor((event) => sessionCtx.emitEvent(event));
+    const toolCallProcessor = createToolCallProcessor((event) => sessionCtx.emitEvent(event), {
+      path: contextTreePath,
+      repoUrl: contextTreeRepoUrl,
+    });
     try {
       while (true) {
         if (!currentQuery) return;

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -177,13 +177,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
     return sessionCtx.formatInboundContent(message).then((text) => text);
   }
 
-  function emitContextTreeUsage(sessionCtx: SessionContext): void {
-    if (!contextTreePath) return;
-    sessionCtx.emitEvent({
-      kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: contextTreeRepoUrl },
-    });
-  }
+  // NOTE: codex's stream exposes only `command_execution` (shell) items — it
+  // cannot cleanly tell which Context Tree node a turn read without parsing
+  // shell commands. Rather than emit a fake per-turn signal (the old
+  // `emitContextTreeUsage` did), codex produces NO `context_tree_usage` events.
+  // Precise codex tree-read tracking is a known gap (P1). See the claude-code
+  // handler's tool-call processor for the real per-read signal.
 
   async function prepareGitWorktrees(
     payload: AgentRuntimeConfigPayload,
@@ -349,7 +348,6 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
     const abort = new AbortController();
     currentAbort = abort;
-    emitContextTreeUsage(sessionCtx);
     sessionCtx.setRuntimeState("working");
 
     // Emit exactly one `turn_end` per turn, after `forwardResult` resolves —

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-team-foundation/first-tree-hub",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "type": "module",
   "description": "First Tree Hub — unified CLI for client and agent management",
   "exports": {

--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -243,11 +243,19 @@ describe("sessionEventService", () => {
 
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: "https://github.com/example/tree" },
+      payload: {
+        purpose: "design_decision",
+        treeRepoUrl: "https://github.com/example/tree",
+        nodePath: "members/Gandy2025/NODE.md",
+      },
     });
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: "https://github.com/example/tree" },
+      payload: {
+        purpose: "design_decision",
+        treeRepoUrl: "https://github.com/example/tree",
+        nodePath: "designs/context-tree-usage-signal.md",
+      },
     });
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "tool_call",
@@ -255,7 +263,7 @@ describe("sessionEventService", () => {
     });
     await sessionEventService.appendEvent(app.db, "missing-agent", c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: null },
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: null },
     });
 
     const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
@@ -273,6 +281,9 @@ describe("sessionEventService", () => {
     expect(new Date(summary.recentEvents[0]?.createdAt ?? 0).getTime()).toBeGreaterThanOrEqual(
       new Date(summary.recentEvents[1]?.createdAt ?? 0).getTime(),
     );
+    // nodePath is surfaced from the stored payload, newest-first.
+    expect(summary.recentEvents[0]?.nodePath).toBe("designs/context-tree-usage-signal.md");
+    expect(summary.recentEvents[1]?.nodePath).toBe("members/Gandy2025/NODE.md");
   });
 
   it("exposes the agent's avatar color token in the feed so the web client renders the same disc as elsewhere", async () => {
@@ -286,7 +297,7 @@ describe("sessionEventService", () => {
     await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "design-spike" });
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: null },
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
     });
 
     const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
@@ -302,7 +313,7 @@ describe("sessionEventService", () => {
     await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "design-spike" });
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: null },
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
     });
 
     const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
@@ -332,7 +343,7 @@ describe("sessionEventService", () => {
 
     await sessionEventService.appendEvent(app.db, agent.uuid, crossOrgChatId, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: null },
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
     });
 
     const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
@@ -353,12 +364,36 @@ describe("sessionEventService", () => {
 
     await sessionEventService.appendEvent(app.db, agent.uuid, c, {
       kind: "context_tree_usage",
-      payload: { purpose: "design_decision", treeRepoUrl: null },
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
     });
 
     const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
     const event = summary.recentEvents[0];
     expect(event?.chatId).toBe(c);
     expect(event?.chatTitle).toBeNull();
+  });
+
+  it("surfaces nodePath null for a pre-P0 event whose payload predates the field", async () => {
+    const app = getApp();
+    const { agent, organizationId } = await createTestAgent(app);
+    const c = chatId();
+    await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "legacy" });
+
+    // Simulate a row written before the nodePath field existed — insert the
+    // legacy payload shape directly (appendEvent now requires nodePath, so it
+    // can't reproduce this). The feed must degrade to nodePath: null rather
+    // than throw at the snapshot-schema parse boundary.
+    await app.db.insert(sessionEvents).values({
+      id: uuidv7(),
+      agentId: agent.uuid,
+      chatId: c,
+      seq: 1,
+      kind: "context_tree_usage",
+      payload: { purpose: "design_decision", treeRepoUrl: null },
+    });
+
+    const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3);
+    expect(summary.recentEvents).toHaveLength(1);
+    expect(summary.recentEvents[0]?.nodePath).toBeNull();
   });
 });

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -169,6 +169,19 @@ export async function clearEvents(db: Database, agentId: string, chatId: string)
 const CONTEXT_TREE_USAGE_FEED_LIMIT = 50;
 
 /**
+ * Read the tree-root-relative `nodePath` out of a stored context_tree_usage
+ * payload (jsonb). Pre-P0 events predate the field and resolve to null; the
+ * payload is `unknown` from the DB driver so we narrow defensively.
+ */
+function nodePathFromPayload(payload: unknown): string | null {
+  if (payload && typeof payload === "object" && "nodePath" in payload) {
+    const value = (payload as { nodePath?: unknown }).nodePath;
+    if (typeof value === "string") return value;
+  }
+  return null;
+}
+
+/**
  * Org-wide aggregate counts + the most recent context-tree usage events
  * for the org. The Context Tab is an org-wide transparency surface — any
  * member can see who has been using the tree, including the chat topic
@@ -217,6 +230,7 @@ export async function summarizeContextTreeUsage(
       // lives in the same org as the caller's snapshot.
       joinedChatId: chats.id,
       chatTopic: chats.topic,
+      payload: sessionEvents.payload,
       createdAt: sessionEvents.createdAt,
     })
     .from(sessionEvents)
@@ -245,6 +259,9 @@ export async function summarizeContextTreeUsage(
       // with a non-null `chatId`.
       chatId: sameOrgChat ? row.rawChatId : null,
       chatTitle: sameOrgChat ? row.chatTopic : null,
+      // Surface which node the agent read straight from the stored payload.
+      // No node-frequency aggregation here — that's P1.
+      nodePath: nodePathFromPayload(row.payload),
       createdAt: row.createdAt.toISOString(),
     };
   });

--- a/packages/shared/src/__tests__/session-event-schema.test.ts
+++ b/packages/shared/src/__tests__/session-event-schema.test.ts
@@ -145,6 +145,50 @@ describe("sessionEventSchema", () => {
     });
   });
 
+  describe("context_tree_usage", () => {
+    it("parses a full payload with a node path", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "context_tree_usage",
+        payload: {
+          purpose: "design_decision",
+          treeRepoUrl: "https://github.com/example/tree",
+          nodePath: "members/Gandy2025/NODE.md",
+        },
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("accepts a null nodePath", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "context_tree_usage",
+        payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: null },
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it("defaults a MISSING nodePath to null (pre-P0 client deploy-skew tolerance)", () => {
+      // A ≤0.14.8 client still emits the old `{ purpose, treeRepoUrl }` shape.
+      // Without `.default(null)` the server's strict appendEvent parse would
+      // reject and drop the event; the default normalises absence to null.
+      const r = sessionEventSchema.safeParse({
+        kind: "context_tree_usage",
+        payload: { purpose: "design_decision", treeRepoUrl: null },
+      });
+      expect(r.success).toBe(true);
+      if (r.success && r.data.kind === "context_tree_usage") {
+        expect(r.data.payload.nodePath).toBeNull();
+      }
+    });
+
+    it("rejects a non-design_decision purpose", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "context_tree_usage",
+        payload: { purpose: "file_read", treeRepoUrl: null, nodePath: null },
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
   describe("turn_end", () => {
     it("parses success and error status", () => {
       for (const status of ["success", "error"] as const) {

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -143,6 +143,12 @@ export const contextTreeUsageEventSchema = z.object({
   // identifying info, so it is masked alongside chatTitle).
   chatId: z.string().nullable(),
   chatTitle: z.string().nullable(),
+  // Tree-root-relative path of the node the agent read (e.g.
+  // `members/Gandy2025/NODE.md`), surfaced from the session event payload so
+  // the web feed can show *which* node was consulted. Null for pre-P0 events
+  // (recorded before per-read node tracking) or reads that could not be
+  // resolved to a node path.
+  nodePath: z.string().nullable(),
   createdAt: z.string(),
 });
 export type ContextTreeUsageEvent = z.infer<typeof contextTreeUsageEventSchema>;

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -59,6 +59,12 @@ export type TurnEndEventPayload = z.infer<typeof turnEndEventPayload>;
 export const contextTreeUsageEventPayload = z.object({
   purpose: z.literal("design_decision"),
   treeRepoUrl: z.string().nullable(),
+  // Tree-root-relative path of the file the agent actually Read (e.g.
+  // `members/Gandy2025/NODE.md`). Null when the read target could not be
+  // resolved to a node path. Emitted only when a view tool reads a file under
+  // the configured Context Tree root — see the client handler's tool-call
+  // processor. (Pre-P0 events lack this field; the server surfaces null then.)
+  nodePath: z.string().nullable(),
 });
 export type ContextTreeUsageEventPayload = z.infer<typeof contextTreeUsageEventPayload>;
 

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -63,8 +63,17 @@ export const contextTreeUsageEventPayload = z.object({
   // `members/Gandy2025/NODE.md`). Null when the read target could not be
   // resolved to a node path. Emitted only when a view tool reads a file under
   // the configured Context Tree root — see the client handler's tool-call
-  // processor. (Pre-P0 events lack this field; the server surfaces null then.)
-  nodePath: z.string().nullable(),
+  // processor.
+  //
+  // `.default(null)`: tolerate a pre-P0 client (≤0.14.8) that still emits the
+  // old `{ purpose, treeRepoUrl }` payload during a server-ahead-of-client
+  // deploy window. There is no client min-version gate, and the server's
+  // `appendEvent` strict-parses every inbound event (ws-client.ts) — without
+  // the default, a missing `nodePath` would reject the event with an error
+  // frame and drop it. The default normalises absence to null instead. New
+  // clients always send the field explicitly; the inferred (output) type stays
+  // `string | null`, so consumers are unaffected.
+  nodePath: z.string().nullable().default(null),
 });
 export type ContextTreeUsageEventPayload = z.infer<typeof contextTreeUsageEventPayload>;
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1062,6 +1062,12 @@
   color: var(--fg-3);
 }
 
+.context-usage-feed-node {
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
 .context-usage-feed-chat {
   background: none;
   border: 0;

--- a/packages/web/src/pages/context-preview-mock.ts
+++ b/packages/web/src/pages/context-preview-mock.ts
@@ -76,6 +76,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         agentAvatarColorToken: "hue-1",
         chatId: "chat-design-spike",
         chatTitle: "design-spike",
+        nodePath: "members/Gandy2025/designs/context-tree-usage-signal.md",
         createdAt: new Date(Date.now() - 2 * 60_000).toISOString(),
       },
       {
@@ -85,6 +86,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         agentAvatarColorToken: "hue-4",
         chatId: "chat-onboarding-q3",
         chatTitle: "onboarding-q3",
+        nodePath: "domains/onboarding/NODE.md",
         createdAt: new Date(Date.now() - 12 * 60_000).toISOString(),
       },
       {
@@ -94,6 +96,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         agentAvatarColorToken: "hue-2",
         chatId: "chat-qa-run-42",
         chatTitle: "qa-run-42",
+        nodePath: "domains/quality/NODE.md",
         createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
       },
       {
@@ -103,6 +106,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         agentAvatarColorToken: "hue-1",
         chatId: "chat-weekly-retro",
         chatTitle: "weekly-retro",
+        nodePath: "NODE.md",
         createdAt: new Date(Date.now() - 4 * 60 * 60_000).toISOString(),
       },
       {
@@ -114,6 +118,9 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         agentAvatarColorToken: null,
         chatId: "chat-internal-review",
         chatTitle: "internal-review",
+        // Pre-P0 event — no node path recorded; the feed falls back to
+        // "read the context tree".
+        nodePath: null,
         createdAt: new Date(Date.now() - 6 * 60 * 60_000).toISOString(),
       },
     ],

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -209,7 +209,19 @@ function ChangeMap({
 function ContextSignal({ snapshot }: { snapshot: ContextTreeSnapshot }) {
   const windowText = snapshot.usage.windowDays === 1 ? "1 day" : `${snapshot.usage.windowDays} days`;
   const agentText = snapshot.usage.agentCount === 1 ? "1 agent" : `${snapshot.usage.agentCount} agents`;
-  const usageText = snapshot.usage.usageCount === 1 ? "1 time" : `${snapshot.usage.usageCount} times`;
+  const usageText = snapshot.usage.usageCount === 1 ? "once" : `${snapshot.usage.usageCount} times`;
+
+  // Honest copy: each usage event is now a real Read of a Context Tree file
+  // (the agent runtime emits one per tree-file read, with the node path). The
+  // signal knows the tree was read — not why — so it makes no "design
+  // decision" claim. See packages/client/src/handlers/claude-code.ts.
+  if (snapshot.usage.usageCount === 0) {
+    return (
+      <div className="text-lead context-signal" style={{ color: "var(--fg-3)" }}>
+        <span>No agent has read the context tree in the last {windowText}.</span>
+      </div>
+    );
+  }
 
   return (
     <div className="text-lead context-signal" style={{ color: "var(--fg-3)" }}>
@@ -217,7 +229,7 @@ function ContextSignal({ snapshot }: { snapshot: ContextTreeSnapshot }) {
         In the last {windowText}, <mark>{agentText}</mark>
       </span>
       <span>
-        used the tree <mark>{usageText}</mark> to make design decisions.
+        read the context tree <mark>{usageText}</mark>.
       </span>
     </div>
   );
@@ -308,15 +320,25 @@ function ContextUsageFeed({ snapshot }: { snapshot: ContextTreeSnapshot }) {
               </span>
               <span className="context-usage-feed-text">
                 <span className="context-usage-feed-agent">{event.agentName}</span>
-                <span className="context-usage-feed-action"> consulted tree for context </span>
+                <span className="context-usage-feed-action"> read </span>
+                {event.nodePath ? (
+                  <span className="context-usage-feed-node" title={event.nodePath}>
+                    {event.nodePath}
+                  </span>
+                ) : (
+                  <span className="context-usage-feed-action">the context tree</span>
+                )}
                 {chatId ? (
-                  <button
-                    type="button"
-                    className="context-usage-feed-chat"
-                    onClick={() => navigate(`/?c=${encodeURIComponent(chatId)}`)}
-                  >
-                    {chatLabel(event)}
-                  </button>
+                  <>
+                    <span className="context-usage-feed-action"> in </span>
+                    <button
+                      type="button"
+                      className="context-usage-feed-chat"
+                      onClick={() => navigate(`/?c=${encodeURIComponent(chatId)}`)}
+                    >
+                      {chatLabel(event)}
+                    </button>
+                  </>
                 ) : null}
               </span>
               <span className="context-usage-feed-time">{relativeTimeLabel(event.createdAt, now)}</span>


### PR DESCRIPTION
## Problem
The `context_tree_usage` session event was a **vanity metric**: the client emitted it on *every inbound message* for any tree-configured session, regardless of whether the agent ever read the tree (claude = per inbound message, codex = per turn). The web Context page ("N agents used the tree X times to make design decisions") was therefore fake.

## What this does (P0 — kept tight)
Move the signal from *"per inbound message"* → *"agent actually Read a tree file, with node path"*, and surface it honestly on the web. **No** node-frequency aggregation, **no** new dashboard (those are P1).

### shared
- `contextTreeUsageEventPayload` gains `nodePath: z.string().nullable()` (kept `purpose`, `treeRepoUrl`).
- web-facing `contextTreeUsageEventSchema` gains `nodePath` so it flows to the web.
- Additive jsonb field — **no DB migration**. Pre-P0 rows surface `nodePath: null`.

### client (core change)
- **claude-code.ts**: `createToolCallProcessor` takes a `{ path, repoUrl }` Context Tree binding. When a view tool (`Read`/`NotebookRead`) **successfully** reads a file under the tree root, it also emits `context_tree_usage` with `nodePath` (tree-root-relative). Emit fires on the **successful `tool_result`**, not the `tool_use` request, so failed/aborted reads never count. Added `treeNodePathOf` helper (trailing-slash-safe prefix match + relativize). Removed the old unconditional `emitContextTreeUsage`.
- **codex.ts**: removed the unconditional emit entirely — codex only sees shell `command_execution` items and can't tell which node was read. No shell parsing; precise codex tracking is a known **P1 gap**.

### server
- `summarizeContextTreeUsage` surfaces `nodePath` from the stored jsonb payload (defensive narrowing → null for legacy rows). No aggregation (P1).

### web
- `ContextSignal`: honest copy ("N agents read the context tree M times", clean zero-state) — drops the "design decisions" claim.
- `ContextUsageFeed`: each row shows which node was read (`{agent} read {nodePath} in {chat}`), falling back to "the context tree" for null. `title` attr for full-path hover.

### versioning
- Bumps `packages/command` `0.14.8 → 0.14.9` (client-consumed shared schema flows through the published CLI tarball). `shared` is `private: true` → no bump (inert).

## Tests
- Client: tree Read succeeds → emits with `nodePath`; **fails (`is_error`) → no emit**; **aborted (no result) → no emit**; outside-tree / sibling-prefix / non-view tool / no-binding / missing `file_path` → none; plus direct `treeNodePathOf` unit tests.
- Server: existing fixtures updated with `nodePath`; node-path surfacing assertions; a legacy-row backward-compat test (missing field → `null`).

## Review
Reviewed independently by **codex** (`codex review` → GATE PASS) and a **second agent session**. Both flagged the same issue — emitting on the `tool_use` request over-counted failed/repeat reads — which is **fixed** here (emit moved to the successful `tool_result`).

## Verification
`pnpm check` ✅ · `pnpm typecheck` ✅ · client 420 ✅ · server session-event 14 + context-tree-snapshot 14 ✅ · shared 241 ✅ · web 201 ✅.

## Scope: read side only (write-back is NOT covered)

This makes the **consumption** signal honest — it shows when agents **read** the tree. To avoid misreading the page:

- The **usage signal + LIVE feed** (`ContextSignal` / `ContextUsageFeed`) are driven entirely by `context_tree_usage` events, which now fire **only on a successful tree-file Read**. They show reads, nothing else.
- The page's **Change Map** (`+N updates`, `added / edited / removed`) is unrelated to this change — it is sourced from the **tree repo git history** (`snapshot.updates/changes/summary`), not session events.
- **There is no agent-activity feed for the write-back / contribution side** (agents editing the tree). Tree writes go through git/PR and surface only as git-sourced counts in the Change Map. An agent-dimension contribution signal is a deliberate **P1+ gap**, consistent with the direction that read usage is the lower-value (vanity-prone) metric and write-back is the real flywheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
