### PR TITLE
fix(web): allow npm scoped package names in chat content

### DIFF
--- a/packages/shared/src/__tests__/mentions.test.ts
+++ b/packages/shared/src/__tests__/mentions.test.ts
@@ -88,6 +88,16 @@ describe("extractMentions", () => {
     expect(extractMentions("@@alice was here", participants)).toEqual([]);
   });
 
+  it("does not match npm scoped package names (`@scope/pkg`)", () => {
+    // The composer's pre-flight check uses the same regex; without the
+    // trailing `/`-rejecting lookahead, `npm i @agent-team-foundation/first-tree-hub`
+    // would surface `agent-team-foundation` as an unresolved mention token
+    // and block the send. Defend the npm-scope shape for the participant
+    // names too — `@alice/foo` is not a mention of alice.
+    expect(extractMentions("npm i @agent-team-foundation/first-tree-hub", participants)).toEqual([]);
+    expect(extractMentions("see @alice/foo for details", participants)).toEqual([]);
+  });
+
   it("handles hyphen-containing participant names", () => {
     expect(extractMentions("@charlie-07 check stats", participants)).toEqual(["agent-charlie"]);
   });
@@ -111,5 +121,13 @@ describe("scanMentionTokens", () => {
 
   it("still scans tokens that don't match any participant — useful for warn logs", () => {
     expect(scanMentionTokens("@ghost")).toEqual(["ghost"]);
+  });
+
+  it("ignores npm scoped package names entirely (no partial-prefix backtrack)", () => {
+    // Without the strict trailing lookahead the engine backtracked the greedy
+    // `[A-Za-z0-9_-]{0,63}` and surfaced `agent-team-` as a partial-match
+    // mention token of `@agent-team-foundation/...`. Pin both forms.
+    expect(scanMentionTokens("npm i @agent-team-foundation/first-tree-hub-shared")).toEqual([]);
+    expect(scanMentionTokens("@alice/foo and @bob/bar")).toEqual([]);
   });
 });

--- a/packages/shared/src/mentions.ts
+++ b/packages/shared/src/mentions.ts
@@ -28,7 +28,13 @@ export type MentionParticipant = {
 // First char must be alphanumeric, matching `AGENT_NAME_REGEX` in
 // `schemas/agent.js`. An `@-foo` or `@_foo` token is not a valid mention
 // (`-foo` can never be a legal new agent name under the tightened rule).
-export const MENTION_REGEX = /(?<![A-Za-z0-9_.@-])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})\b/g;
+//
+// Trailing `(?![A-Za-z0-9_\/-])` replaces a plain `\b`: it forbids the token
+// being followed by `/`, so npm scoped package names (`@scope/pkg`) don't
+// surface as a `scope` mention — the bare `\b` accepts `/` as a boundary and
+// would otherwise (with backtracking) match a truncated prefix like
+// `agent-team-` from `@agent-team-foundation/first-tree-hub-shared`.
+export const MENTION_REGEX = /(?<![A-Za-z0-9_.@-])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})(?![A-Za-z0-9_/-])/g;
 
 /**
  * Strip Markdown code regions (fenced + inline) so identifier-shaped

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -7,7 +7,6 @@ import {
   parseWorkspaceDocKey,
   type QuestionAnswerMessageContent,
   type QuestionMessageContent,
-  scanMentionTokens,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, AtSign, Check, ExternalLink, Eye, MessageSquare, MoreHorizontal, Paperclip, X } from "lucide-react";
@@ -857,10 +856,10 @@ export function ChatView({
       // docs/session-creation-on-first-message.md.
       queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
     },
-    // Backstop: surface server-side `enforceGroupMention` 400s (and any
-    // other send failure) under the composer instead of silently failing.
-    // The pre-flight check in `handleSend` should catch unresolved
-    // `@<token>` locally; this catches anything that slips through.
+    // Server-side `enforceGroupMention` + unresolved-token guard 400s
+    // (e.g. user typed `@<outsider>` who's not in the chat) surface here.
+    // Client no longer pre-flights — unresolved `@<token>` is treated as
+    // plain text locally; the round-trip is the user's notification.
     onError: (err) => {
       setUploadError(err instanceof Error ? err.message : "Failed to send message");
     },
@@ -872,35 +871,16 @@ export function ChatView({
     if (!text && images.length === 0) return;
     if (uploading) return;
 
-    // Unresolved-@-token guard (client mirror of `enforceGroupMention` in
-    // `services/message.ts`). The autocomplete only offers in-chat
-    // members, but the user can still hand-type `@<name>` — typos,
-    // renamed agents, or agents not in this chat. Catching it here
-    // produces a precise hint immediately instead of round-tripping to a
-    // 400 the user has to decode. New participants are added via
-    // ParticipantsHeader's `[+]`, not via `@`.
-    //
-    // Derive the speaker set from `chatDetail.participants` rather than
-    // `mentionCandidates` so it includes self — `mentionCandidates`
-    // intentionally excludes self (you don't autocomplete "@yourself"),
-    // but `@<own-name>` is a legal token the server accepts. Without
-    // self here the guard would reject it with the "[+] button" hint,
-    // which is misleading since the user is already a member.
-    if (text) {
-      const memberNames = new Set(
-        (chatDetail?.participants ?? [])
-          .map((p) => chatScopedAgentIdentity(p.agentId)?.name?.toLowerCase())
-          .filter((n): n is string => !!n),
-      );
-      const unresolved = scanMentionTokens(text).filter((t) => !memberNames.has(t));
-      if (unresolved.length > 0) {
-        const sample = unresolved[0];
-        setUploadError(
-          `Cannot @-mention "${sample}" — they're not in this chat. Use the [+] button above to add them first.`,
-        );
-        return;
-      }
-    }
+    // No client-side unresolved-`@`-token pre-flight: a `@<token>` that
+    // doesn't resolve to a chat member is treated as plain text, matching
+    // Slack/Discord/Feishu. This avoids false positives like npm scoped
+    // package names (`@scope/pkg`) or quoted handles in the body. The
+    // `enforceGroupMention` constraint (group chat must address at least
+    // one member) is reflected via `requiresMention` + `draftMentions`
+    // gating the send button below — `extractMentions` resolves only
+    // against in-chat membership, so an `@<outsider>` simply contributes
+    // nothing and the button stays disabled, prompting the user to use
+    // the `[+]` button or the autocomplete picker.
 
     // Group-chat send guard: don't fire requests we know the server (with
     // proposal §3 enforcement) or downstream `mention_only` agents will drop.
@@ -1309,13 +1289,15 @@ export function ChatView({
   ]);
 
   /** AgentIds the draft text addresses via `@<name>` tokens, resolved
-   * against the in-chat membership (`mentionCandidates`). The client no
-   * longer auto-invites `@<outsider>` — and the server now rejects any
-   * unresolved `@<token>` with a 400 (see `enforceGroupMention` guard in
-   * `services/message.ts`). To avoid the round-trip and a confusing
-   * error, `handleSend` runs the same check locally via
-   * `scanMentionTokens` before firing the mutation; new participants go
-   * through the ParticipantsHeader `[+]` button instead. */
+   * against the in-chat membership (`mentionCandidates`). Used purely
+   * as a UX signal: drives the send-button disable + tooltip when a
+   * group chat has no valid mention yet. Unresolved `@<token>` tokens
+   * (typos, npm package names, outsiders) contribute nothing here —
+   * the button stays disabled, prompting the user to pick from
+   * autocomplete or use ParticipantsHeader's `[+]`. The server still
+   * runs its own unresolved-token guard on the agent path (the PR-393
+   * anti-hallucination fix); on the human web path it's tolerated by the
+   * `mentions.ts` regex excluding npm scoped names from token scans. */
   const draftMentions = useMemo(() => {
     const ps: MentionParticipant[] = mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name }));
     return extractMentions(draft, ps);


### PR DESCRIPTION
## Summary
- Sending a chat message containing an npm scoped package name (e.g. `npm i @agent-team-foundation/first-tree-hub-shared`) was blocked client-side by the unresolved-`@`-token pre-flight, because the shared `MENTION_REGEX` matched `agent-team-foundation` (and via backtracking, the partial prefix `agent-team-`) as a mention token.
- Tightened `MENTION_REGEX` with a strict trailing lookahead so `@scope/pkg` is no longer treated as a mention at all, and removed the client-side pre-flight in `chat-view.tsx` — unresolved `@<token>` is now treated as plain text on the human web path (Slack/Discord/Feishu parity).
- Server-side guard untouched: the agent path's PR-393 anti-hallucination contract (`enforceGroupMention` + unresolved-token rejection) stays exactly as it was.

## Root cause

`/(?<![A-Za-z0-9_.@-])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})\b/g` — the trailing `\b` accepts `/` as a word boundary, so `@agent-team-foundation/...` matches `agent-team-foundation`. Worse, greedy backtracking can also surface partial prefixes like `agent-team-` when a longer match runs into a non-boundary char downstream. The client's `scanMentionTokens` pre-flight then surfaces this as a hard block before the request ever leaves the browser.

## Fix

1. **`packages/shared/src/mentions.ts`** — replace trailing `\b` with `(?![A-Za-z0-9_/-])`. Strict negative lookahead forbids the token being followed by `/`, letters, digits, `_`, or `-`. This collapses both the false positive (`@scope/pkg`) and the backtrack chain (no partial prefix can survive because every shorter candidate is followed by a forbidden char). Single source of truth — the same regex feeds the server's `scanMentionTokens` and `extractMentions`, so server-side fan-out routing stays consistent with client-side resolution.

2. **`packages/web/src/pages/workspace/center/chat-view.tsx`** — drop the unresolved-`@`-token pre-flight in `handleSend`. The previous behavior mirrored the server's `enforceGroupMention` guard for round-trip avoidance; with the npm-scope false positive now structurally impossible, the only remaining unresolved tokens are real typos (`@<outsider>`), which the server already 400s and the existing `sendMut.onError` backstop renders under the composer. `extractMentions` / `draftMentions` is retained as a pure UX signal — it drives the send-button disabled state when a group chat has no valid `@mention` yet, but no longer hard-blocks send.

The architectural cleanup of moving toward "server only trusts explicit `mentions[]`, each client parses its own content" (so the entire `client/server regex-divergence` bug class disappears) is deferred to a separate PR.

## Test plan
- [x] `pnpm check` — biome clean
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared typecheck` clean
- [x] `pnpm --filter @first-tree-hub/web typecheck` clean (incl. design-token guardrails)
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub-shared test` — 259 tests pass, includes 2 new npm-scope cases (one in `extractMentions`, one in `scanMentionTokens` pinning the partial-prefix backtrack invariant)
- [x] `pnpm --filter @first-tree-hub/web test` — 206 tests pass
- [x] `pnpm --filter @first-tree-hub/server test` — 1106 tests pass, including the full `agent-send-unresolved-mention` suite (PR-393 anti-hallucination guard, 11 cases) — unchanged behaviour on agent path

## Manual verification
- [ ] In web chat, type `npm i @agent-team-foundation/first-tree-hub-shared` and send — message goes through
- [ ] In web chat, type `@<some-outsider>` (a real agent name not in this chat) and send — server returns 400 and error surfaces under the composer (no client-side hint about `[+]` anymore, server message instead)
- [ ] Mention autocomplete still surfaces chat-internal members on `@`; `@<member>` send still works

## Behaviour matrix
| Scenario | Before | After |
|---|---|---|
| `@scope/pkg` in message | client blocks | sends normally |
| Real `@<outsider>` typo | client blocks | client allows → server 400 → error in composer |
| Group chat with no `@mention` | send button disabled | unchanged |
| Normal `@<member>` | works | works |
| Agent runtime path `@<outsider>` | server 400 (PR-393) | server 400 (PR-393) — unchanged |