### PR TITLE
fix(cli): forward shell proxy env into launchd plist / systemd unit

### DIFF
--- a/apps/cli/src/__tests__/proxy-env-passthrough.test.ts
+++ b/apps/cli/src/__tests__/proxy-env-passthrough.test.ts
@@ -128,4 +128,15 @@ describe("renderSystemdUnit proxy passthrough", () => {
     });
     expect(unit).toContain('Environment=https_proxy="http://user pass@proxy:8080"');
   });
+
+  it("shell-quotes credential-bearing proxy URLs (the `@` host separator is outside the safe-char set)", () => {
+    // Common proxy auth form `http://user:pass@host:port`. The `@` between
+    // userinfo and host is not in shellQuote's safe-char regex, so the value
+    // must be wrapped in double quotes — otherwise systemd's tokeniser would
+    // split on `@` and read `pass` + `host:port` as two separate values.
+    const unit = renderSystemdUnit(inv, {
+      https_proxy: "http://user:pass@proxy.example.com:6152",
+    });
+    expect(unit).toContain('Environment=https_proxy="http://user:pass@proxy.example.com:6152"');
+  });
 });

--- a/apps/cli/src/__tests__/proxy-env-passthrough.test.ts
+++ b/apps/cli/src/__tests__/proxy-env-passthrough.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { collectProxyEnv, renderPlist, renderSystemdUnit } from "../core/service-install.js";
+
+describe("collectProxyEnv", () => {
+  it("returns empty when no proxy env vars are set", () => {
+    expect(collectProxyEnv({})).toEqual({});
+  });
+
+  it("picks up lowercase keys", () => {
+    expect(
+      collectProxyEnv({
+        https_proxy: "http://127.0.0.1:6152",
+        no_proxy: "localhost,127.0.0.1",
+      }),
+    ).toEqual({
+      https_proxy: "http://127.0.0.1:6152",
+      no_proxy: "localhost,127.0.0.1",
+    });
+  });
+
+  it("picks up uppercase keys", () => {
+    expect(collectProxyEnv({ HTTPS_PROXY: "http://127.0.0.1:6152" })).toEqual({
+      HTTPS_PROXY: "http://127.0.0.1:6152",
+    });
+  });
+
+  it("keeps lowercase and uppercase entries side by side (libcurl/JVM prefer different cases — don't merge or guess)", () => {
+    expect(
+      collectProxyEnv({
+        https_proxy: "http://lower:6152",
+        HTTPS_PROXY: "http://upper:6152",
+      }),
+    ).toEqual({
+      https_proxy: "http://lower:6152",
+      HTTPS_PROXY: "http://upper:6152",
+    });
+  });
+
+  it("skips empty-string values so a `export https_proxy=` (intentional unset) doesn't pollute the unit", () => {
+    expect(
+      collectProxyEnv({
+        https_proxy: "",
+        http_proxy: "http://127.0.0.1:6152",
+      }),
+    ).toEqual({ http_proxy: "http://127.0.0.1:6152" });
+  });
+
+  it("ignores unrelated env vars", () => {
+    expect(
+      collectProxyEnv({
+        PATH: "/usr/bin",
+        HOME: "/Users/me",
+        FOO_PROXY: "http://foo", // not in the canonical list — ignore
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("renderPlist proxy passthrough", () => {
+  const inv = { kind: "bin" as const, program: "/usr/local/bin/first-tree" };
+
+  it("omits proxy entries entirely when no proxy env is provided", () => {
+    const plist = renderPlist(inv, {});
+    expect(plist).not.toMatch(/proxy/i);
+  });
+
+  it("writes one <key>/<string> pair per proxy entry inside EnvironmentVariables", () => {
+    const plist = renderPlist(inv, {
+      https_proxy: "http://127.0.0.1:6152",
+      no_proxy: "localhost,127.0.0.1",
+    });
+    expect(plist).toContain("<key>https_proxy</key>");
+    expect(plist).toContain("<string>http://127.0.0.1:6152</string>");
+    expect(plist).toContain("<key>no_proxy</key>");
+    expect(plist).toContain("<string>localhost,127.0.0.1</string>");
+    // Sanity: the proxy keys live inside the EnvironmentVariables dict, not
+    // as siblings of it. Cheap check: the closing </dict> for EnvironmentVariables
+    // comes after the last proxy entry.
+    const envOpenIdx = plist.indexOf("<key>EnvironmentVariables</key>");
+    const proxyIdx = plist.indexOf("<key>https_proxy</key>");
+    const runAtLoadIdx = plist.indexOf("<key>RunAtLoad</key>");
+    expect(envOpenIdx).toBeGreaterThan(-1);
+    expect(proxyIdx).toBeGreaterThan(envOpenIdx);
+    expect(runAtLoadIdx).toBeGreaterThan(proxyIdx);
+  });
+
+  it("escapes XML special characters in proxy values (URL query strings with & must not break the plist)", () => {
+    const plist = renderPlist(inv, {
+      https_proxy: "http://user:pa&ss@proxy.example:8080/?x=1&y=2",
+    });
+    // Must produce a plist that plutil would accept — i.e. & is escaped.
+    expect(plist).not.toMatch(/pa&ss/);
+    expect(plist).toContain("pa&amp;ss");
+    expect(plist).toContain("x=1&amp;y=2");
+  });
+});
+
+describe("renderSystemdUnit proxy passthrough", () => {
+  const inv = { kind: "bin" as const, program: "/usr/local/bin/first-tree" };
+
+  it("emits no Environment= lines for proxy when no proxy env is provided", () => {
+    const unit = renderSystemdUnit(inv, {});
+    // No proxy-related Environment= lines at all
+    expect(unit).not.toMatch(/Environment=.*proxy/i);
+  });
+
+  it("emits one Environment= line per proxy entry, ordered between PATH/FIRST_TREE_SERVICE_MODE and [Install]", () => {
+    const unit = renderSystemdUnit(inv, {
+      https_proxy: "http://127.0.0.1:6152",
+      no_proxy: "localhost,127.0.0.1",
+    });
+    // Values that are safe under shellQuote() pass through unquoted.
+    expect(unit).toContain("Environment=https_proxy=http://127.0.0.1:6152");
+    // Comma is outside shellQuote's safe-char set, so the value is wrapped in
+    // double quotes — systemd parses that correctly as one value.
+    expect(unit).toContain('Environment=no_proxy="localhost,127.0.0.1"');
+    // Order: proxy lines must come before [Install] (otherwise systemd treats
+    // them as install-section keys, which fails to parse).
+    const proxyIdx = unit.indexOf("Environment=https_proxy=");
+    const installIdx = unit.indexOf("[Install]");
+    expect(proxyIdx).toBeGreaterThan(-1);
+    expect(installIdx).toBeGreaterThan(proxyIdx);
+  });
+
+  it("shell-quotes proxy values that contain shell-significant characters (otherwise systemd would mis-tokenise)", () => {
+    const unit = renderSystemdUnit(inv, {
+      https_proxy: "http://user pass@proxy:8080",
+    });
+    expect(unit).toContain('Environment=https_proxy="http://user pass@proxy:8080"');
+  });
+});

--- a/apps/cli/src/core/service-install.ts
+++ b/apps/cli/src/core/service-install.ts
@@ -130,6 +130,47 @@ const LEGACY_SYSTEMD_UNIT = SERVICE_SUFFIX
 
 const LOG_DIR = join(DEFAULT_HOME_DIR, "logs");
 
+const PROXY_ENV_KEYS = [
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+] as const;
+
+/**
+ * Pick proxy env vars out of `env` (default `process.env`). Returns the subset
+ * that are present and non-empty, preserving case.
+ *
+ * Threaded into the unit / plist templates so a daemon started by launchd /
+ * systemd inherits the same proxy reachability the user's interactive shell
+ * already has. Without this, `git fetch` inside the daemon-spawned agent
+ * runtime can't route through the user's local proxy (Surge, Clash, mihomo,
+ * corporate proxy …) and fails with `SSL_ERROR_SYSCALL` whenever direct
+ * egress to github.com is blocked.
+ *
+ * Both lower- and upper-case keys are scanned because libcurl, git, OpenSSL,
+ * the JVM, and various Windows tools each prefer different cases. Pass through
+ * whatever the user set rather than guess.
+ *
+ * `refresh-unit` (called by the supervisor on auto-update) safely re-runs
+ * this: the supervisor inherits its env from the launchd plist it was started
+ * with, so once these vars land in the plist on first install they stay in
+ * the supervisor's env and the next refresh-rendered plist matches → no drift,
+ * no clobber.
+ */
+export function collectProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of PROXY_ENV_KEYS) {
+    const value = env[key];
+    if (value && value.length > 0) out[key] = value;
+  }
+  return out;
+}
+
 type ResolvedBinary = { kind: "bin"; program: string } | { kind: "node"; program: string; args: string[] };
 
 function whichBin(name: string): string | null {
@@ -197,7 +238,7 @@ function launchdPlistPath(): string {
   return join(homedir(), "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
 }
 
-function renderPlist(invocation: ResolvedBinary): string {
+export function renderPlist(invocation: ResolvedBinary, proxyEnv: Record<string, string> = collectProxyEnv()): string {
   const programArgs: string[] =
     invocation.kind === "bin"
       ? [invocation.program, "daemon", "start", "--no-interactive"]
@@ -220,6 +261,11 @@ function renderPlist(invocation: ResolvedBinary): string {
     ? `\n    <key>FIRST_TREE_HOME</key>\n    <string>${escapeXml(DEFAULT_HOME_DIR)}</string>`
     : "";
 
+  // Forward shell-side proxy env (see `collectProxyEnv` docblock for why).
+  const proxyEnvXml = Object.entries(proxyEnv)
+    .map(([k, v]) => `\n    <key>${escapeXml(k)}</key>\n    <string>${escapeXml(v)}</string>`)
+    .join("");
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -235,7 +281,7 @@ ${argsXml}
     <key>PATH</key>
     <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
     <key>FIRST_TREE_SERVICE_MODE</key>
-    <string>1</string>${homeEnvXml}
+    <string>1</string>${homeEnvXml}${proxyEnvXml}
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -429,7 +475,10 @@ function systemdUnitPath(): string {
   return join(xdg, "systemd", "user", SYSTEMD_UNIT);
 }
 
-function renderSystemdUnit(invocation: ResolvedBinary): string {
+export function renderSystemdUnit(
+  invocation: ResolvedBinary,
+  proxyEnv: Record<string, string> = collectProxyEnv(),
+): string {
   const execStart: string =
     invocation.kind === "bin"
       ? `${shellQuote(invocation.program)} daemon start --no-interactive`
@@ -445,6 +494,11 @@ function renderSystemdUnit(invocation: ResolvedBinary): string {
   // Prod (suffix === "") deliberately omits the line so existing
   // installed units don't churn unnecessarily.
   const homeEnv = SERVICE_SUFFIX ? `Environment=FIRST_TREE_HOME=${shellQuote(DEFAULT_HOME_DIR)}\n` : "";
+
+  // Forward shell-side proxy env (see `collectProxyEnv` docblock for why).
+  const proxyEnvLines = Object.entries(proxyEnv)
+    .map(([k, v]) => `Environment=${k}=${shellQuote(v)}\n`)
+    .join("");
 
   // Restart policy split:
   //   - on-failure  → operator-issued `systemctl stop` (clean exit 0) really stops.
@@ -477,7 +531,7 @@ StandardError=journal
 SyslogIdentifier=${SYSLOG_IDENT}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=FIRST_TREE_SERVICE_MODE=1
-${homeEnv}[Install]
+${homeEnv}${proxyEnvLines}[Install]
 WantedBy=default.target
 `;
 }

--- a/apps/cli/src/core/service-install.ts
+++ b/apps/cli/src/core/service-install.ts
@@ -161,6 +161,13 @@ const PROXY_ENV_KEYS = [
  * with, so once these vars land in the plist on first install they stay in
  * the supervisor's env and the next refresh-rendered plist matches → no drift,
  * no clobber.
+ *
+ * Security note: if a proxy URL embeds credentials (e.g.
+ * `http://user:pass@host:port`), those credentials land in the rendered
+ * plist / systemd unit on disk (mode 0o644 for plist, default file perms
+ * for systemd user units — both group- and world-readable). Exposure level
+ * matches `.zshrc` if the user originally `export`ed the URL there, but
+ * operators relying on credential-bearing proxy URLs should be aware.
  */
 export function collectProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
   const out: Record<string, string> = {};


### PR DESCRIPTION
## Summary

`first-tree daemon start` runs under launchd / systemd, which strip the user's interactive-shell env. The unit template only set `PATH` and `FIRST_TREE_SERVICE_MODE`, so a `git fetch` inside the daemon-spawned agent runtime had no way to reach a local proxy (Surge, Clash, corporate proxy …) — every `prepareGitWorktrees` call was a direct connection.

When direct egress to github.com is blocked (common in mainland China, some corporate networks), every fetch failed with `SSL_ERROR_SYSCALL` and bubbled out as `Session start/resume failed (...)` in chat. The shell-level `git fetch` in the *same* terminal worked fine because the user had `export https_proxy=...` in `.zshrc` — but launchd never sees that env.

This PR forwards `{http,https,all,no}_proxy` (lower + upper case) from the install-time shell into the plist / systemd unit. After install, the daemon and every git subprocess it spawns see the same proxy reachability the user's shell git already had.

## Implementation

- `collectProxyEnv(env = process.env)` — new exported helper, returns the non-empty subset of `PROXY_ENV_KEYS`.
- `renderPlist` and `renderSystemdUnit` now take an optional `proxyEnv` parameter (defaults to `collectProxyEnv()`) and append the entries inside the existing env block, after `FIRST_TREE_HOME`.
- Both render functions are now exported so unit tests can verify template output without spawning launchctl/systemctl.

## Migration note for existing users

**Auto-update alone does not migrate the env.** Existing users' currently-running daemon was started from a plist with no proxy env → supervisor's `process.env` has no proxy → `refresh-unit` (spawned by the supervisor on auto-update) reads that empty env → re-renders a plist still without proxy → no drift, no rewrite. This is the correct behaviour given the "no drift, no clobber" loop-stability invariant (see below).

**To pick up this fix on an existing install**, run one of the following **from a shell with `*_proxy` exported**:

```bash
first-tree login <token>          # or
first-tree daemon install         # or
first-tree daemon refresh-unit    # (hidden; works too)
```

Any of these re-renders the plist / unit from the calling shell's env, which now has the proxy values.

## Why this is loop-stable on auto-update

`refresh-unit` (called by the supervisor on every alpha bump) re-renders the template from the supervisor's `process.env`. The supervisor inherits its env from the launchd plist it was launched with. So the chain is:

1. User installs from shell with `https_proxy=X` → plist has `https_proxy=X`
2. Daemon launches via that plist → supervisor's env has `https_proxy=X`
3. Supervisor auto-updates → spawns `refresh-unit` with its env (including `X`) → new render has `https_proxy=X` → drift check sees no change → no clobber

A user who later wants to change proxy: `export https_proxy=Y; first-tree daemon refresh-unit` from their shell.

## Security note

If a proxy URL embeds credentials (`http://user:pass@host:port`), those credentials land in the rendered plist / systemd unit on disk (mode `0o644` for plist, default file perms for systemd user units — both group- and world-readable). Exposure level matches `.zshrc` if the user originally `export`ed the URL there, but operators relying on credential-bearing proxy URLs should be aware. The same note is in the `collectProxyEnv` docblock so future readers see it next to the code.

## Test plan

- [x] `pnpm check` — biome clean on changed files (16 pre-existing warnings in `packages/github-scan/` untouched)
- [x] `pnpm typecheck` — 13/13 tasks
- [x] `pnpm test` — 6/6 tasks (1123 server + 215 cli + others)
- [x] New unit tests cover `collectProxyEnv` (empty / lowercase / uppercase / mixed / empty-string-value / unrelated-keys) and `renderPlist` / `renderSystemdUnit` proxy emission, ordering, XML escaping, shell quoting (incl. credential-bearing `user:pass@host` URLs)
- [x] Smoke-tested locally on macOS with Surge: install with `https_proxy=http://127.0.0.1:6152` exported → plist gains the env block → `git fetch` from daemon-context succeeds via Surge HTTP proxy

## Background

User-facing investigation in chat `8b6d642e-f7de-467f-b6da-8f4401947fe9`. Stopgap workaround was `git config --global http.https://github.com/.proxy …`. This PR is the root fix.
