### PR TITLE
fix(web): instant composer + cap activity refetch storm

### DIFF
--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { upsertSessionState } from "../services/activity.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
+import type { Notifier } from "../services/notifier.js";
 import { createAdminContext, useTestApp } from "./helpers.js";
 import { readPresence, seedPresence } from "./session-state-helpers.js";
 
@@ -89,5 +90,86 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
     expect(row).toBeDefined();
     expect(row?.activeSessions).toBe(1);
     expect(row?.totalSessions).toBe(1);
+  });
+
+  // Steady-state guard: when the (agent, chat) row is already at the target
+  // state, a repeat upsert must NOT push a `session:state` NOTIFY and must
+  // NOT churn `agent_presence.lastSeenAt` — otherwise the predictive Step 1b
+  // in services/message.ts (called once per message) fans into N session:state
+  // frames per N messages, which the admin WS then re-broadcasts into a
+  // matching N invalidations of `["activity"]` / `["sessions"]` in every open
+  // dashboard tab. The client's `heartbeat` frame remains the canonical
+  // lastSeenAt path.
+  it("does NOT NOTIFY or refresh lastSeenAt when state is unchanged", async () => {
+    const { app, admin, agent, chat } = await setup();
+    // Bring the row to `active` once so the second call is the no-op case.
+    await upsertSessionState(app.db, agent.uuid, chat.id, "active", admin.organizationId);
+    const firstSeen = (await readPresence(app, agent.uuid))?.lastSeenAt?.getTime();
+    expect(firstSeen).toBeDefined();
+
+    const notifier = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      notify: vi.fn(async () => {}),
+      notifyConfigChange: vi.fn(async () => {}),
+      notifySessionStateChange: vi.fn(async () => {}),
+      notifyRuntimeStateChange: vi.fn(async () => {}),
+      notifyChatMessage: vi.fn(async () => {}),
+      notifySessionEvent: vi.fn(async () => {}),
+      pushFrameToInbox: vi.fn(async () => 0),
+      onConfigChange: vi.fn(),
+      onSessionStateChange: vi.fn(),
+      onSessionEvent: vi.fn(),
+      onRuntimeStateChange: vi.fn(),
+      onChatMessage: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    } satisfies Notifier;
+
+    // Wait a beat so a stray lastSeenAt write would be detectable.
+    await new Promise((r) => setTimeout(r, 20));
+
+    await upsertSessionState(app.db, agent.uuid, chat.id, "active", admin.organizationId, notifier);
+
+    expect(notifier.notifySessionStateChange).not.toHaveBeenCalled();
+    const secondSeen = (await readPresence(app, agent.uuid))?.lastSeenAt?.getTime();
+    expect(secondSeen).toBe(firstSeen);
+  });
+
+  // The complement of the previous test: a real state transition (active →
+  // suspended) must still NOTIFY and still refresh presence. Guards against an
+  // over-eager short-circuit that drops the wrong cases.
+  it("DOES NOTIFY when state actually transitions", async () => {
+    const { app, admin, agent, chat } = await setup();
+    await upsertSessionState(app.db, agent.uuid, chat.id, "active", admin.organizationId);
+
+    const notifier = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      notify: vi.fn(async () => {}),
+      notifyConfigChange: vi.fn(async () => {}),
+      notifySessionStateChange: vi.fn(async () => {}),
+      notifyRuntimeStateChange: vi.fn(async () => {}),
+      notifyChatMessage: vi.fn(async () => {}),
+      notifySessionEvent: vi.fn(async () => {}),
+      pushFrameToInbox: vi.fn(async () => 0),
+      onConfigChange: vi.fn(),
+      onSessionStateChange: vi.fn(),
+      onSessionEvent: vi.fn(),
+      onRuntimeStateChange: vi.fn(),
+      onChatMessage: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    } satisfies Notifier;
+
+    await upsertSessionState(app.db, agent.uuid, chat.id, "suspended", admin.organizationId, notifier);
+
+    expect(notifier.notifySessionStateChange).toHaveBeenCalledTimes(1);
+    expect(notifier.notifySessionStateChange).toHaveBeenCalledWith(
+      agent.uuid,
+      chat.id,
+      "suspended",
+      admin.organizationId,
+    );
   });
 });

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -37,20 +37,38 @@ export async function upsertSessionState(
   options?: { touchPresenceLastSeen?: boolean },
 ) {
   const now = new Date();
-  let wrote = false;
+  let stateChanged = false;
   await db.transaction(async (tx) => {
     // Short-circuit when the row is already at the target state: skip the
     // updatedAt refresh so steady-state messaging doesn't churn the row.
     // Insertions and any state transition (evicted → active, active →
     // suspended, etc.) still take the UPDATE branch.
-    await tx
+    //
+    // We use `.returning()` to detect whether INSERT/UPDATE actually fired —
+    // PostgreSQL omits returning rows when the ON CONFLICT DO UPDATE's
+    // `setWhere` predicate is false (same-state no-op). Zero rows back ⇒
+    // skip the downstream presence refresh + NOTIFY. This keeps
+    // `session:state` frames off the wire when an already-active session
+    // receives a burst of steady-state messages (e.g. an agent emitting
+    // many intermediate chat results into the same chat) — without this
+    // short-circuit, the predictive Step 1b in services/message.ts would
+    // NOTIFY once per message and the admin WS would invalidate
+    // `["activity"]` / `["sessions"]` dozens of times per second. The
+    // client's `heartbeat` frame is the canonical lastSeenAt refresh
+    // path (see presence.ts:touchAgent), so dropping the lastSeenAt
+    // side-effect here is safe.
+    const rows = await tx
       .insert(agentChatSessions)
       .values({ agentId, chatId, state, updatedAt: now })
       .onConflictDoUpdate({
         target: [agentChatSessions.agentId, agentChatSessions.chatId],
         set: { state, updatedAt: now },
         setWhere: ne(agentChatSessions.state, state),
-      });
+      })
+      .returning({ agentId: agentChatSessions.agentId });
+
+    if (rows.length === 0) return;
+    stateChanged = true;
 
     // runtimeState is owned by the client's `runtime:state` frame — do not
     // write it here to avoid dual-write conflicts.
@@ -83,11 +101,9 @@ export async function upsertSessionState(
         target: [agentPresence.agentId],
         set: presenceSet,
       });
-
-    wrote = true;
   });
 
-  if (wrote && notifier) {
+  if (stateChanged && notifier) {
     notifier.notifySessionStateChange(agentId, chatId, state, organizationId).catch(() => {});
   }
 }

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -10,7 +10,7 @@ export type MessageWithDelivery = Message & {
   deliveryStatus?: "sent" | "pending" | "delivered" | "acked";
 };
 
-type PaginatedMessages = {
+export type PaginatedMessages = {
   items: MessageWithDelivery[];
   nextCursor: string | null;
 };

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -30,8 +30,8 @@ let latestQc: QC | null = null;
 let refCount = 0;
 
 // `session:state` and `session:event` frames burst when an agent ticks
-// through tool calls — every frame would otherwise force a `me/chats`
-// refetch and the React-Query default (`staleTime: 0`) wouldn't dedupe.
+// through tool calls — every frame would otherwise force an invalidation
+// per frame and the React-Query default (`staleTime: 0`) wouldn't dedupe.
 // Leading-edge fire keeps the working ring / WorkingChip snappy; the
 // trailing window collapses the burst into at most one extra round-trip
 // after it ends.
@@ -42,26 +42,58 @@ let refCount = 0;
 // server-side `liveActivity` window. Also applied to `chat:message`
 // to fold storm-of-messages flurries (formerly invalidated every frame
 // without a throttle).
-const ME_CHATS_INVALIDATE_THROTTLE_MS = 1000;
-let meChatsLastInvalidatedAt = 0;
-let meChatsTrailingTimer: ReturnType<typeof setTimeout> | null = null;
+//
+// Each cache key gets its OWN leading + trailing pair via the factory
+// below so bursts in one channel don't starve another. The server's
+// `session:state` short-circuit (services/activity.ts) is the primary
+// defence — this throttle is the client-side safety net for any frame
+// that does reach us (and for `chat:message` which has no server-side
+// dedupe).
+const INVALIDATE_THROTTLE_MS = 1000;
 
-function invalidateMeChatsThrottled(qc: QC) {
-  const now = Date.now();
-  const elapsed = now - meChatsLastInvalidatedAt;
-  if (elapsed >= ME_CHATS_INVALIDATE_THROTTLE_MS) {
-    meChatsLastInvalidatedAt = now;
-    qc.invalidateQueries({ queryKey: ["me", "chats"] });
-    return;
-  }
-  if (meChatsTrailingTimer === null) {
-    meChatsTrailingTimer = setTimeout(() => {
-      meChatsTrailingTimer = null;
-      meChatsLastInvalidatedAt = Date.now();
-      if (latestQc) latestQc.invalidateQueries({ queryKey: ["me", "chats"] });
-    }, ME_CHATS_INVALIDATE_THROTTLE_MS - elapsed);
-  }
+type ThrottledInvalidator = {
+  invalidate: (qc: QC) => void;
+  dispose: () => void;
+};
+
+function createThrottledInvalidator(queryKey: readonly unknown[], throttleMs: number): ThrottledInvalidator {
+  let lastAt = 0;
+  let trailingTimer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    invalidate(qc: QC) {
+      const now = Date.now();
+      const elapsed = now - lastAt;
+      if (elapsed >= throttleMs) {
+        lastAt = now;
+        qc.invalidateQueries({ queryKey });
+        return;
+      }
+      if (trailingTimer === null) {
+        trailingTimer = setTimeout(() => {
+          trailingTimer = null;
+          lastAt = Date.now();
+          if (latestQc) latestQc.invalidateQueries({ queryKey });
+        }, throttleMs - elapsed);
+      }
+    },
+    dispose() {
+      if (trailingTimer) {
+        clearTimeout(trailingTimer);
+        trailingTimer = null;
+      }
+    },
+  };
 }
+
+const meChatsInvalidator = createThrottledInvalidator(["me", "chats"], INVALIDATE_THROTTLE_MS);
+// `["activity"]` and `["sessions"]` are read by 5+ workspace components
+// each (chat-view, roster, agent-context, new-chat-draft, team, clients,
+// command-palette). A non-throttled invalidation on every `session:state`
+// frame fans out into one GET per mounted component per frame — measured
+// at "dozens per second" while an agent ticks through tool calls. Same
+// 1s window as `me/chats` so all three keys stay roughly in lock-step.
+const activityInvalidator = createThrottledInvalidator(["activity"], INVALIDATE_THROTTLE_MS);
+const sessionsInvalidator = createThrottledInvalidator(["sessions"], INVALIDATE_THROTTLE_MS);
 
 function broadcast(msg: WsMessage) {
   for (const sub of subscribers) {
@@ -73,15 +105,15 @@ function broadcast(msg: WsMessage) {
   }
   if (latestQc) {
     if (msg.type === "session:state") {
-      latestQc.invalidateQueries({ queryKey: ["activity"] });
-      latestQc.invalidateQueries({ queryKey: ["sessions"] });
+      activityInvalidator.invalidate(latestQc);
+      sessionsInvalidator.invalidate(latestQc);
       // `MeChatRow.engagedAgentIds` is derived from
       // `agent_chat_sessions(agent_id, chat_id).state === 'active'`, which
       // is mutated by the same `session:state` event upstream. Invalidate
       // the conversation-list query so the avatar engaged ring switches
       // on / off in real time without waiting for the 15s `refetchInterval`.
       // Throttled because the upstream frames can burst tool-call-fast.
-      invalidateMeChatsThrottled(latestQc);
+      meChatsInvalidator.invalidate(latestQc);
     } else if (msg.type === "session:event") {
       // `MeChatRow.liveActivity` is derived from the most recent
       // `session_events` row for each chat. The same wire frame produced
@@ -89,8 +121,8 @@ function broadcast(msg: WsMessage) {
       // through this socket; invalidate the conversation-list so the
       // WorkingChip in the time slot updates within the throttle window.
       // Re-uses the same leading + trailing throttle helper as
-      // `session:state` (window defined by `ME_CHATS_INVALIDATE_THROTTLE_MS`).
-      invalidateMeChatsThrottled(latestQc);
+      // `session:state` (window defined by `INVALIDATE_THROTTLE_MS`).
+      meChatsInvalidator.invalidate(latestQc);
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
       // carries `{ type, chatId }` (see shared/me-chat.ts:chatMessageFrameSchema);
@@ -101,7 +133,7 @@ function broadcast(msg: WsMessage) {
       // try/catch and the user-facing fallback is the 5s polling refetch
       // already wired into ChatView.
       const chatId = typeof msg.chatId === "string" ? msg.chatId : null;
-      invalidateMeChatsThrottled(latestQc);
+      meChatsInvalidator.invalidate(latestQc);
       if (chatId) {
         latestQc.invalidateQueries({ queryKey: ["chat-messages", chatId] });
         latestQc.invalidateQueries({ queryKey: ["chat-detail", chatId] });
@@ -225,10 +257,9 @@ function teardown() {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
   }
-  if (meChatsTrailingTimer) {
-    clearTimeout(meChatsTrailingTimer);
-    meChatsTrailingTimer = null;
-  }
+  meChatsInvalidator.dispose();
+  activityInvalidator.dispose();
+  sessionsInvalidator.dispose();
   if (ws) {
     ws.close(1000, "unmount");
     ws = null;

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -20,6 +20,7 @@ import {
   type ImageRefContent,
   listChatMessages,
   type MessageWithDelivery,
+  type PaginatedMessages,
   patchChatEngagement,
   readFileAsBase64,
   renameChat,
@@ -843,11 +844,85 @@ export function ChatView({
     refetchInterval: 15_000,
   });
 
+  /**
+   * Optimistic-update helpers for the messages cache. Wrap setQueryData so
+   * the POST-then-refetch round trip doesn't gate the user's own message
+   * from appearing above the composer — we render a `pending` row instantly
+   * and reconcile with the server's row once the request resolves. Shared
+   * between text-only (sendMut) and the image upload path (handleSend).
+   *
+   * The query key is memoized so the three useCallback wrappers below get a
+   * stable reference (otherwise a new `[...]` literal every render would
+   * invalidate the callbacks on every parent re-render).
+   */
+  const messagesQueryKey = useMemo(() => ["chat-messages", chatId] as const, [chatId]);
+  const insertOptimisticMessage = useCallback(
+    (msg: MessageWithDelivery) => {
+      queryClient.setQueryData<PaginatedMessages>(messagesQueryKey, (prev) => ({
+        items: [...(prev?.items ?? []), msg],
+        nextCursor: prev?.nextCursor ?? null,
+      }));
+    },
+    [queryClient, messagesQueryKey],
+  );
+  const replaceOptimisticMessage = useCallback(
+    (tempId: string, saved: MessageWithDelivery) => {
+      queryClient.setQueryData<PaginatedMessages>(messagesQueryKey, (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          items: prev.items.map((m) => (m.id === tempId ? { ...saved, deliveryStatus: "sent" as const } : m)),
+        };
+      });
+    },
+    [queryClient, messagesQueryKey],
+  );
+  const removeOptimisticMessages = useCallback(
+    (tempIds: ReadonlySet<string>) => {
+      if (tempIds.size === 0) return;
+      queryClient.setQueryData<PaginatedMessages>(messagesQueryKey, (prev) => {
+        if (!prev) return prev;
+        return { ...prev, items: prev.items.filter((m) => !tempIds.has(m.id)) };
+      });
+    },
+    [queryClient, messagesQueryKey],
+  );
+  const buildOptimisticTextMessage = useCallback(
+    (text: string): MessageWithDelivery | null => {
+      if (!myAgentId) return null;
+      return {
+        id: `optimistic-${crypto.randomUUID()}`,
+        chatId,
+        senderId: myAgentId,
+        format: "text",
+        content: text,
+        metadata: {},
+        inReplyTo: null,
+        source: "web",
+        createdAt: new Date().toISOString(),
+        deliveryStatus: "pending",
+      };
+    },
+    [chatId, myAgentId],
+  );
+
   const sendMut = useMutation({
     mutationFn: (content: string) => sendChatMessage(chatId, content),
-    onSuccess: () => {
+    // Optimistic insert: render the user's row above the composer immediately
+    // and clear the draft so the input feels responsive even when the POST
+    // round-trip + follow-up GET take 1–2s. The ctx returned here is threaded
+    // to onError / onSuccess so we can reconcile with the server row.
+    onMutate: async (content: string) => {
+      await queryClient.cancelQueries({ queryKey: messagesQueryKey });
+      const previousDraft = draft;
       setDraft("");
-      queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
+      const optimistic = buildOptimisticTextMessage(content);
+      if (!optimistic) return { tempId: null, previousDraft };
+      insertOptimisticMessage(optimistic);
+      return { tempId: optimistic.id, previousDraft };
+    },
+    onSuccess: (saved, _content, ctx) => {
+      if (ctx?.tempId) replaceOptimisticMessage(ctx.tempId, saved);
       // Refresh the workspace sidebar the moment the message is durable —
       // server's predictive Step 1b (in services/message.ts) just upserted an
       // `active` agent_chat_sessions row, so the new chat now satisfies the
@@ -860,8 +935,18 @@ export function ChatView({
     // (e.g. user typed `@<outsider>` who's not in the chat) surface here.
     // Client no longer pre-flights — unresolved `@<token>` is treated as
     // plain text locally; the round-trip is the user's notification.
-    onError: (err) => {
+    onError: (err, _content, ctx) => {
       setUploadError(err instanceof Error ? err.message : "Failed to send message");
+      if (ctx?.tempId) removeOptimisticMessages(new Set([ctx.tempId]));
+      // Put the rejected text back so the user can edit and retry without
+      // re-typing.
+      if (ctx?.previousDraft) setDraft(ctx.previousDraft);
+    },
+    // Resync against the server in the background so any fan-out side-effects
+    // (e.g. server-rewritten content, mention resolution) eventually overwrite
+    // our optimistic snapshot.
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: messagesQueryKey });
     },
   });
 
@@ -901,15 +986,23 @@ export function ChatView({
     if (images.length > 0) {
       setUploading(true);
       setUploadError(null);
+      // Carry the text-draft mentions onto each image message so the
+      // server's group-chat mention guard (services/message.ts) accepts
+      // file-format sends. Without this, every image POST is missing
+      // recipient mentions and 400s before the text message is sent
+      // (issue 387). In direct chats `draftMentions` is empty and the
+      // metadata field is omitted entirely — server check is skipped
+      // anyway, so this is a no-op for 1:1.
+      const imageMetadata = draftMentions.length > 0 ? { mentions: draftMentions } : undefined;
+      // Snapshot draft + clear inputs up front so the composer feels instant.
+      // Optimistic rows render into the cache below; rollback restores both
+      // the textarea draft and any not-yet-acked optimistic tempIds on error.
+      const previousDraft = draft;
+      setDraft("");
+      clearImages();
+      await queryClient.cancelQueries({ queryKey: messagesQueryKey });
+      const pendingTempIds = new Set<string>();
       try {
-        // Carry the text-draft mentions onto each image message so the
-        // server's group-chat mention guard (services/message.ts) accepts
-        // file-format sends. Without this, every image POST is missing
-        // recipient mentions and 400s before the text message is sent
-        // (issue 387). In direct chats `draftMentions` is empty and the
-        // metadata field is omitted entirely — server check is skipped
-        // anyway, so this is a no-op for 1:1.
-        const imageMetadata = draftMentions.length > 0 ? { mentions: draftMentions } : undefined;
         for (const img of images) {
           const data = await readFileAsBase64(img.file);
           const imageId = crypto.randomUUID();
@@ -917,7 +1010,31 @@ export function ChatView({
           // its own message via the imageRef shape immediately on refetch,
           // even if the server write races ahead of the response.
           await putImage({ imageId, base64: data, mimeType: img.file.type });
-          await sendFileMessage(
+          let tempId: string | null = null;
+          if (myAgentId) {
+            const imageRef: ImageRefContent = {
+              imageId,
+              mimeType: img.file.type,
+              filename: img.file.name,
+              size: img.file.size,
+            };
+            const optimistic: MessageWithDelivery = {
+              id: `optimistic-${crypto.randomUUID()}`,
+              chatId,
+              senderId: myAgentId,
+              format: "file",
+              content: imageRef,
+              metadata: imageMetadata ?? {},
+              inReplyTo: null,
+              source: "web",
+              createdAt: new Date().toISOString(),
+              deliveryStatus: "pending",
+            };
+            tempId = optimistic.id;
+            pendingTempIds.add(tempId);
+            insertOptimisticMessage(optimistic);
+          }
+          const saved = await sendFileMessage(
             chatId,
             {
               data,
@@ -928,17 +1045,36 @@ export function ChatView({
             },
             imageMetadata,
           );
+          if (tempId) {
+            replaceOptimisticMessage(tempId, saved);
+            pendingTempIds.delete(tempId);
+          }
         }
-        clearImages();
-        if (text) await sendChatMessage(chatId, text);
-        setDraft("");
-        queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
-        // Mirror sendMut.onSuccess: predictive session-activation only shows
+        if (text) {
+          const optimistic = buildOptimisticTextMessage(text);
+          const tempId = optimistic?.id ?? null;
+          if (optimistic && tempId) {
+            pendingTempIds.add(tempId);
+            insertOptimisticMessage(optimistic);
+          }
+          const saved = await sendChatMessage(chatId, text);
+          if (tempId) {
+            replaceOptimisticMessage(tempId, saved);
+            pendingTempIds.delete(tempId);
+          }
+        }
+        // Mirror sendMut.onSettled: predictive session-activation only shows
         // up in the sidebar after we invalidate, otherwise the file-send path
         // for the first message in a new chat waits for 10s polling.
+        queryClient.invalidateQueries({ queryKey: messagesQueryKey });
         queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
       } catch (err) {
         setUploadError(err instanceof Error ? err.message : "Failed to send image");
+        // Roll back unacknowledged optimistic rows + restore the draft so the
+        // user can retry. Already-acked rows have been swapped to real ids by
+        // replaceOptimisticMessage and are no longer in pendingTempIds.
+        removeOptimisticMessages(pendingTempIds);
+        if (previousDraft) setDraft(previousDraft);
       } finally {
         setUploading(false);
       }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -939,8 +939,12 @@ export function ChatView({
       setUploadError(err instanceof Error ? err.message : "Failed to send message");
       if (ctx?.tempId) removeOptimisticMessages(new Set([ctx.tempId]));
       // Put the rejected text back so the user can edit and retry without
-      // re-typing.
-      if (ctx?.previousDraft) setDraft(ctx.previousDraft);
+      // re-typing — but only if the user hasn't already started typing
+      // something new during the in-flight window. Setting `previousDraft`
+      // unconditionally would overwrite the new keystrokes (PR review
+      // observation #1). Functional setState reads the latest draft inside
+      // React's commit so we don't race the textarea's controlled value.
+      if (ctx?.previousDraft) setDraft((current) => (current === "" ? ctx.previousDraft : current));
     },
     // Resync against the server in the background so any fan-out side-effects
     // (e.g. server-rewritten content, mention resolution) eventually overwrite
@@ -1074,7 +1078,10 @@ export function ChatView({
         // user can retry. Already-acked rows have been swapped to real ids by
         // replaceOptimisticMessage and are no longer in pendingTempIds.
         removeOptimisticMessages(pendingTempIds);
-        if (previousDraft) setDraft(previousDraft);
+        // Only restore the pre-send draft if the user hasn't already started
+        // typing something new during the upload window (PR review
+        // observation #1).
+        if (previousDraft) setDraft((current) => (current === "" ? previousDraft : current));
       } finally {
         setUploading(false);
       }


### PR DESCRIPTION
## Summary

Two independent fixes for user-perceived performance issues in the web dashboard, surfaced together because the second was discovered while investigating reports of slowness.

### 1. Composer felt stuck for 1–2s on every send (`perf(web)`)
The send path was strictly pessimistic — the user's own message appeared above the input only after `POST /messages` + the follow-up refetch of `GET /messages` had both completed. Optimistic-update wrappers around the text and image send paths now render a `deliveryStatus: "pending"` row instantly, reconcile with the server row on success, and roll back + restore the draft on failure. Reuses the existing `MessageWithDelivery` shape and `pending` enum value.

### 2. `/api/v1/orgs/:orgId/activity` hit dozens of times per second (`fix(activity)`)
Reported by @baixiaohang. Root cause was a NOTIFY leak in `upsertSessionState`: every chat message triggers the predictive Step 1b in `services/message.ts`, which calls `upsertSessionState(..., "active", ...)`. The DB UPDATE was already short-circuited by `setWhere`, but the NOTIFY ran unconditionally — so an agent emitting many intermediate tool-call messages on an already-active session blasted N session:state frames per N messages. The admin WS then re-broadcast each frame into a non-throttled invalidation of `["activity"]` / `["sessions"]`, which 5+ workspace components each independently refetch.

Two layers of defence:
- **Server**: `upsertSessionState` now uses `.returning()` on the ON CONFLICT DO UPDATE. Zero rows back means the same-state no-op took the `setWhere` branch — we skip the presence refresh, the lastSeenAt touch, and the NOTIFY. (lastSeenAt is owned by the client's `heartbeat` frame anyway — `presence.ts:touchAgent`.)
- **Client**: Generalize the existing `me/chats` throttle helper into a factory; give `["activity"]` / `["sessions"]` / `["me", "chats"]` each their own 1s leading+trailing pair. The ws:reconnect catch-up invalidations stay non-throttled — those are one-shot syncs.

## Test plan
- [x] `pnpm check` (biome) — 803 files, no errors
- [x] `pnpm --filter @first-tree/server typecheck` + `pnpm --filter @first-tree/web typecheck`
- [x] Server tests: 1108/1108 passing (140 files), including two new cases in `activity.test.ts`:
  - `does NOT NOTIFY or refresh lastSeenAt when state is unchanged`
  - `DOES NOTIFY when state actually transitions`
- [x] Web tests: 206/206 passing (22 files)
- [ ] Manual: send a text + image in chat-view, confirm the composer clears + the row appears with no perceptible delay
- [ ] Manual: open the workspace with a busy agent, watch DevTools network — `/activity` should hit at most ~2 req/s during a tool-call burst, not 20+/s

## Notes
- No `package.json` `version` changes (per repo policy)
- No DB migrations
- The reconnect-time broad invalidate path is intentionally untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)