### PR TITLE
fix: drop binary tool_result previews from session events

### DIFF
--- a/packages/client/src/__tests__/session-event-sanitize.test.ts
+++ b/packages/client/src/__tests__/session-event-sanitize.test.ts
@@ -1,0 +1,73 @@
+import type { SessionEvent } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { sanitizeSessionEventForTransport } from "../client-connection.js";
+
+/**
+ * Outbound boundary for client-to-server WS frames. Binary tool stdout that
+ * survives Buffer.toString('utf8') (NULs + U+FFFD bursts) must be replaced with
+ * a placeholder so the event still persists server-side and the timeline shows
+ * the call happened. The matching last-mile gate (NUL strip on the JSON before
+ * the JSONB insert) lives in the server-side appendEvent.
+ */
+
+const NUL = String.fromCharCode(0);
+const FFFD = String.fromCharCode(0xfffd);
+
+describe("sanitizeSessionEventForTransport", () => {
+  function toolCall(resultPreview: string | undefined): SessionEvent {
+    return {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-1",
+        name: "Bash",
+        args: { command: "gh api repos/foo/bar/actions/runs/1/logs" },
+        status: "ok",
+        durationMs: 1234,
+        ...(resultPreview !== undefined ? { resultPreview } : {}),
+      },
+    };
+  }
+
+  it("passes plain text previews through unchanged", () => {
+    const event = toolCall("clean stdout output\nwith newlines");
+    expect(sanitizeSessionEventForTransport(event)).toBe(event);
+  });
+
+  it("passes events without resultPreview through unchanged", () => {
+    const event = toolCall(undefined);
+    expect(sanitizeSessionEventForTransport(event)).toBe(event);
+  });
+
+  it("replaces a preview containing a NUL with a placeholder", () => {
+    const preview = `PK${NUL}enforce/system.txt${NUL}ZIP-bytes`;
+    const sanitized = sanitizeSessionEventForTransport(toolCall(preview));
+    if (sanitized.kind !== "tool_call") throw new Error("expected tool_call");
+    expect(sanitized.payload.resultPreview).toBe(`[binary content, ${preview.length} chars elided]`);
+  });
+
+  it("replaces a preview with many U+FFFD replacement chars", () => {
+    const preview = `garbage ${FFFD.repeat(20)} bytes`;
+    const sanitized = sanitizeSessionEventForTransport(toolCall(preview));
+    if (sanitized.kind !== "tool_call") throw new Error("expected tool_call");
+    expect(sanitized.payload.resultPreview).toBe(`[binary content, ${preview.length} chars elided]`);
+  });
+
+  it("keeps previews with only a few U+FFFD (below threshold) intact", () => {
+    const preview = `some text with one ${FFFD} and another ${FFFD} elsewhere`;
+    const event = toolCall(preview);
+    expect(sanitizeSessionEventForTransport(event)).toBe(event);
+  });
+
+  it("does not mutate the original event", () => {
+    const preview = `before${NUL}after`;
+    const event = toolCall(preview);
+    sanitizeSessionEventForTransport(event);
+    if (event.kind !== "tool_call") throw new Error("expected tool_call");
+    expect(event.payload.resultPreview).toBe(preview);
+  });
+
+  it("ignores non-tool_call events", () => {
+    const event: SessionEvent = { kind: "error", payload: { source: "sdk", message: `boom${NUL}` } };
+    expect(sanitizeSessionEventForTransport(event)).toBe(event);
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -230,6 +230,35 @@ function decodeJwtExp(token: string): number | null {
 }
 
 /**
+ * Bash stdout reaches handlers as `string` via Buffer.toString('utf8'), so a
+ * tool whose output is binary (e.g. `gh api .../actions/runs/<id>/logs`
+ * returns a ZIP archive) lands in `resultPreview` peppered with U+FFFD
+ * replacements and embedded NULs. PostgreSQL JSONB rejects NUL outright, which
+ * used to drop the entire session event server-side; a forest of `(replacement chars)` would
+ * also be useless to the UI. Replace such previews with a placeholder so the
+ * event still persists and the timeline shows the call happened.
+ */
+const REPLACEMENT_CHAR_BINARY_THRESHOLD = 8;
+
+function looksBinary(s: string): boolean {
+  if (s.includes("\u0000")) return true;
+  return (s.match(/\uFFFD/g)?.length ?? 0) > REPLACEMENT_CHAR_BINARY_THRESHOLD;
+}
+
+export function sanitizeSessionEventForTransport(event: SessionEvent): SessionEvent {
+  if (event.kind !== "tool_call") return event;
+  const preview = event.payload.resultPreview;
+  if (preview === undefined || !looksBinary(preview)) return event;
+  return {
+    ...event,
+    payload: {
+      ...event.payload,
+      resultPreview: `[binary content, ${preview.length} chars elided]`,
+    },
+  };
+}
+
+/**
  * Client WS — one socket per client, many agents multiplexed.
  *
  * Handshake sequence (unified-user-token):
@@ -439,7 +468,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
   reportSessionEvent(agentId: string, chatId: string, event: SessionEvent): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    this.ws.send(JSON.stringify({ type: "session:event", agentId, chatId, event }));
+    const sanitized = sanitizeSessionEventForTransport(event);
+    this.ws.send(JSON.stringify({ type: "session:event", agentId, chatId, event: sanitized }));
   }
 
   /** Ask the server which of the supplied chatIds the client should drop. */

--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -112,6 +112,42 @@ describe("sessionEventService", () => {
     ).rejects.toThrow();
   });
 
+  // PG JSONB rejects U+0000 outright — without the NUL strip in appendEvent,
+  // any tool whose stdout was binary (e.g. `gh api .../actions/runs/<id>/logs`
+  // returns a ZIP archive that survives Buffer.toString('utf8') with embedded
+  // NULs) would drop the whole event server-side. The client sanitizer
+  // replaces obvious binary previews with a placeholder, but this last-mile
+  // gate covers any field/path the client does not.
+  it("persists tool_call events whose payload string fields contain NUL", async () => {
+    const app = getApp();
+    const a = agentId();
+    const c = chatId();
+    const NUL = String.fromCharCode(0);
+
+    const persisted = await sessionEventService.appendEvent(app.db, a, c, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-binary",
+        name: "Bash",
+        args: { command: `echo ${NUL}` },
+        status: "ok",
+        durationMs: 5,
+        resultPreview: `before${NUL}after${NUL}end`,
+      },
+    });
+
+    expect(persisted.seq).toBe(1);
+    expect(persisted.kind).toBe("tool_call");
+    const payload = persisted.payload as {
+      toolUseId: string;
+      resultPreview?: string;
+      args: { command: string };
+    };
+    expect(payload.toolUseId).toBe("tu-binary");
+    expect(payload.resultPreview).toBe("beforeafterend");
+    expect(payload.args.command).toBe("echo ");
+  });
+
   it("listEvents paginates by seq asc", async () => {
     const app = getApp();
     const a = agentId();

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -62,7 +62,14 @@ export async function appendEvent(
 
   for (let attempt = 0; attempt < MAX_SEQ_RETRIES; attempt++) {
     const id = uuidv7();
-    const payloadJson = JSON.stringify(validated.payload);
+    // PG JSONB rejects U+0000 outright. Strip the escaped sequence from the
+    // serialized JSON so a binary preview (e.g. ZIP bytes from
+    // `gh api .../actions/runs/<id>/logs` reaching us through a tool stdout)
+    // does not nuke the whole event. The client already replaces obvious
+    // binary previews with a placeholder; this is the last-mile gate for any
+    // path the client sanitizer does not cover (future handlers, other
+    // free-form string fields).
+    const payloadJson = JSON.stringify(validated.payload).replaceAll("\\u0000", "");
     const result = await db.execute<{
       id: string;
       agent_id: string;


### PR DESCRIPTION
## Summary

- A `Bash` tool whose stdout is binary (production trigger: `gh api .../actions/runs/<id>/logs` returns a ZIP archive) reached `resultPreview` as a string via `Buffer.toString('utf8')`, peppered with U+FFFD and embedded NULs. PostgreSQL JSONB rejects NUL outright, so `appendEvent`'s INSERT failed server-side and the entire `tool_call` event was dropped from the timeline — user reported the warnings in `journalctl --user -u first-tree-client`.
- **Client layer (`packages/client/src/client-connection.ts`)**: new `sanitizeSessionEventForTransport` detects binary previews (NUL present, or U+FFFD count > 8) and replaces `resultPreview` with `[binary content, N chars elided]` before the WS frame is serialized. Wired into `reportSessionEvent` so all handlers (claude-code, codex, future) are covered without per-handler edits.
- **Server layer (`packages/server/src/services/session-event.ts`)**: `appendEvent` strips the literal `` escape from the serialized JSON before the JSONB insert as a last-mile gate for any field/path the client sanitizer does not cover.

## Why two layers

| Layer | Concern |
| --- | --- |
| client `sanitizeSessionEventForTransport` | "What I send must be acceptable to the receiver" — also keeps the UI from rendering `��` garbage. |
| server `appendEvent` NUL strip | "What I store must be acceptable to PG JSONB" — covers any future handler or field the client sanitizer hasn't enumerated. |

Handlers (`claude-code.ts`, `codex.ts`) are untouched — the boundary work happens at the transport seam, not in the protocol-translation code.

## Test plan

- [x] `pnpm typecheck` — 13/13 turbo tasks pass
- [x] `pnpm check` — biome clean (only pre-existing unrelated warnings)
- [x] `pnpm --filter @first-tree/client test session-event-sanitize` — 7/7 new unit tests pass (plain text passthrough, no-preview passthrough, NUL → placeholder, U+FFFD burst → placeholder, sub-threshold U+FFFD passthrough, non-mutation, non-`tool_call` skip)
- [x] `pnpm --filter @first-tree/client test client-connection` — 16/16 existing tests pass (no regression in WS connection lifecycle)
- [x] `pnpm --filter @first-tree/server test session-event` — 24/24 pass, including new "persists tool_call events whose payload string fields contain NUL" integration test (Testcontainers + real PG)
- [x] `pnpm --filter @first-tree/shared test` — 259/259 pass (schema unchanged but verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
