### PR TITLE
ci: add migration linearity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,15 +159,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need main reachable so check-migrations.mjs can compare HEAD's
-          # _journal.json against main's. The job only ever runs `git show`
-          # against origin/main, so a depth-1 fetch of main below is enough —
-          # no need to pull full history.
           fetch-depth: 1
       - name: Fetch main for cross-branch comparison
-        # On a push to main, origin/main and HEAD coincide; the script
-        # detects this and skips the cross-branch check. On PRs we need
-        # an explicit fetch because checkout@v4 only fetches the PR ref.
+        # Only PR runs need to compare HEAD against main. On push-to-main
+        # the local contiguity check is sufficient (a duplicate idx that
+        # snuck through two racing PRs surfaces as a broken sequence in
+        # _journal.json) and fetching main risks a TOCTOU "missing from
+        # HEAD" false positive if another push lands between this push
+        # and the fetch.
+        if: github.event_name == 'pull_request'
         run: git fetch --depth=1 origin main:refs/remotes/origin/main
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,30 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  check-migrations:
+    name: Migrations
+    runs-on: ubuntu-latest
+    # Always runs — even on PRs that touch no server code. Branch protection
+    # no longer requires PRs to be up to date with main, so this job is the
+    # single guard against two PRs landing colliding migration idxs.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need main reachable so check-migrations.mjs can compare HEAD's
+          # _journal.json against main's. The job only ever runs `git show`
+          # against origin/main, so a depth-1 fetch of main below is enough —
+          # no need to pull full history.
+          fetch-depth: 1
+      - name: Fetch main for cross-branch comparison
+        # On a push to main, origin/main and HEAD coincide; the script
+        # detects this and skips the cross-branch check. On PRs we need
+        # an explicit fetch because checkout@v4 only fetches the PR ref.
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: node scripts/check-migrations.mjs
+
   grep-legacy-names:
     name: Forbid legacy CLI / env names
     needs: changes

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Migration linearity guard.
+//
+// Why this exists: branch protection no longer forces PRs to be up to date
+// with main before merging. That removes the implicit guarantee that two
+// concurrently-open PRs which each call `drizzle-kit generate` won't both
+// land a migration with the same idx (e.g. two `0049_*.sql` files with
+// different filename suffixes won't conflict in git, so without this check
+// they'd both squash-merge cleanly and leave drizzle's _journal.json
+// permanently broken on main).
+//
+// What it checks:
+//   1. packages/server/drizzle/meta/_journal.json is contiguous and
+//      well-formed (idx starts at 0, strictly increments by 1, no dup tags,
+//      every entry's `tag` has the matching `NNNN_` prefix).
+//   2. The on-disk .sql files and the journal agree (no orphan .sql, no
+//      missing .sql for a journal entry).
+//   3. Every new journal entry vs. origin/main has idx > max(main idx) —
+//      i.e. PRs may only append migrations, never reuse or rewrite a
+//      number already on main. When the comparison base isn't available
+//      (e.g. workflow_dispatch without a fetched main), the cross-branch
+//      check is skipped with a warning and the local checks still run.
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const drizzleDir = resolve(repoRoot, "packages/server/drizzle");
+const journalPath = resolve(drizzleDir, "meta/_journal.json");
+const journalRelPath = "packages/server/drizzle/meta/_journal.json";
+
+const errors = [];
+const fail = (msg) => errors.push(msg);
+
+function readJournal(source) {
+  let raw;
+  try {
+    raw = source.read();
+  } catch (err) {
+    fail(`${source.label}: cannot read _journal.json (${err.message})`);
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    fail(`${source.label}: _journal.json is not valid JSON (${err.message})`);
+    return null;
+  }
+  if (!Array.isArray(parsed.entries)) {
+    fail(`${source.label}: _journal.json is missing an "entries" array`);
+    return null;
+  }
+  return parsed.entries;
+}
+
+function validateContiguous(entries, label) {
+  const seenTags = new Set();
+  let priorIdx = -1;
+  for (const entry of entries) {
+    const { idx, tag } = entry;
+    if (typeof idx !== "number" || !Number.isInteger(idx) || idx < 0) {
+      fail(`${label}: entry has invalid idx ${JSON.stringify(idx)} (tag=${tag})`);
+      continue;
+    }
+    if (typeof tag !== "string" || !/^\d{4}_[a-z0-9_]+$/.test(tag)) {
+      fail(`${label}: entry idx=${idx} has malformed tag ${JSON.stringify(tag)}`);
+      continue;
+    }
+    const prefix = tag.slice(0, 4);
+    if (parseInt(prefix, 10) !== idx) {
+      fail(`${label}: entry idx=${idx} tag=${tag} — tag prefix ${prefix} does not match idx`);
+    }
+    if (seenTags.has(tag)) {
+      fail(`${label}: duplicate tag ${tag}`);
+    }
+    seenTags.add(tag);
+    if (idx !== priorIdx + 1) {
+      fail(
+        `${label}: idx sequence broken — expected ${priorIdx + 1}, got ${idx} (tag=${tag}). ` +
+          "Journal must be contiguous from 0 with no gaps and no duplicates.",
+      );
+    }
+    priorIdx = idx;
+  }
+}
+
+function validateFilesMatchJournal(entries) {
+  const sqlFiles = readdirSync(drizzleDir)
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  const journalTags = new Set(entries.map((e) => e.tag));
+  const fileTags = new Set(sqlFiles.map((name) => name.replace(/\.sql$/, "")));
+
+  for (const tag of journalTags) {
+    if (!fileTags.has(tag)) {
+      fail(`${journalRelPath} references "${tag}" but ${tag}.sql is missing on disk`);
+    }
+  }
+  for (const tag of fileTags) {
+    if (!journalTags.has(tag)) {
+      fail(`packages/server/drizzle/${tag}.sql exists but is not in ${journalRelPath}`);
+    }
+  }
+}
+
+function readMainJournal() {
+  const base = process.env.MIGRATION_CHECK_BASE_REF ?? "origin/main";
+  const headSha = (() => {
+    try {
+      return execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    } catch {
+      return null;
+    }
+  })();
+  const baseSha = (() => {
+    try {
+      return execFileSync("git", ["rev-parse", base], { encoding: "utf8" }).trim();
+    } catch {
+      return null;
+    }
+  })();
+  if (!baseSha) {
+    console.warn(`warn: ${base} is not available locally; skipping cross-branch idx check.`);
+    return { skipped: true };
+  }
+  if (headSha && baseSha === headSha) {
+    console.log(`info: HEAD equals ${base}; cross-branch idx check is trivially satisfied.`);
+    return { skipped: true };
+  }
+  return {
+    skipped: false,
+    read: () => execFileSync("git", ["show", `${base}:${journalRelPath}`], { encoding: "utf8" }),
+    label: `${base}:${journalRelPath}`,
+  };
+}
+
+const headEntries = readJournal({
+  label: journalRelPath,
+  read: () => readFileSync(journalPath, "utf8"),
+});
+
+if (headEntries) {
+  validateContiguous(headEntries, journalRelPath);
+  validateFilesMatchJournal(headEntries);
+
+  const mainSource = readMainJournal();
+  if (!mainSource.skipped) {
+    const mainEntries = readJournal(mainSource);
+    if (mainEntries) {
+      const mainMaxIdx = mainEntries.length === 0 ? -1 : Math.max(...mainEntries.map((e) => e.idx));
+      const mainTags = new Map(mainEntries.map((e) => [e.tag, e]));
+
+      for (const entry of headEntries) {
+        const existing = mainTags.get(entry.tag);
+        if (existing) {
+          if (existing.idx !== entry.idx) {
+            fail(
+              `tag ${entry.tag}: idx on HEAD (${entry.idx}) differs from main (${existing.idx}) — ` +
+                "migrations are immutable once on main",
+            );
+          }
+          continue;
+        }
+        if (entry.idx <= mainMaxIdx) {
+          fail(
+            `new migration ${entry.tag} has idx=${entry.idx} but main's max idx is ${mainMaxIdx}. ` +
+              "Rebase onto main, delete this migration, and re-run `pnpm --filter @first-tree/server db:generate` " +
+              "so it gets a fresh idx.",
+          );
+        }
+      }
+
+      for (const [tag, entry] of mainTags) {
+        if (!headEntries.some((e) => e.tag === tag)) {
+          fail(
+            `migration ${tag} (idx=${entry.idx}) exists on main but is missing from HEAD — ` +
+              "migrations are immutable once on main",
+          );
+        }
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Migration check FAILED:");
+  for (const err of errors) {
+    console.error(`  - ${err}`);
+  }
+  process.exit(1);
+}
+
+console.log("Migration check OK.");


### PR DESCRIPTION
## Summary

- Adds `scripts/check-migrations.mjs`, run as a new `Migrations` CI job, to enforce that drizzle migrations remain a strictly linear, contiguous sequence on `main`.
- Closes the gap that opened when `main` branch protection's "require branches to be up to date" was disabled: two PRs that each `drizzle-kit generate` against the same base would otherwise both squash-merge with colliding migration idxs (filenames differ by random suffix, so git would not flag a conflict).

## Scope: detective, not preventive

This check is a **tripwire**, not a true preventer. Two PRs that pass CI against an older base can still both squash-merge cleanly; the duplicate idx then surfaces on the *post-merge* main CI run (where the local contiguity check trips on the broken `_journal.json`). That's enough to stop a bad state from being silently shipped to production, but a contributor has to revert and renumber to fix it.

For true prevention, follow-ups would be: re-enable "require branches to be up to date", enable GitHub's merge queue, or auto-rerun PR CI on base updates. Picking one of those is out of scope for this PR.

## What the check enforces

1. `packages/server/drizzle/meta/_journal.json` is well-formed: `idx` starts at 0, strictly increments by 1, no duplicate tags, every tag's `NNNN_` prefix matches its `idx`.
2. The on-disk `.sql` files and the journal agree — no orphan `.sql`, no missing `.sql` for any journal entry.
3. **On PR runs**: new journal entries must have `idx > max(main idx)`, and entries that exist on `main` may not be removed or renumbered. On push-to-main runs the cross-branch comparison is skipped (the local checks above already catch the racing-merge case, and avoiding the `origin/main` fetch removes a TOCTOU window where another push could land between this push and the fetch).

On collision, the failure message tells the contributor exactly how to recover (rebase onto main, delete the local migration, re-run `pnpm --filter @first-tree/server db:generate`).

## Follow-up after merge

Add `Migrations` to the required status checks on `main` branch protection so the guard is mandatory, not advisory.

## Test plan

- [x] Clean checkout: passes (`Migration check OK`)
- [x] PR that legitimately appends `0049_*` while main's max is `0048`: passes
- [x] PR's `0049_*` collides with a different `0049_*` already on main: fails with rebase guidance
- [x] Journal with a missing idx (gap): fails
- [x] Orphan `.sql` not in journal: fails
- [x] Journal entry without matching `.sql`: fails
- [x] Tag prefix mismatches idx (e.g. `idx=49 tag=0050_*`): fails
- [x] \`pnpm check\` (biome) clean on the new script

🤖 Generated with [Claude Code](https://claude.com/claude-code)