### PR TITLE
fix(server): wake delegate on GitHub events in multi-speaker chats

### DIFF
--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -3,8 +3,10 @@ import type { NormalizedEvent } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import type { AudienceTarget } from "../services/github-audience.js";
 import { deliverNormalizedEvent } from "../services/github-delivery.js";
@@ -237,5 +239,86 @@ describe("deliverNormalizedEvent", () => {
     expect(stats.delivered).toBe(1);
     const sent = await app.db.select().from(messages).where(eq(messages.chatId, goodChatId));
     expect(sent).toHaveLength(1);
+  });
+
+  // Regression: a GitHub-bound chat that has been expanded to >=3 speakers
+  // (e.g. a teammate invited in) must still wake the delegate agent that
+  // owns the entity. Before the fix, github-delivery passed neither
+  // `addressedToAgentIds` nor `metadata.mentions`, so for card-format
+  // messages in a multi-speaker chat the fan-out collapsed to
+  // `notify=false` for everyone and the agent never woke.
+  it("wakes the delegate even in a multi-speaker bound chat (no mention required)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const watcher = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `watcher-${randomUUID().slice(0, 6)}`,
+    });
+
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values([
+      { chatId, agentId: human, role: "owner", accessMode: "speaker" },
+      { chatId, agentId: delegate, role: "member", accessMode: "speaker" },
+      { chatId, agentId: watcher, role: "member", accessMode: "speaker" },
+    ]);
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#900",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#900",
+    });
+    const stats = await deliverNormalizedEvent(app, event, [target]);
+    expect(stats).toEqual({ delivered: 1, newChats: 0 });
+
+    const [delegateAgent] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, delegate))
+      .limit(1);
+    const [watcherAgent] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, watcher))
+      .limit(1);
+
+    const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, chatId));
+    const delegateRow = rows.find((r) => r.inboxId === delegateAgent?.inboxId);
+    const watcherRow = rows.find((r) => r.inboxId === watcherAgent?.inboxId);
+
+    // The delegate is the structural target of the audience row — must wake.
+    expect(delegateRow?.notify).toBe(true);
+    // Other group speakers stay silent (history-only) — exactly the
+    // mention-only behaviour for unaddressed participants.
+    expect(watcherRow?.notify).toBe(false);
   });
 });

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -63,20 +63,33 @@ export async function deliverNormalizedEvent(
 
       const card = buildCard(event, target);
       const mentionedUser = card.mentionedUser ?? undefined;
-      const { message, recipients } = await sendMessage(app.db, resolved.chatId, target.humanAgentId, {
-        format: "card",
-        content: card,
-        source: "github",
-        metadata: {
+      // The audience row resolved a specific (human, delegate) pair as the
+      // structural target of this event. Address the delegate explicitly so
+      // a bound chat that has been expanded to ≥3 speakers still wakes the
+      // agent — without this, card-format messages produce no mentionSet
+      // and the multi-speaker fan-out collapses to notify=false for
+      // everyone. Same pattern as `question_answer` (see SendMessageOptions
+      // `addressedToAgentIds`).
+      const { message, recipients } = await sendMessage(
+        app.db,
+        resolved.chatId,
+        target.humanAgentId,
+        {
+          format: "card",
+          content: card,
           source: "github",
-          event: event.rawEventType,
-          action: event.rawAction,
-          entityType: event.entity.type,
-          entityKey: event.entity.key,
-          reason: card.reason,
-          ...(mentionedUser ? { mentionedUser } : {}),
+          metadata: {
+            source: "github",
+            event: event.rawEventType,
+            action: event.rawAction,
+            entityType: event.entity.type,
+            entityKey: event.entity.key,
+            reason: card.reason,
+            ...(mentionedUser ? { mentionedUser } : {}),
+          },
         },
-      });
+        { addressedToAgentIds: [target.delegateAgentId] },
+      );
       notifyRecipients(app.notifier, recipients, message.id);
       stats.delivered += 1;
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Bug**: When a GitHub-bound chat has ≥ 3 speakers (e.g. a teammate was invited into the auto-created PR/issue chat), incoming GitHub webhook events land in the chat history but **never wake the delegate agent**. The card-format message produces no `mentionSet`, no `addressedToAgentIds` is passed, and `isOneOnOne` is false — so multi-speaker fan-out collapses every row to `notify=false`.
- **Why the 2-speaker default chat was unaffected**: the 1:1 implicit-wake rule (`participants.length === 2`) accidentally bailed out the default chat shape. The bug only manifests once another speaker joins the bound chat.
- **Fix**: `github-delivery.ts` now passes `addressedToAgentIds: [target.delegateAgentId]` when calling `sendMessage`. This is the same `SendMessageOptions` channel that the `question_answer` path already uses for system-routed messages whose recipient is fixed at write time.
- **Non-target speakers stay silent** (history-only) — preserves the mention-only fan-out semantics for everyone else in the chat.

## Related

Same class of bug, previously fixed for the `askuser` path:
- #404 — group-chat answer not waking asker
- #417 — follow-up: unread badge projection (still open)

The architectural recipe (`addressedToAgentIds` for system-routed structural targets) is already documented in `agent-hub/messaging.md` and on `SendMessageOptions.addressedToAgentIds`; this PR extends it to the third canonical system-routed channel (GitHub event delivery).

## Test plan

- [x] New unit test in `github-delivery.test.ts`: builds a 3-speaker bound chat (human + delegate + third party), delivers a normalized PR event via an `existing` audience target, asserts that the delegate's `inbox_entries.notify = true` and the third party's `notify = false`. Verified red without the fix, green with the fix.
- [x] All existing tests in `github-delivery.test.ts` still pass (2-speaker chat behaviour unchanged — `isOneOnOne` continues to wake the delegate without needing the new addressed path).
- [x] `pnpm test` on `@first-tree/server` — 1109 tests across 140 files, all green.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm check` (biome) — clean.
- [ ] Reviewer to confirm the canonical comment in `github-delivery.ts` matches the team's style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)