### PR TITLE
fix(chat): raise composer onto the white surface

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1871,11 +1871,11 @@ export function ChatView({
                     padding: "var(--sp-2) var(--sp-3)",
                     border: "var(--hairline) solid var(--border)",
                     borderRadius: 6,
-                    // Blend into the timeline surface (`--bg`) rather than a
-                    // sunken grey box — the hairline border alone delineates
-                    // the slot. Mirrors the editable composer below so the
-                    // read-only state occupies the same visual footprint.
-                    background: "var(--bg)",
+                    // Raised surface (`--bg-raised`) so the slot reads as a
+                    // distinct input card lifted above the timeline (`--bg`),
+                    // sharing the header chrome's surface. Mirrors the editable
+                    // composer below so the read-only state shares its footprint.
+                    background: "var(--bg-raised)",
                   }}
                 >
                   <Eye className="h-4 w-4 shrink-0" style={{ color: "var(--fg-3)" }} />
@@ -1910,10 +1910,11 @@ export function ChatView({
                       position: "relative",
                       border: "var(--hairline) solid var(--border)",
                       borderRadius: 6,
-                      // Composer blends into the timeline surface (`--bg`)
-                      // instead of a sunken grey box; the hairline border
-                      // keeps the input field discernible against it.
-                      background: "var(--bg)",
+                      // Raised surface (`--bg-raised`) lifts the composer above
+                      // the timeline (`--bg`) so it reads as a focused input card
+                      // rather than blending into the page; the hairline border
+                      // still defines its edge.
+                      background: "var(--bg-raised)",
                     }}
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={(e) => {


### PR DESCRIPTION
## What

Follow-up to #515. That PR moved the composer off `--bg-sunken` onto `--bg`, but at `--bg` (the timeline base) the input blended into the page and read as indistinct — user feedback was that it looked the same as the chatview background. This moves the composer card **and** its read-only "watching" state to `--bg-raised` so the input reads as a focused card (pure white in light mode) lifted above the timeline.

## Why `--bg-raised`

`--bg-raised` is the existing "raised surface" token already used by the chat **header** (`chat-view.tsx`) and the right **rail** — the in-code comment there describes header + rail as one continuous `--bg-raised` chrome frame around the `--bg` timeline. Putting the composer on `--bg-raised` completes that frame: header / rail / composer now share one surface, framing the message stream. It also matches what the user asked for directly ("纯白" / match the header).

## Scope

- `packages/web/src/pages/workspace/center/chat-view.tsx` only (token value + comments, 2 occurrences).
- Editable composer card + read-only branch both → `--bg-raised`.
- `textarea` stays `background: transparent`; hairline `--border` still defines the edge.
- Untouched: `new-chat-draft.tsx` hero card, and unrelated `--bg-sunken` usages.

## Themes (raised surface stays a step lighter than the timeline `--bg`)

| context | composer / header (`--bg-raised`) | timeline (`--bg`) |
|---|---|---|
| light `:root` | 1.0 (pure white) | 0.985 |
| `.dark` | 0.175 | 0.145 |
| `.landing-marketing` | 0.1 | 0.04 |

## Checks

- `lint:tokens` ✓ · `biome check` ✓ · web `tsc --noEmit` ✓
- Reviewed by codex-reviewer: **No findings** (the "Raised surface" comment wording nit it raised is already applied here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)