### PR TITLE
fix(web): no-flash chat open + rebrand browser title to First Tree

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#040404" />
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
-    <title>First Tree Hub</title>
+    <title>First Tree</title>
     <script>
       (() => {
         const t = localStorage.getItem("theme");

--- a/packages/web/src/pages/landing/index.tsx
+++ b/packages/web/src/pages/landing/index.tsx
@@ -19,7 +19,7 @@ import { LandingNav } from "./nav.js";
 export function LandingPage() {
   useEffect(() => {
     const previous = document.title;
-    document.title = "First Tree Hub — Communication infrastructure for AI-native teams";
+    document.title = "First Tree — Agent teams run here";
     return () => {
       document.title = previous;
     };

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1131,7 +1131,7 @@ export function ChatView({
   const itemCount = items.length;
   useEffect(() => {
     if (itemCount > 0) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
     }
   }, [itemCount]);
 


### PR DESCRIPTION
## Summary
- Open-chat scroll no longer animates from top to bottom — `scrollIntoView` now uses `behavior: "instant"` so the view lands at the latest message in a single frame, eliminating the flash.
- Browser tab title rebranded from "First Tree Hub" to "First Tree" in two places:
  - default `<title>` in `index.html`
  - landing page `document.title` → `"First Tree — Agent teams run here"`

## Test plan
- [ ] Open a chat with substantial history; confirm the view lands at the bottom with no visible scroll animation.
- [ ] New incoming messages still pin the view to the latest message (now also instant — flag if smoothness is desired on new-message arrivals).
- [ ] Browser tab shows "First Tree" on app routes and "First Tree — Agent teams run here" on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)