### PR TITLE
feat(web): render github event cards inline in chat view

### DIFF
--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { isGithubEventCardContent } from "../github-event-card.js";
+
+/**
+ * Pin the type guard so the chat-view dispatch logic at chat-view.tsx can
+ * safely narrow `MessageWithDelivery.content` (which is `unknown` at the
+ * wire level) before handing it to `GithubEventCardMessage`. A regression
+ * here either renders the JSON `<pre>` fallback for a real github event
+ * (UX regression) or crashes on a malformed payload (robustness
+ * regression).
+ */
+
+const validCard = {
+  type: "github_event",
+  reason: "mentioned",
+  event: "issue_comment",
+  action: "created",
+  kind: "commented",
+  repository: "owner/repo",
+  sender: "@octocat",
+  title: "Fix the bug",
+  body: "@me please review",
+  url: "https://github.com/owner/repo/issues/1",
+  entity: {
+    type: "issue",
+    key: "#1",
+    url: "https://github.com/owner/repo/issues/1",
+  },
+};
+
+describe("isGithubEventCardContent", () => {
+  it("accepts a valid GithubEventCard", () => {
+    expect(isGithubEventCardContent(validCard)).toBe(true);
+  });
+
+  it("accepts all four reason values", () => {
+    for (const reason of ["mentioned", "review_requested", "assigned", "subscribed"] as const) {
+      expect(isGithubEventCardContent({ ...validCard, reason })).toBe(true);
+    }
+  });
+
+  it("accepts mentionedUser when provided", () => {
+    expect(isGithubEventCardContent({ ...validCard, mentionedUser: "@me" })).toBe(true);
+  });
+
+  it("accepts a null entity.url (GitHub sometimes omits it)", () => {
+    expect(isGithubEventCardContent({ ...validCard, entity: { ...validCard.entity, url: null } })).toBe(true);
+  });
+
+  it("accepts a null action (synthetic events)", () => {
+    expect(isGithubEventCardContent({ ...validCard, action: null })).toBe(true);
+  });
+
+  it("rejects when type discriminator is missing or wrong", () => {
+    expect(isGithubEventCardContent({ ...validCard, type: "github_mention" })).toBe(false);
+    const { type: _omit, ...withoutType } = validCard;
+    expect(isGithubEventCardContent(withoutType)).toBe(false);
+  });
+
+  it("rejects an unknown reason value", () => {
+    expect(isGithubEventCardContent({ ...validCard, reason: "cc-d" })).toBe(false);
+  });
+
+  it("rejects when required string fields are missing", () => {
+    const { entity: _e, ...noEntity } = validCard;
+    expect(isGithubEventCardContent(noEntity)).toBe(false);
+    expect(isGithubEventCardContent({ ...validCard, entity: { type: "issue", key: "", url: null } })).toBe(false);
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(isGithubEventCardContent(null)).toBe(false);
+    expect(isGithubEventCardContent(undefined)).toBe(false);
+    expect(isGithubEventCardContent("github_event")).toBe(false);
+    expect(isGithubEventCardContent(42)).toBe(false);
+  });
+
+  it("rejects question / question_answer payloads (no cross-format aliasing)", () => {
+    expect(isGithubEventCardContent({ correlationId: "tu_1", questions: [], allowFreeText: true })).toBe(false);
+    expect(isGithubEventCardContent({ correlationId: "tu_1", answers: {} })).toBe(false);
+  });
+});

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -59,17 +59,24 @@ function actionPhrase(card: GithubEventCard): string {
 
 function highlightMention(body: string, mentionedUser: string | undefined): ReactNode {
   if (!mentionedUser) return body;
-  const idx = body.indexOf(mentionedUser);
-  if (idx < 0) return body;
-  return (
-    <>
-      {body.slice(0, idx)}
-      <span className="font-medium" style={{ color: "var(--accent)" }}>
-        {body.slice(idx, idx + mentionedUser.length)}
-      </span>
-      {body.slice(idx + mentionedUser.length)}
-    </>
-  );
+  // github-delivery writes the bare login (no `@`); GitHub bodies usually
+  // carry the `@` prefix. Try `@login` first, fall back to bare login so
+  // we still highlight if upstream ever changes the convention.
+  const candidates = [`@${mentionedUser}`, mentionedUser];
+  for (const needle of candidates) {
+    const idx = body.indexOf(needle);
+    if (idx < 0) continue;
+    return (
+      <>
+        {body.slice(0, idx)}
+        <span className="font-medium" style={{ color: "var(--accent)" }}>
+          {body.slice(idx, idx + needle.length)}
+        </span>
+        {body.slice(idx + needle.length)}
+      </>
+    );
+  }
+  return body;
 }
 
 const BODY_PREVIEW_MAX = 320;
@@ -84,7 +91,10 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
   const tone = REASON_TONE[content.reason];
   const toneStyle = TONE_STYLE[tone];
   const previewBody = content.body.trim().length > 0 ? truncateBody(content.body) : null;
-  const link = content.entity.url ?? content.url;
+  // schema types both urls as `z.string()` (no `.url()` / `.min(1)`), so an
+  // empty string is a possible wire value; `??` would only catch `null` and
+  // would render `<a href="">` as a dead link.
+  const link = content.entity.url || content.url || null;
 
   return (
     <div className="text-body">
@@ -105,23 +115,28 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
           {REASON_LABEL[content.reason]}
         </span>
         <span style={{ color: "var(--fg-3)" }}>{actionPhrase(content)}</span>
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-[color:var(--fg)] no-underline hover:text-[color:var(--accent-dim)] hover:underline"
-        >
-          <span className="mono" style={{ color: "var(--fg-3)" }}>
-            {content.repository}
-          </span>
-          <span className="mono" style={{ color: "var(--fg-4)" }}>
-            {content.entity.key}
-          </span>
-          {content.title ? <span> — {content.title}</span> : null}
-        </a>
+        {link ? (
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-[color:var(--fg)] no-underline hover:text-[color:var(--accent-dim)] hover:underline"
+          >
+            {/* Inner spans inherit `color` from <a> so hover recolors the
+                whole link, not just the title. Fade weight comes from
+                varying the dim factor via opacity instead. */}
+            <span className="mono" style={{ opacity: 0.65 }}>
+              {content.repository}
+            </span>
+            <span className="mono" style={{ opacity: 0.5 }}>
+              {content.entity.key}
+            </span>
+            {content.title ? <span> — {content.title}</span> : null}
+          </a>
+        ) : null}
         {content.sender ? (
           <span style={{ color: "var(--fg-3)" }}>
-            by <span className="mono">{content.sender}</span>
+            by <span className="mono">@{content.sender}</span>
           </span>
         ) : null}
       </span>

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -1,0 +1,148 @@
+import { type GithubEventCard, githubEventCardSchema } from "@first-tree/shared";
+import type { ReactNode } from "react";
+
+export function isGithubEventCardContent(content: unknown): content is GithubEventCard {
+  return githubEventCardSchema.safeParse(content).success;
+}
+
+type ChipTone = "accent" | "warn" | "success" | "neutral";
+
+const REASON_LABEL: Record<GithubEventCard["reason"], string> = {
+  mentioned: "mentioned",
+  review_requested: "review requested",
+  assigned: "assigned",
+  subscribed: "subscribed",
+};
+
+const REASON_TONE: Record<GithubEventCard["reason"], ChipTone> = {
+  mentioned: "accent",
+  review_requested: "warn",
+  assigned: "success",
+  subscribed: "neutral",
+};
+
+const TONE_STYLE: Record<ChipTone, { background: string; color: string; border: string }> = {
+  accent: {
+    background: "var(--accent-bg)",
+    color: "var(--accent-dim)",
+    border: "var(--accent-ring)",
+  },
+  warn: {
+    background: "var(--bg-warn-soft)",
+    color: "var(--fg-warn-strong)",
+    border: "transparent",
+  },
+  success: {
+    background: "var(--bg-success-soft)",
+    color: "var(--fg-success-strong)",
+    border: "transparent",
+  },
+  neutral: {
+    background: "var(--bg-sunken)",
+    color: "var(--fg-3)",
+    border: "var(--border)",
+  },
+};
+
+function actionPhrase(card: GithubEventCard): string {
+  switch (card.reason) {
+    case "mentioned":
+      return "in";
+    case "review_requested":
+      return "on";
+    case "assigned":
+      return "to you on";
+    case "subscribed":
+      return card.action ? `${card.action.replace(/_/g, " ")} on` : "on";
+  }
+}
+
+function highlightMention(body: string, mentionedUser: string | undefined): ReactNode {
+  if (!mentionedUser) return body;
+  const idx = body.indexOf(mentionedUser);
+  if (idx < 0) return body;
+  return (
+    <>
+      {body.slice(0, idx)}
+      <span className="font-medium" style={{ color: "var(--accent)" }}>
+        {body.slice(idx, idx + mentionedUser.length)}
+      </span>
+      {body.slice(idx + mentionedUser.length)}
+    </>
+  );
+}
+
+const BODY_PREVIEW_MAX = 320;
+
+function truncateBody(body: string): string {
+  const trimmed = body.trim();
+  if (trimmed.length <= BODY_PREVIEW_MAX) return trimmed;
+  return `${trimmed.slice(0, BODY_PREVIEW_MAX)}…`;
+}
+
+export function GithubEventCardMessage({ content }: { content: GithubEventCard }) {
+  const tone = REASON_TONE[content.reason];
+  const toneStyle = TONE_STYLE[tone];
+  const previewBody = content.body.trim().length > 0 ? truncateBody(content.body) : null;
+  const link = content.entity.url ?? content.url;
+
+  return (
+    <div className="text-body">
+      <span style={{ display: "inline-flex", alignItems: "center", flexWrap: "wrap", columnGap: "var(--sp-1_5)" }}>
+        <span
+          className="mono text-label"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            padding: "var(--sp-px) var(--sp-1_5)",
+            borderRadius: "var(--radius-chip)",
+            border: `var(--hairline) solid ${toneStyle.border}`,
+            background: toneStyle.background,
+            color: toneStyle.color,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {REASON_LABEL[content.reason]}
+        </span>
+        <span style={{ color: "var(--fg-3)" }}>{actionPhrase(content)}</span>
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-[color:var(--fg)] no-underline hover:text-[color:var(--accent-dim)] hover:underline"
+        >
+          <span className="mono" style={{ color: "var(--fg-3)" }}>
+            {content.repository}
+          </span>
+          <span className="mono" style={{ color: "var(--fg-4)" }}>
+            {content.entity.key}
+          </span>
+          {content.title ? <span> — {content.title}</span> : null}
+        </a>
+        {content.sender ? (
+          <span style={{ color: "var(--fg-3)" }}>
+            by <span className="mono">{content.sender}</span>
+          </span>
+        ) : null}
+      </span>
+      {previewBody ? (
+        <div
+          className="text-body"
+          style={{
+            marginTop: "var(--sp-1)",
+            color: "var(--fg-3)",
+            borderLeft: "var(--hairline-bold) solid var(--border)",
+            paddingLeft: "var(--sp-2)",
+            whiteSpace: "pre-wrap",
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {highlightMention(previewBody, content.mentionedUser)}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -40,6 +40,7 @@ import {
 import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
+import { GithubEventCardMessage, isGithubEventCardContent } from "../../../components/chat/github-event-card.js";
 import {
   isQuestionAnswerContent,
   isQuestionContent,
@@ -411,6 +412,8 @@ function TextRow({
             <ImageFromRef content={msg.content} />
           ) : msg.format === "text" || msg.format === "markdown" ? (
             <Markdown components={markdownComponents}>{textContent ?? ""}</Markdown>
+          ) : msg.format === "card" && isGithubEventCardContent(msg.content) ? (
+            <GithubEventCardMessage content={msg.content} />
           ) : (
             <pre
               className="mono text-label"


### PR DESCRIPTION
## Summary

- Replace the JSON `<pre>` fallback in `chat-view.tsx` with a dedicated `GithubEventCardMessage` renderer for `format=card` / `content.type="github_event"` messages.
- Inline-text style (no boxed card): reason chip + verb phrase + `repo#key — title` link + `by @sender`, with an optional quoted body preview clamped to 3 lines. `mentionedUser` is highlighted in the body when present.
- Reason chips colour-code via the existing semantic tokens — `mentioned`→accent, `review_requested`→warn, `assigned`→success, `subscribed`→neutral — so dark theme works automatically.
- Unrecognised `card` payloads still hit the JSON `<pre>` fallback, so legacy `github_mention` rows keep rendering.

## Why this shape

The Hub delivers GitHub webhook surfaces as `GithubEventCard` structured content (see `packages/server/src/services/github-delivery.ts:73-92`). Before this PR the recipient just saw a JSON dump of that payload. The renderer is intentionally minimal — the design brief was "make the bot's messages legible without making them visually scream over real human chat" — so it mirrors the Markdown link convention (accent on hover, no underline by default) rather than introducing a new boxed card pattern.

## Files

- `packages/web/src/components/chat/github-event-card.tsx` — new component + `isGithubEventCardContent` type guard (`safeParse` against the shared `githubEventCardSchema`, same pattern as `isQuestionContent`).
- `packages/web/src/components/chat/__tests__/github-event-card.test.ts` — pin the type guard against malformed payloads, cross-format aliasing, and all four reason values.
- `packages/web/src/pages/workspace/center/chat-view.tsx` — one new branch in the message render switch (the JSON `<pre>` fallback stays).

No schema / DB / API changes.

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (includes design-token guardrails)
- [x] `pnpm check` (Biome)
- [x] `pnpm --filter @first-tree/web test` — 23 files / 216 tests, including the 10 new type-guard cases
- [x] Manual: seeded a dev chat with one of each reason value + a trailing human reply; all four cards render correctly in both light and dark theme; hover state matches the Markdown link convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)