### PR TITLE
feat(web): beginner-first standalone /onboarding flow

### DIFF
--- a/packages/server/src/__tests__/github-app-install-url.test.ts
+++ b/packages/server/src/__tests__/github-app-install-url.test.ts
@@ -49,6 +49,40 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
     expect(verified.next).toBe("/settings/github");
   });
 
+  it("bakes an allowlisted ?next= into the signed state (onboarding flow)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/install-url?next=${encodeURIComponent("/onboarding")}`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const state = new URL(res.json<{ installUrl: string }>().installUrl).searchParams.get("state");
+    const cookieNonce = readStateCookie(res.headers["set-cookie"]);
+    const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
+    expect(verified.next).toBe("/onboarding");
+  });
+
+  it("ignores a ?next= that isn't on the allowlist (no open redirect)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/install-url?next=${encodeURIComponent("https://evil.example.com")}`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const state = new URL(res.json<{ installUrl: string }>().installUrl).searchParams.get("state");
+    const cookieNonce = readStateCookie(res.headers["set-cookie"]);
+    const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
+    expect(verified.next).toBe("/settings/github");
+  });
+
   it("403s for a non-admin member of the org", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -43,11 +43,17 @@ import { buildCookie, parseCookieHeader } from "./oauth-cookie.js";
 /**
  * GitHub sign-in surface. All routes are public (no member JWT required).
  *
- * Single flow post-D3 cutover: the GitHub App authorize URL drives both
- * sign-in and install (D1). Returning users with an existing install
- * skip the install dialog and just get `code + state`; first-time
- * installers get `code + state + installation_id`. The legacy OAuth-App
- * path that lived alongside this until D3 has been removed.
+ * `/start` uses the GitHub App **authorize** URL — this is identity only
+ * (sign-in / re-auth). For a user who already has the App installed the
+ * callback may also carry an `installation_id`, but for a user who has NOT
+ * installed it the authorize URL never surfaces the install dialog and
+ * never returns an `installation_id` (codex P1-1; see
+ * `services/github-app.ts`). So sign-in must not be relied on to install
+ * the App. The reliable install entry is `installations/new`, exposed at
+ * `GET /orgs/:orgId/github-app-installation/install-url` and surfaced both
+ * in onboarding's "Connect your code" step and Settings → GitHub. After
+ * that dialog GitHub redirects back here with `code + state +
+ * installation_id`, which the callback verifies and binds.
  *
  * `dev-callback` bypasses GitHub entirely; gated to non-production.
  *

--- a/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
+++ b/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { ALLOWED_POST_INSTALL_NEXT, resolvePostInstallNext } from "../github-app.js";
+
+/**
+ * The install-url endpoint bakes its post-install `next` into a signed OAuth
+ * state JWT that the callback honors *without re-validation*. So the only
+ * gate against an open redirect is this allowlist — keep it tight.
+ */
+describe("resolvePostInstallNext", () => {
+  it("passes through allowlisted internal paths", () => {
+    expect(resolvePostInstallNext("/onboarding")).toBe("/onboarding");
+    expect(resolvePostInstallNext("/settings/github")).toBe("/settings/github");
+  });
+
+  it("falls back to Settings for an absent value", () => {
+    expect(resolvePostInstallNext(undefined)).toBe("/settings/github");
+  });
+
+  it("falls back to Settings for anything off the allowlist (no open redirect)", () => {
+    expect(resolvePostInstallNext("https://evil.example.com")).toBe("/settings/github");
+    expect(resolvePostInstallNext("//evil.example.com")).toBe("/settings/github");
+    expect(resolvePostInstallNext("/onboarding/../settings")).toBe("/settings/github");
+    expect(resolvePostInstallNext("/arbitrary")).toBe("/settings/github");
+    expect(resolvePostInstallNext("")).toBe("/settings/github");
+  });
+
+  it("only allows the two known internal destinations", () => {
+    expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual(["/onboarding", "/settings/github"]);
+  });
+});

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -24,12 +24,32 @@ import { buildCookie } from "../auth/oauth-cookie.js";
 
 /**
  * Where the post-install OAuth callback lands the user once the install
- * dialog is done — back on the Settings → GitHub panel so it can
+ * dialog is done. Default: back on the Settings → GitHub panel so it can
  * re-render with the now-bound installation. The callback resolves the
  * actual destination from the signed state JWT, not from a query param,
  * so this is tamper-proof.
  */
 const POST_INSTALL_NEXT = "/settings/github";
+
+/**
+ * Internal paths the install flow is allowed to return to. The onboarding
+ * flow surfaces the App-install CTA too (the only reliable `installations/new`
+ * entry), and wants the user back in setup rather than dumped on Settings.
+ * Allowlisted — never reflect a caller-supplied path verbatim into the
+ * signed redirect, so a crafted `?next=` can't become an open redirect.
+ */
+export const ALLOWED_POST_INSTALL_NEXT: ReadonlySet<string> = new Set([POST_INSTALL_NEXT, "/onboarding"]);
+
+/**
+ * Resolve the post-install redirect destination from a caller-supplied
+ * `?next=`. Anything not on the allowlist falls back to the Settings
+ * default — the value is baked into the signed OAuth state and honored by
+ * the callback without re-validation, so it must never reflect an arbitrary
+ * path (open-redirect / phishing surface). Exported for unit testing.
+ */
+export function resolvePostInstallNext(requested: string | undefined): string {
+  return requested && ALLOWED_POST_INSTALL_NEXT.has(requested) ? requested : POST_INSTALL_NEXT;
+}
 
 /**
  * Class B — `/api/v1/orgs/:orgId/github-app-installation`.
@@ -102,7 +122,7 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   // GitHub shows the install dialog, the user picks repos, GitHub
   // redirects to `/auth/github/callback?code=…&state=…&installation_id=…`,
   // and the callback verifies the state cookie + binds the install.
-  app.get<{ Params: { orgId: string } }>("/install-url", async (request, reply) => {
+  app.get<{ Params: { orgId: string }; Querystring: { next?: string } }>("/install-url", async (request, reply) => {
     // Admin-gated: the resolved scope is the org the install binds to.
     const scope = await requireOrgAdmin(request, app.db);
     const appCfg = app.config.oauth?.githubApp;
@@ -121,9 +141,13 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
     // primary org (codex P1-3) — an admin in org B installing the App must
     // end up bound to org B. The callback re-checks the caller is still an
     // admin of that org before honoring it.
-    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, POST_INSTALL_NEXT, {
-      targetOrganizationId: scope.organizationId,
-    });
+    const { token, nonce } = await signOAuthState(
+      app.config.secrets.jwtSecret,
+      resolvePostInstallNext(request.query.next),
+      {
+        targetOrganizationId: scope.organizationId,
+      },
+    );
     reply.header(
       "Set-Cookie",
       buildCookie({

--- a/packages/web/src/api/github-app.ts
+++ b/packages/web/src/api/github-app.ts
@@ -43,10 +43,16 @@ export async function getGithubAppInstallation(organizationId: string): Promise<
  *
  * Throws `ApiError` with `status === 503` when the operator hasn't set
  * `FIRST_TREE_GITHUB_APP_SLUG`; the panel surfaces that as a hint.
+ *
+ * `next` controls where GitHub bounces the user after the install dialog
+ * (baked into the signed state server-side). Defaults to Settings → GitHub;
+ * the onboarding flow passes `/onboarding` so the user lands back in setup.
+ * The server allowlists the value, so an arbitrary string is ignored.
  */
-export async function getGithubAppInstallUrl(organizationId: string): Promise<string> {
+export async function getGithubAppInstallUrl(organizationId: string, next?: string): Promise<string> {
+  const qs = next ? `?next=${encodeURIComponent(next)}` : "";
   const { installUrl } = await api.get<{ installUrl: string }>(
-    `/orgs/${organizationId}/github-app-installation/install-url`,
+    `/orgs/${organizationId}/github-app-installation/install-url${qs}`,
   );
   return installUrl;
 }

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -16,6 +16,7 @@ import { ContextPage } from "./pages/context.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
 import { LoginPage } from "./pages/login.js";
 import { OAuthCompletePage } from "./pages/oauth-complete.js";
+import { OnboardingPage } from "./pages/onboarding/onboarding-page.js";
 import { SettingsComputersPage } from "./pages/settings/computers.js";
 import { SettingsGithubPage } from "./pages/settings/github.js";
 import { SettingsIntegrationsPage } from "./pages/settings/integrations.js";
@@ -81,6 +82,10 @@ export function App() {
                 CenterPanel (OnboardingView) — no separate /welcome route, no
                 provider, no banner. */}
               <Route element={<RequireAuth />}>
+                {/* Standalone onboarding — full-screen, outside the workspace
+                    chrome. The workspace root redirects incomplete users
+                    here; this route redirects back once setup is complete. */}
+                <Route path="/onboarding" element={<OnboardingPage />} />
                 <Route
                   element={
                     <PulseProvider>

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -67,12 +67,15 @@ export function LoginPage() {
             <CardTitle className="text-title">
               First Tree <span className="font-normal text-muted-foreground">Hub</span>
             </CardTitle>
+            <p className="text-label text-muted-foreground" style={{ marginTop: "var(--sp-1)" }}>
+              Sign in to set up your team and your first AI teammate.
+            </p>
           </CardHeader>
           <CardContent className="space-y-4">
             <Button asChild className="w-full">
               <a href={githubHref}>
                 <Github className="h-4 w-4" />
-                Continue with GitHub
+                Sign in with GitHub
               </a>
             </Button>
             <p className="text-center text-label text-muted-foreground">

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADMIN_STEPS,
+  clampStepIndex,
+  getStepSequence,
+  INVITEE_STEPS,
+  inferInitialStepIndex,
+  resolveOnboardingPath,
+  shouldEnterOnboarding,
+  shouldLeaveOnboarding,
+  stepVisualState,
+} from "../steps.js";
+
+describe("resolveOnboardingPath", () => {
+  it("admins take the full path", () => {
+    expect(resolveOnboardingPath("admin")).toBe("admin");
+  });
+  it("members and unknown roles take the invitee path", () => {
+    expect(resolveOnboardingPath("member")).toBe("invitee");
+    expect(resolveOnboardingPath(null)).toBe("invitee");
+  });
+});
+
+describe("getStepSequence", () => {
+  it("admin sequence ends at kickoff and starts at team", () => {
+    expect(getStepSequence("admin")).toEqual(ADMIN_STEPS);
+    expect(ADMIN_STEPS[0]).toBe("team");
+    expect(ADMIN_STEPS[ADMIN_STEPS.length - 1]).toBe("kickoff");
+  });
+  it("invitee skips team + code", () => {
+    expect(getStepSequence("invitee")).toEqual(INVITEE_STEPS);
+    expect(INVITEE_STEPS).not.toContain("team");
+    expect(INVITEE_STEPS).not.toContain("connect-code");
+  });
+  it("connect-computer precedes create-agent in both paths (agent needs a computer)", () => {
+    for (const seq of [ADMIN_STEPS, INVITEE_STEPS]) {
+      expect(seq.indexOf("connect-computer")).toBeLessThan(seq.indexOf("create-agent"));
+    }
+  });
+});
+
+describe("inferInitialStepIndex", () => {
+  it("admin: fresh user (connect, unsettled team) starts at team", () => {
+    expect(inferInitialStepIndex("admin", { onboardingStep: "connect", teamSettled: false })).toBe(
+      ADMIN_STEPS.indexOf("team"),
+    );
+  });
+  it("admin: returning user past the team step lands on connect-code", () => {
+    expect(inferInitialStepIndex("admin", { onboardingStep: "connect", teamSettled: true })).toBe(
+      ADMIN_STEPS.indexOf("connect-code"),
+    );
+  });
+  it("create_agent state → the create-agent step (computer already exists)", () => {
+    expect(inferInitialStepIndex("admin", { onboardingStep: "create_agent", teamSettled: true })).toBe(
+      ADMIN_STEPS.indexOf("create-agent"),
+    );
+  });
+  it("completed state → the final kickoff step", () => {
+    expect(inferInitialStepIndex("admin", { onboardingStep: "completed", teamSettled: true })).toBe(
+      ADMIN_STEPS.indexOf("kickoff"),
+    );
+    expect(inferInitialStepIndex("invitee", { onboardingStep: "completed", teamSettled: true })).toBe(
+      INVITEE_STEPS.indexOf("kickoff"),
+    );
+  });
+  it("invitee always starts at welcome when no computer exists", () => {
+    expect(inferInitialStepIndex("invitee", { onboardingStep: "connect", teamSettled: true })).toBe(0);
+    expect(inferInitialStepIndex("invitee", { onboardingStep: null, teamSettled: false })).toBe(0);
+  });
+});
+
+describe("clampStepIndex", () => {
+  it("clamps below 0 and above the last index", () => {
+    expect(clampStepIndex("admin", -3)).toBe(0);
+    expect(clampStepIndex("admin", 99)).toBe(ADMIN_STEPS.length - 1);
+    expect(clampStepIndex("invitee", 2)).toBe(2);
+  });
+});
+
+describe("stepVisualState", () => {
+  it("is complete before, active at, pending after the cursor", () => {
+    expect(stepVisualState(0, 2)).toBe("complete");
+    expect(stepVisualState(2, 2)).toBe("active");
+    expect(stepVisualState(3, 2)).toBe("pending");
+  });
+});
+
+describe("shouldEnterOnboarding", () => {
+  const base = {
+    meLoaded: true,
+    onboardingStep: "connect" as const,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: null,
+  };
+  it("redirects a fresh incomplete user", () => {
+    expect(shouldEnterOnboarding(base)).toBe(true);
+  });
+  it("redirects a user whose agent exists but hasn't kicked off (step completed, not dismissed)", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: "completed" })).toBe(true);
+  });
+  it("does not redirect before /me loads", () => {
+    expect(shouldEnterOnboarding({ ...base, meLoaded: false })).toBe(false);
+  });
+  it("does not redirect on a transient /me failure (null step)", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: null })).toBe(false);
+  });
+  it("does not redirect a dismissed user (they chose to hide it)", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingDismissedAt: "2026-05-22T00:00:00Z" })).toBe(false);
+  });
+  it("does not redirect a completed user", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingCompletedAt: "2026-05-22T00:00:00Z" })).toBe(false);
+  });
+});
+
+describe("shouldLeaveOnboarding", () => {
+  const base = {
+    meLoaded: true,
+    onboardingStep: "connect" as const,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: null,
+  };
+  it("leaves only once terminally complete", () => {
+    expect(shouldLeaveOnboarding({ ...base, onboardingCompletedAt: "2026-05-22T00:00:00Z" })).toBe(true);
+  });
+  it("stays for an incomplete user", () => {
+    expect(shouldLeaveOnboarding(base)).toBe(false);
+  });
+  it("stays for a merely-dismissed user who deliberately returned via Resume", () => {
+    expect(shouldLeaveOnboarding({ ...base, onboardingDismissedAt: "2026-05-22T00:00:00Z" })).toBe(false);
+  });
+  it("waits for /me before deciding", () => {
+    expect(shouldLeaveOnboarding({ ...base, meLoaded: false, onboardingCompletedAt: "x" })).toBe(false);
+  });
+});

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -1,0 +1,141 @@
+/**
+ * Every user-facing string in the onboarding flow, in one place.
+ *
+ * Goal: a complete beginner — someone who has never heard "repo", "runtime",
+ * "context tree", or "binding" — can read these and know what to do and why.
+ * The vocabulary is deliberately small: "team", "your code", "a computer",
+ * "AI teammate", "team knowledge". Implementation words never leak into the
+ * UI; they stay in code and in the agent-facing bootstrap prose.
+ *
+ * Centralised so copy review is a single file, and so it can be unit tested
+ * (no marketing word slips a banned term past review).
+ */
+
+import type { StepId } from "./steps.js";
+
+export type StepCopy = {
+  /** Short label shown in the left progress rail. */
+  label: string;
+  /** Heading at the top of the content column. */
+  title: string;
+  /** One plain-language sentence: why this step exists. */
+  why: string;
+  /** What the user will have once this step is done (shown in the side panel). */
+  outcomes: readonly string[];
+};
+
+export const STEP_COPY: Record<StepId, StepCopy> = {
+  team: {
+    label: "Your team",
+    title: "Name your team",
+    why: "This is the shared space where you, your teammates, and your AI teammates work together.",
+    outcomes: ["A team others can join", "You can rename it or invite people anytime"],
+  },
+  "connect-code": {
+    label: "Your code",
+    title: "Connect your code",
+    why: "Give your AI teammate access to a project so it can actually help — read the code, suggest changes, and open requests for you to review.",
+    outcomes: [
+      "Your AI teammate can see the project you pick",
+      "Nothing ships without you — every change comes back as a request you approve",
+    ],
+  },
+  "connect-computer": {
+    label: "Your computer",
+    title: "Connect a computer",
+    why: "Your AI teammate runs on a real computer — yours or a shared one — so it can do real work, not just chat.",
+    outcomes: ["A computer linked to your team", "Somewhere for your AI teammate to run"],
+  },
+  "create-agent": {
+    label: "AI teammate",
+    title: "Create your AI teammate",
+    why: "Add an AI member to your team. Give it a name and choose who can work with it.",
+    outcomes: ["Your first AI teammate, ready to talk", "You can add more teammates later"],
+  },
+  kickoff: {
+    label: "Get started",
+    title: "Set up your team knowledge",
+    why: "Give your AI teammate a shared knowledge base about your project, so it works with real context instead of starting from scratch every time.",
+    outcomes: [
+      "A shared knowledge base your team and its AI teammates build on",
+      "Your AI teammate starts its first task and tells you what to review",
+    ],
+  },
+  welcome: {
+    label: "Welcome",
+    title: "Welcome to the team",
+    why: "Your team is already set up. Let's get your own AI teammate working in a couple of quick steps.",
+    outcomes: ["You're in the team", "Next: connect a computer and create your AI teammate"],
+  },
+};
+
+/** Shared phrases reused across steps so wording stays consistent. */
+export const COPY = {
+  /** Title shown across the flow's top chrome. */
+  productName: "First Tree",
+  flowEyebrow: "Getting started",
+  continue: "Continue",
+  back: "Back",
+  skipForNow: "Skip for now",
+  finishLater: "I'll finish later",
+  hideSetup: "Hide setup",
+  /** Generic reassurance shown wherever GitHub access is requested. */
+  reviewReassurance: "We never change your code without asking — every change comes back as a request you review.",
+  /** connect-code states */
+  connectCode: {
+    cta: "Connect on GitHub",
+    waiting: "Waiting for GitHub…",
+    connected: "Connected",
+    pickProject: "Which project should your AI teammate help with?",
+    noRepos: "No projects found on your GitHub account yet.",
+    reconnect: "Reconnect GitHub with project access",
+    notConfigured:
+      "Code connection isn't set up on this server yet. You can continue now and connect a project later from Settings.",
+    notAdmin: "Only a team admin can connect code. Ask an admin to finish this, or continue for now.",
+    continueWithout: "Continue without connecting code",
+  },
+  /** connect-computer states */
+  connectComputer: {
+    instruction: "Open a terminal on the computer you want to use and run this:",
+    waiting: "Waiting for your computer…",
+    connected: "connected",
+    noRuntime:
+      "This computer is connected, but no AI runtime is ready on it yet. Install Claude Code (or Codex) and sign in, then it'll show up here.",
+    detecting: "Checking what's installed…",
+  },
+  /** create-agent states */
+  createAgent: {
+    nameLabel: "What should we call your AI teammate?",
+    creating: "Setting up your AI teammate…",
+    creatingHint: "Usually about 10 seconds",
+    timeoutTitle: "This is taking longer than expected.",
+    retry: "Try again",
+  },
+  /** kickoff states */
+  kickoff: {
+    existingTitle: "Do you already have team knowledge set up?",
+    createOption: "Create new team knowledge",
+    createHint: "Recommended — your AI teammate sets it up for you",
+    existingOption: "Connect to existing team knowledge",
+    existingHint: "Paste the link if your team already has one",
+    existingUrlLabel: "Team knowledge link",
+    start: "Start",
+    starting: "Getting your AI teammate started…",
+    invalidUrl: "That doesn't look like a valid link. It should start with https://",
+  },
+  /** invitee states */
+  invitee: {
+    waitingTitle: "Your team is still being set up",
+    waitingBody:
+      "An admin hasn't finished setting up your team's code and knowledge base yet. Once they do, you can connect your AI teammate. You can start chatting in the meantime.",
+    confirmTitle: "Your team is ready",
+    confirmBody: "Your team already set up its projects and knowledge base. Pick what your AI teammate should work on.",
+  },
+  /** failure recovery, shared */
+  errors: {
+    generic: "Something went wrong. Try again in a moment.",
+    chatFailed: "Couldn't start the first task. Try again.",
+    agentFailed: "Couldn't create your AI teammate. Try again.",
+    noAgent: "We couldn't find your AI teammate. Go back a step and create one.",
+  },
+} as const;

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -1,0 +1,242 @@
+import { Check, Copy, ExternalLink, Lock } from "lucide-react";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import type { GithubRepo } from "../../api/github.js";
+
+/** Checklist of outcomes for the side panel: "what you'll have after this". */
+export function OutcomeList({ items }: { items: readonly string[] }) {
+  return (
+    <ul className="flex flex-col" style={{ gap: "var(--sp-2_5)", margin: 0, padding: 0, listStyle: "none" }}>
+      {items.map((item) => (
+        <li key={item} className="flex items-start text-label" style={{ gap: "var(--sp-2)", color: "var(--fg-3)" }}>
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center justify-center"
+            style={{
+              width: "var(--sp-4)",
+              height: "var(--sp-4)",
+              flexShrink: 0,
+              marginTop: "var(--sp-0_5)",
+              borderRadius: 999,
+              background: "color-mix(in oklch, var(--accent) 14%, transparent)",
+              color: "var(--accent)",
+            }}
+          >
+            <Check className="h-3 w-3" />
+          </span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Error / warning note. Tone "error" (red) or "info" (neutral accent). */
+export function FlowNote({ children, tone = "error" }: { children: ReactNode; tone?: "error" | "info" }) {
+  const color = tone === "error" ? "var(--state-error)" : "var(--fg-2)";
+  const bg =
+    tone === "error"
+      ? "color-mix(in oklch, var(--state-error) 12%, transparent)"
+      : "color-mix(in oklch, var(--accent) 8%, transparent)";
+  const border =
+    tone === "error"
+      ? "color-mix(in oklch, var(--state-error) 28%, transparent)"
+      : "color-mix(in oklch, var(--accent) 22%, transparent)";
+  return (
+    <div
+      className="text-label"
+      style={{
+        padding: "var(--sp-2_5) var(--sp-3)",
+        background: bg,
+        border: `var(--hairline) solid ${border}`,
+        borderRadius: "var(--radius-input)",
+        color,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Waiting / connected status row with a pulsing or solid dot. */
+export function StatusRow({ state, label }: { state: "waiting" | "ok"; label: ReactNode }) {
+  return (
+    <div
+      className="inline-flex items-center text-label"
+      style={{
+        gap: "var(--sp-2)",
+        color: state === "ok" ? "color-mix(in oklch, var(--accent) 28%, var(--fg))" : "var(--fg-3)",
+      }}
+    >
+      {state === "ok" ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <span aria-hidden="true" style={{ position: "relative", display: "inline-block", width: 8, height: 8 }}>
+          <span style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--accent)" }} />
+          <span
+            style={{
+              position: "absolute",
+              inset: -3,
+              borderRadius: "50%",
+              border: "var(--hairline) solid var(--accent)",
+              animation: "ring-pulse 1.8s infinite",
+              opacity: 0.55,
+            }}
+          />
+        </span>
+      )}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+/**
+ * The terminal one-liner the user pastes to connect a computer. Shows a
+ * shortened preview but copies the full multi-line command (npm install +
+ * login). Lifted from the legacy Step2Body CommandBox.
+ */
+export function CommandBox({ command }: { command: string | null }) {
+  const [copied, setCopied] = useState(false);
+  const lines = command ? command.split("\n") : [];
+  const connectLine = lines.find((l) => l.startsWith("first-tree")) ?? "";
+  const prefix = "first-tree login ";
+  const preview = connectLine.startsWith(prefix)
+    ? `${prefix}${connectLine.slice(prefix.length, prefix.length + 22)}…`
+    : connectLine.length > 52
+      ? `${connectLine.slice(0, 52)}…`
+      : connectLine;
+
+  const handleCopy = async (): Promise<void> => {
+    if (!command) return;
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+      <pre
+        className="mono text-label"
+        title={connectLine}
+        style={{
+          flex: 1,
+          minHeight: 38,
+          margin: 0,
+          padding: "var(--sp-2_5) var(--sp-3)",
+          background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
+          border: "var(--hairline) solid color-mix(in oklch, var(--border-faint) 58%, transparent)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg-2)",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          minWidth: 0,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {preview || "Generating command…"}
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={!command}
+        className="inline-flex items-center justify-center text-label font-medium"
+        style={{
+          gap: "var(--sp-1_5)",
+          padding: "0 var(--sp-3)",
+          minHeight: 38,
+          background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
+          border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg-2)",
+          cursor: command ? "pointer" : "not-allowed",
+          opacity: command ? 1 : 0.6,
+        }}
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Multi-select project picker over the user's GitHub repos. Identity key is
+ * `cloneUrl` (what gets bound). Beginner-friendly: shows the familiar
+ * `owner/name`, a private padlock, and an open-in-GitHub affordance.
+ */
+export function RepoPicker({
+  repos,
+  selected,
+  onToggle,
+}: {
+  repos: readonly GithubRepo[];
+  selected: readonly string[];
+  onToggle: (cloneUrl: string) => void;
+}) {
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-1)",
+        maxHeight: 320,
+        overflowY: "auto",
+        padding: "var(--sp-1)",
+        border: "var(--hairline) solid var(--border-faint)",
+        borderRadius: "var(--radius-input)",
+      }}
+    >
+      {repos.map((repo) => {
+        const active = selected.includes(repo.cloneUrl);
+        return (
+          <label
+            key={repo.cloneUrl}
+            className="flex items-center text-body"
+            style={{
+              gap: "var(--sp-2_5)",
+              padding: "var(--sp-2) var(--sp-2_5)",
+              borderRadius: "var(--radius-input)",
+              cursor: "pointer",
+              background: active ? "color-mix(in oklch, var(--accent) 8%, transparent)" : "transparent",
+              color: active ? "var(--fg)" : "var(--fg-2)",
+            }}
+          >
+            <input type="checkbox" checked={active} onChange={() => onToggle(repo.cloneUrl)} className="sr-only" />
+            <span
+              aria-hidden="true"
+              className="inline-flex items-center justify-center"
+              style={{
+                width: "var(--sp-4)",
+                height: "var(--sp-4)",
+                flexShrink: 0,
+                borderRadius: "var(--radius-input)",
+                border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-strong)",
+                background: active ? "var(--accent)" : "transparent",
+                color: "var(--bg)",
+              }}
+            >
+              {active && <Check className="h-3 w-3" />}
+            </span>
+            <span
+              className="font-medium"
+              style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            >
+              {repo.fullName}
+            </span>
+            {repo.private && <Lock className="h-3.5 w-3.5" style={{ color: "var(--fg-4)", flexShrink: 0 }} />}
+            <a
+              href={repo.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              style={{ color: "var(--fg-4)", flexShrink: 0, display: "inline-flex" }}
+              aria-label={`Open ${repo.fullName} on GitHub`}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -1,0 +1,226 @@
+import type { AgentVisibility } from "@first-tree/shared";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { clampStepIndex, getStepSequence, inferInitialStepIndex, type OnboardingPath, type StepId } from "./steps.js";
+import { type AgentCreationPhase, type CreateAgentArgs, useAgentCreation } from "./use-agent-creation.js";
+import { type ComputerConnection, useComputerConnection } from "./use-computer-connection.js";
+
+export type TreeMode = "new" | "existing";
+
+export type OnboardingFlowValue = {
+  path: OnboardingPath;
+  sequence: readonly StepId[];
+  activeIndex: number;
+  activeStep: StepId;
+  goNext: () => void;
+  goTo: (index: number) => void;
+
+  organizationId: string | null;
+  memberId: string | null;
+  role: string | null;
+  username: string | null;
+  teamDisplayName: string | null;
+  orgHasOtherMembers: boolean;
+
+  computer: ComputerConnection;
+
+  agentDisplayName: string;
+  setAgentDisplayName: (next: string) => void;
+  visibility: AgentVisibility;
+  setVisibility: (next: AgentVisibility) => void;
+  agentPhase: AgentCreationPhase;
+  agentError: string | null;
+  createAgent: (args: CreateAgentArgs) => Promise<void>;
+  retryAgent: () => Promise<void>;
+  createdAgentUuid: string | null;
+
+  selectedRepoUrls: string[];
+  setSelectedRepoUrls: (next: string[]) => void;
+  treeMode: TreeMode;
+  setTreeMode: (next: TreeMode) => void;
+  treeUrl: string;
+  setTreeUrl: (next: string) => void;
+
+  /** Mark setup finished and drop the user into their first chat. */
+  completeAndEnterChat: (chatId: string) => Promise<void>;
+  /** Hide setup and go to the normal workspace (resumable via Settings). */
+  finishLater: () => Promise<void>;
+};
+
+const OnboardingFlowContext = createContext<OnboardingFlowValue | null>(null);
+
+// Remember the active step for the tab's lifetime so a full-page round-trip
+// (notably the GitHub App install redirect to github.com and back) returns
+// the user exactly where they were instead of resetting to step 1.
+const STEP_KEY = (path: OnboardingPath) => `onboarding:stepIndex:${path}`;
+
+function readPersistedStep(path: OnboardingPath): number | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.sessionStorage.getItem(STEP_KEY(path));
+  if (raw === null) return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) ? n : null;
+}
+
+function writePersistedStep(path: OnboardingPath, index: number): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(STEP_KEY(path), String(index));
+}
+
+function clearPersistedStep(path: OnboardingPath): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(STEP_KEY(path));
+}
+
+export function OnboardingFlowProvider({ path, children }: { path: OnboardingPath; children: ReactNode }) {
+  const navigate = useNavigate();
+  const {
+    organizationId,
+    memberId,
+    role,
+    user,
+    teamDisplayName,
+    orgHasOtherMembers,
+    onboardingStep,
+    refreshMe,
+    dismissOnboarding,
+    markOnboardingCompleted,
+  } = useAuth();
+
+  const sequence = getStepSequence(path);
+  const [activeIndex, setActiveIndex] = useState<number>(() => {
+    const inferred = inferInitialStepIndex(path, {
+      onboardingStep,
+      // We can't observe finer team-rename state synchronously; the team
+      // step is cheap to revisit, so default returning admins past it only
+      // when the server already proves a computer exists.
+      teamSettled: onboardingStep !== "connect",
+    });
+    // Resume a persisted position, but never drop *behind* what the server
+    // can prove (so a stale marker can't strand a user before their real
+    // progress).
+    const persisted = readPersistedStep(path);
+    return clampStepIndex(path, persisted === null ? inferred : Math.max(inferred, persisted));
+  });
+
+  useEffect(() => {
+    writePersistedStep(path, activeIndex);
+  }, [path, activeIndex]);
+
+  const goTo = useCallback((index: number) => setActiveIndex(clampStepIndex(path, index)), [path]);
+  const goNext = useCallback(() => setActiveIndex((i) => clampStepIndex(path, i + 1)), [path]);
+
+  const activeStep = sequence[clampStepIndex(path, activeIndex)] as StepId;
+
+  // The computer poll only needs to run on the two steps that depend on it.
+  const computerEnabled = activeStep === "connect-computer" || activeStep === "create-agent";
+  const computer = useComputerConnection(computerEnabled);
+
+  const onAgentOnline = useCallback(() => {
+    void refreshMe();
+    setActiveIndex((i) => clampStepIndex(path, i + 1));
+  }, [refreshMe, path]);
+  const {
+    phase: agentPhase,
+    error: agentError,
+    create: createAgent,
+    retry: retryAgent,
+    createdUuid: createdAgentUuid,
+  } = useAgentCreation(onAgentOnline);
+
+  const [agentDisplayName, setAgentDisplayName] = useState<string>(() =>
+    user?.username ? `${user.username}'s assistant` : "Assistant",
+  );
+  const [visibility, setVisibility] = useState<AgentVisibility>("organization");
+  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
+  const [treeMode, setTreeMode] = useState<TreeMode>("new");
+  const [treeUrl, setTreeUrl] = useState<string>("");
+
+  const completeAndEnterChat = useCallback(
+    async (chatId: string) => {
+      // Hide the inline workspace stepper AND stamp the terminal flag, then
+      // land in the freshly-created chat. Both writes are idempotent.
+      clearPersistedStep(path);
+      await dismissOnboarding();
+      await markOnboardingCompleted();
+      navigate(`/?c=${encodeURIComponent(chatId)}`);
+    },
+    [path, dismissOnboarding, markOnboardingCompleted, navigate],
+  );
+
+  const finishLater = useCallback(async () => {
+    await dismissOnboarding();
+    navigate("/");
+  }, [dismissOnboarding, navigate]);
+
+  const value = useMemo<OnboardingFlowValue>(
+    () => ({
+      path,
+      sequence,
+      activeIndex,
+      activeStep,
+      goNext,
+      goTo,
+      organizationId,
+      memberId,
+      role,
+      username: user?.username ?? null,
+      teamDisplayName,
+      orgHasOtherMembers,
+      computer,
+      agentDisplayName,
+      setAgentDisplayName,
+      visibility,
+      setVisibility,
+      agentPhase,
+      agentError,
+      createAgent,
+      retryAgent,
+      createdAgentUuid,
+      selectedRepoUrls,
+      setSelectedRepoUrls,
+      treeMode,
+      setTreeMode,
+      treeUrl,
+      setTreeUrl,
+      completeAndEnterChat,
+      finishLater,
+    }),
+    [
+      path,
+      sequence,
+      activeIndex,
+      activeStep,
+      goNext,
+      goTo,
+      organizationId,
+      memberId,
+      role,
+      user?.username,
+      teamDisplayName,
+      orgHasOtherMembers,
+      computer,
+      agentDisplayName,
+      visibility,
+      agentPhase,
+      agentError,
+      createAgent,
+      retryAgent,
+      createdAgentUuid,
+      selectedRepoUrls,
+      treeMode,
+      treeUrl,
+      completeAndEnterChat,
+      finishLater,
+    ],
+  );
+
+  return <OnboardingFlowContext.Provider value={value}>{children}</OnboardingFlowContext.Provider>;
+}
+
+export function useOnboardingFlow(): OnboardingFlowValue {
+  const ctx = useContext(OnboardingFlowContext);
+  if (!ctx) throw new Error("useOnboardingFlow must be used within OnboardingFlowProvider");
+  return ctx;
+}

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,0 +1,58 @@
+import { Navigate } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { OnboardingFlowProvider, useOnboardingFlow } from "./onboarding-flow.js";
+import { OnboardingShell } from "./onboarding-shell.js";
+import { ProgressRail } from "./progress-rail.js";
+import { StepConnectCode } from "./steps/step-connect-code.js";
+import { StepConnectComputer } from "./steps/step-connect-computer.js";
+import { StepCreateAgent } from "./steps/step-create-agent.js";
+import { StepKickoff } from "./steps/step-kickoff.js";
+import { StepTeam } from "./steps/step-team.js";
+import { StepWelcome } from "./steps/step-welcome.js";
+import { resolveOnboardingPath, shouldLeaveOnboarding } from "./steps.js";
+
+/**
+ * Standalone, full-screen onboarding flow at `/onboarding`. Lives outside
+ * the workspace chrome (no rail / top bar) so a brand-new user sees one
+ * clear thing at a time. The workspace root (`/`) bounces incomplete users
+ * here; once setup is terminally complete this route bounces back to `/`.
+ */
+export function OnboardingPage() {
+  const { meLoaded, role, onboardingStep, onboardingDismissedAt, onboardingCompletedAt } = useAuth();
+
+  if (!meLoaded) {
+    return <div className="min-h-screen bg-background" />;
+  }
+  if (shouldLeaveOnboarding({ meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt })) {
+    return <Navigate to="/" replace />;
+  }
+
+  const path = resolveOnboardingPath(role);
+  return (
+    <OnboardingFlowProvider path={path}>
+      <OnboardingShell rail={<ProgressRail />}>
+        <OnboardingBody />
+      </OnboardingShell>
+    </OnboardingFlowProvider>
+  );
+}
+
+function OnboardingBody() {
+  const { activeStep } = useOnboardingFlow();
+  switch (activeStep) {
+    case "team":
+      return <StepTeam />;
+    case "connect-code":
+      return <StepConnectCode />;
+    case "connect-computer":
+      return <StepConnectComputer />;
+    case "create-agent":
+      return <StepCreateAgent />;
+    case "kickoff":
+      return <StepKickoff />;
+    case "welcome":
+      return <StepWelcome />;
+    default:
+      return null;
+  }
+}

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+import { FirstTreeLogo } from "../../components/first-tree-logo.js";
+import { COPY, STEP_COPY } from "./copy.js";
+import { OutcomeList } from "./flow-ui.js";
+import { useOnboardingFlow } from "./onboarding-flow.js";
+
+/**
+ * Full-screen onboarding chrome. Three regions:
+ *   - left: the progress rail (which step you're on)
+ *   - center: the active step — heading, one-line "why", and the form
+ *   - right: "what you'll have" once this step is done, plus reassurance
+ *
+ * The center is the only thing that matters on a phone; the rail and the
+ * outcomes panel are progressive enhancement on wider screens. A compact
+ * "Step X of N" line keeps orientation on small screens where the rail is
+ * hidden.
+ */
+export function OnboardingShell({ rail, children }: { rail: ReactNode; children: ReactNode }) {
+  const { activeStep, activeIndex, sequence, finishLater } = useOnboardingFlow();
+  const copy = STEP_COPY[activeStep];
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <header className="flex items-center justify-between" style={{ padding: "var(--sp-4) var(--sp-5)" }}>
+        <span className="inline-flex items-center" style={{ gap: "var(--sp-2)", color: "var(--fg)" }}>
+          <FirstTreeLogo width={22} height={25} />
+          <span className="text-label font-semibold">{COPY.productName}</span>
+        </span>
+        <button
+          type="button"
+          onClick={() => void finishLater()}
+          className="text-label"
+          style={{ background: "transparent", border: 0, cursor: "pointer", color: "var(--fg-4)" }}
+        >
+          {COPY.finishLater}
+        </button>
+      </header>
+
+      <div
+        className="flex-1 w-full mx-auto flex flex-col lg:flex-row"
+        style={{ maxWidth: "68rem", gap: "var(--sp-8)", padding: "var(--sp-4) var(--sp-5) var(--sp-12)" }}
+      >
+        {/* left rail (desktop) */}
+        <aside className="hidden lg:block" style={{ width: "12rem", flexShrink: 0, paddingTop: "var(--sp-4)" }}>
+          {rail}
+        </aside>
+
+        {/* center content */}
+        <main className="flex-1 min-w-0" style={{ maxWidth: "34rem" }}>
+          <p
+            className="text-eyebrow lg:hidden"
+            style={{ margin: "0 0 var(--sp-2)", color: "var(--fg-4)", textTransform: "uppercase" }}
+          >
+            Step {activeIndex + 1} of {sequence.length}
+          </p>
+          <p className="text-eyebrow" style={{ margin: 0, color: "var(--accent)", textTransform: "uppercase" }}>
+            {COPY.flowEyebrow}
+          </p>
+          <h1 className="text-title font-semibold" style={{ margin: "var(--sp-2) 0 var(--sp-2)", color: "var(--fg)" }}>
+            {copy.title}
+          </h1>
+          <p className="text-body" style={{ margin: "0 0 var(--sp-6)", color: "var(--fg-3)" }}>
+            {copy.why}
+          </p>
+          {children}
+        </main>
+
+        {/* right outcomes panel (wide screens) */}
+        <aside className="hidden xl:block" style={{ width: "16rem", flexShrink: 0, paddingTop: "var(--sp-9)" }}>
+          <div
+            style={{
+              padding: "var(--sp-4)",
+              borderRadius: "var(--radius-card, var(--radius-input))",
+              background: "color-mix(in oklch, var(--bg-raised) 40%, transparent)",
+              border: "var(--hairline) solid var(--border-faint)",
+            }}
+          >
+            <p className="text-label font-semibold" style={{ margin: "0 0 var(--sp-3)", color: "var(--fg-2)" }}>
+              What you'll have
+            </p>
+            <OutcomeList items={copy.outcomes} />
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/progress-rail.tsx
+++ b/packages/web/src/pages/onboarding/progress-rail.tsx
@@ -1,0 +1,97 @@
+import { Check } from "lucide-react";
+import { STEP_COPY } from "./copy.js";
+import { useOnboardingFlow } from "./onboarding-flow.js";
+import { stepVisualState } from "./steps.js";
+
+/**
+ * Vertical progress rail down the left of the onboarding shell. Shows every
+ * step, the one you're on, and the ones you've finished. Finished steps are
+ * clickable so the user can step back to review or change an answer; future
+ * steps are inert (no skipping ahead).
+ */
+export function ProgressRail() {
+  const { sequence, activeIndex, goTo } = useOnboardingFlow();
+
+  return (
+    <ol className="flex flex-col" style={{ gap: 0, margin: 0, padding: 0, listStyle: "none" }}>
+      {sequence.map((id, index) => {
+        const state = stepVisualState(index, activeIndex);
+        const copy = STEP_COPY[id];
+        const isLast = index === sequence.length - 1;
+        const clickable = state === "complete";
+        return (
+          <li key={id} className="flex" style={{ gap: "var(--sp-3)" }}>
+            {/* circle + connector column */}
+            <div className="flex flex-col items-center" style={{ width: "var(--sp-5)" }}>
+              <span
+                aria-hidden="true"
+                className="mono text-caption inline-flex items-center justify-center"
+                style={{
+                  width: "var(--sp-5)",
+                  height: "var(--sp-5)",
+                  flexShrink: 0,
+                  borderRadius: 999,
+                  background: state === "pending" ? "var(--bg)" : "color-mix(in oklch, var(--accent) 10%, var(--bg))",
+                  border:
+                    state === "pending"
+                      ? "var(--hairline) solid var(--border-faint)"
+                      : `var(--hairline) solid var(--accent)`,
+                  color: state === "pending" ? "var(--fg-4)" : "var(--accent)",
+                  fontWeight: state === "active" ? 600 : 400,
+                }}
+              >
+                {state === "complete" ? <Check className="h-3 w-3" /> : index + 1}
+              </span>
+              {!isLast && (
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: "var(--hairline)",
+                    flex: 1,
+                    minHeight: "var(--sp-5)",
+                    margin: "var(--sp-1) 0",
+                    background:
+                      state === "complete"
+                        ? "var(--accent)"
+                        : "color-mix(in oklch, var(--border-faint) 60%, transparent)",
+                  }}
+                />
+              )}
+            </div>
+
+            {/* label */}
+            <div style={{ paddingBottom: "var(--sp-4)", paddingTop: "var(--sp-0_5)" }}>
+              {clickable ? (
+                <button
+                  type="button"
+                  onClick={() => goTo(index)}
+                  className="text-label font-medium"
+                  style={{
+                    background: "transparent",
+                    border: 0,
+                    padding: 0,
+                    cursor: "pointer",
+                    color: "var(--fg-2)",
+                    textAlign: "left",
+                  }}
+                >
+                  {copy.label}
+                </button>
+              ) : (
+                <span
+                  className="text-label"
+                  style={{
+                    color: state === "active" ? "var(--fg)" : "var(--fg-4)",
+                    fontWeight: state === "active" ? 600 : 400,
+                  }}
+                >
+                  {copy.label}
+                </span>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/packages/web/src/pages/onboarding/resolve-agent.ts
+++ b/packages/web/src/pages/onboarding/resolve-agent.ts
@@ -1,0 +1,33 @@
+import { listManagedAgents, type ManagedAgent } from "../../api/agents.js";
+import { readOnboardingAgentUuid } from "../../utils/onboarding-flags.js";
+
+/**
+ * Find the AI teammate the kickoff step should act on.
+ *
+ * Priority:
+ *   1. The exact agent created earlier this session (uuid stashed by the
+ *      create-agent step) — survives revisits where list order is unspecified.
+ *   2. The most recently created managed non-human agent (uuid v7 is
+ *      time-ordered, so a descending string sort puts the newest first).
+ *
+ * Mirrors the legacy `resolveOnboardingAgent` in step3-intro-body.tsx so
+ * behaviour is identical; extracted here so the standalone flow doesn't
+ * depend on the legacy view.
+ */
+export async function resolveOnboardingAgent(): Promise<ManagedAgent> {
+  const agents = await listManagedAgents();
+  const managed = agents.filter((a) => a.type !== "human");
+
+  const stashed = readOnboardingAgentUuid();
+  if (stashed) {
+    const hit = managed.find((a) => a.uuid === stashed);
+    if (hit) return hit;
+  }
+
+  const newestFirst = [...managed].sort((a, b) => b.uuid.localeCompare(a.uuid));
+  const agent = newestFirst[0];
+  if (!agent) {
+    throw new Error("No AI teammate found — create one first.");
+  }
+  return agent;
+}

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure logic for the standalone `/onboarding` flow.
+ *
+ * The React layer (onboarding-page.tsx) stays thin: it owns side effects
+ * (API calls, navigation) and renders the active step. Every *decision* —
+ * which path the user is on, which step is active, whether to redirect in
+ * or out of the flow — lives here as a pure function so it can be unit
+ * tested without a DOM (matching this package's `.test.ts` convention).
+ *
+ * Two paths:
+ *   - "admin"   — the team creator (org admin). Walks the full ceremony:
+ *                 name the team, connect code, connect a computer, create
+ *                 the AI teammate, and kick off the first task.
+ *   - "invitee" — joining a team an admin has already set up. Skips the
+ *                 team + code steps (the team already owns those) and just
+ *                 connects a computer, creates their teammate, and starts.
+ *
+ * Step ids are deliberately product-facing, jargon-free concepts — never
+ * "tree" / "binding" / "runtime" / "installation". The user-facing strings
+ * live in copy.ts.
+ */
+
+export const ADMIN_STEPS = ["team", "connect-code", "connect-computer", "create-agent", "kickoff"] as const;
+export const INVITEE_STEPS = ["welcome", "connect-computer", "create-agent", "kickoff"] as const;
+
+export type AdminStepId = (typeof ADMIN_STEPS)[number];
+export type InviteeStepId = (typeof INVITEE_STEPS)[number];
+export type StepId = AdminStepId | InviteeStepId;
+
+export type OnboardingPath = "admin" | "invitee";
+
+/** Server-inferred coarse onboarding state from `/me` (see api/me.ts). */
+export type ServerOnboardingStep = "connect" | "create_agent" | "completed" | null;
+
+export type StepVisualState = "complete" | "active" | "pending";
+
+/**
+ * Resolve which path the user is on. The team creator is the org admin; a
+ * member who was invited into an already-created team takes the lighter
+ * invitee path. This mirrors the role split the legacy Step 3 used
+ * (`role === "admin"` → admin body, else invitee body) so behaviour is
+ * unchanged for existing accounts — only the surface around it differs.
+ */
+export function resolveOnboardingPath(role: string | null): OnboardingPath {
+  return role === "admin" ? "admin" : "invitee";
+}
+
+/** The ordered step ids for a path. */
+export function getStepSequence(path: OnboardingPath): readonly StepId[] {
+  return path === "admin" ? ADMIN_STEPS : INVITEE_STEPS;
+}
+
+export type InitialStepFacts = {
+  onboardingStep: ServerOnboardingStep;
+  /**
+   * `true` when the team no longer carries its auto-generated default name,
+   * OR the user already confirmed the team step this session. Lets a
+   * returning admin skip straight past "name your team".
+   */
+  teamSettled: boolean;
+};
+
+/**
+ * Pick the step to land on when the page first mounts (or the user reloads
+ * mid-flow). Driven by the few facts the server can vouch for:
+ *
+ *   - `completed` (client + agent both exist) → the final kickoff step
+ *   - `create_agent` (client exists, no agent) → create the teammate
+ *   - `connect` / null (no client yet) → the earliest unfinished setup step
+ *
+ * Finer progress (did they finish connect-code? connect-computer?) isn't
+ * server-observable, so the wizard advances those locally via Continue;
+ * this only needs to avoid dropping a returning user *behind* where the
+ * server proves they already are.
+ */
+export function inferInitialStepIndex(path: OnboardingPath, facts: InitialStepFacts): number {
+  const seq = getStepSequence(path);
+  if (facts.onboardingStep === "completed") return seq.indexOf("kickoff");
+  if (facts.onboardingStep === "create_agent") return seq.indexOf("create-agent");
+  // "connect" or null — no computer connected yet.
+  if (path === "admin") {
+    return facts.teamSettled ? seq.indexOf("connect-code") : 0;
+  }
+  return 0; // invitee → welcome
+}
+
+/** Clamp an arbitrary index into the path's valid range. */
+export function clampStepIndex(path: OnboardingPath, index: number): number {
+  const last = getStepSequence(path).length - 1;
+  if (index < 0) return 0;
+  if (index > last) return last;
+  return index;
+}
+
+/**
+ * Visual state for the stepper pip at `index`, given the active index.
+ * The flow is a linear wizard: everything before the cursor is done,
+ * everything after is not yet reachable.
+ */
+export function stepVisualState(index: number, activeIndex: number): StepVisualState {
+  if (index < activeIndex) return "complete";
+  if (index === activeIndex) return "active";
+  return "pending";
+}
+
+export type OnboardingGateFacts = {
+  /** `false` until `/me` has resolved at least once. */
+  meLoaded: boolean;
+  onboardingStep: ServerOnboardingStep;
+  onboardingDismissedAt: string | null;
+  onboardingCompletedAt: string | null;
+};
+
+/**
+ * Should the workspace root (`/`) bounce an authenticated user into the
+ * standalone onboarding flow?
+ *
+ * Yes only when: `/me` has loaded, the server reports an onboarding state
+ * (so we're not looping on a transient `/me` failure), and the user has
+ * neither completed setup (terminal) nor explicitly hidden it. A user who
+ * dismissed onboarding lands in the normal workspace and reaches setup
+ * again through Settings → Onboarding → Resume.
+ */
+export function shouldEnterOnboarding(facts: OnboardingGateFacts): boolean {
+  if (!facts.meLoaded) return false;
+  if (facts.onboardingStep === null) return false;
+  if (facts.onboardingCompletedAt) return false;
+  if (facts.onboardingDismissedAt) return false;
+  return true;
+}
+
+/**
+ * Should the `/onboarding` route bounce the user back to the workspace?
+ *
+ * Only once setup is terminally complete — so a finished user can't get
+ * stranded on the wizard, while a still-incomplete (or merely dismissed,
+ * but deliberately returning via "Resume") user is allowed to stay and
+ * work through it.
+ */
+export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
+  if (!facts.meLoaded) return false;
+  return facts.onboardingCompletedAt !== null;
+}

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,0 +1,171 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, Github } from "lucide-react";
+import { useState } from "react";
+import { ApiError } from "../../../api/client.js";
+import { listGithubRepos } from "../../../api/github.js";
+import { getGithubAppInstallation, getGithubAppInstallUrl } from "../../../api/github-app.js";
+import { Button } from "../../../components/ui/button.js";
+import { COPY } from "../copy.js";
+import { FlowNote, RepoPicker, StatusRow } from "../flow-ui.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+
+/**
+ * Admin step: install the GitHub App (the only reliable code-connection
+ * entry — `installations/new`, not the sign-in `authorize` URL), then pick
+ * the project the AI teammate should help with.
+ *
+ * Resilient by design — the team's first run can hit any of: App not
+ * installed, App not configured on this server, caller isn't an admin,
+ * GitHub access lacks project scope, or no repos. Each gets a plain message
+ * and a way forward (never a dead end): the user can always continue and
+ * connect code later from Settings.
+ */
+export function StepConnectCode() {
+  const { organizationId, goNext, selectedRepoUrls, setSelectedRepoUrls } = useOnboardingFlow();
+  const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
+  const [redirecting, setRedirecting] = useState(false);
+
+  const installQuery = useQuery({
+    queryKey: ["onboarding", "installation", organizationId],
+    queryFn: () => getGithubAppInstallation(organizationId ?? ""),
+    enabled: !!organizationId,
+    // Poll until an install appears (e.g. the user just came back from
+    // GitHub's install dialog); stop once we have one.
+    refetchInterval: (query) => (query.state.data ? false : 4000),
+  });
+
+  const installed = !!installQuery.data;
+
+  const reposQuery = useQuery({
+    queryKey: ["onboarding", "github-repos"],
+    queryFn: listGithubRepos,
+    enabled: installed,
+  });
+  const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
+
+  const handleConnect = async (): Promise<void> => {
+    if (!organizationId) return;
+    setInstallError(null);
+    setRedirecting(true);
+    try {
+      const url = await getGithubAppInstallUrl(organizationId, "/onboarding");
+      window.location.assign(url);
+    } catch (err) {
+      setRedirecting(false);
+      if (err instanceof ApiError && err.status === 503) setInstallError("not_configured");
+      else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
+      else setInstallError("generic");
+    }
+  };
+
+  const toggleRepo = (cloneUrl: string): void => {
+    setSelectedRepoUrls(
+      selectedRepoUrls.includes(cloneUrl)
+        ? selectedRepoUrls.filter((u) => u !== cloneUrl)
+        : [...selectedRepoUrls, cloneUrl],
+    );
+  };
+
+  // ── Not connected yet ────────────────────────────────────────────────
+  if (!installed) {
+    return (
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+          {COPY.reviewReassurance}
+        </p>
+
+        {installError === "not_configured" ? (
+          <>
+            <FlowNote tone="info">{COPY.connectCode.notConfigured}</FlowNote>
+            <ContinueWithout onClick={goNext} />
+          </>
+        ) : installError === "not_admin" ? (
+          <>
+            <FlowNote tone="info">{COPY.connectCode.notAdmin}</FlowNote>
+            <ContinueWithout onClick={goNext} />
+          </>
+        ) : (
+          <>
+            <Button type="button" onClick={() => void handleConnect()} disabled={redirecting || !organizationId}>
+              <Github className="h-4 w-4" />
+              {COPY.connectCode.cta}
+            </Button>
+            {installError === "generic" && <FlowNote>{COPY.errors.generic}</FlowNote>}
+            <StatusRow state="waiting" label={COPY.connectCode.waiting} />
+            <button
+              type="button"
+              onClick={goNext}
+              className="text-label self-start"
+              style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
+            >
+              {COPY.connectCode.continueWithout}
+            </button>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── Connected — pick the project ─────────────────────────────────────
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <StatusRow state="ok" label={COPY.connectCode.connected} />
+
+      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+        <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+          {COPY.connectCode.pickProject}
+        </p>
+
+        {scopeMissing ? (
+          <FlowNote tone="info">
+            <a
+              href="/api/v1/auth/github/start?next=/onboarding"
+              className="font-medium"
+              style={{ color: "var(--accent)" }}
+            >
+              {COPY.connectCode.reconnect}
+            </a>
+          </FlowNote>
+        ) : reposQuery.isLoading ? (
+          <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+            Loading your projects…
+          </p>
+        ) : (reposQuery.data?.length ?? 0) === 0 ? (
+          <FlowNote tone="info">{COPY.connectCode.noRepos}</FlowNote>
+        ) : (
+          <RepoPicker repos={reposQuery.data ?? []} selected={selectedRepoUrls} onToggle={toggleRepo} />
+        )}
+      </div>
+
+      <div className="flex items-center" style={{ gap: "var(--sp-3)" }}>
+        <Button
+          type="button"
+          onClick={goNext}
+          disabled={selectedRepoUrls.length === 0 && !scopeMissing && (reposQuery.data?.length ?? 0) > 0}
+        >
+          <span>{COPY.continue}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+        {selectedRepoUrls.length === 0 && (
+          <button
+            type="button"
+            onClick={goNext}
+            className="text-label"
+            style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
+          >
+            {COPY.connectCode.continueWithout}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ContinueWithout({ onClick }: { onClick: () => void }) {
+  return (
+    <Button type="button" variant="outline" onClick={onClick}>
+      <span>{COPY.connectCode.continueWithout}</span>
+      <ArrowRight className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
@@ -1,0 +1,63 @@
+import { ArrowRight } from "lucide-react";
+import { Button } from "../../../components/ui/button.js";
+import { COPY } from "../copy.js";
+import { CommandBox, FlowNote, StatusRow } from "../flow-ui.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+
+/**
+ * Connect the computer the AI teammate will run on. The user pastes a
+ * one-liner into a terminal; we poll until the computer shows up and we
+ * confirm an AI runtime is ready on it. No "runtime" jargon — if none is
+ * ready we say so in plain words and tell them what to install.
+ */
+export function StepConnectComputer() {
+  const { computer, goNext } = useOnboardingFlow();
+  const { connectedClient, capabilitiesLoaded, okRuntimes, cliCommand, tokenError } = computer;
+
+  const noRuntime = !!connectedClient && capabilitiesLoaded && okRuntimes.length === 0;
+  const ready = !!connectedClient && okRuntimes.length > 0;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      {!connectedClient ? (
+        <>
+          <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+            {COPY.connectComputer.instruction}
+          </p>
+          <CommandBox command={cliCommand} />
+          {tokenError ? (
+            <FlowNote>{tokenError}</FlowNote>
+          ) : (
+            <StatusRow state="waiting" label={COPY.connectComputer.waiting} />
+          )}
+        </>
+      ) : (
+        <>
+          <StatusRow
+            state="ok"
+            label={
+              <>
+                <span className="mono font-semibold">{connectedClient.hostname ?? connectedClient.id}</span>{" "}
+                {COPY.connectComputer.connected}
+              </>
+            }
+          />
+          {!capabilitiesLoaded ? (
+            <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+              {COPY.connectComputer.detecting}
+            </p>
+          ) : noRuntime ? (
+            <FlowNote tone="info">{COPY.connectComputer.noRuntime}</FlowNote>
+          ) : null}
+        </>
+      )}
+
+      <div className="flex">
+        <Button type="button" onClick={goNext} disabled={!ready}>
+          <span>{COPY.continue}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -1,0 +1,195 @@
+import type { AgentVisibility } from "@first-tree/shared";
+import { ArrowRight } from "lucide-react";
+import { Button } from "../../../components/ui/button.js";
+import { COPY } from "../copy.js";
+import { FlowNote } from "../flow-ui.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+
+const VISIBILITY_OPTIONS: ReadonlyArray<{ value: AgentVisibility; title: string; description: string }> = [
+  {
+    value: "organization",
+    title: "Shared with team",
+    description: "Anyone on your team can talk to this AI teammate.",
+  },
+  {
+    value: "private",
+    title: "Just me",
+    description: "Only you can see and talk to this AI teammate.",
+  },
+];
+
+/**
+ * Name the AI teammate and choose who can use it. The computer + runtime
+ * were settled in the previous step; we read them off the flow and never
+ * surface "runtime" / "client" here. On success the flow auto-advances to
+ * kickoff (the agent-online callback), so this renders form → creating →
+ * (timeout fallback) only.
+ */
+export function StepCreateAgent() {
+  const {
+    agentDisplayName,
+    setAgentDisplayName,
+    visibility,
+    setVisibility,
+    computer,
+    organizationId,
+    createAgent,
+    retryAgent,
+    agentPhase,
+    agentError,
+  } = useOnboardingFlow();
+
+  const trimmed = agentDisplayName.trim();
+  const canCreate =
+    !!trimmed &&
+    !!computer.connectedClient &&
+    !!computer.selectedRuntime &&
+    computer.okRuntimes.includes(computer.selectedRuntime) &&
+    agentPhase === "idle";
+
+  if (agentPhase === "creating") {
+    return (
+      <div className="flex flex-col items-center text-center" style={{ paddingTop: "var(--sp-8)", gap: "var(--sp-3)" }}>
+        <p className="text-subtitle font-semibold" style={{ color: "var(--fg)" }}>
+          {COPY.createAgent.creating}
+        </p>
+        <p className="text-label" style={{ color: "var(--fg-4)" }}>
+          {COPY.createAgent.creatingHint}
+        </p>
+      </div>
+    );
+  }
+
+  if (agentPhase === "timeout") {
+    return (
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <p className="text-subtitle font-semibold" style={{ color: "var(--fg)" }}>
+          {COPY.createAgent.timeoutTitle}
+        </p>
+        <FlowNote tone="info">{COPY.connectComputer.noRuntime}</FlowNote>
+        <div className="flex">
+          <Button type="button" onClick={() => void retryAgent()}>
+            {COPY.createAgent.retry}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const handleCreate = (): void => {
+    if (!canCreate || !computer.connectedClient || !computer.selectedRuntime) return;
+    void createAgent({
+      displayName: trimmed,
+      clientId: computer.connectedClient.id,
+      runtimeProvider: computer.selectedRuntime,
+      visibility,
+      organizationId,
+    });
+  };
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
+      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+        <label htmlFor="onboarding-agent-name" className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
+          {COPY.createAgent.nameLabel}
+        </label>
+        <input
+          id="onboarding-agent-name"
+          aria-label="AI teammate name"
+          value={agentDisplayName}
+          onChange={(e) => setAgentDisplayName(e.target.value)}
+          placeholder="e.g. Buddy, Helper"
+          maxLength={200}
+          className="text-body"
+          style={{
+            padding: "var(--sp-2) var(--sp-3)",
+            background: "var(--bg)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg)",
+            outline: "none",
+            caretColor: "var(--accent)",
+          }}
+          onFocus={(e) => {
+            e.currentTarget.style.borderColor = "var(--accent)";
+          }}
+          onBlur={(e) => {
+            e.currentTarget.style.borderColor = "var(--border)";
+          }}
+        />
+      </div>
+
+      <fieldset className="flex flex-col" style={{ gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}>
+        <legend className="text-label font-medium" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-1)" }}>
+          Who can use it?
+        </legend>
+        {VISIBILITY_OPTIONS.map((opt) => {
+          const active = visibility === opt.value;
+          return (
+            <label
+              key={opt.value}
+              className="flex items-start text-body"
+              style={{
+                gap: "var(--sp-2)",
+                padding: "var(--sp-2) var(--sp-3)",
+                background: active ? "color-mix(in oklch, var(--accent) 8%, var(--bg))" : "var(--bg)",
+                border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-faint)",
+                borderRadius: "var(--radius-input)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="radio"
+                name="onboarding-visibility"
+                value={opt.value}
+                checked={active}
+                onChange={() => setVisibility(opt.value)}
+                className="sr-only"
+              />
+              <span
+                aria-hidden="true"
+                className="inline-flex items-center justify-center"
+                style={{
+                  width: "var(--sp-3_5)",
+                  height: "var(--sp-3_5)",
+                  marginTop: "var(--sp-0_5)",
+                  flexShrink: 0,
+                  borderRadius: "50%",
+                  border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-strong)",
+                }}
+              >
+                {active && (
+                  <span
+                    style={{
+                      width: "var(--sp-1_5)",
+                      height: "var(--sp-1_5)",
+                      borderRadius: "50%",
+                      background: "var(--accent)",
+                    }}
+                  />
+                )}
+              </span>
+              <span className="flex flex-col" style={{ gap: "var(--sp-0_5)", minWidth: 0 }}>
+                <span className="font-medium" style={{ color: active ? "var(--fg)" : "var(--fg-2)" }}>
+                  {opt.title}
+                </span>
+                <span className="text-label" style={{ color: "var(--fg-3)" }}>
+                  {opt.description}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </fieldset>
+
+      {agentError && <FlowNote>{agentError}</FlowNote>}
+
+      <div className="flex">
+        <Button type="button" onClick={handleCreate} disabled={!canCreate}>
+          <span>Create {trimmed || "your AI teammate"}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -1,0 +1,454 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { useState } from "react";
+import { getAgentConfig, updateAgentConfig } from "../../../api/agent-config.js";
+import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
+import { listGithubRepos } from "../../../api/github.js";
+import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
+import {
+  getContextTreeSetting,
+  getSourceReposSetting,
+  putContextTreeSetting,
+  putSourceReposSetting,
+} from "../../../api/org-settings.js";
+import { Button } from "../../../components/ui/button.js";
+import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center/onboarding/bootstrap-prose.js";
+import { COPY } from "../copy.js";
+import { FlowNote, RepoPicker, StatusRow } from "../flow-ui.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+import { resolveOnboardingAgent } from "../resolve-agent.js";
+
+const NO_REPO_BOOTSTRAP =
+  "Introduce yourself to the team — what can you help with, and what's a good first thing for me to try?";
+
+function repoLabel(url: string): string {
+  return url
+    .replace(/^https?:\/\/[^/]+\//, "")
+    .replace(/^git@[^:]+:/, "")
+    .replace(/\.git$/, "");
+}
+
+/** Shared "create the chat + send the first task + finish" sequence. */
+async function runKickoff(args: {
+  bootstrap: string;
+  gitRepoUrls: string[];
+  orgWrites: { organizationId: string; sourceRepos: string[]; contextTreeUrl: string | null } | null;
+  treeMode: "new" | "existing";
+  joinPath?: "invite";
+  complete: (chatId: string) => Promise<void>;
+}): Promise<void> {
+  const agent = await resolveOnboardingAgent();
+
+  if (args.gitRepoUrls.length > 0) {
+    const cfg = await getAgentConfig(agent.uuid);
+    await updateAgentConfig(agent.uuid, {
+      expectedVersion: cfg.version,
+      payload: { gitRepos: args.gitRepoUrls.map((url) => ({ url })) },
+    });
+  }
+
+  // Org-level writes are a convenience cache for future teammates — never
+  // let them block the user's first chat.
+  if (args.orgWrites) {
+    if (args.orgWrites.sourceRepos.length > 0) {
+      await putSourceReposSetting(args.orgWrites.organizationId, {
+        repos: args.orgWrites.sourceRepos.map((url) => ({ url })),
+      }).catch(() => {});
+    }
+    if (args.orgWrites.contextTreeUrl) {
+      await putContextTreeSetting(args.orgWrites.organizationId, { repo: args.orgWrites.contextTreeUrl }).catch(
+        () => {},
+      );
+    }
+  }
+
+  const chat = await createAgentChat(agent.uuid);
+  try {
+    await sendChatMessage(chat.id, args.bootstrap);
+  } catch {
+    // Non-fatal: the chat exists; the agent introduces itself when the
+    // user types.
+  }
+  void reportOnboardingEvent("tree_chat_started", {
+    agentUuid: agent.uuid,
+    chatId: chat.id,
+    treeMode: args.treeMode,
+    ...(args.joinPath ? { joinPath: args.joinPath } : {}),
+  });
+  await args.complete(chat.id);
+}
+
+export function StepKickoff() {
+  const { path } = useOnboardingFlow();
+  return path === "admin" ? <AdminKickoff /> : <InviteeKickoff />;
+}
+
+// ── Admin ───────────────────────────────────────────────────────────────
+
+function AdminKickoff() {
+  const { organizationId, selectedRepoUrls, treeMode, setTreeMode, treeUrl, setTreeUrl, completeAndEnterChat } =
+    useOnboardingFlow();
+  const [phase, setPhase] = useState<"form" | "starting">("form");
+  const [error, setError] = useState<string | null>(null);
+
+  const hasRepos = selectedRepoUrls.length > 0;
+  const trimmedTreeUrl = treeUrl.trim();
+  const urlInvalid = treeMode === "existing" && trimmedTreeUrl.length > 0 && !/^https:\/\//.test(trimmedTreeUrl);
+  const canStart = phase === "form" && (!hasRepos || treeMode === "new" || (trimmedTreeUrl.length > 0 && !urlInvalid));
+
+  const handleStart = async (): Promise<void> => {
+    setError(null);
+    setPhase("starting");
+    try {
+      if (!hasRepos) {
+        await runKickoff({
+          bootstrap: NO_REPO_BOOTSTRAP,
+          gitRepoUrls: [],
+          orgWrites: null,
+          treeMode: "new",
+          complete: completeAndEnterChat,
+        });
+        return;
+      }
+      const useExisting = treeMode === "existing";
+      const bootstrap = useExisting
+        ? buildBindBootstrap(selectedRepoUrls, trimmedTreeUrl)
+        : buildCreateBootstrap(selectedRepoUrls);
+      await runKickoff({
+        bootstrap,
+        gitRepoUrls: selectedRepoUrls,
+        orgWrites: organizationId
+          ? {
+              organizationId,
+              sourceRepos: selectedRepoUrls,
+              contextTreeUrl: useExisting ? trimmedTreeUrl : null,
+            }
+          : null,
+        treeMode: useExisting ? "existing" : "new",
+        complete: completeAndEnterChat,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setPhase("form");
+    }
+  };
+
+  if (phase === "starting") return <StartingState />;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
+      {hasRepos ? (
+        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+          <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+            {COPY.kickoff.existingTitle}
+          </p>
+          <ModeCard
+            active={treeMode === "new"}
+            title={COPY.kickoff.createOption}
+            hint={COPY.kickoff.createHint}
+            onSelect={() => setTreeMode("new")}
+          />
+          <ModeCard
+            active={treeMode === "existing"}
+            title={COPY.kickoff.existingOption}
+            hint={COPY.kickoff.existingHint}
+            onSelect={() => setTreeMode("existing")}
+          />
+          {treeMode === "existing" && (
+            <div className="flex flex-col" style={{ gap: "var(--sp-1_5)", marginTop: "var(--sp-1)" }}>
+              <label htmlFor="onboarding-tree-url" className="text-label" style={{ color: "var(--fg-3)" }}>
+                {COPY.kickoff.existingUrlLabel}
+              </label>
+              <input
+                id="onboarding-tree-url"
+                value={treeUrl}
+                onChange={(e) => setTreeUrl(e.target.value)}
+                placeholder="https://github.com/your-team/knowledge"
+                className="text-body mono"
+                style={{
+                  padding: "var(--sp-2) var(--sp-3)",
+                  background: "var(--bg)",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--radius-input)",
+                  color: "var(--fg)",
+                  outline: "none",
+                }}
+              />
+              {urlInvalid && <FlowNote>{COPY.kickoff.invalidUrl}</FlowNote>}
+            </div>
+          )}
+          <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-4)" }}>
+            Working on: {selectedRepoUrls.map(repoLabel).join(", ")}
+          </p>
+        </div>
+      ) : (
+        <FlowNote tone="info">
+          No project is connected, so your AI teammate will start with a quick intro. You can connect a project later
+          from Settings to give it real context.
+        </FlowNote>
+      )}
+
+      {error && <FlowNote>{error}</FlowNote>}
+
+      <div className="flex">
+        <Button type="button" onClick={() => void handleStart()} disabled={!canStart}>
+          <span>{COPY.kickoff.start}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Invitee ─────────────────────────────────────────────────────────────
+
+function InviteeKickoff() {
+  const { organizationId } = useOnboardingFlow();
+  const teamQuery = useQuery({
+    queryKey: ["onboarding", "team-config", organizationId],
+    queryFn: async () => {
+      const [tree, repos] = await Promise.all([
+        getContextTreeSetting(organizationId ?? ""),
+        getSourceReposSetting(organizationId ?? ""),
+      ]);
+      return { treeUrl: tree.repo ?? "", teamRepoUrls: (repos.repos ?? []).map((r) => r.url) };
+    },
+    enabled: !!organizationId,
+  });
+
+  if (teamQuery.isLoading) {
+    return (
+      <p className="text-label" style={{ color: "var(--fg-4)" }}>
+        Checking what your team has set up…
+      </p>
+    );
+  }
+
+  // Read failure or no tree configured yet → waiting state.
+  if (teamQuery.isError || !teamQuery.data?.treeUrl) {
+    return <InviteeWaiting />;
+  }
+
+  const { treeUrl, teamRepoUrls } = teamQuery.data;
+  return teamRepoUrls.length > 0 ? (
+    <InviteeConfirm treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />
+  ) : (
+    <InviteePicker treeUrl={treeUrl} />
+  );
+}
+
+function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls: string[] }) {
+  const { completeAndEnterChat } = useOnboardingFlow();
+  const [chosen, setChosen] = useState<string[]>(teamRepoUrls);
+  const [phase, setPhase] = useState<"form" | "starting">("form");
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = (url: string): void =>
+    setChosen((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+
+  const handleStart = async (): Promise<void> => {
+    setError(null);
+    setPhase("starting");
+    try {
+      await runKickoff({
+        bootstrap: buildBindBootstrap(chosen, treeUrl),
+        gitRepoUrls: chosen,
+        orgWrites: null, // never mutate team config as an invitee
+        treeMode: "existing",
+        joinPath: "invite",
+        complete: completeAndEnterChat,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setPhase("form");
+    }
+  };
+
+  if (phase === "starting") return <StartingState />;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <FlowNote tone="info">{COPY.invitee.confirmBody}</FlowNote>
+      <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+        {teamRepoUrls.map((url) => {
+          const active = chosen.includes(url);
+          return (
+            <label
+              key={url}
+              className="flex items-center text-body"
+              style={{
+                gap: "var(--sp-2_5)",
+                padding: "var(--sp-2) var(--sp-2_5)",
+                borderRadius: "var(--radius-input)",
+                cursor: "pointer",
+                background: active ? "color-mix(in oklch, var(--accent) 8%, transparent)" : "transparent",
+                color: active ? "var(--fg)" : "var(--fg-2)",
+              }}
+            >
+              <input type="checkbox" checked={active} onChange={() => toggle(url)} className="sr-only" />
+              <span
+                aria-hidden="true"
+                className="inline-flex items-center justify-center"
+                style={{
+                  width: "var(--sp-4)",
+                  height: "var(--sp-4)",
+                  flexShrink: 0,
+                  borderRadius: "var(--radius-input)",
+                  border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-strong)",
+                  background: active ? "var(--accent)" : "transparent",
+                }}
+              />
+              <span className="font-medium">{repoLabel(url)}</span>
+            </label>
+          );
+        })}
+      </div>
+      {error && <FlowNote>{error}</FlowNote>}
+      <div className="flex">
+        <Button type="button" onClick={() => void handleStart()} disabled={chosen.length === 0}>
+          <span>{COPY.kickoff.start}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function InviteePicker({ treeUrl }: { treeUrl: string }) {
+  const { completeAndEnterChat } = useOnboardingFlow();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [phase, setPhase] = useState<"form" | "starting">("form");
+  const [error, setError] = useState<string | null>(null);
+  const reposQuery = useQuery({ queryKey: ["onboarding", "github-repos"], queryFn: listGithubRepos });
+
+  const toggle = (url: string): void =>
+    setSelected((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+
+  const handleStart = async (): Promise<void> => {
+    setError(null);
+    setPhase("starting");
+    try {
+      await runKickoff({
+        bootstrap: buildBindBootstrap(selected, treeUrl),
+        gitRepoUrls: selected,
+        orgWrites: null,
+        treeMode: "existing",
+        joinPath: "invite",
+        complete: completeAndEnterChat,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setPhase("form");
+    }
+  };
+
+  if (phase === "starting") return <StartingState />;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <FlowNote tone="info">Your team's knowledge base is ready. Pick the project you'll work on.</FlowNote>
+      {reposQuery.isLoading ? (
+        <p className="text-label" style={{ color: "var(--fg-4)" }}>
+          Loading your projects…
+        </p>
+      ) : (reposQuery.data?.length ?? 0) === 0 ? (
+        <FlowNote tone="info">{COPY.connectCode.noRepos}</FlowNote>
+      ) : (
+        <RepoPicker repos={reposQuery.data ?? []} selected={selected} onToggle={toggle} />
+      )}
+      {error && <FlowNote>{error}</FlowNote>}
+      <div className="flex">
+        <Button type="button" onClick={() => void handleStart()} disabled={selected.length === 0}>
+          <span>{COPY.kickoff.start}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function InviteeWaiting() {
+  const { finishLater } = useOnboardingFlow();
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
+        {COPY.invitee.waitingTitle}
+      </p>
+      <FlowNote tone="info">{COPY.invitee.waitingBody}</FlowNote>
+      <div className="flex">
+        <Button type="button" variant="outline" onClick={() => void finishLater()}>
+          Start chatting anyway
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── shared ──────────────────────────────────────────────────────────────
+
+function ModeCard({
+  active,
+  title,
+  hint,
+  onSelect,
+}: {
+  active: boolean;
+  title: string;
+  hint: string;
+  onSelect: () => void;
+}) {
+  return (
+    <label
+      className="flex items-start text-body"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-2) var(--sp-3)",
+        background: active ? "color-mix(in oklch, var(--accent) 8%, var(--bg))" : "var(--bg)",
+        border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-faint)",
+        borderRadius: "var(--radius-input)",
+        cursor: "pointer",
+      }}
+    >
+      <input type="radio" name="onboarding-tree-mode" checked={active} onChange={onSelect} className="sr-only" />
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center justify-center"
+        style={{
+          width: "var(--sp-3_5)",
+          height: "var(--sp-3_5)",
+          marginTop: "var(--sp-0_5)",
+          flexShrink: 0,
+          borderRadius: "50%",
+          border: active ? "var(--hairline) solid var(--accent)" : "var(--hairline) solid var(--border-strong)",
+        }}
+      >
+        {active && (
+          <span
+            style={{
+              width: "var(--sp-1_5)",
+              height: "var(--sp-1_5)",
+              borderRadius: "50%",
+              background: "var(--accent)",
+            }}
+          />
+        )}
+      </span>
+      <span className="flex flex-col" style={{ gap: "var(--sp-0_5)", minWidth: 0 }}>
+        <span className="font-medium" style={{ color: active ? "var(--fg)" : "var(--fg-2)" }}>
+          {title}
+        </span>
+        <span className="text-label" style={{ color: "var(--fg-3)" }}>
+          {hint}
+        </span>
+      </span>
+    </label>
+  );
+}
+
+function StartingState() {
+  return (
+    <div className="flex flex-col items-center text-center" style={{ paddingTop: "var(--sp-8)", gap: "var(--sp-3)" }}>
+      <StatusRow state="waiting" label={COPY.kickoff.starting} />
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/steps/step-team.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-team.tsx
@@ -1,0 +1,123 @@
+import type { OrgBrief } from "@first-tree/shared";
+import { ArrowRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../../../api/client.js";
+import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
+import { Button } from "../../../components/ui/button.js";
+import { COPY } from "../copy.js";
+import { FlowNote } from "../flow-ui.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+
+/**
+ * Admin step 1: confirm or rename the team. The team row already exists
+ * (auto-created at sign-in); this just lets the user own its name. One
+ * field, pre-filled, Enter or Continue advances. If the name is unchanged
+ * we skip the PATCH entirely.
+ */
+export function StepTeam() {
+  const { organizationId, goNext } = useOnboardingFlow();
+  const [orgs, setOrgs] = useState<OrgBrief[]>([]);
+  const [name, setName] = useState("");
+  const [initialName, setInitialName] = useState("");
+  const [orgsLoaded, setOrgsLoaded] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const list = await api.get<OrgBrief[]>("/me/organizations");
+        setOrgs(list);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : "Failed to load your team");
+      } finally {
+        setOrgsLoaded(true);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const seed = orgs.find((o) => o.id === organizationId)?.displayName ?? "";
+    setName(seed);
+    setInitialName(seed);
+  }, [orgs, organizationId]);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el || !initialName) return;
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+  }, [initialName]);
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && !saving && orgsLoaded && !loadError;
+
+  const handleSubmit = useCallback(
+    async (event?: React.FormEvent) => {
+      event?.preventDefault();
+      if (!canSubmit || !organizationId) return;
+      setSaveError(null);
+      try {
+        if (trimmed !== initialName.trim()) {
+          setSaving(true);
+          await api.patch(`/orgs/${encodeURIComponent(organizationId)}`, { displayName: trimmed });
+          void reportOnboardingEvent("team_renamed");
+        }
+        goNext();
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : "Failed to rename team");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [canSubmit, organizationId, trimmed, initialName, goNext],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+        <label htmlFor="onboarding-team-name" className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
+          Team name
+        </label>
+        <input
+          ref={inputRef}
+          id="onboarding-team-name"
+          aria-label="Team name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={200}
+          disabled={saving}
+          className="text-body"
+          style={{
+            padding: "var(--sp-2) var(--sp-3)",
+            background: "var(--bg)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg)",
+            outline: "none",
+            caretColor: "var(--accent)",
+          }}
+          onFocus={(e) => {
+            e.currentTarget.style.borderColor = "var(--accent)";
+          }}
+          onBlur={(e) => {
+            e.currentTarget.style.borderColor = "var(--border)";
+          }}
+        />
+      </div>
+
+      {(saveError || loadError) && (
+        <FlowNote>{saveError ?? `Couldn't load your team — ${loadError}. Refresh and try again.`}</FlowNote>
+      )}
+
+      <div className="flex">
+        <Button type="submit" disabled={!canSubmit}>
+          <span>{COPY.continue}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/web/src/pages/onboarding/steps/step-welcome.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-welcome.tsx
@@ -1,0 +1,35 @@
+import { ArrowRight } from "lucide-react";
+import { Button } from "../../../components/ui/button.js";
+import { COPY } from "../copy.js";
+import { useOnboardingFlow } from "../onboarding-flow.js";
+
+/**
+ * Invitee step 1: a warm landing that names the team they just joined and
+ * sets expectations for the two quick steps ahead (connect a computer,
+ * create their AI teammate). No setup work here — just orientation so the
+ * jump from "I clicked an invite link" to "I'm configuring things" isn't
+ * jarring.
+ */
+export function StepWelcome() {
+  const { teamDisplayName, goNext } = useOnboardingFlow();
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
+        You're now part of{" "}
+        <span className="font-semibold" style={{ color: "var(--fg)" }}>
+          {teamDisplayName ?? "your team"}
+        </span>
+        . Your team's projects and knowledge base are already set up — you just need your own AI teammate.
+      </p>
+      <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+        Two quick steps: connect a computer for it to run on, then give it a name.
+      </p>
+      <div className="flex">
+        <Button type="button" onClick={goNext}>
+          <span>{COPY.continue}</span>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/use-agent-creation.ts
+++ b/packages/web/src/pages/onboarding/use-agent-creation.ts
@@ -1,0 +1,116 @@
+import type { AgentVisibility } from "@first-tree/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAgentClientStatus } from "../../api/agent-config.js";
+import { api, withOrg } from "../../api/client.js";
+import { reportOnboardingEvent } from "../../api/onboarding-events.js";
+import { slugify } from "../../utils/agent-naming.js";
+import { writeOnboardingAgentUuid } from "../../utils/onboarding-flags.js";
+
+const RUNTIME_READY_TIMEOUT_MS = 30_000;
+const RUNTIME_READY_POLL_MS = 1_000;
+
+export type AgentCreationPhase = "idle" | "creating" | "online" | "timeout";
+
+export type CreateAgentArgs = {
+  displayName: string;
+  clientId: string;
+  runtimeProvider: string;
+  visibility: AgentVisibility;
+  organizationId: string | null;
+};
+
+/**
+ * Creates the first AI teammate (an unbound `personal_assistant`) and waits
+ * for it to come online on the connected computer.
+ *
+ * Same two-phase shape the legacy Step2Body used: POST `/agents`, then poll
+ * `client-status` until the runtime reports online (or a 30s timeout). The
+ * agent is created without any project binding — the kickoff step attaches
+ * the source repo later, so a slow GitHub call can never block teammate
+ * creation. On success, `onOnline(uuid)` fires once.
+ */
+export function useAgentCreation(onOnline: (uuid: string) => void) {
+  const [phase, setPhase] = useState<AgentCreationPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const createdRef = useRef<string | null>(null);
+  const pollCancelRef = useRef<{ cancelled: boolean } | null>(null);
+  const onOnlineRef = useRef(onOnline);
+  onOnlineRef.current = onOnline;
+
+  useEffect(
+    () => () => {
+      if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+    },
+    [],
+  );
+
+  const pollUntilReady = useCallback(async (agentUuid: string): Promise<void> => {
+    if (pollCancelRef.current) pollCancelRef.current.cancelled = true;
+    const token: { cancelled: boolean } = { cancelled: false };
+    pollCancelRef.current = token;
+
+    const startedAt = Date.now();
+    while (!token.cancelled) {
+      let online = false;
+      try {
+        const status = await getAgentClientStatus(agentUuid);
+        if (token.cancelled) return;
+        online = status.online === true;
+      } catch {
+        if (token.cancelled) return;
+      }
+      if (online) {
+        setPhase("online");
+        onOnlineRef.current(agentUuid);
+        return;
+      }
+      if (Date.now() - startedAt > RUNTIME_READY_TIMEOUT_MS) {
+        if (!token.cancelled) setPhase("timeout");
+        return;
+      }
+      await new Promise((r) => setTimeout(r, RUNTIME_READY_POLL_MS));
+    }
+  }, []);
+
+  const create = useCallback(
+    async (args: CreateAgentArgs): Promise<void> => {
+      const displayName = args.displayName.trim();
+      if (!displayName) return;
+      setError(null);
+      setPhase("creating");
+      const slug = slugify(displayName);
+      let agentUuid: string;
+      try {
+        const res = await api.post<{ uuid: string }>(withOrg("/agents"), {
+          type: "personal_assistant",
+          displayName,
+          ...(slug ? { name: slug } : {}),
+          clientId: args.clientId,
+          runtimeProvider: args.runtimeProvider,
+          visibility: args.visibility,
+          ...(args.organizationId ? { organizationId: args.organizationId } : {}),
+        });
+        agentUuid = res.uuid;
+        createdRef.current = agentUuid;
+        writeOnboardingAgentUuid(agentUuid);
+        void reportOnboardingEvent("agent_created", { runtimeProvider: args.runtimeProvider });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create your AI teammate");
+        setPhase("idle");
+        return;
+      }
+      await pollUntilReady(agentUuid);
+    },
+    [pollUntilReady],
+  );
+
+  const retry = useCallback(async (): Promise<void> => {
+    const agentUuid = createdRef.current;
+    if (!agentUuid) return;
+    setError(null);
+    setPhase("creating");
+    await pollUntilReady(agentUuid);
+  }, [pollUntilReady]);
+
+  return { phase, error, create, retry, createdUuid: createdRef.current };
+}

--- a/packages/web/src/pages/onboarding/use-computer-connection.ts
+++ b/packages/web/src/pages/onboarding/use-computer-connection.ts
@@ -1,0 +1,169 @@
+import type { ClientCapabilities } from "@first-tree/shared";
+import { useEffect, useRef, useState } from "react";
+import { getClientCapabilities, type HubClient, listClients } from "../../api/activity.js";
+import { api } from "../../api/client.js";
+import { runVisibilityAwareInterval } from "../../lib/visibility-interval.js";
+
+const CLIENT_DETECT_POLL_MS = 5_000;
+
+/**
+ * Watches for the user's computer coming online and figures out whether it
+ * can host an AI teammate.
+ *
+ * Lifecycle (mirrors the proven logic from the legacy Step2Body):
+ *   1. Mint a short-lived connect token + bootstrap command (the one-liner
+ *      the user pastes into their terminal).
+ *   2. Poll `listClients()`; the most-recently-seen connected client wins.
+ *   3. Once a client is connected, fetch its capabilities to learn which AI
+ *      runtimes are ready, and auto-pick the best one (Claude Code → Codex).
+ *
+ * Pure presentation state is returned; the React step renders it. Polling
+ * pauses while the tab is hidden (`runVisibilityAwareInterval`) and stops
+ * entirely when `enabled` is false.
+ */
+export type ComputerConnection = {
+  connectedClient: HubClient | null;
+  capabilitiesLoaded: boolean;
+  okRuntimes: string[];
+  selectedRuntime: string | null;
+  setSelectedRuntime: (next: string | null) => void;
+  /** The full multi-line command the user pastes into their terminal. */
+  cliCommand: string | null;
+  /** Non-null when minting the connect token failed. */
+  tokenError: string | null;
+};
+
+function pickPreferredRuntime(caps: ClientCapabilities): string | null {
+  const ok = (provider: string) => caps[provider]?.state === "ok";
+  if (ok("claude-code")) return "claude-code";
+  if (ok("codex")) return "codex";
+  const first = Object.entries(caps).find(([, entry]) => entry.state === "ok");
+  return first ? first[0] : null;
+}
+
+export function useComputerConnection(enabled: boolean): ComputerConnection {
+  const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
+  const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
+  const [capabilitiesClientId, setCapabilitiesClientId] = useState<string | null>(null);
+  const [selectedRuntime, setSelectedRuntime] = useState<string | null>(null);
+  const [connectToken, setConnectToken] = useState<string | null>(null);
+  const [connectTokenExpiresAt, setConnectTokenExpiresAt] = useState<number | null>(null);
+  const [bootstrapCommand, setBootstrapCommand] = useState<string | null>(null);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
+  const capabilitiesClientIdRef = useRef<string | null>(null);
+  const detectSeqRef = useRef(0);
+
+  // Detect the connected computer + its capabilities.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const detect = async (): Promise<void> => {
+      const seq = ++detectSeqRef.current;
+      try {
+        const clients = await listClients();
+        if (cancelled || seq !== detectSeqRef.current) return;
+        const connected = clients
+          .filter((c) => c.status === "connected")
+          .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
+        const latest = connected[0] ?? null;
+        setConnectedClient((prev) => (prev?.id === latest?.id ? prev : latest));
+        if (latest) {
+          if (capabilitiesClientIdRef.current !== latest.id) {
+            capabilitiesClientIdRef.current = null;
+            setCapabilitiesClientId(null);
+            setCapabilities(null);
+          }
+          try {
+            const withCaps = await getClientCapabilities(latest.id);
+            if (cancelled || seq !== detectSeqRef.current) return;
+            capabilitiesClientIdRef.current = latest.id;
+            setCapabilitiesClientId(latest.id);
+            setCapabilities(withCaps.capabilities);
+          } catch {
+            // transient — try again next tick
+          }
+        } else {
+          capabilitiesClientIdRef.current = null;
+          setCapabilitiesClientId(null);
+          setCapabilities(null);
+        }
+      } catch {
+        // best-effort
+      }
+    };
+    const dispose = runVisibilityAwareInterval(detect, CLIENT_DETECT_POLL_MS);
+    return () => {
+      cancelled = true;
+      dispose();
+    };
+  }, [enabled]);
+
+  // Mint / refresh the connect token while no computer is connected yet.
+  useEffect(() => {
+    if (!enabled) return;
+    if (connectedClient) return;
+    if (connectToken && connectTokenExpiresAt && connectTokenExpiresAt > Date.now()) {
+      const refreshAt = Math.max(connectTokenExpiresAt - Date.now(), 0);
+      const handle = window.setTimeout(() => {
+        setConnectToken(null);
+        setConnectTokenExpiresAt(null);
+      }, refreshAt);
+      return () => window.clearTimeout(handle);
+    }
+    if (connectToken) {
+      setConnectToken(null);
+      setConnectTokenExpiresAt(null);
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await api.post<{ token: string; expiresIn: number; bootstrapCommand: string }>(
+          "/me/connect-tokens",
+          {},
+        );
+        if (!cancelled) {
+          setConnectToken(r.token);
+          setConnectTokenExpiresAt(Date.now() + r.expiresIn * 1000);
+          setBootstrapCommand(r.bootstrapCommand);
+          setTokenError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setTokenError(err instanceof Error ? err.message : "Failed to generate connect command");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, connectedClient, connectToken, connectTokenExpiresAt]);
+
+  const activeCapabilities = connectedClient && capabilitiesClientId === connectedClient.id ? capabilities : null;
+
+  // Auto-pick the preferred ready runtime; keep a still-valid prior choice.
+  useEffect(() => {
+    setSelectedRuntime((prev) => {
+      if (!activeCapabilities) return prev;
+      if (prev && activeCapabilities[prev]?.state === "ok") return prev;
+      return pickPreferredRuntime(activeCapabilities);
+    });
+  }, [activeCapabilities]);
+
+  const okRuntimes = activeCapabilities
+    ? Object.entries(activeCapabilities)
+        .filter(([, entry]) => entry.state === "ok")
+        .map(([provider]) => provider)
+    : [];
+
+  const cliCommand =
+    bootstrapCommand ?? (connectToken ? `npm install -g first-tree\nfirst-tree login ${connectToken}` : null);
+
+  return {
+    connectedClient,
+    capabilitiesLoaded: activeCapabilities !== null,
+    okRuntimes,
+    selectedRuntime,
+    setSelectedRuntime,
+    cliCommand,
+    tokenError,
+  };
+}

--- a/packages/web/src/pages/settings/onboarding.tsx
+++ b/packages/web/src/pages/settings/onboarding.tsx
@@ -1,5 +1,5 @@
 import { Check } from "lucide-react";
-import { Navigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { PageHeader } from "../../components/ui/page-header.js";
@@ -16,6 +16,7 @@ import { Section } from "../../components/ui/section.js";
  * one-way action. This page is the recovery path.
  */
 export function SettingsOnboardingPage() {
+  const navigate = useNavigate();
   const { onboardingStep, onboardingDismissedAt, onboardingCompletedAt, dismissOnboarding, restoreOnboarding } =
     useAuth();
   // Terminal state — Step 3 was completed. The wizard is one-shot;
@@ -33,22 +34,27 @@ export function SettingsOnboardingPage() {
   // itself is the kind of asymmetric affordance that makes UI feel buggy.
   const canHide = onboardingStep === "completed";
 
+  const handleResume = async (): Promise<void> => {
+    await restoreOnboarding();
+    navigate("/onboarding");
+  };
+
   return (
     <>
-      <PageHeader title="Onboarding" subtitle="Guided setup controls" />
+      <PageHeader title="Setup" subtitle="Finish or revisit your setup" />
       <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
         <Section
-          title="Onboarding guide"
+          title="Guided setup"
           description={
             isDismissed
-              ? "The stepper is hidden. Bring it back if you want to walk through Step 3 (build your context-tree)."
-              : "The stepper is shown above your workspace. You can hide it any time once your agent is set up."
+              ? "Setup is hidden. Resume it to finish connecting your AI teammate and your team's knowledge base."
+              : "You can hide the guided setup any time once your AI teammate is ready."
           }
           action={isDismissed ? null : <ActiveBadge />}
         >
           {isDismissed ? (
-            <Button type="button" size="sm" onClick={() => void restoreOnboarding()}>
-              Resume onboarding
+            <Button type="button" size="sm" onClick={() => void handleResume()}>
+              Resume setup
             </Button>
           ) : (
             <Button
@@ -57,9 +63,9 @@ export function SettingsOnboardingPage() {
               variant="outline"
               onClick={() => void dismissOnboarding()}
               disabled={!canHide}
-              title={canHide ? undefined : "Finish setting up your agent first"}
+              title={canHide ? undefined : "Finish setting up your AI teammate first"}
             >
-              Hide onboarding guide
+              Hide setup guide
             </Button>
           )}
         </Section>

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -1,8 +1,10 @@
 import { CHAT_SOURCES, type ChatEngagementView, type ChatSource, chatEngagementViewSchema } from "@first-tree/shared";
 import { useCallback, useEffect } from "react";
-import { useSearchParams } from "react-router";
+import { Navigate, useSearchParams } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
 import { DocPreviewDrawer } from "../../components/doc-preview-drawer.js";
 import { useAdminWs } from "../../hooks/use-admin-ws.js";
+import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { CenterPanel } from "./center/index.js";
 import { OnboardingStepper } from "./center/onboarding-stepper.js";
 import { type GroupMode, parseGroupMode } from "./conversations/group-rows.js";
@@ -95,6 +97,7 @@ export function parseParticipantList(params: URLSearchParams): string[] {
 
 export function WorkspacePage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt } = useAuth();
   const selectedChatId = searchParams.get("c");
   const legacyAgentId = searchParams.get("a");
   const legacySource = searchParams.get("source");
@@ -207,6 +210,14 @@ export function WorkspacePage() {
     // win and leave the URL in a half-cleared state.
     setSearchParams(nextParamsForClearFilters(searchParams), { replace: true });
   }, [searchParams, setSearchParams]);
+
+  // Brand-new / incomplete users go through the standalone /onboarding flow
+  // instead of the inline center-panel onboarding. Dismissed or completed
+  // users fall through to the normal workspace (the inline OnboardingView
+  // stays as a reversible fallback for the dismissed-but-not-completed case).
+  if (shouldEnterOnboarding({ meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt })) {
+    return <Navigate to="/onboarding" replace />;
+  }
 
   return (
     <div className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Why

New-user onboarding currently lives inline in the ChatView center panel and assumes a developer who already knows GitHub / CLI / repos / runtimes / context-trees. This rebuilds it as a dedicated, full-screen **`/onboarding`** flow designed for a complete beginner — someone who just wants an AI teammate working on their project — so the path from landing page → "my AI teammate is doing its first task" needs no docs, no engineer, no manual CLI, no DB.

It also fixes a verified drift the proposal flagged: **sign-in (`authorize`) never reliably installs the GitHub App**, so the only real install entry (`installations/new`) was buried in Settings and absent from onboarding. Connecting code is now a first-class, explained step.

Builds on `hub-onboarding-redesign.20260522.md`; implements the task `new-user-onboarding-refactor.20260522.md`.

## What changes for the user

- **One step at a time**, each with a plain-language *why* and a *"what you'll have"* panel. Vocabulary is reduced to **team / your code / your computer / AI teammate / team knowledge** — no *repo*, *runtime*, *binding*, *context-tree* in the UI.
- **Sign-in (identity) and connecting code (installing the GitHub App) are separate, explained steps.** The connect-code step calls `install-url` (`installations/new`), not the sign-in `authorize` URL. Resilient failure states: not installed, App not configured (503), not an admin, missing repo scope, no repos — each with a way forward (never a dead end).
- **Admin vs invitee paths.** Admins set up team + code + knowledge; invitees bind to the team's **existing** knowledge base (never creating a duplicate), with a clear waiting state + "what's missing / who to ask" when the team isn't configured yet.
- **Completion = AI teammate online + first task kicked off** (per the agreed bar). Stamps `onboarding_completed_at`, drops the user into their first chat, and is resumable from **Settings → Setup**.
- The standalone flow **replaces** the inline wizard via a redirect; the old `OnboardingView` is left untouched as a reversible fallback (no deletion).

## Implementation

- `packages/web/src/pages/onboarding/`:
  - `steps.ts` — pure path/step/gate logic (unit tested).
  - `onboarding-flow.tsx` — flow context reusing the proven connect-token / client-poll / agent-create / repo-picker / org-settings / bootstrap-prose APIs. Persists the active step in `sessionStorage` so the GitHub-App full-page redirect resumes in place.
  - `progress-rail.tsx`, `onboarding-shell.tsx`, `onboarding-page.tsx`, `flow-ui.tsx`, and per-step components.
- `install-url` accepts an **allowlisted** `?next=` so the post-install redirect returns to `/onboarding` (open-redirect safe).
- Corrects the `auth/github.ts` comment that wrongly claimed the `authorize` URL installs the App.
- Gate added in `WorkspacePage`; `/onboarding` route added outside the workspace chrome.

## Decisions / deviations from the proposal (with reasoning)

- **Completion bar** = "agent online + first task kicked off" (not "wait for a real PR") — deterministic, no spinner-staring for a beginner.
- **Repo picker data source** = existing `/me/github/repos` (OAuth), not a new installation-covered endpoint — chosen for the "shortest credible path"; the installation-covered repos endpoint is a sensible follow-up (a picked repo still clones/works locally; App coverage only affects server-side webhook/PR features).
- Hero marketing copy left untouched (pinned by brief); continuity is provided by the new login tagline + jargon-free steps.

## Testing

Done in-sandbox:
- `pnpm check` (Biome, repo-wide) ✅ · `pnpm typecheck` (turbo, 13/13) ✅ · web design-token lint ✅
- Web: 258 tests pass incl. **22 new** unit tests for step/gate logic; production `vite build` ✅
- Server (against a real Postgres): `post-install-next` (4, new), `github-app-install-url` incl. **new `?next=` allowlist** cases (6), `me-onboarding` (16), `github-app-callback-target-org` (4), `oauth-flow` (14) — all ✅

Could **not** run in this sandbox (no browser; network allowlist blocks Playwright's Chromium download; no real GitHub App/OAuth):
- Automated visual / browser E2E of the rendered flow
- The live GitHub App install round-trip (needs a configured App + real account)

These need a deploy/preview env. Flagging explicitly rather than claiming visual coverage.

## Test plan
- [ ] Solo admin: landing → Sign in → name team → Connect code (install App) → connect computer → create AI teammate → start → lands in first chat; `onboarding_completed_at` set.
- [ ] Connect-code edge states: App not configured (503), not admin, missing repo scope, no repos, "continue without".
- [ ] GitHub-App install round-trip returns to `/onboarding` at the connect-code step (sessionStorage resume).
- [ ] Invitee on a configured team: welcome → connect computer → create teammate → bind to existing knowledge (no duplicate) → first chat.
- [ ] Invitee on an unconfigured team: clear waiting state + "start chatting anyway".
- [ ] Dismiss / resume via Settings → Setup → `/onboarding`.
- [ ] Completed user can't get stuck on `/onboarding` (redirects to `/`).

https://claude.ai/code/session_01YPHcnxBSVW68GyRroG2q3C

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPHcnxBSVW68GyRroG2q3C)_