### PR TITLE
fix(server): respect pending questions and unread when auto-archiving chats

### DIFF
--- a/packages/server/src/__tests__/chat-archive.test.ts
+++ b/packages/server/src/__tests__/chat-archive.test.ts
@@ -21,6 +21,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { pendingQuestions } from "../db/schema/pending-questions.js";
 import { sweepChatArchive } from "../services/chat-archive.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -72,6 +73,21 @@ async function addHumanMember(app: App, chatId: string, agentId: string): Promis
     role: "member",
     accessMode: "speaker",
     source: "manual",
+  });
+}
+
+async function seedPendingQuestion(
+  app: App,
+  chatId: string,
+  agentId: string,
+  status: "pending" | "answered" | "superseded" = "pending",
+): Promise<void> {
+  await app.db.insert(pendingQuestions).values({
+    id: randomUUID(),
+    chatId,
+    agentId,
+    messageId: randomUUID(),
+    status,
   });
 }
 
@@ -300,6 +316,110 @@ describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
     expect(second.mappedRowsArchived).toBe(0);
     expect(await getEngagement(app, chatId, human)).toBe("archived");
   });
+
+  it("does not archive any user when the chat has a pending ask-user question", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#12",
+      chatId,
+      boundVia: "direct",
+      entityState: "merged",
+    });
+    // Delegate has an unanswered ask-user question outstanding on this chat.
+    // Even though every mapped entity is terminal and the chat is idle, the
+    // archive must wait — otherwise the question disappears from the user's
+    // "needs you" surface with the chat itself.
+    await seedPendingQuestion(app, chatId, delegate, "pending");
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.mappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, chatId, human)).toBeNull();
+  });
+
+  it("ignores answered / superseded questions when deciding eligibility", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#13",
+      chatId,
+      boundVia: "direct",
+      entityState: "merged",
+    });
+    // Two historic rows, both resolved — must not block the archive.
+    await seedPendingQuestion(app, chatId, delegate, "answered");
+    await seedPendingQuestion(app, chatId, delegate, "superseded");
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.mappedRowsArchived).toBe(1);
+    expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
+  it("skips a user with unread > 0 while still archiving the other user on the same chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const h1 = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const h2 = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    // Two mapping rows on the same chat — one per (human, delegate, entity).
+    // PK includes humanAgentId, so this is permitted.
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: h1,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#14",
+        chatId,
+        boundVia: "direct",
+        entityState: "merged",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: h2,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#14",
+        chatId,
+        boundVia: "direct",
+        entityState: "merged",
+      },
+    ]);
+    // h1 still has unread (mention or manual mark — both surface here per
+    // the semantic overload of unread_mention_count). h2 is fully read.
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: h1,
+      engagementStatus: "active",
+      unreadMentionCount: 3,
+      lastReadAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.mappedRowsArchived).toBe(1);
+    // h1 keeps the explicit active row — guard short-circuits before write.
+    expect(await getEngagement(app, chatId, h1)).toBe("active");
+    // h2 had no prior row — sweeper materialises one in 'archived'.
+    expect(await getEngagement(app, chatId, h2)).toBe("archived");
+  });
 });
 
 describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
@@ -418,6 +538,24 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
     await sweepChatArchive(app.db);
 
     expect(await getEngagement(app, chatId, robot)).toBeNull();
+  });
+
+  it("does not archive when the chat has a pending ask-user question", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await addHumanMember(app, chatId, human);
+    await seedReadAcknowledgement(app, chatId, human);
+    // Same carve-out as Route A: a delegate's outstanding question keeps the
+    // chat out of the Archived tab even on the long-idle no-mapping path.
+    await seedPendingQuestion(app, chatId, delegate, "pending");
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.unmappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, chatId, human)).toBe("active");
   });
 });
 

--- a/packages/server/src/services/chat-archive.ts
+++ b/packages/server/src/services/chat-archive.ts
@@ -11,11 +11,14 @@
  *   Route A — chats with at least one `github_entity_chat_mappings` row.
  *     Archive (for every mapped human) once *all* bound entities are
  *     terminal (`entity_state` in `('closed','merged')`) AND the chat has
- *     been silent for `mappedIdleSeconds` (default 1h).
+ *     been silent for `mappedIdleSeconds` (default 1h). Additionally:
+ *     skip the whole chat if it has any `pending` ask-user question, and
+ *     skip individual users whose `unread_mention_count > 0`.
  *
  *   Route B — chats with no GitHub mapping. Archive only the (chat, user)
  *     pairs where the user has no unread mentions AND the chat has been
- *     silent for `unmappedIdleSeconds` (default 12h).
+ *     silent for `unmappedIdleSeconds` (default 12h). Same chat-level
+ *     pending-question skip as Route A.
  *
  * Per-user safety: writes use the same UPSERT + setWhere guard as the
  * removed `archiveChatsForMergedPr` — only implicit-active or
@@ -64,13 +67,23 @@ export async function sweepChatArchive(
 /**
  * Route A: chats whose every GitHub-mapped entity is terminal AND have been
  * silent for at least `idleSeconds`. Archives every (chat, human) pair from
- * the mapping table — matches the legacy `archiveChatsForMergedPr` reach.
+ * the mapping table — matches the legacy `archiveChatsForMergedPr` reach,
+ * minus the per-user unread / chat-level pending-question carve-outs added
+ * here.
  *
  * Implemented as a single `INSERT … SELECT … ON CONFLICT` round-trip:
  *  - The inner CTE picks chats whose `BOOL_AND(entity_state IN
- *    ('closed','merged'))` and idle timestamp both hold.
+ *    ('closed','merged'))` and idle timestamp both hold, and that have no
+ *    `pending` ask-user question outstanding. The pending-question carve-out
+ *    is chat-scoped (a single pending row defers the whole chat) because the
+ *    askee is always some human member of the chat, so per-user dispatch
+ *    would not buy anything and the chat-level skip is cheaper.
  *  - The outer SELECT joins back to the mapping table for the (chat,
- *    human) pairs.
+ *    human) pairs. A second per-user guard excludes humans whose
+ *    `unread_mention_count > 0` — the schema column is semantically
+ *    overloaded as "any kind of unread" (see chat_user_state docstring and
+ *    me-chat.ts:markChatUnread), so this also covers manually-marked-unread
+ *    chats.
  *  - A LEFT JOIN on `chat_user_state` filters out rows that are already
  *    `archived`/`deleted` so we never even SELECT them again on the next
  *    tick (the `ON CONFLICT … WHERE` guard handles the race window).
@@ -87,6 +100,10 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
        WHERE c.parent_chat_id IS NULL
          AND c.last_message_at IS NOT NULL
          AND c.last_message_at < NOW() - make_interval(secs => ${idleSeconds})
+         AND NOT EXISTS (
+           SELECT 1 FROM pending_questions pq
+            WHERE pq.chat_id = m.chat_id AND pq.status = 'pending'
+         )
        GROUP BY m.chat_id
       HAVING bool_and(m.entity_state IN ('closed', 'merged'))
        LIMIT ${batchSize}
@@ -98,9 +115,11 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
       LEFT JOIN chat_user_state cus
              ON cus.chat_id = m.chat_id AND cus.agent_id = m.human_agent_id
      WHERE COALESCE(cus.engagement_status, 'active') = 'active'
+       AND COALESCE(cus.unread_mention_count, 0) = 0
         ON CONFLICT (chat_id, agent_id) DO UPDATE
            SET engagement_status = 'archived'
          WHERE chat_user_state.engagement_status = 'active'
+           AND chat_user_state.unread_mention_count = 0
     RETURNING chat_id
   `);
   return rows.length;
@@ -116,7 +135,9 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
  *     chat in their Archived tab without ever having seen it,
  *   - the user has no unread mentions,
  *   - the user's engagement is currently `active` (either an explicit
- *     row or the implicit default via missing row).
+ *     row or the implicit default via missing row),
+ *   - the chat has no `pending` ask-user question outstanding (chat-level
+ *     skip, same rationale as Route A: askee is always a human member).
  *
  * The `last_read_at IS NOT NULL` condition implies `cus` is materialised,
  * so the `COALESCE(cus.engagement_status, 'active') = 'active'` clause
@@ -148,10 +169,15 @@ async function sweepUnmapped(db: Database, idleSeconds: number, batchSize: numbe
        AND cus.last_read_at IS NOT NULL
        AND cus.unread_mention_count = 0
        AND cus.engagement_status = 'active'
+       AND NOT EXISTS (
+         SELECT 1 FROM pending_questions pq
+          WHERE pq.chat_id = cm.chat_id AND pq.status = 'pending'
+       )
      LIMIT ${batchSize}
         ON CONFLICT (chat_id, agent_id) DO UPDATE
            SET engagement_status = 'archived'
          WHERE chat_user_state.engagement_status = 'active'
+           AND chat_user_state.unread_mention_count = 0
     RETURNING chat_id
   `);
   return rows.length;


### PR DESCRIPTION
## Summary

- Route A (GitHub-mapped chats) previously archived purely on terminal entity state + idleness, ignoring per-user unread (`unread_mention_count > 0`) and chat-level pending ask-user questions.
- Route B (unmapped chats) already gated on unread, but missed pending questions.
- Added the missing guards to both routes, with a matching `ON CONFLICT … WHERE unread_mention_count = 0` clause to close the SELECT-to-UPSERT race.

## Why

Symptom we kept hitting: a chat with an outstanding `ask-user` question (or a chat the user explicitly marked unread) would flip to **Archived** as soon as the bound PR merged, but the red "needs you" badge / pending row stayed on the user's surface. The signals the user cared about (unread, open question) were ignored by the sweeper.

## What changed

- `services/chat-archive.ts`
  - **Route A** CTE adds a chat-level `NOT EXISTS pending_questions WHERE status = 'pending'`. The outer SELECT adds a per-user `COALESCE(cus.unread_mention_count, 0) = 0`.
  - **Route B** WHERE adds the same chat-level pending-question carve-out.
  - Both routes: tightened the `ON CONFLICT … WHERE` to also require `unread_mention_count = 0` so a concurrent unread bump can't sneak past the SELECT guard.

- The pending-question carve-out is intentionally **chat-scoped, not per-askee**: `pending_questions` has no askee column (askee is implicit in chat membership), so per-user dispatch buys nothing and the chat-level skip is cheaper. Resolved rows (`answered`/`superseded`) are ignored.

- Index coverage: `idx_pending_questions_chat_status (chat_id, status)` already exists, so the new `NOT EXISTS` clauses are anti-join lookups, not seq scans.

- No schema / migration changes.

## Tests

Added 4 cases to `__tests__/chat-archive.test.ts` (now 18 total, all green; full server suite 1149/1149 green; `pnpm check` + `pnpm typecheck` green):

- Route A: pending question blocks the entire chat from archiving
- Route A: answered / superseded historical rows do **not** block archiving
- Route A: same chat with two humans — h1 has unread → stays active, h2 fully read → archived
- Route B: pending question blocks the chat from archiving

## Test plan

- [x] `pnpm exec vitest run chat-archive` — 18/18 pass against real Postgres
- [x] Full server suite — 1149/1149 pass
- [x] `pnpm check` — zero warnings on changed files
- [x] `pnpm typecheck` — 13/13 tasks pass
- [ ] Staging soak: confirm a freshly-merged PR with an open ask-user does NOT flip the chat to Archived
- [ ] Staging soak: confirm a chat the user manually marked unread does NOT auto-archive even after idle threshold