### PR TITLE
feat(web): re-attribute GitHub dispatcher cards and simplify card layout

### DIFF
--- a/packages/server/src/__tests__/message-system-sender-strip.test.ts
+++ b/packages/server/src/__tests__/message-system-sender-strip.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * The web UI re-attributes a message row to a synthetic "GitHub" sender
+ * when `metadata.systemSender === "github"` (chat-view + the conjunctive
+ * trust gate in `github-event-card.tsx`). Because `sendMessageSchema`
+ * accepts arbitrary metadata at the HTTP boundary, a malicious agent
+ * could otherwise POST a regular text message with that key set and the
+ * UI would render it as if it came from GitHub. The service layer
+ * unconditionally strips the key unless the caller opts in via
+ * `allowSystemSender: true` — only `github-delivery.deliverNormalizedEvent`
+ * does. These tests pin both halves: the strip on the default path and
+ * the persistence when the trusted opt-in is set.
+ */
+describe("sendMessage strips metadata.systemSender from untrusted callers", () => {
+  const getApp = useTestApp();
+
+  it("drops metadata.systemSender on a default (non-opted-in) send", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { agent: human } = await createTestAgent(app, { name: `strip-h-${uid}`, type: "human" });
+    const { agent: peer } = await createTestAgent(app, { name: `strip-p-${uid}` });
+    const chat = await createChat(app.db, human.uuid, { type: "group", participantIds: [peer.uuid] });
+
+    const { message } = await sendMessage(app.db, chat.id, human.uuid, {
+      source: "api",
+      format: "text",
+      content: "hello",
+      // A malicious caller (web / agent SDK POST) might try to smuggle
+      // this in alongside their normal text.
+      metadata: { systemSender: "github", mentions: [peer.uuid] },
+    });
+
+    const stored = message.metadata as Record<string, unknown>;
+    expect(stored.systemSender).toBeUndefined();
+    // Other metadata (mentions) must survive — the strip is targeted.
+    expect(stored.mentions).toEqual([peer.uuid]);
+  });
+
+  it("preserves metadata.systemSender when the trusted-internal opt-in is set", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { agent: human } = await createTestAgent(app, { name: `strip-h2-${uid}`, type: "human" });
+    const { agent: peer } = await createTestAgent(app, { name: `strip-p2-${uid}` });
+    const chat = await createChat(app.db, human.uuid, { type: "group", participantIds: [peer.uuid] });
+
+    const { message } = await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      {
+        source: "github",
+        format: "text",
+        content: "hello",
+        metadata: { systemSender: "github", mentions: [peer.uuid] },
+      },
+      { allowSystemSender: true },
+    );
+
+    const stored = message.metadata as Record<string, unknown>;
+    expect(stored.systemSender).toBe("github");
+  });
+});

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -93,6 +93,14 @@ export async function deliverNormalizedEvent(
             entityType: event.entity.type,
             entityKey: event.entity.key,
             reason: card.reason,
+            // Tells the web UI to render this card with a synthetic
+            // "GitHub" sender (icon + name) in place of the human-agent
+            // row whose id we still store as `senderId`. Keeping the DB
+            // senderId as the human agent preserves multi-speaker
+            // fan-out / read-receipts / mention-resolution; only the
+            // visual attribution shifts. Scoped to GitHub cards so an
+            // arbitrary client cannot impersonate other sources.
+            systemSender: "github",
             ...(mentionedUser ? { mentionedUser } : {}),
           },
         },

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -104,7 +104,14 @@ export async function deliverNormalizedEvent(
             ...(mentionedUser ? { mentionedUser } : {}),
           },
         },
-        { addressedToAgentIds: [target.delegateAgentId] },
+        {
+          addressedToAgentIds: [target.delegateAgentId],
+          // Opt in to writing `metadata.systemSender` — the message service
+          // strips that key from every other caller (web / agent SDK POST)
+          // so HTTP boundaries cannot impersonate the GitHub sender in the
+          // chat UI. This is the one trusted-internal path.
+          allowSystemSender: true,
+        },
       );
       notifyRecipients(app.notifier, recipients, message.id);
       stats.delivered += 1;

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -16,6 +16,24 @@ import { assertSenderMayEmitQuestion, recordPendingQuestionFromMessage } from ".
 
 const log = createLogger("message");
 
+/**
+ * Metadata keys reserved for trusted-internal write paths. Stripped from
+ * untrusted-caller input (any send that doesn't opt in) so an HTTP POST
+ * cannot smuggle a UI-trust marker into a regular message — see the
+ * `allowSystemSender` field on `SendMessageOptions` for the threat model.
+ *
+ * Returns the same reference when nothing is stripped, so the common case
+ * (no reserved keys present) does not allocate.
+ */
+function stripUntrustedMetadataKeys(
+  meta: Record<string, unknown>,
+  options: SendMessageOptions,
+): Record<string, unknown> {
+  if (options.allowSystemSender || !("systemSender" in meta)) return meta;
+  const { systemSender: _drop, ...rest } = meta;
+  return rest;
+}
+
 export type SendMessageResult = {
   message: typeof messages.$inferSelect;
   /** Inbox IDs that received this message (for notification). */
@@ -89,6 +107,20 @@ export type SendMessageOptions = {
    * when no explicit declaration was made.
    */
   extractMentionsFromContent?: boolean;
+  /**
+   * Trusted-internal opt-in for writing `metadata.systemSender`. The web UI
+   * uses that key to re-attribute a row to a synthetic "GitHub" sender
+   * (avatar + name override) instead of the row's actual `senderId`. To
+   * prevent a non-dispatcher caller (HTTP POST from web / agent SDK) from
+   * smuggling the same marker into an ordinary message — which would let
+   * an arbitrary agent post a phishing message that renders as if from
+   * GitHub — the service unconditionally strips the key from
+   * `data.metadata` when this option is not set. Only
+   * `github-delivery.deliverNormalizedEvent` is expected to set this to
+   * `true`. Defense-in-depth alongside the conjunctive UI trust gate in
+   * `github-event-card.tsx#isTrustedGithubDispatcherMessage`.
+   */
+  allowSystemSender?: boolean;
 };
 
 export async function sendMessage(
@@ -198,7 +230,7 @@ async function sendMessageInner(
     //     where the typed message is the sole source of routing intent.
     //     Agent / programmatic callers leave this off so a narrative
     //     `@<peer>` in content never silently wakes anyone.
-    const incomingMeta = (data.metadata ?? {}) as Record<string, unknown>;
+    const incomingMeta = stripUntrustedMetadataKeys((data.metadata ?? {}) as Record<string, unknown>, options);
     // Server-side bottom-line on `metadata.documentContext`: shape via shared
     // schema + byte budgets and sha256 calibration. Snapshot content arrives
     // from a trusted runtime, but server still has to verify so a client bug

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isGithubEventCardContent } from "../github-event-card.js";
+import { isGithubEventCardContent, isGithubSystemSenderMetadata } from "../github-event-card.js";
 
 /**
  * Pin the type guard so the chat-view dispatch logic at chat-view.tsx can
@@ -77,5 +77,34 @@ describe("isGithubEventCardContent", () => {
   it("rejects question / question_answer payloads (no cross-format aliasing)", () => {
     expect(isGithubEventCardContent({ correlationId: "tu_1", questions: [], allowFreeText: true })).toBe(false);
     expect(isGithubEventCardContent({ correlationId: "tu_1", answers: {} })).toBe(false);
+  });
+});
+
+/**
+ * Pins the metadata gate that controls when the chat view re-attributes a
+ * row to the synthetic "GitHub" sender. A regression here either fails to
+ * override the human-agent attribution for legitimate dispatcher cards
+ * (UX regression — recipient sees their own avatar on the card) or
+ * accepts a stray `systemSender` from non-GitHub paths (impersonation
+ * risk). The check is intentionally strict on both shape and value.
+ */
+describe("isGithubSystemSenderMetadata", () => {
+  it("accepts metadata with systemSender === 'github'", () => {
+    expect(isGithubSystemSenderMetadata({ systemSender: "github" })).toBe(true);
+    expect(isGithubSystemSenderMetadata({ systemSender: "github", reason: "mentioned" })).toBe(true);
+  });
+
+  it("rejects other systemSender values and bare metadata", () => {
+    expect(isGithubSystemSenderMetadata({ systemSender: "feishu" })).toBe(false);
+    expect(isGithubSystemSenderMetadata({ systemSender: "" })).toBe(false);
+    expect(isGithubSystemSenderMetadata({ source: "github" })).toBe(false);
+    expect(isGithubSystemSenderMetadata({})).toBe(false);
+  });
+
+  it("rejects non-object inputs without throwing", () => {
+    expect(isGithubSystemSenderMetadata(null)).toBe(false);
+    expect(isGithubSystemSenderMetadata(undefined)).toBe(false);
+    expect(isGithubSystemSenderMetadata("github")).toBe(false);
+    expect(isGithubSystemSenderMetadata(42)).toBe(false);
   });
 });

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isGithubEventCardContent, isGithubSystemSenderMetadata } from "../github-event-card.js";
+import {
+  isGithubEventCardContent,
+  isGithubSystemSenderMetadata,
+  isTrustedGithubDispatcherMessage,
+} from "../github-event-card.js";
 
 /**
  * Pin the type guard so the chat-view dispatch logic at chat-view.tsx can
@@ -106,5 +110,49 @@ describe("isGithubSystemSenderMetadata", () => {
     expect(isGithubSystemSenderMetadata(undefined)).toBe(false);
     expect(isGithubSystemSenderMetadata("github")).toBe(false);
     expect(isGithubSystemSenderMetadata(42)).toBe(false);
+  });
+});
+
+/**
+ * The chat view re-attributes a row to the synthetic "GitHub" sender only
+ * when every signal lines up. These tests pin the conjunctive guard so a
+ * future change cannot weaken it back to a metadata-only check without
+ * lighting up red — the metadata field alone is forgeable (per the
+ * external code review on this PR), so each test inverts exactly one of
+ * the four required properties and expects rejection.
+ */
+const trustedMsg = {
+  source: "github",
+  format: "card",
+  content: validCard,
+  metadata: { systemSender: "github" },
+};
+
+describe("isTrustedGithubDispatcherMessage", () => {
+  it("accepts a message that matches every dispatcher signal", () => {
+    expect(isTrustedGithubDispatcherMessage(trustedMsg)).toBe(true);
+  });
+
+  it("rejects when source is not 'github' (agent CLI / web / api send)", () => {
+    for (const source of ["api", "cli", "web", "feishu", null, undefined]) {
+      expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, source })).toBe(false);
+    }
+  });
+
+  it("rejects when format is not 'card' (plain text / markdown send)", () => {
+    for (const format of ["text", "markdown", "question", "file"]) {
+      expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, format })).toBe(false);
+    }
+  });
+
+  it("rejects when the content payload is not a valid GithubEventCard", () => {
+    expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, content: "hello" })).toBe(false);
+    expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, content: { type: "github_mention" } })).toBe(false);
+  });
+
+  it("rejects when the metadata marker is missing or wrong", () => {
+    expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: {} })).toBe(false);
+    expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: { systemSender: "feishu" } })).toBe(false);
+    expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: null })).toBe(false);
   });
 });

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -235,7 +235,7 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
 
   return (
     <div className="text-body">
-      {/* L1 — entity row: clickable chip + title + faded repo */}
+      {/* L1 — entity row: syntax-highlight chip + clickable title + faded repo */}
       <div
         style={{
           display: "flex",
@@ -245,23 +245,23 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
           rowGap: "var(--sp-px)",
         }}
       >
-        {link ? (
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="no-underline hover:opacity-80"
-            style={{ textDecoration: "none" }}
-          >
-            {entityChip}
-          </a>
-        ) : (
-          entityChip
-        )}
+        {entityChip}
         {content.title ? (
-          <span className="font-medium" style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto" }}>
-            {content.title}
-          </span>
+          link ? (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium no-underline hover:underline"
+              style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto", textDecoration: "none" }}
+            >
+              {content.title}
+            </a>
+          ) : (
+            <span className="font-medium" style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto" }}>
+              {content.title}
+            </span>
+          )
         ) : null}
         <span className="mono text-caption" style={{ color: "var(--fg-4)", marginLeft: "auto", flexShrink: 0 }}>
           {repoShort}

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -1,59 +1,116 @@
-import { type GithubEventCard, githubEventCardSchema } from "@first-tree/shared";
+import { type GithubEntityType, type GithubEventCard, githubEventCardSchema } from "@first-tree/shared";
+import { Github } from "lucide-react";
 import type { ReactNode } from "react";
 
 export function isGithubEventCardContent(content: unknown): content is GithubEventCard {
   return githubEventCardSchema.safeParse(content).success;
 }
 
-type ChipTone = "accent" | "warn" | "success" | "neutral";
+/**
+ * The GitHub-dispatcher delivery path writes `systemSender: "github"` into
+ * `message.metadata` so the chat view can render the row with a synthetic
+ * "GitHub" sender (icon + name) instead of the human-agent row whose id we
+ * still keep in `senderId` for routing / read-receipts. Helpers live here
+ * next to the card so the metadata flag and the visual override stay in
+ * lockstep.
+ */
+export const GITHUB_SYSTEM_SENDER_NAME = "GitHub";
 
-const REASON_LABEL: Record<GithubEventCard["reason"], string> = {
-  mentioned: "mentioned",
-  review_requested: "review requested",
-  assigned: "assigned",
-  subscribed: "subscribed",
+export function isGithubSystemSenderMetadata(metadata: unknown): boolean {
+  if (typeof metadata !== "object" || metadata === null) return false;
+  return (metadata as { systemSender?: unknown }).systemSender === "github";
+}
+
+export function GithubSystemAvatar({ size = 20 }: { size?: number }) {
+  const dim = `${size}px`;
+  return (
+    <span
+      role="img"
+      aria-label={GITHUB_SYSTEM_SENDER_NAME}
+      style={{
+        width: dim,
+        height: dim,
+        borderRadius: "50%",
+        background: "var(--fg)",
+        color: "var(--bg)",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        lineHeight: 1,
+      }}
+    >
+      <Github size={Math.round(size * 0.65)} strokeWidth={2} />
+    </span>
+  );
+}
+
+const ENTITY_TAG_LABEL: Record<GithubEntityType, string> = {
+  issue: "Issue",
+  pull_request: "PR",
+  discussion: "Discussion",
+  commit: "Commit",
 };
 
-const REASON_TONE: Record<GithubEventCard["reason"], ChipTone> = {
-  mentioned: "accent",
-  review_requested: "warn",
-  assigned: "success",
-  subscribed: "neutral",
-};
+/**
+ * `entity.key` arrives as `owner/repo#N` or `owner/repo@<sha>`. Strip the
+ * repo prefix so the chip renders the short `#N` / `@<sha>` form. Falls
+ * back defensively to the segment after the last `/` if the prefix does
+ * not match (older messages, schema drift).
+ */
+function shortEntityNumber(key: string, repository: string): string {
+  if (repository && (key.startsWith(`${repository}#`) || key.startsWith(`${repository}@`))) {
+    return key.slice(repository.length);
+  }
+  const lastSlash = key.lastIndexOf("/");
+  return lastSlash >= 0 ? key.slice(lastSlash + 1) : key;
+}
 
-const TONE_STYLE: Record<ChipTone, { background: string; color: string; border: string }> = {
-  accent: {
-    background: "var(--accent-bg)",
-    color: "var(--accent-dim)",
-    border: "var(--accent-ring)",
-  },
-  warn: {
-    background: "var(--bg-warn-soft)",
-    color: "var(--fg-warn-strong)",
-    border: "transparent",
-  },
-  success: {
-    background: "var(--bg-success-soft)",
-    color: "var(--fg-success-strong)",
-    border: "transparent",
-  },
-  neutral: {
-    background: "var(--bg-sunken)",
-    color: "var(--fg-3)",
-    border: "var(--border)",
-  },
-};
+function shortRepoName(repository: string): string {
+  const lastSlash = repository.lastIndexOf("/");
+  return lastSlash >= 0 ? repository.slice(lastSlash + 1) : repository;
+}
 
-function actionPhrase(card: GithubEventCard): string {
-  switch (card.reason) {
-    case "mentioned":
-      return "in";
+function subscribedVerb(kind: GithubEventCard["kind"]): string {
+  switch (kind) {
+    case "opened":
+      return "opened this";
+    case "closed":
+      return "closed this";
+    case "merged":
+      return "merged this";
+    case "reopened":
+      return "reopened this";
+    case "commented":
+      return "commented";
+    case "reviewed":
+      return "reviewed";
+    case "review_comment":
+      return "left a review comment";
     case "review_requested":
-      return "on";
+      return "requested a review";
+    case "synchronized":
+      return "pushed new commits";
+    case "commit_commented":
+      return "commented on a commit";
     case "assigned":
-      return "to you on";
+      return "updated assignees";
+    case "edited":
+      return "edited this";
+    case "other":
+      return "updated this";
+  }
+}
+
+function actionVerb(content: GithubEventCard): string {
+  switch (content.reason) {
+    case "mentioned":
+      return "mentioned you";
+    case "review_requested":
+      return "requested your review";
+    case "assigned":
+      return "assigned this to you";
     case "subscribed":
-      return card.action ? `${card.action.replace(/_/g, " ")} on` : "on";
+      return subscribedVerb(content.kind);
   }
 }
 
@@ -88,58 +145,79 @@ function truncateBody(body: string): string {
 }
 
 export function GithubEventCardMessage({ content }: { content: GithubEventCard }) {
-  const tone = REASON_TONE[content.reason];
-  const toneStyle = TONE_STYLE[tone];
-  const previewBody = content.body.trim().length > 0 ? truncateBody(content.body) : null;
   // schema types both urls as `z.string()` (no `.url()` / `.min(1)`), so an
   // empty string is a possible wire value; `??` would only catch `null` and
   // would render `<a href="">` as a dead link.
   const link = content.entity.url || content.url || null;
+  const previewBody = content.body.trim().length > 0 ? truncateBody(content.body) : null;
+  const tagLabel = ENTITY_TAG_LABEL[content.entity.type];
+  const entityNumber = shortEntityNumber(content.entity.key, content.repository);
+  const repoShort = shortRepoName(content.repository);
+  const verb = actionVerb(content);
+
+  const entityChip = (
+    <span
+      className="mono text-label"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "var(--sp-1)",
+        padding: "var(--sp-px) var(--sp-1_5)",
+        borderRadius: "var(--radius-chip)",
+        background: "var(--bg-sunken)",
+        border: "var(--hairline) solid var(--border)",
+        whiteSpace: "nowrap",
+        lineHeight: 1.4,
+      }}
+    >
+      <span className="font-semibold" style={{ color: "var(--accent-dim)" }}>
+        {tagLabel}
+      </span>
+      <span style={{ color: "var(--fg-3)" }}>{entityNumber}</span>
+    </span>
+  );
 
   return (
     <div className="text-body">
-      <span style={{ display: "inline-flex", alignItems: "center", flexWrap: "wrap", columnGap: "var(--sp-1_5)" }}>
-        <span
-          className="mono text-label"
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            padding: "var(--sp-px) var(--sp-1_5)",
-            borderRadius: "var(--radius-chip)",
-            border: `var(--hairline) solid ${toneStyle.border}`,
-            background: toneStyle.background,
-            color: toneStyle.color,
-            whiteSpace: "nowrap",
-          }}
-        >
-          {REASON_LABEL[content.reason]}
-        </span>
-        <span style={{ color: "var(--fg-3)" }}>{actionPhrase(content)}</span>
+      {/* L1 — entity row: clickable chip + title + faded repo */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          flexWrap: "wrap",
+          columnGap: "var(--sp-1_5)",
+          rowGap: "var(--sp-px)",
+        }}
+      >
         {link ? (
           <a
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            className="font-medium text-[color:var(--fg)] no-underline hover:text-[color:var(--accent-dim)] hover:underline"
+            className="no-underline hover:opacity-80"
+            style={{ textDecoration: "none" }}
           >
-            {/* Inner spans inherit `color` from <a> so hover recolors the
-                whole link, not just the title. Fade weight comes from
-                varying the dim factor via opacity instead. */}
-            <span className="mono" style={{ opacity: 0.65 }}>
-              {content.repository}
-            </span>
-            <span className="mono" style={{ opacity: 0.5 }}>
-              {content.entity.key}
-            </span>
-            {content.title ? <span> — {content.title}</span> : null}
+            {entityChip}
           </a>
-        ) : null}
-        {content.sender ? (
-          <span style={{ color: "var(--fg-3)" }}>
-            by <span className="mono">@{content.sender}</span>
+        ) : (
+          entityChip
+        )}
+        {content.title ? (
+          <span className="font-medium" style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto" }}>
+            {content.title}
           </span>
         ) : null}
-      </span>
+        <span className="mono text-caption" style={{ color: "var(--fg-4)", marginLeft: "auto", flexShrink: 0 }}>
+          {repoShort}
+        </span>
+      </div>
+
+      {/* L2 — action sentence: @actor verb */}
+      <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+        <span className="mono">@{content.sender}</span> {verb}
+      </div>
+
+      {/* L3 — quoted body preview */}
       {previewBody ? (
         <div
           className="text-body"

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -21,6 +21,35 @@ export function isGithubSystemSenderMetadata(metadata: unknown): boolean {
   return (metadata as { systemSender?: unknown }).systemSender === "github";
 }
 
+/**
+ * Conjunctive trust gate for re-attributing a row to the synthetic
+ * "GitHub" sender. Metadata alone is not sufficient — `sendMessageSchema`
+ * accepts arbitrary `metadata`, so a malicious agent could otherwise post
+ * a normal text message with `{ systemSender: "github" }` and have the UI
+ * render it as if from GitHub (sender-impersonation / phishing surface
+ * flagged in code review). The dispatcher path uniquely sets
+ * ALL of: `source === "github"`, `format === "card"`, a content payload
+ * that validates as a `GithubEventCard`, and the metadata marker.
+ * Requiring the conjunction makes the override impossible to trigger
+ * from regular agent sends and impossible to trigger accidentally even
+ * if a future write path mis-copies one flag.
+ */
+type TrustedGithubMessageShape = {
+  source: string | null | undefined;
+  format: string;
+  content: unknown;
+  metadata: unknown;
+};
+
+export function isTrustedGithubDispatcherMessage(msg: TrustedGithubMessageShape): boolean {
+  return (
+    msg.source === "github" &&
+    msg.format === "card" &&
+    isGithubEventCardContent(msg.content) &&
+    isGithubSystemSenderMetadata(msg.metadata)
+  );
+}
+
 export function GithubSystemAvatar({ size = 20 }: { size?: number }) {
   const dim = `${size}px`;
   return (
@@ -93,7 +122,13 @@ function subscribedVerb(kind: GithubEventCard["kind"]): string {
     case "commit_commented":
       return "commented on a commit";
     case "assigned":
-      return "updated assignees";
+      // Passive voice on the subscribed track avoids a semantic clash
+      // with `actionVerb`'s "assigned this to you" (reason=assigned),
+      // which addresses the recipient directly. The subscribed track is
+      // an audience announcement, not a directed assignment, so a
+      // bystander reads "was assigned" without inferring it's pointed at
+      // them.
+      return "was assigned";
     case "edited":
       return "edited this";
     case "other":
@@ -114,22 +149,43 @@ function actionVerb(content: GithubEventCard): string {
   }
 }
 
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function highlightMention(body: string, mentionedUser: string | undefined): ReactNode {
   if (!mentionedUser) return body;
   // github-delivery writes the bare login (no `@`); GitHub bodies usually
-  // carry the `@` prefix. Try `@login` first, fall back to bare login so
-  // we still highlight if upstream ever changes the convention.
-  const candidates = [`@${mentionedUser}`, mentionedUser];
-  for (const needle of candidates) {
-    const idx = body.indexOf(needle);
-    if (idx < 0) continue;
+  // carry the `@` prefix. Try `@login` first (literal `indexOf`, since `@`
+  // is not a word char so a partial match like `@melon` for login `me` is
+  // impossible). Fall back to a word-boundary regex so a bare-login
+  // search for `me` doesn't highlight the `me` inside `melon` — the
+  // fallback fires only when upstream stops including `@` in the body,
+  // so its match window is rarer and worth the stricter check.
+  const prefixed = `@${mentionedUser}`;
+  const prefixedIdx = body.indexOf(prefixed);
+  if (prefixedIdx >= 0) {
     return (
       <>
-        {body.slice(0, idx)}
+        {body.slice(0, prefixedIdx)}
         <span className="font-medium" style={{ color: "var(--accent)" }}>
-          {body.slice(idx, idx + needle.length)}
+          {body.slice(prefixedIdx, prefixedIdx + prefixed.length)}
         </span>
-        {body.slice(idx + needle.length)}
+        {body.slice(prefixedIdx + prefixed.length)}
+      </>
+    );
+  }
+  const bareMatch = new RegExp(`\\b${escapeRegex(mentionedUser)}\\b`).exec(body);
+  if (bareMatch) {
+    const start = bareMatch.index;
+    const end = start + bareMatch[0].length;
+    return (
+      <>
+        {body.slice(0, start)}
+        <span className="font-medium" style={{ color: "var(--accent)" }}>
+          {body.slice(start, end)}
+        </span>
+        {body.slice(end)}
       </>
     );
   }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -44,7 +44,7 @@ import {
   GithubEventCardMessage,
   GithubSystemAvatar,
   isGithubEventCardContent,
-  isGithubSystemSenderMetadata,
+  isTrustedGithubDispatcherMessage,
 } from "../../../components/chat/github-event-card.js";
 import {
   isQuestionAnswerContent,
@@ -281,9 +281,13 @@ function TextRow({
   // GitHub-dispatcher cards keep the human-agent uuid in `senderId` so
   // routing / read-receipts / mention-resolution stay consistent, but we
   // re-attribute the row to a synthetic "GitHub" sender in the UI. The
-  // `isSelf` check is also overridden so the recipient does not see their
-  // own name color treatment on a card the dispatcher wrote on their row.
-  const isGithubSystem = isGithubSystemSenderMetadata(msg.metadata);
+  // gate is conjunctive (`source` + `format` + content shape + metadata
+  // marker) because `sendMessageSchema` accepts arbitrary metadata — a
+  // metadata-only check would let any agent spoof a "from GitHub" card by
+  // posting plain text with the marker set. `isSelf` is also overridden
+  // so the recipient does not see their own name color treatment on a
+  // card the dispatcher wrote on their row.
+  const isGithubSystem = isTrustedGithubDispatcherMessage(msg);
   const senderName = isGithubSystem ? GITHUB_SYSTEM_SENDER_NAME : agentNameFn(msg.senderId);
   const isSelf = !isGithubSystem && myAgentId === msg.senderId;
   const docBasePath = documentBasePathFromMetadata(msg.metadata);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -39,7 +39,13 @@ import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
-import { GithubEventCardMessage, isGithubEventCardContent } from "../../../components/chat/github-event-card.js";
+import {
+  GITHUB_SYSTEM_SENDER_NAME,
+  GithubEventCardMessage,
+  GithubSystemAvatar,
+  isGithubEventCardContent,
+  isGithubSystemSenderMetadata,
+} from "../../../components/chat/github-event-card.js";
 import {
   isQuestionAnswerContent,
   isQuestionContent,
@@ -272,8 +278,14 @@ function TextRow({
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const slugToId = useAgentSlugToIdMap();
-  const senderName = agentNameFn(msg.senderId);
-  const isSelf = myAgentId === msg.senderId;
+  // GitHub-dispatcher cards keep the human-agent uuid in `senderId` so
+  // routing / read-receipts / mention-resolution stay consistent, but we
+  // re-attribute the row to a synthetic "GitHub" sender in the UI. The
+  // `isSelf` check is also overridden so the recipient does not see their
+  // own name color treatment on a card the dispatcher wrote on their row.
+  const isGithubSystem = isGithubSystemSenderMetadata(msg.metadata);
+  const senderName = isGithubSystem ? GITHUB_SYSTEM_SENDER_NAME : agentNameFn(msg.senderId);
+  const isSelf = !isGithubSystem && myAgentId === msg.senderId;
   const docBasePath = documentBasePathFromMetadata(msg.metadata);
   const docSnapshots = useMemo(() => documentSnapshotMapFromMetadata(msg.metadata), [msg.metadata]);
   // Linkify plain `.md` mentions only on agent-sourced messages. Anything the
@@ -376,12 +388,16 @@ function TextRow({
         padding: "var(--sp-1_5) 0",
       }}
     >
-      <Avatar
-        name={senderName}
-        imageUrl={agentAvatarFn(msg.senderId)}
-        seed={msg.senderId}
-        colorToken={agentColorTokenFn(msg.senderId)}
-      />
+      {isGithubSystem ? (
+        <GithubSystemAvatar size={20} />
+      ) : (
+        <Avatar
+          name={senderName}
+          imageUrl={agentAvatarFn(msg.senderId)}
+          seed={msg.senderId}
+          colorToken={agentColorTokenFn(msg.senderId)}
+        />
+      )}
       <div className="min-w-0">
         <div className="flex items-baseline" style={{ gap: 8 }}>
           <span


### PR DESCRIPTION
## Summary
- **Sender re-attribution**: github-delivery now writes `systemSender: "github"` into the message metadata; chat-view renders a synthetic "GitHub" avatar + name on those rows. DB `senderId` keeps the human agent, so multi-speaker fan-out / read-receipts / mention-resolution stay unchanged.
- **Card layout collapsed to three lines** (L1 entity chip + title + faded repo, L2 `@actor` verb-phrase, L3 quoted body): removes the redundant reason-chip-plus-preposition pair and brings the actor to the front. L1 chip is a single clickable link unified across `PR` / `Issue` / `Discussion` / `Commit`.
- **L2 verb matrix** covers the dispatcher's full enum — `mentioned` / `review_requested` / `assigned`, plus all 13 `subscribed` kinds (`opened`, `closed`, `merged`, `reopened`, `commented`, `reviewed`, `review_comment`, `synchronized`, `commit_commented`, `assigned`, `edited`, `review_requested`, `other`).
- Added focused vitest cases pinning `isGithubSystemSenderMetadata` (the gate that re-attributes the row) on positive / negative / non-object inputs.

## Before / After
**Before**: card was sent on the recipient's row, so the chat showed the recipient's avatar + name with `by @actor` buried at the end of a long entity line; the reason chip (`mentioned`) and a preposition (`in`) both encoded the action.

**After**:
```
[GitHub icon] GitHub · 14:23
[PR #123] Add card design refresh                first-tree-hub
@octocat requested your review
| Hey @liuchao-001 can you take a look at...
```

## Test plan
- [x] `pnpm check` — clean (only pre-existing warnings)
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @first-tree/server test` — 1150 / 1150 pass
- [x] `pnpm --filter @first-tree/web test` — 275 / 275 pass (3 new)
- [ ] Manual: trigger a GitHub webhook (mention / review_requested / assigned / subscribed-comment) and confirm the card renders with the "GitHub" sender, no `by @actor` redundancy, clickable entity chip
- [ ] Manual: verify the `[bot]` suffix path renders naturally (e.g. dependabot, claude-bot)
- [ ] Manual: confirm legacy in-database card messages (old shape) still render via the unchanged schema parse