### PR TITLE
release: bump apps/cli to v0.5.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Patch release for v0.5.1
- Bumps `apps/cli/package.json` from `0.5.0` → `0.5.1`
- Lockfile sync: no diff produced (version bump doesn't affect dependency resolution — same as #520)

## What's in v0.5.1

Single bug fix from #523 (already merged to main):

- **`fix(cli): move @first-tree/github-scan to devDependencies`** — v0.5.0 was unusable from npm: the published tarball shipped `"@first-tree/github-scan": "workspace:*"` in `dependencies`, breaking every consumer install with `EUNSUPPORTEDPROTOCOL`. Moved to devDependencies so the published `dependencies` block is clean. tsdown already bundles github-scan into `dist/`, so the published CLI is self-contained at runtime.

## Test plan

- [ ] CI green (lint / typecheck / unit / build)
- [ ] After tag `v0.5.1` push: `Publish Command Latest` job succeeds
- [ ] On a clean machine, `npm install -g first-tree@0.5.1` succeeds (this is the install command that was broken on 0.5.0)
- [ ] `first-tree github scan --help` still works in the installed v0.5.1 (sanity check: github-scan was bundled into dist correctly)

## Out of scope (handled by user post-merge)

- Tag `v0.5.1` push on the merge commit — triggers the `Publish Command Latest` workflow
- Drafting GitHub Release notes for v0.5.1

## Follow-up (separate PR)

Per #523 review thread: add a CI guard to the publish workflow that fails the build if any `workspace:*` leaks into the `dependencies` of a package about to be published. This would have caught the v0.5.0 bug before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)