### PR TITLE
feat(chat): cross-agent workspace doc preview via shared-root snapshots

### DIFF
--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -117,3 +117,115 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
     expect(rewrittenText).toBe("first design.md then again design.md");
   });
 });
+
+/**
+ * Cross-agent doc preview: with a workspace fence, an absolute `.md` path that
+ * realpaths into ANOTHER agent's workspace (same chat) under the shared
+ * `workspaces/` common root is snapshotted with a global
+ * `<ownerSlug>/<chatId>/<rel>` key and rewritten to the short `<ownerSlug>/<rel>`
+ * form. Self paths keep their bare key + #480 behaviour; out-of-scope paths
+ * (other chat, other root, hidden) stay verbatim.
+ */
+describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => {
+  let workspacesRoot: string;
+  let selfRoot: string;
+  const chatId = "chat-xyz";
+  const selfSlug = "coder";
+  const otherSlug = "assistant";
+
+  beforeAll(async () => {
+    workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-ws-"));
+    // self workspace: workspaces/coder/chat-xyz
+    selfRoot = join(workspacesRoot, selfSlug, chatId);
+    await mkdir(selfRoot, { recursive: true });
+    await writeFile(join(selfRoot, "mine.md"), "# mine\n", "utf8");
+    // Self file whose relative path collides with a cross short form
+    // (`assistant/design.md`) — used to prove the collision → full-key rewrite.
+    await mkdir(join(selfRoot, otherSlug), { recursive: true });
+    await writeFile(join(selfRoot, otherSlug, "design.md"), "# my own assistant notes\n", "utf8");
+    // sibling agent workspace (same chat): workspaces/assistant/chat-xyz
+    const otherRoot = join(workspacesRoot, otherSlug, chatId);
+    await mkdir(join(otherRoot, "docs"), { recursive: true });
+    await writeFile(join(otherRoot, "design.md"), "# their design\n", "utf8");
+    await writeFile(join(otherRoot, "docs", "intro.md"), "# their intro\n", "utf8");
+    await mkdir(join(otherRoot, ".agent"), { recursive: true });
+    await writeFile(join(otherRoot, ".agent", "secret.md"), "# their secret\n", "utf8");
+    await symlink(join(otherRoot, ".agent", "secret.md"), join(otherRoot, "leak.md"));
+    // sibling agent in a DIFFERENT chat: workspaces/assistant/other-chat
+    const otherChatRoot = join(workspacesRoot, otherSlug, "other-chat");
+    await mkdir(otherChatRoot, { recursive: true });
+    await writeFile(join(otherChatRoot, "private.md"), "# other chat\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(workspacesRoot, { recursive: true, force: true });
+  });
+
+  const fence = () => ({ workspacesRoot, chatId, selfSlug });
+
+  it("snapshots a sibling agent's doc with a global key + short rewrite", async () => {
+    const abs = join(workspacesRoot, otherSlug, chatId, "design.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs} please`, selfRoot, fence());
+
+    expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/design.md`]);
+    expect(docs[0]?.content).toBe("# their design\n");
+    expect(rewrittenText).toBe(`see ${otherSlug}/design.md please`);
+  });
+
+  it("preserves subdir + :line suffix in the cross rewrite", async () => {
+    const abs = join(workspacesRoot, otherSlug, chatId, "docs", "intro.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:10 now`, selfRoot, fence());
+
+    expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/docs/intro.md`]);
+    expect(rewrittenText).toBe(`open ${otherSlug}/docs/intro.md:10 now`);
+  });
+
+  it("keeps the self path bare (Case A unchanged) even with a fence", async () => {
+    const abs = join(selfRoot, "mine.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`my ${abs} file`, selfRoot, fence());
+
+    expect(docs.map((d) => d.path)).toEqual(["mine.md"]);
+    expect(rewrittenText).toBe("my mine.md file");
+  });
+
+  it("rejects a sibling doc from a DIFFERENT chat (chat-scope fence)", async () => {
+    const abs = join(workspacesRoot, otherSlug, "other-chat", "private.md");
+    const text = `cross-chat ${abs} nope`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("rejects a sibling symlink whose realpath crosses into a hidden dir", async () => {
+    const abs = join(workspacesRoot, otherSlug, chatId, "leak.md");
+    const text = `leak ${abs}`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("does NOT cross-resolve when no fence is supplied (opt-in)", async () => {
+    const abs = join(workspacesRoot, otherSlug, chatId, "design.md");
+    const text = `see ${abs} please`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot);
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("rewrites a cross mention to the FULL global key when its short form collides with a self key (P2-b)", async () => {
+    // Self file `assistant/design.md` (relative) AND the sibling agent's
+    // `assistant/<chat>/design.md` are both referenced. The cross short form
+    // would be `assistant/design.md` — identical to the self key — so the cross
+    // mention must be rewritten to the full global key instead.
+    const crossAbs = join(workspacesRoot, otherSlug, chatId, "design.md");
+    const text = `self ${otherSlug}/design.md and cross ${crossAbs}`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
+
+    expect(docs.map((d) => d.path).sort()).toEqual([`${otherSlug}/${chatId}/design.md`, `${otherSlug}/design.md`]);
+    // Self relative mention stays verbatim; cross mention becomes the full key.
+    expect(rewrittenText).toBe(`self ${otherSlug}/design.md and cross ${otherSlug}/${chatId}/design.md`);
+  });
+});

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import {
+  buildWorkspaceDocKey,
   MAX_DOC_SNAPSHOT_BYTES,
   MAX_DOC_SNAPSHOTS_PER_MESSAGE,
   MAX_TOTAL_DOC_SNAPSHOT_BYTES,
@@ -42,9 +43,35 @@ import {
  * byte budgets + sha256 so a misbehaving runtime cannot lodge mismatched
  * data.
  */
+/**
+ * Fence that widens snapshotting from "the sender's own workspace root" to
+ * "any agent's workspace under the shared `workspaces/` common root, scoped to
+ * the current chat". Passed by the runtime; absent in legacy/unit call sites,
+ * in which case behaviour is exactly the pre-existing self-only path.
+ */
+export type WorkspaceFence = {
+  /** Shared `workspaces/` common root (parent of every `<agentSlug>/<chatId>`). */
+  workspacesRoot: string;
+  /** Current chat — only `<*>/<chatId>/…` files are in scope. */
+  chatId: string;
+  /** Sender's own dir name under `workspacesRoot`; excluded from cross-resolution. */
+  selfSlug: string;
+};
+
+type ResolvedOccurrence = DocPathOccurrence & {
+  kind: "self" | "cross" | null;
+  /** Snapshot key: bare base-relative for self, global `<slug>/<chatId>/<rel>` for cross. */
+  key: string | null;
+  /** Realpath of the file to read (cross only; self resolves against `root`). */
+  file: string | null;
+  /** Rewrite replacement for a cross mention: short `<ownerSlug>/<rel>`. */
+  shortForm: string;
+};
+
 export async function buildMessageDocumentSnapshots(
   text: string,
   root: string,
+  fence?: WorkspaceFence,
 ): Promise<{ docs: SnapshotDoc[]; skipped: number; rewrittenText: string }> {
   const occurrences = collectDocPathOccurrences(text);
   if (occurrences.length === 0) return { docs: [], skipped: 0, rewrittenText: text };
@@ -52,19 +79,31 @@ export async function buildMessageDocumentSnapshots(
   const rootReal = await safeRealpath(root);
   if (!rootReal) return { docs: [], skipped: occurrences.length, rewrittenText: text };
 
-  // Pass 1 — resolve every occurrence to its canonical workspace-relative key
-  // (or null). Absolute-in-root paths canonicalise to the same relative key
-  // web derives once the text is rewritten, so a click hits the snapshot.
-  const resolved = await Promise.all(
-    occurrences.map(async (occ) => ({
-      ...occ,
-      canonical: await canonicalizeWorkspacePath(rootReal, occ.writtenPath),
-    })),
+  const workspacesRootReal = fence ? await safeRealpath(fence.workspacesRoot) : null;
+
+  // Pass 1 — resolve every occurrence to a snapshot plan:
+  //   self  → bare key relative to `root` (unchanged from #474/#480); the
+  //           absolute-in-root case canonicalises to the same relative key web
+  //           derives once the text is rewritten.
+  //   cross → global key `<ownerSlug>/<chatId>/<rel>` for a file that realpaths
+  //           into ANOTHER agent's workspace under the shared common root.
+  const resolved: ResolvedOccurrence[] = await Promise.all(
+    occurrences.map(async (occ): Promise<ResolvedOccurrence> => {
+      const selfKey = await canonicalizeWorkspacePath(rootReal, occ.writtenPath);
+      if (selfKey) return { ...occ, kind: "self", key: selfKey, file: null, shortForm: "" };
+      // Only an ABSOLUTE path can escape the sender's own root into a sibling
+      // workspace; a relative mention always resolves under `root`.
+      if (workspacesRootReal && fence && isAbsolute(occ.writtenPath)) {
+        const cross = await resolveCrossWorkspaceDoc(workspacesRootReal, fence, occ.writtenPath);
+        if (cross) return { ...occ, kind: "cross", key: cross.key, file: cross.file, shortForm: cross.shortForm };
+      }
+      return { ...occ, kind: null, key: null, file: null, shortForm: "" };
+    }),
   );
 
-  // Pass 2 — build snapshots. De-dupe by canonical path so the same file
-  // mentioned twice is read once; the on-wire key is the canonical path the
-  // web cache lookup produces from a clicked href.
+  // Pass 2 — build snapshots. De-dupe by snapshot key so the same file
+  // mentioned twice is read once; the on-wire key is what the web cache lookup
+  // produces from a clicked href.
   const docs: SnapshotDoc[] = [];
   let totalBytes = 0;
   let skipped = 0;
@@ -72,20 +111,22 @@ export async function buildMessageDocumentSnapshots(
   const snapshotted = new Set<string>();
 
   for (const occ of resolved) {
-    const canonical = occ.canonical;
-    if (!canonical || !canonical.toLowerCase().endsWith(".md")) {
+    const key = occ.key;
+    if (!key || !key.toLowerCase().endsWith(".md")) {
       skipped += 1;
       continue;
     }
-    if (seen.has(canonical)) continue;
-    seen.add(canonical);
+    if (seen.has(key)) continue;
+    seen.add(key);
 
     if (docs.length >= MAX_DOC_SNAPSHOTS_PER_MESSAGE) {
       skipped += 1;
       continue;
     }
 
-    const file = await resolveWorkspaceFile(rootReal, canonical);
+    // Self keys resolve back against `root`; cross keys already carry the
+    // realpath'd file from the fenced lookup.
+    const file = occ.kind === "cross" ? occ.file : await resolveWorkspaceFile(rootReal, key);
     if (!file) {
       skipped += 1;
       continue;
@@ -120,25 +161,44 @@ export async function buildMessageDocumentSnapshots(
         continue;
       }
       const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
-      docs.push({ path: canonical, sha256, size, content });
+      docs.push({ path: key, sha256, size, content });
       totalBytes += size;
-      snapshotted.add(canonical);
+      snapshotted.add(key);
     } catch {
       skipped += 1;
     }
   }
 
-  // Pass 3 — rewrite the text spans of resolved ABSOLUTE-in-root tokens to
-  // their canonical relative path (web can't map an absolute path to a
-  // snapshot key without knowing `root`). The rewrite surface is kept minimal:
-  // relative mentions — canonical or not (`./docs/foo.md`) — are left verbatim
-  // because web already canonicalises them during its re-scan match. Only
-  // tokens that actually produced a snapshot are rewritten, so "rewritten ⇔
-  // previewable" holds and an unsnapshot-able mention is never mutated.
+  // Self snapshot keys are bare base-relative paths; a cross short form
+  // `<ownerSlug>/<rel>` can therefore collide with one (e.g. the sender also
+  // snapshotted a real file at `assistant/design.md`). Web gives a direct
+  // self-key match priority, so a colliding short form would link to the WRONG
+  // (self) snapshot. Detect the collision here and fall back to the FULL global
+  // key for that cross mention so web direct-matches the right snapshot
+  // (review P2-b).
+  const selfKeys = new Set<string>();
+  for (const occ of resolved) {
+    if (occ.kind === "self" && occ.key && snapshotted.has(occ.key)) selfKeys.add(occ.key);
+  }
+
+  // Pass 3 — rewrite text spans to the form web re-scans into the snapshot key.
+  // Web can't map an absolute path (it doesn't know `root`), nor a cross global
+  // key from a bare absolute path, so:
+  //   self + absolute-in-root → canonical bare relative path (unchanged #480)
+  //   cross                   → short `<ownerSlug>/<rel>` (web re-expands with
+  //                             chatId), OR the full global key when the short
+  //                             form would collide with a self snapshot key.
+  // Self RELATIVE mentions (`./docs/foo.md`) are left verbatim because web
+  // already canonicalises them on re-scan. Only tokens that actually produced a
+  // snapshot are rewritten, so "rewritten ⇔ previewable" holds.
   const rewrites: Array<{ start: number; end: number; replacement: string }> = [];
   for (const occ of resolved) {
-    if (occ.canonical && isAbsolute(occ.writtenPath) && snapshotted.has(occ.canonical)) {
-      rewrites.push({ start: occ.start, end: occ.end, replacement: `${occ.canonical}${occ.lineSuffix}` });
+    if (!occ.key || !snapshotted.has(occ.key)) continue;
+    if (occ.kind === "self" && isAbsolute(occ.writtenPath)) {
+      rewrites.push({ start: occ.start, end: occ.end, replacement: `${occ.key}${occ.lineSuffix}` });
+    } else if (occ.kind === "cross") {
+      const replacement = selfKeys.has(occ.shortForm) ? occ.key : occ.shortForm;
+      rewrites.push({ start: occ.start, end: occ.end, replacement: `${replacement}${occ.lineSuffix}` });
     }
   }
 
@@ -246,6 +306,61 @@ async function canonicalizeWorkspacePath(rootReal: string, writtenPath: string):
   const prefix = rootReal.endsWith(sep) ? rootReal : rootReal + sep;
   if (real !== rootReal && !real.startsWith(prefix)) return null;
   return normalizeDocLinkPath(relative(rootReal, real));
+}
+
+/**
+ * Resolve an ABSOLUTE `.md` path that points into a DIFFERENT agent's
+ * workspace under the shared common root. Returns the global snapshot key
+ * `<ownerSlug>/<chatId>/<rel>`, the realpath'd file to read, and the short
+ * `<ownerSlug>/<rel>` form to rewrite into the outbound text — or null when
+ * the path is outside the common root, belongs to another chat, hides, is the
+ * sender's own workspace (handled as a self path), is not a regular `.md`
+ * file, or cannot be realpath'd.
+ *
+ * realpath runs BEFORE the containment check so an ancestor symlink cannot
+ * fake "inside the common root" — same discipline as the self-path resolver.
+ */
+async function resolveCrossWorkspaceDoc(
+  workspacesRootReal: string,
+  fence: WorkspaceFence,
+  absPath: string,
+): Promise<{ key: string; file: string; shortForm: string } | null> {
+  const real = await safeRealpath(absPath);
+  if (!real) return null;
+
+  const prefix = workspacesRootReal.endsWith(sep) ? workspacesRootReal : workspacesRootReal + sep;
+  if (!real.startsWith(prefix)) return null;
+
+  const segments = relative(workspacesRootReal, real)
+    .split(sep)
+    .filter((s) => s.length > 0 && s !== ".");
+  // Need at least <ownerSlug>/<chatId>/<file>.
+  if (segments.length < 3) return null;
+  // Reject any hidden segment (`.agent/`, `.git/`, dotfiles) anywhere in the
+  // realpath — closes the symlink-into-hidden-dir escape after realpath.
+  if (segments.some((s) => s.startsWith("."))) return null;
+
+  const [ownerSlug, segChatId, ...rest] = segments;
+  if (!ownerSlug || !segChatId) return null;
+  // Chat-scope fence: only the current chat's workspaces are in range, so one
+  // chat can never preview another chat's private workspace docs.
+  if (segChatId !== fence.chatId) return null;
+  // The sender's own workspace is handled by the self-path resolver (bare key,
+  // #480 rewrite). Keep cross strictly cross-agent.
+  if (ownerSlug === fence.selfSlug) return null;
+
+  const rel = rest.join("/");
+  const key = buildWorkspaceDocKey(ownerSlug, segChatId, rel);
+  if (!key || !key.toLowerCase().endsWith(".md")) return null;
+
+  try {
+    const st = await stat(real);
+    if (!st.isFile()) return null;
+  } catch {
+    return null;
+  }
+
+  return { key, file: real, shortForm: `${ownerSlug}/${rel}` };
 }
 
 /**

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -51,6 +51,16 @@ export type ResultSinkDeps = {
    * worktree instead of the per-chat workspace root.
    */
   getDocumentBasePath?: () => Promise<string | null>;
+  /**
+   * Shared `workspaces/` common root (parent of every `<agentSlug>/<chatId>`).
+   * Set alongside `selfSlug` to enable cross-agent doc snapshots: an absolute
+   * `.md` path that realpaths into ANOTHER agent's workspace under this root
+   * (same chat) is snapshotted with a global `<ownerSlug>/<chatId>/<rel>` key.
+   * Absent → self-only behaviour (pre-existing).
+   */
+  workspacesRoot?: string;
+  /** This agent's own dir name under `workspacesRoot` (excluded from cross). */
+  selfSlug?: string;
 };
 
 export type ResultSink = (text: string) => Promise<void>;
@@ -80,7 +90,14 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
       // messages may still hold `kind:"path"`; the web reader keeps handling
       // them for back-compat — this only stops emitting new ones.)
       try {
-        const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, documentBasePath);
+        // Enable cross-agent resolution only when the runtime supplied the
+        // shared common root + this agent's slug; otherwise fall back to the
+        // self-only path (e.g. legacy callers / tests).
+        const fence =
+          deps.workspacesRoot && deps.selfSlug
+            ? { workspacesRoot: deps.workspacesRoot, chatId: deps.chatId, selfSlug: deps.selfSlug }
+            : undefined;
+        const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, documentBasePath, fence);
         content = rewrittenText;
         if (docs.length > 0) {
           metadata.documentContext = documentContextSchema.parse({ kind: "snapshot", docs });

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type {
   AgentRuntimeConfigPayload,
   GitRepo,
@@ -804,6 +804,12 @@ export class SessionManager {
       },
       log,
       getDocumentBasePath: () => this.resolveDocumentBasePath(log, chatId),
+      // Cross-agent doc preview: `workspaceRoot` is `<workspaces>/<agentSlug>`
+      // (see agent-slot.ts), so the shared common root is its parent and this
+      // agent's slug is its basename — derived from existing config, no new
+      // config surface (decision: config-ascent).
+      workspacesRoot: dirname(this.config.handlerConfig.workspaceRoot),
+      selfSlug: basename(this.config.handlerConfig.workspaceRoot),
     });
 
     const envCtx = { sdk: this.config.sdk, agent: this.config.agentIdentity, chatId };

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -137,4 +137,94 @@ describe("validateDocumentContext", () => {
       ).toThrow(BadRequestError);
     }
   });
+
+  describe("cross-agent provenance (chatScope)", () => {
+    const scope = (slugs: string[]) => ({ chatId: "chat-1", participantSlugs: new Set(slugs) });
+
+    it("accepts a cross-agent global key when the owner is a chat participant", () => {
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("assistant/chat-1/design.md", "# theirs\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).not.toThrow();
+    });
+
+    it("rejects a cross-agent global key when the owner is NOT a chat participant", () => {
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("intruder/chat-1/secret.md", "# leak\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).toThrow(BadRequestError);
+    });
+
+    it("leaves bare self keys unaffected by the participant check", () => {
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("docs/design.md", "# mine\n")],
+            },
+          },
+          scope(["coder"]),
+        ),
+      ).not.toThrow();
+    });
+
+    it("rejects a participant-owned global key that names a DIFFERENT chat (chatId fence — P1)", () => {
+      // `assistant` is a participant, so `assistant/other-chat/design.md` is a
+      // cross key shape pointing at another chat's workspace — it must not slip
+      // past the `workspaces/*/<currentChatId>/` fence.
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("assistant/other-chat/design.md", "# x\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).toThrow(BadRequestError);
+    });
+
+    it("allows a deep SELF path whose first segment is not a participant slug", () => {
+      // `docs/api/design.md` is a legitimate nested self path; `docs` is not a
+      // participant, so the chatId-fence rule must not over-reject it.
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("docs/api/design.md", "# nested\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).not.toThrow();
+    });
+
+    it("skips the provenance check entirely when no chatScope is supplied (back-compat)", () => {
+      expect(() =>
+        validateDocumentContext({
+          documentContext: {
+            kind: "snapshot",
+            docs: [snapshotDoc("intruder/chat-1/secret.md", "# leak\n")],
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/server/src/services/doc-snapshots.ts
+++ b/packages/server/src/services/doc-snapshots.ts
@@ -3,6 +3,7 @@ import {
   documentContextSchema,
   MAX_DOC_SNAPSHOT_BYTES,
   MAX_TOTAL_DOC_SNAPSHOT_BYTES,
+  parseWorkspaceDocKey,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { BadRequestError } from "../errors.js";
 
@@ -22,8 +23,20 @@ import { BadRequestError } from "../errors.js";
  * Why throw BadRequestError instead of silently stripping: snapshot data
  * comes from a trusted runtime; a schema mismatch typically signals a
  * client bug, and surfacing it loudly is more useful than hiding it.
+ *
+ * `chatScope` (optional) enables cross-agent provenance authz: a snapshot key
+ * shaped like a global cross key `<ownerSlug>/<chatId>/<rel>` whose chatId
+ * segment matches the message's chat must name an owner that is a participant
+ * of that chat. This is defense-in-depth on top of the runtime's structural
+ * fence — a compromised runtime cannot embed (and broadcast) a non-participant
+ * agent's workspace doc. Self / legacy bare keys carry no owner segment for
+ * this chat and are unaffected. When omitted (other callers / tests), the
+ * provenance check is skipped.
  */
-export function validateDocumentContext(metadata: Record<string, unknown> | undefined): void {
+export function validateDocumentContext(
+  metadata: Record<string, unknown> | undefined,
+  chatScope?: { chatId: string; participantSlugs: ReadonlySet<string> },
+): void {
   if (!metadata) return;
   const raw = metadata.documentContext;
   if (raw === undefined || raw === null) return;
@@ -39,6 +52,34 @@ export function validateDocumentContext(metadata: Record<string, unknown> | unde
 
   let totalBytes = 0;
   for (const doc of ctx.docs) {
+    if (chatScope) {
+      const key = parseWorkspaceDocKey(doc.path);
+      if (key) {
+        const ownerIsParticipant = chatScope.participantSlugs.has(key.agentSlug.toLowerCase());
+        if (key.chatId === chatScope.chatId) {
+          // Cross-agent global key for THIS chat — the owner must be a speaker
+          // participant, else a doc from a non-member's workspace would be
+          // broadcast into the chat.
+          if (!ownerIsParticipant) {
+            throw new BadRequestError("Document snapshot references a non-participant agent workspace", {
+              "doc_snapshot.path": doc.path,
+              "doc_snapshot.owner_slug": key.agentSlug,
+            });
+          }
+        } else if (ownerIsParticipant) {
+          // Owner-shaped global key naming a DIFFERENT chat. A participant-owned
+          // key whose chat segment isn't this chat would pull another chat's
+          // private workspace doc past the `workspaces/*/<currentChatId>/` fence
+          // — reject it (review P1). A deep SELF path whose first segment isn't
+          // a participant slug (e.g. `docs/api/design.md`) is left alone.
+          throw new BadRequestError("Document snapshot references another chat's agent workspace", {
+            "doc_snapshot.path": doc.path,
+            "doc_snapshot.owner_slug": key.agentSlug,
+            "doc_snapshot.key_chat_id": key.chatId,
+          });
+        }
+      }
+    }
     const actualBytes = Buffer.byteLength(doc.content, "utf8");
     if (actualBytes > MAX_DOC_SNAPSHOT_BYTES) {
       throw new BadRequestError("Document snapshot exceeds per-file byte budget", {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -202,8 +202,14 @@ async function sendMessageInner(
     // Server-side bottom-line on `metadata.documentContext`: shape via shared
     // schema + byte budgets and sha256 calibration. Snapshot content arrives
     // from a trusted runtime, but server still has to verify so a client bug
-    // can't lodge mismatched hash/size into immutable message history.
-    validateDocumentContext(incomingMeta);
+    // can't lodge mismatched hash/size into immutable message history. The
+    // chat scope additionally rejects a cross-agent snapshot key whose owner
+    // is not a speaker participant of this chat (cross-workspace doc preview
+    // provenance check).
+    validateDocumentContext(incomingMeta, {
+      chatId,
+      participantSlugs: new Set(participants.map((p) => p.name?.toLowerCase()).filter((n): n is string => Boolean(n))),
+    });
     const explicitMentionsRaw = incomingMeta.mentions;
     const explicitMentions = Array.isArray(explicitMentionsRaw)
       ? explicitMentionsRaw.filter((m): m is string => typeof m === "string")

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,7 +2,12 @@
 
 // -- Mention extraction (shared by server fan-out resolver and client auto-forward) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";
-export { isCanonicalDocLinkPath, normalizeDocLinkPath } from "./lib/doc-path.js";
+export {
+  buildWorkspaceDocKey,
+  isCanonicalDocLinkPath,
+  normalizeDocLinkPath,
+  parseWorkspaceDocKey,
+} from "./lib/doc-path.js";
 export { extractMentions, MENTION_REGEX, type MentionParticipant, scanMentionTokens, stripCode } from "./mentions.js";
 // -- OAuth-callback open-redirect guard --
 export { DEFAULT_SAFE_REDIRECT, safeRedirectPath } from "./safe-redirect.js";

--- a/packages/shared/src/lib/__tests__/doc-path.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-path.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isCanonicalDocLinkPath, normalizeDocLinkPath } from "../doc-path.js";
+import {
+  buildWorkspaceDocKey,
+  isCanonicalDocLinkPath,
+  normalizeDocLinkPath,
+  parseWorkspaceDocKey,
+} from "../doc-path.js";
 
 describe("normalizeDocLinkPath", () => {
   it("returns the canonical workspace-relative form", () => {
@@ -70,5 +75,65 @@ describe("isCanonicalDocLinkPath", () => {
     expect(isCanonicalDocLinkPath("https://x/a.md")).toBe(false);
     expect(isCanonicalDocLinkPath(".agent/x.md")).toBe(false);
     expect(isCanonicalDocLinkPath("../x.md")).toBe(false);
+  });
+});
+
+describe("buildWorkspaceDocKey", () => {
+  it("builds a canonical global cross-agent key", () => {
+    expect(buildWorkspaceDocKey("assistant", "chat-1", "design.md")).toBe("assistant/chat-1/design.md");
+    expect(buildWorkspaceDocKey("assistant", "chat-1", "docs/design.md")).toBe("assistant/chat-1/docs/design.md");
+    // rel is normalised before assembly
+    expect(buildWorkspaceDocKey("assistant", "chat-1", "./docs/design.md")).toBe("assistant/chat-1/docs/design.md");
+  });
+
+  it("rejects when slug / chatId are missing, hidden, or contain a slash", () => {
+    expect(buildWorkspaceDocKey("", "chat-1", "a.md")).toBeNull();
+    expect(buildWorkspaceDocKey("assistant", "", "a.md")).toBeNull();
+    expect(buildWorkspaceDocKey(".hidden", "chat-1", "a.md")).toBeNull();
+    expect(buildWorkspaceDocKey("assistant", ".x", "a.md")).toBeNull();
+    expect(buildWorkspaceDocKey("a/b", "chat-1", "a.md")).toBeNull();
+    expect(buildWorkspaceDocKey("assistant", "c/d", "a.md")).toBeNull();
+  });
+
+  it("rejects when rel escapes / hides / is empty", () => {
+    expect(buildWorkspaceDocKey("assistant", "chat-1", "../secret.md")).toBeNull();
+    expect(buildWorkspaceDocKey("assistant", "chat-1", ".agent/x.md")).toBeNull();
+    expect(buildWorkspaceDocKey("assistant", "chat-1", "")).toBeNull();
+  });
+
+  it("produces a key that is itself canonical", () => {
+    const key = buildWorkspaceDocKey("assistant", "chat-1", "docs/design.md");
+    expect(key).not.toBeNull();
+    expect(isCanonicalDocLinkPath(key as string)).toBe(true);
+  });
+});
+
+describe("parseWorkspaceDocKey", () => {
+  it("splits a global key into slug / chatId / rel", () => {
+    expect(parseWorkspaceDocKey("assistant/chat-1/design.md")).toEqual({
+      agentSlug: "assistant",
+      chatId: "chat-1",
+      rel: "design.md",
+    });
+    expect(parseWorkspaceDocKey("assistant/chat-1/docs/design.md")).toEqual({
+      agentSlug: "assistant",
+      chatId: "chat-1",
+      rel: "docs/design.md",
+    });
+  });
+
+  it("returns null for fewer than three segments", () => {
+    expect(parseWorkspaceDocKey("design.md")).toBeNull();
+    expect(parseWorkspaceDocKey("chat-1/design.md")).toBeNull();
+  });
+
+  it("returns null for non-canonical / rejected input", () => {
+    expect(parseWorkspaceDocKey("../a/b.md")).toBeNull();
+    expect(parseWorkspaceDocKey(".agent/chat/x.md")).toBeNull();
+  });
+
+  it("round-trips with buildWorkspaceDocKey", () => {
+    const key = buildWorkspaceDocKey("assistant", "chat-1", "docs/design.md") as string;
+    expect(parseWorkspaceDocKey(key)).toEqual({ agentSlug: "assistant", chatId: "chat-1", rel: "docs/design.md" });
   });
 });

--- a/packages/shared/src/lib/doc-path.ts
+++ b/packages/shared/src/lib/doc-path.ts
@@ -60,3 +60,58 @@ export function isCanonicalDocLinkPath(path: string): boolean {
   const normalized = normalizeDocLinkPath(path);
   return normalized !== null && normalized === path;
 }
+
+/**
+ * Cross-agent workspace doc key.
+ *
+ * doc-preview snapshots from the SENDER's own workspace keep a bare,
+ * base-relative key (`docs/foo.md`) — unchanged, zero-regression. A snapshot
+ * of a file in ANOTHER agent's workspace needs a globally-unique key so web's
+ * cache lookup is unambiguous: `<agentSlug>/<chatId>/<rel>`, i.e. the path
+ * relative to the shared `workspaces/` common root (minus that root). Runtime
+ * builds it when it snapshots a sibling-workspace file; web reconstructs the
+ * same key from a scanned token to match the snapshot; server parses it to
+ * re-check the owner is a chat participant. All three must agree, so the
+ * build/parse logic lives here next to `normalizeDocLinkPath`.
+ *
+ * `chatId` scopes the key to a single chat: a `workspaces/<X>/<chatId>` dir
+ * only exists when X has run a session in that chat, so the chatId segment is
+ * the structural fence that keeps one chat from previewing another chat's
+ * private workspace docs.
+ */
+export function buildWorkspaceDocKey(agentSlug: string, chatId: string, rel: string): string | null {
+  const slug = agentSlug.trim();
+  const chat = chatId.trim();
+  // slug / chatId must each be a single, non-hidden path segment.
+  if (!slug || !chat || slug.includes("/") || chat.includes("/")) return null;
+  if (slug.startsWith(".") || chat.startsWith(".")) return null;
+  const relNorm = normalizeDocLinkPath(rel);
+  if (!relNorm) return null;
+  const key = `${slug}/${chat}/${relNorm}`;
+  // Re-validate the assembled key so a slug/chatId containing a stray dot
+  // segment or other non-canonical token can never produce a key that web
+  // would later canonicalise into a different string (silent cache miss).
+  return isCanonicalDocLinkPath(key) ? key : null;
+}
+
+/**
+ * Inverse of {@link buildWorkspaceDocKey}. Splits a canonical key into
+ * `{ agentSlug, chatId, rel }`, or `null` when it has fewer than three
+ * segments / is non-canonical.
+ *
+ * NOTE — ambiguity: a bare self key with three or more segments
+ * (`docs/sub/a.md`) parses too. Callers that need to tell "global cross key"
+ * from "deep self path" apart MUST additionally require `chatId` to equal the
+ * current chat's id (chat ids are uuids, so a self subdir literally named the
+ * chat id is effectively impossible). See web `chat-view` / server authz.
+ */
+export function parseWorkspaceDocKey(key: string): { agentSlug: string; chatId: string; rel: string } | null {
+  const norm = normalizeDocLinkPath(key);
+  if (!norm) return null;
+  const segs = norm.split("/");
+  if (segs.length < 3) return null;
+  const [agentSlug, chatId, ...rest] = segs;
+  const rel = rest.join("/");
+  if (!agentSlug || !chatId || rel.length === 0) return null;
+  return { agentSlug, chatId, rel };
+}

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -1,3 +1,4 @@
+import { parseWorkspaceDocKey } from "@agent-team-foundation/first-tree-hub-shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, X } from "lucide-react";
 import {
@@ -13,6 +14,7 @@ import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
 import { getMeDoc } from "../api/me-docs.js";
 import { docPreviewPathFromHref } from "../lib/doc-preview-links.js";
+import { useAgentSlugToIdMap } from "../lib/use-agent-name-map.js";
 import { cn } from "../lib/utils.js";
 import { type DocSnapshotEntry, docSnapshotQueryKey } from "../pages/workspace/center/chat-view.js";
 import { Button } from "./ui/button.js";
@@ -190,17 +192,37 @@ export function DocPreviewDrawer() {
     };
   }, [hasDocRef, isMobile]);
 
+  // A cross-agent docPath is a global key `<ownerSlug>/<chatId>/<rel>`; the
+  // path-based fallback endpoint is keyed by (owner agentId, rel) under
+  // `workspaces/<ownerName>/<chatId>/`, so strip the owner+chatId prefix and
+  // send just `rel`. Self / legacy bare keys (or a deep self path whose chatId
+  // segment doesn't match this chat) pass through unchanged.
+  const slugToId = useAgentSlugToIdMap();
+  const parsedKey = docPath ? parseWorkspaceDocKey(docPath) : null;
+  const isCrossKey = parsedKey !== null && parsedKey.chatId === docChatId;
+  // For a cross key the OWNER is named in the key itself — resolve the owner
+  // agent id from that slug rather than trusting `docAgent` (the click handler
+  // may have stored the sender as a hasDocRef placeholder when the owner slug
+  // couldn't be resolved). This keeps the fallback pointed at the owner's
+  // workspace even after a reload / cache miss; if the owner can't be resolved
+  // we DISABLE the fallback rather than query the sender, which could surface a
+  // same-named file from the WRONG workspace (review P2-a).
+  const crossOwnerId = isCrossKey && parsedKey ? slugToId(parsedKey.agentSlug) : null;
+  const fallbackAgentId = isCrossKey ? crossOwnerId : docAgentId;
+  const apiPath = isCrossKey && parsedKey ? parsedKey.rel : (docPath ?? "");
+  const apiBasePath = isCrossKey ? undefined : docBasePath;
   const previewQuery = useQuery({
-    queryKey: ["me", "docs", "preview", docChatId, docAgentId, docBasePath, docPath],
+    queryKey: ["me", "docs", "preview", docChatId, fallbackAgentId, apiBasePath, apiPath],
     queryFn: () =>
       getMeDoc(docChatId ?? "", {
-        agentId: docAgentId ?? "",
-        basePath: docBasePath,
-        path: docPath ?? "",
+        agentId: fallbackAgentId ?? "",
+        basePath: apiBasePath,
+        path: apiPath,
       }),
     // Skip the network round-trip when we already have an inline snapshot
-    // pre-staged in the React Query cache — see chat-view click handler.
-    enabled: hasDocRef && !inlineSnapshot,
+    // pre-staged in the React Query cache — see chat-view click handler. Also
+    // skip for a cross key whose owner couldn't be resolved (fail closed).
+    enabled: hasDocRef && !inlineSnapshot && Boolean(fallbackAgentId),
   });
   const resolvedDocPath = inlineSnapshot?.path ?? previewQuery.data?.ref.path ?? docPath;
   const displayDocPath = inlineSnapshot?.path ?? previewQuery.data?.path ?? docPath;

--- a/packages/web/src/lib/__tests__/doc-preview-links.test.ts
+++ b/packages/web/src/lib/__tests__/doc-preview-links.test.ts
@@ -95,4 +95,45 @@ describe("linkifyMarkdownDocPaths", () => {
       "ok [docs/intro.md](docs/intro.md) but not .agent/secret.md",
     );
   });
+
+  it("expands a short cross-agent token to the global key when a chatId is given", () => {
+    // Runtime rewrote a sibling-workspace mention to `assistant/design.md` and
+    // embedded the snapshot under the global key `assistant/<chatId>/design.md`.
+    // Web re-expands the token with the current chat id and links to that key.
+    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/design.md"]), "chat-1")).toBe(
+      "see [assistant/design.md](assistant/chat-1/design.md)",
+    );
+  });
+
+  it("prefers a direct (self/legacy) bare key over the cross expansion", () => {
+    // A literal self subdir named like another agent still matches its bare key
+    // first, so self previews never get hijacked by cross expansion.
+    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/design.md"]), "chat-1")).toBe(
+      "see [assistant/design.md](assistant/design.md)",
+    );
+  });
+
+  it("does not cross-expand without a chatId (self-only matching)", () => {
+    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/design.md"]))).toBe(
+      "see assistant/design.md",
+    );
+  });
+
+  it("leaves a cross token plain when its expanded global key isn't snapshotted", () => {
+    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/other.md"]), "chat-1")).toBe(
+      "see assistant/design.md",
+    );
+  });
+
+  it("disambiguates a self/cross collision: self short token vs full cross key (P2-b)", () => {
+    // Runtime emits the FULL global key for the colliding cross mention, so the
+    // bare `assistant/design.md` token is unambiguously the SELF snapshot and
+    // the full-key token resolves to the cross snapshot — distinct targets.
+    const set = new Set(["assistant/design.md", "assistant/chat-1/design.md"]);
+    expect(
+      linkifyMarkdownDocPaths("self assistant/design.md and cross assistant/chat-1/design.md", set, "chat-1"),
+    ).toBe(
+      "self [assistant/design.md](assistant/design.md) and cross [assistant/chat-1/design.md](assistant/chat-1/design.md)",
+    );
+  });
 });

--- a/packages/web/src/lib/doc-preview-links.ts
+++ b/packages/web/src/lib/doc-preview-links.ts
@@ -1,4 +1,5 @@
 import {
+  buildWorkspaceDocKey,
   normalizeDocLinkPath,
   scanBareDocPathTokens,
   stripDocPathLineSuffix,
@@ -62,8 +63,16 @@ export function docPreviewPathFromHref(href: string, currentDocPath?: string | n
  * the user still sees the line number, but the href has no `:` before a `/`,
  * so react-markdown's `defaultUrlTransform` keeps it instead of stripping it
  * to `""` (an empty href made the anchor reload the whole page on click).
+ *
+ * Cross-agent (`chatId` provided): a snapshot of a file in ANOTHER agent's
+ * workspace is keyed globally as `<ownerSlug>/<chatId>/<rel>`, and the runtime
+ * rewrites the visible mention to the short `<ownerSlug>/<rel>` form. So when
+ * a bare canonical token isn't itself a snapshot key, we also try expanding it
+ * with the current chat id (`<firstSeg>/<chatId>/<rest>`) and link to that
+ * global key if it matches. Self/legacy bare keys still match directly and
+ * win (tried first), so self previews are unchanged.
  */
-export function linkifyMarkdownDocPaths(markdown: string, snapshotPaths: ReadonlySet<string>): string {
+export function linkifyMarkdownDocPaths(markdown: string, snapshotPaths: ReadonlySet<string>, chatId?: string): string {
   if (snapshotPaths.size === 0) return markdown;
   const matches = scanBareDocPathTokens(markdown);
   if (matches.length === 0) return markdown;
@@ -79,11 +88,31 @@ export function linkifyMarkdownDocPaths(markdown: string, snapshotPaths: Readonl
     // like `.agent/secret.md` / `../outside.md` canonicalise to null; tokens
     // with no embedded snapshot are conversational mentions, not previews.
     const canonical = normalizeDocLinkPath(stripDocPathLineSuffix(match.raw));
-    if (!canonical || !snapshotPaths.has(canonical)) continue;
+    if (!canonical) continue;
+    const target = resolveSnapshotKey(canonical, snapshotPaths, chatId);
+    if (!target) continue;
     out += markdown.slice(cursor, match.start);
-    out += `[${match.raw}](${canonical})`;
+    out += `[${match.raw}](${target})`;
     cursor = match.end;
   }
   out += markdown.slice(cursor);
   return out;
+}
+
+/**
+ * Map a canonical bare token to the snapshot key it should link to, or null if
+ * none. Self/legacy bare keys are tried first (so self previews are unchanged);
+ * otherwise, with a chat id, the token is treated as the short cross form
+ * `<ownerSlug>/<rest>` and expanded to the global `<ownerSlug>/<chatId>/<rest>`
+ * key.
+ */
+function resolveSnapshotKey(canonical: string, snapshotPaths: ReadonlySet<string>, chatId?: string): string | null {
+  if (snapshotPaths.has(canonical)) return canonical;
+  if (!chatId) return null;
+  const slash = canonical.indexOf("/");
+  if (slash <= 0) return null;
+  const ownerSlug = canonical.slice(0, slash);
+  const rest = canonical.slice(slash + 1);
+  const global = buildWorkspaceDocKey(ownerSlug, chatId, rest);
+  return global && snapshotPaths.has(global) ? global : null;
 }

--- a/packages/web/src/lib/use-agent-name-map.ts
+++ b/packages/web/src/lib/use-agent-name-map.ts
@@ -60,6 +60,50 @@ export function useAgentNameMap(): (uuid: string | null | undefined) => string {
 }
 
 /**
+ * Reverse of {@link useAgentNameMap}: resolves an agent's `name` (the @handle
+ * slug, which is also its workspace directory name) to its UUID.
+ *
+ * Used by cross-agent doc preview: a snapshot key carries the OWNER agent's
+ * slug (`<ownerSlug>/<chatId>/<rel>`), but the path-based fallback endpoint
+ * (`GET /chats/:id/docs/preview`) is keyed by agent UUID. The inline-snapshot
+ * path renders straight from cache and needs no UUID, so an unresolved slug
+ * (owner not in the loaded roster) is non-fatal — callers fall back to the
+ * message sender.
+ */
+export function useAgentSlugToIdMap(): (slug: string | null | undefined) => string | null {
+  const { data } = useQuery({
+    queryKey: ["agents", "name-map"],
+    queryFn: () => listAgents({ limit: 100 }),
+    staleTime: 30_000,
+  });
+  const { data: managed } = useQuery({
+    queryKey: ["managed-agents", "name-map"],
+    queryFn: listManagedAgents,
+    staleTime: 30_000,
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, string>();
+    // Cross-org managed agents first; org-scoped roster overwrites on collision
+    // (more authoritative for the selected tenant), matching useAgentNameMap.
+    if (managed) {
+      for (const a of managed) {
+        if (a.name) map.set(a.name.toLowerCase(), a.uuid);
+      }
+    }
+    if (data?.items) {
+      for (const a of data.items) {
+        if (a.name) map.set(a.name.toLowerCase(), a.uuid);
+      }
+    }
+    return (slug: string | null | undefined) => {
+      if (!slug) return null;
+      return map.get(slug.toLowerCase()) ?? null;
+    };
+  }, [data, managed]);
+}
+
+/**
  * Minimal identity pair surfaced to components that want to render the
  * full `<AgentChip>` (display name + `@name`) instead of a single string.
  * `displayName` is non-null post-Phase 2 of the agent-naming refactor;

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -4,6 +4,7 @@ import {
   documentContextSchema,
   extractMentions,
   type MentionParticipant,
+  parseWorkspaceDocKey,
   type QuestionAnswerMessageContent,
   type QuestionMessageContent,
   scanMentionTokens,
@@ -68,7 +69,7 @@ import {
 import { Button } from "../../../components/ui/button.js";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { docPreviewPathFromHref, linkifyMarkdownDocPaths } from "../../../lib/doc-preview-links.js";
-import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
+import { useAgentIdentityMap, useAgentNameMap, useAgentSlugToIdMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { cn } from "../../../lib/utils.js";
 import { computeRequiresMention } from "../../../utils/requires-mention.js";
@@ -278,6 +279,7 @@ function TextRow({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const slugToId = useAgentSlugToIdMap();
   const senderName = agentNameFn(msg.senderId);
   const isSelf = myAgentId === msg.senderId;
   const docBasePath = documentBasePathFromMetadata(msg.metadata);
@@ -295,8 +297,8 @@ function TextRow({
     if (typeof msg.content !== "string") return JSON.stringify(msg.content);
     if (msg.source === "web") return msg.content;
     const snapshotPaths = new Set(docSnapshots?.keys() ?? []);
-    return linkifyMarkdownDocPaths(msg.content, snapshotPaths);
-  }, [msg.format, msg.content, msg.source, docSnapshots]);
+    return linkifyMarkdownDocPaths(msg.content, snapshotPaths, msg.chatId);
+  }, [msg.format, msg.content, msg.source, msg.chatId, docSnapshots]);
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ href, children, ...props }) {
@@ -319,7 +321,21 @@ function TextRow({
           event.preventDefault();
           const next = new URLSearchParams(searchParams);
           next.set("docChat", msg.chatId);
-          next.set("docAgent", msg.senderId);
+          // Owner attribution for `docAgent`: a global cross-agent key
+          // `<ownerSlug>/<chatId>/…` (chatId segment === this chat) belongs to
+          // the OWNER, not the sender; self / legacy bare keys stay the sender.
+          // `docAgent` is only a hint here — the drawer authoritatively
+          // re-resolves the owner from the key's own slug for the path-based
+          // fallback (review P2-a), so an unresolved owner does NOT mis-query
+          // the sender's workspace; it just leaves this placeholder in the URL
+          // for `hasDocRef`. The inline snapshot path renders from cache
+          // regardless of `docAgent`.
+          const parsedKey = parseWorkspaceDocKey(docPath);
+          const ownerId =
+            parsedKey && parsedKey.chatId === msg.chatId
+              ? (slugToId(parsedKey.agentSlug) ?? msg.senderId)
+              : msg.senderId;
+          next.set("docAgent", ownerId);
           next.set("docPath", docPath);
 
           // Prefer the inline snapshot variant: hand the drawer the bytes via
@@ -356,7 +372,7 @@ function TextRow({
         );
       },
     }),
-    [docBasePath, docSnapshots, msg.chatId, msg.id, msg.senderId, queryClient, searchParams, setSearchParams],
+    [docBasePath, docSnapshots, msg.chatId, msg.id, msg.senderId, queryClient, searchParams, setSearchParams, slugToId],
   );
 
   return (


### PR DESCRIPTION
## Background / Goal

doc-preview today only renders a `.md` link when the **sender's own** runtime
snapshotted the file from **its own** workspace root. A doc written into
**another agent's** workspace (e.g. an assistant's `workspaces/<assistant>/<chatId>/…`)
referenced by a different agent was never previewable — it fell outside the
per-sender root fence (the boundary #480 explicitly excluded).

Goal: let **any agent preview a `.md` that lives in any agent's workspace in
the same chat**. This is a product-level generalization, not a one-case patch.

## Approach — register-a-root + realpath fence + relative-root global key

Stop using "which agent's directory the file happens to sit in" as a proxy for
"may this doc be previewed". Instead: a referenced path is snapshot-able when
its **realpath lands inside the shared `workspaces/` common root**, scoped to
`<owner>/<currentChatId>/…`. One fence covers every agent workspace and is
extensible — a future source (e.g. Context Tree) is just "register another
root", same realpath + containment + relative-root-key machinery.

### Confirmed decisions
1. **Topology** — same-machine shared FS (sender runtime reads sibling
   workspaces). Cross-machine left as a future degradation hook
   (owner-runtime snapshot / server relay); the framework accommodates both.
2. **Authz** — chatId structural fence **+** server re-check that the owner is
   a speaker participant of the chat.
3. **Key** — global `<agentSlug>/<chatId>/<rel>` for cross references; self
   references keep their **bare base-relative key** (zero #480 Case A
   regression). Visible cross mentions use the short `<owner>/<rel>` form
   (web re-expands with the current chat id), upgraded to the full global key
   when a short form would collide with a self key.
4. **Common root** — derived by config-ascent (`dirname(workspaceRoot)`); no
   new config surface (honours `FIRST_TREE_HUB_HOME`).

## Security model

- **realpath BEFORE containment** — an ancestor symlink cannot fake "inside
  the common root".
- **chatId-segment fence** — only `<*>/<currentChatId>/…` is in range, so one
  chat can never preview another chat's private workspace docs.
- **hidden-segment rejection** — `.agent/`, `.git/`, dotfiles rejected even
  when reached via a symlink (re-checked after realpath).
- **server owner-in-participants re-validation** (defense in depth) — a
  cross-agent global key for this chat must name a participant; a
  participant-owned key naming a *different* chat is rejected (400). Deep self
  paths whose first segment isn't a participant slug are unaffected.

## Affected packages

| Package | Change |
|---|---|
| `shared` | `buildWorkspaceDocKey` / `parseWorkspaceDocKey` — one key format runtime/web/server agree on |
| `client/runtime` | optional workspace fence in `buildMessageDocumentSnapshots`; cross-workspace resolution; collision-safe rewrite |
| `web` | chat-context-aware `linkifyMarkdownDocPaths`; drawer re-resolves owner from the key (no sender mis-query on cache miss); `useAgentSlugToIdMap` |
| `server` | cross-key provenance authz in `validateDocumentContext` |

**Backwards compatible**: self/legacy bare keys unchanged, historical messages
keep rendering, **#480 Case A preserved** (self absolute path → clean bare
relative rewrite).

Evolution: PR #356 (path preview) → #415 (inline snapshot) → #458 (bare paths)
→ #474 (base-path resolution + snapshot-gate) → #476 (drop `kind:"path"`) →
#480 (self absolute-in-root) → **this PR (cross-agent workspaces)**.

## Independent review (codex-reviewer, 2 rounds)

- **Round 1** — 1×P1 + 2×P2:
  - P1 (security): cross-chat global-key shape could bypass the chatId fence →
    fixed by tightening server provenance (participant-owned foreign-chat keys
    rejected) while keeping deep self paths.
  - P2-a: owner unresolved → fell back to sender → wrong file on cache miss →
    fixed: drawer re-resolves owner from the key, disables fallback if
    unresolved (fail closed).
  - P2-b: cross short form could collide with a self bare key → fixed: runtime
    rewrites to the full global key on collision.
- **Round 2 (re-review)** — **no blocking findings**.

## Tests

- `shared` 249 · `client` 412 · `web` 206 · `server` 1101 — all green.
- Per-package `typecheck` clean; `biome` clean on all changed files.
- New coverage: shared key build/parse; client cross-agent fence + chat-scope +
  symlink/hidden rejection + collision→full-key; web cross-expansion +
  collision disambiguation; server owner-in-participants + foreign-chat reject +
  deep-self-path allow.

> Note: the repo-wide `pnpm check` currently errors on pre-existing nested
> `.claude/worktrees/*/biome.json` configs (unrelated to this diff); targeted
> `biome check` on the changed files is clean.

A design doc was produced and reviewed before implementation (kept local,
per repo convention not to commit design docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
