### PR TITLE
fix(client): route legacy sessions to their per-chat cwd; fresh-start as fallback (R2 hotfix for #506)

### DIFF
--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfig } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -348,5 +348,106 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     // Legacy must STILL survive after shutdown (no rm of cwd or sibling).
     expect(existsSync(legacyChatDir)).toBe(true);
     rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("E8: resume of a stale pre-upgrade sessionId falls back to fresh start (R2 fallback)", async () => {
+    // Defensive fallback path: when sessionId can't be located at EITHER
+    // cwd (legacy chatId dir or agent home), the handler mints a fresh
+    // id and starts cold — Hub-side chat history is preserved.
+    // SessionManager then persists the returned id, so subsequent inbox
+    // messages resume against the new id cleanly (no permanent error loop).
+    capturedSdkOptions.length = 0;
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-e8-"));
+    const workspaceRoot = join(dataDir, "workspaces", "agent-1");
+    const gitMirrorManager: GitMirrorManager = createGitMirrorManager({ dataDir });
+
+    const cache = buildCache([]);
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
+    // No transcript exists anywhere under `~/.claude/projects/<encoded-cwd>/`.
+    const staleSessionId = "72a19485-ca9e-4bc3-9add-a57e8314e5c3";
+    const returnedSessionId = await handler.resume(
+      makeMessage("chat-e8", "msg-e8"),
+      staleSessionId,
+      buildSessionCtx("chat-e8"),
+    );
+
+    // Returned sessionId MUST differ from the stale input — that's how
+    // SessionManager learns to update its registry.
+    expect(returnedSessionId).not.toBe(staleSessionId);
+    expect(returnedSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+
+    // The SDK was invoked WITHOUT a resume argument (fresh start semantics).
+    expect(capturedSdkOptions.length).toBeGreaterThan(0);
+    const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
+    expect(lastOptions?.resume).toBeUndefined();
+    expect(lastOptions?.sessionId).toBe(returnedSessionId);
+
+    await handler.shutdown();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("E9: resume of a pre-redesign session routes to the legacy chat-dir cwd (R2 primary path)", async () => {
+    // Primary R2 path: a session created BEFORE the cwd reversal has its
+    // Claude SDK transcript keyed off the OLD per-chat cwd encoding.
+    // `resume()` must detect this and run the SDK against the legacy cwd
+    // verbatim, preserving the agent's SDK turn history across upgrade.
+    capturedSdkOptions.length = 0;
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-e9-"));
+    const workspaceRoot = join(dataDir, "workspaces", "agent-1");
+    const chatId = "chat-e9";
+    const gitMirrorManager: GitMirrorManager = createGitMirrorManager({ dataDir });
+
+    // Simulate the v1.x layout that pre-existed on disk before the upgrade.
+    const legacyCwd = join(workspaceRoot, chatId);
+    mkdirSync(join(legacyCwd, ".agent"), { recursive: true });
+    writeFileSync(join(legacyCwd, "CLAUDE.md"), "legacy session prompt\n");
+    writeFileSync(join(legacyCwd, ".agent", "identity.json"), '{"agentId":"legacy"}');
+
+    // Materialise the SDK transcript at the legacy-cwd-encoded path under
+    // `~/.claude/projects/`. The probe (`claudeSessionFileExists`) follows
+    // the same encoding rule the SDK uses: replace every non-alphanumeric
+    // char in the absolute cwd with "-".
+    const legacySessionId = "abcd1234-5678-90ab-cdef-1234567890ab";
+    const legacyEncoded = legacyCwd.replace(/[^a-zA-Z0-9-]/g, "-");
+    const legacyTranscriptDir = join(homedir(), ".claude", "projects", legacyEncoded);
+    mkdirSync(legacyTranscriptDir, { recursive: true });
+    const legacyTranscriptPath = join(legacyTranscriptDir, `${legacySessionId}.jsonl`);
+    writeFileSync(legacyTranscriptPath, '{"type":"system","subtype":"init"}\n');
+
+    try {
+      const cache = buildCache([]);
+      await cache.refresh(AGENT_ID);
+
+      const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
+      const returnedSessionId = await handler.resume(
+        makeMessage(chatId, "msg-e9"),
+        legacySessionId,
+        buildSessionCtx(chatId),
+      );
+
+      // The legacy sessionId MUST be preserved — no fresh-id rotation here.
+      expect(returnedSessionId).toBe(legacySessionId);
+
+      // SDK was invoked with the legacy sessionId on the `resume` channel.
+      expect(capturedSdkOptions.length).toBeGreaterThan(0);
+      const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
+      expect(lastOptions?.resume).toBe(legacySessionId);
+      // cwd points at the legacy chat dir, NOT at the agent home root.
+      expect(lastOptions?.cwd).toBe(legacyCwd);
+
+      // The legacy dir's existing files are untouched — we intentionally
+      // skip ensureAgentBootstrap so the v1.x layout (CLAUDE.md, identity.json)
+      // is not overwritten with new-design files.
+      expect(readFileSync(join(legacyCwd, "CLAUDE.md"), "utf-8")).toBe("legacy session prompt\n");
+      expect(readFileSync(join(legacyCwd, ".agent", "identity.json"), "utf-8")).toBe('{"agentId":"legacy"}');
+
+      await handler.shutdown();
+    } finally {
+      // Always clean up the fake SDK transcript so this test stays hermetic.
+      rmSync(legacyTranscriptDir, { recursive: true, force: true });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   CanUseTool,
@@ -1088,6 +1088,41 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
+   * Probe whether the Claude Code SDK can resume the given session at the
+   * current cwd. The SDK stores per-project transcripts at
+   * `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`, where
+   * `encoded-cwd` is the absolute cwd with every non-alphanumeric char
+   * replaced by `-`. If the file is missing, `query({ resume })` throws
+   * `No conversation found with session ID: <id>` asynchronously inside
+   * the consume loop, surfacing as an SDK error in the chat timeline.
+   *
+   * This shows up after the agent-session-cwd-redesign upgrade: per-chat
+   * cwd transcripts live under a chatId-suffixed encoded path that no
+   * longer matches the new per-agent-home encoding, so legacy sessionIds
+   * can't be resumed in place. See proposal §⓪.3 R2.
+   *
+   * 🔍 Encoding rule sourcing: the `[^a-zA-Z0-9-]` → `-` substitution
+   * matches Claude Agent SDK 0.2.x's on-disk behavior, verified empirically
+   * by listing `~/.claude/projects/` against known cwds — an absolute path
+   * like `/Users/alice/project` becomes the directory `-Users-alice-project`,
+   * and `/foo/.bar` becomes `-foo--bar` (the `.` is non-alphanumeric).
+   * The SDK does not export a public helper for the encoding, so an
+   * upstream change here would silently invalidate this probe → fallback
+   * either fails to trigger (loud SDK error returns) or triggers
+   * unnecessarily (cold-start an existing session). When bumping
+   * `@anthropic-ai/claude-agent-sdk`, re-verify the encoding rule.
+   *
+   * Returning `false` lets the caller pick either:
+   *   - run the resume against a different cwd that DOES have the
+   *     transcript (legacy chat dir, see `resume()` body); or
+   *   - mint a fresh sessionId and fall through to start() semantics.
+   */
+  function claudeSessionFileExists(workspaceCwd: string, sessionId: string): boolean {
+    const encoded = workspaceCwd.replace(/[^a-zA-Z0-9-]/g, "-");
+    return existsSync(join(homedir(), ".claude", "projects", encoded, `${sessionId}.jsonl`));
+  }
+
+  /**
    * Hash-check the existing identity.json against the current agent metadata
    * and rewrite it (plus the rest of the .agent/ stable section) only when
    * something changed. Cheap to run on every session start — the typical
@@ -1228,6 +1263,41 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       ctx = sessionCtx;
       claudeSessionId = sessionId;
       retryCount = 0;
+
+      // R2 backward-compat: a session created BEFORE this PR ran with cwd =
+      // `<workspaceRoot>/<chatId>/`, so its Claude SDK transcript is keyed
+      // off that path's encoding under `~/.claude/projects/`. The new
+      // per-agent-home cwd would NOT find it and would error with `No
+      // conversation found ...`. To preserve the agent's SDK turn history
+      // across upgrade, probe the legacy chat dir first — if the transcript
+      // is there, run the resume against the legacy cwd verbatim and skip
+      // every piece of agent-home setup (the legacy dir already has its
+      // own `.agent/`, CLAUDE.md, and gitRepos checkout at top-level).
+      const legacyCwd = join(workspaceRoot, sessionCtx.chatId);
+      const isLegacy = existsSync(legacyCwd) && claudeSessionFileExists(legacyCwd, sessionId);
+
+      if (isLegacy) {
+        cwd = legacyCwd;
+        sessionCtx.log(
+          `Resume: detected pre-redesign SDK transcript at legacy cwd ${legacyCwd}; ` +
+            "running this session under the legacy per-chat layout to preserve agent memory",
+        );
+        const chatContext = await fetchChatContextOrLog(sessionCtx);
+        // Intentionally NOT calling ensureAgentBootstrap / prepareSourceRepos /
+        // markWorkspaceInitComplete here — those write the new agent-home
+        // layout, which would pollute the legacy chat dir. The dir already
+        // carries the v1.x bootstrap output (CLAUDE.md, AGENTS.md, .agent/,
+        // <localPath>/ source repos), and the agent reads it via the SDK's
+        // `settingSources: ["project"]` option.
+        spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+        if (message) {
+          inputController?.push(await toSDKUserMessage(message, sessionCtx, sessionId));
+        }
+        sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
+        return sessionId;
+      }
+
+      // Normal new-design resume path: cwd is the agent home.
       cwd = acquireAgentHome(workspaceRoot);
 
       // Identical control flow to start(): bootstrap is idempotent and the
@@ -1241,6 +1311,25 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       await prepareSourceRepos(cwd, payload, sessionCtx);
 
       markWorkspaceInitComplete(cwd);
+
+      // Defensive fallback: sessionId isn't recognised at EITHER cwd (likely
+      // a stale registry entry from machine swap / fs cleanup / tampering).
+      // Mint a fresh id and start cold — Hub message history survives.
+      if (!claudeSessionFileExists(cwd, sessionId)) {
+        const freshSessionId = randomUUID();
+        sessionCtx.log(
+          `Resume: SDK transcript for ${sessionId} not found at legacy (${legacyCwd}) ` +
+            `or agent home (${cwd}); starting fresh session ${freshSessionId} — ` +
+            "Hub message history is preserved.",
+        );
+        claudeSessionId = freshSessionId;
+        spawnQuery(freshSessionId, sessionCtx, undefined, chatContext);
+        if (message) {
+          inputController?.push(await toSDKUserMessage(message, sessionCtx, freshSessionId));
+        }
+        sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
+        return freshSessionId;
+      }
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
       spawnQuery(sessionId, sessionCtx, sessionId, chatContext);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -528,7 +528,17 @@ export class SessionManager {
     entry.lastActivity = Date.now();
 
     try {
-      await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx);
+      // Mirror the pattern in `startNewSession` (line 449): the handler may
+      // return a DIFFERENT sessionId than the one passed in — e.g. when the
+      // claude-code handler detects a stale SDK transcript and falls
+      // through to fresh-start semantics — and `entry.claudeSessionId` has
+      // to track the handler's truth or future resume cycles will keep
+      // calling the stale id. PR #530 nit baixiaohang flagged: without the
+      // assignment back, a fresh-start fallback would persist the OLD id,
+      // and the next suspend→resume cycle would re-trigger the same
+      // missing-transcript fallback ad infinitum.
+      const resumedSessionId = await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx);
+      entry.claudeSessionId = resumedSessionId;
       this.config.log.info({ chatId: entry.chatId, sessionId: entry.claudeSessionId }, "session resumed");
       this.persistRegistry();
       this.notifySessionState(entry.chatId, "active");


### PR DESCRIPTION
## Summary

**Hotfix for production bug surfaced after [#506](https://github.com/agent-team-foundation/first-tree/pull/506) merged.**

User report after upgrade:
\`\`\`
ERROR · SDK · 05/22 22:41
No conversation found with session ID: 72a19485-ca9e-4bc3-9add-a57e8314e5c3
\`\`\`

This is **R2** from [proposal §⓪.3](https://github.com/agent-team-foundation/first-tree-context/blob/main/proposals/agent-session-cwd-redesign.20260519.md). PR #506 changed the runtime cwd from \`<workspaces>/<agent>/<chatId>/\` to \`<workspaces>/<agent>/\`. The Claude Agent SDK stores per-project session transcripts at:

\`\`\`
~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
\`\`\`

where \`<encoded-cwd>\` replaces every non-alphanumeric char in the absolute cwd with \`-\`. The legacy chatId-suffixed encoding no longer matches the new per-agent encoding, so calling \`query({ resume: <legacy-sessionId> })\` throws \`No conversation found ...\` asynchronously inside the SDK consume loop — surfacing as an SDK error event in the chat timeline.

## Fix (revised per yuezengwu's directive)

**Earlier draft of this PR**: detect missing transcript, fall through to fresh start with a new sessionId.

**Revised approach (this PR)**: backward-compat routing. Legacy sessions resume against their **original per-chat cwd** so the SDK transcript is found in place and agent memory is preserved across upgrade. Fresh-start fallback only when the transcript is missing from BOTH legacy AND new cwd.

\`resume()\` probe priority:

1. **Legacy hit** (\`<workspaceRoot>/<chatId>/<sessionId>.jsonl\` exists under \`~/.claude/projects/\`): use the legacy chat-dir as cwd verbatim. Skip \`ensureAgentBootstrap\` / \`prepareSourceRepos\` / \`markWorkspaceInitComplete\` — the legacy dir already carries the v1.x bootstrap output and we MUST NOT overwrite it. Return the legacy sessionId unchanged.
2. **New-design hit** (\`<workspaceRoot>/<sessionId>.jsonl\`): standard PR #506 path. cwd = agent home, full bootstrap, source repos materialised.
3. **Neither hit** (stale registry / machine swap / fs cleanup): mint fresh sessionId, fall through to start() semantics. Hub message history is preserved; agent re-enters cold.

\`SessionManager.resumeSession\` already plumbed the start-path assignment (\`session-manager.ts:449\`); this PR also fixes the resume-path counterpart at line 531 (baixiaohang nit 2) so case 3 doesn't infinite-loop on future suspend→resume cycles.

## Why Codex doesn't need the same fix

Codex stores session transcripts at \`~/.codex/sessions/<year>/<month>/<day>/rollout-<timestamp>-<sessionId>.jsonl\` — date-organized, not cwd-keyed. \`resumeThread(id)\` works across cwd changes by design.

## Files changed

- \`packages/client/src/handlers/claude-code.ts\`:
  - Add \`claudeSessionFileExists(workspaceCwd, sessionId)\` helper with sourcing-comment per baixiaohang nit 1 (\`[^a-zA-Z0-9-]\` → \`-\` encoding is empirical SDK 0.2.x behavior; re-verify on SDK upgrade)
  - \`resume()\` probes legacy cwd first, falls through to new cwd, then to fresh-start
- \`packages/client/src/runtime/session-manager.ts\`:
  - Line 531: assign \`entry.handler.resume(...)\` return value back to \`entry.claudeSessionId\` (baixiaohang nit 2 — mirror line 449 pattern)
- \`packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts\`:
  - E8 (revised): unknown sessionId → fresh start, NEW sessionId returned
  - E9 (new): legacy transcript at per-chat cwd → resume against legacy cwd, legacy sessionId preserved, legacy dir contents untouched (verifies the primary R2 path)

## Test plan

- [x] \`pnpm -F @first-tree/client typecheck\` clean
- [x] \`pnpm -F @first-tree/client test\` — 55 files / 466 tests pass (E8 + E9 included)
- [x] Manual filesystem inspection confirms the SDK transcript encoding rule on this dev box
- [ ] Post-merge: production resume of a pre-upgrade session should show \"Resume: detected pre-redesign SDK transcript at legacy cwd ... running this session under the legacy per-chat layout\" in client logs; agent's prior turn history remains accessible

## Risk

Narrow but the surface widened slightly vs the original PR #530:
- Added \`session-manager.ts:531\` assignment fix (defensively addresses nit 2). Doesn't change the legacy-routing happy path.
- The legacy-routing branch INTENTIONALLY skips bootstrap calls on legacy cwd; this means legacy sessions don't get the new prompt injection (Source Repositories list, Working Directory Convention block). Acceptable because legacy sessions already have their old CLAUDE.md / AGENTS.md on disk with the chat context baked in pre-redesign.
- Legacy sessions naturally age out as chat closes / new chat opens, so this branch becomes dead code over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)