### PR TITLE
fix(web): detect reconnects in "+ New Connection" modal via connectedAt

### DIFF
--- a/packages/server/src/__tests__/me-clients-reconnect.test.ts
+++ b/packages/server/src/__tests__/me-clients-reconnect.test.ts
@@ -1,0 +1,158 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
+import * as clientService from "../services/client.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+/**
+ * Server-side regression net for the "+ New Connection" modal fix
+ * (`packages/web/src/pages/clients/new-connection-dialog.tsx`).
+ *
+ * The web modal flips Waiting→Connected by polling `GET /me/clients` and
+ * matching the predicate
+ *
+ *   c.status === "connected" && c.userId === me && c.connectedAt >= openedAt
+ *
+ * The predicate is unit-tested as a pure function (`selectArrivedClient`).
+ * What this file pins is the *server contract* the predicate relies on:
+ * when the CLI re-registers an already-known `client_id` (i.e. the
+ * `ON CONFLICT DO UPDATE` branch of `registerClient`, hit on every
+ * "machine that was previously paired and now reconnects"), `connectedAt`
+ * is rewritten to the new handshake time AND that timestamp survives the
+ * `/me/clients` wire serialization.
+ *
+ * Without this, an id-set baseline (the previous web implementation) was
+ * silently correct only for brand-new machines. Reconnects reused the
+ * same `clients.id` row, so the diff was empty and the modal hung in
+ * Waiting forever. See PR #505 for full root-cause analysis.
+ */
+
+const FUDGE_MS = 1_000;
+
+describe("GET /me/clients — reconnect path rewrites connectedAt", () => {
+  const getApp = useTestApp();
+
+  it("re-registering an existing client_id stamps connectedAt to NOW and the wire reflects it", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    const clientId = `cli-rc-${crypto.randomUUID().slice(0, 8)}`;
+
+    // First handshake — INSERT branch of registerClient. Mirrors the very
+    // first `first-tree-hub connect <token>` on a fresh machine.
+    await clientService.registerClient(app.db, {
+      clientId,
+      userId: ctx.userId,
+      organizationId: ctx.organizationId,
+      instanceId: "test-instance",
+    });
+
+    const first = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(first.statusCode).toBe(200);
+    const firstRow = (first.json() as Array<{ id: string; status: string; connectedAt: string | null }>).find(
+      (c) => c.id === clientId,
+    );
+    if (!firstRow?.connectedAt) throw new Error("first registration did not stamp connectedAt");
+    expect(firstRow.status).toBe("connected");
+    const connectedAt1 = Date.parse(firstRow.connectedAt);
+
+    // Simulate WS close — status flips to disconnected. `connectedAt` is
+    // intentionally NOT touched here (see services/client.ts disconnectClient);
+    // it stays at T1 until the next register rewrites it.
+    await clientService.disconnectClient(app.db, clientId);
+
+    // Capture the modal-open stamp. Match production logic — the dialog at
+    // packages/web/src/pages/clients/new-connection-dialog.tsx applies a 1s
+    // fudge to absorb browser↔server clock skew; we apply the same here so
+    // the boundary assertion mirrors what the predicate actually evaluates.
+    const openedAt = Date.now() - FUDGE_MS;
+
+    // A small sleep ensures `connectedAt2` lands strictly after `connectedAt1`
+    // on machines where PG's NOW() can resolve to the same millisecond as the
+    // previous insert. Without it `expect(connectedAt2).toBeGreaterThan(...)`
+    // would be flaky.
+    await new Promise((r) => setTimeout(r, 25));
+
+    // Second handshake — ON CONFLICT DO UPDATE branch. This is the
+    // production scenario where the user runs the connect command on a
+    // machine whose client.yaml already pins this stable clientId
+    // (`packages/shared/src/config/client-config.ts` declares the id as
+    // stable per-machine).
+    await clientService.registerClient(app.db, {
+      clientId,
+      userId: ctx.userId,
+      organizationId: ctx.organizationId,
+      instanceId: "test-instance",
+    });
+
+    const second = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(second.statusCode).toBe(200);
+    const secondRow = (second.json() as Array<{ id: string; status: string; connectedAt: string | null }>).find(
+      (c) => c.id === clientId,
+    );
+    if (!secondRow?.connectedAt) throw new Error("reconnect did not stamp connectedAt");
+    expect(secondRow.status).toBe("connected");
+    const connectedAt2 = Date.parse(secondRow.connectedAt);
+
+    // Contract 1: reconnect rewrites connectedAt. Without this the modal's
+    // timestamp-based detector would never fire on re-pairs.
+    expect(connectedAt2).toBeGreaterThan(connectedAt1);
+
+    // Contract 2: the new stamp is at or after the modal-open timestamp.
+    // This is exactly the comparison `selectArrivedClient` makes — proving
+    // the server delivers a value that flips Waiting → Connected for the
+    // reconnect case.
+    expect(connectedAt2).toBeGreaterThanOrEqual(openedAt);
+  });
+
+  it("a long-standing connection's historical connectedAt stays BELOW a later modal-open stamp (no false success)", async () => {
+    // Counterpart to the test above: an already-connected machine sitting in
+    // the list with a connectedAt from minutes ago must not be picked up as
+    // "just arrived" when the user opens the modal. This is the second
+    // unchecked manual case from the PR review — pinned at the contract
+    // level so it can't regress silently.
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    const clientId = `cli-old-${crypto.randomUUID().slice(0, 8)}`;
+
+    await clientService.registerClient(app.db, {
+      clientId,
+      userId: ctx.userId,
+      organizationId: ctx.organizationId,
+      instanceId: "test-instance",
+    });
+
+    // Backdate connectedAt directly via PG to simulate a machine that's been
+    // connected for a while. A small `setTimeout` wouldn't clear the
+    // modal's 1s clock-skew fudge; patching the row makes the historical
+    // intent unambiguous regardless of how fast the test runs.
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1_000);
+    await app.db.update(clients).set({ connectedAt: oneHourAgo }).where(eq(clients.id, clientId));
+
+    const openedAt = Date.now() - FUDGE_MS;
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const row = (res.json() as Array<{ id: string; status: string; connectedAt: string | null }>).find(
+      (c) => c.id === clientId,
+    );
+    if (!row?.connectedAt) throw new Error("historical client lost its connectedAt stamp");
+    expect(row.status).toBe("connected");
+    const connectedAt = Date.parse(row.connectedAt);
+
+    // The historical stamp is strictly before openedAt; the predicate
+    // `connectedAt >= openedAt` returns false → modal stays in Waiting.
+    expect(connectedAt).toBeLessThan(openedAt);
+  });
+});

--- a/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
+++ b/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { HubClient } from "../../../api/activity.js";
+import { selectArrivedClient } from "../new-connection-dialog.js";
+
+/**
+ * Pure-function unit tests for the "+ New Connection" wait-loop detector.
+ * The hook itself drives this from a setInterval; the visual surface is
+ * covered by manual e2e on /clients → "+ New Connection". Regression net
+ * exists because the previous id-set baseline silently missed the
+ * reconnect case (machines whose `client.id` is stable per-machine — see
+ * `packages/shared/src/config/client-config.ts`).
+ */
+
+const ME = "user-me";
+const OTHER = "user-other";
+const T0 = 1_700_000_000_000;
+const OPENED_AT = T0;
+
+function client(overrides: Partial<HubClient>): HubClient {
+  return {
+    id: overrides.id ?? "client-1",
+    userId: ME,
+    status: "connected",
+    authState: "ok",
+    sdkVersion: "v1.0.0",
+    hostname: "host",
+    os: "macOS",
+    agentCount: 0,
+    connectedAt: new Date(T0).toISOString(),
+    lastSeenAt: new Date(T0).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("selectArrivedClient", () => {
+  it("returns null for an empty list", () => {
+    expect(selectArrivedClient([], OPENED_AT, ME)).toBeNull();
+  });
+
+  it("returns null when userId is the empty string (auth not warm)", () => {
+    expect(selectArrivedClient([client({})], OPENED_AT, "")).toBeNull();
+  });
+
+  it("catches a brand-new machine whose handshake landed after the modal opened", () => {
+    const arrived = client({ id: "fresh", connectedAt: new Date(OPENED_AT + 5_000).toISOString() });
+    expect(selectArrivedClient([arrived], OPENED_AT, ME)).toBe(arrived);
+  });
+
+  it("catches a reconnect — same client.id, connectedAt rewritten to NOW by server ON CONFLICT", () => {
+    // Modal opens; an old client row is sitting there as disconnected with a
+    // historical connectedAt. User runs the connect command on that same
+    // machine; server flips status=connected and updates connectedAt to NOW.
+    // The fix is that we trust connectedAt, not "is the id new?".
+    const reconnected = client({
+      id: "stable-machine",
+      connectedAt: new Date(OPENED_AT + 4_000).toISOString(),
+    });
+    expect(selectArrivedClient([reconnected], OPENED_AT, ME)).toBe(reconnected);
+  });
+
+  it("ignores an already-connected machine with a historical connectedAt (no false success)", () => {
+    const old = client({
+      id: "long-running",
+      connectedAt: new Date(OPENED_AT - 60_000).toISOString(),
+    });
+    expect(selectArrivedClient([old], OPENED_AT, ME)).toBeNull();
+  });
+
+  it("ignores rows whose status is disconnected even if connectedAt is recent", () => {
+    // Defensive: server contract says status=disconnected → connectedAt
+    // reflects the *previous* connection. We must not auto-success on a row
+    // that's offline regardless of when it last connected.
+    const offline = client({
+      id: "flapping",
+      status: "disconnected",
+      connectedAt: new Date(OPENED_AT + 1_000).toISOString(),
+    });
+    expect(selectArrivedClient([offline], OPENED_AT, ME)).toBeNull();
+  });
+
+  it("ignores rows whose connectedAt is null (never connected since cold-start)", () => {
+    const naked = client({ id: "never", connectedAt: null });
+    expect(selectArrivedClient([naked], OPENED_AT, ME)).toBeNull();
+  });
+
+  it("ignores rows owned by another user (defence in depth — server already scopes /me/clients)", () => {
+    const theirs = client({
+      id: "theirs",
+      userId: OTHER,
+      connectedAt: new Date(OPENED_AT + 2_000).toISOString(),
+    });
+    expect(selectArrivedClient([theirs], OPENED_AT, ME)).toBeNull();
+  });
+
+  it("treats connectedAt EXACTLY equal to openedAt as 'after' (≥, not >)", () => {
+    // The dialog already subtracts a 1s fudge from openedAt to absorb clock
+    // skew, but the boundary itself should be inclusive — a handshake stamp
+    // that happens to tie the threshold is still a valid arrival.
+    const onTheDot = client({ id: "boundary", connectedAt: new Date(OPENED_AT).toISOString() });
+    expect(selectArrivedClient([onTheDot], OPENED_AT, ME)).toBe(onTheDot);
+  });
+
+  it("returns the first matching client when several qualify", () => {
+    const a = client({ id: "a", connectedAt: new Date(OPENED_AT + 1_000).toISOString() });
+    const b = client({ id: "b", connectedAt: new Date(OPENED_AT + 2_000).toISOString() });
+    expect(selectArrivedClient([a, b], OPENED_AT, ME)?.id).toBe("a");
+  });
+});

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -6,16 +6,50 @@ import { ConnectCommandPanel, type ConnectPhase } from "../../components/connect
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 
+/**
+ * Pure detector for the "+ New Connection" wait loop. Exported so the unit
+ * test can pin the contract — drift here changes when the modal flips from
+ * Waiting to Connected, and the bug fixed in this file (id-set baseline
+ * missing reconnects of machines whose client.id is stable per-machine) is
+ * the kind of thing that wants a regression net.
+ *
+ * Detection rule: the client must be owned by the caller, currently connected,
+ * and its handshake (`connectedAt`) must have landed at or after the modal
+ * was opened. `clients.connectedAt` is rewritten on every fresh handshake —
+ * both first-time insert and `ON CONFLICT DO UPDATE` reconnect — so this
+ * works for brand-new machines AND re-pairs of previously-known machines.
+ *
+ * @param openedAt epoch-ms; the modal-open timestamp (already adjusted for
+ *   any clock-skew fudge by the caller).
+ */
+export function selectArrivedClient(clients: HubClient[], openedAt: number, userId: string): HubClient | null {
+  if (!userId) return null;
+  return (
+    clients.find((c) => {
+      if (c.status !== "connected" || c.userId !== userId || !c.connectedAt) return false;
+      return new Date(c.connectedAt).getTime() >= openedAt;
+    }) ?? null
+  );
+}
+
 const POLL_MS = 3_000;
 const SUCCESS_HOLD_MS = 1_200;
+// Tolerance subtracted from the modal-open timestamp so a tiny clock skew
+// between the browser and the server (or a connect handshake that races a
+// hair ahead of the open) still falls inside the "after open" window.
+const CONNECT_DETECT_FUDGE_MS = 1_000;
 
 /**
  * "Connect computer" modal — replaces the always-on ConnectStrip.
  *
  * Lifecycle:
- *   1. open=true        → snapshot existing client ids → mint a connect token
- *   2. phase="waiting"  → poll /clients every 3s; first new id with
- *                         status="connected" AND owned by the caller wins
+ *   1. open=true        → record open timestamp → mint a connect token
+ *   2. phase="waiting"  → poll /clients every 3s; first client owned by the
+ *                         caller with status="connected" and connectedAt
+ *                         AFTER the open timestamp wins. Timestamp-based so
+ *                         re-pairing a machine that already has a client_id
+ *                         row (status flips disconnected→connected, id is
+ *                         reused) is still detected.
  *   3. phase="success"  → brief hold (~1.2s), then close + invalidate
  *
  * Cancel / backdrop close: drops the unused token (server expires it on TTL).
@@ -27,22 +61,21 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
   const [token, setToken] = useState<ConnectTokenResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [arrivedHostname, setArrivedHostname] = useState<string | null>(null);
-  const baselineRef = useRef<Set<string>>(new Set());
+  const openedAtRef = useRef<number>(0);
 
-  // 1. On open: snapshot, mint, switch to waiting. Reset all state on close.
+  // 1. On open: stamp open time, mint, switch to waiting. Reset all state on close.
   useEffect(() => {
     if (!open) {
       setPhase("loading");
       setToken(null);
       setErrorMessage(null);
       setArrivedHostname(null);
-      baselineRef.current = new Set();
+      openedAtRef.current = 0;
       return;
     }
 
     let cancelled = false;
-    const existing = (queryClient.getQueryData<HubClient[]>(["clients"]) ?? []).map((c) => c.id);
-    baselineRef.current = new Set(existing);
+    openedAtRef.current = Date.now() - CONNECT_DETECT_FUDGE_MS;
 
     (async () => {
       try {
@@ -60,16 +93,17 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
     return () => {
       cancelled = true;
     };
-  }, [open, queryClient]);
+  }, [open]);
 
-  // 2. While waiting: poll for the new client. Owner check guards admin role.
+  // 2. While waiting: poll for a client whose handshake landed AFTER the modal
+  //    opened. Timestamp comparison (not id-set diff) is what lets us catch a
+  //    reconnect of a machine whose client_id row already existed.
   useEffect(() => {
     if (!open || phase !== "waiting" || !user) return;
     const tick = async () => {
       try {
         const fresh = await queryClient.fetchQuery({ queryKey: ["clients"], queryFn: listClients });
-        const baseline = baselineRef.current;
-        const arrived = fresh.find((c) => !baseline.has(c.id) && c.status === "connected" && c.userId === user.id);
+        const arrived = selectArrivedClient(fresh, openedAtRef.current, user.id);
         if (arrived) {
           setArrivedHostname(arrived.hostname ?? null);
           setPhase("success");


### PR DESCRIPTION
## Problem

In the `+ New Connection` modal on `/clients`, after the user runs the connect command on a previously-paired machine, the modal stays in **Waiting…** forever even though the client is back online. Polling is happening (`/me/clients` every 3s) but the UI never flips to **Connected**.

## Root cause

The wait-loop detector matched on **id-set diff**:

```ts
const baseline = baselineRef.current;             // ids snapshotted at open
const arrived = fresh.find(
  (c) => !baseline.has(c.id) && c.status === "connected" && c.userId === user.id,
);
```

But `client.id` is **stable per machine** — auto-generated once and persisted to `client.yaml` (`packages/shared/src/config/client-config.ts:17-25`):

```ts
client: {
  // Stable per-machine client identifier. Auto-generated on first start
  // and written back to client.yaml so the SDK keeps the same id across
  // restarts — agents pin to `clients.id` on the server, so a fresh
  // random id every run would orphan every pinned agent.
  id: field(z.string().regex(/^client_[a-f0-9]{8}$/), { auto: "client-id" }),
}
```

Reconnecting a previously-paired machine reuses the same row via `ON CONFLICT DO UPDATE` (`packages/server/src/services/client.ts:113-126`), only flipping `status` from `disconnected` → `connected` and rewriting `connectedAt`. The baseline already contained that id, so `!baseline.has(c.id)` was always `false` → `find()` never matched → modal never transitioned.

Two related drifts made this stick:

- After [#383](https://github.com/agent-team-foundation/first-tree-hub/pull/383) split `ClientsPage`'s query into `["clients", "org"]` / `["clients", "me"]`, the modal's `getQueryData(["clients"])` returned `undefined` on open. The topbar chip (`useDisconnectedComputers`) is now the only thing populating `["clients"]`, so the baseline was incidental rather than intentional.
- Only true on a host with no prior `client.yaml` (brand-new machine) did the old path work — which is exactly what manual testing tends to exercise.

## Fix

Switch detection from id-set diff to a `connectedAt >= openedAt` timestamp comparison. `connectedAt` is set to `NOW()` on **both** the insert branch and the `ON CONFLICT DO UPDATE` branch, so it captures every fresh handshake regardless of whether the row is new. A 1s fudge absorbs minor browser↔server clock skew.

Detection rule now:

```ts
clients.find((c) =>
  c.status === "connected" &&
  c.userId === userId &&
  c.connectedAt !== null &&
  new Date(c.connectedAt).getTime() >= openedAt,
);
```

Extracted as `selectArrivedClient` (pure) so the unit test can pin the contract — matches the local convention from `selectDisconnectedComputers` in `use-disconnected-computers.ts`.

## Test plan

- [x] `pnpm --filter @first-tree/web test` — 216/216 passing (10 new cases in `selectArrivedClient.test.ts`)
- [x] `pnpm --filter @first-tree/web typecheck`
- [x] `pnpm --filter @first-tree/web exec biome check src/pages/clients/`
- [ ] Manual: open `+ New Connection`, run command on a **brand-new** machine → modal flips to green within ~3s
- [ ] Manual: open `+ New Connection`, run command on a **previously-paired** machine that is currently disconnected → modal flips to green within ~3s (the regression case)
- [ ] Manual: open `+ New Connection` with an already-connected machine sitting in your list, do NOT run the command → modal stays in Waiting (no false success on historical `connectedAt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)