### PR TITLE
fix(server): sink history backfill into addChatParticipants helper

### DIFF
--- a/packages/server/src/__tests__/participant-mode-backfill.test.ts
+++ b/packages/server/src/__tests__/participant-mode-backfill.test.ts
@@ -1,0 +1,244 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import type { Database } from "../db/connection.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { createChat, ensureParticipant } from "../services/chat.js";
+import { PRECEDING_CONTEXT_MAX_ENTRIES } from "../services/inbox.js";
+import { addMeChatParticipants } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { addChatParticipants } from "../services/participant-mode.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Silent-context backfill invariant — covers every join entrypoint via the
+ * single helper `addChatParticipants` (proposal: backfill anchored to the
+ * row-write helper, not service entrypoints).
+ *
+ * Companion to `add-participant-backfill.test.ts` (which pins the
+ * `chat.ts::addParticipant` entrypoint specifically). The cases here pin the
+ * helper-layer contract so any new join entrypoint that routes through
+ * `addChatParticipants` inherits backfill automatically.
+ *
+ * Why this exists: PR #393 originally hooked backfill at
+ * `chat.ts::addParticipant`. The web "add member" button went through
+ * `me-chat.ts::addMeChatParticipants` instead, silently regressing the
+ * invariant. Sinking backfill into the helper closes that whole class of
+ * bug. These tests are the guard rail.
+ */
+
+async function countSilentEntries(db: Database, inboxId: string, chatId: string): Promise<number> {
+  const rows = await db
+    .select({ id: inboxEntries.id })
+    .from(inboxEntries)
+    .where(
+      and(
+        eq(inboxEntries.inboxId, inboxId),
+        eq(inboxEntries.chatId, chatId),
+        eq(inboxEntries.notify, false),
+        eq(inboxEntries.status, "pending"),
+      ),
+    );
+  return rows.length;
+}
+
+describe("addChatParticipants — silent-context backfill invariant", () => {
+  const getApp = useTestApp();
+
+  it("brand-new joiner inserted directly via helper gets backfilled", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    for (let i = 0; i < 7; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `m${i}` });
+    }
+
+    await app.db.transaction((tx) =>
+      addChatParticipants(tx, chat.id, [{ agentId: newcomer.agent.uuid, role: "member" }]),
+    );
+
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(7);
+  });
+
+  it("watcher → speaker upgrade is treated as a join and triggers backfill", async () => {
+    // Watchers do not receive inbox fan-out (message.ts only joins
+    // access_mode='speaker'), so the moment they become speakers everything
+    // before that moment is unreachable without the silent replay.
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+    const promoted = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    for (let i = 0; i < 4; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `w${i}` });
+    }
+
+    // Seed a watcher row directly — recomputeChatWatchers would also work
+    // but routes through the manager join logic; we want to pin the helper
+    // behaviour in isolation.
+    await app.db.insert(chatMembership).values({
+      chatId: chat.id,
+      agentId: promoted.agent.uuid,
+      role: "member",
+      accessMode: "watcher",
+      mode: "mention_only",
+      source: "manual",
+    });
+
+    // Watcher had no inbox rows so far (fan-out skips them).
+    expect(await countSilentEntries(app.db, promoted.agent.inboxId, chat.id)).toBe(0);
+
+    await app.db.transaction((tx) =>
+      addChatParticipants(tx, chat.id, [{ agentId: promoted.agent.uuid }], { upgradeWatcherToSpeaker: true }),
+    );
+
+    expect(await countSilentEntries(app.db, promoted.agent.inboxId, chat.id)).toBe(4);
+  });
+
+  it("already-speaker no-op insert does not double-backfill", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [newcomer.agent.uuid],
+    });
+    for (let i = 0; i < 3; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `n${i}` });
+    }
+
+    // `newcomer` was added as a speaker at chat creation time; createChat
+    // sends no messages of its own, so the silent-row count is currently 0
+    // (backfill ran but found no prior history). Now seed history and
+    // re-invoke helper as an idempotent UPSERT — no new silent rows.
+    const before = await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id);
+
+    await app.db.transaction((tx) =>
+      addChatParticipants(tx, chat.id, [{ agentId: newcomer.agent.uuid }], { upgradeWatcherToSpeaker: true }),
+    );
+
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(before);
+  });
+
+  it("mixed batch backfills only the agents that crossed into speaker", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const existing = await createTestAgent(app, { type: "autonomous_agent" });
+    const brandNew = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [existing.agent.uuid],
+    });
+    for (let i = 0; i < 5; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `b${i}` });
+    }
+
+    const existingBefore = await countSilentEntries(app.db, existing.agent.inboxId, chat.id);
+
+    await app.db.transaction((tx) =>
+      addChatParticipants(
+        tx,
+        chat.id,
+        [
+          { agentId: existing.agent.uuid }, // already a speaker — must NOT re-backfill
+          { agentId: brandNew.agent.uuid }, // brand-new — must backfill
+        ],
+        { upgradeWatcherToSpeaker: true },
+      ),
+    );
+
+    expect(await countSilentEntries(app.db, existing.agent.inboxId, chat.id)).toBe(existingBefore);
+    expect(await countSilentEntries(app.db, brandNew.agent.inboxId, chat.id)).toBe(5);
+  });
+});
+
+describe("backfill invariant — service entrypoints (regression: PR #393 follow-up)", () => {
+  const getApp = useTestApp();
+
+  it("addMeChatParticipants (web `POST /chats/:id/participants`) backfills the joiner", async () => {
+    // The bug this PR fixes: the web "add member" button went through
+    // `addMeChatParticipants`, which never called `backfillSilentContext...`.
+    // The agent joined with an empty inbox and read no history.
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { type: "autonomous_agent", name: "amcp-peer" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent", name: "amcp-newcomer" });
+
+    const chat = await createChat(app.db, owner.humanAgentUuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    for (let i = 0; i < 6; i++) {
+      await sendMessage(app.db, chat.id, owner.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: `web-${i}`,
+      });
+    }
+
+    await addMeChatParticipants(app.db, chat.id, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [newcomer.agent.uuid],
+    });
+
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(6);
+  });
+
+  it("ensureParticipant (adapter/HTTP send fallback) backfills the joiner on first call", async () => {
+    // adapter-mapping calls ensureParticipant on every IM message. The first
+    // call promotes a missing/watcher row to speaker — that crossing must
+    // backfill. Subsequent calls short-circuit (already a speaker) and must
+    // not re-backfill.
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    for (let i = 0; i < 5; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `e${i}` });
+    }
+
+    await ensureParticipant(app.db, chat.id, newcomer.agent.uuid);
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(5);
+
+    // Idempotent: a second call (e.g. the next IM message) must not double up.
+    await ensureParticipant(app.db, chat.id, newcomer.agent.uuid);
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(5);
+  });
+
+  it("backfill caps at PRECEDING_CONTEXT_MAX_ENTRIES across helper-level invocations", async () => {
+    // Sanity: the helper does not bypass the global cap when called directly.
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    const total = PRECEDING_CONTEXT_MAX_ENTRIES + 10;
+    for (let i = 0; i < total; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `c${i}` });
+    }
+
+    await app.db.transaction((tx) => addChatParticipants(tx, chat.id, [{ agentId: newcomer.agent.uuid }]));
+
+    expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(PRECEDING_CONTEXT_MAX_ENTRIES);
+  });
+});

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -9,7 +9,6 @@ import { messages } from "../db/schema/messages.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
-import { backfillSilentContextForNewParticipants } from "./inbox.js";
 import { resolveChatTitle } from "./me-chat.js";
 import { WIRE_RECIPIENT_MODE } from "./message-dispatcher.js";
 import { addChatParticipants } from "./participant-mode.js";
@@ -359,9 +358,9 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
 
   // Resolve the target by uuid or by name. Name lookup is scoped to the
   // chat's organization so an agent in another org can never be pulled in
-  // by name collision. `inboxId` is needed for the v1.7 silent-context
-  // backfill; `visibility` and `managerId` are needed for PR #402's
-  // owner-exclusive check.
+  // by name collision. `visibility` and `managerId` are needed for PR #402's
+  // owner-exclusive check; `inboxId` is fetched by `addChatParticipants`
+  // itself for the silent-context backfill, so no need to thread it here.
   const targetSelector = data.agentId
     ? eq(agents.uuid, data.agentId)
     : and(eq(agents.organizationId, chat.organizationId), eq(agents.name, data.agentName ?? ""));
@@ -369,7 +368,6 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
     .select({
       id: agents.uuid,
       organizationId: agents.organizationId,
-      inboxId: agents.inboxId,
       visibility: agents.visibility,
       managerId: agents.managerId,
     })
@@ -428,14 +426,13 @@ export async function addParticipant(db: Database, chatId: string, requesterId: 
   // structurally separate so read state is preserved without a state-carry
   // transaction.
   await db.transaction(async (tx) => {
+    // Silent-context backfill is now an invariant of `addChatParticipants`
+    // (proposals/hub-chat-message-v1-design §四 改造 2 follow-up): the helper
+    // detects watcher → speaker / brand-new crossings and writes the silent
+    // inbox rows itself, so every join entrypoint inherits the behaviour for
+    // free instead of having to remember the hook.
     await addChatParticipants(tx, chatId, [{ agentId: targetAgent.id }], { upgradeWatcherToSpeaker: true });
     await recomputeChatWatchers(tx, chatId);
-    // v1 §四 改造 2: backfill the most recent N messages as silent
-    // (notify=false) inbox rows for the new participant so a future trigger
-    // (mention / chat send / replyTo) can replay them as preceding
-    // context. Hook lives in the service layer — caller-agnostic, so
-    // human web / dispatcher / future agent-CLI all benefit.
-    await backfillSilentContextForNewParticipants(tx, chatId, [{ inboxId: targetAgent.inboxId }]);
   });
   invalidateChatAudience(chatId);
 

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,5 +1,6 @@
 import type { InboxEntryWithMessage, PrecedingMessage } from "@first-tree/shared";
 import { and, asc, desc, eq, gt, gte, inArray, lt, sql } from "drizzle-orm";
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
@@ -14,6 +15,13 @@ type ClaimedEntry = typeof inboxEntries.$inferSelect;
 
 /** Structurally-typed DB so both `Database` and transaction clients work. */
 type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete" | "insert">;
+
+/** Wider DB shape that matches both the concrete `Database` and the
+ *  `PgDatabase` widening used by sibling services (e.g. participant-mode).
+ *  Used by entrypoints that need to accept a tx handed in from outside this
+ *  module. The narrower `TxLike` is retained for module-internal callers. */
+// biome-ignore lint/suspicious/noExplicitAny: needed for cross-schema compatibility
+type WideTxLike = PgDatabase<PgQueryResultHKT, any, any>;
 
 const DEFAULT_INBOX_TIMEOUT_SECONDS = 300;
 const DEFAULT_MAX_RETRY_COUNT = 3;
@@ -67,7 +75,7 @@ export const PRECEDING_CONTEXT_WINDOW_SECONDS = 24 * 60 * 60;
  * See proposals/hub-chat-message-v1-design §四 改造 2.
  */
 export async function backfillSilentContextForNewParticipants(
-  tx: TxLike,
+  tx: WideTxLike,
   chatId: string,
   newParticipants: ReadonlyArray<{ inboxId: string }>,
 ): Promise<void> {

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -40,12 +40,13 @@
  * any) is unaffected — no state-carry transaction needed.
  */
 
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
+import { backfillSilentContextForNewParticipants } from "./inbox.js";
 
 /**
  * Structural DB type that accepts both the top-level `Database` and a
@@ -90,15 +91,43 @@ export type AddChatParticipantsOptions = {
  *
  * Reads:
  *   - `chats.id` for the target chat (NotFoundError on missing).
- *   - `agents.uuid` for every requested participant (BadRequestError on
- *     missing). When `assertHuman` is set, also validates `agents.type`.
+ *   - `agents.uuid`, `agents.type`, `agents.inboxId` for every requested
+ *     participant (BadRequestError on missing). When `assertHuman` is set,
+ *     also validates `agents.type`. `inboxId` feeds the silent-context
+ *     backfill (see below).
+ *   - `chat_membership` rows for the (chatId, agentIds) tuple, to classify
+ *     each input as `alreadySpeaker` (skip) / `upgradingWatcher` / `brandNew`.
  *
- * Writes one INSERT (multi-row) per call.
+ * Writes:
+ *   - One INSERT (multi-row) into `chat_membership` per call.
+ *   - One INSERT (multi-row) into `inbox_entries` carrying the chat's most
+ *     recent N messages as silent (notify=false) rows, for every agent whose
+ *     access_mode just transitioned to `speaker` (`brandNew` ∪
+ *     `upgradingWatcher`). Skipped when no such transition happens.
+ *
+ * Why backfill lives here (not at the service entrypoints):
+ *
+ *   The "an agent crossing into `accessMode='speaker'` must be able to read
+ *   prior chat history" invariant is a property of writing the membership
+ *   row, not of any particular service entrypoint. Anchoring it to the
+ *   single helper that owns the write means new service entrypoints
+ *   (`addParticipant`, `addMeChatParticipants`, `ensureParticipant`,
+ *   `joinChat`, `joinAsParticipant`, `findOrCreateChatForChannel`, …) all
+ *   inherit it for free. The previous arrangement — backfill scattered at
+ *   `addParticipant` only — regressed silently when the web path went
+ *   through `addMeChatParticipants` instead (PR #393 follow-up).
+ *
+ * Watcher → speaker upgrades also backfill: watchers do not receive inbox
+ * fan-out (`message.ts` filters by `access_mode='speaker'`), so the moment
+ * they become speakers, everything before that moment is unreachable
+ * without the silent-context replay.
  *
  * No watcher / audience-cache side effects — the caller owns those, since
  * different entrypoints have different surrounding work (watcher recompute,
- * audience invalidation). Keeping this module side-effect-free makes it
- * testable from any tx context.
+ * audience invalidation). Keeping this module otherwise side-effect-free
+ * makes it testable from any tx context. Backfill is the one exception
+ * because, unlike watcher / audience cache, it is an invariant of writing
+ * the row itself, not a choice the caller makes.
  *
  * v2: `chat_membership.mode` is written as the constant `"mention_only"`.
  * No chat-type / agent-type / peer-shape derivation. See file-level
@@ -121,7 +150,7 @@ export async function addChatParticipants(
 
   const agentIds = participants.map((p) => p.agentId);
   const agentRows = await tx
-    .select({ uuid: agents.uuid, type: agents.type })
+    .select({ uuid: agents.uuid, type: agents.type, inboxId: agents.inboxId })
     .from(agents)
     .where(inArray(agents.uuid, agentIds));
   const agentSet = new Set(agentRows.map((r) => r.uuid));
@@ -138,6 +167,16 @@ export async function addChatParticipants(
       );
     }
   }
+
+  // Classify each requested agent against the live chat_membership row (if
+  // any) so we can decide who actually crosses into speaker. Read inside the
+  // caller's tx so a concurrent membership write can't move the line under us.
+  const existing = await tx
+    .select({ agentId: chatMembership.agentId, accessMode: chatMembership.accessMode })
+    .from(chatMembership)
+    .where(and(eq(chatMembership.chatId, chatId), inArray(chatMembership.agentId, agentIds)));
+  const existingMode = new Map(existing.map((r) => [r.agentId, r.accessMode]));
+  const inboxByAgent = new Map(agentRows.map((r) => [r.uuid, r.inboxId]));
 
   const rows = participants.map((spec) => ({
     chatId,
@@ -167,5 +206,26 @@ export async function addChatParticipants(
     await insert.onConflictDoNothing({ target: [chatMembership.chatId, chatMembership.agentId] });
   } else {
     await insert;
+  }
+
+  // Silent-context backfill invariant. Triggers when an agent crosses into
+  // `accessMode='speaker'` — either brand-new (no prior membership row) or
+  // promoted from watcher. Already-speaker rows are skipped because
+  // re-inserting them was a no-op above. When `upgradeWatcherToSpeaker` is
+  // not set, the watcher branch is naturally empty (the INSERT would have
+  // crashed on the unique key) — defensive filtering keeps the contract
+  // explicit either way.
+  const crossingIntoSpeaker = participants.filter((p) => {
+    const prior = existingMode.get(p.agentId);
+    if (prior === "speaker") return false;
+    if (prior === "watcher") return options.upgradeWatcherToSpeaker === true;
+    return true;
+  });
+  if (crossingIntoSpeaker.length > 0) {
+    const backfillTargets = crossingIntoSpeaker
+      .map((p) => inboxByAgent.get(p.agentId))
+      .filter((inboxId): inboxId is string => typeof inboxId === "string")
+      .map((inboxId) => ({ inboxId }));
+    await backfillSilentContextForNewParticipants(tx, chatId, backfillTargets);
   }
 }


### PR DESCRIPTION
## Summary

- New participants pulled into a group chat from the **web UI** read no history when later @-mentioned. The silent-context backfill landed in PR #393 only on `chat.ts::addParticipant`; the web path goes through `me-chat.ts::addMeChatParticipants` and silently skipped it. Five different join entrypoints all needed the hook, only one had it.
- **Root-cause fix**: sink the backfill invariant into `participant-mode.ts::addChatParticipants` — the helper that is, by the file-header contract, *the only place* in the codebase that writes `chat_membership.access_mode='speaker'` rows. Every join entrypoint inherits the behaviour for free, including any future one.
- Service-layer callers shed the manual hook. The hook on `chat.ts::addParticipant` (and its extra `inboxId` SELECT column) is removed.

## Design

The backfill is a data-integrity invariant: an agent crossing into `accessMode='speaker'` is only able to read history written **after** that moment (inbox fan-out joins on `access_mode='speaker'` — `message.ts:158`), so prior history needs a silent replay. Anchoring this to the row-writing helper instead of to each service entrypoint closes the whole class of bug.

Watcher → speaker upgrades also backfill: watchers never received inbox fan-out either, so the moment they're promoted is the same kind of crossing.

`addChatParticipants` now:
1. SELECTs `agents.inboxId` alongside the existing columns.
2. SELECTs the current `chat_membership` row for the (chatId, agentIds) tuple (one round-trip) to classify inputs as `alreadySpeaker` / `upgradingWatcher` / `brandNew`.
3. Performs the existing INSERT.
4. Calls `backfillSilentContextForNewParticipants` for `upgradingWatcher ∪ brandNew`.

The new SELECT is on a write path, not a hot read path — acceptable cost.

`inbox.ts::backfillSilentContextForNewParticipants`'s `tx` parameter is widened from the module-local `TxLike` to a new `WideTxLike` shaped as `PgDatabase<...>` so it accepts the `DbLike` participant-mode passes in without an `as` assertion. `TxLike` is retained for module-internal callers.

## Test plan

- [x] New file `packages/server/src/__tests__/participant-mode-backfill.test.ts` — 7 cases:
  - helper-layer invariant: brand-new join, watcher → speaker upgrade, already-speaker no-op, mixed-batch selectivity
  - regression: `addMeChatParticipants` (the original web bug), `ensureParticipant` (adapter/HTTP path) with idempotency, `PRECEDING_CONTEXT_MAX_ENTRIES` cap
- [x] `add-participant-backfill.test.ts` (pre-existing) still passes — its assertions are entrypoint-level behaviour, unchanged
- [x] `pnpm typecheck` — 13/13 tasks pass
- [x] `pnpm --filter @first-tree/server test` — **1157 tests passed** (baseline 1150 + 7 new)
- [x] `pnpm check` — no new warnings

## Follow-ups (out of scope, suggested as separate work)

There's a secondary cohesion issue this PR deliberately does not touch: the **add system** (`addParticipant` ↔ `addMeChatParticipants`) and **join system** (`joinChat` ↔ `joinMeChat`) are pairs of near-duplicate services that diverged from PR #402 and the v2 chat_membership refactor. Worth merging in a separate refactor PR after this fix lands — but the present change makes the backfill invariant robust to whatever shape those services eventually take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)