### PR TITLE
fix(server): route GitHub events by human, not (human, delegate) tuple

### DIFF
--- a/packages/server/src/__tests__/agent-created-webhook-e2e.test.ts
+++ b/packages/server/src/__tests__/agent-created-webhook-e2e.test.ts
@@ -250,6 +250,115 @@ describe("Agent-created → real webhook end-to-end", () => {
     expect(sentToOrg).toHaveLength(0);
   });
 
+  it("issues.assigned does NOT mint a sibling chat when the assignee's delegateMention differs from the chat's agent_created delegate", async () => {
+    // Regression for the assignee-creates-new-chat bug. Real-world repro:
+    //   1. Inside a chat, the user asked their assistant agent to open an
+    //      issue via `gh issue create`. Mapping written under
+    //      (human, assistantDelegate, issue).
+    //   2. The human's `delegateMention` happens to point at a *different*
+    //      delegate (e.g. their main workhorse agent) — the assistant that
+    //      created the issue was a one-off helper.
+    //   3. A collaborator opens the issue on GitHub and assigns it to the
+    //      human. The assign webhook arrives with `involves=[human,
+    //      reason=assigned]` and sender=collaborator (external actor).
+    //
+    // Bug (pre-fix): audience built `kind:"new"` for (human, delegateMention)
+    // because the dedup key included delegate, then `resolveTargetChat` did
+    // not find a mapping under that delegate and minted a fresh chat.
+    //
+    // Fix: audience dedups by human alone; resolveTargetChat falls back to
+    // any chat already bound for (human, entity) regardless of delegate.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 200005;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const assistantDelegate = await seedDelegateAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `assistant-${randomUUID().slice(0, 6)}`,
+    });
+    const workhorseDelegate = await seedDelegateAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `workhorse-${randomUUID().slice(0, 6)}`,
+    });
+    // The human's delegateMention points at the workhorse, NOT the assistant
+    // that created the issue. This is the misalignment the bug exposes.
+    const humanName = `assignee-${randomUUID().slice(0, 6)}`;
+    const human = await app.db
+      .insert(agents)
+      .values({
+        uuid: randomUUID(),
+        name: humanName,
+        organizationId: admin.organizationId,
+        type: "human",
+        displayName: humanName,
+        inboxId: `inbox_${randomUUID()}`,
+        managerId: admin.memberId,
+        delegateMention: workhorseDelegate,
+      })
+      .returning({ uuid: agents.uuid });
+    const humanUuid = human[0]?.uuid;
+    if (!humanUuid) throw new Error("seeded human agent missing uuid");
+
+    const chatId = await seedDirectChat(app, admin.organizationId, humanUuid, assistantDelegate);
+
+    // Stage 1: assistant agent opens the issue via gh issue create.
+    await maybeBindGithubEntityFromToolCall(app.db, assistantDelegate, chatId, {
+      toolUseId: "tu-assign-1",
+      name: "Bash",
+      args: { command: 'gh issue create --title "track Z" --body "ctx"' },
+      status: "ok",
+      resultPreview: "https://github.com/owner/repo/issues/905",
+    });
+    const initialMappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#905"));
+    expect(initialMappings).toHaveLength(1);
+    expect(initialMappings[0]?.chatId).toBe(chatId);
+    expect(initialMappings[0]?.delegateAgentId).toBe(assistantDelegate);
+
+    const beforeChats = (await app.db.select().from(chats)).length;
+    const beforeMessages = (await app.db.select().from(messages).where(eq(messages.chatId, chatId))).length;
+
+    // Stage 2: collaborator assigns the issue to our human. Webhook fires
+    // with involves=[human]. Old code would mint a sibling chat for
+    // (human, workhorseDelegate); new code routes back to chatId.
+    const res = await postWebhook(app, "issues", {
+      action: "assigned",
+      issue: {
+        number: 905,
+        title: "track Z",
+        html_url: "https://github.com/owner/repo/issues/905",
+        body: "ctx",
+        assignee: { login: humanName },
+      },
+      assignee: { login: humanName },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "collaborator-zed", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.delivered).toBe(1);
+    expect(body.newChats).toBe(0);
+
+    // No extra chats, card landed in the original chat, no sibling mapping.
+    const afterChats = (await app.db.select().from(chats)).length;
+    expect(afterChats).toBe(beforeChats);
+    const sent = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(sent).toHaveLength(beforeMessages + 1);
+    const finalMappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#905"));
+    expect(finalMappings).toHaveLength(1);
+    expect(finalMappings[0]?.chatId).toBe(chatId);
+    expect(finalMappings[0]?.delegateAgentId).toBe(assistantDelegate);
+  });
+
   it("opened webhook with body @mention still creates a chat (mention exemption preserved)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -304,6 +304,61 @@ describe("resolveAudience", () => {
     expect(audience[0]?.chatId).toBe(chatId);
   });
 
+  it("dedups involves by human even when the existing mapping uses a different delegate", async () => {
+    // Regression for the assignee-creates-new-chat bug. The chat-binding was
+    // written under (human, delegateA) when the agent first created the
+    // entity. A later assign webhook arrives with involves=[human]; the human
+    // is configured with delegateMention=delegateB. Audience must dedup by
+    // human alone so the involves path does NOT add a sibling `kind: "new"`
+    // row — the entity is already routed to the existing chat.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `dave-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegateB,
+    });
+    const chatId = await seedChat(app, admin.organizationId, human);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegateA,
+      entityType: "issue",
+      entityKey: "owner/repo#202",
+      chatId,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#202",
+        actorLogin: "outsider",
+        involves: [{ githubLogin: humanName, reason: "assigned" }],
+        kind: "assigned",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toHaveLength(1);
+    expect(audience[0]?.kind).toBe("existing");
+    expect(audience[0]?.delegateAgentId).toBe(delegateA);
+    expect(audience[0]?.chatId).toBe(chatId);
+  });
+
   it("keeps subscribed targets when actor is our-app-bot (route Hub's own writes back to existing chats)", async () => {
     // Background: when an agent creates a PR via Hub's GitHub App token, the
     // resulting `pull_request.opened` webhook arrives with `sender = <app>[bot]`.

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -304,6 +304,72 @@ describe("resolveAudience", () => {
     expect(audience[0]?.chatId).toBe(chatId);
   });
 
+  it("collapses subscribed rows by human (sibling mappings on same chat → one audience target)", async () => {
+    // Once `resolveTargetChat` step (a.5) lands sibling mapping rows
+    // (same chat, different delegate under the same human), naive subscribed
+    // expansion would post the same card to the chat N times. Subscribed
+    // dedup collapses by humanAgentId; sibling rows always share chatId by
+    // construction, so we keep the earliest bound_at row as the
+    // representative.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateOriginal = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-original-${randomUUID().slice(0, 6)}`,
+    });
+    const delegateSibling = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-sibling-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `eve-${randomUUID().slice(0, 6)}`,
+    });
+    const chatId = await seedChat(app, admin.organizationId, human);
+
+    // Original row first (earlier bound_at), then sibling — simulates the
+    // (a.5) write order. We do not control bound_at directly; the default
+    // `now()` clock + serial insert order suffices because the assertions
+    // only require the representative to be one of the two rows sharing
+    // chatId, and both point at the same chat.
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegateOriginal,
+      entityType: "issue",
+      entityKey: "owner/repo#301",
+      chatId,
+    });
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegateSibling,
+      entityType: "issue",
+      entityKey: "owner/repo#301",
+      chatId,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#301",
+        actorLogin: "outsider",
+        kind: "commented",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toHaveLength(1);
+    expect(audience[0]?.kind).toBe("existing");
+    expect(audience[0]?.humanAgentId).toBe(human);
+    expect(audience[0]?.chatId).toBe(chatId);
+  });
+
   it("dedups involves by human even when the existing mapping uses a different delegate", async () => {
     // Regression for the assignee-creates-new-chat bug. The chat-binding was
     // written under (human, delegateA) when the agent first created the

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -312,6 +312,55 @@ describe("resolveTargetChat", () => {
     expect(mappings[0]?.chatId).toBe(r1.chatId);
   });
 
+  it("reuses the existing chat when a different delegate hits the same (human, entity) tuple", async () => {
+    // Regression for the assignee-creates-new-chat bug. The agent that
+    // created the issue (delegateA) wrote a mapping under (human, delegateA).
+    // A later webhook resolves the audience via `human.delegateMention =
+    // delegateB` — under the old logic this minted a sibling chat. With the
+    // (a.5) human-scoped fallback in place, the existing chat is reused and a
+    // sibling mapping row is recorded so subsequent events hit (a) directly.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedDelegate(app, admin.organizationId, admin.memberId, `dlgA-${randomUUID().slice(0, 6)}`);
+    const delegateB = await seedDelegate(app, admin.organizationId, admin.memberId, `dlgB-${randomUUID().slice(0, 6)}`);
+
+    const created = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegateA,
+      entity: issue42,
+      relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
+    });
+
+    const followUp = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegateB,
+      entity: issue42,
+      relatedEntities: [],
+      eventType: "issues",
+      action: "assigned",
+    });
+
+    expect(followUp.chatId).toBe(created.chatId);
+    expect(followUp.created).toBe(false);
+
+    // Sibling mapping row written for (human, delegateB, entity) → same chat;
+    // both rows now exist so the next event for either delegate hits (a).
+    const mappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, issue42.key));
+    expect(mappings).toHaveLength(2);
+    expect(new Set(mappings.map((m) => m.delegateAgentId))).toEqual(new Set([delegateA, delegateB]));
+    expect(new Set(mappings.map((m) => m.chatId))).toEqual(new Set([created.chatId]));
+
+    const allChats = await app.db.select({ id: chats.id }).from(chats).where(eq(chats.id, created.chatId));
+    expect(allChats).toHaveLength(1);
+  });
+
   it("renders 'PR Review' topic when a PR chat is first created by review_requested", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -346,9 +346,12 @@ describe("resolveTargetChat", () => {
 
     expect(followUp.chatId).toBe(created.chatId);
     expect(followUp.created).toBe(false);
+    expect(followUp.boundVia).toBe("human_fallback");
 
     // Sibling mapping row written for (human, delegateB, entity) → same chat;
     // both rows now exist so the next event for either delegate hits (a).
+    // The sibling carries bound_via="human_fallback" so audit / telemetry can
+    // tell it apart from a first-touch direct binding.
     const mappings = await app.db
       .select()
       .from(githubEntityChatMappings)
@@ -356,6 +359,10 @@ describe("resolveTargetChat", () => {
     expect(mappings).toHaveLength(2);
     expect(new Set(mappings.map((m) => m.delegateAgentId))).toEqual(new Set([delegateA, delegateB]));
     expect(new Set(mappings.map((m) => m.chatId))).toEqual(new Set([created.chatId]));
+    const sibling = mappings.find((m) => m.delegateAgentId === delegateB);
+    expect(sibling?.boundVia).toBe("human_fallback");
+    const original = mappings.find((m) => m.delegateAgentId === delegateA);
+    expect(original?.boundVia).toBe("direct");
 
     const allChats = await app.db.select({ id: chats.id }).from(chats).where(eq(chats.id, created.chatId));
     expect(allChats).toHaveLength(1);

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -143,7 +143,15 @@ export async function resolveAudience(
     involveLogin: null,
   }));
 
-  const subscribedKeys = new Set(subscribed.map((s) => `${s.humanAgentId} ${s.delegateAgentId}`));
+  // Dedup involved candidates by `humanAgentId` only — once any (human, *,
+  // entity) mapping exists, the entity is already routed to that human's
+  // chat and the involves-driven path must NOT fork a sibling chat just
+  // because the candidate's `delegateMention` differs from the delegate
+  // recorded on the existing mapping. The downstream resolver still applies
+  // a human-scoped fallback (see `resolveTargetChat` step a.5), so even if
+  // a race lets a `kind: "new"` row through with a different delegate, the
+  // chat is reused — this dedup is the first line of defence.
+  const subscribedHumanIds = new Set(subscribed.map((s) => s.humanAgentId));
 
   const involved: AudienceTarget[] = [];
   if (event.involves.length > 0) {
@@ -190,8 +198,7 @@ export async function resolveAudience(
       if (c.status !== "active" || !c.delegateMention || !c.name) continue;
       const verdict = evaluateDelegateTarget(delegateById.get(c.delegateMention), organizationId);
       if (verdict !== "ok") continue;
-      const key = `${c.id} ${c.delegateMention}`;
-      if (subscribedKeys.has(key)) continue;
+      if (subscribedHumanIds.has(c.id)) continue;
       const candidateLogin = c.name.toLowerCase();
       const reason = reasonByLogin.get(candidateLogin);
       if (!reason) continue;

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -124,6 +124,7 @@ export async function resolveAudience(
       humanAgentId: githubEntityChatMappings.humanAgentId,
       delegateAgentId: githubEntityChatMappings.delegateAgentId,
       chatId: githubEntityChatMappings.chatId,
+      boundAt: githubEntityChatMappings.boundAt,
     })
     .from(githubEntityChatMappings)
     .where(
@@ -134,7 +135,22 @@ export async function resolveAudience(
       ),
     );
 
-  const subscribed: AudienceTarget[] = subscribedRows.map((row) => ({
+  // Dedup subscribed rows by `humanAgentId` (keep earliest `bound_at`).
+  // After `resolveTargetChat` step (a.5) lands, the same `(human, entity)`
+  // pair can have multiple mapping rows pointing at the *same* chat (one
+  // per delegate that ever drove an event for this entity under this
+  // human). Without this dedup the audience loops the same chatId N times
+  // and `deliverNormalizedEvent` posts N identical cards. Sibling rows are
+  // guaranteed to share `chatId` because (a.5) always inserts using the
+  // human-scoped lookup's `chatId`, so collapsing them is loss-free.
+  const earliestByHuman = new Map<string, (typeof subscribedRows)[number]>();
+  for (const row of subscribedRows) {
+    const current = earliestByHuman.get(row.humanAgentId);
+    if (!current || row.boundAt < current.boundAt) {
+      earliestByHuman.set(row.humanAgentId, row);
+    }
+  }
+  const subscribed: AudienceTarget[] = [...earliestByHuman.values()].map((row) => ({
     humanAgentId: row.humanAgentId,
     delegateAgentId: row.delegateAgentId,
     kind: "existing",

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -1,6 +1,6 @@
 import type { ToolCallEventPayload } from "@first-tree/shared";
 import { chatMetadataSchema } from "@first-tree/shared";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { formatEntityTitle } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
@@ -104,6 +104,26 @@ export async function resolveTargetChat(
     return { chatId: direct.chatId, created: false, boundVia: direct.boundVia };
   }
 
+  // (a.5) Human-scoped fallback. The mapping primary key still includes
+  // `delegate_agent_id`, but routing treats `(org, human, entity)` as the
+  // logical cluster: an entity that is already bound to a chat under this
+  // human should never trigger a fresh chat just because a *different*
+  // delegate happened to drive this event. Pick the existing chat (open
+  // entities first, then earliest `bound_at`) and write a sibling mapping
+  // row so the next event hits (a) directly.
+  const humanScoped = await lookupMappingByHuman(db, organizationId, humanAgentId, entity);
+  if (humanScoped) {
+    const inserted = await insertMappingIfAbsent(db, {
+      organizationId,
+      humanAgentId,
+      delegateAgentId,
+      entity,
+      chatId: humanScoped.chatId,
+      boundVia: "direct",
+    });
+    return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
+  }
+
   // (b) Fixes-link reuse.
   for (const ref of relatedEntities) {
     const linked = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, ref);
@@ -172,6 +192,38 @@ async function lookupMapping(
     .limit(1);
   if (!row) return null;
   return { chatId: row.chatId, boundVia: asBoundVia(row.boundVia) };
+}
+
+/**
+ * Find any chat already bound to `(org, human, entity)` regardless of delegate.
+ *
+ * Multiple rows can legitimately exist when the same human created the entity
+ * via one delegate and later got fanned out via another delegate's
+ * `delegateMention` configuration. Pick deterministically:
+ *   1. `entity_state = 'open'` rows first (active conversation).
+ *   2. Then earliest `bound_at` — the original chat is the canonical thread.
+ */
+async function lookupMappingByHuman(
+  db: Database,
+  organizationId: string,
+  humanAgentId: string,
+  entity: GithubEntity,
+): Promise<{ chatId: string } | null> {
+  const [row] = await db
+    .select({ chatId: githubEntityChatMappings.chatId })
+    .from(githubEntityChatMappings)
+    .where(
+      and(
+        eq(githubEntityChatMappings.organizationId, organizationId),
+        eq(githubEntityChatMappings.humanAgentId, humanAgentId),
+        eq(githubEntityChatMappings.entityType, entity.type),
+        eq(githubEntityChatMappings.entityKey, entity.key),
+      ),
+    )
+    .orderBy(desc(sql`${githubEntityChatMappings.entityState} = 'open'`), asc(githubEntityChatMappings.boundAt))
+    .limit(1);
+  if (!row) return null;
+  return { chatId: row.chatId };
 }
 
 async function insertMappingIfAbsent(

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -16,20 +16,28 @@ const log = createLogger("GithubEntityChat");
 
 /**
  * `bound_via` audit values:
- *   - "direct"        — first-touch row created in `resolveTargetChat` step (c)
- *   - "fixes_link"    — secondary row written by the `Fixes #N` linker
- *   - "agent_created" — proactively written when an agent's tool_call creates
- *                       a PR/Issue, before the corresponding `*.opened` webhook
- *                       arrives. See `maybeBindGithubEntityFromToolCall`.
+ *   - "direct"         — first-touch row created in `resolveTargetChat` step (c)
+ *   - "fixes_link"     — secondary row written by the `Fixes #N` linker
+ *   - "agent_created"  — proactively written when an agent's tool_call creates
+ *                        a PR/Issue, before the corresponding `*.opened` webhook
+ *                        arrives. See `maybeBindGithubEntityFromToolCall`.
+ *   - "human_fallback" — sibling row written by step (a.5) when an event arrives
+ *                        for a `(human, delegate)` pair that has no mapping yet,
+ *                        but another delegate under the same `(human, entity)`
+ *                        already does. Reuses the existing chat instead of
+ *                        minting a fresh one. Surfaces in telemetry so we can
+ *                        observe how often the involves→delegate mismatch path
+ *                        actually fires in production.
  *
  * Routing logic ignores the distinction; this column is purely for audit /
  * future strategy tweaks.
  */
-export type BoundVia = "direct" | "fixes_link" | "agent_created";
+export type BoundVia = "direct" | "fixes_link" | "agent_created" | "human_fallback";
 
 function asBoundVia(value: string): BoundVia {
   if (value === "fixes_link") return "fixes_link";
   if (value === "agent_created") return "agent_created";
+  if (value === "human_fallback") return "human_fallback";
   return "direct";
 }
 
@@ -119,7 +127,7 @@ export async function resolveTargetChat(
       delegateAgentId,
       entity,
       chatId: humanScoped.chatId,
-      boundVia: "direct",
+      boundVia: "human_fallback",
     });
     return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
   }


### PR DESCRIPTION
## Summary

- **Bug**: After an agent created an issue via `gh issue create` inside a chat, assigning that issue on GitHub to the same human minted a second chat for the same entity.
- **Cause**: The mapping was written under `(human, reporterDelegate, entity)`, but the assign webhook's audience resolved `(human, delegateMention)` to a *different* delegate. The strict four-tuple lookup in `resolveTargetChat` missed, `isMentionMatched=true` skipped the creation-event guard, and step (c) minted a sibling chat.
- **Fix**: route by human first.
  - `resolveAudience`: dedup `kind:"new"` candidates by `humanAgentId` only — once any `(human, *, entity)` mapping exists, the involves path does not fork a parallel target with a different delegate.
  - `resolveTargetChat` step (a.5): after a direct miss, look up any chat already bound to `(org, human, entity)` regardless of delegate (open entities and earliest `bound_at` win), reuse it, and write a sibling mapping row so the next event hits step (a) directly.
- Schema and primary key `(org, human, delegate, entity)` unchanged — many-to-many between humans and delegates still works.

## Test plan

Regression coverage was authored against the *pre-fix* code first; all three failed precisely with the user-reported symptom, then pass after the fix is restored.

- [x] `resolve-target-chat.test.ts` — "reuses the existing chat when a different delegate hits the same (human, entity) tuple" (asserts shared `chatId`, single chat in DB, sibling mapping row written).
- [x] `github-audience.test.ts` — "dedups involves by human even when the existing mapping uses a different delegate" (asserts audience length 1, kind=existing, delegate from the recorded mapping).
- [x] `agent-created-webhook-e2e.test.ts` — full HMAC-signed webhook path: `gh issue create` writes the binding, then `issues.assigned` from a collaborator routes back to the same chat. `delivered=1`, `newChats=0`, no extra chats, no sibling mapping.
- [x] `pnpm --filter @first-tree/server test --run` — 1153 / 1153 pass.
- [x] `pnpm --filter @first-tree/server typecheck` and `pnpm check` — clean (0 new warnings).