### PR TITLE
fix(cli): stop double-prepending @<recipient> in chat send content

### DIFF
--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -182,7 +182,14 @@ export function registerChatCommands(program: Command): void {
 
         const result = await sdk.sendMessage(chatId, {
           format: options.format,
-          content: `@${agentName} ${content}`,
+          // Send the agent's raw content verbatim. The server owns mention
+          // injection: `receiverNames` declares routing intent, and the
+          // agent endpoint's `normalizeMentionsInContent` will prepend
+          // `@<name>` only when the content doesn't already contain it
+          // (idempotent, case-insensitive). Prepending here too would
+          // double-stamp when the agent already wrote `@<name>` in the
+          // body — see services/message.ts step 2c.
+          content,
           metadata,
           source: "cli",
           // Server resolves the name against the current chat's participant

--- a/packages/e2e/src/tests/cli-chat-send.e2e.test.ts
+++ b/packages/e2e/src/tests/cli-chat-send.e2e.test.ts
@@ -130,4 +130,40 @@ describe("CLI `chat send` happy path against spawned dist CLI", () => {
     expect(row.rows[0]?.sender_id).toBe(creds.humanAgentId);
     expect(row.rows[0]?.format).toBe("text");
   });
+
+  // Regression: CLI used to unconditionally prepend `@<recipientName>` to the
+  // content, so an agent whose LLM output already contained `@<recipientName>`
+  // ended up sending `@a @a body`. The prepend is now the server's job
+  // (`normalizeMentionsInContent` — idempotent + case-insensitive); CLI only
+  // declares routing intent via `receiverNames`. This test pins that
+  // single-source-of-truth split: a leading-`@` body must land verbatim, not
+  // double-stamped.
+  it("does not double-prepend @<recipient> when the body already starts with it", async () => {
+    const creds = readCredentialsOrThrow(handle);
+    const tag = randomBytes(3).toString("hex");
+    const messageBody = `@${recipientName} cli-send-leading-at ${tag}`;
+
+    const result = await execCli({
+      home: handle.clientHome,
+      serverBaseUrl: handle.serverBaseUrl,
+      args: ["chat", "send", recipientName, messageBody, "--agent", creds.humanAgentName],
+      extraEnv: { FIRST_TREE_HUB_CHAT_ID: chatId },
+      timeoutMs: 15_000,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `chat send exited with code ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+    }
+
+    // `messages.content` is jsonb storing a string — `#>>'{}'` extracts the
+    // raw text so we can assert exact equality (not substring), which is the
+    // whole point of the regression check.
+    const row = await pg.query<{ content: string }>(
+      "SELECT content #>> '{}' AS content FROM messages WHERE chat_id = $1 AND content::text LIKE '%' || $2 || '%' LIMIT 1",
+      [chatId, tag],
+    );
+    expect(row.rows[0], `message with tag "${tag}" not found in PG`).toBeDefined();
+    expect(row.rows[0]?.content).toBe(messageBody);
+  });
 });


### PR DESCRIPTION
## Summary
- `apps/cli/src/commands/chat.ts` 在 `chat send <agentName> "..."` 时无条件把 content 改成 `` `@${agentName} ${content}` ``。当 agent 的 LLM 输出本身已经写了 `@<name>`（被 prompt 教育要这样唤醒群里成员），落库就变成 `@a @a body`，web 上看到「前面两个同样的 @」。
- 修复：让 CLI 把 raw content 原样发出去，mention 注入交给 server。Agent 端点的 `normalizeMentionsInContent`（services/message.ts 步骤 2c）本身就是幂等且大小写不敏感的，会按 `receiverNames` 声明的路由意图自动补 `@<name>`、已有则跳过。
- 单一来源：客户端只表达「我要发这段原文 + 路由给谁」，content 怎么落地完全由 server 决定，避免两边各做半套出现这次的漂移。

## Test plan
- [x] `pnpm check` — 803 files clean
- [x] `pnpm typecheck` — 11/11 tasks 全过
- [x] `pnpm --filter @first-tree/server test` — 1106 tests 全过（含 `agent-send-mention-injection` 系列的 idempotency / case-insensitive / normalize 全套）
- [x] `pnpm --filter @agent-team-foundation/first-tree-hub test` — CLI 包 125 tests 全过
- [x] `E2E_WITH_CLIENT=1 pnpm e2e:full` — 37/37 tests pass（42.55s），含新增 regression case `does not double-prepend @<recipient> when the body already starts with it`