### PR TITLE
fix(client): auto-recover worktree target after orphan dev-server leftover

### DIFF
--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -96,6 +96,10 @@ export class ClientRuntime {
     this.gitMirrorManager = createGitMirrorManager({
       dataDir: DEFAULT_DATA_DIR,
       log: createLogger("git-mirror"),
+      // Authorise auto-recovery of orphaned worktree leftovers (kill holders +
+      // rm -rf) for any target under the per-agent workspaces tree. Operator
+      // paths outside this root still fail loud — see GitMirrorManagerOptions.
+      hubManagedRoots: [join(DEFAULT_DATA_DIR, "workspaces")],
     });
     registerBuiltinHandlers();
 

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -764,9 +764,7 @@ describe("GitMirrorManager — hubManagedRoots safety guards", () => {
   it("createGitMirrorManager accepts a strict subdir of dataDir (the production wiring)", () => {
     const dataDir = mkdtempSync(join(tmpdir(), "ftt-guard-"));
     try {
-      expect(() =>
-        createGitMirrorManager({ dataDir, hubManagedRoots: [join(dataDir, "workspaces")] }),
-      ).not.toThrow();
+      expect(() => createGitMirrorManager({ dataDir, hubManagedRoots: [join(dataDir, "workspaces")] })).not.toThrow();
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -215,7 +215,7 @@ describe("GitMirrorManager — lifecycle", () => {
     const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
     await m.ensureMirror(fixtureUrl);
 
-    const target = join(managedRoot, "agent-x", "chat-X", "first-tree-hub");
+    const target = join(managedRoot, "agent-x", "chat-X", "agent-worktree");
     // Recreate the production shape — packages/web/.vite/deps/_metadata.json,
     // no `.git` marker.
     mkdirSync(join(target, "packages", "web", ".vite", "deps"), { recursive: true });
@@ -270,7 +270,7 @@ describe("GitMirrorManager — lifecycle", () => {
     const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
     await m.ensureMirror(fixtureUrl);
 
-    const target = join(managedRoot, "agent-x", "chat-Y", "first-tree-hub");
+    const target = join(managedRoot, "agent-x", "chat-Y", "agent-worktree");
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "leftover.txt"), "cache");
 
@@ -314,7 +314,7 @@ describe("GitMirrorManager — lifecycle", () => {
     mkdirSync(managedRoot, { recursive: true });
     const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
     await m.ensureMirror(fixtureUrl);
-    const target = join(managedRoot, "agent-x", "chat-Z", "first-tree-hub");
+    const target = join(managedRoot, "agent-x", "chat-Z", "agent-worktree");
     const { branchName } = await m.createWorktree({
       url: fixtureUrl,
       targetPath: target,

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -725,6 +725,30 @@ describe("GitMirrorManager — hubManagedRoots safety guards", () => {
     }
   });
 
+  it("createGitMirrorManager aggregates multiple bad roots into one error (operator sees full picture)", () => {
+    // Without aggregation an operator who misconfigured 3 roots would have to
+    // fix-restart-fix-restart-fix-restart. The combined message names every
+    // offending entry up front.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-guard-multi-"));
+    try {
+      const validRoot = join(dataDir, "workspaces");
+      const badA = "/";
+      const badB = join(dataDir, "..", "elsewhere");
+      expect.assertions(3);
+      try {
+        createGitMirrorManager({ dataDir, hubManagedRoots: [badA, validRoot, badB] });
+      } catch (err) {
+        expect(err).toBeInstanceOf(GitMirrorError);
+        const msg = err instanceof Error ? err.message : String(err);
+        // Both bad roots present; the valid one is NOT in the message.
+        expect(msg).toContain(badA);
+        expect(msg).toContain("2 entries");
+      }
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("createGitMirrorManager throws when a managed root equals dataDir itself", () => {
     // Granting `dataDir` as a managed root would expose `git-mirrors/`,
     // `chats/`, `images/`, etc. to the self-heal rm -rf — too broad. The

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -18,6 +18,7 @@ import {
   isLikelySshAuthFailure,
   sshToHttpsBaseRewrite,
 } from "../runtime/git-mirror-manager.js";
+import { isUnderManagedRoot } from "../runtime/worktree-cleanup.js";
 
 let workRoot: string;
 let fixtureRepo: string;
@@ -681,6 +682,70 @@ describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailur
     "fatal: could not read Username for 'https://github.com'",
   ])("does NOT match: %s", (msg) => {
     expect(isLikelySshAuthFailure(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — hubManagedRoots safety guards", () => {
+  it("isUnderManagedRoot returns false when target === root (refuses to nuke the managed root itself)", () => {
+    // Without this guard, a caller that accidentally passes the managed root
+    // as a worktree target would let the self-heal branch `rm -rf` the entire
+    // `<dataDir>/workspaces` tree (every agent, every session). Worktree
+    // targets always sit at least two levels deeper; the exact-match case is
+    // never a legitimate request.
+    expect(isUnderManagedRoot("/data/ws", ["/data/ws"])).toBe(false);
+    expect(isUnderManagedRoot("/data/ws/", ["/data/ws"])).toBe(false);
+  });
+
+  it("isUnderManagedRoot returns true for proper descendants", () => {
+    expect(isUnderManagedRoot("/data/ws/agent/chat/repo", ["/data/ws"])).toBe(true);
+    expect(isUnderManagedRoot("/data/ws/a", ["/data/ws"])).toBe(true);
+  });
+
+  it("isUnderManagedRoot returns false for siblings whose name shares a prefix (path traversal guard)", () => {
+    // `/data/ws-evil` looks like a sibling of `/data/ws` and a naive
+    // `startsWith` check would say it's "inside" — the helper uses `relative`
+    // so the result starts with `..` and is correctly rejected.
+    expect(isUnderManagedRoot("/data/ws-evil/agent", ["/data/ws"])).toBe(false);
+    expect(isUnderManagedRoot("/elsewhere/repo", ["/data/ws"])).toBe(false);
+  });
+
+  it("createGitMirrorManager throws when a managed root is outside dataDir (fail-loud against weaponised config)", () => {
+    // The dangerous shapes: `["/"]`, `[os.homedir()]`, `[tmpdir()]`. Each one
+    // would let the createWorktree self-heal branch `rm -rf` arbitrary host
+    // paths. Catch them at construction so the operator sees a startup error
+    // rather than a quiet, much-later data-loss event.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-guard-"));
+    try {
+      expect(() => createGitMirrorManager({ dataDir, hubManagedRoots: ["/"] })).toThrow(GitMirrorError);
+      expect(() => createGitMirrorManager({ dataDir, hubManagedRoots: [join(dataDir, "..", "elsewhere")] })).toThrow(
+        GitMirrorError,
+      );
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("createGitMirrorManager throws when a managed root equals dataDir itself", () => {
+    // Granting `dataDir` as a managed root would expose `git-mirrors/`,
+    // `chats/`, `images/`, etc. to the self-heal rm -rf — too broad. The
+    // root must be a STRICT subdir.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-guard-"));
+    try {
+      expect(() => createGitMirrorManager({ dataDir, hubManagedRoots: [dataDir] })).toThrow(GitMirrorError);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("createGitMirrorManager accepts a strict subdir of dataDir (the production wiring)", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-guard-"));
+    try {
+      expect(() =>
+        createGitMirrorManager({ dataDir, hubManagedRoots: [join(dataDir, "workspaces")] }),
+      ).not.toThrow();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -53,6 +53,44 @@ function makeManager(): GitMirrorManager {
 
 function gitIn(cwd: string, args: string): string {
   return execSync(`git ${args}`, { cwd }).toString().trim();
+}
+
+/**
+ * Spawn a detached, long-lived child whose cwd is `dir`. Used by the orphan-
+ * cleanup tests to model a vite/esbuild process still holding the worktree
+ * after its parent session died. The caller MUST clean the pid up in a
+ * `finally` block — vitest will otherwise hang at process exit waiting for it.
+ *
+ * Uses `node` (always on PATH where the suite runs) over `sleep` because
+ * `sleep` is signalled instantly on SIGTERM whereas a node script keeps the
+ * promise-based wait honest (and a future test could swap in a custom signal
+ * handler if it needs to model a misbehaving holder).
+ */
+async function spawnLongLivedChildInDir(dir: string): Promise<{ pid: number; proc: ChildProcess }> {
+  const proc = spawn(process.execPath, ["-e", "setInterval(()=>{},1e6)"], {
+    cwd: dir,
+    detached: true,
+    stdio: "ignore",
+  });
+  proc.unref();
+  if (proc.pid === undefined) {
+    throw new Error("failed to spawn long-lived test child");
+  }
+  // Wait briefly so lsof sees the cwd before the test calls into the manager.
+  await new Promise((r) => setTimeout(r, 50));
+  return { pid: proc.pid, proc };
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ESRCH") return false;
+    // Any other error (e.g. EPERM) implies the pid exists but we can't signal
+    // — count as alive to avoid false-negative assertions.
+    return true;
+  }
 }
 
 function tryGitIn(cwd: string, args: string): { ok: boolean; stdout: string } {
@@ -162,6 +200,143 @@ describe("GitMirrorManager — lifecycle", () => {
       m.createWorktree({ url: fixtureUrl, targetPath: occupied, sessionKey: "chat-C", agentName: "agent-x" }),
     ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
     expect(existsSync(join(occupied, "user-data.txt"))).toBe(true);
+  });
+
+  it("createWorktree auto-recovers when a leftover sits in a hub-managed root", async () => {
+    // Reproduces the production incident: previous session left a directory
+    // tree at the worktree target (typical cause: orphaned vite/.vite dep
+    // cache rewritten by a daemonised dev server after the worktree was
+    // removed). Without self-heal the next session start throws D13. With
+    // `hubManagedRoots` configured, the manager rm -rf's the leftover and
+    // proceeds with `worktree add`.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-"));
+    const managedRoot = join(dataDir, "workspaces");
+    mkdirSync(managedRoot, { recursive: true });
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    await m.ensureMirror(fixtureUrl);
+
+    const target = join(managedRoot, "agent-x", "chat-X", "first-tree-hub");
+    // Recreate the production shape — packages/web/.vite/deps/_metadata.json,
+    // no `.git` marker.
+    mkdirSync(join(target, "packages", "web", ".vite", "deps"), { recursive: true });
+    writeFileSync(join(target, "packages", "web", ".vite", "deps", "_metadata.json"), "{}");
+
+    const created = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "chat-X",
+      agentName: "agent-x",
+    });
+    expect(created.worktreePath).toBe(target);
+    expect(existsSync(join(target, "README.md"))).toBe(true);
+    // The leftover cache dir is gone — the new checkout doesn't carry
+    // `packages/web/` because the fixture repo doesn't have one.
+    expect(existsSync(join(target, "packages"))).toBe(false);
+
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("createWorktree still throws D13 for occupants outside every managed root", async () => {
+    // Belt-and-braces for the safety guard: even with `hubManagedRoots`
+    // configured, targets OUTSIDE every managed root must still fail loud
+    // rather than silently delete operator data.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-guard-"));
+    const managedRoot = join(dataDir, "workspaces");
+    mkdirSync(managedRoot, { recursive: true });
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    await m.ensureMirror(fixtureUrl);
+
+    // Target lives outside `managedRoot` — operator-supplied path.
+    const outside = join(workRoot, "operator-dir");
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, "user-data.txt"), "important");
+    await expect(
+      m.createWorktree({ url: fixtureUrl, targetPath: outside, sessionKey: "chat-O", agentName: "agent-x" }),
+    ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
+    expect(existsSync(join(outside, "user-data.txt"))).toBe(true);
+
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("createWorktree kills a process holding the leftover before recovery", async () => {
+    // Simulates the actual orphan: a long-running child (e.g. vite) whose cwd
+    // is the leftover dir. Without the pre-rm kill the rm -rf races against
+    // the child's writes and the worktree add can find the dir non-empty
+    // again. After the fix, the child gets SIGTERM'd, the rm sticks, and
+    // `git worktree add` succeeds.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-kill-"));
+    const managedRoot = join(dataDir, "workspaces");
+    mkdirSync(managedRoot, { recursive: true });
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    await m.ensureMirror(fixtureUrl);
+
+    const target = join(managedRoot, "agent-x", "chat-Y", "first-tree-hub");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "leftover.txt"), "cache");
+
+    // Spawn an orphan with cwd inside the leftover. Detach so it survives
+    // its parent; the test process kills it via the manager's recovery path.
+    const child = await spawnLongLivedChildInDir(target);
+    expect(processIsAlive(child.pid)).toBe(true);
+
+    try {
+      const created = await m.createWorktree({
+        url: fixtureUrl,
+        targetPath: target,
+        sessionKey: "chat-Y",
+        agentName: "agent-x",
+      });
+      expect(created.worktreePath).toBe(target);
+      expect(existsSync(join(target, "README.md"))).toBe(true);
+      expect(existsSync(join(target, "leftover.txt"))).toBe(false);
+      // Give the kernel a beat to mark the pid as zombie/reaped.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(processIsAlive(child.pid)).toBe(false);
+    } finally {
+      // Belt-and-braces in case the recovery path didn't kill it.
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // ignore — already reaped
+      }
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removeWorktree kills processes whose cwd is inside the worktree before deleting", async () => {
+    // The other half of the orphan story: when a session ends with a child
+    // (vite / esbuild / test watcher) still holding the worktree as cwd,
+    // `git worktree remove --force` may succeed but the child immediately
+    // recreates files under the deleted path. We pre-kill so the next session
+    // start sees an empty parent and the `worktree add` is clean.
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-rm-kill-"));
+    const managedRoot = join(dataDir, "workspaces");
+    mkdirSync(managedRoot, { recursive: true });
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    await m.ensureMirror(fixtureUrl);
+    const target = join(managedRoot, "agent-x", "chat-Z", "first-tree-hub");
+    const { branchName } = await m.createWorktree({
+      url: fixtureUrl,
+      targetPath: target,
+      sessionKey: "chat-Z",
+      agentName: "agent-x",
+    });
+    const child = await spawnLongLivedChildInDir(target);
+    expect(processIsAlive(child.pid)).toBe(true);
+
+    try {
+      await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
+      expect(existsSync(target)).toBe(false);
+      await new Promise((r) => setTimeout(r, 100));
+      expect(processIsAlive(child.pid)).toBe(false);
+    } finally {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // ignore — already reaped
+      }
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   it("removeWorktree deletes both the worktree and the session branch", async () => {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -231,7 +231,21 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   const cloneTimeoutMs =
     opts.cloneTimeoutMs ?? Number(process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS ?? DEFAULT_CLONE_TIMEOUT_MS);
   const log = opts.log;
+  const resolvedDataDir = resolve(opts.dataDir);
   const hubManagedRoots = (opts.hubManagedRoots ?? []).map((p) => resolve(p));
+  // Fail loud at construction if any managed root would let the self-heal
+  // branch escape `<dataDir>`. Without this guard a misconfigured caller
+  // (`hubManagedRoots: ["/"]`, `[os.homedir()]`, etc.) would weaponise the
+  // `createWorktree` rm -rf path against arbitrary host paths. Strict subdir:
+  // the root itself MUST sit inside `dataDir` and MUST NOT equal `dataDir`
+  // (so we never grant "the whole hub data dir is fair game").
+  for (const root of hubManagedRoots) {
+    if (!isUnderManagedRoot(root, [resolvedDataDir])) {
+      throw new GitMirrorError(
+        `hubManagedRoots entry "${root}" is not inside dataDir "${resolvedDataDir}" — refusing to construct manager (would let self-heal rm -rf escape the hub data dir)`,
+      );
+    }
+  }
 
   // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /
   // gcMirrors for the same URL from racing on the same directory.

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -239,12 +239,15 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   // `createWorktree` rm -rf path against arbitrary host paths. Strict subdir:
   // the root itself MUST sit inside `dataDir` and MUST NOT equal `dataDir`
   // (so we never grant "the whole hub data dir is fair game").
-  for (const root of hubManagedRoots) {
-    if (!isUnderManagedRoot(root, [resolvedDataDir])) {
-      throw new GitMirrorError(
-        `hubManagedRoots entry "${root}" is not inside dataDir "${resolvedDataDir}" — refusing to construct manager (would let self-heal rm -rf escape the hub data dir)`,
-      );
-    }
+  //
+  // Aggregate every bad root into one error so an operator who misconfigured
+  // multiple entries sees the whole picture on their first startup attempt
+  // instead of grinding through one-fix-then-restart cycles.
+  const badRoots = hubManagedRoots.filter((root) => !isUnderManagedRoot(root, [resolvedDataDir]));
+  if (badRoots.length > 0) {
+    throw new GitMirrorError(
+      `hubManagedRoots contains ${badRoots.length} entr${badRoots.length === 1 ? "y" : "ies"} not strictly inside dataDir "${resolvedDataDir}" — refusing to construct manager (would let self-heal rm -rf escape the hub data dir): ${badRoots.map((p) => `"${p}"`).join(", ")}`,
+    );
   }
 
   // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type { pino } from "../observability/logger.js";
+import { isUnderManagedRoot, killProcessesHoldingPath } from "./worktree-cleanup.js";
 
 const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -43,6 +44,21 @@ export type GitMirrorManagerOptions = {
   dataDir: string;
   cloneTimeoutMs?: number;
   log?: pino.Logger;
+  /**
+   * Paths under which Hub owns the directory tree end-to-end (typically
+   * `<dataDir>/workspaces`). When a worktree target sits inside one of these
+   * roots and a stale non-managed leftover is found at session start, the
+   * manager auto-recovers — kill any process still holding the path, `rm -rf`
+   * the leftover, then proceed with the normal `git worktree add` flow.
+   *
+   * Targets OUTSIDE every managed root still fail loud with D13: those are
+   * operator-supplied paths and we refuse to silently delete user data.
+   *
+   * Omit to disable self-healing (current D13-always-throws behaviour). The
+   * production runtimes always pass the workspaces root; tests opt in
+   * explicitly to exercise the recovery path.
+   */
+  hubManagedRoots?: readonly string[];
 };
 
 export interface GitMirrorManager {
@@ -215,6 +231,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   const cloneTimeoutMs =
     opts.cloneTimeoutMs ?? Number(process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS ?? DEFAULT_CLONE_TIMEOUT_MS);
   const log = opts.log;
+  const hubManagedRoots = (opts.hubManagedRoots ?? []).map((p) => resolve(p));
 
   // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /
   // gcMirrors for the same URL from racing on the same directory.
@@ -584,18 +601,52 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         const branchName = deriveSessionBranchName(sessionKey, agentName, url);
 
         // D13: target path must be free OR a Hub-managed worktree we can reuse.
+        // Self-heal exception: when the path sits inside a hub-managed root the
+        // leftover is almost always an orphaned dev-server cache (vite/.vite,
+        // node_modules/.cache, etc) re-written by a daemonised child that
+        // outlived the previous session — see worktree-cleanup.ts header for
+        // the full incident. Kill any process still holding it, rm -rf, and
+        // fall through to the normal `git worktree add` path.
         if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {
-          log?.warn(
-            {
-              gitUrl: url,
-              targetPath: absTarget,
-              occupantKind: classifyOccupant(absTarget),
-            },
-            "worktree create conflict",
-          );
-          throw new GitMirrorWorktreeConflictError(
-            `Worktree target "${absTarget}" is already occupied by ${classifyOccupant(absTarget)} — aborting (D13)`,
-          );
+          const occupantKind = classifyOccupant(absTarget);
+          if (hubManagedRoots.length > 0 && isUnderManagedRoot(absTarget, hubManagedRoots)) {
+            log?.warn(
+              {
+                gitUrl: url,
+                targetPath: absTarget,
+                occupantKind,
+                hubManagedRoots,
+              },
+              "worktree target occupied inside hub-managed root — auto-recovering (kill holders + rm -rf)",
+            );
+            await killProcessesHoldingPath(absTarget, log);
+            try {
+              rmSync(absTarget, { recursive: true, force: true });
+            } catch (err) {
+              throw new GitMirrorWorktreeConflictError(
+                `Worktree target "${absTarget}" cleanup failed after killing holders: ${
+                  err instanceof Error ? err.message : String(err)
+                } (D13)`,
+              );
+            }
+            if (existsSync(absTarget)) {
+              throw new GitMirrorWorktreeConflictError(
+                `Worktree target "${absTarget}" still occupied after auto-recovery — aborting (D13)`,
+              );
+            }
+          } else {
+            log?.warn(
+              {
+                gitUrl: url,
+                targetPath: absTarget,
+                occupantKind,
+              },
+              "worktree create conflict",
+            );
+            throw new GitMirrorWorktreeConflictError(
+              `Worktree target "${absTarget}" is already occupied by ${occupantKind} — aborting (D13)`,
+            );
+          }
         }
 
         // Crash-recovery matrix + cross-process race recovery, wrapped in a
@@ -673,6 +724,16 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
       return withUrlLock(url, async () => {
         const absTarget = resolve(path);
         const mirror = mirrorDir(url);
+        // Kill any daemonised child the previous session left behind (vite,
+        // esbuild, test watcher, ...) BEFORE we try to rmdir. Without this the
+        // child keeps writing under `absTarget`, which both makes
+        // `git worktree remove` flaky AND repopulates the directory between
+        // the rm and the next session's `worktree add` — exactly the D13
+        // failure mode this commit fixes. Gated by `hubManagedRoots` so we
+        // never signal processes whose cwd happens to be an operator path.
+        if (hubManagedRoots.length > 0 && isUnderManagedRoot(absTarget, hubManagedRoots) && existsSync(absTarget)) {
+          await killProcessesHoldingPath(absTarget, log);
+        }
         if (!isBareRepo(mirror)) {
           // Mirror was already GC'd; just rm the orphan dir if it exists.
           if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import type { UpdateAttempt } from "@first-tree/shared";
 import { DEFAULT_DATA_DIR } from "@first-tree/shared/config";
 import { ClientConnection } from "../client-connection.js";
@@ -89,6 +90,10 @@ export class AgentRuntime {
     this.gitMirrorManager = createGitMirrorManager({
       dataDir: DEFAULT_DATA_DIR,
       log: createLogger("git-mirror"),
+      // Authorise auto-recovery of orphaned worktree leftovers (kill holders +
+      // rm -rf) for any target under the per-agent workspaces tree. Operator
+      // paths outside this root still fail loud — see GitMirrorManagerOptions.
+      hubManagedRoots: [join(DEFAULT_DATA_DIR, "workspaces")],
     });
 
     for (const [name, agentConfig] of Object.entries(this.config.agents)) {

--- a/packages/client/src/runtime/worktree-cleanup.ts
+++ b/packages/client/src/runtime/worktree-cleanup.ts
@@ -1,0 +1,227 @@
+import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { relative, sep } from "node:path";
+import type { pino } from "../observability/logger.js";
+
+/**
+ * Pre-cleanup helpers for worktree paths the Hub owns.
+ *
+ * Why this module exists: agent sessions often spawn dev servers (vite, esbuild,
+ * test watchers) inside the worktree as background children. When Hub tears the
+ * worktree down those children outlive the agent process — daemonised, attached
+ * to a different process group, or simply not tracked by the SDK. The orphan
+ * keeps the cwd open, keeps writing cache files (`.vite/deps/...`,
+ * `node_modules/.cache/...`) under the just-deleted directory, and on the next
+ * session start the rebuilt path collides with the D13 guard in
+ * `createWorktree` because there's a non-empty dir but no `.git` marker.
+ *
+ * Two consumers:
+ *   - `removeWorktree` calls `killProcessesHoldingPath` BEFORE `git worktree
+ *     remove --force` so the rmdir actually sticks.
+ *   - `createWorktree` calls `killProcessesHoldingPath` then `rmSync` when a
+ *     non-managed leftover sits in a path under a hub-managed root — see the
+ *     `hubManagedRoots` option on `GitMirrorManager`.
+ */
+
+/** Generous upper bound on a single lsof run before we give up. */
+const LSOF_TIMEOUT_MS = 5_000;
+/** How long to wait between SIGTERM and SIGKILL on holdouts. */
+const SIGTERM_GRACE_MS = 750;
+
+/**
+ * Candidate `lsof` binaries, tried in order. macOS ships lsof at
+ * `/usr/sbin/lsof` which is on the interactive `PATH` (via `/etc/paths`) but
+ * NOT in the minimal env launchd / our test harness hands to children. Linux
+ * distros typically have it at `/usr/bin/lsof`. We fall back to the bare name
+ * last so a wrapper installed via Homebrew etc. still wins when present.
+ */
+const LSOF_CANDIDATE_PATHS = ["/usr/sbin/lsof", "/usr/bin/lsof", "/sbin/lsof", "lsof"] as const;
+
+function resolveLsofBinary(): string | null {
+  for (const candidate of LSOF_CANDIDATE_PATHS) {
+    if (candidate === "lsof") return "lsof"; // last-resort PATH lookup
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {
+      // not present, try next
+    }
+  }
+  return null;
+}
+
+/**
+ * True when `target` is `root`, or contained inside `root` after path
+ * normalisation. Used to guard destructive cleanup behind an explicit
+ * "Hub owns this directory" assertion — operator-supplied paths outside any
+ * managed root must NOT be auto-cleaned.
+ */
+export function isUnderManagedRoot(target: string, roots: readonly string[]): boolean {
+  for (const root of roots) {
+    const rel = relative(root, target);
+    if (rel === "") return true;
+    if (rel.startsWith("..")) continue;
+    // `path.relative` returns OS-native separators; reject if it bottoms out
+    // to an absolute path on the foreign side (relative across volumes on
+    // Windows). Hub data dirs never cross volumes on POSIX so this is just
+    // belt-and-braces.
+    if (rel.startsWith(sep)) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Enumerate PIDs that hold any file open under `path` (including cwd, mmap'd
+ * binaries, regular fds). Uses `lsof +D` which recurses into the directory
+ * tree. Returns an empty list when:
+ *   - the path doesn't exist
+ *   - `lsof` exits non-zero or isn't on PATH
+ *   - the timeout expires
+ * Never throws — callers continue with the destructive op regardless.
+ */
+export async function findPidsHoldingPath(path: string, log?: pino.Logger): Promise<number[]> {
+  if (!existsSync(path)) return [];
+  const lsofBin = resolveLsofBinary();
+  if (!lsofBin) {
+    log?.debug({ path }, "no lsof binary found on disk — skipping holder scan");
+    return [];
+  }
+  return await new Promise<number[]>((resolveExec) => {
+    let stdout = "";
+    let stderr = "";
+    // `-w` suppresses lock-acquisition warnings on Linux; `-n -P` skip name/port
+    // resolution so we don't time out on a slow DNS. `-F p` switches to the
+    // field-prefixed parseable output (lines `pNNNN`). `+D` recurses AND
+    // matches processes whose cwd is `path` (cwd is reported as fd type `cwd`
+    // — see `lsof(8)` — which `+D` enumerates alongside open files); with the
+    // self-pid excluded below the cost is bounded by the dir's filecount.
+    const proc = spawn(lsofBin, ["-w", "-n", "-P", "-F", "p", "+D", path], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let settled = false;
+    const settle = (pids: number[]) => {
+      if (settled) return;
+      settled = true;
+      resolveExec(pids);
+    };
+    proc.stdout.on("data", (d) => {
+      stdout += String(d);
+    });
+    proc.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+    const timer = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // ignore — child already exited
+      }
+      log?.warn({ path, timeoutMs: LSOF_TIMEOUT_MS }, "lsof timed out while scanning worktree holders");
+      settle([]);
+    }, LSOF_TIMEOUT_MS);
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      log?.debug({ path, err: String(err) }, "lsof spawn failed — assuming no holders");
+      settle([]);
+    });
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      // lsof exits 1 when its scan turned up no matching files — that's the
+      // happy "nobody is holding it" path, not an error. Treat any unparseable
+      // exit as "unknown, proceed without killing".
+      if (code !== 0 && code !== 1) {
+        log?.debug(
+          { path, exitCode: code, stderr: stderr.slice(0, 256) },
+          "lsof exited non-zero — assuming no holders",
+        );
+        settle([]);
+        return;
+      }
+      const selfPid = process.pid;
+      const pids = new Set<number>();
+      for (const line of stdout.split("\n")) {
+        const m = line.match(/^p(\d+)$/);
+        if (!m) continue;
+        const pid = Number(m[1]);
+        if (!Number.isFinite(pid) || pid <= 1) continue;
+        if (pid === selfPid) continue;
+        pids.add(pid);
+      }
+      settle([...pids]);
+    });
+  });
+}
+
+/**
+ * Best-effort kill every process holding a file under `path`. Sends SIGTERM,
+ * waits {@link SIGTERM_GRACE_MS}, then SIGKILLs any holdouts. Returns the PIDs
+ * we asked the kernel to kill and any that we could not signal (typically
+ * because they belong to another uid).
+ *
+ * Idempotent: a second call on the same path is cheap when no holders remain.
+ * Never throws — caller decides what to do when `failedToKill` is non-empty.
+ */
+export async function killProcessesHoldingPath(
+  path: string,
+  log?: pino.Logger,
+): Promise<{ killed: number[]; failedToKill: number[] }> {
+  const pids = await findPidsHoldingPath(path, log);
+  if (pids.length === 0) return { killed: [], failedToKill: [] };
+
+  log?.warn({ path, pids }, "killing processes holding worktree path");
+
+  const failedToKill: number[] = [];
+  const termed: number[] = [];
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGTERM");
+      termed.push(pid);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") {
+        // process already gone — count as terminated so we still skip SIGKILL
+        termed.push(pid);
+      } else {
+        log?.warn({ path, pid, err: String(err) }, "SIGTERM failed");
+        failedToKill.push(pid);
+      }
+    }
+  }
+
+  if (termed.length === 0) {
+    return { killed: [], failedToKill };
+  }
+
+  await new Promise((r) => setTimeout(r, SIGTERM_GRACE_MS));
+
+  // Anything still alive gets SIGKILL. `kill(pid, 0)` is the standard liveness
+  // probe — succeeds when the pid exists and we can signal it, throws ESRCH
+  // otherwise.
+  const killed: number[] = [];
+  for (const pid of termed) {
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") alive = false;
+    }
+    if (!alive) {
+      killed.push(pid);
+      continue;
+    }
+    try {
+      process.kill(pid, "SIGKILL");
+      killed.push(pid);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") {
+        killed.push(pid);
+      } else {
+        log?.warn({ path, pid, err: String(err) }, "SIGKILL failed");
+        failedToKill.push(pid);
+      }
+    }
+  }
+
+  return { killed, failedToKill };
+}

--- a/packages/client/src/runtime/worktree-cleanup.ts
+++ b/packages/client/src/runtime/worktree-cleanup.ts
@@ -21,6 +21,14 @@ import type { pino } from "../observability/logger.js";
  *   - `createWorktree` calls `killProcessesHoldingPath` then `rmSync` when a
  *     non-managed leftover sits in a path under a hub-managed root — see the
  *     `hubManagedRoots` option on `GitMirrorManager`.
+ *
+ * Platform support: `lsof` is the universal way to enumerate file holders
+ * on POSIX. We try a few well-known paths before falling back to PATH (macOS
+ * launchd / systemd strip `/usr/sbin` from `Environment=PATH`). Windows ships
+ * no equivalent; `resolveLsofBinary` returns `null` there and the helpers
+ * become no-ops — the self-heal path then relies on `existsSync(absTarget)`
+ * after the post-cleanup attempt to surface failure. Windows isn't in Hub's
+ * supported daemon matrix today; revisit if/when that changes.
  */
 
 /** Generous upper bound on a single lsof run before we give up. */

--- a/packages/client/src/runtime/worktree-cleanup.ts
+++ b/packages/client/src/runtime/worktree-cleanup.ts
@@ -58,15 +58,18 @@ function resolveLsofBinary(): string | null {
 }
 
 /**
- * True when `target` is `root`, or contained inside `root` after path
- * normalisation. Used to guard destructive cleanup behind an explicit
- * "Hub owns this directory" assertion — operator-supplied paths outside any
- * managed root must NOT be auto-cleaned.
+ * True when `target` is contained STRICTLY inside `root` after path
+ * normalisation. The exact-match case (`target === root`) returns false on
+ * purpose: a caller that passes the managed root itself as a worktree target
+ * would otherwise let the self-heal branch `rm -rf` the entire
+ * `<dataDir>/workspaces` tree. Worktree targets always sit at least two levels
+ * deeper (`<agent>/<chatId>/<repo>`), so the exact-match path is never a
+ * legitimate request — fail closed.
  */
 export function isUnderManagedRoot(target: string, roots: readonly string[]): boolean {
   for (const root of roots) {
     const rel = relative(root, target);
-    if (rel === "") return true;
+    if (rel === "") continue; // target === root: never auto-clean the root itself
     if (rel.startsWith("..")) continue;
     // `path.relative` returns OS-native separators; reject if it bottoms out
     // to an absolute path on the foreign side (relative across volumes on


### PR DESCRIPTION
## Summary

Fixes the D13 ("Worktree target … is already occupied by directory") error that fires on session resume when a previous session's daemonised dev server (vite / esbuild / test watcher) outlived its parent and kept writing cache files into the just-deleted worktree path.

Root cause (live evidence from today's incident on @liuchao-001's machine): orphaned vite (pid 7746) holding `…/code-reviewer/<chatId>/first-tree-hub` as cwd, recreating `packages/web/.vite/deps/_metadata.json` after `git worktree remove --force` had taken the dir down. The next `createWorktree` saw a non-empty path with no `.git` marker and threw D13.

Two complementary fixes, both gated by the new `hubManagedRoots` option:

- **A. `removeWorktree` pre-kill** — `lsof +D <path>` → SIGTERM → SIGKILL on any process holding files under the worktree path BEFORE `git worktree remove --force`. Daemonised children can no longer repopulate the dir between sessions.
- **B. `createWorktree` self-heal** — when the target is non-managed-but-occupied AND lives inside `<dataDir>/workspaces`, kill holders, `rm -rf`, then run the normal `worktree add` flow. Targets OUTSIDE every managed root still fail loud (D13) so operator-supplied paths are never silently wiped.

The `lsof` lookup tries `/usr/sbin/lsof`, `/usr/bin/lsof`, then PATH — necessary because macOS's launchd-style env strips `/usr/sbin`.

## Files

- `packages/client/src/runtime/worktree-cleanup.ts` *(new)* — `isUnderManagedRoot`, `findPidsHoldingPath`, `killProcessesHoldingPath`.
- `packages/client/src/runtime/git-mirror-manager.ts` — new `hubManagedRoots` option; self-heal in `createWorktree`; pre-kill in `removeWorktree`.
- `packages/client/src/runtime/runtime.ts` + `apps/cli/src/core/client-runtime.ts` — pass `[<dataDir>/workspaces]` as managed root.
- `packages/client/src/__tests__/git-mirror-manager.test.ts` — 4 new tests: self-heal of leftover cache dir; D13 still fires outside managed roots; pre-create kill of holder; pre-remove kill of holder.

## Test plan

- [x] `pnpm --filter @first-tree/client typecheck` (clean)
- [x] `pnpm typecheck` workspace-wide (clean)
- [x] `pnpm --filter @first-tree/client test --run` — **457 passed**, including 4 new
- [x] `pnpm test` workspace-wide — **all 13 tasks green**
- [ ] Manual: kill stray vite + rm leftover `…/code-reviewer/3450719e-…/first-tree-hub`, then start a code-reviewer session to confirm resume no longer throws D13 (will do once this lands on the daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)