### PR TITLE
feat(chat): one message carries text + multiple attachments (route 2 / PG-bytea)

### DIFF
--- a/docs/message-text-attachments-design.md
+++ b/docs/message-text-attachments-design.md
@@ -1,0 +1,134 @@
+# Message text + attachments — local design doc
+
+Companion to Context Tree proposal `hub-message-text-attachments.20260521.md`
+(merged). This file is the hub-side reference: invariants you need to keep in
+mind when touching `services/message.ts`, `services/attachment.ts`,
+`api/chats.ts`, the web composer, or the agent runtime handlers.
+
+## Design at a glance
+
+- **Single bubble.** One send = one message = one bubble. Text caption +
+  arbitrary attachments ride together; the old "split per image" path is
+  gone.
+- **A′ on the wire.** Caption lives in `content`; attachments ride
+  `metadata.attachments[]` as refs (no base64, no client-local ids). No new
+  `format` value — old readers degrade gracefully (render the caption, ignore
+  the attachments) and the @mention guard stays on the existing text path.
+- **Route 2 / PG-bytea for storage.** Bytes persist in `message_attachments`
+  (bytea, `STORAGE EXTERNAL`); messages carry only references. No new infra,
+  follows the agent-avatar precedent, fits "PostgreSQL only / stateless
+  server".
+- **Authenticated fetch, no signed URLs.** Web uses the existing JWT, agent
+  runtime uses its token; membership is re-checked per request. Avoids
+  signed-URL churn against the 5s message refetch.
+- **Two-phase bind.** Upload returns an unbound `attachmentId` (`message_id
+  IS NULL`). At send time the server validates uploader / unbound / same-chat
+  (C3), folds authoritative refs into `metadata.attachments`, and binds in
+  the same transaction so a rollback drops both. `SELECT … FOR UPDATE` +
+  `RETURNING` row-count closes the rebind race.
+
+## Security double-gates
+
+- **C1** — type gate: magicless safe text/docs (`.md/.csv/.json/...`) are
+  allowed; executables (MZ/ELF/Mach-O/shebang) and a denied-extension list
+  are rejected.
+- **C2** — download response: only a png/jpeg/gif/webp allow-list is served
+  inline; everything else (incl. SVG) is `Content-Disposition: attachment` +
+  `X-Content-Type-Options: nosniff`.
+- **C3** — at send: each referenced attachment must have been uploaded by
+  the sender, still unbound, and in the same chat. Forged
+  `metadata.attachments` keys submitted by clients are stripped before
+  insert (see `SERVER_MANAGED_METADATA_KEYS` in shared).
+
+## Invariants worth not breaking
+
+- **`kind` is a pure function of mime.** Compute it via
+  `deriveAttachmentKind(mime)`; the DB CHECK constraint
+  (`message_attachments_kind_check`) defends against drift. Don't add a
+  `kind` parameter to any service entry point — the caller has no say.
+- **`metadata.attachments` is server-managed.** Listed in
+  `SERVER_MANAGED_METADATA_KEYS`; `stripUntrustedMetadataKeys` removes it
+  from every caller-supplied `metadata` before the insert. Adding a new
+  server-managed key means adding to that set, not adding a new ad-hoc
+  `delete`.
+- **`getMessageAttachments(metadata)` is the only parser.** Server, web,
+  agent runtime all share it (`packages/shared/src/schemas/message.ts`).
+  Don't reinvent the `safeParse → .data.attachments` dance locally.
+- **No internal links to external IM users.** Feishu downgrade is a
+  filename + size list, never URLs (no Hub session on the far side). Real
+  file forwarding via the Feishu upload API is a follow-up.
+
+## Limits
+
+- Single file ≤ 10 MB. Per-message total ≤ 25 MB. Max 9 attachments per
+  message. Per-org quota 10 GB.
+
+## Known follow-ups
+
+- **drizzle meta snapshot chain is broken.** `drizzle-kit generate` cannot
+  run; migration 0048 is hand-authored. Repairing the snapshot chain is the
+  immediate post-merge follow-up (see PR #497 description).
+- **org-quota overcommit window.** The quota check is non-atomic; two
+  concurrent uploads can both pass at the cap. Worst case is bounded
+  (single-file cap × concurrency); accepted for now because the obvious
+  short fix (`SELECT … FOR UPDATE` on the org row) serialises all uploads
+  within an org and is a worse trade-off than the rare overcommit.
+- **Mime↔extension consistency.** Currently soft (we trust the magic-byte
+  sniff plus the deny-list); future hardening can tighten by cross-checking
+  extension against mime category.
+
+## Future evolution — rich-text + inline attachments
+
+If the product later wants **inline attachments** — images interleaved with
+text in the caption, instead of stacked below it — **do not introduce a new
+`format` value**. The A′ contract works as-is:
+
+> Reuse `metadata.attachments[]` unchanged; in the caption use markdown
+> `![alt](attachment:<attachmentId>)` to reference an attachment that is
+> already in the same message's `metadata.attachments`.
+
+Concretely:
+
+```json
+{
+  "format": "markdown",
+  "content": "Look at this UI: ![mockup](attachment:att_1)\n…and the data flow: ![flow](attachment:att_2)",
+  "metadata": {
+    "attachments": [
+      { "attachmentId": "att_1", "mimeType": "image/png", "filename": "ui.png", "size": 12345, "kind": "image" },
+      { "attachmentId": "att_2", "mimeType": "image/png", "filename": "flow.png", "size": 23456, "kind": "image" }
+    ]
+  }
+}
+```
+
+Why this is the most restrained path:
+
+- **No new `format`.** A′'s core property — `format` describes presentation
+  intent, not data shape — stays intact.
+- **No DB-schema change.** `message_attachments` and `metadata.attachments`
+  are already what we need.
+- **Old clients keep working.** A client that doesn't recognise the
+  `attachment:` URI scheme renders the markdown as plain text; the
+  attachments still show in the existing bottom-of-bubble list (rendered
+  off `metadata.attachments`). Zero break.
+- **Adapters keep their downgrades.** Feishu's filename-list downgrade
+  works unchanged — it reads `metadata.attachments` and ignores the
+  caption's URI scheme.
+
+Rejected alternatives:
+
+- **A new `format: "rich-text"` carrying block arrays** (Feishu `post` /
+  Slack `blocks` style). This would require a new data model and parallel
+  read paths in every consumer (server adapter, web renderer, agent
+  runtime, feishu downgrade). It would also break older clients hard
+  rather than degrading them. The block-array model is what other
+  platforms built natively from day one — for us it's a migration
+  liability, not a feature.
+- **A new metadata key (e.g. `metadata.inlineSpec`) mapping caption
+  positions to attachment ids.** Doable but redundant with the markdown
+  URI approach, which already encodes the position implicitly.
+
+When you actually need this: the implementation work is in the rendering
+clients (markdown image renderer + URI scheme resolver), not on the wire
+contract.

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -11,7 +11,7 @@ import type {
 import {
   type AttachmentRef,
   deriveRepoLocalPath,
-  messageAttachmentsMetadataSchema,
+  getMessageAttachments,
   type QuestionItem,
   type QuestionMessageContent,
   questionItemSchema,
@@ -128,13 +128,6 @@ async function writeLegacyImageToTempFile(content: LegacyImageFileContent, chatI
   const path = join(dir, `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`);
   await writeFile(path, Buffer.from(content.data, "base64"));
   return path;
-}
-
-/** Read the A′ attachment refs off a message's metadata, or [] when none. */
-function parseAttachments(metadata: Record<string, unknown> | null): AttachmentRef[] {
-  if (!metadata) return [];
-  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
-  return parsed.success ? parsed.data.attachments : [];
 }
 
 /**
@@ -530,7 +523,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // an explicit "do not answer from it" placeholder so the model never
     // answers on missing content — and it's retryable (route 2 is durable),
     // not the permanent loss the old WS-push path implied.
-    const attachments = parseAttachments(message.metadata);
+    const attachments = getMessageAttachments(message.metadata);
     if (attachments.length > 0) {
       const caption = await sessionCtx.formatInboundContent(message);
       const blocks: string[] = [];

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -9,7 +9,9 @@ import type {
   SupportedImageMime,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import {
+  type AttachmentRef,
   deriveRepoLocalPath,
+  messageAttachmentsMetadataSchema,
   type QuestionItem,
   type QuestionMessageContent,
   questionItemSchema,
@@ -26,6 +28,7 @@ import type {
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
+import { findAttachmentPath, writeAttachmentFile } from "../runtime/attachment-store.js";
 import { bootstrapWorkspace, installFirstTreeIntegration } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { renderChatContextSection } from "../runtime/chat-context-section.js";
@@ -125,6 +128,34 @@ async function writeLegacyImageToTempFile(content: LegacyImageFileContent, chatI
   const path = join(dir, `${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`);
   await writeFile(path, Buffer.from(content.data, "base64"));
   return path;
+}
+
+/** Read the A′ attachment refs off a message's metadata, or [] when none. */
+function parseAttachments(metadata: Record<string, unknown> | null): AttachmentRef[] {
+  if (!metadata) return [];
+  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data.attachments : [];
+}
+
+/**
+ * Ensure an attachment's bytes are on local disk (download + cache), returning
+ * its path — or null when the download fails (server unreachable, revoked
+ * access). Route 2 is durable, so a failure is retryable, not permanent loss.
+ */
+async function materialiseAttachment(
+  sessionCtx: SessionContext,
+  chatId: string,
+  att: AttachmentRef,
+): Promise<string | null> {
+  const cached = findAttachmentPath(chatId, att.attachmentId, att.filename);
+  if (cached) return cached;
+  try {
+    const bytes = await sessionCtx.sdk.downloadChatAttachment(chatId, att.attachmentId);
+    return await writeAttachmentFile(chatId, att.attachmentId, att.filename, bytes);
+  } catch (err) {
+    sessionCtx.log(`attachment download failed (${att.filename}): ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
 }
 
 function extractContentBlocks(message: unknown): unknown[] {
@@ -489,6 +520,39 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           };
         }
       }
+    }
+
+    // Attachments (route 2 / A′): a regular text/markdown message whose
+    // `metadata.attachments[]` references files persisted server-side. Render
+    // the caption + preceding context exactly like a text message, then
+    // download each attachment to local disk and point the model at the path
+    // for its Read tool (image → vision, doc → text). A failed download yields
+    // an explicit "do not answer from it" placeholder so the model never
+    // answers on missing content — and it's retryable (route 2 is durable),
+    // not the permanent loss the old WS-push path implied.
+    const attachments = parseAttachments(message.metadata);
+    if (attachments.length > 0) {
+      const caption = await sessionCtx.formatInboundContent(message);
+      const blocks: string[] = [];
+      for (const att of attachments) {
+        const path = await materialiseAttachment(sessionCtx, message.chatId, att);
+        if (path) {
+          const what = att.kind === "image" ? "An image" : "A file";
+          blocks.push(
+            `${what} was shared in this chat. Use the Read tool to read it, then respond based on its content.\n\nFilename: ${att.filename}\nPath: ${path}`,
+          );
+        } else {
+          blocks.push(
+            `[attachment "${att.filename}" unavailable on this device — DO NOT answer based on its content; ask the user to resend if it is required.]`,
+          );
+        }
+      }
+      return {
+        type: "user",
+        message: { role: "user", content: [caption, ...blocks].join("\n\n") },
+        parent_tool_use_id: null,
+        session_id: sessionId,
+      };
     }
 
     // Default text content — sender attribution lives in the runtime so every

--- a/packages/client/src/runtime/attachment-store.ts
+++ b/packages/client/src/runtime/attachment-store.ts
@@ -1,0 +1,53 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
+
+/**
+ * Local cache of message attachments (route 2 / PG-bytea). Unlike the legacy
+ * image store — whose bytes arrived via a best-effort `image_payload` WS push —
+ * these bytes are fetched on demand from the server's member-gated download
+ * route and written here so the model's Read tool can open them. Reliable +
+ * re-fetchable: a cache miss just means "download again", never "lost".
+ */
+
+function sanitize(segment: string): string {
+  return /^[a-zA-Z0-9._-]+$/.test(segment) ? segment : "unknown";
+}
+
+function attachmentDir(chatId: string): string {
+  return join(DEFAULT_DATA_DIR, "chats", sanitize(chatId), "attachments");
+}
+
+/** Lower-cased dotted extension from a filename, or "" — kept so the on-disk
+ *  file carries a real suffix (Claude's Read uses it for image vs text). */
+function extFromFilename(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0) return "";
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return /^[a-z0-9]+$/.test(ext) ? `.${ext}` : "";
+}
+
+export function attachmentPath(chatId: string, attachmentId: string, filename: string): string {
+  return join(attachmentDir(chatId), `${sanitize(attachmentId)}${extFromFilename(filename)}`);
+}
+
+/** Locate a previously-downloaded attachment on disk, or null. */
+export function findAttachmentPath(chatId: string, attachmentId: string, filename: string): string | null {
+  const p = attachmentPath(chatId, attachmentId, filename);
+  return existsSync(p) ? p : null;
+}
+
+/** Persist downloaded bytes to disk, returning the path. Idempotent. */
+export async function writeAttachmentFile(
+  chatId: string,
+  attachmentId: string,
+  filename: string,
+  bytes: Buffer,
+): Promise<string> {
+  const dir = attachmentDir(chatId);
+  await mkdir(dir, { recursive: true });
+  const p = attachmentPath(chatId, attachmentId, filename);
+  await writeFile(p, bytes);
+  return p;
+}

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -287,6 +287,18 @@ export class FirstTreeHubSDK {
     return this.requestJson<ContextTreeConfig>("/api/v1/agent/context-tree/info");
   }
 
+  /**
+   * Download a message attachment's raw bytes (route 2 / PG-bytea). Member-gated
+   * server-side; the runtime materialises the bytes to local disk so the model
+   * can Read them. Returns the bytes as a Buffer — the caller already knows the
+   * filename/mime from the message's `metadata.attachments` ref.
+   */
+  async downloadChatAttachment(chatId: string, attachmentId: string): Promise<Buffer> {
+    const response = await this.doFetch(`/api/v1/agent/chats/${chatId}/attachments/${attachmentId}`);
+    if (!response.ok) throw await this.toSdkError(response);
+    return Buffer.from(await response.arrayBuffer());
+  }
+
   private queryString(options?: { limit?: number; cursor?: string }): string {
     const params = new URLSearchParams();
     if (options?.limit !== undefined) params.set("limit", String(options.limit));

--- a/packages/server/drizzle/0048_message_attachments.sql
+++ b/packages/server/drizzle/0048_message_attachments.sql
@@ -1,0 +1,30 @@
+-- Message attachments — file bytes persisted server-side (route 2 / PG-bytea).
+-- See proposals/hub-message-text-attachments.20260521.md.
+--
+-- NOTE: hand-authored. `drizzle-kit generate` cannot run on this branch — the
+-- drizzle/meta snapshot chain is incomplete (48 journal entries, 7 snapshots),
+-- so generate aborts with a snapshot collision. This migration is purely
+-- additive (one new table) and follows drizzle's output format; recent
+-- migrations here (e.g. 0045) are likewise hand-curated. Reconcile the meta
+-- snapshot chain separately (infra follow-up) if `generate` is needed again.
+CREATE TABLE "message_attachments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"chat_id" text NOT NULL,
+	"message_id" text,
+	"uploader_id" text NOT NULL,
+	"mime" text NOT NULL,
+	"filename" text NOT NULL,
+	"size" integer NOT NULL,
+	"sha256" text NOT NULL,
+	"kind" text NOT NULL,
+	"bytes" bytea NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "message_attachments" ADD CONSTRAINT "message_attachments_chat_id_chats_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "message_attachments" ADD CONSTRAINT "message_attachments_message_id_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."messages"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_message_attachments_message" ON "message_attachments" USING btree ("message_id");--> statement-breakpoint
+CREATE INDEX "idx_message_attachments_chat" ON "message_attachments" USING btree ("chat_id");--> statement-breakpoint
+CREATE INDEX "idx_message_attachments_created" ON "message_attachments" USING btree ("created_at");--> statement-breakpoint
+-- Already-compressed media → skip pointless TOAST compression; store out-of-line.
+ALTER TABLE "message_attachments" ALTER COLUMN "bytes" SET STORAGE EXTERNAL;

--- a/packages/server/drizzle/0048_message_attachments.sql
+++ b/packages/server/drizzle/0048_message_attachments.sql
@@ -16,7 +16,7 @@ CREATE TABLE "message_attachments" (
 	"filename" text NOT NULL,
 	"size" integer NOT NULL,
 	"sha256" text NOT NULL,
-	"kind" text NOT NULL,
+	"kind" text NOT NULL CONSTRAINT "message_attachments_kind_check" CHECK ("kind" IN ('image', 'file')),
 	"bytes" bytea NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1779840000000,
       "tag": "0047_v2_messages_source_required",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1779926400000,
+      "tag": "0048_message_attachments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
     "@agent-team-foundation/first-tree-hub-shared": "workspace:*",
     "@autotelic/fastify-opentelemetry": "^0.23.0",
     "@fastify/cors": "^11.2.0",
+    "@fastify/multipart": "^10.0.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",
     "@fastify/websocket": "^11.2.0",

--- a/packages/server/src/__tests__/attachment-binding.test.ts
+++ b/packages/server/src/__tests__/attachment-binding.test.ts
@@ -1,0 +1,221 @@
+import { eq, inArray } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { messageAttachments } from "../db/schema/message-attachments.js";
+import {
+  createAttachment,
+  gcOrphanedAttachments,
+  getAttachmentForDownload,
+  prepareAttachmentsForSend,
+} from "../services/attachment.js";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/** Helper: upload one attachment as `uploaderId` into `chatId`. */
+async function upload(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  chatId: string,
+  uploaderId: string,
+  name = "notes.md",
+) {
+  return createAttachment(app.db, {
+    chatId,
+    uploaderId,
+    filename: name,
+    declaredMime: "text/markdown",
+    bytes: Buffer.from("# hello\nbody\n"),
+  });
+}
+
+describe("attachment binding (C3 + send)", () => {
+  const getApp = useTestApp();
+
+  it("rejects attaching another agent's upload, accepts the uploader's own", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-a2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+
+    const ref = await upload(app, chat.id, a1.uuid);
+
+    // C3: a2 cannot reference a1's pending upload.
+    await expect(
+      prepareAttachmentsForSend(app.db, { chatId: chat.id, senderId: a2.uuid, attachmentIds: [ref.attachmentId] }),
+    ).rejects.toThrow(/uploaded by someone else/i);
+
+    // The uploader can, and gets authoritative refs back.
+    const refs = await prepareAttachmentsForSend(app.db, {
+      chatId: chat.id,
+      senderId: a1.uuid,
+      attachmentIds: [ref.attachmentId],
+    });
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.attachmentId).toBe(ref.attachmentId);
+    expect(refs[0]?.mimeType).toBe("text/markdown");
+    expect(refs[0]?.kind).toBe("file");
+  });
+
+  it("binds attachments into metadata.attachments on send and rejects re-binding", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-b1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-b2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+
+    const ref = await upload(app, chat.id, a1.uuid);
+
+    const result = await sendMessage(
+      app.db,
+      chat.id,
+      a1.uuid,
+      { source: "web", format: "text", content: "see attached", metadata: { mentions: [a2.uuid] } },
+      { attachmentIds: [ref.attachmentId] },
+    );
+
+    // A′: the message stays plain text; the attachment rides metadata.attachments.
+    expect(result.message.format).toBe("text");
+    const meta = result.message.metadata as { attachments?: Array<{ attachmentId: string }> };
+    expect(meta.attachments).toHaveLength(1);
+    expect(meta.attachments?.[0]?.attachmentId).toBe(ref.attachmentId);
+
+    // Already bound → a second send referencing it is rejected.
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        a1.uuid,
+        { source: "web", format: "text", content: "again", metadata: { mentions: [a2.uuid] } },
+        { attachmentIds: [ref.attachmentId] },
+      ),
+    ).rejects.toThrow(/already attached/i);
+  });
+});
+
+describe("attachment security hardening (codex blockers)", () => {
+  const getApp = useTestApp();
+
+  // Blocker 1: a caller can omit attachmentIds and forge metadata.attachments;
+  // the server must strip the client-supplied key so only server-generated refs
+  // (from prepareAttachmentsForSend) survive.
+  it("strips client-forged metadata.attachments when no attachmentIds are given", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-c1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-c2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+    const ref = await upload(app, chat.id, a1.uuid);
+
+    const result = await sendMessage(app.db, chat.id, a1.uuid, {
+      source: "web",
+      format: "text",
+      content: "sneaky",
+      // Forged: references a real upload but bypasses attachmentIds validation.
+      metadata: {
+        attachments: [
+          { attachmentId: ref.attachmentId, mimeType: "text/markdown", filename: "x.md", size: 5, kind: "file" },
+        ],
+      },
+    });
+
+    const meta = result.message.metadata as { attachments?: unknown };
+    expect(meta.attachments).toBeUndefined();
+    // The referenced upload stays unbound (the forge didn't bind it).
+    const [row] = await app.db
+      .select({ messageId: messageAttachments.messageId })
+      .from(messageAttachments)
+      .where(eq(messageAttachments.id, ref.attachmentId));
+    expect(row?.messageId).toBeNull();
+  });
+
+  // Blocker 2: a given upload must bind to at most one message under concurrency.
+  it("binds an upload to at most one message under concurrent sends", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-r1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-r2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+    const ref = await upload(app, chat.id, a1.uuid);
+
+    const send = () =>
+      sendMessage(
+        app.db,
+        chat.id,
+        a1.uuid,
+        { source: "web", format: "text", content: "x", metadata: { mentions: [a2.uuid] } },
+        { attachmentIds: [ref.attachmentId] },
+      );
+    const results = await Promise.allSettled([send(), send()]);
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+  });
+
+  // Blocker 3: orphan GC removes aged unbound uploads, keeps bound + recent.
+  it("gcOrphanedAttachments deletes aged unbound uploads but keeps bound + recent", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-g1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-g2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+
+    const orphan = await upload(app, chat.id, a1.uuid, "orphan.md");
+    const recent = await upload(app, chat.id, a1.uuid, "recent.md");
+    const boundRef = await upload(app, chat.id, a1.uuid, "bound.md");
+    await sendMessage(
+      app.db,
+      chat.id,
+      a1.uuid,
+      { source: "web", format: "text", content: "x", metadata: { mentions: [a2.uuid] } },
+      { attachmentIds: [boundRef.attachmentId] },
+    );
+
+    // Age the orphan past the 24h TTL.
+    await app.db
+      .update(messageAttachments)
+      .set({ createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000) })
+      .where(eq(messageAttachments.id, orphan.attachmentId));
+
+    const deleted = await gcOrphanedAttachments(app.db);
+    expect(deleted).toBeGreaterThanOrEqual(1);
+
+    const remaining = await app.db
+      .select({ id: messageAttachments.id })
+      .from(messageAttachments)
+      .where(inArray(messageAttachments.id, [orphan.attachmentId, recent.attachmentId, boundRef.attachmentId]));
+    const ids = new Set(remaining.map((r) => r.id));
+    expect(ids.has(orphan.attachmentId)).toBe(false);
+    expect(ids.has(recent.attachmentId)).toBe(true);
+    expect(ids.has(boundRef.attachmentId)).toBe(true);
+  });
+
+  // Non-blocking hardening: an unbound upload is downloadable only by uploader.
+  it("gates unbound-attachment download to the uploader, opens up once bound", async () => {
+    const app = getApp();
+    const { agent: a1 } = await createTestAgent(app, { name: `att-d1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `att-d2-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, a1.uuid, { type: "group", participantIds: [a2.uuid] });
+    const ref = await upload(app, chat.id, a1.uuid);
+
+    // Still unbound: another member cannot pull it.
+    await expect(
+      getAttachmentForDownload(app.db, { chatId: chat.id, attachmentId: ref.attachmentId, viewerId: a2.uuid }),
+    ).rejects.toThrow();
+    // The uploader can.
+    const own = await getAttachmentForDownload(app.db, {
+      chatId: chat.id,
+      attachmentId: ref.attachmentId,
+      viewerId: a1.uuid,
+    });
+    expect(own.filename).toBe("notes.md");
+
+    // Once bound to a message, any chat member can download it.
+    await sendMessage(
+      app.db,
+      chat.id,
+      a1.uuid,
+      { source: "web", format: "text", content: "x", metadata: { mentions: [a2.uuid] } },
+      { attachmentIds: [ref.attachmentId] },
+    );
+    const seen = await getAttachmentForDownload(app.db, {
+      chatId: chat.id,
+      attachmentId: ref.attachmentId,
+      viewerId: a2.uuid,
+    });
+    expect(seen.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -7,8 +7,10 @@ import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
 import { agentAvatarImageUrl } from "../../services/agent.js";
+import { getAttachmentForDownload } from "../../services/attachment.js";
 import * as chatService from "../../services/chat.js";
 import { WIRE_RECIPIENT_MODE } from "../../services/message-dispatcher.js";
+import { sendAttachmentResponse } from "../attachment-response.js";
 
 const log = createLogger("AgentChatsRoute");
 
@@ -81,6 +83,25 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       avatarImageUrl: agentAvatarImageUrl(r.agentId, r.avatarImageUpdatedAt ?? null),
     }));
   });
+
+  /**
+   * GET /agent/chats/:chatId/attachments/:attachmentId — download an
+   * attachment's bytes for the agent runtime to materialise locally and Read
+   * (route 2). Same member-gated, hardened-header path as the web route; the
+   * viewer is the agent itself.
+   */
+  app.get<{ Params: { chatId: string; attachmentId: string } }>(
+    "/:chatId/attachments/:attachmentId",
+    async (request, reply) => {
+      const identity = requireAgent(request);
+      const att = await getAttachmentForDownload(app.db, {
+        chatId: request.params.chatId,
+        attachmentId: request.params.attachmentId,
+        viewerId: identity.uuid,
+      });
+      sendAttachmentResponse(reply, att);
+    },
+  );
 
   // Participant management
   app.post<{ Params: { chatId: string } }>("/:chatId/participants", async (request, reply) => {

--- a/packages/server/src/api/attachment-response.ts
+++ b/packages/server/src/api/attachment-response.ts
@@ -1,0 +1,36 @@
+import { isInlineSafeImage } from "@agent-team-foundation/first-tree-hub-shared";
+import type { FastifyReply } from "fastify";
+import type { DownloadableAttachment } from "../services/attachment.js";
+
+/** Strip control chars / quotes for a safe Content-Disposition filename. */
+function dispositionFilename(name: string): string {
+  const cleaned = name
+    .replace(/[\r\n"\\]/g, "_")
+    .trim()
+    .slice(0, 200);
+  return cleaned.length > 0 ? cleaned : "attachment";
+}
+
+/**
+ * Write hardened download headers and send the bytes (C2). Only the
+ * inline-safe image allow-list (png/jpeg/gif/webp) is served inline so
+ * `<img>`/blob rendering works; everything else — including `image/svg+xml`,
+ * which can carry script — is forced to download with a neutral content type
+ * and `nosniff`, so a malicious payload can never execute in the Hub origin.
+ *
+ * Bytes are sent as a single Buffer (≤ the per-file cap). True chunked
+ * streaming isn't possible from a PG `bytea` column (postgres-js reads the
+ * value whole); the size cap bounds memory instead.
+ */
+export function sendAttachmentResponse(reply: FastifyReply, att: DownloadableAttachment): void {
+  const inline = isInlineSafeImage(att.mime);
+  reply.header("Content-Type", inline ? att.mime : "application/octet-stream");
+  reply.header("X-Content-Type-Options", "nosniff");
+  reply.header(
+    "Content-Disposition",
+    `${inline ? "inline" : "attachment"}; filename="${dispositionFilename(att.filename)}"`,
+  );
+  reply.header("Content-Length", String(att.size));
+  reply.header("Cache-Control", "private, max-age=3600");
+  reply.send(att.bytes);
+}

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -1,4 +1,5 @@
 import {
+  ATTACHMENT_LIMITS,
   addMeChatParticipantsSchema,
   paginationQuerySchema,
   patchChatEngagementSchema,
@@ -14,8 +15,10 @@ import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
+import { BadRequestError } from "../errors.js";
 import { assertAllAgentsVisibleInOrg, requireChatAccess } from "../scope/require-resource.js";
 import { agentAvatarImageUrl } from "../services/agent.js";
+import { createAttachment, getAttachmentForDownload } from "../services/attachment.js";
 import { ensureParticipant, joinChat, leaveChat } from "../services/chat.js";
 import { findInstallationByOrg } from "../services/github-app-installations.js";
 import { mintContextTreeInstallationToken } from "../services/github-app-token.js";
@@ -36,6 +39,7 @@ import { WIRE_RECIPIENT_MODE } from "../services/message-dispatcher.js";
 import { notifyRecipients } from "../services/notifier.js";
 import { submitAnswer } from "../services/questions.js";
 import { extractSummary } from "../services/session.js";
+import { sendAttachmentResponse } from "./attachment-response.js";
 
 /**
  * Class C — resource-scoped chat routes. Mounted at
@@ -323,6 +327,9 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       // Human web endpoint: typed `@<name>` is the user's intent expression
       // — the only path where the message *itself* is the routing decision.
       extractMentionsFromContent: true,
+      // Attachments uploaded via POST /chats/:id/attachments, validated +
+      // bound inside the send transaction (A′: refs ride metadata.attachments).
+      attachmentIds: body.attachmentIds,
     });
 
     notifyRecipients(app.notifier, result.recipients, result.message.id);
@@ -337,6 +344,55 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       createdAt: result.message.createdAt.toISOString(),
     });
   });
+
+  /**
+   * POST /chats/:chatId/attachments — upload one file (multipart) to be
+   * referenced by a subsequent message send. Persists to PG (route 2); returns
+   * an AttachmentRef the composer puts in `attachmentIds` when it sends. The
+   * row is unbound until the send binds it (C3). Caller speaks as their human
+   * agent and must be a chat participant.
+   */
+  app.post<{ Params: { chatId: string } }>("/:chatId/attachments", async (request, reply) => {
+    const { scope } = await requireChatAccess(request, app.db);
+    await ensureParticipant(app.db, request.params.chatId, scope.humanAgentId);
+
+    const file = await request.file();
+    if (!file) throw new BadRequestError("No file uploaded.");
+    let bytes: Buffer;
+    try {
+      bytes = await file.toBuffer();
+    } catch {
+      throw new BadRequestError(`Attachment exceeds the ${ATTACHMENT_LIMITS.maxFileBytes / (1024 * 1024)}MB limit.`);
+    }
+
+    const ref = await createAttachment(app.db, {
+      chatId: request.params.chatId,
+      uploaderId: scope.humanAgentId,
+      filename: file.filename,
+      declaredMime: file.mimetype,
+      bytes,
+    });
+    return reply.status(201).send(ref);
+  });
+
+  /**
+   * GET /chats/:chatId/attachments/:attachmentId — stream an attachment's bytes
+   * to a chat member. Membership re-checked per request; download headers are
+   * hardened (C2) — only the inline-safe image allow-list is served inline,
+   * everything else (incl. SVG) is forced to download with nosniff.
+   */
+  app.get<{ Params: { chatId: string; attachmentId: string } }>(
+    "/:chatId/attachments/:attachmentId",
+    async (request, reply) => {
+      const { scope } = await requireChatAccess(request, app.db);
+      const att = await getAttachmentForDownload(app.db, {
+        chatId: request.params.chatId,
+        attachmentId: request.params.attachmentId,
+        viewerId: scope.humanAgentId,
+      });
+      sendAttachmentResponse(reply, att);
+    },
+  );
 
   /**
    * POST /chats/:chatId/questions/:correlationId/answer — submit an answer

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,10 +1,12 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { extname, join, resolve } from "node:path";
+import { ATTACHMENT_LIMITS } from "@agent-team-foundation/first-tree-hub-shared";
 import { DEFAULT_DATA_DIR } from "@agent-team-foundation/first-tree-hub-shared/config";
 import { FIRST_TREE_HUB_ATTR, redactUrl } from "@agent-team-foundation/first-tree-hub-shared/observability";
 import fastifyOpenTelemetry from "@autotelic/fastify-opentelemetry";
 import cors from "@fastify/cors";
+import multipart from "@fastify/multipart";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
@@ -321,6 +323,15 @@ export async function buildApp(config: Config) {
   // this codebase are JSON envelopes; image content travels via HTTP.
   await app.register(websocket, {
     options: { maxPayload: config.ws?.maxPayload ?? 65_536 },
+  });
+
+  // Multipart — message attachment uploads (route 2 / PG-bytea). `fileSize`
+  // caps a single file server-side so the messages routes don't inherit
+  // Fastify's 1 MB default body limit; one file per request (the composer
+  // uploads each attachment separately, then sends one message referencing
+  // them). See services/attachment.ts + proposals/hub-message-text-attachments.
+  await app.register(multipart, {
+    limits: { fileSize: ATTACHMENT_LIMITS.maxFileBytes, files: 1 },
   });
 
   // CORS — explicit origins if configured; allow all in dev; same-origin in production

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -16,6 +16,7 @@ export { githubEntityChatMappings } from "./github-entity-chat-mappings.js";
 export { inboxEntries } from "./inbox-entries.js";
 export { invitationRedemptions, invitations } from "./invitations.js";
 export { members } from "./members.js";
+export { messageAttachments } from "./message-attachments.js";
 export { messages } from "./messages.js";
 export { notifications } from "./notifications.js";
 export { organizationSettings } from "./organization-settings.js";

--- a/packages/server/src/db/schema/message-attachments.ts
+++ b/packages/server/src/db/schema/message-attachments.ts
@@ -1,0 +1,55 @@
+import { customType, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { chats } from "./chats.js";
+import { messages } from "./messages.js";
+
+/**
+ * `bytea` column type — Drizzle ships pg primitives but not bytea. Reads come
+ * back as Node `Buffer` (postgres-js); writes accept any `Uint8Array`. Mirrors
+ * the inline-avatar `bytea` in agents.ts; attachments are larger (≤10 MB) so the
+ * download route streams and the column is set `STORAGE EXTERNAL` (no pointless
+ * TOAST compression of already-compressed media) via a follow-up custom
+ * migration — see drizzle/.
+ */
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType: () => "bytea",
+});
+
+/**
+ * Message attachments — file bytes persisted server-side (route 2 / PG-bytea,
+ * proposals/hub-message-text-attachments.20260521.md). The message itself only
+ * carries references under `metadata.attachments[]` (A′); clients fetch bytes on
+ * demand from the member-gated download route.
+ *
+ * Two-phase lifecycle: rows are created by the upload endpoint with
+ * `message_id = NULL`, then bound to a message at send time (uploader + unbound
+ * checks guard against cross-user reference). An orphan-GC sweep deletes rows
+ * left unbound past a TTL. FK cascade removes attachments with their message /
+ * chat.
+ */
+export const messageAttachments = pgTable(
+  "message_attachments",
+  {
+    id: text("id").primaryKey(),
+    chatId: text("chat_id")
+      .notNull()
+      .references(() => chats.id, { onDelete: "cascade" }),
+    /** NULL until the attachment is bound to a sent message. */
+    messageId: text("message_id").references(() => messages.id, { onDelete: "cascade" }),
+    /** Agent uuid of the uploader. No FK — agents may be soft-deleted. */
+    uploaderId: text("uploader_id").notNull(),
+    mime: text("mime").notNull(),
+    filename: text("filename").notNull(),
+    size: integer("size").notNull(),
+    sha256: text("sha256").notNull(),
+    /** "image" | "file" — render/delivery split (deriveAttachmentKind). */
+    kind: text("kind").notNull(),
+    bytes: bytea("bytes").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_message_attachments_message").on(table.messageId),
+    index("idx_message_attachments_chat").on(table.chatId),
+    // Orphan-GC sweep: WHERE message_id IS NULL AND created_at < now() - ttl.
+    index("idx_message_attachments_created").on(table.createdAt),
+  ],
+);

--- a/packages/server/src/db/schema/message-attachments.ts
+++ b/packages/server/src/db/schema/message-attachments.ts
@@ -1,4 +1,5 @@
-import { customType, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { check, customType, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { chats } from "./chats.js";
 import { messages } from "./messages.js";
 
@@ -41,7 +42,13 @@ export const messageAttachments = pgTable(
     filename: text("filename").notNull(),
     size: integer("size").notNull(),
     sha256: text("sha256").notNull(),
-    /** "image" | "file" — render/delivery split (deriveAttachmentKind). */
+    /**
+     * "image" | "file" — render/delivery split. Stamped on upload via
+     * `deriveAttachmentKind(mime)` (shared); the CHECK constraint below
+     * defends against accidental drift if anyone tries to write a value
+     * other than the two enums (typos, future contributors who don't see
+     * the shared helper).
+     */
     kind: text("kind").notNull(),
     bytes: bytea("bytes").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -51,5 +58,6 @@ export const messageAttachments = pgTable(
     index("idx_message_attachments_chat").on(table.chatId),
     // Orphan-GC sweep: WHERE message_id IS NULL AND created_at < now() - ttl.
     index("idx_message_attachments_created").on(table.createdAt),
+    check("message_attachments_kind_check", sql`${table.kind} IN ('image', 'file')`),
   ],
 );

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -1,3 +1,4 @@
+import { type AttachmentRef, messageAttachmentsMetadataSchema } from "@agent-team-foundation/first-tree-hub-shared";
 import { FIRST_TREE_HUB_ATTR } from "@agent-team-foundation/first-tree-hub-shared/observability";
 import { Client, EventDispatcher, LoggerLevel, WSClient } from "@larksuiteoapi/node-sdk";
 import { trace } from "@opentelemetry/api";
@@ -736,8 +737,8 @@ async function processFeishuOutboundClaimed(
         continue;
       }
 
-      // Format and send via official SDK
-      const { msgType, content } = formatForFeishu(msg.format, msg.content);
+      // Format and send via official SDK (attachments → filename list, no links)
+      const { msgType, content } = formatForFeishu(msg.format, msg.content, attachmentsFromMetadata(msg.metadata));
 
       const result = await botApiCall(bot, () =>
         bot.client.im.v1.message.create({
@@ -789,18 +790,48 @@ async function ackEntry(db: Database, entryId: number): Promise<void> {
   await db.update(inboxEntries).set({ status: "acked", ackedAt: new Date() }).where(eq(inboxEntries.id, entryId));
 }
 
-/** Convert internal message format to Feishu msg_type + content string. */
-function formatForFeishu(format: string, content: unknown): { msgType: string; content: string } {
+/** Extract A′ attachment refs from a message's metadata, or [] when none. */
+function attachmentsFromMetadata(metadata: unknown): AttachmentRef[] {
+  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data.attachments : [];
+}
+
+function formatAttachmentSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Convert internal message format to Feishu msg_type + content string.
+ *
+ * Attachments (route 2 / A′) are downgraded to a plain filename + size list
+ * appended to the text — external Feishu users have no Hub session, so we
+ * deliberately do NOT embed download links (real file forwarding via the Feishu
+ * upload API is a follow-up).
+ */
+function formatForFeishu(
+  format: string,
+  content: unknown,
+  attachments: AttachmentRef[] = [],
+): { msgType: string; content: string } {
+  const suffix =
+    attachments.length > 0
+      ? `\n\n📎 ${attachments.length} attachment${attachments.length > 1 ? "s" : ""}:\n${attachments
+          .map((a) => `• ${a.filename} (${formatAttachmentSize(a.size)})`)
+          .join("\n")}`
+      : "";
+
   if (format === "text") {
     const text = typeof content === "string" ? content : JSON.stringify(content);
-    return { msgType: "text", content: JSON.stringify({ text }) };
+    return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
   }
 
   if (format === "markdown") {
     const text = typeof content === "string" ? content : JSON.stringify(content);
     const card = {
       config: { wide_screen_mode: true },
-      elements: [{ tag: "markdown", content: text }],
+      elements: [{ tag: "markdown", content: text + suffix }],
     };
     return { msgType: "interactive", content: JSON.stringify(card) };
   }
@@ -810,5 +841,5 @@ function formatForFeishu(format: string, content: unknown): { msgType: string; c
   }
 
   const text = typeof content === "string" ? content : JSON.stringify(content);
-  return { msgType: "text", content: JSON.stringify({ text }) };
+  return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
 }

--- a/packages/server/src/services/adapter-manager.ts
+++ b/packages/server/src/services/adapter-manager.ts
@@ -1,4 +1,4 @@
-import { type AttachmentRef, messageAttachmentsMetadataSchema } from "@agent-team-foundation/first-tree-hub-shared";
+import { getMessageAttachments } from "@agent-team-foundation/first-tree-hub-shared";
 import { FIRST_TREE_HUB_ATTR } from "@agent-team-foundation/first-tree-hub-shared/observability";
 import { Client, EventDispatcher, LoggerLevel, WSClient } from "@larksuiteoapi/node-sdk";
 import { trace } from "@opentelemetry/api";
@@ -13,6 +13,7 @@ import { messages } from "../db/schema/messages.js";
 import { adapterAttrs, withSpan } from "../observability/index.js";
 import * as mappingService from "./adapter-mapping.js";
 import { decryptCredentials } from "./crypto.js";
+import { formatForFeishu } from "./feishu/format-message.js";
 import type { FeishuBotCredentials, InboundEvent } from "./feishu/types.js";
 import { sendMessage } from "./message.js";
 import { type Notifier, notifyRecipients } from "./notifier.js";
@@ -738,7 +739,7 @@ async function processFeishuOutboundClaimed(
       }
 
       // Format and send via official SDK (attachments → filename list, no links)
-      const { msgType, content } = formatForFeishu(msg.format, msg.content, attachmentsFromMetadata(msg.metadata));
+      const { msgType, content } = formatForFeishu(msg.format, msg.content, getMessageAttachments(msg.metadata));
 
       const result = await botApiCall(bot, () =>
         bot.client.im.v1.message.create({
@@ -788,58 +789,4 @@ async function processFeishuOutboundClaimed(
 
 async function ackEntry(db: Database, entryId: number): Promise<void> {
   await db.update(inboxEntries).set({ status: "acked", ackedAt: new Date() }).where(eq(inboxEntries.id, entryId));
-}
-
-/** Extract A′ attachment refs from a message's metadata, or [] when none. */
-function attachmentsFromMetadata(metadata: unknown): AttachmentRef[] {
-  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
-  return parsed.success ? parsed.data.attachments : [];
-}
-
-function formatAttachmentSize(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
-  return `${(n / 1024 / 1024).toFixed(1)} MB`;
-}
-
-/**
- * Convert internal message format to Feishu msg_type + content string.
- *
- * Attachments (route 2 / A′) are downgraded to a plain filename + size list
- * appended to the text — external Feishu users have no Hub session, so we
- * deliberately do NOT embed download links (real file forwarding via the Feishu
- * upload API is a follow-up).
- */
-function formatForFeishu(
-  format: string,
-  content: unknown,
-  attachments: AttachmentRef[] = [],
-): { msgType: string; content: string } {
-  const suffix =
-    attachments.length > 0
-      ? `\n\n📎 ${attachments.length} attachment${attachments.length > 1 ? "s" : ""}:\n${attachments
-          .map((a) => `• ${a.filename} (${formatAttachmentSize(a.size)})`)
-          .join("\n")}`
-      : "";
-
-  if (format === "text") {
-    const text = typeof content === "string" ? content : JSON.stringify(content);
-    return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
-  }
-
-  if (format === "markdown") {
-    const text = typeof content === "string" ? content : JSON.stringify(content);
-    const card = {
-      config: { wide_screen_mode: true },
-      elements: [{ tag: "markdown", content: text + suffix }],
-    };
-    return { msgType: "interactive", content: JSON.stringify(card) };
-  }
-
-  if (format === "card" && typeof content === "object") {
-    return { msgType: "interactive", content: JSON.stringify(content) };
-  }
-
-  const text = typeof content === "string" ? content : JSON.stringify(content);
-  return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
 }

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -4,6 +4,7 @@ import {
   type AttachmentRef,
   AttachmentRejectedError,
   classifyAttachment,
+  deriveAttachmentKind,
 } from "@agent-team-foundation/first-tree-hub-shared";
 import { and, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -65,6 +66,12 @@ export async function createAttachment(
 
   const id = randomUUID();
   const sha256 = createHash("sha256").update(args.bytes).digest("hex");
+  // Single source of truth for kind: always `deriveAttachmentKind(mime)`. The
+  // DB CHECK constraint (`kind IN ('image', 'file')`) defends against any
+  // accidental write of another value, but this call site keeps the derivation
+  // explicit so future contributors don't accept a `kind` parameter from a
+  // caller — kind is a pure function of mime, never of caller intent.
+  const kind = deriveAttachmentKind(classification.mimeType);
   await db.insert(messageAttachments).values({
     id,
     chatId: args.chatId,
@@ -74,7 +81,7 @@ export async function createAttachment(
     filename: args.filename,
     size: args.bytes.length,
     sha256,
-    kind: classification.kind,
+    kind,
     bytes: args.bytes,
   });
 
@@ -83,7 +90,7 @@ export async function createAttachment(
     mimeType: classification.mimeType,
     filename: args.filename,
     size: args.bytes.length,
-    kind: classification.kind,
+    kind,
   };
 }
 
@@ -121,7 +128,6 @@ export async function prepareAttachmentsForSend(
       mime: messageAttachments.mime,
       filename: messageAttachments.filename,
       size: messageAttachments.size,
-      kind: messageAttachments.kind,
     })
     .from(messageAttachments)
     .where(inArray(messageAttachments.id, ids))
@@ -140,8 +146,17 @@ export async function prepareAttachmentsForSend(
     if (row.messageId !== null) throw new BadRequestError("Attachment is already attached to a message.");
     if (row.chatId !== args.chatId) throw new BadRequestError("Attachment belongs to a different chat.");
     totalBytes += row.size;
-    const kind = row.kind === "image" ? "image" : "file";
-    refs.push({ attachmentId: row.id, mimeType: row.mime, filename: row.filename, size: row.size, kind });
+    // Re-derive kind from mime here (instead of trusting the DB column) so the
+    // read path can never disagree with the write path — `deriveAttachmentKind`
+    // is the single source of truth. The DB CHECK ensures stored `kind` is
+    // valid; this guarantees the *returned* ref is always consistent with mime.
+    refs.push({
+      attachmentId: row.id,
+      mimeType: row.mime,
+      filename: row.filename,
+      size: row.size,
+      kind: deriveAttachmentKind(row.mime),
+    });
   }
   if (totalBytes > ATTACHMENT_LIMITS.maxMessageBytes) {
     throw new BadRequestError(

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -1,0 +1,232 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  ATTACHMENT_LIMITS,
+  type AttachmentRef,
+  AttachmentRejectedError,
+  classifyAttachment,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { and, eq, inArray, isNull, lt, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { Database } from "../db/connection.js";
+import { chats } from "../db/schema/chats.js";
+import { messageAttachments } from "../db/schema/message-attachments.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { assertParticipant } from "./chat.js";
+
+/** Subset of the drizzle client used here — satisfied by both `Database` and a tx. */
+type AttachmentDb = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "insert" | "update" | "delete">;
+
+/** Unbound attachments left past this age are swept by the orphan GC. */
+const ORPHAN_TTL_MS = 24 * 60 * 60 * 1000;
+
+async function orgIdForChat(db: AttachmentDb, chatId: string): Promise<string> {
+  const [row] = await db.select({ orgId: chats.organizationId }).from(chats).where(eq(chats.id, chatId)).limit(1);
+  if (!row) throw new NotFoundError("Chat not found");
+  return row.orgId;
+}
+
+/**
+ * Validate + persist one uploaded file (route 2 / PG-bytea). Runs the shared
+ * type double-gate (size, extension deny list, magic-byte sniff, C1 magicless
+ * safe-text allowance), computes sha256, derives kind, and enforces the org
+ * storage quota before inserting. The row is created **unbound**
+ * (`message_id = NULL`) and bound to a message at send time.
+ *
+ * The caller (route) must have already proven the uploader is a chat speaker.
+ */
+export async function createAttachment(
+  db: AttachmentDb,
+  args: { chatId: string; uploaderId: string; filename: string; declaredMime: string; bytes: Buffer },
+): Promise<AttachmentRef> {
+  let classification: { kind: "image" | "file"; mimeType: string };
+  try {
+    classification = classifyAttachment({
+      filename: args.filename,
+      declaredMime: args.declaredMime,
+      head: args.bytes.subarray(0, 512),
+      size: args.bytes.length,
+    });
+  } catch (err) {
+    // Surface the shared validator's reason as a 400 (it is not an AppError).
+    if (err instanceof AttachmentRejectedError) throw new BadRequestError(err.message);
+    throw err;
+  }
+
+  const orgId = await orgIdForChat(db, args.chatId);
+  const [usage] = await db
+    .select({ total: sql<string>`coalesce(sum(${messageAttachments.size}), 0)` })
+    .from(messageAttachments)
+    .innerJoin(chats, eq(messageAttachments.chatId, chats.id))
+    .where(eq(chats.organizationId, orgId));
+  const used = Number(usage?.total ?? 0);
+  if (used + args.bytes.length > ATTACHMENT_LIMITS.orgQuotaBytes) {
+    throw new BadRequestError("Organization attachment storage quota exceeded.");
+  }
+
+  const id = randomUUID();
+  const sha256 = createHash("sha256").update(args.bytes).digest("hex");
+  await db.insert(messageAttachments).values({
+    id,
+    chatId: args.chatId,
+    messageId: null,
+    uploaderId: args.uploaderId,
+    mime: classification.mimeType,
+    filename: args.filename,
+    size: args.bytes.length,
+    sha256,
+    kind: classification.kind,
+    bytes: args.bytes,
+  });
+
+  return {
+    attachmentId: id,
+    mimeType: classification.mimeType,
+    filename: args.filename,
+    size: args.bytes.length,
+    kind: classification.kind,
+  };
+}
+
+/**
+ * Validate the attachments a send references and return their authoritative
+ * refs (mime/size/kind from the DB, never trusting client-sent values).
+ * Enforces C3: each referenced attachment must be uploaded by the sender, still
+ * unbound, and belong to this chat — blocking cross-user / replay references.
+ * Also enforces the per-message count + total-size caps.
+ *
+ * Returns refs in the caller's requested order. Does NOT mutate — bind happens
+ * in {@link bindAttachmentsToMessage} after the message row exists.
+ */
+export async function prepareAttachmentsForSend(
+  tx: AttachmentDb,
+  args: { chatId: string; senderId: string; attachmentIds: readonly string[] },
+): Promise<AttachmentRef[]> {
+  const ids = [...new Set(args.attachmentIds)];
+  if (ids.length === 0) return [];
+  if (ids.length > ATTACHMENT_LIMITS.maxMessageCount) {
+    throw new BadRequestError(`Too many attachments (max ${ATTACHMENT_LIMITS.maxMessageCount} per message).`);
+  }
+
+  // `FOR UPDATE` locks the rows for this transaction so two concurrent sends
+  // can't both pass the unbound check below: the second send blocks here until
+  // the first commits, then sees `messageId !== null` and is rejected. Combined
+  // with the row-count assertion in bindAttachmentsToMessage, a given upload can
+  // bind to at most one message.
+  const rows = await tx
+    .select({
+      id: messageAttachments.id,
+      chatId: messageAttachments.chatId,
+      messageId: messageAttachments.messageId,
+      uploaderId: messageAttachments.uploaderId,
+      mime: messageAttachments.mime,
+      filename: messageAttachments.filename,
+      size: messageAttachments.size,
+      kind: messageAttachments.kind,
+    })
+    .from(messageAttachments)
+    .where(inArray(messageAttachments.id, ids))
+    .for("update");
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  let totalBytes = 0;
+  const refs: AttachmentRef[] = [];
+  for (const id of ids) {
+    const row = byId.get(id);
+    if (!row) throw new BadRequestError("Attachment not found or already expired.");
+    if (row.uploaderId !== args.senderId) {
+      // C3: never let a sender attach someone else's pending upload.
+      throw new ForbiddenError("Cannot attach a file uploaded by someone else.");
+    }
+    if (row.messageId !== null) throw new BadRequestError("Attachment is already attached to a message.");
+    if (row.chatId !== args.chatId) throw new BadRequestError("Attachment belongs to a different chat.");
+    totalBytes += row.size;
+    const kind = row.kind === "image" ? "image" : "file";
+    refs.push({ attachmentId: row.id, mimeType: row.mime, filename: row.filename, size: row.size, kind });
+  }
+  if (totalBytes > ATTACHMENT_LIMITS.maxMessageBytes) {
+    throw new BadRequestError(
+      `Attachments exceed the per-message size limit (${ATTACHMENT_LIMITS.maxMessageBytes} bytes).`,
+    );
+  }
+  return refs;
+}
+
+/**
+ * Bind validated attachments to their message (sets `message_id`). The
+ * `isNull(message_id)` guard + row-count assertion close the rebind race: if a
+ * concurrent send bound any of these rows between validation and here, fewer
+ * rows update than expected and we throw to roll back the whole send (so a
+ * message is never persisted referencing an attachment bound elsewhere).
+ */
+export async function bindAttachmentsToMessage(
+  tx: AttachmentDb,
+  args: { messageId: string; attachmentIds: readonly string[] },
+): Promise<void> {
+  const ids = [...new Set(args.attachmentIds)];
+  if (ids.length === 0) return;
+  const bound = await tx
+    .update(messageAttachments)
+    .set({ messageId: args.messageId })
+    .where(and(inArray(messageAttachments.id, ids), isNull(messageAttachments.messageId)))
+    .returning({ id: messageAttachments.id });
+  if (bound.length !== ids.length) {
+    throw new ConflictError("An attachment was bound to another message concurrently — retry the send.");
+  }
+}
+
+export type DownloadableAttachment = {
+  bytes: Buffer;
+  mime: string;
+  filename: string;
+  kind: string;
+  size: number;
+};
+
+/**
+ * Fetch an attachment's bytes for download, gated on the viewer being a current
+ * speaker of the chat (membership re-checked on every request — leaving the
+ * chat revokes access immediately). Bytes never leave the server except through
+ * this authenticated route.
+ */
+export async function getAttachmentForDownload(
+  db: Database,
+  args: { chatId: string; attachmentId: string; viewerId: string },
+): Promise<DownloadableAttachment> {
+  await assertParticipant(db, args.chatId, args.viewerId);
+  const [row] = await db
+    .select({
+      chatId: messageAttachments.chatId,
+      messageId: messageAttachments.messageId,
+      uploaderId: messageAttachments.uploaderId,
+      bytes: messageAttachments.bytes,
+      mime: messageAttachments.mime,
+      filename: messageAttachments.filename,
+      kind: messageAttachments.kind,
+      size: messageAttachments.size,
+    })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.id, args.attachmentId))
+    .limit(1);
+  if (!row || row.chatId !== args.chatId) throw new NotFoundError("Attachment not found");
+  // Still-unbound uploads are only readable by their uploader — they aren't part
+  // of any message yet, so no other chat member should be able to pull them via
+  // a guessed id (defence in depth on top of the random UUID).
+  if (row.messageId === null && row.uploaderId !== args.viewerId) {
+    throw new NotFoundError("Attachment not found");
+  }
+  return { bytes: row.bytes, mime: row.mime, filename: row.filename, kind: row.kind, size: row.size };
+}
+
+/**
+ * Delete attachments that were uploaded but never bound to a message within the
+ * TTL (e.g. the user attached a file then abandoned the compose). Returns the
+ * number deleted. Intended to run on a periodic sweep.
+ */
+export async function gcOrphanedAttachments(db: AttachmentDb): Promise<number> {
+  const cutoff = new Date(Date.now() - ORPHAN_TTL_MS);
+  const deleted = await db
+    .delete(messageAttachments)
+    .where(and(isNull(messageAttachments.messageId), lt(messageAttachments.createdAt, cutoff)))
+    .returning({ id: messageAttachments.id });
+  return deleted.length;
+}

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../observability/index.js";
 import type { AdapterManager } from "./adapter-manager.js";
+import { gcOrphanedAttachments } from "./attachment.js";
 import * as clientService from "./client.js";
 import * as inboxService from "./inbox.js";
 import type { KaelRuntime } from "./kael-runtime.js";
@@ -44,6 +45,13 @@ export function createBackgroundTasks(
               { ackedDeleted: pruned.ackedDeleted, stalePendingDeleted: pruned.stalePendingDeleted },
               "pruned silent inbox rows",
             );
+          }
+          // Orphan-attachment GC piggy-backs on the same timer: delete uploads
+          // that were never bound to a message within the TTL (abandoned
+          // compose) so they don't pin PG storage / org quota forever.
+          const gcDeleted = await gcOrphanedAttachments(app.db);
+          if (gcDeleted > 0) {
+            log.debug({ deleted: gcDeleted }, "gc'd orphaned attachments");
           }
         } catch (err) {
           log.error({ err }, "failed to reset timed-out inbox entries");

--- a/packages/server/src/services/feishu/format-message.ts
+++ b/packages/server/src/services/feishu/format-message.ts
@@ -1,0 +1,60 @@
+import type { AttachmentRef } from "@agent-team-foundation/first-tree-hub-shared";
+
+/**
+ * Feishu-specific message formatting. Owns *how* attachments are surfaced to
+ * external Feishu users — a filename + size list appended to the text, no
+ * internal download links (external users have no Hub session). The Feishu
+ * upload API path is a follow-up; until then this is the deliberate downgrade.
+ *
+ * Lives here (not in `adapter-manager.ts`) so each adapter's "consume
+ * `metadata.attachments`" logic stays in its own folder. The manager is the
+ * router/dispatcher; per-adapter rendering shouldn't leak back into it.
+ */
+
+function formatAttachmentSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Convert an internal message (format + content + attachments) into Feishu
+ * `msg_type` + serialised content string for `im.v1.message.create`.
+ *
+ * Attachments are downgraded to a filename + size list appended to the text —
+ * see file header for why. Caller passes `attachments=[]` for messages without
+ * any.
+ */
+export function formatForFeishu(
+  format: string,
+  content: unknown,
+  attachments: AttachmentRef[] = [],
+): { msgType: string; content: string } {
+  const suffix =
+    attachments.length > 0
+      ? `\n\n📎 ${attachments.length} attachment${attachments.length > 1 ? "s" : ""}:\n${attachments
+          .map((a) => `• ${a.filename} (${formatAttachmentSize(a.size)})`)
+          .join("\n")}`
+      : "";
+
+  if (format === "text") {
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
+  }
+
+  if (format === "markdown") {
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    const card = {
+      config: { wide_screen_mode: true },
+      elements: [{ tag: "markdown", content: text + suffix }],
+    };
+    return { msgType: "interactive", content: JSON.stringify(card) };
+  }
+
+  if (format === "card" && typeof content === "object") {
+    return { msgType: "interactive", content: JSON.stringify(content) };
+  }
+
+  const text = typeof content === "string" ? content : JSON.stringify(content);
+  return { msgType: "text", content: JSON.stringify({ text: text + suffix }) };
+}

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -10,6 +10,7 @@ import { messages } from "../db/schema/messages.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { createLogger, messageAttrs, withSpan } from "../observability/index.js";
 import { upsertSessionState } from "./activity.js";
+import { bindAttachmentsToMessage, prepareAttachmentsForSend } from "./attachment.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { validateDocumentContext } from "./doc-snapshots.js";
 import { assertSenderMayEmitQuestion, recordPendingQuestionFromMessage } from "./questions.js";
@@ -89,6 +90,14 @@ export type SendMessageOptions = {
    * when no explicit declaration was made.
    */
   extractMentionsFromContent?: boolean;
+  /**
+   * Attachment ids (from `POST /chats/:id/attachments`) to bind to this
+   * message. Validated inside the send transaction (must be uploaded by the
+   * sender, still unbound, same chat — C3) and folded into
+   * `metadata.attachments` as authoritative refs. The message stays a regular
+   * text/markdown message (A′) — attachments ride metadata, no new `format`.
+   */
+  attachmentIds?: readonly string[];
 };
 
 export async function sendMessage(
@@ -198,7 +207,14 @@ async function sendMessageInner(
     //     where the typed message is the sole source of routing intent.
     //     Agent / programmatic callers leave this off so a narrative
     //     `@<peer>` in content never silently wakes anyone.
-    const incomingMeta = (data.metadata ?? {}) as Record<string, unknown>;
+    // Copy the incoming metadata, then drop any client-supplied `attachments`
+    // key (C3 hardening). Attachment refs may ONLY be produced server-side by
+    // `prepareAttachmentsForSend` and folded in at insert time — without this a
+    // caller could omit `attachmentIds` and write a forged `metadata.attachments`
+    // straight into the message, bypassing the uploader / unbound / same-chat /
+    // count / size validation entirely.
+    const incomingMeta: Record<string, unknown> = { ...((data.metadata ?? {}) as Record<string, unknown>) };
+    delete incomingMeta.attachments;
     // Server-side bottom-line on `metadata.documentContext`: shape via shared
     // schema + byte budgets and sha256 calibration. Snapshot content arrives
     // from a trusted runtime, but server still has to verify so a client bug
@@ -442,7 +458,18 @@ async function sendMessageInner(
     const projectionMentions: string[] = isSilentSend ? [] : dmAutoProjection;
 
     // 3. Store the message (with merged metadata + normalised content).
+    //    Attachments (route 2 / PG-bytea): validate the referenced uploads are
+    //    the sender's own, still unbound, and in this chat (C3), fold their
+    //    authoritative refs into metadata.attachments before the insert, then
+    //    bind them to the new message id — all in this tx so a rollback drops
+    //    both. The message itself stays plain text/markdown (A′).
     const messageId = randomUUID();
+    const attachmentRefs =
+      options.attachmentIds && options.attachmentIds.length > 0
+        ? await prepareAttachmentsForSend(tx, { chatId, senderId, attachmentIds: options.attachmentIds })
+        : [];
+    const metadataWithAttachments =
+      attachmentRefs.length > 0 ? { ...metadataToStore, attachments: attachmentRefs } : metadataToStore;
     const [msg] = await tx
       .insert(messages)
       .values({
@@ -451,11 +478,14 @@ async function sendMessageInner(
         senderId,
         format: data.format,
         content: outboundContent,
-        metadata: metadataToStore,
+        metadata: metadataWithAttachments,
         inReplyTo: data.inReplyTo ?? null,
         source: data.source,
       })
       .returning();
+    if (attachmentRefs.length > 0) {
+      await bindAttachmentsToMessage(tx, { messageId, attachmentIds: options.attachmentIds ?? [] });
+    }
 
     // 3b. For ask-user questions, record the pending lifecycle row in the
     //     same transaction so a rollback drops both. The content was just

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { extractMentions, type SendMessage, scanMentionTokens } from "@agent-team-foundation/first-tree-hub-shared";
+import {
+  extractMentions,
+  type SendMessage,
+  scanMentionTokens,
+  stripUntrustedMetadataKeys,
+} from "@agent-team-foundation/first-tree-hub-shared";
 import { and, desc, eq, lt } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -207,14 +212,18 @@ async function sendMessageInner(
     //     where the typed message is the sole source of routing intent.
     //     Agent / programmatic callers leave this off so a narrative
     //     `@<peer>` in content never silently wakes anyone.
-    // Copy the incoming metadata, then drop any client-supplied `attachments`
-    // key (C3 hardening). Attachment refs may ONLY be produced server-side by
-    // `prepareAttachmentsForSend` and folded in at insert time — without this a
-    // caller could omit `attachmentIds` and write a forged `metadata.attachments`
-    // straight into the message, bypassing the uploader / unbound / same-chat /
-    // count / size validation entirely.
-    const incomingMeta: Record<string, unknown> = { ...((data.metadata ?? {}) as Record<string, unknown>) };
-    delete incomingMeta.attachments;
+    // Copy the incoming metadata, then strip every server-managed key
+    // (`attachments`, `editedAt`, ... — see `SERVER_MANAGED_METADATA_KEYS`
+    // in shared). C3 hardening: attachment refs may ONLY be produced
+    // server-side by `prepareAttachmentsForSend` and folded in at insert time
+    // — without this a caller could omit `attachmentIds` and write a forged
+    // `metadata.attachments` straight into the message, bypassing the
+    // uploader / unbound / same-chat / count / size validation entirely. Same
+    // defence applies to every other server-managed key (e.g. `editedAt`);
+    // centralising the set in shared makes future additions one-line.
+    const incomingMeta: Record<string, unknown> = stripUntrustedMetadataKeys(
+      (data.metadata ?? {}) as Record<string, unknown>,
+    );
     // Server-side bottom-line on `metadata.documentContext`: shape via shared
     // schema + byte budgets and sha256 calibration. Snapshot content arrives
     // from a trusted runtime, but server still has to verify so a client bug

--- a/packages/shared/src/__tests__/attachments.test.ts
+++ b/packages/shared/src/__tests__/attachments.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  ATTACHMENT_LIMITS,
+  AttachmentRejectedError,
+  classifyAttachment,
+  fileExtension,
+  isInlineSafeImage,
+  looksExecutable,
+  sniffMime,
+} from "../attachments.js";
+import { deriveAttachmentKind } from "../schemas/message.js";
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PDF = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]); // %PDF-
+const MZ = new Uint8Array([0x4d, 0x5a, 0x90, 0x00]); // Windows PE
+const ELF = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]);
+const TEXT = new TextEncoder().encode("# Hello\njust markdown text\n");
+
+function classify(filename: string, declaredMime: string, head: Uint8Array, size = head.length) {
+  return classifyAttachment({ filename, declaredMime, head, size });
+}
+
+describe("deriveAttachmentKind", () => {
+  it("maps image/* to image and everything else to file", () => {
+    expect(deriveAttachmentKind("image/png")).toBe("image");
+    expect(deriveAttachmentKind("image/svg+xml")).toBe("image");
+    expect(deriveAttachmentKind("application/pdf")).toBe("file");
+    expect(deriveAttachmentKind("text/markdown")).toBe("file");
+  });
+});
+
+describe("sniffMime / looksExecutable", () => {
+  it("sniffs known media", () => {
+    expect(sniffMime(PNG)).toBe("image/png");
+    expect(sniffMime(PDF)).toBe("application/pdf");
+    expect(sniffMime(TEXT)).toBeNull();
+  });
+  it("flags executables regardless of name", () => {
+    expect(looksExecutable(MZ)).toBe(true);
+    expect(looksExecutable(ELF)).toBe(true);
+    expect(looksExecutable(new TextEncoder().encode("#!/bin/sh"))).toBe(true);
+    expect(looksExecutable(PNG)).toBe(false);
+  });
+});
+
+describe("classifyAttachment", () => {
+  it("accepts a real PNG (sniffed image)", () => {
+    expect(classify("shot.png", "image/png", PNG)).toEqual({ kind: "image", mimeType: "image/png" });
+  });
+
+  it("accepts a real PDF as a file", () => {
+    expect(classify("doc.pdf", "application/pdf", PDF)).toEqual({ kind: "file", mimeType: "application/pdf" });
+  });
+
+  // C1: magicless safe text/doc types must be allowed even though sniff returns null.
+  it("accepts magicless safe text (.md) and trusts the declared mime", () => {
+    expect(classify("notes.md", "text/markdown", TEXT)).toEqual({ kind: "file", mimeType: "text/markdown" });
+    expect(classify("data.csv", "text/csv", TEXT).kind).toBe("file");
+    expect(classify("a.json", "application/json", TEXT).kind).toBe("file");
+  });
+
+  it("rejects an unknown extension with no magic (could-not-verify)", () => {
+    expect(() => classify("mystery.xyz", "application/octet-stream", TEXT)).toThrow(AttachmentRejectedError);
+  });
+
+  it("rejects denied executable extensions", () => {
+    expect(() => classify("run.exe", "application/octet-stream", TEXT)).toThrow(/not allowed/);
+    expect(() => classify("go.sh", "text/x-sh", TEXT)).toThrow(/not allowed/);
+  });
+
+  // Disguised binary: executable bytes under an image name must still be rejected.
+  it("rejects executable bytes even with an image filename", () => {
+    expect(() => classify("cat.png", "image/png", MZ)).toThrow(/Executable/);
+  });
+
+  it("enforces the per-file size cap and rejects empties", () => {
+    expect(() => classify("big.png", "image/png", PNG, ATTACHMENT_LIMITS.maxFileBytes + 1)).toThrow(/too large/i);
+    expect(() => classify("empty.png", "image/png", PNG, 0)).toThrow(/Empty/);
+  });
+});
+
+describe("isInlineSafeImage / fileExtension", () => {
+  it("only allows the inline image allow-list (svg excluded)", () => {
+    expect(isInlineSafeImage("image/png")).toBe(true);
+    expect(isInlineSafeImage("image/webp")).toBe(true);
+    expect(isInlineSafeImage("image/svg+xml")).toBe(false);
+    expect(isInlineSafeImage("application/pdf")).toBe(false);
+  });
+  it("extracts lower-cased extensions", () => {
+    expect(fileExtension("a/b/Photo.PNG")).toBe(".png");
+    expect(fileExtension("noext")).toBe("");
+    expect(fileExtension(".bashrc")).toBe("");
+  });
+});

--- a/packages/shared/src/attachments.ts
+++ b/packages/shared/src/attachments.ts
@@ -1,0 +1,219 @@
+import { deriveAttachmentKind } from "./schemas/message.js";
+
+/**
+ * Attachment validation + limits, shared by the server (authoritative gate at
+ * the upload endpoint) and the web composer (pre-flight UX). Dependency-free on
+ * purpose — the magic-byte sniff is a small inline signature table, not a
+ * library, so `@agent-team-foundation/first-tree-hub-shared` stays runtime-free.
+ *
+ * Design: proposals/hub-message-text-attachments.20260521.md (route 2 + PG-bytea).
+ * Only mime/type validation lives in shared (O3) — storage / signing / GC stay
+ * server-side until a second caller exists.
+ */
+
+const MB = 1024 * 1024;
+
+/** Hard size / count gates (decision 4). */
+export const ATTACHMENT_LIMITS = {
+  /** Per single attachment. */
+  maxFileBytes: 10 * MB,
+  /** Sum of all attachments on one message. */
+  maxMessageBytes: 25 * MB,
+  /** Attachments per message. */
+  maxMessageCount: 9,
+  /** Per-org total stored bytes (PG bytea footprint guard). */
+  orgQuotaBytes: 10 * 1024 * MB,
+} as const;
+
+/**
+ * HTTP `bodyLimit` for the (single-file) multipart upload endpoint. Sized to
+ * one max file plus multipart envelope overhead — NOT the per-message total.
+ * Explicit because the messages routes otherwise inherit Fastify's 1 MB
+ * default (see app.ts), which would silently cap uploads.
+ */
+export const ATTACHMENT_UPLOAD_BODY_LIMIT = ATTACHMENT_LIMITS.maxFileBytes + 4 * MB;
+
+/**
+ * Extensions never accepted — executables, scripts, installers, libraries,
+ * shortcuts. Scripts have no reliable magic bytes, so the extension gate is the
+ * primary defence for those (the byte sniff catches disguised binaries).
+ */
+export const DENIED_ATTACHMENT_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".exe",
+  ".bat",
+  ".cmd",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".ps1",
+  ".scr",
+  ".jar",
+  ".app",
+  ".dmg",
+  ".msi",
+  ".vbs",
+  ".com",
+  ".pif",
+  ".dll",
+  ".so",
+  ".lnk",
+  ".bin",
+  ".cgi",
+  ".jse",
+  ".wsf",
+]);
+
+/**
+ * Safe text/document types that legitimately have NO magic bytes (C1). For
+ * these, "no magic detected" must be ALLOWED — rejecting on "couldn't sniff"
+ * would block the documents this feature exists to carry. `.svg` is included
+ * but is download-only (see {@link INLINE_SAFE_IMAGE_MIMES}).
+ */
+export const MAGICLESS_SAFE_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".md",
+  ".markdown",
+  ".txt",
+  ".text",
+  ".csv",
+  ".tsv",
+  ".json",
+  ".jsonl",
+  ".log",
+  ".yaml",
+  ".yml",
+  ".xml",
+  ".html",
+  ".htm",
+  ".rtf",
+  ".svg",
+]);
+
+/**
+ * The only mime types served inline (`<img>`). Everything else — including
+ * `image/svg+xml`, which can carry script — is served with
+ * `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` so a
+ * malicious payload can never execute in the Hub origin (C2).
+ */
+export const INLINE_SAFE_IMAGE_MIMES: ReadonlySet<string> = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+export function fileExtension(filename: string): string {
+  const slash = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+  const base = slash >= 0 ? filename.slice(slash + 1) : filename;
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot).toLowerCase() : "";
+}
+
+function startsWith(head: Uint8Array, sig: readonly number[], offset = 0): boolean {
+  if (head.length < offset + sig.length) return false;
+  for (let i = 0; i < sig.length; i++) {
+    if (head[offset + i] !== sig[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Detect executable / native-binary content regardless of declared mime or
+ * extension. These are rejected unconditionally (the "rename evil.exe to
+ * cat.png" case).
+ */
+export function looksExecutable(head: Uint8Array): boolean {
+  // Windows PE ("MZ"), ELF (0x7F 'E' 'L' 'F'), shebang ("#!")
+  if (startsWith(head, [0x4d, 0x5a])) return true;
+  if (startsWith(head, [0x7f, 0x45, 0x4c, 0x46])) return true;
+  if (startsWith(head, [0x23, 0x21])) return true;
+  // Mach-O (32/64, LE/BE) + universal binary
+  for (const sig of [
+    [0xfe, 0xed, 0xfa, 0xce],
+    [0xfe, 0xed, 0xfa, 0xcf],
+    [0xce, 0xfa, 0xed, 0xfe],
+    [0xcf, 0xfa, 0xed, 0xfe],
+    [0xca, 0xfe, 0xba, 0xbe],
+  ]) {
+    if (startsWith(head, sig)) return true;
+  }
+  return false;
+}
+
+/**
+ * Best-effort magic-byte sniff for the formats we expect. Returns the detected
+ * mime, or `null` when nothing matched (which is fine for magicless safe text —
+ * see {@link classifyAttachment}).
+ */
+export function sniffMime(head: Uint8Array): string | null {
+  if (startsWith(head, [0x89, 0x50, 0x4e, 0x47])) return "image/png";
+  if (startsWith(head, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWith(head, [0x47, 0x49, 0x46, 0x38])) return "image/gif";
+  // WEBP: "RIFF" .... "WEBP"
+  if (startsWith(head, [0x52, 0x49, 0x46, 0x46]) && startsWith(head, [0x57, 0x45, 0x42, 0x50], 8)) {
+    return "image/webp";
+  }
+  if (startsWith(head, [0x25, 0x50, 0x44, 0x46])) return "application/pdf"; // %PDF
+  if (startsWith(head, [0x50, 0x4b, 0x03, 0x04])) return "application/zip"; // also docx/xlsx/pptx
+  if (startsWith(head, [0x1f, 0x8b])) return "application/gzip";
+  return null;
+}
+
+export class AttachmentRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AttachmentRejectedError";
+  }
+}
+
+export type AttachmentClassification = {
+  /** image → may be inline (if also INLINE_SAFE); file → card + download. */
+  kind: "image" | "file";
+  /** mime to persist: sniffed when known, else the declared mime. */
+  mimeType: string;
+};
+
+/**
+ * Authoritative type gate (server) + reusable pre-flight (web). Throws
+ * {@link AttachmentRejectedError} on any disallowed input.
+ *
+ *   1. size cap;
+ *   2. extension deny list (scripts/executables/installers);
+ *   3. executable byte signature → reject regardless of name (disguised binary);
+ *   4. magic sniff: if detected, trust it; if NOT detected, allow only when the
+ *      extension is a known magicless-safe text/doc type (C1) — otherwise reject
+ *      "couldn't verify".
+ */
+export function classifyAttachment(args: {
+  filename: string;
+  declaredMime: string;
+  head: Uint8Array;
+  size: number;
+}): AttachmentClassification {
+  if (args.size <= 0) throw new AttachmentRejectedError("Empty attachment.");
+  if (args.size > ATTACHMENT_LIMITS.maxFileBytes) {
+    throw new AttachmentRejectedError(
+      `Attachment too large (${(args.size / MB).toFixed(1)}MB; max ${ATTACHMENT_LIMITS.maxFileBytes / MB}MB).`,
+    );
+  }
+
+  const ext = fileExtension(args.filename);
+  if (DENIED_ATTACHMENT_EXTENSIONS.has(ext)) {
+    throw new AttachmentRejectedError(`File type "${ext}" is not allowed.`);
+  }
+  if (looksExecutable(args.head)) {
+    throw new AttachmentRejectedError("Executable content is not allowed.");
+  }
+
+  const sniffed = sniffMime(args.head);
+  if (!sniffed && !MAGICLESS_SAFE_EXTENSIONS.has(ext)) {
+    throw new AttachmentRejectedError("Could not verify file type — upload a supported document or image.");
+  }
+
+  const mimeType = sniffed ?? args.declaredMime;
+  return { kind: deriveAttachmentKind(mimeType), mimeType };
+}
+
+/** Whether the download route may serve this mime inline (`<img>`) vs forced download (C2). */
+export function isInlineSafeImage(mimeType: string): boolean {
+  return INLINE_SAFE_IMAGE_MIMES.has(mimeType);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -408,6 +408,7 @@ export {
   type ClientMessage,
   clientMessageSchema,
   deriveAttachmentKind,
+  getMessageAttachments,
   MESSAGE_FORMATS,
   MESSAGE_SOURCES,
   type Message,
@@ -423,8 +424,10 @@ export {
   type PrecedingMessage,
   participantModeSchema,
   precedingMessageSchema,
+  SERVER_MANAGED_METADATA_KEYS,
   type SendMessage,
   sendMessageSchema,
+  stripUntrustedMetadataKeys,
 } from "./schemas/message.js";
 export {
   GITHUB_EVENT_CARD_REASONS,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,19 @@
 // Schemas
 
+export {
+  ATTACHMENT_LIMITS,
+  ATTACHMENT_UPLOAD_BODY_LIMIT,
+  type AttachmentClassification,
+  AttachmentRejectedError,
+  classifyAttachment,
+  DENIED_ATTACHMENT_EXTENSIONS,
+  fileExtension,
+  INLINE_SAFE_IMAGE_MIMES,
+  isInlineSafeImage,
+  looksExecutable,
+  MAGICLESS_SAFE_EXTENSIONS,
+  sniffMime,
+} from "./attachments.js";
 // -- Mention extraction (shared by server fan-out resolver and client auto-forward) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";
 export {
@@ -389,14 +403,18 @@ export {
   updateMemberSchema,
 } from "./schemas/member.js";
 export {
+  type AttachmentRef,
+  attachmentRefSchema,
   type ClientMessage,
   clientMessageSchema,
+  deriveAttachmentKind,
   MESSAGE_FORMATS,
   MESSAGE_SOURCES,
   type Message,
   type MessageFormat,
   type MessagePurpose,
   type MessageSource,
+  messageAttachmentsMetadataSchema,
   messageFormatSchema,
   messagePurposeSchema,
   messageSchema,

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -117,6 +117,50 @@ export function deriveAttachmentKind(mimeType: string): "image" | "file" {
   return mimeType.startsWith("image/") ? "image" : "file";
 }
 
+/**
+ * Read A′ attachment refs off a message's metadata, or [] when none. Single
+ * call site for `messageAttachmentsMetadataSchema.safeParse(...).data.attachments`
+ * — server adapter / web renderer / agent runtime all consume the same shape,
+ * so a shared helper prevents the parse + fallback from drifting across them.
+ */
+export function getMessageAttachments(metadata: unknown): AttachmentRef[] {
+  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data.attachments : [];
+}
+
+/**
+ * Metadata keys that are **server-managed**: the server stamps them on writes,
+ * clients must never set them. Listed here as the single source of truth so
+ * `stripUntrustedMetadataKeys` is the only place that needs to know about new
+ * server-managed keys — adding one to the set is enough to plug it across
+ * every write path that consumes client-supplied metadata.
+ *
+ *   - `attachments` — folded in from `attachmentIds` after C3 validation
+ *     (server/services/message.ts:sendMessage + prepareAttachmentsForSend).
+ *   - `editedAt`    — stamped on edits (server/services/message.ts:editMessage).
+ *
+ * NOTE: this is the **defensive-strip set**, not a complete inventory of
+ * every metadata key the platform uses. Client-trusted keys (`mentions`,
+ * `documentContext`, ...) intentionally are not listed — they go through
+ * their own validation paths.
+ */
+export const SERVER_MANAGED_METADATA_KEYS = new Set<string>(["attachments", "editedAt"]);
+
+/**
+ * Return a shallow copy of `metadata` with every {@link SERVER_MANAGED_METADATA_KEYS}
+ * key removed. Use this at every write path that accepts caller-supplied
+ * metadata so a client cannot forge server-stamped fields (e.g. C3 forged
+ * `metadata.attachments`). Centralised so future server-managed keys only
+ * need to be added to the set above.
+ */
+export function stripUntrustedMetadataKeys(metadata: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...metadata };
+  for (const key of SERVER_MANAGED_METADATA_KEYS) {
+    delete result[key];
+  }
+  return result;
+}
+
 export const sendMessageSchema = z.object({
   format: messageFormatSchema.default("text"),
   content: z.unknown(),

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -77,6 +77,46 @@ export type MessageFormat = z.infer<typeof messageFormatSchema>;
 export const messagePurposeSchema = z.enum(["agent-final-text"]);
 export type MessagePurpose = z.infer<typeof messagePurposeSchema>;
 
+// -- Message attachments (A′: no new `format`; attachments ride `metadata.attachments`) --
+
+/**
+ * Reference to a file attached to a message. The bytes live server-side in
+ * `message_attachments` (PG bytea, see proposals/hub-message-text-attachments);
+ * the message itself only carries this reference under `metadata.attachments[]`.
+ * There is no base64 and no client-local id here — clients fetch the bytes on
+ * demand from `GET /chats/:chatId/attachments/:attachmentId` with their normal
+ * auth (web JWT / agent token).
+ *
+ * A message with `metadata.attachments` is a *regular* text/markdown message
+ * whose `content` string is the caption (may be empty for an attachment-only
+ * send). This keeps old readers gracefully degrading — they render the caption
+ * and ignore the attachments — and keeps the @mention guard on the existing
+ * text path.
+ */
+export const attachmentRefSchema = z.object({
+  attachmentId: z.string().uuid(),
+  mimeType: z.string().min(1),
+  filename: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  /** Render/delivery split (image → thumbnail/vision, file → card/Read). */
+  kind: z.enum(["image", "file"]),
+});
+export type AttachmentRef = z.infer<typeof attachmentRefSchema>;
+
+/** Shape of the `metadata.attachments` field carried on a message. */
+export const messageAttachmentsMetadataSchema = z.object({
+  attachments: z.array(attachmentRefSchema),
+});
+
+/**
+ * Single source of truth for the image/file split. Server stamps it on upload,
+ * web/runtime read it back — call this everywhere instead of re-deriving from
+ * `mimeType` ad hoc so the two sides can never drift.
+ */
+export function deriveAttachmentKind(mimeType: string): "image" | "file" {
+  return mimeType.startsWith("image/") ? "image" : "file";
+}
+
 export const sendMessageSchema = z.object({
   format: messageFormatSchema.default("text"),
   content: z.unknown(),
@@ -105,6 +145,14 @@ export const sendMessageSchema = z.object({
    * prefer this over relying on `@<name>` extraction from `content`.
    */
   receiverNames: z.array(z.string().min(1)).optional(),
+  /**
+   * Ids of files previously uploaded via `POST /chats/:id/attachments` to
+   * attach to this message. The server validates ownership/binding (C3) and
+   * folds the authoritative refs into the stored `metadata.attachments` — the
+   * message stays a regular text/markdown message (A′). Caption goes in
+   * `content` and may be empty for an attachment-only send.
+   */
+  attachmentIds: z.array(z.string().uuid()).optional(),
 });
 export type SendMessage = z.infer<typeof sendMessageSchema>;
 

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -1,11 +1,12 @@
 import type {
+  AttachmentRef,
   Chat,
   ChatDetail,
   ChatEngagementStatus,
   ChatGithubEntityListResponse,
   Message,
 } from "@agent-team-foundation/first-tree-hub-shared";
-import { api, withOrg } from "./client.js";
+import { api, apiFetchBlob, apiUpload, withOrg } from "./client.js";
 
 type PaginatedChats = {
   items: (Chat & { participantCount: number })[];
@@ -63,6 +64,44 @@ export function sendChatMessage(chatId: string, content: string): Promise<Messag
     format: "text",
     content,
   });
+}
+
+/**
+ * Upload one file to a chat (route 2 / PG-bytea). Returns the persisted
+ * {@link AttachmentRef}; the composer collects these and sends a single message
+ * referencing them via `attachmentIds`. The server runs the type double-gate +
+ * quota and leaves the row unbound until the send binds it.
+ */
+export function uploadChatAttachment(chatId: string, file: File): Promise<AttachmentRef> {
+  const form = new FormData();
+  form.append("file", file, file.name);
+  return apiUpload<AttachmentRef>(`/chats/${encodeURIComponent(chatId)}/attachments`, form);
+}
+
+/**
+ * Send one message carrying a text caption (may be empty) + previously-uploaded
+ * attachments (A′: refs ride `metadata.attachments`, no new format). The server
+ * validates each attachmentId belongs to the sender and is unbound (C3).
+ */
+export function sendChatMessageWithAttachments(
+  chatId: string,
+  args: { text: string; attachmentIds: string[] },
+): Promise<Message> {
+  return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
+    format: "text",
+    content: args.text,
+    attachmentIds: args.attachmentIds,
+  });
+}
+
+/** Authenticated path of a chat attachment's download route (for fetch→blob). */
+export function chatAttachmentPath(chatId: string, attachmentId: string): string {
+  return `/chats/${encodeURIComponent(chatId)}/attachments/${encodeURIComponent(attachmentId)}`;
+}
+
+/** Fetch an attachment's bytes as a Blob (authenticated) for inline rendering / download. */
+export function fetchChatAttachmentBlob(chatId: string, attachmentId: string): Promise<Blob> {
+  return apiFetchBlob(chatAttachmentPath(chatId, attachmentId));
 }
 
 /**

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -209,3 +209,52 @@ export const api = {
   put: <T>(path: string, body?: unknown) => request<T>(path, { method: "PUT", body }),
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
 };
+
+/** Add the bearer token + handle a single 401 refresh, returning the raw Response. */
+async function authedFetch(path: string, init: RequestInit): Promise<Response> {
+  const headersFor = (token?: string): HeadersInit => ({
+    ...(init.headers as Record<string, string> | undefined),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  });
+  const tokens = getStoredTokens();
+  let res = await fetch(`${BASE_URL}${path}`, { ...init, headers: headersFor(tokens?.accessToken) });
+  if (res.status === 401 && tokens?.refreshToken) {
+    const refreshed = await tryRefresh(tokens.refreshToken);
+    if (refreshed) res = await fetch(`${BASE_URL}${path}`, { ...init, headers: headersFor(refreshed.accessToken) });
+  }
+  return res;
+}
+
+async function throwApiError(res: Response): Promise<never> {
+  if (res.status === 401) {
+    clearStoredTokens();
+    window.dispatchEvent(new CustomEvent("auth:logout"));
+  }
+  const text = await res.text();
+  let message = text;
+  try {
+    const json = JSON.parse(text) as { error?: string };
+    message = json.error ?? text;
+  } catch {
+    // non-JSON body — use the raw text
+  }
+  throw new ApiError(res.status, message);
+}
+
+/**
+ * Upload `FormData` (multipart). Distinct from `api.post` because the browser
+ * must set the multipart boundary itself — we deliberately do NOT set
+ * Content-Type. Used for attachment uploads.
+ */
+export async function apiUpload<T>(path: string, formData: FormData): Promise<T> {
+  const res = await authedFetch(path, { method: "POST", body: formData });
+  if (!res.ok) await throwApiError(res);
+  return (await res.json()) as T;
+}
+
+/** Fetch binary bytes (authenticated) as a Blob — for attachment rendering. */
+export async function apiFetchBlob(path: string): Promise<Blob> {
+  const res = await authedFetch(path, { method: "GET" });
+  if (!res.ok) await throwApiError(res);
+  return res.blob();
+}

--- a/packages/web/src/lib/use-pending-attachments.ts
+++ b/packages/web/src/lib/use-pending-attachments.ts
@@ -1,0 +1,111 @@
+import {
+  ATTACHMENT_LIMITS,
+  DENIED_ATTACHMENT_EXTENSIONS,
+  deriveAttachmentKind,
+  fileExtension,
+} from "@agent-team-foundation/first-tree-hub-shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type PendingAttachment = {
+  id: string;
+  file: File;
+  kind: "image" | "file";
+  /** Object-URL thumbnail for images only; undefined for other files. Revoked on remove/clear. */
+  previewUrl?: string;
+};
+
+export type UsePendingAttachments = {
+  pendingAttachments: PendingAttachment[];
+  addFiles: (files: File[]) => void;
+  removeAttachment: (id: string) => void;
+  /** Revoke every staged preview and empty the list (call after a send). */
+  clearAttachments: () => void;
+};
+
+/**
+ * Stages files (any type) for an outbound message — the generalized successor
+ * of `usePendingImages`. Enforces the shared attachment limits client-side
+ * (size, count, per-message total, executable/extension deny) so the user gets
+ * instant feedback; the server re-validates authoritatively on upload. Images
+ * get a revocable object-URL for a thumbnail; other files render as a card.
+ *
+ * Callbacks are read through a ref so the returned functions keep stable
+ * identities regardless of inline closures the caller passes.
+ */
+export function usePendingAttachments(
+  opts: { onError?: (message: string) => void; onChange?: () => void } = {},
+): UsePendingAttachments {
+  const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
+
+  const optsRef = useRef(opts);
+  useEffect(() => {
+    optsRef.current = opts;
+  });
+
+  const addFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+
+    setPendingAttachments((prev) => {
+      const accepted: PendingAttachment[] = [];
+      let count = prev.length;
+      let total = prev.reduce((sum, a) => sum + a.file.size, 0);
+
+      for (const file of files) {
+        const ext = fileExtension(file.name);
+        if (DENIED_ATTACHMENT_EXTENSIONS.has(ext)) {
+          optsRef.current.onError?.(`File type "${ext}" is not allowed.`);
+          continue;
+        }
+        if (file.size > ATTACHMENT_LIMITS.maxFileBytes) {
+          optsRef.current.onError?.(
+            `"${file.name}" is too large (${(file.size / 1024 / 1024).toFixed(1)}MB; max ${ATTACHMENT_LIMITS.maxFileBytes / 1024 / 1024}MB).`,
+          );
+          continue;
+        }
+        if (count + 1 > ATTACHMENT_LIMITS.maxMessageCount) {
+          optsRef.current.onError?.(`Too many attachments (max ${ATTACHMENT_LIMITS.maxMessageCount}).`);
+          break;
+        }
+        if (total + file.size > ATTACHMENT_LIMITS.maxMessageBytes) {
+          optsRef.current.onError?.(
+            `Attachments exceed the ${ATTACHMENT_LIMITS.maxMessageBytes / 1024 / 1024}MB per-message limit.`,
+          );
+          break;
+        }
+        const kind = deriveAttachmentKind(file.type);
+        accepted.push({
+          id: crypto.randomUUID(),
+          file,
+          kind,
+          previewUrl: kind === "image" ? URL.createObjectURL(file) : undefined,
+        });
+        count += 1;
+        total += file.size;
+      }
+
+      if (accepted.length === 0) return prev;
+      optsRef.current.onChange?.();
+      return [...prev, ...accepted];
+    });
+  }, []);
+
+  const removeAttachment = useCallback((id: string) => {
+    setPendingAttachments((prev) => {
+      const found = prev.find((a) => a.id === id);
+      if (found?.previewUrl) URL.revokeObjectURL(found.previewUrl);
+      return prev.filter((a) => a.id !== id);
+    });
+    optsRef.current.onChange?.();
+  }, []);
+
+  const clearAttachments = useCallback(() => {
+    setPendingAttachments((prev) => {
+      for (const a of prev) {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+      }
+      return [];
+    });
+  }, []);
+
+  return { pendingAttachments, addFiles, removeAttachment, clearAttachments };
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -4,9 +4,9 @@ import {
   type ChatParticipantDetail,
   documentContextSchema,
   extractMentions,
+  getMessageAttachments,
   isInlineSafeImage,
   type MentionParticipant,
-  messageAttachmentsMetadataSchema,
   parseWorkspaceDocKey,
   type QuestionAnswerMessageContent,
   type QuestionMessageContent,
@@ -529,12 +529,6 @@ function ImageFromRef({ content }: { content: ImageRefContent }) {
       …
     </span>
   );
-}
-
-/** Read A′ attachment refs off a message's metadata, or [] when none. */
-function getMessageAttachments(metadata: Record<string, unknown>): AttachmentRef[] {
-  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
-  return parsed.success ? parsed.data.attachments : [];
 }
 
 function formatBytes(n: number): string {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,9 +1,12 @@
 import {
+  type AttachmentRef,
   CHAT_ENGAGEMENT_STATUSES,
   type ChatParticipantDetail,
   documentContextSchema,
   extractMentions,
+  isInlineSafeImage,
   type MentionParticipant,
+  messageAttachmentsMetadataSchema,
   parseWorkspaceDocKey,
   type QuestionAnswerMessageContent,
   type QuestionMessageContent,
@@ -16,17 +19,18 @@ import { useSearchParams } from "react-router";
 import { getActivityOverview } from "../../../api/activity.js";
 import {
   type FileMessageContent,
+  fetchChatAttachmentBlob,
   getChat,
   type ImageRefContent,
   listChatMessages,
   type MessageWithDelivery,
   patchChatEngagement,
-  readFileAsBase64,
   renameChat,
   sendChatMessage,
-  sendFileMessage,
+  sendChatMessageWithAttachments,
+  uploadChatAttachment,
 } from "../../../api/chats.js";
-import { getImage, putImage } from "../../../api/image-store.js";
+import { getImage } from "../../../api/image-store.js";
 import {
   agentSessionsQueryKey,
   asAssistantTextPayload,
@@ -56,7 +60,7 @@ import { Markdown } from "../../../components/ui/markdown.js";
 import { docPreviewPathFromHref, linkifyMarkdownDocPaths } from "../../../lib/doc-preview-links.js";
 import { useAgentIdentityMap, useAgentNameMap, useAgentSlugToIdMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
-import { usePendingImages } from "../../../lib/use-pending-images.js";
+import { usePendingAttachments } from "../../../lib/use-pending-attachments.js";
 import { cn } from "../../../lib/utils.js";
 import { computeRequiresMention } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
@@ -425,6 +429,7 @@ function TextRow({
             </pre>
           )}
         </div>
+        <MessageAttachments chatId={msg.chatId} metadata={msg.metadata} />
       </div>
     </div>
   );
@@ -523,6 +528,133 @@ function ImageFromRef({ content }: { content: ImageRefContent }) {
     <span className="text-label" style={{ color: "var(--fg-4)" }}>
       …
     </span>
+  );
+}
+
+/** Read A′ attachment refs off a message's metadata, or [] when none. */
+function getMessageAttachments(metadata: Record<string, unknown>): AttachmentRef[] {
+  const parsed = messageAttachmentsMetadataSchema.safeParse(metadata);
+  return parsed.success ? parsed.data.attachments : [];
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Render a message's attachments (route 2) below its caption. Inline-safe
+ * images (png/jpeg/gif/webp) show a thumbnail fetched via authenticated
+ * blob; everything else — including SVG — renders as a download card.
+ */
+function MessageAttachments({ chatId, metadata }: { chatId: string; metadata: Record<string, unknown> }) {
+  const attachments = useMemo(() => getMessageAttachments(metadata), [metadata]);
+  if (attachments.length === 0) return null;
+  return (
+    <div className="flex flex-col" style={{ gap: 4, marginTop: 2 }}>
+      {attachments.map((att) =>
+        att.kind === "image" && isInlineSafeImage(att.mimeType) ? (
+          <AttachmentImage key={att.attachmentId} chatId={chatId} att={att} />
+        ) : (
+          <FileCard key={att.attachmentId} chatId={chatId} att={att} />
+        ),
+      )}
+    </div>
+  );
+}
+
+/** Inline image — bytes fetched (authenticated) and shown via an object URL. */
+function AttachmentImage({ chatId, att }: { chatId: string; att: AttachmentRef }) {
+  const [state, setState] = useState<{ kind: "loading" } | { kind: "hit"; src: string } | { kind: "miss" }>({
+    kind: "loading",
+  });
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    fetchChatAttachmentBlob(chatId, att.attachmentId)
+      .then((blob) => {
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setState({ kind: "hit", src: objectUrl });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "miss" });
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [chatId, att.attachmentId]);
+
+  if (state.kind === "hit") {
+    return (
+      <img
+        src={state.src}
+        alt={att.filename}
+        style={{ maxWidth: 320, borderRadius: "var(--radius-panel)", marginTop: 4 }}
+      />
+    );
+  }
+  if (state.kind === "miss") {
+    return (
+      <span className="text-label" style={{ color: "var(--fg-3)", fontStyle: "italic" }}>
+        [Image "{att.filename}" failed to load]
+      </span>
+    );
+  }
+  return (
+    <span className="text-label" style={{ color: "var(--fg-4)" }}>
+      …
+    </span>
+  );
+}
+
+/** Non-image (or non-inline) attachment — an icon + name + size download card. */
+function FileCard({ chatId, att }: { chatId: string; att: AttachmentRef }) {
+  const [downloading, setDownloading] = useState(false);
+  const onDownload = async () => {
+    setDownloading(true);
+    try {
+      const blob = await fetchChatAttachmentBlob(chatId, att.attachmentId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = att.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloading(false);
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onDownload}
+      disabled={downloading}
+      className="flex items-center text-label"
+      title={`Download ${att.filename}`}
+      style={{
+        gap: 8,
+        marginTop: 4,
+        padding: "var(--sp-1_5) var(--sp-2)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-input)",
+        background: "var(--bg-sunken)",
+        color: "var(--fg)",
+        cursor: "pointer",
+        maxWidth: 320,
+        textAlign: "left",
+      }}
+    >
+      <Paperclip className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--fg-3)" }} />
+      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{att.filename}</span>
+      <span className="mono" style={{ color: "var(--fg-4)", marginLeft: "auto" }}>
+        {formatBytes(att.size)}
+      </span>
+    </button>
   );
 }
 
@@ -716,10 +848,9 @@ export function ChatView({
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const { pendingImages, addImages, removeImage, clearImages } = usePendingImages({
+  const { pendingAttachments, addFiles, removeAttachment, clearAttachments } = usePendingAttachments({
     onError: setUploadError,
-    // Dismiss a stale upload error (e.g. "image too large") the moment the
-    // user adds or removes an image — they're already fixing it.
+    // Adding/removing is a "user is fixing it" signal — drop a now-stale error.
     onChange: () => setUploadError(null),
   });
   // Right-rail visibility — defaults to hidden so the chat area gets the
@@ -867,8 +998,8 @@ export function ChatView({
 
   const handleSend = async () => {
     const text = draft.trim();
-    const images = pendingImages;
-    if (!text && images.length === 0) return;
+    const attachments = pendingAttachments;
+    if (!text && attachments.length === 0) return;
     if (uploading) return;
 
     // No client-side unresolved-`@`-token pre-flight: a `@<token>` that
@@ -882,63 +1013,41 @@ export function ChatView({
     // nothing and the button stays disabled, prompting the user to use
     // the `[+]` button or the autocomplete picker.
 
-    // Group-chat send guard: don't fire requests we know the server (with
-    // proposal §3 enforcement) or downstream `mention_only` agents will drop.
-    // Applies to image-only sends too — the server-side mention check runs
-    // per message regardless of format, so an image without an addressee
-    // would 400 just like a text without an addressee (issue 387). Surface
-    // a hint when the user has only attached images so the silent-return
-    // doesn't look like a stuck send.
+    // Group-chat send guard: don't fire requests the server's mention check
+    // (services/message.ts) would 400. Applies to attachment sends too — a
+    // pure-attachment message (empty caption) with no @mention is rejected
+    // server-side just like an empty text, so surface a hint instead of a
+    // silent stuck send.
     if (requiresMention && draftMentions.length === 0) {
-      if (images.length > 0) {
-        // English matches the other uploadError strings in this file
-        // (Failed to send image / Failed to add participants / Image too large).
-        setUploadError("@mention a group member in the text — images will be addressed to the same recipient(s).");
+      if (attachments.length > 0) {
+        setUploadError("@mention a group member in the text — the attachments go to the same recipient(s).");
       }
       return;
     }
 
-    if (images.length > 0) {
+    if (attachments.length > 0) {
       setUploading(true);
       setUploadError(null);
       try {
-        // Carry the text-draft mentions onto each image message so the
-        // server's group-chat mention guard (services/message.ts) accepts
-        // file-format sends. Without this, every image POST is missing
-        // recipient mentions and 400s before the text message is sent
-        // (issue 387). In direct chats `draftMentions` is empty and the
-        // metadata field is omitted entirely — server check is skipped
-        // anyway, so this is a no-op for 1:1.
-        const imageMetadata = draftMentions.length > 0 ? { mentions: draftMentions } : undefined;
-        for (const img of images) {
-          const data = await readFileAsBase64(img.file);
-          const imageId = crypto.randomUUID();
-          // Write to IndexedDB before the POST so the sending tab can render
-          // its own message via the imageRef shape immediately on refetch,
-          // even if the server write races ahead of the response.
-          await putImage({ imageId, base64: data, mimeType: img.file.type });
-          await sendFileMessage(
-            chatId,
-            {
-              data,
-              mimeType: img.file.type,
-              filename: img.file.name,
-              size: img.file.size,
-              imageId,
-            },
-            imageMetadata,
-          );
+        // Upload each file (route 2 / PG-bytea), then send ONE message that
+        // carries the caption + all attachment refs (A′). The server validates
+        // the refs are ours + unbound (C3) and folds them into
+        // metadata.attachments. One send → one message → one bubble.
+        const attachmentIds: string[] = [];
+        for (const att of attachments) {
+          const ref = await uploadChatAttachment(chatId, att.file);
+          attachmentIds.push(ref.attachmentId);
         }
-        clearImages();
-        if (text) await sendChatMessage(chatId, text);
+        await sendChatMessageWithAttachments(chatId, { text, attachmentIds });
+        clearAttachments();
         setDraft("");
         queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
-        // Mirror sendMut.onSuccess: predictive session-activation only shows
-        // up in the sidebar after we invalidate, otherwise the file-send path
-        // for the first message in a new chat waits for 10s polling.
+        // Mirror sendMut.onSuccess: predictive session-activation only shows in
+        // the sidebar after we invalidate, otherwise the first message in a new
+        // chat waits for the 10s polling refetch.
         queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
       } catch (err) {
-        setUploadError(err instanceof Error ? err.message : "Failed to send image");
+        setUploadError(err instanceof Error ? err.message : "Failed to send attachment");
       } finally {
         setUploading(false);
       }
@@ -1743,18 +1852,19 @@ export function ChatView({
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={(e) => {
                       e.preventDefault();
-                      addImages(Array.from(e.dataTransfer.files));
+                      addFiles(Array.from(e.dataTransfer.files));
                     }}
                   >
-                    {/* Image preview area — above textarea */}
-                    {pendingImages.length > 0 && (
+                    {/* Attachment preview area — above textarea. Images show a
+                        thumbnail; other files show an icon + name chip. */}
+                    {pendingAttachments.length > 0 && (
                       <div
                         className="flex items-center"
                         style={{ gap: 6, padding: "var(--sp-1_5) var(--sp-2_5) 0", overflowX: "auto" }}
                       >
-                        {pendingImages.map((img) => (
+                        {pendingAttachments.map((att) => (
                           <div
-                            key={img.id}
+                            key={att.id}
                             style={{
                               position: "relative",
                               flexShrink: 0,
@@ -1763,14 +1873,33 @@ export function ChatView({
                               overflow: "hidden",
                             }}
                           >
-                            <img
-                              src={img.previewUrl}
-                              alt={img.file.name}
-                              style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
-                            />
+                            {att.kind === "image" && att.previewUrl ? (
+                              <img
+                                src={att.previewUrl}
+                                alt={att.file.name}
+                                style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
+                              />
+                            ) : (
+                              <div
+                                className="flex items-center text-label"
+                                style={{
+                                  gap: 4,
+                                  height: 32,
+                                  padding: "0 var(--sp-2)",
+                                  maxWidth: 180,
+                                  color: "var(--fg-2)",
+                                }}
+                                title={att.file.name}
+                              >
+                                <Paperclip className="h-3 w-3 shrink-0" />
+                                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                                  {att.file.name}
+                                </span>
+                              </div>
+                            )}
                             <button
                               type="button"
-                              onClick={() => removeImage(img.id)}
+                              onClick={() => removeAttachment(att.id)}
                               style={{
                                 position: "absolute",
                                 top: 1,
@@ -1843,7 +1972,7 @@ export function ChatView({
                           const files = Array.from(e.clipboardData.files);
                           if (files.length > 0) {
                             e.preventDefault();
-                            addImages(files);
+                            addFiles(files);
                           }
                         }}
                         placeholder={
@@ -1937,7 +2066,7 @@ export function ChatView({
                         <button
                           type="button"
                           onClick={() => fileInputRef.current?.click()}
-                          title="Attach image"
+                          title="Attach file"
                           style={{
                             background: "none",
                             border: "none",
@@ -1953,12 +2082,11 @@ export function ChatView({
                         <input
                           ref={fileInputRef}
                           type="file"
-                          accept="image/*"
                           multiple
                           style={{ display: "none" }}
                           onChange={(e) => {
                             if (e.target.files) {
-                              addImages(Array.from(e.target.files));
+                              addFiles(Array.from(e.target.files));
                               e.target.value = "";
                             }
                           }}
@@ -1976,7 +2104,7 @@ export function ChatView({
                           disabled={
                             sendMut.isPending ||
                             uploading ||
-                            (!draft.trim() && pendingImages.length === 0) ||
+                            (!draft.trim() && pendingAttachments.length === 0) ||
                             (requiresMention && draftMentions.length === 0)
                           }
                           title={
@@ -1989,7 +2117,7 @@ export function ChatView({
                             "inline-flex items-center justify-center transition-opacity",
                             (sendMut.isPending ||
                               uploading ||
-                              (!draft.trim() && pendingImages.length === 0) ||
+                              (!draft.trim() && pendingAttachments.length === 0) ||
                               (requiresMention && draftMentions.length === 0)) &&
                               "opacity-40 cursor-not-allowed",
                           )}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -3,8 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Paperclip, Plus, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getActivityOverview, type RuntimeAgent } from "../../../api/activity.js";
-import { readFileAsBase64, sendChatMessage, sendFileMessage } from "../../../api/chats.js";
-import { putImage } from "../../../api/image-store.js";
+import { sendChatMessage, sendChatMessageWithAttachments, uploadChatAttachment } from "../../../api/chats.js";
 import { createMeChat } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
 import {
@@ -17,7 +16,7 @@ import {
 } from "../../../components/mention-autocomplete.js";
 import { useAgentIdentityMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
-import { type PendingImage, usePendingImages } from "../../../lib/use-pending-images.js";
+import { type PendingAttachment, usePendingAttachments } from "../../../lib/use-pending-attachments.js";
 import { cn } from "../../../lib/utils.js";
 
 /**
@@ -41,17 +40,19 @@ import { cn } from "../../../lib/utils.js";
  *     in the room". This unifies entry points without making them
  *     mutually exclusive.
  *
- *   - Images attach via the Paperclip button, drag-drop, or paste —
- *     staged through `usePendingImages` (shared with the in-chat
- *     composer). Bytes are read and uploaded only on send, after the
- *     chat exists. An image-only send (empty body) is allowed; a group
+ *   - Files (any type) attach via the Paperclip button, drag-drop, or
+ *     paste — staged through `usePendingAttachments` (shared with the
+ *     in-chat composer). Bytes upload only on send, after the chat
+ *     exists. An attachment-only send (empty body) is allowed; a group
  *     (2+ chips) still needs an `@` in the body so the server's per-
- *     message mention guard accepts the file send.
+ *     message mention guard accepts the send.
  *
- * On send: createMeChat({participantIds: chips ∪ body @s}) → for each
- * staged image putImage(IndexedDB) + sendFileMessage → sendChatMessage
- * with the verbatim body. Empty body is allowed when there's ≥1 chip and
- * (a non-empty body or ≥1 image).
+ * On send: createMeChat({participantIds: chips ∪ body @s}) → upload each
+ * staged file (route 2 / PG-bytea) → send ONE message carrying the body
+ * caption + attachment refs in metadata.attachments (A′) — the same
+ * single-message flow as the in-chat composer, so both produce one
+ * message / one bubble. Empty body is allowed when there's ≥1 chip and
+ * (a non-empty body or ≥1 attachment).
  */
 
 export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => void }) {
@@ -73,7 +74,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
   // Image staging shared with the in-chat composer (same image/* + 5 MB
   // rules and object-URL lifecycle). Bytes are read and uploaded only on
   // send, after the chat is created — see `createMut` below.
-  const { pendingImages, addImages, removeImage, clearImages } = usePendingImages({
+  const { pendingAttachments, addFiles, removeAttachment, clearAttachments } = usePendingAttachments({
     onError: setError,
     onChange: () => setError(null),
   });
@@ -171,44 +172,28 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
     mutationFn: async ({
       participantIds,
       text,
-      images,
-      mentions,
+      attachments,
     }: {
       participantIds: string[];
       text: string;
-      images: PendingImage[];
-      mentions: string[];
+      attachments: PendingAttachment[];
     }) => {
       const created = await createMeChat({ participantIds });
       const chatId = created.chatId;
-      // Send images first (mirrors the in-chat composer ordering), then the
-      // text body, so the new chat opens with attachments above the message.
-      if (images.length > 0) {
-        // Carry the @-mentions onto each image message so the server's
-        // group-chat mention guard accepts file-format sends (issue 387).
-        // Single-chip (direct) chats have no mentions and skip the check.
-        const imageMetadata = mentions.length > 0 ? { mentions } : undefined;
-        for (const img of images) {
-          const data = await readFileAsBase64(img.file);
-          const imageId = crypto.randomUUID();
-          // Write to IndexedDB before the POST so the sending tab can render
-          // the image from its imageRef immediately on refetch.
-          await putImage({ imageId, base64: data, mimeType: img.file.type });
-          await sendFileMessage(
-            chatId,
-            {
-              data,
-              mimeType: img.file.type,
-              filename: img.file.name,
-              size: img.file.size,
-              imageId,
-            },
-            imageMetadata,
-          );
-        }
-      }
       const trimmed = text.trim();
-      if (trimmed.length > 0) {
+      if (attachments.length > 0) {
+        // Upload each file (route 2 / PG-bytea), then send ONE message that
+        // carries the caption + all attachment refs (A′) — same flow as the
+        // in-chat composer. @-mentions in `trimmed` route the message; the
+        // server folds the refs into metadata.attachments. One send → one
+        // message → one bubble.
+        const attachmentIds: string[] = [];
+        for (const att of attachments) {
+          const ref = await uploadChatAttachment(chatId, att.file);
+          attachmentIds.push(ref.attachmentId);
+        }
+        await sendChatMessageWithAttachments(chatId, { text: trimmed, attachmentIds });
+      } else if (trimmed.length > 0) {
         await sendChatMessage(chatId, trimmed);
       }
       return chatId;
@@ -216,7 +201,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
     onSuccess: (chatId) => {
       setDraft("");
       setChips([]);
-      clearImages();
+      clearAttachments();
       seededDefaultRef.current = false;
       queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
       onCreated(chatId);
@@ -231,21 +216,21 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
     if (chips.length === 0) return false;
     // Body OR at least one image — image-only sends are allowed (mirrors the
     // in-chat composer's "text non-empty or has image" rule).
-    if (draft.trim().length === 0 && pendingImages.length === 0) return false;
+    if (draft.trim().length === 0 && pendingAttachments.length === 0) return false;
     // Groups still need an @ even for image-only sends: the server's
     // group-chat mention guard runs per message regardless of format.
     if (chips.length >= 2 && bodyMentions.length === 0) return false;
     return true;
-  }, [sending, createMut.isPending, chips.length, draft, bodyMentions.length, pendingImages.length]);
+  }, [sending, createMut.isPending, chips.length, draft, bodyMentions.length, pendingAttachments.length]);
 
   const sendBlockedReason = useMemo(() => {
     if (chips.length === 0) return "Add at least one participant";
-    if (draft.trim().length === 0 && pendingImages.length === 0) return null;
+    if (draft.trim().length === 0 && pendingAttachments.length === 0) return null;
     if (chips.length >= 2 && bodyMentions.length === 0) {
       return "Group chats need an @ to wake at least one participant";
     }
     return null;
-  }, [chips.length, draft, bodyMentions.length, pendingImages.length]);
+  }, [chips.length, draft, bodyMentions.length, pendingAttachments.length]);
 
   const handleSend = async (): Promise<void> => {
     if (!canSend) return;
@@ -261,7 +246,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
     setError(null);
     setSending(true);
     try {
-      await createMut.mutateAsync({ participantIds, text: draft, images: pendingImages, mentions: bodyMentions });
+      await createMut.mutateAsync({ participantIds, text: draft, attachments: pendingAttachments });
     } finally {
       setSending(false);
     }
@@ -295,7 +280,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
             onDragOver={(e) => e.preventDefault()}
             onDrop={(e) => {
               e.preventDefault();
-              addImages(Array.from(e.dataTransfer.files));
+              addFiles(Array.from(e.dataTransfer.files));
             }}
           >
             <ParticipantChips
@@ -308,15 +293,16 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
               onAdd={addChip}
               onRemove={removeChip}
             />
-            {/* Image preview row — between the chip row and the textarea. */}
-            {pendingImages.length > 0 && (
+            {/* Attachment preview row — images show a thumbnail, other files an
+                icon + name chip. Between the chip row and the textarea. */}
+            {pendingAttachments.length > 0 && (
               <div
                 className="flex items-center"
                 style={{ gap: 6, padding: "0 var(--sp-2_5) var(--sp-1)", overflowX: "auto" }}
               >
-                {pendingImages.map((img) => (
+                {pendingAttachments.map((att) => (
                   <div
-                    key={img.id}
+                    key={att.id}
                     style={{
                       position: "relative",
                       flexShrink: 0,
@@ -325,15 +311,28 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                       overflow: "hidden",
                     }}
                   >
-                    <img
-                      src={img.previewUrl}
-                      alt={img.file.name}
-                      style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
-                    />
+                    {att.kind === "image" && att.previewUrl ? (
+                      <img
+                        src={att.previewUrl}
+                        alt={att.file.name}
+                        style={{ height: 32, width: "auto", display: "block", objectFit: "cover" }}
+                      />
+                    ) : (
+                      <div
+                        className="flex items-center text-label"
+                        style={{ gap: 4, height: 32, padding: "0 var(--sp-2)", maxWidth: 180, color: "var(--fg-2)" }}
+                        title={att.file.name}
+                      >
+                        <Paperclip className="h-3 w-3 shrink-0" />
+                        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {att.file.name}
+                        </span>
+                      </div>
+                    )}
                     <button
                       type="button"
-                      onClick={() => removeImage(img.id)}
-                      title="Remove image"
+                      onClick={() => removeAttachment(att.id)}
+                      title="Remove attachment"
                       style={{
                         position: "absolute",
                         top: 1,
@@ -379,7 +378,7 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                   const files = Array.from(e.clipboardData.files);
                   if (files.length > 0) {
                     e.preventDefault();
-                    addImages(files);
+                    addFiles(files);
                   }
                 }}
                 placeholder={
@@ -443,8 +442,8 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={sending || createMut.isPending}
-                  title="Attach image"
-                  aria-label="Attach image"
+                  title="Attach file"
+                  aria-label="Attach file"
                   className="inline-flex items-center"
                   style={{
                     background: "none",
@@ -459,19 +458,18 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept="image/*"
                   multiple
                   style={{ display: "none" }}
                   onChange={(e) => {
                     if (e.target.files) {
-                      addImages(Array.from(e.target.files));
+                      addFiles(Array.from(e.target.files));
                       e.target.value = "";
                     }
                   }}
                 />
               </span>
               <span className="flex items-center" style={{ gap: 8 }}>
-                {sending && pendingImages.length > 0 && (
+                {sending && pendingAttachments.length > 0 && (
                   <span className="mono text-caption" style={{ color: "var(--accent)" }}>
                     uploading…
                   </span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/multipart':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@fastify/rate-limit':
         specifier: ^10.3.0
         version: 10.3.0
@@ -1024,8 +1027,14 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -1038,6 +1047,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.0.0':
+    resolution: {integrity: sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
@@ -5229,10 +5241,14 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/busboy@3.2.0': {}
+
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
+
+  '@fastify/deepmerge@3.2.1': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -5245,6 +5261,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@10.0.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+      secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
     dependencies:


### PR DESCRIPTION
## Problem

In the hub chat view, adding attachments + text in one composer and sending produced **N+1 separate messages** (one per image as `format:"file"`, plus a separate `format:"text"`), instead of a single message — a clear "one send = one message" UX gap. Root cause: each message had a single mutually-exclusive `format` with no combined "text + attachments" shape.

## Solution

A single message now carries a **text caption + multiple attachments of any file type**, rendered as one bubble.

- **Storage — route 2 / PG-bytea** (follows the existing agent-avatar precedent; no new infra, fits "PostgreSQL only / stateless server"): bytes persist in a new `message_attachments` table; messages carry only references.
- **Download — authenticated fetch (no signed URLs)**: web uses the existing JWT (`fetch`→blob), the agent runtime uses its token; membership is re-checked per request. Avoids signed-URL churn against the 5s message refetch.
- **Data model — A′ (no new `format`)**: caption stays in `content`; attachments ride `metadata.attachments[]`. Old clients degrade gracefully (still render the caption) and the @mention guard stays on the existing text path.
- **Both composers unified**: chat-view and new-chat-draft both *upload each file then send one message* referencing them — one send → one message → one bubble. The old per-image split-send is removed.
- **Agent runtime**: reads `metadata.attachments`, downloads each (authenticated) to local disk, points the model at the path for its Read tool; a failed download yields an explicit "do not answer from it" placeholder (retryable — route 2 is durable).
- **Feishu adapter**: downgraded to a filename + size list (no internal links for external users); new `image_payload` WS frames are no longer produced (legacy read path retained for historical messages).

## Security (type / download / authorization double-gates)

- **C1** — type gate allows magicless safe text/docs (`.md/.csv/.json/...`) instead of rejecting "couldn't sniff"; rejects executables by magic bytes (MZ/ELF/Mach-O/shebang) and a denied-extension list.
- **C2** — download headers hardened: only a png/jpeg/gif/webp allow-list is served inline; everything else (incl. SVG) is `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` (anti-XSS).
- **C3** — at send, each referenced attachment must be uploaded by the sender, still unbound, and in the same chat.

### codex independent review — 3 blockers found and closed
1. **Forged `metadata.attachments`** — server now strips any client-supplied `attachments` key; only server-validated refs from `prepareAttachmentsForSend` are stored.
2. **Concurrent rebind race** — `SELECT … FOR UPDATE` row lock + a `RETURNING` row-count assertion on bind (mismatch → `ConflictError`, rolls back the send).
3. **Orphan GC not scheduled** — `gcOrphanedAttachments` wired into the 60s background sweep.
- Also added (non-blocking): unbound uploads are downloadable only by their uploader (open to all members once bound).

## Numbers & migration

- Limits: single file 10 MB / per-message total 25 MB / 9 attachments / 10 GB per-org quota.
- Migration `0048_message_attachments` (bytea column with `STORAGE EXTERNAL`; `kind` column carries a `CHECK ('image' | 'file')` constraint).

## Testing

- `pnpm typecheck` 11/11; biome clean.
- Full suite green: server 1112 / shared 271 / web 206 / client 431 / command 125; zero regressions; migration applied via testcontainers.
- New security tests: type gate (C1/C2), C3 ownership/binding, forged-metadata strip, concurrent-bind, orphan GC, unbound-download gate.

## Review chain

Independent review by `@codex-reviewer` (first round: 3 blockers → fixed → re-review **passed**).

Follow-up review pass with `@baixiaohang` (10 items, design-level) — decisions applied in this PR:
- Unified `getMessageAttachments` parser in shared (deduped 3 call sites).
- Feishu-specific format moved from `adapter-manager` into `services/feishu/format-message.ts`.
- Server-managed metadata keys centralised in `SERVER_MANAGED_METADATA_KEYS` / `stripUntrustedMetadataKeys` (shared) — replaces the ad-hoc `delete incomingMeta.attachments`.
- `kind` column gets a CHECK constraint; the read path re-derives `kind` from `mime` via `deriveAttachmentKind` so there is only one source of truth.
- Local design doc `docs/message-text-attachments-design.md` added, including the **Future evolution: rich-text + inline attachments** section (`![](attachment:<id>)` reuses the existing schema — no new `format`).

## Implicit contract changes

Centralising the server-managed metadata strip codifies an invariant that **the server is the sole writer of certain `metadata.*` keys**; clients setting them in a `POST /messages` body are silently stripped before insert.

Today's set is `attachments` and `editedAt` (see `SERVER_MANAGED_METADATA_KEYS` in `packages/shared/src/schemas/message.ts`). `attachments` is new in this PR; `editedAt` already had this behaviour de facto via the edit endpoint. `grep` on `main` confirms no external caller sets `metadata.attachments`, so this PR is the first to introduce the key and there are no in-tree consumers to migrate.

If you add a new server-stamped `metadata` key in the future, add it to that set — one line is enough; every write path that goes through `services/message.ts:sendMessage` will pick it up.

## Related

- Context Tree proposal `proposals/hub-message-text-attachments.20260521.md` (merged, PR #317).
- Local technical design doc `docs/message-text-attachments-design.md` (added in this PR — covers invariants, security gates, limits, and future evolution).

## Immediate follow-up — drizzle meta snapshot chain

`drizzle-kit generate` currently aborts on this branch — the drizzle/meta snapshot chain is broken (48 journal entries, 7 snapshots), so migration `0048_message_attachments.sql` is hand-authored. Recent migrations on `main` have the same workaround.

- **Owner**: @gandy-developer
- **Window**: within 7 days after this PR merges, open a dedicated PR to repair the snapshot chain.
- **Acceptance**: `drizzle-kit generate` succeeds on a fresh schema change; no future migration is hand-authored.
- **Long-term**: add a CI check (`drizzle-kit check` or equivalent) to fail PRs that break the snapshot chain again.

Until that repair lands, any PR that adds a table/column on this branch should pause and confirm whether the snapshot fix is complete; otherwise the workaround compounds.

## Known / follow-ups (non-blocking)

- ⚠️ **No live UI visual walkthrough** in the implementation environment (no browser) — recommend a manual pass on local dev before/after merge. Functional + type + unit/integration coverage is in place.
- **org-quota concurrent-overcommit window** — the quota check is non-atomic; two concurrent uploads within an org can both pass at the cap. Worst case is bounded (≤ single-file cap × concurrency); the obvious short fix (`SELECT … FOR UPDATE` on the org row) would serialise all uploads within an org, which is a worse trade-off than the rare overcommit. Properly addressed by a counter table / `org_quota_lock` row when real load demands it.
- **Stricter mime↔extension consistency** — currently soft (trust magic-byte sniff + deny-list); future hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
