### PR TITLE
fix(server): mint message id as uuid v7 per architecture rule

### DIFF
--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { extractMentions, type SendMessage, scanMentionTokens } from "@first-tree/shared";
 import { and, desc, eq, lt } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
@@ -9,6 +8,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { createLogger, messageAttrs, withSpan } from "../observability/index.js";
+import { uuidv7 } from "../uuid.js";
 import { upsertSessionState } from "./activity.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { validateDocumentContext } from "./doc-snapshots.js";
@@ -442,7 +442,13 @@ async function sendMessageInner(
     const projectionMentions: string[] = isSilentSend ? [] : dmAutoProjection;
 
     // 3. Store the message (with merged metadata + normalised content).
-    const messageId = randomUUID();
+    // UUID v7 per the "UUID v7 as Message ID" architecture rule in
+    // CLAUDE.md — time-ordered so message id lex order matches creation
+    // order. randomUUID() (v4) was the pre-existing implementation; the
+    // mismatch was caught when the web client's "new messages" divider
+    // relied on lex ordering to find newer-than-anchor messages and
+    // silently dropped some (PR #286, rev 8).
+    const messageId = uuidv7();
     const [msg] = await tx
       .insert(messages)
       .values({


### PR DESCRIPTION
## Summary

`packages/server/src/services/message.ts` was minting message ids with `crypto.randomUUID()` (UUID v4) since the service was written. But [CLAUDE.md Architecture Rules](../blob/main/CLAUDE.md) state:

> **UUID v7 as Message ID:** Time-ordered; messages are immutable after creation.

Every other service in this package already uses `uuidv7()` from `src/uuid.ts` — `message.ts` was the lone holdout. This PR fixes the inconsistency.

## Why now

The mismatch was caught during PR #286 review. The web client's "New Messages" divider used lex comparison on message ids to find the first message newer than a chat-open anchor — a valid technique under v7's time-ordering, but UUID v4's random bytes meant some new messages sorted *before* the anchor and were silently misclassified as already-seen. PR #286 fixed the symptom on the web side (switched to index-based comparison). This PR fixes the root cause so future code can rely on the documented ordering invariant.

## Scope

- 1 line of executable change: `randomUUID()` → `uuidv7()` at `packages/server/src/services/message.ts:445`
- Drops `randomUUID` import (no longer used in this file); adds `uuidv7` import from `../uuid.js`
- Inline comment explaining why

## What does NOT change

- DB schema (messages.id is `uuid`, accepts both v4 and v7)
- Any query (server has no `ORDER BY messages.id` anywhere; ordering goes through `createdAt`)
- Historical data — mixed v4 (old) + v7 (new) coexist cleanly

## Test plan

- [x] `pnpm --filter @first-tree/server typecheck` ✅
- [x] `pnpm check` ✅
- [ ] CI: `Lint & Type Check` / `Test` / `Migrations` / `Forbid legacy CLI / env names`

🤖 Generated with [Claude Code](https://claude.com/claude-code)