### PR TITLE
refactor(chat): unify header + sidebar add-participant into one dropdown

### DIFF
--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -1,0 +1,260 @@
+import { useMutation } from "@tanstack/react-query";
+import { Loader2, Plus, UserPlus } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { addMeChatParticipants } from "../api/me-chats.js";
+import { Avatar as RealAvatar } from "./avatar.js";
+import {
+  ambiguousDisplayNames,
+  groupAndSortCandidates,
+  type MentionCandidate,
+  MentionLabel,
+} from "./mention-autocomplete.js";
+
+type AgentIdentityResolver = (
+  uuid: string | null | undefined,
+) => { name: string | null; displayName: string; avatarImageUrl: string | null } | null;
+
+/**
+ * Shared "add an agent to this chat" dropdown. Backs both the header
+ * quick-add icon (`variant="icon"`) and the right-sidebar inline row
+ * (`variant="inline"`). Only the trigger shell differs by variant; the
+ * dropdown list is identical across both surfaces: avatar + "mine / others"
+ * grouping with a divider.
+ *
+ * The component owns disclosure (open / click-outside / Esc), keyboard
+ * navigation, and the immediate `addMeChatParticipants` mutation. Callers
+ * pass the candidate union (members + org-discoverable, already shaped to
+ * `MentionCandidate`, self excluded) and the current `participantIds`; the
+ * already-in members are filtered out here.
+ */
+export function AddParticipantDropdown({
+  chatId,
+  candidates,
+  participantIds,
+  agentIdentity,
+  onAdded,
+  variant,
+}: {
+  chatId: string;
+  candidates: MentionCandidate[];
+  participantIds: string[];
+  agentIdentity: AgentIdentityResolver;
+  onAdded: () => void;
+  variant: "icon" | "inline";
+}) {
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  // Click-outside closes the dropdown.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (ev: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(ev.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Esc closes only this dropdown. Capture phase + stopPropagation so it
+  // fires before chat-view's bubble-phase sidebar Esc handler — without
+  // this, Esc in the header/sidebar picker would also collapse the rail.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key !== "Escape") return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      setOpen(false);
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [open]);
+
+  const addMut = useMutation({
+    mutationFn: (agentId: string) => addMeChatParticipants(chatId, { participantIds: [agentId] }),
+    onSuccess: () => {
+      setOpen(false);
+      onAdded();
+    },
+  });
+
+  const outsideCandidates = useMemo(
+    () => candidates.filter((c) => !participantIds.includes(c.agentId)),
+    [candidates, participantIds],
+  );
+  const allAdded = outsideCandidates.length === 0;
+  const disabled = allAdded || addMut.isPending;
+
+  // Unified appearance: mine-first / others grouping with a divider.
+  // `items` carries the divider marker; `selectable` is the divider-free
+  // list that keyboard navigation walks.
+  const items = useMemo(() => groupAndSortCandidates(outsideCandidates), [outsideCandidates]);
+  const selectable = useMemo(() => items.filter((it): it is MentionCandidate => !("divider" in it)), [items]);
+  const ambiguous = useMemo(() => ambiguousDisplayNames(outsideCandidates), [outsideCandidates]);
+
+  // Reset the highlight whenever the menu opens or the option set changes,
+  // and focus the menu so it receives arrow / Enter keystrokes.
+  useEffect(() => {
+    if (open) {
+      setHighlight(0);
+      menuRef.current?.focus();
+    }
+  }, [open]);
+
+  const commit = (agentId: string): void => {
+    if (addMut.isPending) return;
+    addMut.mutate(agentId);
+  };
+
+  const onMenuKeyDown = (e: React.KeyboardEvent): void => {
+    if (selectable.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((i) => (i + 1) % selectable.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((i) => (i - 1 + selectable.length) % selectable.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const picked = selectable[highlight] ?? selectable[0];
+      if (picked) commit(picked.agentId);
+    }
+    // Escape is handled by the capture-phase document listener above.
+  };
+
+  const label = addMut.isPending ? "Adding…" : allAdded ? "All added" : "Add";
+
+  return (
+    <div ref={containerRef} className="relative">
+      {variant === "icon" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          disabled={disabled}
+          title={allAdded ? "All available agents are already in this chat" : "Add participant"}
+          aria-label="Add participant"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+          style={{
+            width: 28,
+            height: 28,
+            border: 0,
+            background: "transparent",
+            borderRadius: "var(--radius-input)",
+            color: disabled ? "var(--fg-4)" : "var(--fg-3)",
+            cursor: disabled ? "not-allowed" : "pointer",
+          }}
+        >
+          <UserPlus size={16} />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          disabled={disabled}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          className="flex w-full items-center transition-colors hover:bg-[var(--bg-hover)]"
+          style={{
+            gap: "var(--sp-2_5)",
+            padding: "var(--sp-1_75) var(--sp-2)",
+            borderRadius: "var(--radius-input)",
+            border: 0,
+            background: "transparent",
+            color: disabled ? "var(--fg-4)" : "var(--fg-3)",
+            cursor: disabled ? "not-allowed" : "pointer",
+            opacity: allAdded ? 0.55 : 1,
+          }}
+        >
+          {/* Dashed-circle avatar stand-in — keeps the row left edge aligned
+              with the avatars on the participant rows above. */}
+          <span
+            aria-hidden="true"
+            className="flex shrink-0 items-center justify-center"
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 999,
+              border: "var(--hairline) dashed var(--border)",
+              color: "inherit",
+            }}
+          >
+            {addMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+          </span>
+          <span className="text-body">{label}</span>
+        </button>
+      )}
+
+      {open && !allAdded && (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Add participant"
+          tabIndex={-1}
+          onKeyDown={onMenuKeyDown}
+          className="absolute z-20 max-h-72 overflow-auto border shadow-lg outline-none"
+          style={{
+            top: "calc(100% + var(--sp-1))",
+            // Icon trigger sits at the panel's right edge → grow leftward;
+            // the inline row spans the rail → match its full width.
+            ...(variant === "icon" ? { right: 0, minWidth: 280 } : { left: 0, right: 0 }),
+            background: "var(--bg-raised)",
+            borderColor: "var(--border)",
+            borderRadius: "var(--radius-input)",
+          }}
+        >
+          {(() => {
+            let idx = -1;
+            return items.map((it) => {
+              if ("divider" in it) {
+                return (
+                  <div
+                    key="__divider"
+                    role="presentation"
+                    style={{
+                      height: "var(--hairline)",
+                      background: "var(--border-faint)",
+                      margin: "var(--sp-0_5) var(--sp-3)",
+                    }}
+                  />
+                );
+              }
+              idx += 1;
+              const myIdx = idx;
+              const active = myIdx === highlight;
+              const ident = agentIdentity(it.agentId);
+              const fallback = it.displayName ?? it.name ?? it.agentId.slice(0, 8);
+              return (
+                <button
+                  key={it.agentId}
+                  type="button"
+                  role="menuitem"
+                  title={it.name ? `@${it.name}` : undefined}
+                  onClick={() => commit(it.agentId)}
+                  onMouseEnter={() => setHighlight(myIdx)}
+                  disabled={addMut.isPending}
+                  className="flex w-full items-center text-left transition-colors"
+                  style={{
+                    gap: "var(--sp-2_5)",
+                    padding: "var(--sp-1_75) var(--sp-2)",
+                    border: 0,
+                    background: active ? "var(--bg-hover)" : "transparent",
+                    cursor: addMut.isPending ? "default" : "pointer",
+                  }}
+                >
+                  <RealAvatar src={ident?.avatarImageUrl ?? null} name={fallback} seed={it.agentId} size={28} />
+                  <MentionLabel candidate={it} ambiguous={ambiguous} />
+                </button>
+              );
+            });
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -10,18 +10,7 @@ import {
   scanMentionTokens,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  ArrowUp,
-  AtSign,
-  Check,
-  ExternalLink,
-  Eye,
-  MessageSquare,
-  MoreHorizontal,
-  Paperclip,
-  UserPlus,
-  X,
-} from "lucide-react";
+import { ArrowUp, AtSign, Check, ExternalLink, Eye, MessageSquare, MoreHorizontal, Paperclip, X } from "lucide-react";
 import { type MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
@@ -39,7 +28,6 @@ import {
   sendFileMessage,
 } from "../../../api/chats.js";
 import { getImage, putImage } from "../../../api/image-store.js";
-import { addMeChatParticipants } from "../../../api/me-chats.js";
 import {
   agentSessionsQueryKey,
   asAssistantTextPayload,
@@ -50,6 +38,7 @@ import {
   type SessionListItem,
 } from "../../../api/sessions.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import {
   isQuestionAnswerContent,
@@ -59,11 +48,8 @@ import {
 } from "../../../components/chat/question-message.js";
 import { WorkingBubble } from "../../../components/chat/working-bubble.js";
 import {
-  ambiguousDisplayNames,
-  groupAndSortCandidates,
   MentionAutocompletePopover,
   type MentionCandidate,
-  MentionLabel,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { Button } from "../../../components/ui/button.js";
@@ -840,7 +826,7 @@ export function ChatView({
     refetchInterval: 5_000,
   });
 
-  const { data: chatDetail } = useQuery({
+  const { data: chatDetail, isLoading: chatDetailLoading } = useQuery({
     queryKey: ["chat-detail", chatId],
     queryFn: () => getChat(chatId),
     enabled: !!chatId,
@@ -1549,7 +1535,8 @@ export function ChatView({
                 }}
               />
               {readOnly ? null : (
-                <AddParticipantQuickButton
+                <AddParticipantDropdown
+                  variant="icon"
                   chatId={chatId}
                   participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
                   candidates={addableCandidates}
@@ -2057,6 +2044,9 @@ export function ChatView({
         {showSidebar ? (
           <ChatRightSidebar
             chatId={chatId}
+            participants={chatDetail?.participants ?? []}
+            participantsLoading={chatDetailLoading}
+            managedByMe={managedByMeMap}
             addParticipantsCandidates={addableCandidates}
             agentIdentity={chatScopedAgentIdentity}
             onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
@@ -2257,154 +2247,4 @@ function participantDotView(state: string): { bg: string; border: string } | nul
     default:
       return null;
   }
-}
-
-/**
- * Header-anchored quick-add icon — same backend mutation and same
- * grouped picker as the sidebar's inline "+ Add participant" button.
- * Both surfaces share the V1 one-way-door notice so users see the
- * irreversibility before they commit (membership is non-revocable
- * until the deferred remove flow lands).
- */
-function AddParticipantQuickButton({
-  chatId,
-  participantIds,
-  candidates,
-  agentIdentity: _agentIdentity,
-  onAdded,
-}: {
-  chatId: string;
-  participantIds: string[];
-  candidates: MentionCandidate[];
-  /** Identity resolver covering ALL agents (incl. the viewer's own,
-   *  which `mentionCandidates` excludes). Lets the chip row label
-   *  self correctly instead of falling back to a UUID prefix. The
-   *  `avatarImageUrl` and `avatarColorToken` fields are threaded into
-   *  the chip's leading avatar so a manager-configured image / hue
-   *  shows up here as well as on the left-rail row. */
-  agentIdentity: (uuid: string | null | undefined) => {
-    name: string | null;
-    displayName: string;
-    avatarImageUrl: string | null;
-    avatarColorToken: string | null;
-  } | null;
-  onAdded: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (ev: MouseEvent) => {
-      if (!containerRef.current) return;
-      if (containerRef.current.contains(ev.target as Node)) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
-  const addMut = useMutation({
-    mutationFn: (agentId: string) => addMeChatParticipants(chatId, { participantIds: [agentId] }),
-    onSuccess: () => {
-      setOpen(false);
-      onAdded();
-    },
-  });
-
-  const outsideCandidates = useMemo(
-    () => candidates.filter((c) => !participantIds.includes(c.agentId)),
-    [candidates, participantIds],
-  );
-  const disabled = outsideCandidates.length === 0 || addMut.isPending;
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        disabled={disabled}
-        title={outsideCandidates.length === 0 ? "All available agents are already in this chat" : "Add participant"}
-        aria-label="Add participant"
-        className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-        style={{
-          width: 28,
-          height: 28,
-          border: 0,
-          background: "transparent",
-          borderRadius: "var(--radius-input)",
-          color: disabled ? "var(--fg-4)" : "var(--fg-3)",
-          cursor: disabled ? "not-allowed" : "pointer",
-        }}
-      >
-        <UserPlus size={16} />
-      </button>
-      {open && outsideCandidates.length > 0 && (
-        <div
-          role="menu"
-          aria-label="Add participant"
-          onKeyDown={(e) => {
-            // Escape closes this menu first; without stopPropagation
-            // it bubbles to chat-view's document-level Esc handler and
-            // collapses the whole rail at the same time.
-            if (e.key === "Escape") {
-              e.preventDefault();
-              e.stopPropagation();
-              setOpen(false);
-            }
-          }}
-          className="absolute z-20 max-h-72 overflow-auto rounded-md border shadow-lg"
-          // Right-anchored so the dropdown grows leftward from the icon,
-          // matching the legacy chip-row position and keeping the long
-          // grouped picker (mine vs teammates) off the panel edge.
-          style={{
-            top: "calc(100% + var(--sp-1))",
-            right: 0,
-            minWidth: 280,
-            background: "var(--bg-raised)",
-            borderColor: "var(--border)",
-          }}
-        >
-          {(() => {
-            const ambiguous = ambiguousDisplayNames(outsideCandidates);
-            return groupAndSortCandidates(outsideCandidates).map((item) => {
-              if ("divider" in item) {
-                return (
-                  <div
-                    key="__divider"
-                    role="presentation"
-                    style={{
-                      height: "var(--hairline)",
-                      background: "var(--border-faint)",
-                      margin: "var(--sp-0_5) var(--sp-3)",
-                    }}
-                  />
-                );
-              }
-              return (
-                <button
-                  key={item.agentId}
-                  type="button"
-                  role="menuitem"
-                  title={item.name ? `@${item.name}` : undefined}
-                  onClick={() => addMut.mutate(item.agentId)}
-                  disabled={addMut.isPending}
-                  className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
-                  style={{
-                    background: "transparent",
-                    color: "var(--fg)",
-                    border: "none",
-                    cursor: "pointer",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  <MentionLabel candidate={item} ambiguous={ambiguous} />
-                </button>
-              );
-            });
-          })()}
-        </div>
-      )}
-    </div>
-  );
 }

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -1,3 +1,4 @@
+import type { ChatParticipantDetail } from "@agent-team-foundation/first-tree-hub-shared";
 import { X } from "lucide-react";
 import type { MentionCandidate } from "../../../components/mention-autocomplete.js";
 import { GitHubSection } from "./github-section.js";
@@ -24,6 +25,9 @@ import { ParticipantsSection } from "./participants-section.js";
  */
 export function ChatRightSidebar({
   chatId,
+  participants,
+  participantsLoading,
+  managedByMe,
   addParticipantsCandidates,
   agentIdentity,
   onAdded,
@@ -31,6 +35,9 @@ export function ChatRightSidebar({
   readOnly,
 }: {
   chatId: string;
+  participants: ChatParticipantDetail[];
+  participantsLoading: boolean;
+  managedByMe: Map<string, boolean>;
   addParticipantsCandidates: MentionCandidate[];
   agentIdentity: (uuid: string | null | undefined) => {
     name: string | null;
@@ -81,6 +88,9 @@ export function ChatRightSidebar({
       <div className="flex-1 overflow-y-auto">
         <ParticipantsSection
           chatId={chatId}
+          participants={participants}
+          participantsLoading={participantsLoading}
+          managedByMe={managedByMe}
           addParticipantsCandidates={addParticipantsCandidates}
           agentIdentity={agentIdentity}
           onAdded={onAdded}

--- a/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
@@ -1,17 +1,9 @@
 import type { ChatParticipantDetail } from "@agent-team-foundation/first-tree-hub-shared";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { Loader2, Plus } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { getActivityOverview } from "../../../api/activity.js";
-import { getChat } from "../../../api/chats.js";
-import { addMeChatParticipants } from "../../../api/me-chats.js";
+import { useMemo } from "react";
 import { useAuth } from "../../../auth/auth-context.js";
+import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
-import {
-  ambiguousDisplayNames,
-  type MentionCandidate,
-  MentionLabel,
-} from "../../../components/mention-autocomplete.js";
+import type { MentionCandidate } from "../../../components/mention-autocomplete.js";
 import { AgentRow } from "./agent-row.js";
 
 /**
@@ -21,21 +13,28 @@ import { AgentRow } from "./agent-row.js";
  * Remove / Change role are deferred to a future iteration alongside the
  * missing backend routes for member-side participant removal).
  *
- * The bottom "Add" affordance mirrors the header quick-add icon —
- * both go through the same `addMeChatParticipants` mutation.
- * Membership is currently non-revocable, but neither surface shows an
- * inline notice — the banner read as noise once users were already
- * in the picker, and the irreversibility lives in product docs / FAQs
- * instead.
+ * The bottom "Add" affordance shares <AddParticipantDropdown> with the
+ * header quick-add icon — both go through the same `addMeChatParticipants`
+ * mutation and the same grouped, avatar'd picker.
+ *
+ * Membership data (`participants` / `managedByMe`) is passed down from
+ * ChatView, which already holds the `chat-detail` + `activity` queries —
+ * this section no longer re-declares them.
  */
 export function ParticipantsSection({
   chatId,
+  participants,
+  participantsLoading,
+  managedByMe,
   addParticipantsCandidates,
   agentIdentity,
   onAdded,
   readOnly,
 }: {
   chatId: string;
+  participants: ChatParticipantDetail[];
+  participantsLoading: boolean;
+  managedByMe: Map<string, boolean>;
   addParticipantsCandidates: MentionCandidate[];
   agentIdentity: (
     uuid: string | null | undefined,
@@ -44,24 +43,7 @@ export function ParticipantsSection({
   readOnly: boolean;
 }) {
   const { role } = useAuth();
-  const chatQuery = useQuery({
-    queryKey: ["chat-detail", chatId],
-    queryFn: () => getChat(chatId),
-    enabled: !!chatId,
-  });
-  const activityQuery = useQuery({
-    queryKey: ["activity"],
-    queryFn: getActivityOverview,
-    refetchInterval: 15_000,
-  });
 
-  const managedByMe = useMemo(() => {
-    const m = new Map<string, boolean>();
-    for (const a of activityQuery.data?.agents ?? []) m.set(a.agentId, a.managedByMe);
-    return m;
-  }, [activityQuery.data?.agents]);
-
-  const participants = chatQuery.data?.participants ?? [];
   // Humans first (the people in the room), then agents (the tools and
   // teammates). Within each group, server order is preserved.
   const sorted = useMemo(() => {
@@ -82,7 +64,7 @@ export function ParticipantsSection({
       </div>
 
       <div className="flex flex-col" style={{ padding: "0 var(--sp-2) var(--sp-1)", gap: 2 }}>
-        {chatQuery.isLoading ? (
+        {participantsLoading ? (
           <div className="text-body" style={{ padding: "var(--sp-2)", color: "var(--fg-3)" }}>
             Loading…
           </div>
@@ -108,7 +90,8 @@ export function ParticipantsSection({
 
       {readOnly ? null : (
         <div style={{ padding: "var(--sp-1) var(--sp-2) var(--sp-2)" }}>
-          <AddParticipantInlineButton
+          <AddParticipantDropdown
+            variant="inline"
             chatId={chatId}
             candidates={addParticipantsCandidates}
             participantIds={participants.map((p) => p.agentId)}
@@ -141,167 +124,6 @@ function HumanRow({ participant }: { participant: ChatParticipantDetail }) {
       <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 2 }}>
         <div className="truncate text-subtitle">{participant.displayName}</div>
       </div>
-    </div>
-  );
-}
-
-/**
- * Inline "Add" row at the bottom of the Participants section. Visually
- * folds into the participant list — same row padding and an avatar-sized
- * dashed-circle stand-in (so the left edge lines up with HumanRow /
- * AgentRow) so the eye reads it as the list's next row, not a separate
- * button.
- *
- * States:
- *   - default:  "Add"        (clickable, opens the picker dropdown)
- *   - pending:  "Adding…"    (spinner in the slot, disabled)
- *   - all in:   "All added"  (disabled, dimmed, no dropdown)
- *
- * Shares `addMeChatParticipants` with the header quick-add icon.
- */
-function AddParticipantInlineButton({
-  chatId,
-  candidates,
-  participantIds,
-  agentIdentity,
-  onAdded,
-}: {
-  chatId: string;
-  candidates: MentionCandidate[];
-  participantIds: string[];
-  agentIdentity: (
-    uuid: string | null | undefined,
-  ) => { name: string | null; displayName: string; avatarImageUrl: string | null } | null;
-  onAdded: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (!open) return;
-    const handler = (ev: MouseEvent) => {
-      if (!containerRef.current) return;
-      if (containerRef.current.contains(ev.target as Node)) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-  // Esc must close the dropdown without leaking to chat-view's
-  // sidebar-level Esc handler. The trigger button keeps focus while the
-  // menu is open, so a React-level handler scoped to the menu div never
-  // sees the keystroke. Attaching to `document` in capture phase fires
-  // before chat-view's bubble-phase listener, so stopPropagation here
-  // peels off only the dropdown and leaves a closed dropdown's Esc free
-  // to bubble and collapse the sidebar as before.
-  useEffect(() => {
-    if (!open) return;
-    const handler = (ev: KeyboardEvent) => {
-      if (ev.key !== "Escape") return;
-      ev.preventDefault();
-      ev.stopPropagation();
-      setOpen(false);
-    };
-    document.addEventListener("keydown", handler, true);
-    return () => document.removeEventListener("keydown", handler, true);
-  }, [open]);
-
-  const addMut = useMutation({
-    mutationFn: (agentId: string) => addMeChatParticipants(chatId, { participantIds: [agentId] }),
-    onSuccess: () => {
-      setOpen(false);
-      onAdded();
-    },
-  });
-
-  const outsideCandidates = useMemo(
-    () => candidates.filter((c) => !participantIds.includes(c.agentId)),
-    [candidates, participantIds],
-  );
-  const allAdded = outsideCandidates.length === 0;
-  const disabled = allAdded || addMut.isPending;
-  const label = addMut.isPending ? "Adding…" : allAdded ? "All added" : "Add";
-
-  return (
-    <div ref={containerRef} style={{ position: "relative" }}>
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        disabled={disabled}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="flex w-full items-center transition-colors hover:bg-[var(--bg-hover)]"
-        style={{
-          gap: "var(--sp-2_5)",
-          padding: "var(--sp-1_75) var(--sp-2)",
-          borderRadius: "var(--radius-input)",
-          border: 0,
-          background: "transparent",
-          color: disabled ? "var(--fg-4)" : "var(--fg-3)",
-          cursor: disabled ? "not-allowed" : "pointer",
-          opacity: allAdded ? 0.55 : 1,
-        }}
-      >
-        {/* Dashed-circle avatar stand-in — keeps the row left edge
-            aligned with the avatars on participant rows above. */}
-        <span
-          aria-hidden="true"
-          className="flex shrink-0 items-center justify-center"
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 999,
-            border: "var(--hairline) dashed var(--border)",
-            color: "inherit",
-          }}
-        >
-          {addMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
-        </span>
-        <span className="text-body">{label}</span>
-      </button>
-      {open && !allAdded && (
-        <div
-          role="menu"
-          aria-label="Add participant"
-          className="absolute z-20 max-h-72 overflow-auto border shadow-lg"
-          style={{
-            top: "calc(100% + var(--sp-1))",
-            left: 0,
-            right: 0,
-            background: "var(--bg-raised)",
-            borderColor: "var(--border)",
-            borderRadius: "var(--radius-input)",
-          }}
-        >
-          {(() => {
-            const ambiguous = ambiguousDisplayNames(outsideCandidates);
-            return outsideCandidates.map((cand) => {
-              const ident = agentIdentity(cand.agentId);
-              const avatarUrl = ident?.avatarImageUrl ?? null;
-              const fallback = cand.displayName ?? cand.name ?? cand.agentId.slice(0, 8);
-              return (
-                <button
-                  key={cand.agentId}
-                  type="button"
-                  role="menuitem"
-                  onClick={() => addMut.mutate(cand.agentId)}
-                  disabled={addMut.isPending}
-                  className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
-                  style={{
-                    gap: "var(--sp-2_5)",
-                    padding: "var(--sp-1_75) var(--sp-2)",
-                    border: 0,
-                    background: "transparent",
-                    cursor: addMut.isPending ? "default" : "pointer",
-                  }}
-                >
-                  <RealAvatar src={avatarUrl} name={fallback} seed={cand.agentId} size={28} />
-                  <MentionLabel candidate={cand} ambiguous={ambiguous} />
-                </button>
-              );
-            });
-          })()}
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Unifies the two "add an agent to this chat" entry points into a single shared component.

- **New** `<AddParticipantDropdown variant="icon" | "inline">` (`packages/web/src/components/add-participant-dropdown.tsx`) backs both:
  - the chat **header** quick-add icon (`variant="icon"`), and
  - the right-**sidebar** inline "Add" row (`variant="inline"`, three-state Add / Adding… / All added).
- The `variant` prop swaps **only the trigger shell**. The candidate dropdown is now **identical across both surfaces**: avatar + "mine / others" grouping with a divider. (The header dropdown previously had no avatars — it now matches the sidebar.)
- The component owns disclosure (open / click-outside / Esc, capture-phase + `stopPropagation` so Esc closes only the dropdown and never collapses the rail), **keyboard navigation** (arrows / Enter, skipping the divider), and the immediate `addMeChatParticipants` mutation.

## Also

- **Drops the duplicate `chat-detail` + `activity` queries** the participants section was re-declaring. Membership data (`participants` / `participantsLoading` / `managedByMe`) is now passed down from `ChatView`, which already holds those queries.
- Removes the now-obsolete `AddParticipantQuickButton` (chat-view) and `AddParticipantInlineButton` (participants-section).

## Out of scope

- The **new-chat `ParticipantChips`** is intentionally **untouched** — its deferred-commit chip model (`createMeChat` on send) and `@`-mention ↔ chip linkage are conversation-creation semantics that don't belong in the immediate-add dropdown.

## Behavior preserved

Sidebar three-state + "All added" disabled; add → member list refreshes (`onAdded` → invalidate `chat-detail`); header grouping + divider; Esc scoping (dropdown only, not the rail).

## Verification

- `pnpm --filter @first-tree-hub/web typecheck` ✅ (incl. design-token guardrails)
- `biome check` on the changed files ✅
- `pnpm --filter @first-tree-hub/web test` ✅ 206/206
- **User-verified locally** (header / sidebar dropdowns identical: avatar + grouping + divider; keyboard nav; immediate refresh; three-state; Esc scoping).

Net: +297 / −365 across 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)