### PR TITLE
fix(client): resolve doc-preview base path against per-agent-home for new chats

### DIFF
--- a/packages/client/src/__tests__/document-base-path.test.ts
+++ b/packages/client/src/__tests__/document-base-path.test.ts
@@ -1,6 +1,9 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
-import { describe, expect, it } from "vitest";
-import { documentBasePathFromRuntimeConfig } from "../runtime/session-manager.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { documentBasePathFromRuntimeConfig, resolveSessionDocRoot } from "../runtime/session-manager.js";
 
 function payload(gitRepos: AgentRuntimeConfigPayload["gitRepos"]): AgentRuntimeConfigPayload {
   return { kind: "claude-code", prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos };
@@ -9,11 +12,11 @@ function payload(gitRepos: AgentRuntimeConfigPayload["gitRepos"]): AgentRuntimeC
 const PER_CHAT = "/data/workspaces/agent/chat-123";
 
 describe("documentBasePathFromRuntimeConfig", () => {
-  it("returns the per-chat workspace root when there are zero repos", () => {
+  it("returns the session doc root when there are zero repos", () => {
     expect(documentBasePathFromRuntimeConfig(payload([]), PER_CHAT)).toBe(PER_CHAT);
   });
 
-  it("returns the per-chat workspace root when there are multiple repos", () => {
+  it("returns the session doc root when there are multiple repos", () => {
     const result = documentBasePathFromRuntimeConfig(
       payload([{ url: "https://github.com/a/one.git" }, { url: "https://github.com/a/two.git" }]),
       PER_CHAT,
@@ -21,7 +24,7 @@ describe("documentBasePathFromRuntimeConfig", () => {
     expect(result).toBe(PER_CHAT);
   });
 
-  it("returns an ABSOLUTE repo worktree path (perChatRoot + derived localPath) for a single repo", () => {
+  it("returns an ABSOLUTE repo worktree path (sessionRoot + derived localPath) for a single repo", () => {
     // Regression: the old code returned a bare relative localPath
     // ("first-tree"), which the runtime resolved against its own
     // process.cwd() (the launch dir, not the per-chat workspace) and failed to
@@ -37,7 +40,45 @@ describe("documentBasePathFromRuntimeConfig", () => {
     ).toBe(`${PER_CHAT}/nested/repo`);
   });
 
-  it("falls back to the per-chat root when a single repo's localPath is blank", () => {
+  it("falls back to the session doc root when a single repo's localPath is blank", () => {
     expect(documentBasePathFromRuntimeConfig(payload([{ url: "", localPath: "   " }]), PER_CHAT)).toBe(PER_CHAT);
+  });
+});
+
+describe("resolveSessionDocRoot — per-agent-home vs legacy per-chat layout", () => {
+  let workspaceRoot: string;
+
+  beforeAll(() => {
+    // Stand in for `<workspaces>/<agentSlug>` — the agent home AND the handler's
+    // `workspaceRoot`. acquireAgentHome returns this path verbatim.
+    workspaceRoot = mkdtempSync(join(tmpdir(), "ft-session-doc-root-"));
+  });
+
+  afterAll(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("returns the agent home for a NEW chat with no legacy per-chat dir (the #506 regression)", () => {
+    // Post-#506 a fresh chat runs cwd = agent home with the source repo at the
+    // top level; no `<workspaceRoot>/<chatId>/` dir is ever created. The base
+    // MUST be the agent home, not the phantom per-chat dir — otherwise the
+    // snapshot scanner realpaths a non-existent root and embeds zero snapshots,
+    // so every `.md` mention stays plain text.
+    expect(resolveSessionDocRoot(workspaceRoot, "new-chat-no-dir")).toBe(workspaceRoot);
+  });
+
+  it("returns the legacy per-chat dir when it exists on disk (pre-#506 chats)", () => {
+    const chatId = "legacy-chat-on-disk";
+    mkdirSync(join(workspaceRoot, chatId), { recursive: true });
+    expect(resolveSessionDocRoot(workspaceRoot, chatId)).toBe(join(workspaceRoot, chatId));
+  });
+
+  it("resolves a NEW single-repo chat's doc base under the agent home, not a per-chat phantom", () => {
+    // End-to-end of the bug: compose the root resolver with the base builder.
+    const base = documentBasePathFromRuntimeConfig(
+      payload([{ url: "https://github.com/agent-team-foundation/first-tree-hub.git" }]),
+      resolveSessionDocRoot(workspaceRoot, "another-new-chat"),
+    );
+    expect(base).toBe(join(workspaceRoot, "first-tree-hub"));
   });
 });

--- a/packages/client/src/__tests__/document-base-path.test.ts
+++ b/packages/client/src/__tests__/document-base-path.test.ts
@@ -76,9 +76,9 @@ describe("resolveSessionDocRoot — per-agent-home vs legacy per-chat layout", (
   it("resolves a NEW single-repo chat's doc base under the agent home, not a per-chat phantom", () => {
     // End-to-end of the bug: compose the root resolver with the base builder.
     const base = documentBasePathFromRuntimeConfig(
-      payload([{ url: "https://github.com/agent-team-foundation/first-tree-hub.git" }]),
+      payload([{ url: "https://github.com/agent-team-foundation/first-tree.git" }]),
       resolveSessionDocRoot(workspaceRoot, "another-new-chat"),
     );
-    expect(base).toBe(join(workspaceRoot, "first-tree-hub"));
+    expect(base).toBe(join(workspaceRoot, "first-tree"));
   });
 });

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import type {
   AgentRuntimeConfigPayload,
@@ -43,7 +44,62 @@ type PendingMessage = {
 };
 
 /**
- * Resolve the base path the runtime reads markdown doc snapshots against.
+ * Resolve the directory the runtime reads markdown doc snapshots against —
+ * the same dir the handler actually hands the agent as cwd for this chat.
+ *
+ * Two layouts coexist after the per-agent-home redesign (#506) and its
+ * legacy-resume hotfix (#530):
+ *  - NEW chats run cwd = the per-agent home (`<workspaceRoot>` itself, see
+ *    `acquireAgentHome`), with predeclared source repos materialised at the
+ *    TOP LEVEL (`<workspaceRoot>/<localPath>`). No `<workspaceRoot>/<chatId>/`
+ *    dir is ever created.
+ *  - LEGACY chats (created before #506) keep their original per-chat cwd
+ *    `<workspaceRoot>/<chatId>/`, with their own v1.x layout (source repos at
+ *    `<workspaceRoot>/<chatId>/<localPath>`); #530 resumes them in place.
+ *
+ * The doc base MUST agree with whichever cwd the handler chose, or the
+ * snapshot scanner realpaths a non-existent root and embeds ZERO snapshots —
+ * so every `.md` mention stays plain text instead of rendering a clickable
+ * preview (the symptom this fixes for new chats). We discriminate by the same
+ * cheap signal #530's claude-code `resume()` uses first: does the legacy
+ * per-chat dir physically exist? Present ⇒ legacy layout; absent ⇒ per-agent
+ * home.
+ *
+ * Pure read-only `existsSync` — no `acquireWorkspace`/`acquireAgentHome`,
+ * whose mkdir side effects must not run on every outbound message.
+ *
+ * IMPORTANT — `existsSync(legacyDir)` is a *proxy* for "the handler chose the
+ * legacy cwd". It is exact for new chats (no legacy dir ⇒ agent home, for both
+ * handlers) but `SessionManager` is handler-agnostic (it only knows
+ * `workspaceRoot`, never the handler kind), so two legacy-chat cases diverge —
+ * the resolver returns the legacy dir while the handler actually ran at the
+ * agent home:
+ *   1. CODEX legacy chats. The codex handler has NO legacy-cwd branch:
+ *      `start()` and `resume()` both use `acquireAgentHome` (see
+ *      `handlers/codex.ts`; #530 left codex alone because its transcripts are
+ *      not cwd-keyed). Pre-#506 codex still created `<workspaceRoot>/<chatId>/`,
+ *      and those dirs persist (`cleanWorkspaces` is a no-op), so every legacy
+ *      codex chat hits this divergence.
+ *   2. A claude-code legacy chat whose SDK transcript was lost resumes COLD at
+ *      the agent home (#530 case 3) while its `<chatId>/` dir still exists.
+ * In both, a freshly-written doc at the agent home may snapshot a STALE copy
+ * from the legacy dir, or stay plain text if it exists only at the home.
+ *
+ * This is NOT a regression: the prior code used `join(workspaceRoot, chatId)`
+ * unconditionally, so legacy chats already resolved to the legacy dir — this
+ * fix changes only the new-chat (no-legacy-dir) path. The divergence is
+ * graceful (older revision, never an empty/wrong file), bounded to legacy chats
+ * (which shrink over time), and the clean fix is to thread the handler's
+ * resolved cwd through to the sink instead of re-probing here.
+ */
+export function resolveSessionDocRoot(workspaceRoot: string, chatId: string): string {
+  const legacyPerChatRoot = join(workspaceRoot, chatId);
+  return existsSync(legacyPerChatRoot) ? legacyPerChatRoot : workspaceRoot;
+}
+
+/**
+ * Resolve the base path the runtime reads markdown doc snapshots against,
+ * given the session doc root from {@link resolveSessionDocRoot}.
  *
  * NEVER returns null — every chat has a workspace, and the snapshot scanner
  * existence-checks each candidate inside the returned root, so a bare mention
@@ -54,20 +110,20 @@ type PendingMessage = {
  *
  * Resolution:
  *  - exactly one repo → that repo's worktree, the unambiguous markdown-link
- *    root. The worktree is materialised at `<perChatRoot>/<localPath>`, so the
+ *    root. The worktree is materialised at `<sessionRoot>/<localPath>`, so the
  *    base MUST be that ABSOLUTE path. Returning a bare relative `localPath`
  *    (the old behaviour) made the runtime resolve it against its own
- *    `process.cwd()` — the launch dir, not the per-chat workspace — so it
+ *    `process.cwd()` — the launch dir, not the session workspace — so it
  *    silently failed to find any doc and cloud preview was dead.
- *  - zero or multiple repos → the per-chat workspace root.
+ *  - zero or multiple repos → the session doc root.
  */
-export function documentBasePathFromRuntimeConfig(payload: AgentRuntimeConfigPayload, perChatRoot: string): string {
+export function documentBasePathFromRuntimeConfig(payload: AgentRuntimeConfigPayload, sessionRoot: string): string {
   if (payload.gitRepos.length === 1) {
     const repo = payload.gitRepos[0];
     const localPath = repo ? repoLocalPath(repo).trim() : "";
-    if (localPath.length > 0) return join(perChatRoot, localPath);
+    if (localPath.length > 0) return join(sessionRoot, localPath);
   }
-  return perChatRoot;
+  return sessionRoot;
 }
 
 function repoLocalPath(repo: GitRepo): string {
@@ -816,11 +872,11 @@ export class SessionManager {
     // exactly like result-sink does (L3: unify capture across send paths).
     // result-sink keeps its own async `getDocumentBasePath`; both read the
     // same cache (`refreshIfNewer(_, 0)` returns the cached payload), so the
-    // base they compute agrees. Falls back to the per-chat root when the
+    // base they compute agrees. Falls back to the session doc root when the
     // cache has no payload yet (== the single/zero-repo default).
-    const perChatRoot = join(this.config.handlerConfig.workspaceRoot, chatId);
+    const sessionRoot = resolveSessionDocRoot(this.config.handlerConfig.workspaceRoot, chatId);
     const cachedPayload = this.config.agentConfigCache?.get(this.config.agentIdentity.agentId)?.payload;
-    const docBase = cachedPayload ? documentBasePathFromRuntimeConfig(cachedPayload, perChatRoot) : perChatRoot;
+    const docBase = cachedPayload ? documentBasePathFromRuntimeConfig(cachedPayload, sessionRoot) : sessionRoot;
 
     const forwardResult = createResultSink({
       sdk: this.config.sdk,
@@ -868,20 +924,20 @@ export class SessionManager {
   }
 
   private async resolveDocumentBasePath(log: (msg: string) => void, chatId: string): Promise<string> {
-    // Per-chat workspace root: the same dir the handler hands the agent as cwd
-    // (`acquireWorkspace(workspaceRoot, chatId)` returns `<workspaceRoot>/<chatId>`).
-    // Computed with a pure `join` — NOT `acquireWorkspace`, whose mkdir/rmSync
-    // side effects must not run on every outbound message.
-    const perChatRoot = join(this.config.handlerConfig.workspaceRoot, chatId);
-    if (!this.config.agentConfigCache) return perChatRoot;
+    // Session doc root: the dir the handler actually hands the agent as cwd —
+    // the per-agent home for new chats, the legacy `<workspaceRoot>/<chatId>/`
+    // dir for pre-#506 chats. See `resolveSessionDocRoot` (read-only existsSync;
+    // no acquire* side effects on every outbound message).
+    const sessionRoot = resolveSessionDocRoot(this.config.handlerConfig.workspaceRoot, chatId);
+    if (!this.config.agentConfigCache) return sessionRoot;
     try {
       const { payload } = await this.config.agentConfigCache.refreshIfNewer(this.config.agentIdentity.agentId, 0);
-      return documentBasePathFromRuntimeConfig(payload, perChatRoot);
+      return documentBasePathFromRuntimeConfig(payload, sessionRoot);
     } catch (err) {
       log(
-        `document preview base path: config unavailable, using workspace root: ${err instanceof Error ? err.message : String(err)}`,
+        `document preview base path: config unavailable, using session doc root: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return perChatRoot;
+      return sessionRoot;
     }
   }
 


### PR DESCRIPTION
## Problem

The chat **doc-preview** feature only renders a `.md` mention as a clickable
link when the runtime snapshotted that file at send time (the "snapshot
gate"). `buildMessageDocumentSnapshots` `realpath`s its base dir first and
returns **zero snapshots** if that fails — so when the base dir doesn't
exist, every `.md` mention in the message silently stays plain text.

After #506 (per-agent-home cwd + source repo at top level), a **new chat**
no longer gets a `<workspaceRoot>/<chatId>/` directory; its cwd is the
per-agent home and the repo lives at `<workspaceRoot>/<localPath>`. But the
doc-base resolver in `session-manager.ts` still computed
`join(workspaceRoot, chatId)`, pointing at a directory that does not exist.

**Result:** doc preview was dead for every chat created after #506 — the
symptom reported in dev (md docs render as plain text, not previewable
links). #506 didn't touch `session-manager.ts`, so the resolver was never
migrated; #530 fixed the analogous cwd issue for session *resume* but not
the doc-base path.

## Fix

Add `resolveSessionDocRoot(workspaceRoot, chatId)`, mirroring #530's
claude-code `resume()` discriminator: use the legacy per-chat dir when it
**physically exists**, else the per-agent home. Both doc-base call sites
(the sync env path used by `first-tree chat send`, and the async
`resolveDocumentBasePath` used by result-sink) now route through it.

**No regression:** the prior code resolved legacy chats to the legacy dir
too, so only the new-chat (no-legacy-dir) path changes behaviour. This is a
strict improvement.

## Known limitation (follow-up, not in this PR)

`existsSync(legacyDir)` is a *proxy* for "the handler chose the legacy cwd".
It is exact for new chats but `SessionManager` is handler-agnostic, so two
**legacy-chat** cases still diverge (resolver returns the legacy dir while
the handler actually ran at the agent home):

1. **codex legacy chats** — the codex handler has no legacy-cwd branch
   (`handlers/codex.ts` always uses `acquireAgentHome`); its surviving
   pre-#506 `<chatId>/` dir trips the proxy.
2. a claude-code legacy chat whose SDK transcript was lost resumes cold at
   the agent home (#530 case 3) while its `<chatId>/` dir still exists.

Both are graceful (an older revision may be previewed, never an empty/wrong
file), bounded to pre-#506 chats (which shrink over time), and **not a
regression** versus today. The clean fix is to thread the handler's
resolved cwd through to the sink instead of re-probing here — tracked as a
follow-up.

## Test plan

- New `resolveSessionDocRoot` tests: new-chat regression (→ agent home),
  legacy-dir-on-disk (→ per-chat), single-repo end-to-end.
- Existing `document-base-path` + `doc-snapshots` suites updated/green.
- `pnpm --filter @first-tree/client typecheck` clean; biome clean on
  changed files.
- `first-tree-cli-contract.integration.test.ts` fails locally for an
  unrelated reason (on-PATH CLI can't find bundled `skills/` payloads); not
  caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
