### PR TITLE
feat(chat): doc-preview for chat-send + explicit-link rewrite (L3 core)

### DIFF
--- a/apps/cli/src/__tests__/doc-capture-failure.test.ts
+++ b/apps/cli/src/__tests__/doc-capture-failure.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Mirror of the result-sink dead-link guard for the `chat send` path: when
+ * snapshot validation throws, `captureOutboundDocs` must return the ORIGINAL
+ * content and no documentContext (its catch already does this — pinned here so
+ * a future refactor can't regress it into shipping rewritten links without
+ * snapshots).
+ *
+ * Force the failure by mocking the snapshot builder to return a doc that fails
+ * the shared schema (`sha256` not 64 hex).
+ */
+vi.mock("@first-tree/client", () => ({
+  buildMessageDocumentSnapshots: vi.fn(async () => ({
+    docs: [{ path: "design.md", sha256: "not-64-hex", size: 1, content: "x" }],
+    skipped: 0,
+    rewrittenText: "see [design.md](design.md) please",
+  })),
+}));
+
+import { captureOutboundDocs } from "../core/doc-capture.js";
+
+describe("captureOutboundDocs — failure preserves the original body", () => {
+  it("returns the original content and no documentContext when validation throws", async () => {
+    const out = await captureOutboundDocs("see design.md please", { FIRST_TREE_HUB_DOC_BASE: "/ws/coder/chat-1" });
+    expect(out.content).toBe("see design.md please");
+    expect(out.documentContext).toBeUndefined();
+  });
+});

--- a/apps/cli/src/__tests__/doc-capture.test.ts
+++ b/apps/cli/src/__tests__/doc-capture.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { captureOutboundDocs } from "../core/doc-capture.js";
+
+/**
+ * `chat send` doc capture (L3 阶段1): the CLI snapshots referenced `.md` the
+ * same way result-sink does, driven by the runtime-injected env. These tests
+ * exercise the env contract + pass-through behaviour; the snapshot/rewrite
+ * mechanics themselves are covered by client `doc-snapshots.test.ts`.
+ */
+describe("captureOutboundDocs (chat send L3 capture)", () => {
+  let base: string;
+
+  beforeAll(async () => {
+    base = await mkdtemp(join(tmpdir(), "cli-doc-capture-"));
+    await writeFile(join(base, "design.md"), "# design\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it("pass-through when no doc base in env (not in an agent session)", async () => {
+    const out = await captureOutboundDocs("see design.md please", {});
+    expect(out.content).toBe("see design.md please");
+    expect(out.documentContext).toBeUndefined();
+  });
+
+  it("snapshots a referenced workspace .md and attaches documentContext (explicit link)", async () => {
+    const out = await captureOutboundDocs("see design.md please", { FIRST_TREE_HUB_DOC_BASE: base });
+    expect(out.content).toBe("see [design.md](design.md) please");
+    const ctx = out.documentContext as { kind?: string; docs?: Array<{ path: string }> } | undefined;
+    expect(ctx?.kind).toBe("snapshot");
+    expect(ctx?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+  });
+
+  it("rewrites an absolute-in-base path into an explicit relative link + snapshots it", async () => {
+    const abs = join(base, "design.md");
+    const out = await captureOutboundDocs(`wrote ${abs} now`, { FIRST_TREE_HUB_DOC_BASE: base });
+    expect(out.content).toBe("wrote [design.md](design.md) now");
+    const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
+    expect(ctx?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+  });
+
+  it("no documentContext when the referenced path is not in the workspace", async () => {
+    const out = await captureOutboundDocs("see /etc/nope/missing.md", { FIRST_TREE_HUB_DOC_BASE: base });
+    expect(out.content).toBe("see /etc/nope/missing.md");
+    expect(out.documentContext).toBeUndefined();
+  });
+
+  it("no documentContext when the message references no .md", async () => {
+    const out = await captureOutboundDocs("just a plain message", { FIRST_TREE_HUB_DOC_BASE: base });
+    expect(out.content).toBe("just a plain message");
+    expect(out.documentContext).toBeUndefined();
+  });
+});

--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -7,6 +7,7 @@ import { fail, success } from "../cli/output.js";
 import { resolveSenderName } from "../core/agent-messaging.js";
 import { ensureFreshAccessToken, resolveServerUrl } from "../core/bootstrap.js";
 import { cliFetch } from "../core/cli-fetch.js";
+import { captureOutboundDocs } from "../core/doc-capture.js";
 import { print } from "../core/output.js";
 import { CLI_USER_AGENT } from "../core/version.js";
 
@@ -180,17 +181,28 @@ export function registerChatCommands(program: Command): void {
 
         const sdk = createSdk(options.agent);
 
+        // L3: snapshot any `.md` this message references, exactly like the
+        // runtime's result-sink does for final-text — closing the biggest
+        // doc-preview gap (chat-send messages never built snapshots before).
+        // Pure pass-through outside an agent session / when the runtime did
+        // not inject FIRST_TREE_HUB_DOC_BASE. `content` may come back rewritten
+        // (absolute-in-root paths → relative) so the web preview can match.
+        const captured = await captureOutboundDocs(content);
+        const outboundMetadata = captured.documentContext
+          ? { ...(metadata ?? {}), documentContext: captured.documentContext }
+          : metadata;
+
         const result = await sdk.sendMessage(chatId, {
           format: options.format,
-          // Send the agent's raw content verbatim. The server owns mention
-          // injection: `receiverNames` declares routing intent, and the
-          // agent endpoint's `normalizeMentionsInContent` will prepend
-          // `@<name>` only when the content doesn't already contain it
-          // (idempotent, case-insensitive). Prepending here too would
-          // double-stamp when the agent already wrote `@<name>` in the
-          // body — see services/message.ts step 2c.
-          content,
-          metadata,
+          // Send the agent's content verbatim (modulo the doc-path rewrite
+          // above). The server owns mention injection: `receiverNames`
+          // declares routing intent, and the agent endpoint's
+          // `normalizeMentionsInContent` will prepend `@<name>` only when the
+          // content doesn't already contain it (idempotent, case-insensitive).
+          // Prepending here too would double-stamp when the agent already
+          // wrote `@<name>` in the body — see services/message.ts step 2c.
+          content: captured.content,
+          metadata: outboundMetadata,
           source: "cli",
           // Server resolves the name against the current chat's participant
           // list and adds it to mentions; an unknown name fails the write

--- a/apps/cli/src/core/doc-capture.ts
+++ b/apps/cli/src/core/doc-capture.ts
@@ -1,0 +1,47 @@
+import { buildMessageDocumentSnapshots, type WorkspaceFence } from "@first-tree/client";
+import { documentContextSchema } from "@first-tree/shared";
+
+/**
+ * Snapshot the `.md` documents an outbound `chat send` message references, the
+ * same way the runtime's `result-sink` does for an agent's final-text reply
+ * (L3: unify doc-preview capture across ALL send paths, not just final-text).
+ *
+ * The runtime injects the resolved doc context into the agent's environment
+ * (`buildAgentEnv` → `FIRST_TREE_HUB_DOC_BASE` / `_WORKSPACES_ROOT` /
+ * `_AGENT_SLUG`); we read it here so the CLI sub-process resolves against the
+ * exact same base + cross-agent fence as the runtime — no config reconstruction,
+ * no server round-trip.
+ *
+ * Returns the (possibly rewritten) content + a validated `documentContext` to
+ * merge into message metadata. When no doc base is present (not in an agent
+ * session, or the runtime predates this wiring) it is a pure pass-through, so
+ * `chat send` keeps working unchanged.
+ *
+ * Capture failure NEVER blocks the send: any error degrades to passing the
+ * original content through with no `documentContext`.
+ */
+export async function captureOutboundDocs(
+  content: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ content: string; documentContext?: unknown }> {
+  const base = env.FIRST_TREE_HUB_DOC_BASE;
+  if (!base) return { content };
+
+  const chatId = env.FIRST_TREE_HUB_CHAT_ID;
+  const workspacesRoot = env.FIRST_TREE_HUB_WORKSPACES_ROOT;
+  const selfSlug = env.FIRST_TREE_HUB_AGENT_SLUG;
+  const fence: WorkspaceFence | undefined =
+    workspacesRoot && selfSlug && chatId ? { workspacesRoot, chatId, selfSlug } : undefined;
+
+  try {
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(content, base, fence);
+    if (docs.length === 0) return { content: rewrittenText };
+    // Validate through the shared schema (same as result-sink) so a malformed
+    // doc can never be lodged into immutable message history; on a parse error
+    // fall back to sending the content with no documentContext.
+    const documentContext = documentContextSchema.parse({ kind: "snapshot", docs });
+    return { content: rewrittenText, documentContext };
+  } catch {
+    return { content };
+  }
+}

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -285,4 +285,41 @@ describe("buildAgentEnv", () => {
     });
     expect(env.FIRST_TREE_HUB_CHAT_ID).toBe("chat-right");
   });
+
+  it("injects doc-preview context (base + workspaces root + slug) when provided, for `chat send` capture", () => {
+    const env = buildAgentEnv({} as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://hub" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      docContext: { base: "/ws/coder/chat-1", workspacesRoot: "/ws", selfSlug: "coder" },
+    });
+    expect(env.FIRST_TREE_HUB_DOC_BASE).toBe("/ws/coder/chat-1");
+    expect(env.FIRST_TREE_HUB_WORKSPACES_ROOT).toBe("/ws");
+    expect(env.FIRST_TREE_HUB_AGENT_SLUG).toBe("coder");
+  });
+
+  it("omits doc-preview env vars when no docContext is provided (self-only / non-agent shells)", () => {
+    const env = buildAgentEnv({} as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://hub" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+    });
+    expect(env.FIRST_TREE_HUB_DOC_BASE).toBeUndefined();
+    expect(env.FIRST_TREE_HUB_WORKSPACES_ROOT).toBeUndefined();
+    expect(env.FIRST_TREE_HUB_AGENT_SLUG).toBeUndefined();
+  });
 });

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -5,13 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildMessageDocumentSnapshots } from "../runtime/doc-snapshots.js";
 
 /**
- * Unit tests for the runtime snapshot builder, focused on Option R (Case A):
- * an absolute `.md` path that lands inside the workspace root is snapshotted
- * AND rewritten in the outbound text to its canonical workspace-relative path,
- * so web's unchanged re-scan can match it. Relative mentions and out-of-root /
- * hidden / escaping paths must behave exactly as before.
+ * Unit tests for the runtime snapshot builder. Every resolved+snapshotted `.md`
+ * reference is rewritten into an EXPLICIT markdown link whose href is the
+ * canonical snapshot key (bare → `[display](key)`; inline target → key), so web
+ * resolves a click by direct href→snapshot lookup without re-scanning. Out-of-
+ * root / hidden / escaping paths get no snapshot and are left verbatim.
  */
-describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R / Case A)", () => {
+describe("buildMessageDocumentSnapshots — explicit-link rewrite (self / Case A)", () => {
   let root: string;
   let outside: string;
 
@@ -42,7 +42,7 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
 
     expect(docs.map((d) => d.path)).toEqual(["design.md"]);
     expect(docs[0]?.content).toBe("# design\n");
-    expect(rewrittenText).toBe("wrote design.md just now");
+    expect(rewrittenText).toBe("wrote [design.md](design.md) just now");
   });
 
   it("rewrites an absolute target inside an inline markdown link in place", async () => {
@@ -58,7 +58,8 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:42:7 here`, root);
 
     expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("open docs/intro.md:42:7 here");
+    // Explicit link: `:line` kept on the display, stripped from the key href.
+    expect(rewrittenText).toBe("open [docs/intro.md:42:7](docs/intro.md) here");
   });
 
   it("leaves an out-of-root absolute path untouched — no snapshot, no rewrite", async () => {
@@ -70,21 +71,24 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
     expect(rewrittenText).toBe(text);
   });
 
-  it("leaves relative tokens completely unchanged (regression)", async () => {
+  it("wraps a bare relative mention into an explicit link; an already-canonical inline href is left as-is", async () => {
     const text = "see docs/intro.md and [d](design.md)";
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
 
     expect(docs.map((d) => d.path).sort()).toEqual(["design.md", "docs/intro.md"]);
-    // Text is byte-for-byte identical: relative mentions are never rewritten.
-    expect(rewrittenText).toBe(text);
+    // Bare `docs/intro.md` → explicit link; inline `[d](design.md)` href is
+    // already the canonical key, so it stays byte-identical.
+    expect(rewrittenText).toBe("see [docs/intro.md](docs/intro.md) and [d](design.md)");
   });
 
-  it("does not rewrite a non-canonical RELATIVE token (web canonicalises it on re-scan)", async () => {
+  it("canonicalises a non-canonical inline target (`./docs/intro.md` → `docs/intro.md`)", async () => {
     const text = "see [d](./docs/intro.md)";
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
 
     expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe(text);
+    // Web no longer canonicalises on re-scan; the runtime points the target
+    // straight at the snapshot key so the click is a direct lookup.
+    expect(rewrittenText).toBe("see [d](docs/intro.md)");
   });
 
   it("rejects a symlink whose realpath crosses into a hidden dir — relative AND absolute forms", async () => {
@@ -114,7 +118,22 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
 
     expect(docs.map((d) => d.path)).toEqual(["design.md"]);
-    expect(rewrittenText).toBe("first design.md then again design.md");
+    expect(rewrittenText).toBe("first [design.md](design.md) then again [design.md](design.md)");
+  });
+
+  it("invariant: every rewritten explicit-link href is a real snapshot key", async () => {
+    // The core "two ends agree by construction" guarantee — web resolves a
+    // click by direct href→snapshot lookup, so every href the rewrite emits
+    // MUST be one of the snapshot keys (else a dead link). Mixes bare +
+    // inline + absolute + relative + :line in one message.
+    const absDesign = join(root, "design.md");
+    const text = `a ${absDesign} b docs/intro.md c [x](${join(root, "docs", "intro.md")}) d ${absDesign}:9`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
+
+    const keys = new Set(docs.map((d) => d.path));
+    const hrefs = [...rewrittenText.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]);
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) expect(keys.has(href ?? "")).toBe(true);
   });
 });
 
@@ -122,9 +141,10 @@ describe("buildMessageDocumentSnapshots — absolute-in-root rewrite (Option R /
  * Cross-agent doc preview: with a workspace fence, an absolute `.md` path that
  * realpaths into ANOTHER agent's workspace (same chat) under the shared
  * `workspaces/` common root is snapshotted with a global
- * `<ownerSlug>/<chatId>/<rel>` key and rewritten to the short `<ownerSlug>/<rel>`
- * form. Self paths keep their bare key + #480 behaviour; out-of-scope paths
- * (other chat, other root, hidden) stay verbatim.
+ * `<ownerSlug>/<chatId>/<rel>` key and rewritten into an explicit link with a
+ * short `<ownerSlug>/<rel>` display and the FULL global key as href. Self paths
+ * get an explicit relative link; out-of-scope paths (other chat, other root,
+ * hidden) stay verbatim.
  */
 describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => {
   let workspacesRoot: string;
@@ -169,7 +189,9 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
 
     expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/design.md`]);
     expect(docs[0]?.content).toBe("# their design\n");
-    expect(rewrittenText).toBe(`see ${otherSlug}/design.md please`);
+    // Explicit link: short `<slug>/<rel>` display, FULL global key href so web
+    // direct-matches without chatId re-expansion.
+    expect(rewrittenText).toBe(`see [${otherSlug}/design.md](${otherSlug}/${chatId}/design.md) please`);
   });
 
   it("preserves subdir + :line suffix in the cross rewrite", async () => {
@@ -177,15 +199,15 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:10 now`, selfRoot, fence());
 
     expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/docs/intro.md`]);
-    expect(rewrittenText).toBe(`open ${otherSlug}/docs/intro.md:10 now`);
+    expect(rewrittenText).toBe(`open [${otherSlug}/docs/intro.md:10](${otherSlug}/${chatId}/docs/intro.md) now`);
   });
 
-  it("keeps the self path bare (Case A unchanged) even with a fence", async () => {
+  it("rewrites a self path into an explicit relative link even with a fence", async () => {
     const abs = join(selfRoot, "mine.md");
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`my ${abs} file`, selfRoot, fence());
 
     expect(docs.map((d) => d.path)).toEqual(["mine.md"]);
-    expect(rewrittenText).toBe("my mine.md file");
+    expect(rewrittenText).toBe("my [mine.md](mine.md) file");
   });
 
   it("rejects a sibling doc from a DIFFERENT chat (chat-scope fence)", async () => {
@@ -215,17 +237,20 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
     expect(rewrittenText).toBe(text);
   });
 
-  it("rewrites a cross mention to the FULL global key when its short form collides with a self key (P2-b)", async () => {
+  it("a self ref and a cross ref that share a short form get DISTINCT hrefs (no collision)", async () => {
     // Self file `assistant/design.md` (relative) AND the sibling agent's
-    // `assistant/<chat>/design.md` are both referenced. The cross short form
-    // would be `assistant/design.md` — identical to the self key — so the cross
-    // mention must be rewritten to the full global key instead.
+    // `assistant/<chat>/design.md` are both referenced — both display as
+    // `assistant/design.md`. With explicit links the hrefs are the canonical
+    // keys (self relative vs cross GLOBAL), so they can never collide and web
+    // direct-matches each to the right snapshot — no collision handling needed.
     const crossAbs = join(workspacesRoot, otherSlug, chatId, "design.md");
     const text = `self ${otherSlug}/design.md and cross ${crossAbs}`;
     const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
 
     expect(docs.map((d) => d.path).sort()).toEqual([`${otherSlug}/${chatId}/design.md`, `${otherSlug}/design.md`]);
-    // Self relative mention stays verbatim; cross mention becomes the full key.
-    expect(rewrittenText).toBe(`self ${otherSlug}/design.md and cross ${otherSlug}/${chatId}/design.md`);
+    expect(rewrittenText).toBe(
+      `self [${otherSlug}/design.md](${otherSlug}/design.md) and ` +
+        `cross [${otherSlug}/design.md](${otherSlug}/${chatId}/design.md)`,
+    );
   });
 });

--- a/packages/client/src/__tests__/result-sink-capture-failure.test.ts
+++ b/packages/client/src/__tests__/result-sink-capture-failure.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression for the codex review finding: when snapshot validation throws,
+ * result-sink must send the ORIGINAL body — never the rewritten explicit-link
+ * text — so it can't ship `[display](key)` links with no matching snapshot
+ * (dead links). Keeps the "rewritten ⇔ snapshotted" invariant atomic.
+ *
+ * We force the failure by mocking the snapshot builder to return a doc that
+ * fails the shared schema (`sha256` not 64 hex), which makes
+ * `documentContextSchema.parse` throw inside result-sink.
+ */
+vi.mock("../runtime/doc-snapshots.js", () => ({
+  buildMessageDocumentSnapshots: vi.fn(async () => ({
+    docs: [{ path: "design.md", sha256: "not-64-hex", size: 1, content: "x" }],
+    skipped: 0,
+    rewrittenText: "see [design.md](design.md) please",
+  })),
+}));
+
+import { createResultSink } from "../runtime/result-sink.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+
+describe("createResultSink — capture/parse failure preserves the original body", () => {
+  it("sends the ORIGINAL text and no documentContext when snapshot validation throws", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const sdk = { serverUrl: "http://test", sendMessage } as unknown as FirstTreeHubSDK;
+    const sink = createResultSink({
+      sdk,
+      agent: {
+        agentId: "me",
+        inboxId: "inbox",
+        displayName: "me",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      getTrigger: () => null,
+      clearTrigger: () => {},
+      log: () => {},
+      getDocumentBasePath: vi.fn().mockResolvedValue("/ws/coder/chat-1"),
+      workspacesRoot: "/ws",
+      selfSlug: "coder",
+    });
+
+    await sink("see design.md please");
+
+    const [, body] = sendMessage.mock.calls[0] ?? [];
+    const sent = body as { content?: string; metadata?: { documentContext?: unknown } };
+    // Body restored to the original — NOT the rewritten explicit-link form.
+    expect(sent.content).toBe("see design.md please");
+    expect(sent.metadata?.documentContext).toBeUndefined();
+  });
+});

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -323,9 +323,9 @@ describe("createResultSink — forwardResult enrichment", () => {
       expect(body.metadata?.documentContext).toBeUndefined();
     });
 
-    it("sends content with absolute-in-root paths rewritten to relative (Option R wiring)", async () => {
+    it("sends content with referenced docs rewritten to explicit links (Option R wiring)", async () => {
       // The sink must forward `rewrittenText`, not the agent's original body, so
-      // web's unchanged re-scan sees a relative token and matches the snapshot.
+      // web renders a native link whose href is the snapshot key.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
@@ -339,7 +339,7 @@ describe("createResultSink — forwardResult enrichment", () => {
         content?: string;
         metadata?: { documentContext?: { docs?: Array<{ path: string }> } };
       };
-      expect(sent.content).toBe("done — wrote design.md for review");
+      expect(sent.content).toBe("done — wrote [design.md](design.md) for review");
       expect(sent.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["design.md"]);
     });
   });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -25,6 +25,8 @@ export { probeCapabilities } from "./runtime/capabilities/index.js";
 export type { AgentSlotYamlConfig, RuntimeConfig, SessionConfig } from "./runtime/config.js";
 export { loadRuntimeConfig } from "./runtime/config.js";
 export { Deduplicator } from "./runtime/deduplicator.js";
+export type { WorkspaceFence } from "./runtime/doc-snapshots.js";
+export { buildMessageDocumentSnapshots } from "./runtime/doc-snapshots.js";
 export type { GitMirrorManager, GitMirrorManagerOptions } from "./runtime/git-mirror-manager.js";
 export { createGitMirrorManager, GitMirrorError } from "./runtime/git-mirror-manager.js";
 export type {

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -24,7 +24,20 @@ import type { AgentIdentity, SessionMessage } from "./handler.js";
  */
 export function buildAgentEnv(
   parentEnv: NodeJS.ProcessEnv,
-  ctx: { sdk: Pick<FirstTreeHubSDK, "serverUrl">; agent: AgentIdentity; chatId: string },
+  ctx: {
+    sdk: Pick<FirstTreeHubSDK, "serverUrl">;
+    agent: AgentIdentity;
+    chatId: string;
+    /**
+     * Resolved doc-preview context for this session, so a `first-tree-hub
+     * chat send` sub-process can snapshot referenced `.md` the same way
+     * `result-sink` does for final-text (L3: unify capture across send
+     * paths). Absent → `chat send` skips snapshotting (self-only fallback /
+     * no doc base). All three are required together for cross-agent
+     * resolution; `base` alone still enables self snapshots.
+     */
+    docContext?: { base: string; workspacesRoot: string; selfSlug: string };
+  },
 ): NodeJS.ProcessEnv {
   return {
     ...parentEnv,
@@ -32,6 +45,13 @@ export function buildAgentEnv(
     FIRST_TREE_HUB_AGENT_ID: ctx.agent.agentId,
     FIRST_TREE_HUB_INBOX_ID: ctx.agent.inboxId,
     FIRST_TREE_HUB_CHAT_ID: ctx.chatId,
+    ...(ctx.docContext
+      ? {
+          FIRST_TREE_HUB_DOC_BASE: ctx.docContext.base,
+          FIRST_TREE_HUB_WORKSPACES_ROOT: ctx.docContext.workspacesRoot,
+          FIRST_TREE_HUB_AGENT_SLUG: ctx.docContext.selfSlug,
+        }
+      : {}),
   };
 }
 

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -18,20 +18,26 @@ import {
  * safely-resolvable target into a snapshot of the file's contents at send
  * time.
  *
- * Resolution is constrained to `root`. A path resolves when its real target
- * is a regular `.md` file physically inside the worktree with no hidden
- * segment. Two written forms resolve:
- *   - workspace-relative (`docs/foo.md`, `./docs/foo.md`); and
- *   - **absolute paths that land inside `root`** (`<root>/docs/foo.md`).
- *     Web cannot map an absolute path back to a snapshot key (it does not
- *     know `root`), so for every resolved token whose written form is not
- *     already the canonical relative path, we **rewrite that span in the
- *     outbound text** to the canonical relative path (preserving any
- *     `:line[:col]` suffix). The caller sends `rewrittenText`, and web's
- *     unchanged re-scan then sees a relative token, matches the snapshot,
- *     and renders the preview link. This keeps web/server/schema untouched
- *     and is immune to server-side body rewrites (e.g. `@mention` prepend)
- *     because web re-scans rather than trusting byte offsets.
+ * Resolution is constrained to `root` (+ the optional cross-agent fence). A
+ * path resolves when its real target is a regular `.md` file physically inside
+ * an allowed root with no hidden segment. Relative (`docs/foo.md`,
+ * `./docs/foo.md`) and absolute-inside-root (`<root>/docs/foo.md`) forms both
+ * resolve.
+ *
+ * For every resolved+snapshotted reference we **rewrite its span in the
+ * outbound text into an EXPLICIT markdown link** whose href is the canonical
+ * snapshot key — a bare mention becomes `[display](key)`, an inline
+ * `[label](target)` keeps its label and points the target at the key. The
+ * caller sends `rewrittenText`. Web then renders a native markdown link and
+ * resolves a click by a direct href→snapshot lookup: it does NOT re-scan free
+ * text, re-derive keys, or expand cross short-forms. That removes the whole
+ * "the runtime scanner and the web scanner must agree" failure class (and the
+ * cross-agent web-version skew it caused), and is immune to server-side body
+ * rewrites (e.g. `@mention` prepend) since a `[..](..)` link survives wherever
+ * it lands. Only snapshotted refs are rewritten, so "rewritten ⇔ has a
+ * snapshot ⇔ web can render it" holds. (Web keeps a legacy bare-token re-scan
+ * for messages authored before this — it is simply inert here because the
+ * scanner skips inline links.)
  *
  * Anything that escapes the worktree (absolute path resolving OUTSIDE root,
  * `..` traversal, symlink pointing to a hidden segment inside or outside
@@ -169,36 +175,32 @@ export async function buildMessageDocumentSnapshots(
     }
   }
 
-  // Self snapshot keys are bare base-relative paths; a cross short form
-  // `<ownerSlug>/<rel>` can therefore collide with one (e.g. the sender also
-  // snapshotted a real file at `assistant/design.md`). Web gives a direct
-  // self-key match priority, so a colliding short form would link to the WRONG
-  // (self) snapshot. Detect the collision here and fall back to the FULL global
-  // key for that cross mention so web direct-matches the right snapshot
-  // (review P2-b).
-  const selfKeys = new Set<string>();
-  for (const occ of resolved) {
-    if (occ.kind === "self" && occ.key && snapshotted.has(occ.key)) selfKeys.add(occ.key);
-  }
-
-  // Pass 3 — rewrite text spans to the form web re-scans into the snapshot key.
-  // Web can't map an absolute path (it doesn't know `root`), nor a cross global
-  // key from a bare absolute path, so:
-  //   self + absolute-in-root → canonical bare relative path (unchanged #480)
-  //   cross                   → short `<ownerSlug>/<rel>` (web re-expands with
-  //                             chatId), OR the full global key when the short
-  //                             form would collide with a self snapshot key.
-  // Self RELATIVE mentions (`./docs/foo.md`) are left verbatim because web
-  // already canonicalises them on re-scan. Only tokens that actually produced a
-  // snapshot are rewritten, so "rewritten ⇔ previewable" holds.
+  // Pass 3 — rewrite every resolved+snapshotted reference into an EXPLICIT
+  // markdown link whose href is the canonical snapshot key. Web then renders a
+  // native link and resolves a click by a direct href→snapshot lookup; it no
+  // longer re-scans free text or re-derives/expands keys. That removes the
+  // "two scanners must agree" fragility — and, because the href carries the
+  // FULL key (relative for self, global `<slug>/<chatId>/<rel>` for cross),
+  // the cross-agent web-version skew is gone too (no chatId re-expansion on
+  // the web side). The href being explicit also makes short-form/self-key
+  // collisions impossible, so no collision handling is needed.
+  //   - bare mention   → `[display](key)` (display = canonical relative for
+  //                       self, short `<slug>/<rel>` for cross; `:line` kept on
+  //                       the display, stripped from the key href).
+  //   - inline `[label](target)` → target replaced with the key; the agent's
+  //                       label is preserved.
+  // Only tokens that actually produced a snapshot are rewritten, so the
+  // invariant "rewritten ⇔ has a snapshot ⇔ web can render it" holds.
   const rewrites: Array<{ start: number; end: number; replacement: string }> = [];
   for (const occ of resolved) {
     if (!occ.key || !snapshotted.has(occ.key)) continue;
-    if (occ.kind === "self" && isAbsolute(occ.writtenPath)) {
-      rewrites.push({ start: occ.start, end: occ.end, replacement: `${occ.key}${occ.lineSuffix}` });
-    } else if (occ.kind === "cross") {
-      const replacement = selfKeys.has(occ.shortForm) ? occ.key : occ.shortForm;
-      rewrites.push({ start: occ.start, end: occ.end, replacement: `${replacement}${occ.lineSuffix}` });
+    if (occ.source === "inline") {
+      // Point the agent's existing link at the canonical key (no-op when it
+      // already is); the label between `[` and `]` is left untouched.
+      rewrites.push({ start: occ.start, end: occ.end, replacement: occ.key });
+    } else {
+      const display = occ.kind === "cross" ? occ.shortForm : occ.key;
+      rewrites.push({ start: occ.start, end: occ.end, replacement: `[${display}${occ.lineSuffix}](${occ.key})` });
     }
   }
 
@@ -220,16 +222,23 @@ type DocPathOccurrence = {
   lineSuffix: string;
   start: number;
   end: number;
+  /**
+   * `bare` — a plain `path.md` mention; rewritten into an explicit
+   * `[display](key)` markdown link so web renders a native link (no re-scan).
+   * `inline` — the `(target)` of an agent-authored `[label](target.md)`; only
+   * the target is rewritten to the canonical key (the agent's label is kept).
+   */
+  source: "bare" | "inline";
 };
 
 function collectDocPathOccurrences(text: string): DocPathOccurrence[] {
   const out: DocPathOccurrence[] = [];
   for (const link of scanInlineMarkdownLinks(text)) {
-    out.push({ writtenPath: link.target, lineSuffix: "", start: link.start, end: link.end });
+    out.push({ writtenPath: link.target, lineSuffix: "", start: link.start, end: link.end, source: "inline" });
   }
   for (const m of scanBareDocPathTokens(text)) {
     const writtenPath = stripDocPathLineSuffix(m.raw);
-    out.push({ writtenPath, lineSuffix: m.raw.slice(writtenPath.length), start: m.start, end: m.end });
+    out.push({ writtenPath, lineSuffix: m.raw.slice(writtenPath.length), start: m.start, end: m.end, source: "bare" });
   }
   return out;
 }

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -98,10 +98,16 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
             ? { workspacesRoot: deps.workspacesRoot, chatId: deps.chatId, selfSlug: deps.selfSlug }
             : undefined;
         const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, documentBasePath, fence);
-        content = rewrittenText;
+        // Validate BEFORE committing the rewritten body: `rewrittenText`
+        // contains explicit `[display](key)` links that only make sense paired
+        // with their snapshots. If schema validation throws, the catch must
+        // leave `content` as the ORIGINAL text — otherwise we'd ship explicit
+        // links with no matching snapshot (dead links), breaking the
+        // "rewritten ⇔ snapshotted" invariant (codex review finding).
         if (docs.length > 0) {
           metadata.documentContext = documentContextSchema.parse({ kind: "snapshot", docs });
         }
+        content = rewrittenText;
         if (skipped > 0) {
           deps.log(`doc snapshot: skipped ${skipped} unresolvable link(s)`);
         }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -794,6 +794,24 @@ export class SessionManager {
     // now flows only into the inbound-formatter path.
     const participants = createParticipantCache(this.config.sdk, chatId, log);
 
+    // Cross-agent doc preview: `workspaceRoot` is `<workspaces>/<agentSlug>`
+    // (see agent-slot.ts), so the shared common root is its parent and this
+    // agent's slug is its basename — derived from existing config, no new
+    // config surface (decision: config-ascent).
+    const workspacesRoot = dirname(this.config.handlerConfig.workspaceRoot);
+    const selfSlug = basename(this.config.handlerConfig.workspaceRoot);
+    // Resolve the doc base SYNCHRONOUSLY from the already-populated config
+    // cache so it can ride the agent's env (`buildAgentEnv` is sync). This
+    // lets a `first-tree-hub chat send` sub-process snapshot referenced docs
+    // exactly like result-sink does (L3: unify capture across send paths).
+    // result-sink keeps its own async `getDocumentBasePath`; both read the
+    // same cache (`refreshIfNewer(_, 0)` returns the cached payload), so the
+    // base they compute agrees. Falls back to the per-chat root when the
+    // cache has no payload yet (== the single/zero-repo default).
+    const perChatRoot = join(this.config.handlerConfig.workspaceRoot, chatId);
+    const cachedPayload = this.config.agentConfigCache?.get(this.config.agentIdentity.agentId)?.payload;
+    const docBase = cachedPayload ? documentBasePathFromRuntimeConfig(cachedPayload, perChatRoot) : perChatRoot;
+
     const forwardResult = createResultSink({
       sdk: this.config.sdk,
       agent: this.config.agentIdentity,
@@ -804,15 +822,16 @@ export class SessionManager {
       },
       log,
       getDocumentBasePath: () => this.resolveDocumentBasePath(log, chatId),
-      // Cross-agent doc preview: `workspaceRoot` is `<workspaces>/<agentSlug>`
-      // (see agent-slot.ts), so the shared common root is its parent and this
-      // agent's slug is its basename — derived from existing config, no new
-      // config surface (decision: config-ascent).
-      workspacesRoot: dirname(this.config.handlerConfig.workspaceRoot),
-      selfSlug: basename(this.config.handlerConfig.workspaceRoot),
+      workspacesRoot,
+      selfSlug,
     });
 
-    const envCtx = { sdk: this.config.sdk, agent: this.config.agentIdentity, chatId };
+    const envCtx = {
+      sdk: this.config.sdk,
+      agent: this.config.agentIdentity,
+      chatId,
+      docContext: { base: docBase, workspacesRoot, selfSlug },
+    };
 
     return {
       agent: this.config.agentIdentity,


### PR DESCRIPTION
## What & why

doc-preview (clickable `.md` in chat → preview drawer) kept breaking across many PRs because of two structural gaps:

1. **Snapshots were only built for an agent's final-text** (`result-sink`). Messages sent via `first-tree-hub chat send` — the main way agents reference docs to each other — **never built a snapshot**, so they were never previewable.
2. **Web re-scanned message text and had to agree with the runtime on every key shape.** Any key-format evolution (absolute paths, cross-agent global keys) required changing *both* ends and deploying both → cross-agent refs broke whenever the deployed web lagged the runtime (version skew), and rendering was format-fragile.

This is the **L3 core** (phases 1+2): unify capture across send paths, and make the **runtime the single authority** for links so web stops guessing.

## Changes (client + cli only — web untouched)

**1. Capture on `chat send`**
- `runtime/agent-io.ts` `buildAgentEnv` injects the resolved doc context into the agent env: `FIRST_TREE_HUB_DOC_BASE` / `_WORKSPACES_ROOT` / `_AGENT_SLUG`.
- `runtime/session-manager.ts` resolves the doc base **synchronously** from the already-populated config cache (`agentConfigCache.get()`) — no async ripple, same base `result-sink` uses.
- New `apps/cli/src/core/doc-capture.ts` (`captureOutboundDocs`) reuses the **same** `buildMessageDocumentSnapshots`; `apps/cli/src/commands/chat.ts` calls it before send. Capture failure never blocks the send.
- `client/src/index.ts` exports `buildMessageDocumentSnapshots` + `WorkspaceFence` for the CLI.

**2. Explicit-link rewrite (kills "two scanners must agree")**
- `runtime/doc-snapshots.ts` Pass 3 now rewrites **every resolved + snapshotted** reference into an explicit markdown link whose **href is the canonical snapshot key** (relative for self, global `<slug>/<chatId>/<rel>` for cross). Bare → `[display](key)`; an inline `[label](target)` keeps its label and points the target at the key.
- Web renders a native link and resolves a click by a **direct href→snapshot lookup** (`docPreviewPathFromHref` → `docSnapshots.get`). It no longer re-scans free text or expands keys → the cross-agent web-version skew is gone and rendering is format-independent. **Web code is unchanged** (its re-scan is a no-op on inline links, kept only as a legacy fallback for old messages).
- Drops the now-unnecessary short-form/self-key collision handling (explicit global-key hrefs can't collide).

## codex review finding + fix

codex flagged a Medium dead-link bug: `result-sink` assigned `content = rewrittenText` **before** `documentContextSchema.parse`, so a validation throw shipped explicit links with no snapshot. **Fixed**: the rewritten body is committed only **after** schema validation succeeds, so a failure leaves the original text intact ("rewritten ⇔ snapshotted" stays atomic). The `chat send` path already restored original content on failure. Both paths now have **regression tests** (`result-sink-capture-failure.test.ts`, `doc-capture-failure.test.ts`). codex re-review: **no new blocking issues, Medium closed.**

## Scope boundary (honest)

Covers a `.md` referenced in a message that resolves **inside the agent's own per-chat workspace / bound repo** (and same-chat sibling workspaces). It does **NOT** cover:
- docs outside the workspace (e.g. a shared dev checkout like `/Users/.../github/...`) or the Context Tree;
- browsing docs that were never mentioned;
- "see latest" (snapshots are point-in-time / frozen at send).

These were explicitly de-scoped (L2 / registry / Case B territory).

## Testing

- `client` **435/435**, `cli` **131/131**, `web` **206/206** (web untouched — proves compatibility with the explicit-link model).
- Per-package typecheck + biome clean.
- New tests: `buildAgentEnv` doc-env injection; chat-send capture (incl. failure-preserves-original-body); explicit-link rewrite for bare/inline/absolute/cross/`:line`; and a **"every rewritten href is a real snapshot key"** invariant.

> ⚠️ **End-to-end regression on live chats** (the two reproduction chats + real `chat send`) requires this runtime to be **deployed** — it can't be verified against the currently-running (old) runtime. To be done after merge + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)