### PR TITLE
fix(context-tree): gate Context feed chat links by access + center cold-load state

### DIFF
--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -1,7 +1,10 @@
 import { and, eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import * as sessionEventService from "../services/session-event.js";
@@ -277,6 +280,9 @@ describe("sessionEventService", () => {
       expect(event.chatId).toBe(c);
       expect(event.chatTitle).toBe("design-spike");
       expect(typeof event.createdAt).toBe("string");
+      // Fail-closed: no viewer supplied → no clickable deep link, even though
+      // the chat label stays visible org-wide.
+      expect(event.viewerCanAccess).toBe(false);
     }
     expect(new Date(summary.recentEvents[0]?.createdAt ?? 0).getTime()).toBeGreaterThanOrEqual(
       new Date(summary.recentEvents[1]?.createdAt ?? 0).getTime(),
@@ -396,4 +402,112 @@ describe("sessionEventService", () => {
     expect(summary.recentEvents).toHaveLength(1);
     expect(summary.recentEvents[0]?.nodePath).toBeNull();
   });
+
+  it("marks viewerCanAccess true when the caller's human agent is a direct member (watcher) of the chat", async () => {
+    const app = getApp();
+    const { agent, memberId, organizationId } = await createTestAgent(app);
+    const humanAgentId = await humanAgentIdFor(app, memberId);
+    const c = chatId();
+    await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "design" });
+    // A watcher row is enough — requireChatAccess's direct branch grants
+    // access to speakers AND watchers, and the feed mirrors that.
+    await app.db.insert(chatMembership).values({ chatId: c, agentId: humanAgentId, accessMode: "watcher" });
+    await sessionEventService.appendEvent(app.db, agent.uuid, c, {
+      kind: "context_tree_usage",
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
+    });
+
+    const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3, {
+      humanAgentId,
+      memberId,
+    });
+    expect(summary.recentEvents[0]?.viewerCanAccess).toBe(true);
+  });
+
+  it("marks viewerCanAccess true when the caller manages an agent that speaks in the chat", async () => {
+    const app = getApp();
+    const { agent, memberId, organizationId } = await createTestAgent(app);
+    const humanAgentId = await humanAgentIdFor(app, memberId);
+    const c = chatId();
+    await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "design" });
+    // No direct membership for the caller's human agent — access must come
+    // from the supervised-speaker branch: the emitter agent is a speaker and
+    // is managed by the caller (createTestAgent pins managerId = memberId).
+    await app.db.insert(chatMembership).values({ chatId: c, agentId: agent.uuid, accessMode: "speaker" });
+    await sessionEventService.appendEvent(app.db, agent.uuid, c, {
+      kind: "context_tree_usage",
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
+    });
+
+    const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3, {
+      humanAgentId,
+      memberId,
+    });
+    expect(summary.recentEvents[0]?.viewerCanAccess).toBe(true);
+  });
+
+  it("marks viewerCanAccess false when the caller is neither a member nor manages a speaker (label still shown)", async () => {
+    const app = getApp();
+    const viewerCtx = await createTestAgent(app);
+    // A second member in the same org whose agent is the chat's only speaker.
+    const otherCtx = await createTestAgent(app);
+    const humanAgentId = await humanAgentIdFor(app, viewerCtx.memberId);
+    const organizationId = viewerCtx.organizationId;
+    const c = chatId();
+    await app.db.insert(chats).values({ id: c, organizationId, type: "direct", topic: "private" });
+    // The speaker is managed by a *different* member — the supervised branch
+    // must not grant the caller access.
+    await app.db.insert(chatMembership).values({ chatId: c, agentId: otherCtx.agent.uuid, accessMode: "speaker" });
+    await sessionEventService.appendEvent(app.db, viewerCtx.agent.uuid, c, {
+      kind: "context_tree_usage",
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
+    });
+
+    const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3, {
+      humanAgentId,
+      memberId: viewerCtx.memberId,
+    });
+    const event = summary.recentEvents.find((e) => e.chatId === c);
+    expect(event?.viewerCanAccess).toBe(false);
+    // Org-wide transparency is unchanged: the label/id stay visible.
+    expect(event?.chatId).toBe(c);
+    expect(event?.chatTitle).toBe("private");
+  });
+
+  it("marks viewerCanAccess false for a cross-org chat even when a viewer is supplied", async () => {
+    const app = getApp();
+    const { agent, memberId, organizationId } = await createTestAgent(app);
+    const humanAgentId = await humanAgentIdFor(app, memberId);
+
+    const orgB = uuidv7();
+    await app.db.insert(organizations).values({
+      id: orgB,
+      name: `org-b-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Org B",
+    });
+    const crossOrgChatId = chatId();
+    await app.db.insert(chats).values({ id: crossOrgChatId, organizationId: orgB, type: "direct", topic: "leaked" });
+    await sessionEventService.appendEvent(app.db, agent.uuid, crossOrgChatId, {
+      kind: "context_tree_usage",
+      payload: { purpose: "design_decision", treeRepoUrl: null, nodePath: "NODE.md" },
+    });
+
+    const summary = await sessionEventService.summarizeContextTreeUsage(app.db, organizationId, 3, {
+      humanAgentId,
+      memberId,
+    });
+    expect(summary.recentEvents[0]?.chatId).toBeNull();
+    expect(summary.recentEvents[0]?.viewerCanAccess).toBe(false);
+  });
 });
+
+/** Resolve the human agent uuid for a member row (the chat_membership anchor). */
+async function humanAgentIdFor(app: FastifyInstance, memberId: string): Promise<string> {
+  const [row] = await app.db
+    .select({ agentId: members.agentId })
+    .from(members)
+    .where(eq(members.id, memberId))
+    .limit(1);
+  if (!row) throw new Error("member row missing");
+  return row.agentId;
+}

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -1,6 +1,7 @@
 import { contextTreeSnapshotSchema } from "@agent-team-foundation/first-tree-hub-shared";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
+import { resolveOrgViewer } from "../scope/require-resource.js";
 import { requireUser } from "../scope/require-user.js";
 import {
   type ContextTreeBinding,
@@ -49,8 +50,9 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
       const window = query.window ?? "7d";
       const rawSnapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
       const snapshot = mintResult ? decorateSnapshotWithMintGuidance(rawSnapshot, binding, mintResult) : rawSnapshot;
+      const viewer = orgId ? await resolveOrgViewer(app.db, userId, orgId) : null;
       const usage = orgId
-        ? await summarizeContextTreeUsage(app.db, orgId, contextTreeSnapshotWindowDays(window))
+        ? await summarizeContextTreeUsage(app.db, orgId, contextTreeSnapshotWindowDays(window), viewer ?? undefined)
         : snapshot.usage;
       return contextTreeSnapshotSchema.parse({ ...snapshot, usage });
     },

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -53,6 +53,7 @@ export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promis
         app.db,
         scope.organizationId,
         contextTreeSnapshotWindowDays(window),
+        { humanAgentId: scope.humanAgentId, memberId: scope.memberId },
       );
       return contextTreeSnapshotSchema.parse({ ...snapshot, usage });
     },

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -60,6 +60,27 @@ async function resolveCallerInOrg(
 }
 
 /**
+ * Resolve the caller's active membership in `orgId` without throwing —
+ * returns `null` when the caller is not an active member. Use for surfaces
+ * that should degrade gracefully (e.g. computing per-event chat access for
+ * the org-wide Context usage feed) rather than 404, where the throwing
+ * `resolveCallerInOrg` would be wrong.
+ */
+export async function resolveOrgViewer(
+  db: Database,
+  userId: string,
+  orgId: string,
+): Promise<{ memberId: string; humanAgentId: string } | null> {
+  const [row] = await db
+    .select({ id: members.id, role: members.role, agentId: members.agentId })
+    .from(members)
+    .where(and(eq(members.userId, userId), eq(members.organizationId, orgId), eq(members.status, "active")))
+    .limit(1);
+  if (!row || (row.role !== "admin" && row.role !== "member")) return null;
+  return { memberId: row.id, humanAgentId: row.agentId };
+}
+
+/**
  * Gate access to a single agent. `kind = "visible"` checks read-style
  * visibility (org-visible OR managed by caller). `kind = "manage"` adds
  * "or caller is admin in agent's org".

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -5,9 +5,10 @@ import type {
   SessionEventKind,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { sessionEventSchema } from "@agent-team-foundation/first-tree-hub-shared";
-import { and, asc, desc, eq, gt, gte, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import { createLogger } from "../observability/index.js";
@@ -182,6 +183,58 @@ function nodePathFromPayload(payload: unknown): string | null {
 }
 
 /**
+ * The caller's identity within the org whose usage feed is being read.
+ * Used to decide, per event, whether the caller may actually open the chat
+ * (`viewerCanAccess`). Both fields are scoped to the same org as the feed,
+ * so they mirror the values `requireChatAccess` would resolve for the chat.
+ */
+export type ContextTreeUsageViewer = {
+  /** The caller's HUMAN agent in this org (the chat_membership anchor). */
+  humanAgentId: string;
+  /** The caller's `members.id` in this org (the manage-a-speaker anchor). */
+  memberId: string;
+};
+
+/**
+ * Of `chatIds` (all in the viewer's org), the subset the viewer may open.
+ * Mirrors `requireChatAccess` exactly: a chat is accessible if the caller's
+ * human agent has any `chat_membership` row (speaker OR watcher), or the
+ * caller manages an agent that is a `speaker` in the chat. Two batched
+ * queries bounded by `chatIds` — no per-event N+1.
+ */
+async function accessibleChatIdSet(
+  db: Database,
+  viewer: ContextTreeUsageViewer,
+  chatIds: string[],
+): Promise<Set<string>> {
+  const accessible = new Set<string>();
+  if (chatIds.length === 0) return accessible;
+
+  // Direct membership — caller's human agent is a speaker or watcher.
+  const directRows = await db
+    .select({ chatId: chatMembership.chatId })
+    .from(chatMembership)
+    .where(and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.agentId, viewer.humanAgentId)));
+  for (const row of directRows) accessible.add(row.chatId);
+
+  // Supervised speaker — caller manages an agent that speaks in the chat.
+  const supervisedRows = await db
+    .select({ chatId: chatMembership.chatId })
+    .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+    .where(
+      and(
+        inArray(chatMembership.chatId, chatIds),
+        eq(chatMembership.accessMode, "speaker"),
+        eq(agents.managerId, viewer.memberId),
+      ),
+    );
+  for (const row of supervisedRows) accessible.add(row.chatId);
+
+  return accessible;
+}
+
+/**
  * Org-wide aggregate counts + the most recent context-tree usage events
  * for the org. The Context Tab is an org-wide transparency surface — any
  * member can see who has been using the tree, including the chat topic
@@ -195,11 +248,18 @@ function nodePathFromPayload(payload: unknown): string | null {
  * `organization_id = $org` predicate so the planner cannot accidentally
  * surface a foreign org's topic; the resulting `joinedChatId` is the
  * authoritative signal for "this chat lives in this org".
+ *
+ * `viewerCanAccess` is layered on top: the topic/id stay org-wide visible,
+ * but only a `viewer` who passes `requireChatAccess`'s membership rule for a
+ * given chat gets `viewerCanAccess: true` (the web feed turns that into a
+ * clickable deep link; everyone else sees inert text). Fail-closed: when no
+ * `viewer` is supplied every event is `viewerCanAccess: false`.
  */
 export async function summarizeContextTreeUsage(
   db: Database,
   organizationId: string,
   windowDays: number,
+  viewer?: ContextTreeUsageViewer,
 ): Promise<ContextTreeUsageSummary> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const [aggregate] = await db
@@ -246,6 +306,12 @@ export async function summarizeContextTreeUsage(
     .orderBy(desc(sessionEvents.createdAt))
     .limit(CONTEXT_TREE_USAGE_FEED_LIMIT);
 
+  // Resolve which in-org chats the caller may actually open, in one batch up
+  // front so the per-event map stays O(1). Cross-org events are excluded here
+  // because their chatId is masked away anyway.
+  const inOrgChatIds = [...new Set(recentRows.filter((row) => row.joinedChatId !== null).map((row) => row.rawChatId))];
+  const accessibleChatIds = viewer ? await accessibleChatIdSet(db, viewer, inOrgChatIds) : new Set<string>();
+
   const recentEvents: ContextTreeUsageEvent[] = recentRows.map((row) => {
     const sameOrgChat = row.joinedChatId !== null;
     return {
@@ -262,6 +328,10 @@ export async function summarizeContextTreeUsage(
       // Surface which node the agent read straight from the stored payload.
       // No node-frequency aggregation here — that's P1.
       nodePath: nodePathFromPayload(row.payload),
+      // Org-wide we expose the chat label, but only a viewer who passes the
+      // chat's membership rule gets a clickable link. Cross-org rows have no
+      // chatId, so they can never be accessible.
+      viewerCanAccess: sameOrgChat && accessibleChatIds.has(row.rawChatId),
       createdAt: row.createdAt.toISOString(),
     };
   });

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -149,6 +149,14 @@ export const contextTreeUsageEventSchema = z.object({
   // (recorded before per-read node tracking) or reads that could not be
   // resolved to a node path.
   nodePath: z.string().nullable(),
+  // Whether the caller may actually open this chat — true iff they satisfy
+  // the same membership rule as `requireChatAccess` (their human agent has a
+  // chat_membership row, i.e. speaker OR watcher, OR they manage a speaker in
+  // the chat). The feed shares chatId/chatTitle org-wide for transparency, but
+  // only a viewer who can access the chat should get a clickable deep link;
+  // others render it as inert text. Always false for cross-org events (where
+  // chatId is masked to null) and computed fresh per request (never stored).
+  viewerCanAccess: z.boolean(),
   createdAt: z.string(),
 });
 export type ContextTreeUsageEvent = z.infer<typeof contextTreeUsageEventSchema>;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1084,6 +1084,20 @@
   text-decoration: underline;
 }
 
+/*
+ * Inert variant for chats the viewer cannot open (non-member). Keeps the
+ * label's color/sizing/truncation but drops the link affordance — no pointer
+ * cursor, no hover underline. The `title` attribute carries the explanation.
+ */
+.context-usage-feed-chat.is-static {
+  cursor: default;
+}
+
+.context-usage-feed-chat.is-static:hover {
+  color: var(--fg-2);
+  text-decoration: none;
+}
+
 .context-usage-feed-time {
   color: var(--fg-3);
   font-variant-numeric: tabular-nums;

--- a/packages/web/src/pages/context-preview-mock.ts
+++ b/packages/web/src/pages/context-preview-mock.ts
@@ -77,6 +77,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         chatId: "chat-design-spike",
         chatTitle: "design-spike",
         nodePath: "members/Gandy2025/designs/context-tree-usage-signal.md",
+        viewerCanAccess: true,
         createdAt: new Date(Date.now() - 2 * 60_000).toISOString(),
       },
       {
@@ -87,6 +88,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         chatId: "chat-onboarding-q3",
         chatTitle: "onboarding-q3",
         nodePath: "domains/onboarding/NODE.md",
+        viewerCanAccess: true,
         createdAt: new Date(Date.now() - 12 * 60_000).toISOString(),
       },
       {
@@ -97,6 +99,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         chatId: "chat-qa-run-42",
         chatTitle: "qa-run-42",
         nodePath: "domains/quality/NODE.md",
+        viewerCanAccess: true,
         createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
       },
       {
@@ -107,6 +110,7 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         chatId: "chat-weekly-retro",
         chatTitle: "weekly-retro",
         nodePath: "NODE.md",
+        viewerCanAccess: true,
         createdAt: new Date(Date.now() - 4 * 60 * 60_000).toISOString(),
       },
       {
@@ -121,6 +125,9 @@ export const MOCK_CONTEXT_SNAPSHOT: ContextTreeSnapshot = {
         // Pre-P0 event — no node path recorded; the feed falls back to
         // "read the context tree".
         nodePath: null,
+        // Caller is not a member of this chat — the label shows but renders as
+        // inert text (no deep link), exercising the non-clickable preview path.
+        viewerCanAccess: false,
         createdAt: new Date(Date.now() - 6 * 60 * 60_000).toISOString(),
       },
     ],

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -331,13 +331,23 @@ function ContextUsageFeed({ snapshot }: { snapshot: ContextTreeSnapshot }) {
                 {chatId ? (
                   <>
                     <span className="context-usage-feed-action"> in </span>
-                    <button
-                      type="button"
-                      className="context-usage-feed-chat"
-                      onClick={() => navigate(`/?c=${encodeURIComponent(chatId)}`)}
-                    >
-                      {chatLabel(event)}
-                    </button>
+                    {event.viewerCanAccess ? (
+                      <button
+                        type="button"
+                        className="context-usage-feed-chat"
+                        onClick={() => navigate(`/?c=${encodeURIComponent(chatId)}`)}
+                      >
+                        {chatLabel(event)}
+                      </button>
+                    ) : (
+                      // Org-wide the label is visible, but a non-member must not
+                      // be able to navigate into a chat the server would 404 —
+                      // render inert text instead of a link. See
+                      // summarizeContextTreeUsage / viewerCanAccess.
+                      <span className="context-usage-feed-chat is-static" title="No access to this chat">
+                        {chatLabel(event)}
+                      </span>
+                    )}
                   </>
                 ) : null}
               </span>
@@ -392,15 +402,18 @@ function relativeTimeLabel(value: string, nowMs: number): string {
 }
 
 function LoadingState() {
+  // Cold-load only (no cached snapshot). Center an intentional loading state
+  // in the content area with a spinning icon, rather than a single static line
+  // pinned to the top-left. `animate-spin` is the same spinner utility used
+  // across the app (see save-bar / agent-row).
   return (
-    <Panel>
-      <PanelBody>
-        <div className="flex items-center text-body" style={{ color: "var(--fg-2)", gap: "var(--sp-2)" }}>
-          <RefreshCw size={17} />
-          Loading team context...
-        </div>
-      </PanelBody>
-    </Panel>
+    <div
+      className="flex flex-col items-center justify-center text-body"
+      style={{ color: "var(--fg-2)", gap: "var(--sp-3)", minHeight: "50vh", textAlign: "center" }}
+    >
+      <RefreshCw size={22} className="animate-spin" aria-hidden="true" />
+      <span>Loading team context...</span>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Two changes to the **Context** tab, both verified locally and reviewed by codex-reviewer (no blocking issues).

### 1. Gate Context Usage Feed chat links by access (bug + minor info-leak UX)

The Context Usage Feed shows each event as `<agent> read … in #<chat>`. The trailing `#<chat>` was **always** a clickable button that navigates to `/?c=<chatId>`. The feed exposes chat title/id org-wide on purpose (transparency), but a viewer who is **not a member** of that chat lands on a route the server `404`s (`requireChatAccess`), and the chat view has no error branch — so it **hangs forever on "Loading chat…"**.

Now each event carries a server-computed **`viewerCanAccess`** flag:

- **No DB migration** — it is derived per request, never stored.
- Mirrors `requireChatAccess` exactly: direct `chat_membership` for the caller's human agent (**speaker OR watcher**), or a **speaker the caller manages**.
- Resolved **fail-closed** (no viewer → not clickable) in **two batched queries** bounded by the in-org chat ids — **no N+1**.
- Both snapshot routes pass the viewer (`/orgs/:orgId/snapshot` from `requireOrgMembership` scope; legacy `/snapshot` via a non-throwing `resolveOrgViewer`).
- Frontend: clickable `<button>` when accessible, otherwise **inert text** with a `No access to this chat` tooltip. **Org-wide label visibility and cross-org masking are unchanged.**

The optional manual-URL (`/?c=<id>`) 404 empty-state fallback was intentionally **out of scope** for this PR.

### 2. Polish the Context tab cold-load state

The cold-load `LoadingState` (no cached snapshot) was a static line pinned to the top-left with a non-spinning icon. It now **centers in the content area** and spins the `RefreshCw` icon via the app-wide `animate-spin` utility, using design tokens for spacing/color. No data-logic changes.

## Files

- `packages/shared/src/schemas/context-tree.ts` — add `viewerCanAccess: z.boolean()`
- `packages/server/src/services/session-event.ts` — `viewer` param + `accessibleChatIdSet()` (mirrors `requireChatAccess`)
- `packages/server/src/scope/require-resource.ts` — `resolveOrgViewer()` (non-throwing member resolution)
- `packages/server/src/api/context-tree-snapshot.ts`, `packages/server/src/api/orgs/context-tree-snapshot.ts` — pass viewer
- `packages/web/src/pages/context.tsx` — button↔inert text + centered/spinning loading state
- `packages/web/src/index.css` — `.context-usage-feed-chat.is-static`
- `packages/web/src/pages/context-preview-mock.ts` — mock data field (4 accessible / 1 not, to exercise both states)
- `packages/server/src/__tests__/session-event.test.ts` — 4 new access cases + fail-closed assertion

## Verification

- `pnpm check` — clean (biome)
- `pnpm typecheck` — 11/11 (incl. after rebase onto latest `main`)
- `pnpm test` — server **1106** pass (session-event 18; new: direct watcher → true, manages speaker → true, non-member w/ unmanaged speaker → false, cross-org → false), web **206** pass, shared pass

## Review

Reviewed by **codex-reviewer** — no blocking issues. Confirmed the access logic is equivalent to `requireChatAccess`, cross-org masking intact, fail-closed holds, and the org-wide title/id visibility (intended design) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)