### PR TITLE
release: bump apps/cli to v0.5.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.14.9",
+  "version": "0.5.0",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging.",
   "keywords": [


### PR DESCRIPTION
## Summary
- Release commit for v0.5.0 — first published version under the new unified `first-tree` brand
- Bumps `apps/cli/package.json` from `0.14.9` to `0.5.0` (continuation of the legacy npm `first-tree@0.4.5` line)
- Lockfile sync: no diff produced (apps/cli version bump does not affect dependency resolution)

## Why 0.5.0 and not 1.0.0
- npm `first-tree` package latest is currently `0.4.5` (published by the legacy first-tree CLI repo, now archived as `first-tree-legacy`)
- Continuing the existing version sequence avoids a one-off semver jump and keeps `npm view first-tree` history clean
- The hub-internal `0.14.x` line was internal-only; users only see the npm-published sequence

## Test plan
- [ ] CI green (lint / typecheck / unit / e2e)
- [ ] `npm view first-tree version` returns `0.4.5` before merge (sanity)
- [ ] After tag v0.5.0 push: `Publish Command Latest` job succeeds → `npm view first-tree version` returns `0.5.0`

## Out of scope (handled separately by user)
- Trusted Publisher config on npmjs.com (in flight with bestony)
- Tag `v0.5.0` push (handled manually by user post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)