### PR TITLE
fix(client): retry git fetch / set-head on transient network errors

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -707,6 +707,10 @@ describe("GitMirrorManager — transient network error heuristic (isLikelyTransi
     "GnuTLS recv error (-110): The TLS connection was non-properly terminated.",
     "transfer closed with outstanding read data remaining",
     "ssh: connect to host github.com port 22: Network is unreachable",
+    // Raw OpenSSL form for a TLS connection the peer closed mid-stream —
+    // distinct from `SSL_ERROR_SYSCALL` and distinct from the cert-verify
+    // failures (negative case below). Narrow pattern by design.
+    "fatal: unable to access 'https://github.com/x/y/': error:0A000126:SSL routines::unexpected eof while reading",
   ])("matches transient network error: %s", (msg) => {
     expect(isLikelyTransientNetworkError(msg)).toBe(true);
   });
@@ -729,9 +733,17 @@ describe("GitMirrorManager — transient network error heuristic (isLikelyTransi
     // Deterministic content errors — retrying won't help.
     "fatal: repository 'https://example.com/none.git/' not found",
     "fatal: couldn't find remote ref refs/heads/missing",
-    // TLS trust failures — retrying would mask the real misconfiguration.
+    // TLS trust failures — retrying would mask the real misconfiguration and
+    // burn the full retry budget on a deterministic error. Covers the
+    // user-friendly form, the raw OpenSSL form (the regression Codex flagged
+    // on PR #548 — earlier `/SSL routines/i` pattern swept this up as
+    // transient), and the common variants (expired cert, missing CA bundle).
     "fatal: unable to access 'https://example.com/x.git/': SSL certificate problem: self signed certificate",
     "fatal: unable to access 'https://example.com/x.git/': server certificate verification failed.",
+    "fatal: unable to access 'https://example.com/x.git/': error:0A000086:SSL routines::certificate verify failed",
+    "fatal: unable to access 'https://example.com/x.git/': error:0A000412:SSL routines::sslv3 alert bad certificate",
+    "fatal: unable to access 'https://example.com/x.git/': SSL certificate problem: unable to get local issuer certificate",
+    "fatal: unable to access 'https://example.com/x.git/': SSL certificate problem: certificate has expired",
     // Our own per-call timeout — retrying with a fresh full budget is the
     // wrong policy; the op was either making progress or wasn't.
     "git fetch --prune origin timed out after 300000ms",

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   canonicalizeRepoUrl,
   createGitMirrorManager,
@@ -16,6 +16,8 @@ import {
   httpsToSshBaseRewrite,
   isLikelyHttpsAuthFailure,
   isLikelySshAuthFailure,
+  isLikelyTransientNetworkError,
+  retryOnTransientNetwork,
   sshToHttpsBaseRewrite,
 } from "../runtime/git-mirror-manager.js";
 import { isUnderManagedRoot } from "../runtime/worktree-cleanup.js";
@@ -682,6 +684,184 @@ describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailur
     "fatal: could not read Username for 'https://github.com'",
   ])("does NOT match: %s", (msg) => {
     expect(isLikelySshAuthFailure(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — transient network error heuristic (isLikelyTransientNetworkError)", () => {
+  it.each([
+    // The canonical session-resume failure that motivated the retry path —
+    // verbatim from the operator-reported chat error.
+    "git fetch --prune origin exited with code 128: fatal: unable to access 'https://github.com/agent-team-foundation/first-tree/': LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443",
+    "fatal: unable to access 'https://github.com/foo/bar/': OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 54",
+    "fatal: unable to access 'https://github.com/x/y/': Recv failure: Connection reset by peer",
+    "fatal: unable to access 'https://github.com/x/y/': Failed to connect to 127.0.0.1 port 6152: Connection refused",
+    "fatal: unable to access 'https://github.com/x/y/': Operation timed out after 30000 milliseconds",
+    "fatal: unable to access 'https://github.com/x/y/': Could not resolve host: github.com",
+    "ssh: Could not resolve hostname github.com: Temporary failure in name resolution",
+    "fatal: the remote end hung up unexpectedly\nfatal: early EOF\nfatal: index-pack failed",
+    "error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: PROTOCOL_ERROR (err 1)",
+    "error: RPC failed; HTTP 500 curl 22",
+    "fatal: unexpected disconnect while reading sideband packet",
+    "fetch-pack: unexpected disconnect while reading sideband packet",
+    "fatal: TLS handshake failed",
+    "GnuTLS recv error (-110): The TLS connection was non-properly terminated.",
+    "transfer closed with outstanding read data remaining",
+    "ssh: connect to host github.com port 22: Network is unreachable",
+  ])("matches transient network error: %s", (msg) => {
+    expect(isLikelyTransientNetworkError(msg)).toBe(true);
+  });
+
+  it.each([
+    "",
+    // Credential failures must NOT be retried — they go through the protocol
+    // fallback path, not the same-protocol retry loop.
+    "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+    "fatal: could not read Username for 'https://github.com'",
+    "remote: HTTP Basic: Access denied",
+    "fatal: unable to access 'https://example.com/x.git/': The requested URL returned error: 401",
+    "fatal: unable to access 'https://example.com/x.git/': The requested URL returned error: 403",
+    "git@github.com: Permission denied (publickey).",
+    "Host key verification failed.",
+    // Even a stderr that mentions a transient-looking word should be classified
+    // as credential when the credential pattern matches — switching protocol
+    // is the right move, not retrying the same one.
+    "fatal: Authentication failed for 'https://github.com/x.git/': SSL connection established",
+    // Deterministic content errors — retrying won't help.
+    "fatal: repository 'https://example.com/none.git/' not found",
+    "fatal: couldn't find remote ref refs/heads/missing",
+    // TLS trust failures — retrying would mask the real misconfiguration.
+    "fatal: unable to access 'https://example.com/x.git/': SSL certificate problem: self signed certificate",
+    "fatal: unable to access 'https://example.com/x.git/': server certificate verification failed.",
+    // Our own per-call timeout — retrying with a fresh full budget is the
+    // wrong policy; the op was either making progress or wasn't.
+    "git fetch --prune origin timed out after 300000ms",
+    // Repo-state / local errors.
+    "fatal: index file corrupt",
+    "error: Could not write config file",
+  ])("does NOT match: %s", (msg) => {
+    expect(isLikelyTransientNetworkError(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — retryOnTransientNetwork policy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const transientErr = new Error("LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443");
+  const credentialErr = new Error("fatal: Authentication failed for 'https://github.com/foo.git/'");
+  const isRetryable = isLikelyTransientNetworkError;
+
+  /**
+   * Drive an async expression to completion under fake timers. Each iteration
+   * flushes microtasks (so the awaited `setTimeout` registers its scheduler
+   * call) and then drains pending timers. Stops when the promise settles.
+   * Mirrors the pattern in sdk-retry.test.ts so behaviour is comparable.
+   */
+  async function flush<T>(promise: Promise<T>, maxFlushes = 50): Promise<T> {
+    let settled = false;
+    let result: T | undefined;
+    let error: unknown;
+    promise.then(
+      (v) => {
+        result = v;
+        settled = true;
+      },
+      (e) => {
+        error = e;
+        settled = true;
+      },
+    );
+    for (let i = 0; i < maxFlushes && !settled; i++) {
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+    }
+    if (!settled) throw new Error("flush: promise never settled within maxFlushes iterations");
+    if (error !== undefined) throw error;
+    return result as T;
+  }
+
+  it("returns the first success without sleeping", async () => {
+    const op = vi.fn().mockResolvedValueOnce("ok");
+    const onRetry = vi.fn();
+    const result = await flush(retryOnTransientNetwork(op, { delaysMs: [500, 1500, 3000], isRetryable, onRetry }));
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("retries a transient failure up to 4 attempts (1 + 3) and then surfaces it", async () => {
+    const op = vi.fn().mockRejectedValue(transientErr);
+    const onRetry = vi.fn();
+    await expect(
+      flush(retryOnTransientNetwork(op, { delaysMs: [500, 1500, 3000], isRetryable, onRetry })),
+    ).rejects.toThrow(transientErr);
+    expect(op).toHaveBeenCalledTimes(4);
+    // 3 retries scheduled → 3 onRetry callbacks
+    expect(onRetry).toHaveBeenCalledTimes(3);
+    const recordedDelays = onRetry.mock.calls.map((c) => (c[0] as { nextDelayMs: number }).nextDelayMs);
+    // Each scheduled delay must be ≥ the base and within 25% jitter window.
+    expect(recordedDelays[0]).toBeGreaterThanOrEqual(500);
+    expect(recordedDelays[0]).toBeLessThanOrEqual(500 + Math.floor(500 / 4));
+    expect(recordedDelays[1]).toBeGreaterThanOrEqual(1500);
+    expect(recordedDelays[1]).toBeLessThanOrEqual(1500 + Math.floor(1500 / 4));
+    expect(recordedDelays[2]).toBeGreaterThanOrEqual(3000);
+    expect(recordedDelays[2]).toBeLessThanOrEqual(3000 + Math.floor(3000 / 4));
+  });
+
+  it("recovers when a transient failure is followed by a success", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(transientErr)
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValueOnce("ok");
+    const onRetry = vi.fn();
+    const result = await flush(retryOnTransientNetwork(op, { delaysMs: [500, 1500, 3000], isRetryable, onRetry }));
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a non-transient (credential) failure", async () => {
+    const op = vi.fn().mockRejectedValue(credentialErr);
+    const onRetry = vi.fn();
+    await expect(
+      flush(retryOnTransientNetwork(op, { delaysMs: [500, 1500, 3000], isRetryable, onRetry })),
+    ).rejects.toThrow(credentialErr);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("propagates the original error instance unchanged so downstream `instanceof` checks still work", async () => {
+    // The fetchOrigin SSH fallback path does `direction.shouldRetry(primaryMessage)`
+    // on the terminal error — if the retry helper wrapped the error in something
+    // else, the fallback classifier would see the wrapper's message instead of
+    // the underlying git stderr and silently miscategorise the failure.
+    class AuthErr extends Error {
+      readonly tag = "auth";
+    }
+    const original = new AuthErr("fatal: Authentication failed for 'https://github.com/x.git/'");
+    const op = vi.fn().mockRejectedValue(original);
+    await expect(flush(retryOnTransientNetwork(op, { delaysMs: [500, 1500], isRetryable }))).rejects.toBe(original);
+  });
+
+  it("with an empty delays array, makes exactly one attempt (no retries)", async () => {
+    const op = vi.fn().mockRejectedValue(transientErr);
+    await expect(flush(retryOnTransientNetwork(op, { delaysMs: [], isRetryable }))).rejects.toThrow(transientErr);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles non-Error throwables by classifying via String(value)", async () => {
+    const op = vi.fn().mockRejectedValue("LibreSSL SSL_connect: SSL_ERROR_SYSCALL");
+    const onRetry = vi.fn();
+    await expect(flush(retryOnTransientNetwork(op, { delaysMs: [500], isRetryable, onRetry }))).rejects.toBe(
+      "LibreSSL SSL_connect: SSL_ERROR_SYSCALL",
+    );
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -1133,6 +1133,13 @@ describe("GitMirrorManager — ssh fallback", () => {
     expect(caught).not.toBeInstanceOf(GitMirrorAuthError);
   });
 
+  // 30s vitest timeout: `Connection refused` is in the transient-retry set
+  // (intentionally — localhost-proxy listeners commonly bounce), so this
+  // test now eats the full ~5s of retry sleeps plus 4 × git-curl-fail-fast
+  // attempts before reaching the terminal assertion. On Linux dev machines
+  // that pushes wall-clock to ~15s, past vitest's default 5s testTimeout.
+  // CI Linux runners aren't affected, but cross-platform portability
+  // matters — see PR #548 review feedback.
   it("does NOT classify a non-credential https failure as auth — bootstrap against an unreachable https URL throws raw GitMirrorError", async () => {
     // Drive `ensureMirror` (which goes through the same `fetchOrigin` helper
     // as `fetchMirror`) against an https URL whose connect() always refuses.
@@ -1154,7 +1161,7 @@ describe("GitMirrorManager — ssh fallback", () => {
     }
     expect(caught).toBeInstanceOf(GitMirrorError);
     expect(caught).not.toBeInstanceOf(GitMirrorAuthError);
-  });
+  }, 30_000);
 });
 
 describe("GitMirrorManager — concurrency", () => {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -1070,9 +1070,30 @@ export function isLikelyTransientNetworkError(message: string): boolean {
   // Don't shadow a credential failure: switching to SSH is the right move
   // for those, retrying the same protocol is not.
   if (isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message)) return false;
+  // Don't shadow a TLS trust failure: those are deterministic misconfigurations
+  // (custom intercepting cert chain, expired cert, missing CA bundle, …) that
+  // a 5s retry budget won't fix. Burning the budget AND emitting transient-
+  // warning log lines for a deterministic failure would also mislead operators
+  // diagnosing a real cert problem. Matches both the user-friendly form
+  // (`SSL certificate problem: …`) and the raw OpenSSL form
+  // (`error:…:SSL routines::certificate verify failed`).
+  if (
+    /SSL certificate problem/i.test(message) ||
+    /server certificate verification failed/i.test(message) ||
+    /certificate verify failed/i.test(message) ||
+    /self.signed certificate/i.test(message) ||
+    /unable to get local issuer certificate/i.test(message) ||
+    /certificate has expired/i.test(message)
+  )
+    return false;
   return (
     /SSL_ERROR_SYSCALL/i.test(message) ||
-    /SSL\w+ error|SSL routines/i.test(message) ||
+    // OpenSSL's transient "the peer closed mid-stream" signal. Matches the
+    // raw form (`error:…:SSL routines::unexpected eof while reading`) emitted
+    // when github.com's edge resets the TLS connection mid-fetch. Narrowly
+    // scoped to the exact phrase to avoid re-introducing the broad
+    // `SSL routines` match that swept up cert verify failures.
+    /unexpected eof while reading/i.test(message) ||
     /TLS handshake|gnutls_handshake|gnutls\s+recv\s+error/i.test(message) ||
     /\bConnection reset(?:\s+by\s+peer)?\b/i.test(message) ||
     /\bConnection refused\b/i.test(message) ||

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -14,7 +14,15 @@ const SESSION_BRANCH_PREFIX = "hub-session";
  * Backoff schedule for retrying a remote-talking git op (`fetch`,
  * `remote set-head --auto`) on a transient network-layer failure. Each entry
  * is the wait BEFORE the next attempt, so this lays out 4 attempts total
- * (1 initial + 3 retries) with a worst-case sleep budget of ~5s.
+ * (1 initial + 3 retries) with a worst-case sleep budget of ~5s **per
+ * protocol attempt**.
+ *
+ * Per-call totals depend on whether the helper chains a primary + fallback:
+ *   - `fetchOrigin` ≤ 5s sleep budget: the SSH fallback only fires when
+ *     the primary's terminal failure is credential-shaped, which a transient
+ *     stderr will never be. So a transient-only failure burns ~5s.
+ *   - `setHeadAuto` ≤ 10s sleep budget: the fallback fires on ANY terminal
+ *     primary failure, so a doubly-transient run burns ~5s + ~5s ≈ 10s.
  *
  * Tuned for the operator-visible case of session start/resume hitting a
  * proxy / VPN that flips a rule, restarts a TUN, or drops a TLS handshake
@@ -397,6 +405,13 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * mirrors the historical `gitOk` semantics — non-fatal). No `GitMirrorAuthError`
    * here: callers that need origin/HEAD already get a clear
    * `GitMirrorError("Cannot resolve default branch …")` if both attempts fail.
+   */
+  /**
+   * Worst-case sleep budget: ~10s (primary ~5s + fallback ~5s). Unlike
+   * `fetchOrigin`, which gates fallback on a credential-shaped terminal
+   * error, `setHeadAuto` always falls through on any primary failure, so
+   * a doubly-transient run pays both retry budgets. Per-call 30s timeout
+   * still caps each individual git invocation.
    */
   async function setHeadAuto(mirrorPath: string, originUrl: string): Promise<boolean> {
     try {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -11,6 +11,22 @@ const FETCH_REFSPEC = "+refs/heads/*:refs/remotes/origin/*";
 const SESSION_BRANCH_PREFIX = "hub-session";
 
 /**
+ * Backoff schedule for retrying a remote-talking git op (`fetch`,
+ * `remote set-head --auto`) on a transient network-layer failure. Each entry
+ * is the wait BEFORE the next attempt, so this lays out 4 attempts total
+ * (1 initial + 3 retries) with a worst-case sleep budget of ~5s.
+ *
+ * Tuned for the operator-visible case of session start/resume hitting a
+ * proxy / VPN that flips a rule, restarts a TUN, or drops a TLS handshake
+ * mid-flight. The user's own manual workaround in those cases is "@-mention
+ * the agent again 2 seconds later" — this is that, automated.
+ *
+ * Per-step jitter (up to 25% of the delay) prevents thundering-herd retries
+ * when several agents resume in lockstep against the same flaky proxy.
+ */
+const NETWORK_RETRY_DELAYS_MS: readonly number[] = [500, 1500, 3000];
+
+/**
  * Per-URL bare mirror manager.
  *
  * Layout:
@@ -327,6 +343,24 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     }
   }
 
+  async function gitWithNetworkRetry(
+    args: string[],
+    cwd: string | null,
+    timeoutMs: number,
+    opLabel: string,
+  ): Promise<{ stdout: string; stderr: string; elapsedMs: number }> {
+    return retryOnTransientNetwork(() => git(args, cwd, timeoutMs), {
+      delaysMs: NETWORK_RETRY_DELAYS_MS,
+      isRetryable: isLikelyTransientNetworkError,
+      onRetry: ({ attempt, nextDelayMs, message }) => {
+        log?.warn(
+          { op: opLabel, attempt, nextDelayMs, stderr: message.slice(0, 512) },
+          "git remote op hit transient network error — retrying",
+        );
+      },
+    });
+  }
+
   /**
    * `git fetch --prune origin` with one-shot bidirectional protocol fallback.
    *
@@ -365,14 +399,26 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * `GitMirrorError("Cannot resolve default branch …")` if both attempts fail.
    */
   async function setHeadAuto(mirrorPath: string, originUrl: string): Promise<boolean> {
-    if (await gitOk(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000)) return true;
+    try {
+      await gitWithNetworkRetry(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000, "set-head:primary");
+      return true;
+    } catch {
+      // Primary attempt failed terminally (after any transient retries). Fall
+      // through to the SSH-side rewrite — same fallback rules as fetchOrigin.
+    }
     const direction = pickFallbackDirection(originUrl);
     if (!direction) return false;
-    return await gitOk(
-      ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "remote", "set-head", "origin", "--auto"],
-      mirrorPath,
-      30_000,
-    );
+    try {
+      await gitWithNetworkRetry(
+        ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "remote", "set-head", "origin", "--auto"],
+        mirrorPath,
+        30_000,
+        "set-head:fallback",
+      );
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async function readOriginUrl(mirrorPath: string): Promise<string | null> {
@@ -390,7 +436,12 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   ): Promise<{ elapsedMs: number; usedFallback: boolean }> {
     const direction = pickFallbackDirection(originUrl);
     try {
-      const { elapsedMs } = await git(["fetch", "--prune", "origin"], mirrorPath, cloneTimeoutMs);
+      const { elapsedMs } = await gitWithNetworkRetry(
+        ["fetch", "--prune", "origin"],
+        mirrorPath,
+        cloneTimeoutMs,
+        "fetch:primary",
+      );
       return { elapsedMs, usedFallback: false };
     } catch (primaryErr) {
       const primaryMessage = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
@@ -407,10 +458,11 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         "fetch failed with credential-shaped error; retrying with peer-protocol insteadOf rewrite",
       );
       try {
-        const { elapsedMs } = await git(
+        const { elapsedMs } = await gitWithNetworkRetry(
           ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "fetch", "--prune", "origin"],
           mirrorPath,
           cloneTimeoutMs,
+          "fetch:fallback",
         );
         log?.info({ gitUrl: originUrl, toProtocol: direction.toProtocol }, "protocol-fallback fetch succeeded");
         return { elapsedMs, usedFallback: true };
@@ -980,6 +1032,68 @@ export function isLikelyAuthFailure(message: string): boolean {
 }
 
 /**
+ * Heuristic for transient network-layer failures emitted by `git` over
+ * HTTPS or SSH. These are the failure modes a brief proxy/VPN hiccup, TLS
+ * handshake blip, or peer connection reset produces mid-fetch — exactly
+ * what `SSL_connect: SSL_ERROR_SYSCALL` looks like when Surge / Clash
+ * swaps a rule mid-flight, what `early EOF` looks like when an HTTP/2
+ * stream is reset, and what `Connection refused` looks like when a local
+ * proxy listener restarts.
+ *
+ * Used by the `gitWithNetworkRetry` wrapper around `fetch` and
+ * `remote set-head --auto` to absorb the kind of hiccup that today
+ * surfaces as `Session start/resume failed (…)` in chat and only goes
+ * away when the operator manually @-mentions the agent again two seconds
+ * later.
+ *
+ * Negative space (intentionally NOT matched):
+ *   - credential failures — handled by the protocol-fallback path; retrying
+ *     in the same protocol won't help.
+ *   - `Repository not found`, `couldn't find remote ref` — deterministic
+ *     content errors; a 500ms retry won't fix them.
+ *   - `SSL certificate problem` — TLS trust failures; retrying won't help
+ *     and silently masking them would hide a real misconfiguration.
+ *   - `git … timed out after Xms` — our own per-call timeout. The op was
+ *     making progress (or wasn't); either way another full timeout window
+ *     is the wrong response.
+ *
+ * On localhost-proxy specifically (the common case for this codebase),
+ * `ECONNREFUSED` IS a transient signal — when Surge / Clash bounces the
+ * listener, the next attempt sees the same listener back up within
+ * seconds. This is why we diverge from the SDK's `doFetch` policy (which
+ * does NOT retry `ECONNREFUSED` because there the peer is the remote hub).
+ *
+ * Exported for unit testing.
+ */
+export function isLikelyTransientNetworkError(message: string): boolean {
+  if (!message) return false;
+  // Don't shadow a credential failure: switching to SSH is the right move
+  // for those, retrying the same protocol is not.
+  if (isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message)) return false;
+  return (
+    /SSL_ERROR_SYSCALL/i.test(message) ||
+    /SSL\w+ error|SSL routines/i.test(message) ||
+    /TLS handshake|gnutls_handshake|gnutls\s+recv\s+error/i.test(message) ||
+    /\bConnection reset(?:\s+by\s+peer)?\b/i.test(message) ||
+    /\bConnection refused\b/i.test(message) ||
+    /\bConnection timed out\b/i.test(message) ||
+    /\bOperation timed out\b/i.test(message) ||
+    /\bNetwork is unreachable\b/i.test(message) ||
+    /Could not resolve host(?:name)?/i.test(message) ||
+    /Temporary failure in name resolution/i.test(message) ||
+    /\bRPC failed\b/i.test(message) ||
+    /\bearly EOF\b/i.test(message) ||
+    /the remote end hung up unexpectedly/i.test(message) ||
+    /transfer closed with outstanding read data remaining/i.test(message) ||
+    /HTTP\/2 stream\s+\d+\s+was\s+(?:not\s+)?(?:reset|closed)/i.test(message) ||
+    /HTTP\/2 stream was reset/i.test(message) ||
+    /unexpected disconnect while reading sideband packet/i.test(message) ||
+    /fetch-pack: unexpected disconnect/i.test(message) ||
+    /\bsend-pack:\s+unexpected\s+disconnect\b/i.test(message)
+  );
+}
+
+/**
  * Map an HTTPS git URL to the `insteadOf` rewrite needed to make git resolve
  * it through SSH. Returns *base* strings (suitable for
  * `git -c url.<sshBase>.insteadOf=<httpsBase>`) — git's `insteadOf` is a
@@ -1125,4 +1239,53 @@ function pickFallbackDirection(originUrl: string): FallbackDirection | null {
 function truncate(text: string, max = 512): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max)}…[truncated]`;
+}
+
+/**
+ * Run `op` once, and on a `isRetryable`-classified failure replay it on the
+ * given backoff schedule. Non-retryable failures propagate to the caller
+ * immediately — those won't be cured by waiting and silently retrying would
+ * mask real bugs and exhaust the retry budget.
+ *
+ * Per-attempt timeouts (when `op` enforces one of its own) are NOT reset
+ * across attempts: each attempt gets its own full budget. Right policy for
+ * `git fetch` where a slow but progressing transfer on attempt N+1 should
+ * not be aborted because attempt N ate part of a shared budget.
+ *
+ * Exported so unit tests can drive the retry policy with a mock `op`
+ * instead of standing up a real flaky network. Module-scope so the helper
+ * stays pure and side-effect-free.
+ */
+export async function retryOnTransientNetwork<T>(
+  op: (attempt: number) => Promise<T>,
+  options: {
+    delaysMs: readonly number[];
+    isRetryable: (message: string) => boolean;
+    onRetry?: (info: { attempt: number; nextDelayMs: number; message: string }) => void;
+  },
+): Promise<T> {
+  const { delaysMs, isRetryable, onRetry } = options;
+  const maxAttempts = delaysMs.length + 1;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await op(attempt);
+    } catch (err) {
+      lastErr = err;
+      const message = err instanceof Error ? err.message : String(err);
+      if (!isRetryable(message)) throw err;
+      if (attempt === maxAttempts) throw err;
+      // `delaysMs.length === maxAttempts - 1`, so `attempt - 1` is in range
+      // for every iteration that reaches this line. The explicit guard keeps
+      // TS strict happy without resorting to a non-null assertion.
+      const baseDelay = delaysMs[attempt - 1];
+      if (baseDelay === undefined) throw err;
+      const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelay / 4)));
+      const delayMs = baseDelay + jitter;
+      onRetry?.({ attempt, nextDelayMs: delayMs, message });
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  // Unreachable — the loop always either returns or throws by `maxAttempts`.
+  throw lastErr;
 }


### PR DESCRIPTION
## Summary

`git fetch --prune origin` (and `remote set-head --auto`) inside the mirror manager runs with **no retry on transient network-layer failures** — only credential-shaped errors trigger the SSH protocol fallback. So when a local proxy / VPN flips a rule, restarts its TUN, or drops a TLS handshake mid-flight, every session start / resume hitting that mirror fails outright with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL` (and similar). The operator's manual workaround is "@-mention the agent again two seconds later" — re-running the same fetch almost always succeeds, which is the strongest evidence the failure is transient.

This PR wraps both remote ops in a small same-protocol retry layer.

## Implementation

- **`retryOnTransientNetwork`** — new module-scope helper that replays `op` on the `[500ms, 1500ms, 3000ms]` backoff (1 initial + 3 retries) when the failure stderr matches `isLikelyTransientNetworkError`. Non-transient failures propagate immediately. Up to 25% jitter per delay so peer agents resuming in lockstep don't thunder against the same flaky proxy.
- **`isLikelyTransientNetworkError`** — new classifier for the failure modes a brief network blip produces: `SSL_ERROR_SYSCALL`, OpenSSL `unexpected eof while reading`, `Connection reset/refused/timed out`, `Could not resolve host`, `RPC failed`, `early EOF` / `hung up unexpectedly`, `HTTP/2 stream reset`, `TLS handshake`, `GnuTLS recv error`, `transfer closed with outstanding read data`, `unexpected disconnect while reading sideband packet`. Two short-circuit guards run before positive matching: credential failures (routed through the existing protocol fallback) and TLS cert failures (deterministic misconfiguration — covers user-friendly `SSL certificate problem` AND raw OpenSSL `error:…:SSL routines::certificate verify failed`). Repo-not-found, TLS cert errors, and our own per-call timeout are NOT classified as transient — silently retrying those would mask real bugs and chew through the retry budget.
- **`fetchOrigin`** and **`setHeadAuto`** now run each protocol attempt (the primary and the SSH-fallback) through `gitWithNetworkRetry`, so a transient blip during either attempt gets its own retry budget before the caller sees the failure.

## Worst-case latency

| Function | Sleep budget on terminal failure | Why |
|---|---|---|
| `fetchOrigin` | ≤ ~5s | SSH fallback only fires on credential-shaped failures; a transient terminal stderr never matches `direction.shouldRetry`. |
| `setHeadAuto` | ≤ ~10s | Fallback fires on ANY primary terminal failure, so a doubly-transient run chains both retry budgets. |

Per-call 30s timeout still caps each individual git invocation. The trade — eating 5–10s once per genuinely-broken fetch vs. demanding a manual @-mention from the operator every time — is unambiguously the right call given the user-reported pain.

## Divergence from SDK doFetch retry

PR #324 added a similar retry to the SDK's `doFetch`, but that policy **does NOT** retry `ECONNREFUSED` (because there the peer is the remote Hub server — refused means refused). In our case the peer is a localhost proxy listener; when Surge / Clash bounces the listener, the next attempt sees it back up within seconds. The classifier docblock spells this out.

## Migration / rollout

Pure runtime behaviour change. No config, no schema, no migration. Existing installs pick up the retry automatically on the next client auto-update.

## Test plan

- [x] `pnpm typecheck` — 13/13 tasks pass
- [x] `pnpm exec biome check` on the two changed files — clean
- [x] `pnpm --filter @first-tree/client test` — all 132 tests in `git-mirror-manager.test.ts` pass (existing 100 + 32 new):
  - Classifier exhaustiveness against the production-reported `SSL_ERROR_SYSCALL` stderr and 15 other transient signatures (including the raw OpenSSL `unexpected eof while reading` form)
  - Negative coverage for credential / repo-not-found / TLS cert (user-friendly + raw OpenSSL `certificate verify failed`) / timeout / corruption messages
  - Retry policy behaviour: success on first attempt, recovery mid-retry, 4-attempts ceiling, no-retry on non-transient, error-instance pass-through (so downstream `instanceof` / `direction.shouldRetry` checks still work), empty delays = single attempt, non-Error throwables
- [x] Bumped the existing `does NOT classify a non-credential https failure as auth` test to `30_000` ms — `Connection refused` is now retryable, so this test eats ~5s of sleeps + 4 × git attempts before its terminal assertion. CI macOS runner unaffected (`Test` job ~1m30s), but Linux dev environments push past vitest's default 5s timeout.
- [x] Pre-existing failures in `first-tree-cli-contract.integration.test.ts` are unrelated — they invoke the `first-tree` binary on PATH which is missing bundled `skills/` payloads. Verified by greping that no other code in the monorepo imports the new helpers, and by `pnpm typecheck` (13/13) which would have caught any signature drift.

## Background

User report from `liuchao-001`: `code-reviewer` session resume intermittently fails with `LibreSSL SSL_connect: SSL_ERROR_SYSCALL`. Manually @-mentioning the agent immediately afterwards always succeeds. PR #526 (proxy env passthrough into the launchd plist) is the necessary precondition for any of this to reach the proxy at all and is already in place — confirmed by inspecting the operator's installed plist. The remaining problem is the missing retry, which this PR fixes.