### PR TITLE
fix(server): add retention/TTL cleanup for processed_events dedup ledger (#509)

### DIFF
--- a/packages/server/drizzle/0049_processed_events_retention_index.sql
+++ b/packages/server/drizzle/0049_processed_events_retention_index.sql
@@ -1,0 +1,14 @@
+-- Retention support for `processed_events` (webhook dedup ledger used by
+-- GitHub App + Feishu). Rows accumulate at every webhook delivery and
+-- were previously never deleted — at realistic load the table would grow
+-- by ~1M rows / year. The dedup ledger is only meaningful for as long as
+-- a redelivery could still arrive (GitHub retries ~8h, Feishu similar),
+-- so 30-day retention is overkill-safe.
+--
+-- Cleanup is a background DELETE driven by
+-- `services/adapter-mapping.ts::pruneProcessedEvents`. Without this btree
+-- on `created_at` the DELETE WHERE created_at < threshold would scan the
+-- whole table on every tick; with it the cleanup stays a bounded
+-- operation. See #509.
+CREATE INDEX IF NOT EXISTS "idx_processed_events_created_at"
+  ON "processed_events" USING btree ("created_at");

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1779926400000,
       "tag": "0048_github_entity_state",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0049_processed_events_retention_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/adapter-mapping.test.ts
+++ b/packages/server/src/__tests__/adapter-mapping.test.ts
@@ -1,4 +1,6 @@
+import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { processedEvents } from "../db/schema/processed-events.js";
 import * as mappingService from "../services/adapter-mapping.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
@@ -25,6 +27,33 @@ describe("Adapter mapping service", () => {
       const r2 = await mappingService.claimEvent(app.db, "evt_cross_1", "slack");
       expect(r1).toBe(true);
       expect(r2).toBe(true);
+    });
+
+    // M3 (#509): the dedup ledger must not grow unboundedly. Rows older
+    // than the retention window are deleted so the table stays bounded
+    // and the `INSERT ... ON CONFLICT` unique-index lookup at every
+    // claim doesn't degrade as load scales.
+    it("pruneProcessedEvents deletes rows older than the retention window and keeps fresh ones", async () => {
+      const app = getApp();
+
+      // Seed three rows: one fresh, one borderline (just inside the
+      // window), one stale (older than the window).
+      await mappingService.claimEvent(app.db, "evt_fresh", "feishu");
+      await mappingService.claimEvent(app.db, "evt_borderline", "feishu");
+      await mappingService.claimEvent(app.db, "evt_stale", "feishu");
+
+      // Force the stale row's `created_at` back by 60 days; the
+      // borderline row stays under the 30-day window we'll prune with.
+      await app.db.execute(
+        sql`UPDATE processed_events SET created_at = NOW() - interval '60 days' WHERE event_id = 'evt_stale'`,
+      );
+
+      const result = await mappingService.pruneProcessedEvents(app.db, 30 * 24 * 60 * 60);
+      expect(result.deleted).toBe(1);
+
+      const remaining = await app.db.select({ eventId: processedEvents.eventId }).from(processedEvents);
+      const ids = remaining.map((r) => r.eventId).sort();
+      expect(ids).toEqual(["evt_borderline", "evt_fresh"]);
     });
   });
 

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -31,6 +31,7 @@ const baseConfig: Config = {
     archiveMappedIdleSeconds: 60 * 60,
     archiveUnmappedIdleSeconds: 12 * 60 * 60,
     notificationWebhookUrl: undefined,
+    processedEventsRetentionSeconds: 30 * 24 * 60 * 60,
   },
   update: {
     channel: "latest",

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -140,6 +140,7 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       archiveMappedIdleSeconds: 60 * 60,
       archiveUnmappedIdleSeconds: 12 * 60 * 60,
       notificationWebhookUrl: undefined,
+      processedEventsRetentionSeconds: 30 * 24 * 60 * 60,
     },
     update: {
       // Pin a deterministic version so welcome-frame tests can assert

--- a/packages/server/src/db/schema/processed-events.ts
+++ b/packages/server/src/db/schema/processed-events.ts
@@ -1,9 +1,16 @@
-import { pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { index, pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
 
 /**
  * Webhook event deduplication.
+ *
  * Multiple bots in the same group chat receive the same event from Feishu,
  * so we use INSERT ... ON CONFLICT DO NOTHING to ensure single processing.
+ *
+ * Retention: rows are deleted by `pruneProcessedEvents` (background task)
+ * after `processedEventsRetentionSeconds` (default 30 days). The
+ * `idx_processed_events_created_at` btree supports that DELETE's WHERE
+ * scan so cleanup stays a tiny operation once the table is in steady
+ * state. See #509.
  */
 export const processedEvents = pgTable(
   "processed_events",
@@ -13,5 +20,8 @@ export const processedEvents = pgTable(
     platform: text("platform").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [unique("uq_processed_event").on(table.eventId, table.platform)],
+  (table) => [
+    unique("uq_processed_event").on(table.eventId, table.platform),
+    index("idx_processed_events_created_at").on(table.createdAt),
+  ],
 );

--- a/packages/server/src/services/adapter-mapping.ts
+++ b/packages/server/src/services/adapter-mapping.ts
@@ -32,6 +32,26 @@ export async function unclaimEvent(db: Database, eventId: string, platform: stri
   await db.execute(sql`DELETE FROM processed_events WHERE event_id = ${eventId} AND platform = ${platform}`);
 }
 
+/**
+ * Drop dedup-ledger rows older than `maxAgeSeconds`. The ledger is only
+ * meaningful for as long as a redelivery could still arrive (GitHub
+ * retries for ~8h, Feishu similar); anything older is safe to delete and
+ * keeping it just inflates the `INSERT ... ON CONFLICT` index lookup at
+ * every claim. The `idx_processed_events_created_at` btree (migration
+ * 0049) keeps this DELETE bounded once the table is in steady state.
+ *
+ * Returns the row count so the background task can log a meaningful
+ * counter when cleanup runs.
+ *
+ * See #509.
+ */
+export async function pruneProcessedEvents(db: Database, maxAgeSeconds: number): Promise<{ deleted: number }> {
+  const result = await db.execute<{ event_id: string }>(
+    sql`DELETE FROM processed_events WHERE created_at < NOW() - make_interval(secs => ${maxAgeSeconds}) RETURNING event_id`,
+  );
+  return { deleted: result.length };
+}
+
 // ── Agent mapping ───────────────────────────────────────────────────
 
 /** Look up the internal agent ID for an external user. */

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -30,8 +30,13 @@ export function createBackgroundTasks(
 
   return {
     start() {
-      // Inbox timeout reset — runs every 60 seconds
+      // Inbox timeout reset — runs every 60 seconds. The tick now bundles
+      // three independent maintenance steps; the `step` label tells the
+      // operator which one threw if the catch fires, so a silent failure
+      // in (say) the processed_events prune no longer masquerades as an
+      // inbox reset failure. See #519 review.
       inboxTimer = setInterval(async () => {
+        let step = "reset_timed_out";
         try {
           const timeoutSeconds = app.config.runtime.inboxTimeoutSeconds;
           const maxRetries = app.config.runtime.maxRetryCount;
@@ -41,6 +46,7 @@ export function createBackgroundTasks(
           // window for stale-pending; acked rows are deleted regardless of
           // age (they've fulfilled their context-replay purpose). See
           // pruneStaleSilentEntries jsdoc.
+          step = "prune_silent_inbox";
           const pruned = await inboxService.pruneStaleSilentEntries(app.db);
           if (pruned.ackedDeleted > 0 || pruned.stalePendingDeleted > 0) {
             log.debug(
@@ -51,6 +57,7 @@ export function createBackgroundTasks(
           // processed_events dedup ledger GC piggy-backs on the same
           // timer — the DELETE is small once steady-state retention
           // kicks in, and bundling avoids a second interval. See #509.
+          step = "prune_processed_events";
           const prunedEvents = await mappingService.pruneProcessedEvents(
             app.db,
             app.config.runtime.processedEventsRetentionSeconds,
@@ -59,7 +66,7 @@ export function createBackgroundTasks(
             log.debug({ deleted: prunedEvents.deleted }, "pruned processed_events");
           }
         } catch (err) {
-          log.error({ err }, "failed to reset timed-out inbox entries");
+          log.error({ err, step }, "inbox-timer tick failed");
         }
       }, 60_000);
 

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../observability/index.js";
 import type { AdapterManager } from "./adapter-manager.js";
+import * as mappingService from "./adapter-mapping.js";
 import * as chatArchiveService from "./chat-archive.js";
 import * as clientService from "./client.js";
 import * as inboxService from "./inbox.js";
@@ -46,6 +47,16 @@ export function createBackgroundTasks(
               { ackedDeleted: pruned.ackedDeleted, stalePendingDeleted: pruned.stalePendingDeleted },
               "pruned silent inbox rows",
             );
+          }
+          // processed_events dedup ledger GC piggy-backs on the same
+          // timer — the DELETE is small once steady-state retention
+          // kicks in, and bundling avoids a second interval. See #509.
+          const prunedEvents = await mappingService.pruneProcessedEvents(
+            app.db,
+            app.config.runtime.processedEventsRetentionSeconds,
+          );
+          if (prunedEvents.deleted > 0) {
+            log.debug({ deleted: prunedEvents.deleted }, "pruned processed_events");
           }
         } catch (err) {
           log.error({ err }, "failed to reset timed-out inbox entries");

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -384,6 +384,25 @@ export const serverConfigSchema = defineConfig({
     notificationWebhookUrl: field(z.string().url().optional(), {
       env: "FIRST_TREE_NOTIFICATION_WEBHOOK_URL",
     }),
+    /**
+     * Retention window for the `processed_events` dedup ledger (used by
+     * GitHub App + Feishu webhook claim/unclaim). Rows older than this
+     * are deleted on every inbox-timer tick. Default 30 days is overkill-
+     * safe — GitHub's webhook retry policy redelivers for ~8h, Feishu
+     * similar, so anything beyond a day has zero dedup value. Without
+     * cleanup the table grows ~1M rows/year and degrades every claim's
+     * unique-index lookup. See #509.
+     */
+    processedEventsRetentionSeconds: field(
+      z.coerce
+        .number()
+        .int()
+        .positive()
+        .default(30 * 24 * 60 * 60),
+      {
+        env: "FIRST_TREE_PROCESSED_EVENTS_RETENTION_SECONDS",
+      },
+    ),
   },
 });
 


### PR DESCRIPTION
Closes #509.

## Summary

`processed_events` is the dedup ledger used by both the GitHub App webhook and the Feishu adapter (`claimEvent` / `unclaimEvent` in `adapter-mapping.ts`). Every delivery's `(event_id, platform)` was inserted permanently — at a realistic load (~1M rows/year) the table grows unboundedly, inflating the `INSERT ... ON CONFLICT` unique-index lookup at every claim and forcing autovacuum churn.

Five coordinated changes:

1. **Schema + migration `0049`** — add `idx_processed_events_created_at` btree on `created_at`. Without it, the cleanup DELETE would scan the whole table; with it the operation stays bounded once retention is in steady state.

2. **`pruneProcessedEvents(db, maxAgeSeconds)`** — service function issuing the bounded DELETE and returning the row count for observability. Lives next to `claimEvent` / `unclaimEvent` in `adapter-mapping.ts`.

3. **Runtime config `processedEventsRetentionSeconds`** — default 30 days (`FIRST_TREE_PROCESSED_EVENTS_RETENTION_SECONDS`). 30 days is overkill-safe: GitHub retries webhooks for ~8h, Feishu similar, so anything beyond a day has zero dedup value.

4. **Cleanup wiring** — piggy-backs on the existing inbox timer (60s) and `pruneStaleSilentEntries` slot. No second interval; DELETE is small once steady state is reached.

5. **Test** — seeds three rows (fresh, borderline, stale), forces the stale one back by 60 days, runs prune with the default 30-day window, asserts exactly one deletion and the other two remain.

## Test plan

- [x] New test in `adapter-mapping.test.ts` (`pruneProcessedEvents` deletes stale rows, retains fresh ones).
- [x] All 1121 server tests pass (`pnpm test`).
- [x] `@first-tree/server typecheck` clean (after updating two test fixture configs to include the new field).
- [x] `pnpm check` (biome) clean (0 errors).
- [ ] Note: the migration was hand-written following the established pattern (the journal already drifts from the actual schema since #510, and recent migrations like `0048` were added directly without `drizzle-kit generate` snapshots). Reviewer to confirm this is the expected workflow.

## Related

- #509 — this issue
- M1 sibling: #516 (delivery observability)
- M2 sibling: #517 (cross-org binding guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)