### PR TITLE
ci(migrations): add LATEST sentinel to force conflicts on racing PRs

### DIFF
--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,0 +1,1 @@
+0048_github_entity_state

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "build": "tsdown src/index.ts src/app.ts src/observability/index.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "db:generate": "drizzle-kit generate",
+    "db:generate": "drizzle-kit generate && node ../../scripts/sync-migration-head.mjs",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"
   },

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -15,7 +15,15 @@
 //      every entry's `tag` has the matching `NNNN_` prefix).
 //   2. The on-disk .sql files and the journal agree (no orphan .sql, no
 //      missing .sql for a journal entry).
-//   3. Every new journal entry vs. origin/main has idx > max(main idx) —
+//   3. packages/server/drizzle/LATEST holds the journal's last tag. This
+//      sentinel is the merge-time anchor: because every migration PR
+//      rewrites the same single line, two PRs that race to add a migration
+//      against the same base produce a deterministic git modify/modify
+//      conflict at merge time (instead of the unreliable add/add-adjacent
+//      behavior that journal-append alone gives). Keep it in sync via
+//      `pnpm --filter @first-tree/server db:generate`, which now invokes
+//      scripts/sync-migration-head.mjs.
+//   4. Every new journal entry vs. origin/main has idx > max(main idx) —
 //      i.e. PRs may only append migrations, never reuse or rewrite a
 //      number already on main. When the comparison base isn't available
 //      (e.g. workflow_dispatch without a fetched main), the cross-branch
@@ -30,6 +38,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const drizzleDir = resolve(repoRoot, "packages/server/drizzle");
 const journalPath = resolve(drizzleDir, "meta/_journal.json");
 const journalRelPath = "packages/server/drizzle/meta/_journal.json";
+const latestPath = resolve(drizzleDir, "LATEST");
+const latestRelPath = "packages/server/drizzle/LATEST";
 
 const errors = [];
 const fail = (msg) => errors.push(msg);
@@ -84,6 +94,31 @@ function validateContiguous(entries, label) {
       );
     }
     priorIdx = idx;
+  }
+}
+
+function validateLatestSentinel(entries) {
+  if (entries.length === 0) return;
+  const expected = entries.at(-1).tag;
+  let raw;
+  try {
+    raw = readFileSync(latestPath, "utf8");
+  } catch (err) {
+    fail(
+      `${latestRelPath}: cannot read sentinel (${err.message}). ` +
+        "Run `pnpm --filter @first-tree/server db:generate` to recreate it, " +
+        "or `node scripts/sync-migration-head.mjs` to sync without regenerating.",
+    );
+    return;
+  }
+  const actual = raw.trim();
+  if (actual !== expected) {
+    fail(
+      `${latestRelPath}: sentinel is "${actual}" but the journal's last tag is "${expected}". ` +
+        "Run `node scripts/sync-migration-head.mjs` (or re-run `db:generate`) so the sentinel " +
+        "matches the journal — this file is the merge-time anchor that forces a git conflict " +
+        "when two PRs race to add a migration.",
+    );
   }
 }
 
@@ -145,6 +180,7 @@ const headEntries = readJournal({
 if (headEntries) {
   validateContiguous(headEntries, journalRelPath);
   validateFilesMatchJournal(headEntries);
+  validateLatestSentinel(headEntries);
 
   const mainSource = readMainJournal();
   if (!mainSource.skipped) {

--- a/scripts/sync-migration-head.mjs
+++ b/scripts/sync-migration-head.mjs
@@ -19,7 +19,10 @@ const latestPath = resolve(repoRoot, "packages/server/drizzle/LATEST");
 const journal = JSON.parse(readFileSync(journalPath, "utf8"));
 const lastEntry = journal.entries?.at(-1);
 if (!lastEntry?.tag) {
-  console.error("sync-migration-head: _journal.json has no entries — nothing to sync.");
+  // Reachable in practice only if `drizzle-kit generate` produced nothing
+  // (the prior step in `db:generate`). Surface that instead of a generic
+  // "no entries" error.
+  console.error("sync-migration-head: _journal.json has no entries — did `drizzle-kit generate` produce a migration?");
   process.exit(1);
 }
 

--- a/scripts/sync-migration-head.mjs
+++ b/scripts/sync-migration-head.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Sync packages/server/drizzle/LATEST with the last entry in _journal.json.
+//
+// Called automatically from `pnpm --filter @first-tree/server db:generate` so
+// every freshly generated migration also bumps the LATEST sentinel. The
+// sentinel is the merge-time anchor: every migration PR rewrites the same
+// single line, which forces git to report a modify/modify conflict if two
+// PRs try to land migrations against the same base. See
+// scripts/check-migrations.mjs for the CI-side validation.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const journalPath = resolve(repoRoot, "packages/server/drizzle/meta/_journal.json");
+const latestPath = resolve(repoRoot, "packages/server/drizzle/LATEST");
+
+const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+const lastEntry = journal.entries?.at(-1);
+if (!lastEntry?.tag) {
+  console.error("sync-migration-head: _journal.json has no entries — nothing to sync.");
+  process.exit(1);
+}
+
+writeFileSync(latestPath, `${lastEntry.tag}\n`);
+console.log(`sync-migration-head: LATEST -> ${lastEntry.tag}`);


### PR DESCRIPTION
## Summary

Closes the residual gap left after PR #534. The check-migrations CI job catches collisions *after* main is corrupted — this PR makes the collision impossible to merge in the first place.

Mechanism: a single-line sentinel file `packages/server/drizzle/LATEST` holds the latest migration tag. Every migration PR rewrites this same line. Two PRs racing to add migrations against the same base produce a deterministic git **modify/modify** conflict on `LATEST` (instead of the unreliable add/add-adjacent behavior on `_journal.json`), which blocks the GitHub merge button until a human rebases.

## What changes

- **`packages/server/drizzle/LATEST`** (new) — one line, currently `0048_github_entity_state`. The merge-time anchor.
- **`scripts/sync-migration-head.mjs`** (new) — reads `_journal.json`, writes its last tag to `LATEST`. Zero deps.
- **`packages/server/package.json`** — `db:generate` now chains the sync script so contributors never have to remember `LATEST` exists.
- **`scripts/check-migrations.mjs`** — adds an assertion that `LATEST` equals the journal's last tag. A PR that forgets to sync fails CI with an actionable message pointing at the sync script.

## Why a separate file, not journal manipulation

Looked at drizzle's existing artifacts: the journal's `entries[]` append, the per-migration `meta/NNNN_snapshot.json` files, and `drizzle.config.ts` all either expose an add-at-end pattern or a different-file-per-migration pattern — none of them are a single line that every new migration must rewrite. Drizzle-kit also has no documented pre/post-hook to inject one. A separate sentinel file is the smallest, clearest intervention.

## Verification

Simulated two concurrent PRs both branching off the same base and each adding a 0049 migration with the sentinel sync wired in. After PR-A merges into the proxy main, attempting to merge PR-B produces:

\`\`\`
Auto-merging packages/server/drizzle/LATEST
CONFLICT (content): Merge conflict in packages/server/drizzle/LATEST
Auto-merging packages/server/drizzle/meta/_journal.json
CONFLICT (content): Merge conflict in packages/server/drizzle/meta/_journal.json
Automatic merge failed; fix conflicts and then commit the result.
\`\`\`

Conflict on `LATEST` is guaranteed by construction; the journal happens to also conflict in this simulation because of the differing \`when\` timestamps, but we don't rely on that — \`LATEST\` is the deterministic anchor.

## Test plan

- [x] Clean checkout: \`check-migrations\` passes
- [x] LATEST drifts ahead of journal: fails with sync hint
- [x] Journal advances but LATEST not synced: fails with sync hint
- [x] After running \`sync-migration-head.mjs\`: passes
- [x] Simulated two-PR race: PR-B merge produces \`CONFLICT (content)\` on LATEST
- [x] biome check clean on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)