### PR TITLE
feat(client): hint to prefer in-workspace repo worktrees

### DIFF
--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -523,5 +523,9 @@ this command.
   cannot render as markdown.
 - For multi-line / markdown / special chars (quotes, \`$\`, backticks, newlines),
   use **stdin** with real newlines, plus \`-f markdown\`.
+
+## Source Repos
+
+For development tasks, prefer the repo worktrees already present in this workspace.
 `;
 }


### PR DESCRIPTION
## Summary
- Append a one-line `## Source Repos` section to the static `tools.md` content emitted by `generateToolsDoc()` in `packages/client/src/runtime/bootstrap.ts`, nudging agents to default to the per-session repo worktrees the Hub runtime already prepares under the workspace root rather than reaching for arbitrary clones elsewhere on disk (e.g. `~/dev/<repo>`, which is a separate clone, not a session-scoped worktree).
- Pure prompt content change; no type, schema, or runtime behavior changes.

## Background
Each chat session gets dedicated worktrees under `<workspace>/<repo>/` via `git-mirror-manager` (bare mirror in `<dataDir>/git-mirrors/<sha>/` + per-session branch `hub-session-<sessionHash>-<urlHash>`). Without this hint, agents may reach for unrelated clones on the operator's machine and edit branches that don't belong to the current session.

## Test plan
- [x] \`pnpm --filter @first-tree/client typecheck\` passes
- [x] \`pnpm check\` (Biome) passes — 803 files, no fixes applied
- [ ] On a fresh chat session, verify the workspace's \`.agent/tools.md\` contains the new \`## Source Repos\` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)