### PR TITLE
fix(client): drop evictIdle 120s working→blocked auto-migration

### DIFF
--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -426,7 +426,12 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
     }
   });
 
-  it("also exempts 'blocked' (the state evictIdle itself flips 'working' into after 2 minutes)", async () => {
+  // `blocked` is no longer auto-set by evictIdle (the 120s auto-migration
+  // was removed because reasoning-model thinking turns commonly exceed 2
+  // minutes between SDK events, producing false-positive UI warnings).
+  // The grace-window exemption still covers `blocked` so any handler that
+  // sets it explicitly — present or future — is treated like `working`.
+  it("also exempts 'blocked' from idle suspend inside the grace window", async () => {
     vi.useFakeTimers();
     try {
       let capturedCtx: SessionContext | undefined;
@@ -474,6 +479,47 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
       await vi.advanceTimersByTimeAsync(20_000);
 
       expect(handler.suspend).toHaveBeenCalledTimes(1);
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression for the removed 120s working→blocked auto-migration.
+  // Before this change evictIdle would flip a `working` session to
+  // `blocked` after 2 minutes of SDK silence, surfacing as a yellow UI
+  // warning even when the agent was just deep-thinking. The grace
+  // window above proved that's never a real problem (we don't actually
+  // suspend), so the auto-migration was pure UX noise — removed.
+  it("does NOT auto-migrate 'working' → 'blocked' on inactivity (no false alarms during long reasoning)", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
+      let capturedCtx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, ctx) {
+          capturedCtx = ctx;
+          return "s-no-auto-blocked";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        // Big idle_timeout so we don't trip the suspend path while we're
+        // proving the *non*-transition.
+        session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
+        onRuntimeStateChange: (state) => runtimeChanges.push(state),
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
+      defined(capturedCtx, "ctx").setRuntimeState("working");
+      runtimeChanges.length = 0;
+
+      // Past the old 120s threshold; the runtime would previously have
+      // flipped the state to `blocked` here.
+      await vi.advanceTimersByTimeAsync(180_000);
+
+      expect(runtimeChanges).not.toContain("blocked");
+      expect(handler.suspend).not.toHaveBeenCalled();
       await sm.shutdown();
     } finally {
       vi.useRealTimers();

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -763,10 +763,15 @@ export class SessionManager {
    *        - `working` — a turn is in flight. Set by the handler at the top
    *          of its consume loop AND by `SessionManager` on every `inject`
    *          (because the handler can't observe inject from inside the SDK
-   *          for-await — see #530 follow-up). Clearing it back to `idle`
-   *          happens on each `result` message from the SDK.
-   *        - `blocked` — `working`, but no SDK output for
-   *          `blockedThresholdMs`. Diagnostic only.
+   *          for-await — see #536). Cleared back to `idle` on each
+   *          `result` message from the SDK.
+   *        - `blocked` — only reachable if a handler chooses to set it
+   *          explicitly. The runtime no longer auto-migrates `working` →
+   *          `blocked` on inactivity: with reasoning models a 2-minute
+   *          quiet stretch is normal deep-thinking, not a stuck process,
+   *          and the auto-migration was producing false-positive UI
+   *          warnings. State kept as a semantic slot for future use
+   *          (e.g. if/when the SDK transport exposes a real stuck signal).
    *        - `idle` — no work in flight.
    *      If you add a new way to wake the session up, you MUST also set
    *      `runtimeState` to `working` from that path, or this guard will
@@ -778,80 +783,67 @@ export class SessionManager {
   private evictIdle(): void {
     const timeoutMs = this.config.session.idle_timeout * 1000;
     const workingGraceMs = this.config.session.working_grace_seconds * 1000;
-    // Blocked detection — 2 minutes without activity while session is active
-    const blockedThresholdMs = 120_000;
     const now = Date.now();
     const agentId = this.config.agentIdentity.agentId;
 
     for (const [, session] of this.sessions) {
       if (session.status !== "active") continue;
       const inactiveMs = now - session.lastActivity;
+      if (inactiveMs <= timeoutMs) continue;
 
-      if (inactiveMs > timeoutMs) {
-        const currentState = this.sessionRuntimeStates.get(session.chatId);
+      const currentState = this.sessionRuntimeStates.get(session.chatId);
 
-        // Hard cap: regardless of `runtimeState`, once we are past
-        // `idle_timeout + working_grace_seconds` the slot MUST be
-        // reclaimed. Anything else means a stuck handler can hold a slot
-        // forever just by never flipping `runtimeState` back to `idle`.
-        const pastHardCap = inactiveMs >= timeoutMs + workingGraceMs;
+      // Hard cap: regardless of `runtimeState`, once we are past
+      // `idle_timeout + working_grace_seconds` the slot MUST be reclaimed.
+      // Anything else means a stuck handler can hold a slot forever just
+      // by never flipping `runtimeState` back to `idle`.
+      const pastHardCap = inactiveMs >= timeoutMs + workingGraceMs;
 
-        // #418: when an AskUserQuestion is in flight, suspending tears down
-        // the SDK transport and silently drops the bridge entry — the
-        // eventual answer then arrives with no live waiter and the asker
-        // session is permanently stuck. Skip the suspend so the awaiter
-        // can resolve through the live-bridge path. `lastActivity` still
-        // ticks forward on inject, so a runaway pending entry is bounded
-        // by the supersede paths (chat archive / client claim) and, as a
-        // last resort, by the hard cap above.
-        if (!pastHardCap && hasPendingForChat(agentId, session.chatId)) {
-          this.config.log.info(
-            { chatId: session.chatId, inactiveSec: Math.round(inactiveMs / 1000) },
-            "session idle but AskUserQuestion in flight — skipping suspend",
-          );
-          continue;
-        }
+      // #418: when an AskUserQuestion is in flight, suspending tears down
+      // the SDK transport and silently drops the bridge entry — the
+      // eventual answer then arrives with no live waiter and the asker
+      // session is permanently stuck. Skip the suspend so the awaiter can
+      // resolve through the live-bridge path. `lastActivity` still ticks
+      // forward on inject, so a runaway pending entry is bounded by the
+      // supersede paths (chat archive / client claim) and, as a last
+      // resort, by the hard cap above.
+      if (!pastHardCap && hasPendingForChat(agentId, session.chatId)) {
+        this.config.log.info(
+          { chatId: session.chatId, inactiveSec: Math.round(inactiveMs / 1000) },
+          "session idle but AskUserQuestion in flight — skipping suspend",
+        );
+        continue;
+      }
 
-        // `lastActivity` is bumped per inbound SDK message/event (handler
-        // `touch()`), so a long thinking turn or a single very large message
-        // looks identical to "session has been idle" here. Without this
-        // exemption the runtime suspends the SDK transport mid-thinking and
-        // the work is lost. The hard cap above bounds the worst case.
-        const stillProgressing = currentState === "working" || currentState === "blocked";
-        if (stillProgressing && !pastHardCap) {
-          this.config.log.info(
-            {
-              chatId: session.chatId,
-              runtimeState: currentState,
-              inactiveSec: Math.round(inactiveMs / 1000),
-              graceSec: this.config.session.working_grace_seconds,
-            },
-            "session idle threshold reached but still working — skipping suspend",
-          );
-          continue;
-        }
-
+      // `lastActivity` is bumped per inbound SDK message/event (handler
+      // `touch()`), so a long thinking turn or a single very large message
+      // looks identical to "session has been idle" here. Without this
+      // exemption the runtime suspends the SDK transport mid-thinking and
+      // the work is lost. The hard cap above bounds the worst case.
+      const stillProgressing = currentState === "working" || currentState === "blocked";
+      if (stillProgressing && !pastHardCap) {
         this.config.log.info(
           {
             chatId: session.chatId,
-            idleTimeoutSec: this.config.session.idle_timeout,
-            runtimeState: currentState ?? "idle",
-            pastHardCap,
+            runtimeState: currentState,
+            inactiveSec: Math.round(inactiveMs / 1000),
+            graceSec: this.config.session.working_grace_seconds,
           },
-          "session idle, suspending",
+          "session idle threshold reached but still working — skipping suspend",
         );
-        this.suspendSession(session);
-      } else if (inactiveMs > blockedThresholdMs) {
-        // Only mark blocked if handler was actively working — don't override idle
-        const currentState = this.sessionRuntimeStates.get(session.chatId);
-        if (currentState === "working") {
-          this.config.log.warn(
-            { chatId: session.chatId, inactiveSec: Math.round(inactiveMs / 1000) },
-            "session working but no output, marking blocked",
-          );
-          this.setSessionRuntimeState(session.chatId, "blocked");
-        }
+        continue;
       }
+
+      this.config.log.info(
+        {
+          chatId: session.chatId,
+          idleTimeoutSec: this.config.session.idle_timeout,
+          runtimeState: currentState ?? "idle",
+          pastHardCap,
+        },
+        "session idle, suspending",
+      );
+      this.suspendSession(session);
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #536. After that PR shipped, the architect agent was still emitting yellow \`session working but no output, marking blocked\` warnings ~2min into long reasoning turns — even though the working-grace window correctly prevented any suspend. The 120s auto-migration was just guessing \"stuck\" based on SDK silence, which is wrong with reasoning models where 2-5min deep-thinks are normal.

- Remove the \`else if (inactiveMs > blockedThresholdMs)\` branch in \`evictIdle\`. \`runtimeState\` now stays at \`working\` until the handler sets it back to \`idle\` (per result message) or idle/grace suspends the session.
- Keep \`blocked\` as a semantic slot in \`RuntimeState\` — evictIdle's working-state grace still exempts it, so any future handler-driven \`blocked\` signal works without further runtime changes.
- Update the invariant docblock on \`evictIdle\` to make the new contract explicit (handler-driven only).

## Repro

```
13:56:20  Session resumed
13:58:34  inactiveSec:121, msg: \"session working but no output, marking blocked\"
          ← level=40 warn, runtimeState working → blocked, then aggregate → blocked, UI yellow
```

No actual suspend — the SDK kept producing output and the turn completed normally. The state migration was UX noise only.

## Test plan

- [x] \`pnpm --filter @first-tree/client typecheck\`
- [x] \`pnpm check\` (no new biome issues)
- [x] New regression: \`working\` session silent for 3 min does NOT emit \`blocked\` AND is not suspended (idle_timeout=1h to isolate the non-transition from suspend)
- [x] Existing \"exempts \`blocked\` from idle suspend\" test updated for the new wording (path is now handler-driven, not auto)
- [x] All session-{manager, runtime-state, state-notifications, manager-question-answer} suites pass (51/51)
- [ ] Manual: monitor architect chat for a long reasoning turn — UI should stay green throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)