### PR TITLE
fix(chat): blend composer into the message surface

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1873,7 +1873,11 @@ export function ChatView({
                     padding: "var(--sp-2) var(--sp-3)",
                     border: "var(--hairline) solid var(--border)",
                     borderRadius: 6,
-                    background: "var(--bg-sunken)",
+                    // Blend into the timeline surface (`--bg`) rather than a
+                    // sunken grey box — the hairline border alone delineates
+                    // the slot. Mirrors the editable composer below so the
+                    // read-only state occupies the same visual footprint.
+                    background: "var(--bg)",
                   }}
                 >
                   <Eye className="h-4 w-4 shrink-0" style={{ color: "var(--fg-3)" }} />
@@ -1908,7 +1912,10 @@ export function ChatView({
                       position: "relative",
                       border: "var(--hairline) solid var(--border)",
                       borderRadius: 6,
-                      background: "var(--bg-sunken)",
+                      // Composer blends into the timeline surface (`--bg`)
+                      // instead of a sunken grey box; the hairline border
+                      // keeps the input field discernible against it.
+                      background: "var(--bg)",
                     }}
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={(e) => {


### PR DESCRIPTION
## What

The chat composer (and its read-only "watching" state) sat on `--bg-sunken`, rendering as a grey box detached from the message timeline above. This switches both to `--bg` — the surface the `<main>` panel and timeline already use — so the composer reads as one continuous surface with the message stream ("seamless / blend-in" direction confirmed with the user).

## Why `--bg`

`<main>` (`workspace/index.tsx`) is `var(--bg)`, and the timeline + composer band both inherit it. The composer `textarea` is already `background: transparent`, so moving the card from `--bg-sunken` to `--bg` makes the whole composer share the timeline surface. The hairline `--border` is kept as the **sole** delineation, so the input stays discernible.

## Scope

- `packages/web/src/pages/workspace/center/chat-view.tsx` only (+9 −2):
  - editable composer card: `--bg-sunken` → `--bg`
  - read-only branch: same, so read/write states share one visual footprint
- **Not** touched: `new-chat-draft.tsx` — that composer is a centered `--bg-raised` + shadow hero card (a different, intentional pattern, never a grey box). Confirmed with the user to leave as-is.
- Other `--bg-sunken` usages (code blocks, header "watching" badge, rename input, deleted-chat banner, avatar overflow chip) are unrelated and left untouched.
- No top divider added between composer and timeline — confirmed with the user.

## Themes verified

| context | card / timeline (`--bg`) | border (`--border`) |
|---|---|---|
| light `:root` | 0.985 (match) | 0.9 — visible |
| `.dark` | 0.145 (match) | 0.26 — visible |
| `.landing-marketing` | 0.04 (match) | 0.2 — visible |

## Checks

- `lint:tokens` (design-token guardrails) ✓
- `biome check` ✓
- web `tsc --noEmit` ✓
- Reviewed by codex-reviewer: **No findings** (same diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)