### PR TITLE
refactor(server): unify participant-join entrypoints around a single Layer-2 service

### DIFF
--- a/docs/chat-first-workspace-product-design.md
+++ b/docs/chat-first-workspace-product-design.md
@@ -483,11 +483,17 @@ UI concept and does not appear in the API path.
 ```text
 GET    /me/chats                          — paginated list
 POST   /me/chats                          — create
-POST   /me/chats/:chatId/read             — mark-read
-POST   /me/chats/:chatId/participants     — add member
-POST   /me/chats/:chatId/join             — watcher → speaker
-POST   /me/chats/:chatId/leave            — speaker → watcher (or detach)
+POST   /chats/:chatId/read                — mark-read
+POST   /chats/:chatId/participants        — add member
+POST   /chats/:chatId/workspace-join      — watcher → speaker
+POST   /chats/:chatId/workspace-leave     — speaker → watcher (or detach)
 ```
+
+Note: an earlier draft listed these under `/me/chats/...`; the actual
+shipping routes live under `/chats/...` (see `packages/server/src/api/chats.ts`
++ `me-chats.ts`). The v1 supervision-check `POST /chats/:chatId/join` route
+was removed alongside its `chat.ts::joinChat` service — the v2 watcher-based
+`/workspace-join` is the only "manager joins chat" path today.
 
 ### `GET /me/chats`
 
@@ -605,18 +611,26 @@ Both UPDATEs run; whichever row exists takes effect. Idempotent.
 
 Returns `{ chatId, lastReadAt, unreadMentionCount: 0 }`.
 
-### `POST /me/chats/:chatId/join`
+### `POST /chats/:chatId/workspace-join`
 
-Watcher → speaking participant. State-carry transaction (§State
-Transitions). If the user has no watcher row but has visibility, inserts
-a fresh `chat_participants` row.
+Watcher → speaking participant. Single-table UPDATE on
+`chat_membership.access_mode` ('watcher' → 'speaker'); `chat_user_state`
+rows for the (chat, agent) pair are not touched (read state survives the
+flip — see §State Transitions).
 
-Returns updated participants list.
+Refuses with 403 if the caller has no watcher row in the chat (admins
+without a managed participant must not be able to drop into arbitrary
+chats); refuses with 409 if the caller is already a speaker. See
+`packages/server/src/services/watcher.ts::ensureCanJoin`.
 
-### `POST /me/chats/:chatId/leave`
+Returns 204.
 
-Speaking participant → watcher (if `stillVisible`) or fully detach. State-
-carry transaction (§State Transitions).
+### `POST /chats/:chatId/workspace-leave`
+
+Speaking participant → watcher (if `stillVisible`) or fully detach.
+Single-table UPDATE on `chat_membership.access_mode`; `chat_user_state`
+row (if any) is preserved per §11.4 default — read state is remembered
+for re-add.
 
 Returns `{ chatId, membershipKind: 'watching' | null }`.
 

--- a/packages/server/src/__tests__/agent-visibility.test.ts
+++ b/packages/server/src/__tests__/agent-visibility.test.ts
@@ -457,8 +457,13 @@ describe("Chat Access Control", () => {
     });
   });
 
-  describe("POST /admin/chats/:chatId/join — manager joins chat", () => {
-    it("manager can join a chat of their managed agent", async () => {
+  describe("POST /chats/:chatId/workspace-join — manager joins chat", () => {
+    // The v1 supervision-check route `POST /chats/:chatId/join` was removed
+    // along with its `joinChat` service. In v2 the manager's relationship to
+    // the chat is materialised as a watcher row by `recomputeChatWatchers`
+    // (run on every speaker write via `addChatParticipants`), and the
+    // `/workspace-join` route gates on "you're already a watcher".
+    it("manager can join a chat of their managed agent (watcher → speaker)", async () => {
       const app = getApp();
       const adminBundle = await authedRequest(app);
       const member = await createMemberAndLogin(app, adminBundle);
@@ -475,18 +480,28 @@ describe("Chat Access Control", () => {
         managerId: member.memberId,
       });
 
-      // Create a chat between the two agents (not including human agent)
+      // Create a chat between the two agents (not including human agent).
+      // `createChat` → `addChatParticipants` already recomputes watchers, so
+      // the member's human agent lands as a watcher row immediately and
+      // `/workspace-join` will accept the promotion.
       const chat = await createChat(app.db, agentA.uuid, {
         type: "group",
         participantIds: [agentB.uuid],
       });
 
-      // Member joins the chat
-      const res = await member.req("POST", `/api/v1/chats/${chat.id}/join`);
-      expect(res.statusCode).toBe(200);
-      const body = res.json<{ participants: Array<{ agentId: string }> }>();
-      const participantIds = body.participants.map((p) => p.agentId);
-      expect(participantIds).toContain(member.agentId);
+      // Member joins the chat.
+      const res = await member.req("POST", `/api/v1/chats/${chat.id}/workspace-join`);
+      expect(res.statusCode).toBe(204);
+
+      // Verify the human agent is now a speaker in the chat.
+      const { chatMembership } = await import("../db/schema/chat-membership.js");
+      const { and: andOp, eq: eqOp } = await import("drizzle-orm");
+      const [row] = await app.db
+        .select({ accessMode: chatMembership.accessMode })
+        .from(chatMembership)
+        .where(andOp(eqOp(chatMembership.chatId, chat.id), eqOp(chatMembership.agentId, member.agentId)))
+        .limit(1);
+      expect(row?.accessMode).toBe("speaker");
     });
 
     it("member cannot join a chat they don't supervise", async () => {
@@ -513,10 +528,10 @@ describe("Chat Access Control", () => {
         participantIds: [agentA2.uuid],
       });
 
-      // Member B tries to join — refused. Under the new requireChatAccess
-      // model the gate returns 404 (not 403) so a non-participant cannot
-      // enumerate chat UUIDs by probing.
-      const res = await memberB.req("POST", `/api/v1/chats/${chat.id}/join`);
+      // Member B tries to join — refused. memberB has no watcher row for
+      // this chat (they manage none of its speakers), so requireChatAccess
+      // returns 404 (probing-protection) before `joinMeChat` is even called.
+      const res = await memberB.req("POST", `/api/v1/chats/${chat.id}/workspace-join`);
       expect(res.statusCode).toBe(404);
     });
   });

--- a/packages/server/src/__tests__/chat-upgrade.test.ts
+++ b/packages/server/src/__tests__/chat-upgrade.test.ts
@@ -2,18 +2,22 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
-import { addParticipant, createChat, ensureParticipant, joinChat } from "../services/chat.js";
-import { createTestAgent, useTestApp } from "./helpers.js";
+import { addParticipant, createChat, ensureParticipant } from "../services/chat.js";
+import { joinMeChat } from "../services/me-chat.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
  * Validates `addChatParticipants` invariants under v2:
  *
  *   - `chat_membership.mode` is decision-inert; every speaker row written
  *     through `createChat` / `addParticipant` / `ensureParticipant` /
- *     `joinChat` lands as the constant `'mention_only'`. There is no
- *     longer a chat-type re-grade pass — `chats.type` is locked to
- *     `'group'` (first-tree-context PR #465) and the v1 size=2→3
- *     `regradeNonHumansToMentionOnly` helper has been retired.
+ *     `joinMeChat` (watcher → speaker upgrade) lands as the constant
+ *     `'mention_only'`. There is no longer a chat-type re-grade pass —
+ *     `chats.type` is locked to `'group'` (first-tree-context PR #465) and
+ *     the v1 size=2→3 `regradeNonHumansToMentionOnly` helper has been
+ *     retired. The v1 `joinChat` service / `POST /:chatId/join` route was
+ *     also removed; the only "manager joins chat" path today is
+ *     `joinMeChat` / `POST /:chatId/workspace-join`.
  *
  * The `describe` label "chat upgrade — direct to group" is kept to
  * preserve git history and downstream test-output greppability, but the
@@ -72,40 +76,35 @@ describe("chat upgrade — direct to group", () => {
     expect((await loadParticipant(chat.id, a3.uuid))?.mode).toBe("mention_only");
   });
 
-  it("upgrades the chat and keeps the joining human at full mode (Web-console join path)", async () => {
+  it("keeps the joining human at mention_only when they go watcher → speaker via joinMeChat", async () => {
+    // The v2 "manager joins chat" path: `POST /:chatId/workspace-join` →
+    // `joinMeChat` → `joinAsParticipant`. The watcher row that gates this
+    // path is materialised by `recomputeChatWatchers`, which is now
+    // automatically run by `addChatParticipants` — so the admin's
+    // human-agent watcher row lands the moment `createChat` finishes.
     const app = getApp();
-    const uid = crypto.randomUUID().slice(0, 6);
-    const a1 = await createTestAgent(app, { name: `hup-a1-${uid}` });
-    const { agent: a2 } = await createTestAgent(app, { name: `hup-a2-${uid}` });
-
-    // A human agent owned by the same member who manages a1 — joinChat
-    // authorises via managerId.
-    const { agent: human } = await createTestAgent(app, {
-      name: `hup-human-${uid}`,
-      type: "human",
-    });
-    // Rewrite managerId so joinChat permits the join (supervision must match
-    // at least one existing participant).
+    const admin = await createTestAdmin(app);
     const { agents: agentsTable } = await import("../db/schema/agents.js");
-    // a1's member manages both a1 and the human agent row by default; but
-    // the human agent we just created belongs to a *different* admin. Force
-    // it to the same manager so the join is authorised.
-    await app.db.update(agentsTable).set({ managerId: a1.memberId }).where(eq(agentsTable.uuid, human.uuid));
-    await app.db.update(agentsTable).set({ managerId: a1.memberId }).where(eq(agentsTable.uuid, a2.uuid));
+
+    const a1 = await createTestAgent(app, { name: `hup-a1-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: a2 } = await createTestAgent(app, { name: `hup-a2-${crypto.randomUUID().slice(0, 6)}` });
+
+    // Force both non-human agents onto the admin so the recompute that runs
+    // inside `createChat` pins the admin's human agent as a watcher.
+    await app.db.update(agentsTable).set({ managerId: admin.memberId }).where(eq(agentsTable.uuid, a1.agent.uuid));
+    await app.db.update(agentsTable).set({ managerId: admin.memberId }).where(eq(agentsTable.uuid, a2.uuid));
 
     const chat = await createChat(app.db, a1.agent.uuid, {
       type: "group",
       participantIds: [a2.uuid],
     });
 
-    await joinChat(app.db, chat.id, a1.memberId, human.uuid);
+    await joinMeChat(app.db, chat.id, admin.humanAgentUuid);
 
     expect(await loadChatType(chat.id)).toBe("group");
-    // v2: `chat_membership.mode` is decision-inert; every speaker row is
-    // written as the constant `'mention_only'`.
     expect((await loadParticipant(chat.id, a1.agent.uuid))?.mode).toBe("mention_only");
     expect((await loadParticipant(chat.id, a2.uuid))?.mode).toBe("mention_only");
-    expect((await loadParticipant(chat.id, human.uuid))?.mode).toBe("mention_only");
+    expect((await loadParticipant(chat.id, admin.humanAgentUuid))?.mode).toBe("mention_only");
   });
 
   it("is a no-op on a chat that is already a group (doesn't re-flip existing participant modes)", async () => {

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -1,0 +1,324 @@
+import { AGENT_VISIBILITY } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { assertChatVisibleInOrgOrNotFound, inviteParticipantsToChat } from "../services/participant-invite.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Layer-2 invite service contract. Both the agent-JWT path
+ * (`chat.ts::addParticipant`) and the user-JWT web path
+ * (`me-chat.ts::addMeChatParticipants`) collapse onto
+ * `inviteParticipantsToChat`. These tests pin the shared contract directly
+ * at the service layer so any future entrypoint that delegates here
+ * inherits the same behaviour.
+ */
+describe("inviteParticipantsToChat", () => {
+  const getApp = useTestApp();
+
+  it("rejects an empty target list", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const chat = await createChat(app.db, owner.agent.uuid, { type: "group", participantIds: [] });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: owner.agent.uuid,
+        targetAgentIds: [],
+        errorOnAlreadySpeaker: false,
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it("404s when the chat does not exist", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const target = await createTestAgent(app, { type: "autonomous_agent" });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: "00000000-0000-0000-0000-000000000000",
+        callerAgentId: owner.agent.uuid,
+        targetAgentIds: [target.agent.uuid],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it("refuses a caller who is not a speaker of the chat (ForbiddenError)", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const stranger = await createTestAgent(app, { type: "autonomous_agent" });
+    const target = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, { type: "group", participantIds: [] });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: stranger.agent.uuid,
+        targetAgentIds: [target.agent.uuid],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it("rejects unknown target agents with BadRequestError (listing the missing ids)", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const chat = await createChat(app.db, owner.agent.uuid, { type: "group", participantIds: [] });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: owner.agent.uuid,
+        targetAgentIds: ["00000000-0000-0000-0000-000000000000"],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(/Agents not found/);
+  });
+
+  it("rejects cross-org targets with BadRequestError", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    // `createTestAgent` resolves the *default* org for every call, so two
+    // agents created back-to-back land in the same org. To produce a
+    // cross-org target we rewrite the agent's organization_id post hoc.
+    const stranger = await createTestAgent(app, { type: "autonomous_agent" });
+    const otherOrgId = "11111111-1111-1111-1111-111111111111";
+    const { organizations } = await import("../db/schema/organizations.js");
+    await app.db.insert(organizations).values({ id: otherOrgId, name: "Other Org", displayName: "Other Org" });
+    await app.db.update(agents).set({ organizationId: otherOrgId }).where(eq(agents.uuid, stranger.agent.uuid));
+
+    const chat = await createChat(app.db, owner.agent.uuid, { type: "group", participantIds: [] });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: owner.agent.uuid,
+        targetAgentIds: [stranger.agent.uuid],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(/Cross-organization/);
+  });
+
+  it("refuses a non-owner inviting a private target (owner-exclusive rule)", async () => {
+    const app = getApp();
+    // Caller and target are in the same org but managed by different members.
+    const caller = await createTestAgent(app, { type: "autonomous_agent" });
+    const targetOwner = await createTestAgent(app, { type: "autonomous_agent" });
+
+    // Pin the target's org to caller's org and mark it private.
+    await app.db
+      .update(agents)
+      .set({ organizationId: caller.organizationId, visibility: AGENT_VISIBILITY.PRIVATE })
+      .where(eq(agents.uuid, targetOwner.agent.uuid));
+
+    const chat = await createChat(app.db, caller.agent.uuid, { type: "group", participantIds: [] });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: caller.agent.uuid,
+        targetAgentIds: [targetOwner.agent.uuid],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(/Only the owner/);
+  });
+
+  it("throws ConflictError on already-speaker target when errorOnAlreadySpeaker=true", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: owner.agent.uuid,
+        targetAgentIds: [peer.agent.uuid],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(ConflictError);
+  });
+
+  it("silently skips already-speaker targets when errorOnAlreadySpeaker=false (partial-idempotent batch)", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const existingSpeaker = await createTestAgent(app, { type: "autonomous_agent" });
+    const brandNew = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [existingSpeaker.agent.uuid],
+    });
+
+    await inviteParticipantsToChat(app.db, {
+      chatId: chat.id,
+      callerAgentId: owner.agent.uuid,
+      targetAgentIds: [existingSpeaker.agent.uuid, brandNew.agent.uuid],
+      errorOnAlreadySpeaker: false,
+    });
+
+    const speakers = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.accessMode, "speaker")));
+    const speakerIds = new Set(speakers.map((s) => s.agentId));
+    expect(speakerIds.has(existingSpeaker.agent.uuid)).toBe(true);
+    expect(speakerIds.has(brandNew.agent.uuid)).toBe(true);
+  });
+
+  it("is a true no-op when every target is already a speaker (no write, no recompute side-effects)", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "autonomous_agent" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+
+    // Sanity: peer is already a speaker.
+    const beforeRows = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(eq(chatMembership.chatId, chat.id));
+
+    await inviteParticipantsToChat(app.db, {
+      chatId: chat.id,
+      callerAgentId: owner.agent.uuid,
+      targetAgentIds: [peer.agent.uuid],
+      errorOnAlreadySpeaker: false,
+    });
+
+    const afterRows = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(eq(chatMembership.chatId, chat.id));
+    expect(afterRows.length).toBe(beforeRows.length);
+  });
+
+  it("brand-new invitee receives the silent-context backfill (regression for PR #545)", async () => {
+    // Direct service-level proof that the backfill invariant inherited from
+    // `addChatParticipants` survives the Layer-2 collapse. PR #545's tests
+    // pinned this on the addParticipant/addMeChatParticipants entrypoints;
+    // here we pin it on the underlying invite service so any future Layer-3
+    // shell that delegates to invite inherits the assertion for free.
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peer = await createTestAgent(app, { type: "autonomous_agent" });
+    const newcomer = await createTestAgent(app, { type: "autonomous_agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    for (let i = 0; i < 6; i++) {
+      await sendMessage(app.db, chat.id, owner.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: `inv-${i}`,
+      });
+    }
+
+    await inviteParticipantsToChat(app.db, {
+      chatId: chat.id,
+      callerAgentId: owner.agent.uuid,
+      targetAgentIds: [newcomer.agent.uuid],
+      errorOnAlreadySpeaker: true,
+    });
+
+    const silentRows = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, newcomer.agent.inboxId),
+          eq(inboxEntries.chatId, chat.id),
+          eq(inboxEntries.notify, false),
+          eq(inboxEntries.status, "pending"),
+        ),
+      );
+    expect(silentRows.length).toBe(6);
+  });
+
+  it("self-add of a private agent is permitted (owner-exclusive carve-out)", async () => {
+    // Agent rejoining a chat it already owns must not be blocked by the
+    // owner-exclusive check, even if the agent is private. The carve-out
+    // is the `t.uuid !== callerAgentId` clause inside the invite service:
+    // private-owner-exclusive does not fire when caller IS the target.
+    const app = getApp();
+    const self = await createTestAgent(app, { type: "autonomous_agent" });
+    await app.db.update(agents).set({ visibility: AGENT_VISIBILITY.PRIVATE }).where(eq(agents.uuid, self.agent.uuid));
+
+    // `self` creates the chat → `self` is automatically a speaker (createChat
+    // includes the creator). Private agents are allowed to land in chats
+    // they own themselves; `createChat` shares the same self-add carve-out.
+    const chat = await createChat(app.db, self.agent.uuid, { type: "group", participantIds: [] });
+
+    // `self` invites `self`. Without the carve-out this would raise
+    // ForbiddenError (private + caller !== target.managerId is the usual
+    // owner-exclusive trip). With the carve-out, the call passes the gate
+    // and the already-speaker silent-skip turns it into a no-op.
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: self.agent.uuid,
+        targetAgentIds: [self.agent.uuid],
+        errorOnAlreadySpeaker: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertChatVisibleInOrgOrNotFound", () => {
+  const getApp = useTestApp();
+
+  it("404s when the chat does not exist", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human" });
+    await expect(
+      assertChatVisibleInOrgOrNotFound(app.db, "00000000-0000-0000-0000-000000000000", caller.organizationId),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it("404s when the chat is in a different org from the caller (probing protection)", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human" });
+    const chatOwner = await createTestAgent(app, { type: "autonomous_agent" });
+    const chat = await createChat(app.db, chatOwner.agent.uuid, { type: "group", participantIds: [] });
+
+    // Force the chat into a different org so the caller can't see it.
+    const otherOrgId = "22222222-2222-2222-2222-222222222222";
+    const { organizations } = await import("../db/schema/organizations.js");
+    const { chats } = await import("../db/schema/chats.js");
+    await app.db.insert(organizations).values({
+      id: otherOrgId,
+      name: "Other Org for chat",
+      displayName: "Other Org for chat",
+    });
+    await app.db.update(chats).set({ organizationId: otherOrgId }).where(eq(chats.id, chat.id));
+
+    await expect(assertChatVisibleInOrgOrNotFound(app.db, chat.id, caller.organizationId)).rejects.toThrow(
+      NotFoundError,
+    );
+  });
+
+  it("passes when chat exists and is in the caller's org", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human" });
+    const chat = await createChat(app.db, caller.agent.uuid, { type: "group", participantIds: [] });
+    await expect(assertChatVisibleInOrgOrNotFound(app.db, chat.id, caller.organizationId)).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -17,7 +17,7 @@ import { messages } from "../db/schema/messages.js";
 import { assertAllAgentsVisibleInOrg, requireChatAccess } from "../scope/require-resource.js";
 import { agentAvatarImageUrl } from "../services/agent.js";
 import { getChatAgentStatuses } from "../services/agent-chat-status.js";
-import { ensureParticipant, joinChat, leaveChat } from "../services/chat.js";
+import { ensureParticipant, leaveChat } from "../services/chat.js";
 import { findInstallationByOrg } from "../services/github-app-installations.js";
 import { mintContextTreeInstallationToken } from "../services/github-app-token.js";
 import { resolveChatGithubEntity } from "../services/github-entity-live.js";
@@ -289,20 +289,11 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  app.post<{ Params: { chatId: string } }>("/:chatId/join", async (request, reply) => {
-    const { scope } = await requireChatAccess(request, app.db);
-    const participants = await joinChat(app.db, request.params.chatId, scope.memberId, scope.humanAgentId);
-    return reply.status(200).send({
-      chatId: request.params.chatId,
-      participants: participants.map((p) => ({
-        agentId: p.agentId,
-        role: p.role,
-        // v2: wire `mode` field is decision-inert. Project the constant.
-        mode: WIRE_RECIPIENT_MODE,
-        joinedAt: p.joinedAt.toISOString(),
-      })),
-    });
-  });
+  // `POST /:chatId/join` (v1 supervision-check join) was removed alongside
+  // its `chat.ts::joinChat` service — the v2 watcher-based path
+  // `POST /:chatId/workspace-join` (below, see also
+  // `me-chat.ts::joinMeChat`) supersedes it and is the only "manager joins
+  // chat" route the web / CLI actually call.
 
   app.post<{ Params: { chatId: string } }>("/:chatId/leave", async (request, reply) => {
     const { scope } = await requireChatAccess(request, app.db);

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -38,6 +38,21 @@ export class ForbiddenError extends AppError {
   }
 }
 
+/**
+ * Thrown by `inviteParticipantsToChat` when the caller is not currently a
+ * speaker of the target chat. Subtypes `ForbiddenError` so existing 403
+ * mapping still fires, but exposes a stable identity that callers can match
+ * with `instanceof` instead of regex-sniffing the message — used by the web
+ * `addMeChatParticipants` shell to remap into a probing-protection 404.
+ */
+export class CallerNotSpeakerError extends ForbiddenError {
+  readonly code = "CALLER_NOT_SPEAKER";
+  constructor(callerAgentId: string, chatId: string, attrs?: AppErrorAttrs) {
+    super(`Caller "${callerAgentId}" is not a speaker of chat "${chatId}"`, attrs);
+    this.name = "CallerNotSpeakerError";
+  }
+}
+
 export class ConflictError extends AppError {
   constructor(message = "Conflict", attrs?: AppErrorAttrs) {
     super(409, message, attrs);

--- a/packages/server/src/services/chat-audience-cache.ts
+++ b/packages/server/src/services/chat-audience-cache.ts
@@ -7,12 +7,17 @@
  *
  * The cache exposes both a populator (`getCachedAudience`) and an
  * invalidator (`invalidateChatAudience`). Participant-mutation paths
- * (`addMeChatParticipants`, `joinMeChat`, `leaveMeChat`,
- * `recomputeChatWatchers`, `joinAsParticipant`, `leaveAsParticipant`)
  * MUST call `invalidateChatAudience` after their tx commits so the
  * very next dispatch reflects the new audience without waiting for
  * the TTL to age out — without invalidation, a freshly-added speaker
  * would miss `chat:message` pushes for up to TTL_MS.
+ *
+ * Canonical bundles already enclose this step internally — callers that
+ * route through `applyMembershipWrite` (used by `inviteParticipantsToChat`
+ * / `ensureParticipant`) or through `joinAsParticipant` /
+ * `leaveAsParticipant` do NOT need to call it themselves. Direct callers
+ * of `addChatParticipants`, `recomputeChatWatchers`, or any other ad-hoc
+ * speaker-row write are still responsible.
  *
  * Cross-instance correctness: not handled here. The PG NOTIFY layer
  * already broadcasts message events to every replica; each replica's

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -6,14 +6,15 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { resolveChatTitle } from "./me-chat.js";
 import { WIRE_RECIPIENT_MODE } from "./message-dispatcher.js";
-import { addChatParticipants } from "./participant-mode.js";
+import { inviteParticipantsToChat } from "./participant-invite.js";
+import { addChatParticipants, applyMembershipWrite, recomputeChatWatchers } from "./participant-mode.js";
 import { extractSummary } from "./session.js";
-import { leaveAsParticipant, recomputeChatWatchers } from "./watcher.js";
+import { leaveAsParticipant } from "./watcher.js";
 
 export async function createChat(db: Database, creatorId: string, data: CreateChat) {
   const chatId = randomUUID();
@@ -78,9 +79,11 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
 
     // Mode is derived per-row by `addChatParticipants` from
     // `(chats.type, agents.type)` — `services/participant-mode.ts` is the
-    // single authoritative encoder of the rule (group / non-human →
-    // `mention_only`; direct + agent-only → `mention_only` for the
-    // anti-echo invariant from migration 0029). Do NOT pass `mode` here.
+    // single authoritative encoder. The helper also encloses the watcher
+    // recompute (so every active manager whose managed non-human agent is
+    // now in the chat lands in the "Watching" set) and the silent-context
+    // backfill (no-op here because the chat has no messages yet). Do NOT
+    // pass `mode` and do NOT call `recomputeChatWatchers` again.
     await addChatParticipants(
       tx,
       chatId,
@@ -89,13 +92,6 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
         role: agentId === creatorId ? "owner" : "member",
       })),
     );
-
-    // Watcher rows: every active manager whose managed non-human agent
-    // is now in the chat (and who isn't already a speaker) should see
-    // this chat under "Watching". Without this call, watchers were
-    // only created on the `/me/chats` path — agent-to-agent / webhook /
-    // adapter / admin chats silently broke design AC #8.
-    await recomputeChatWatchers(tx, chatId);
 
     const participants = await tx
       .select()
@@ -312,13 +308,40 @@ export async function isParticipant(db: Database, chatId: string, agentId: strin
   return Boolean(row);
 }
 
-/** Ensure an agent is a speaker of a chat. Silently adds them if not already. */
+/**
+ * Idempotent "ensure this agent is a speaker of this chat" admit.
+ *
+ * **Caller-responsibility contract — read before using.** This helper does
+ * NO authorisation. It is a Layer-1.5 wrapper for `applyMembershipWrite`
+ * whose only job is the short-circuit "already a speaker → return without
+ * opening a tx". Use it only when the caller has already verified that the
+ * given agent has a legitimate reason to be in the chat. The two legitimate
+ * callers today are:
+ *
+ *   1. `adapter-mapping.ts` (Feishu/Slack bridge) — IM platform has already
+ *      authenticated the sender / bot. The hub side has no separate notion
+ *      of "did this user choose to enter the chat" — joining is implicit by
+ *      sending a message on the platform.
+ *   2. `api/chats.ts` HTTP message + question-answer routes — the `scope`
+ *      middleware has already gated the request through `requireChatAccess`
+ *      before reaching the handler that calls this.
+ *
+ * Do NOT call this from new code paths to "lightly join" an agent — for
+ * speaker-invokes-invite use `inviteParticipantsToChat`; for manager
+ * self-join use `joinAsParticipant`. Adding a new legitimate caller? Append
+ * it to the list above and document the external authorisation step in your
+ * PR — reviewers should see it.
+ *
+ * Behaviour:
+ *   - If already a speaker → 1-SELECT short-circuit, no tx opened. This is
+ *     the hot path for the IM bridge (every inbound message hits this).
+ *   - Otherwise → `applyMembershipWrite`, which encloses backfill, watcher
+ *     recompute, and post-commit audience invalidation.
+ */
 export async function ensureParticipant(db: Database, chatId: string, agentId: string): Promise<void> {
-  // Short-circuit if already a speaker so we don't spuriously trigger the
-  // direct→group upgrade on every admin message in a chat the sender already
-  // belongs to. Read outside the transaction — if a race adds this agent
-  // concurrently, the UPSERT inside the transaction is the authoritative
-  // dedupe.
+  // Short-circuit if already a speaker. Read outside the tx — if a race
+  // adds this agent concurrently, the UPSERT inside `applyMembershipWrite`
+  // is the authoritative dedupe.
   const [existing] = await db
     .select({ accessMode: chatMembership.accessMode })
     .from(chatMembership)
@@ -326,115 +349,41 @@ export async function ensureParticipant(db: Database, chatId: string, agentId: s
     .limit(1);
   if (existing?.accessMode === "speaker") return;
 
-  // This is a genuine join — apply the same upgrade rule as joinChat /
-  // addParticipant. Web-console "start typing in a chat" funnels through
-  // here, so missing this call left the proposal's no-echo invariant
-  // silently off for UI-initiated joins. Atomic: upgrade + UPSERT must not
-  // interleave with sendMessage's participant read.
-  //
-  // If a watcher row already exists for this (chat, agent) pair, the
-  // ON CONFLICT DO UPDATE upgrades it to speaker in place. chat_user_state
-  // is structurally separate so the user's read state survives the
-  // promotion untouched — no state-carry needed (proposal §8.4).
-  await db.transaction(async (tx) => {
-    // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
-    // `chat_membership.mode` is decision-inert. `upgradeWatcherToSpeaker`
-    // promotes a pre-existing watcher row in place so chat_user_state is
-    // preserved automatically (the row, if any, lives in a separate table
-    // and survives the access_mode flip untouched — proposal §8.4).
-    await addChatParticipants(tx, chatId, [{ agentId }], { upgradeWatcherToSpeaker: true });
-    // Reconcile watcher rows for managers of any non-human in chat.
-    await recomputeChatWatchers(tx, chatId);
-  });
-  invalidateChatAudience(chatId);
+  await applyMembershipWrite(db, chatId, [{ agentId }], { upgradeWatcherToSpeaker: true });
 }
 
+/**
+ * Agent-JWT entrypoint: `POST /agent/.../chats/:id/participants`.
+ *
+ * Thin shell over `inviteParticipantsToChat`:
+ *   1. Resolve the wire target (by uuid OR by name) to a uuid — name lookup
+ *      is the only Layer-3 surface specific to this entrypoint.
+ *   2. Delegate to the invite service with `errorOnAlreadySpeaker: true`
+ *      (agent-SDK contract: already-in is a 409, not a silent skip).
+ *   3. Return the resulting speaker list (the wire shape this entrypoint
+ *      has always returned).
+ */
 export async function addParticipant(db: Database, chatId: string, requesterId: string, data: AddParticipant) {
-  // Verify chat exists
+  // Resolve the wire target. Name lookup is scoped to the chat's
+  // organization so an agent in another org can never be pulled in by name
+  // collision. Resolving in the shell (vs. inside the invite service) keeps
+  // the Layer-2 contract uniform on uuid inputs.
   const chat = await getChat(db, chatId);
-
-  // Verify requester is a participant
-  await assertParticipant(db, chatId, requesterId);
-
-  // Resolve the target by uuid or by name. Name lookup is scoped to the
-  // chat's organization so an agent in another org can never be pulled in
-  // by name collision. `visibility` and `managerId` are needed for PR #402's
-  // owner-exclusive check; `inboxId` is fetched by `addChatParticipants`
-  // itself for the silent-context backfill, so no need to thread it here.
   const targetSelector = data.agentId
     ? eq(agents.uuid, data.agentId)
     : and(eq(agents.organizationId, chat.organizationId), eq(agents.name, data.agentName ?? ""));
-  const [targetAgent] = await db
-    .select({
-      id: agents.uuid,
-      organizationId: agents.organizationId,
-      visibility: agents.visibility,
-      managerId: agents.managerId,
-    })
-    .from(agents)
-    .where(targetSelector)
-    .limit(1);
-
+  const [targetAgent] = await db.select({ id: agents.uuid }).from(agents).where(targetSelector).limit(1);
   if (!targetAgent) {
     const ref = data.agentId ?? data.agentName ?? "(unknown)";
     throw new NotFoundError(`Agent "${ref}" not found`);
   }
 
-  if (targetAgent.organizationId !== chat.organizationId) {
-    throw new BadRequestError("Cannot add agent from different organization");
-  }
-
-  // Owner-exclusive rule for private targets. The requester is an
-  // agent on the SDK side; resolve its owner via `agents.managerId`
-  // and compare with the target's owner — only the same member may
-  // bring a private agent into a chat. Closes the agent-SDK bypass of
-  // the discovery filter (RFC §4.4.2 / §4.5). `targetAgent.id !==
-  // requesterId` skips the self-add case so an agent rejoining its own
-  // chat via `joinChat` semantics isn't incidentally blocked.
-  if (targetAgent.visibility === AGENT_VISIBILITY.PRIVATE && targetAgent.id !== requesterId) {
-    const [requester] = await db
-      .select({ managerId: agents.managerId })
-      .from(agents)
-      .where(eq(agents.uuid, requesterId))
-      .limit(1);
-    if (!requester) {
-      // Should be unreachable — `assertParticipant` above proved the
-      // requester is in chat_membership, which FK-references agents.
-      throw new NotFoundError(`Agent "${requesterId}" not found`);
-    }
-    if (requester.managerId !== targetAgent.managerId) {
-      throw new ForbiddenError(`Only the owner can add a private agent to a chat: ${targetAgent.id}`);
-    }
-  }
-
-  // Check not already a speaker. A watcher row is allowed — it's the
-  // expected source state for the manager's "promote myself to speaker"
-  // path (the UPSERT below upgrades it).
-  const [existing] = await db
-    .select({ accessMode: chatMembership.accessMode })
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, targetAgent.id)))
-    .limit(1);
-
-  if (existing?.accessMode === "speaker") {
-    throw new ConflictError(`Agent "${data.agentName ?? targetAgent.id}" is already a participant`);
-  }
-
-  // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
-  // `chat_membership.mode` is decision-inert. `upgradeWatcherToSpeaker`
-  // promotes any pre-existing watcher row in place — chat_user_state is
-  // structurally separate so read state is preserved without a state-carry
-  // transaction.
-  await db.transaction(async (tx) => {
-    // Silent-context backfill is now an invariant of `addChatParticipants`
-    // (proposals/hub-chat-message-v1-design §四 改造 2 follow-up): the helper
-    // detects watcher → speaker / brand-new crossings and writes the silent
-    // inbox rows itself, so every join entrypoint inherits the behaviour for
-    // free instead of having to remember the hook.
-    await addChatParticipants(tx, chatId, [{ agentId: targetAgent.id }], { upgradeWatcherToSpeaker: true });
-    await recomputeChatWatchers(tx, chatId);
+  await inviteParticipantsToChat(db, {
+    chatId,
+    callerAgentId: requesterId,
+    targetAgentIds: [targetAgent.id],
+    errorOnAlreadySpeaker: true,
   });
-  invalidateChatAudience(chatId);
 
   return db
     .select()
@@ -603,87 +552,6 @@ export async function listChatsForMember(db: Database, memberId: string, humanAg
   }
 
   return result;
-}
-
-/**
- * Manager joins a chat. Adds their human agent as a participant.
- * Requires the member to have supervision rights (manages at least one existing participant).
- */
-// TODO: getChat is called only for organizationId validation; could be merged
-// with the participants query to reduce one DB round-trip
-export async function joinChat(db: Database, chatId: string, memberId: string, humanAgentId: string) {
-  const chat = await getChat(db, chatId);
-
-  // Check supervision rights: member must manage at least one speaker.
-  const speakers = await db
-    .select()
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
-
-  const participantAgentIds = speakers.map((p) => p.agentId);
-  if (participantAgentIds.length === 0) {
-    throw new NotFoundError("Chat has no participants");
-  }
-
-  // Check if already a speaker
-  if (participantAgentIds.includes(humanAgentId)) {
-    throw new ConflictError("Already a participant in this chat");
-  }
-
-  // Verify supervision: at least one participant is managed by this member
-  const managedParticipants = await db
-    .select({ uuid: agents.uuid })
-    .from(agents)
-    .where(and(inArray(agents.uuid, participantAgentIds), eq(agents.managerId, memberId)));
-
-  if (managedParticipants.length === 0) {
-    throw new ForbiddenError("You can only join chats where you manage at least one participant");
-  }
-
-  // Verify human agent belongs to same org as chat
-  const [humanAgent] = await db
-    .select({ organizationId: agents.organizationId })
-    .from(agents)
-    .where(eq(agents.uuid, humanAgentId))
-    .limit(1);
-
-  if (!humanAgent || humanAgent.organizationId !== chat.organizationId) {
-    throw new BadRequestError("Agent does not belong to the same organization as the chat");
-  }
-
-  // Human joining a direct chat turns it into a group — existing
-  // non-human speakers switch to mention_only so they only respond
-  // when explicitly addressed. Atomic: upgrade + UPSERT must not
-  // interleave with sendMessage's participant read.
-  //
-  // If a watcher row already exists for the joining manager (the
-  // common case — migration 0030's backfill, or a prior recompute
-  // pass), the ON CONFLICT DO UPDATE upgrades it to speaker in
-  // place. chat_user_state lives in a separate table by design, so
-  // the manager's read state survives the promotion automatically —
-  // no state-carry transaction needed.
-  await db.transaction(async (tx) => {
-    // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
-    // `chat_membership.mode` is decision-inert.
-    //
-    // The join contract admits only the manager's human agent —
-    // `assertHuman: true` makes a non-human caller surface as a 400 rather
-    // than silently inserting. `upgradeWatcherToSpeaker` promotes the
-    // manager's pre-existing watcher row in place (common case — migration
-    // 0030 or prior recompute pass). chat_user_state is structurally
-    // separate so read state survives the promotion automatically.
-    await addChatParticipants(tx, chatId, [{ agentId: humanAgentId, role: "member" }], {
-      assertHuman: true,
-      upgradeWatcherToSpeaker: true,
-    });
-    await recomputeChatWatchers(tx, chatId);
-  });
-  invalidateChatAudience(chatId);
-
-  return db
-    .select()
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
 }
 
 /**

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -564,10 +564,12 @@ export async function listChatsForMember(db: Database, memberId: string, humanAg
  * rule that recompute is only for set rebuild — never on a transition
  * path (review #228 issue #2). The returned participant list is fetched
  * after the tx commits, matching the admin route's existing contract.
+ *
+ * `leaveAsParticipant` itself runs the post-commit `invalidateChatAudience`,
+ * so this shell doesn't need to.
  */
 export async function leaveChat(db: Database, chatId: string, humanAgentId: string) {
   await leaveAsParticipant(db, chatId, humanAgentId);
-  invalidateChatAudience(chatId);
   return db
     .select()
     .from(chatMembership)

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -5,9 +5,9 @@
  * Responsibilities:
  *   - Cursor-paginated conversation list (single-stream JOIN over the
  *     unified `chat_membership` + `chat_user_state` tables).
- *   - Create a new chat (no dedupe, runs `recomputeChatWatchers` after).
- *   - Add participants (idempotent, UPSERT into `chat_membership`,
- *     runs `recomputeChatWatchers` after).
+ *   - Create a new chat (delegates participant writes — and the derived
+ *     watcher recompute — to `addChatParticipants`).
+ *   - Add participants (delegates to `inviteParticipantsToChat`).
  *   - Mark-read (UPSERT into `chat_user_state`).
  *   - Join → watcher to speaker (delegates to `watcher.ts`).
  *   - Leave → speaker to watcher or detach (delegates to `watcher.ts`).
@@ -48,15 +48,10 @@ import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
 import { resolveAgentChatStatuses } from "./agent-chat-status.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
+import { assertChatVisibleInOrgOrNotFound, inviteParticipantsToChat } from "./participant-invite.js";
 import { addChatParticipants } from "./participant-mode.js";
 import { extractSummary } from "./session.js";
-import {
-  ensureCanJoin,
-  joinAsParticipant,
-  leaveAsParticipant,
-  recomputeChatWatchers,
-  resolveChatMembership,
-} from "./watcher.js";
+import { ensureCanJoin, joinAsParticipant, leaveAsParticipant, resolveChatMembership } from "./watcher.js";
 
 // ---------------------------------------------------------------------------
 // Cursor encoding
@@ -624,11 +619,12 @@ export async function createMeChat(
       topic,
     });
 
-    // v2: mode is decision-inert; `addChatParticipants` writes the
-    // constant `'mention_only'` for every speaker row. The single-writer
-    // entrypoint is retained so a future per-receiver wake policy lands
-    // in one place. See
-    // proposals/hub-chat-message-v2-simplify-mode.20260520.md.
+    // v2: mode is decision-inert; `addChatParticipants` writes the constant
+    // `'mention_only'` for every speaker row. The helper also encloses the
+    // derived watcher recompute (so managers of any non-human participant
+    // land as watchers) and the silent-context backfill (no-op here — the
+    // chat has no messages yet). Don't call `recomputeChatWatchers` again.
+    // See proposals/hub-chat-message-v2-simplify-mode.20260520.md.
     await addChatParticipants(
       tx,
       chatId,
@@ -637,10 +633,6 @@ export async function createMeChat(
         role: agentId === humanAgentId ? ("owner" as const) : ("member" as const),
       })),
     );
-
-    // Add watcher rows for managers of any non-human participant.
-    // Idempotent.
-    await recomputeChatWatchers(tx, chatId);
   });
 
   // Fresh chat — no cache entry exists yet, but populate consistency
@@ -653,6 +645,21 @@ export async function createMeChat(
 // Add participants
 // ---------------------------------------------------------------------------
 
+/**
+ * Web entrypoint: `POST /chats/:id/participants` (user JWT).
+ *
+ * Thin shell over `inviteParticipantsToChat`. Two responsibilities specific
+ * to the web wire shape:
+ *   1. Probing-protection 404: if the chat doesn't exist OR lives in a
+ *      different org from the caller, the wire surface is the same 404 so
+ *      a non-member cannot probe chat existence by uuid.
+ *   2. Empty-body 400 (the Layer-2 service rejects this too, but the web
+ *      route prefers the early signal).
+ *
+ * Everything else — caller-is-speaker, cross-org targets, private
+ * owner-exclusive, the actual write — is delegated. `errorOnAlreadySpeaker:
+ * false` because the batch UI treats re-adding someone as a no-op.
+ */
 export async function addMeChatParticipants(
   db: Database,
   chatId: string,
@@ -660,123 +667,36 @@ export async function addMeChatParticipants(
   callerOrganizationId: string,
   body: AddMeChatParticipants,
 ): Promise<void> {
-  const distinct = [...new Set(body.participantIds)];
-  if (distinct.length === 0) throw new BadRequestError("At least one participant required");
-
-  const [chat] = await db
-    .select({ id: chats.id, organizationId: chats.organizationId, type: chats.type })
-    .from(chats)
-    .where(eq(chats.id, chatId))
-    .limit(1);
-  if (!chat) throw new NotFoundError(`Chat "${chatId}" not found`);
-
-  // Caller-side authorisation. 404 (not 403) for "cannot see this
-  // chat" so non-participants cannot probe chat existence by uuid.
-  // Two gates: (1) chat lives in caller's active org; (2) caller is a
-  // speaking participant (watchers cannot invite speakers).
-  if (chat.organizationId !== callerOrganizationId) {
-    throw new NotFoundError(`Chat "${chatId}" not found`);
+  if (body.participantIds.length === 0) {
+    throw new BadRequestError("At least one participant required");
   }
-  // Resolve caller's chat-membership AND owner member-id in one query.
-  // The owner member-id is the authoritative input to the
-  // owner-exclusive check below — deriving it from the caller agent's
-  // `managerId` (rather than accepting it as a parameter) prevents an
-  // internal caller from mismatching the two and bypassing the check.
-  // Works regardless of caller agent type: a human agent's managerId
-  // is its own member; an autonomous/personal_assistant agent's
-  // managerId is the member that owns it.
-  const [callerRow] = await db
-    .select({ ownerMemberId: agents.managerId })
-    .from(chatMembership)
-    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
-    .where(
-      and(
-        eq(chatMembership.chatId, chatId),
-        eq(chatMembership.agentId, callerHumanAgentId),
-        eq(chatMembership.accessMode, "speaker"),
-      ),
-    )
-    .limit(1);
-  if (!callerRow) {
-    throw new NotFoundError(`Chat "${chatId}" not found`);
-  }
-  const callerMemberId = callerRow.ownerMemberId;
+  // Probing-protection 404: chat-in-caller-org. The invite service raises
+  // `ForbiddenError` when the caller isn't a speaker; the web wire wants
+  // both that failure mode AND chat-not-in-our-org to surface as NotFound,
+  // so we pre-check the org boundary here. `assertChatVisibleInOrgOrNotFound`
+  // lives next to the invite service so the assertion travels with the
+  // service whose error semantics it adjusts.
+  await assertChatVisibleInOrgOrNotFound(db, chatId, callerOrganizationId);
 
-  const found = await db
-    .select({
-      uuid: agents.uuid,
-      organizationId: agents.organizationId,
-      type: agents.type,
-      visibility: agents.visibility,
-      managerId: agents.managerId,
-    })
-    .from(agents)
-    .where(inArray(agents.uuid, distinct));
-
-  if (found.length !== distinct.length) {
-    const foundSet = new Set(found.map((a) => a.uuid));
-    const missing = distinct.filter((id) => !foundSet.has(id));
-    throw new BadRequestError(`Agents not found: ${missing.join(", ")}`);
-  }
-  const crossOrg = found.filter((a) => a.organizationId !== chat.organizationId);
-  if (crossOrg.length > 0) {
-    throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((a) => a.uuid).join(", ")}`);
-  }
-
-  // Owner-exclusive rule for private agents. Only the agent's manager
-  // (the owner) can pull a private agent into a chat — inviting it into
-  // the chat is the owner's own scoped "consent" to expose it to other
-  // members. Mirrors the "邀请即同意 / Owner-exclusive" property in
-  // `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.4.2 /
-  // §4.5, and prevents anyone with an agent's UUID from bypassing the
-  // discovery filter to drop someone else's private agent into a chat.
-  // Living at the service layer (not just the API caller-side
-  // `assertAllAgentsVisibleInOrg` gate) so the invariant holds for any
-  // future entrypoint that builds on this service.
-  const privateNotOwned = found.filter(
-    (a) => a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== callerMemberId,
-  );
-  if (privateNotOwned.length > 0) {
-    throw new ForbiddenError(
-      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.uuid).join(", ")}`,
-    );
-  }
-
-  await db.transaction(async (tx) => {
-    // Existing speakers (for the direct → group upgrade rule and
-    // for filtering out already-speaking agents from the insert
-    // batch).
-    const existingSpeakers = await tx
-      .select({ agentId: chatMembership.agentId })
-      .from(chatMembership)
-      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
-    const existingSpeakerSet = new Set(existingSpeakers.map((e) => e.agentId));
-    const toUpsert = distinct.filter((id) => !existingSpeakerSet.has(id));
-    if (toUpsert.length === 0) {
-      // Idempotent — nothing to do, but still recompute watchers in
-      // case the caller is fixing a stale watcher set.
-      await recomputeChatWatchers(tx, chatId);
-      return;
-    }
-
-    // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
-    // `chat_membership.mode` is decision-inert. `upgradeWatcherToSpeaker:
-    // true` promotes any pre-existing watcher row in place — chat_user_state
-    // lives in a separate table so the user's read state survives the
-    // promotion untouched (no state-carry transaction needed).
-    await addChatParticipants(
-      tx,
+  try {
+    await inviteParticipantsToChat(db, {
       chatId,
-      toUpsert.map((agentId) => ({ agentId, role: "member" as const })),
-      { upgradeWatcherToSpeaker: true },
-    );
-
-    await recomputeChatWatchers(tx, chatId);
-  });
-
-  // Bust the WS audience cache so the next `chat:message` dispatch
-  // resolves the fresh speaker set.
-  invalidateChatAudience(chatId);
+      callerAgentId: callerHumanAgentId,
+      targetAgentIds: body.participantIds,
+      // Web batch path is partial-idempotent: re-adding someone already in
+      // the chat is a no-op (the UI doesn't model 409 per-target).
+      errorOnAlreadySpeaker: false,
+    });
+  } catch (err) {
+    // The invite service surfaces "caller is not a speaker" as
+    // `ForbiddenError`. The web wire prefers `NotFoundError` to avoid
+    // leaking chat existence to non-members — collapse the two failure
+    // modes (chat-in-other-org, caller-not-speaker) into a single 404.
+    if (err instanceof ForbiddenError && /not a speaker/i.test(err.message)) {
+      throw new NotFoundError(`Chat "${chatId}" not found`);
+    }
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -44,7 +44,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
-import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
+import { BadRequestError, CallerNotSpeakerError, ForbiddenError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
 import { resolveAgentChatStatuses } from "./agent-chat-status.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
@@ -671,11 +671,11 @@ export async function addMeChatParticipants(
     throw new BadRequestError("At least one participant required");
   }
   // Probing-protection 404: chat-in-caller-org. The invite service raises
-  // `ForbiddenError` when the caller isn't a speaker; the web wire wants
-  // both that failure mode AND chat-not-in-our-org to surface as NotFound,
-  // so we pre-check the org boundary here. `assertChatVisibleInOrgOrNotFound`
-  // lives next to the invite service so the assertion travels with the
-  // service whose error semantics it adjusts.
+  // `CallerNotSpeakerError` when the caller isn't a speaker; the web wire
+  // wants both that failure mode AND chat-not-in-our-org to surface as
+  // NotFound, so we pre-check the org boundary here.
+  // `assertChatVisibleInOrgOrNotFound` lives next to the invite service so
+  // the assertion travels with the service whose error semantics it adjusts.
   await assertChatVisibleInOrgOrNotFound(db, chatId, callerOrganizationId);
 
   try {
@@ -688,11 +688,14 @@ export async function addMeChatParticipants(
       errorOnAlreadySpeaker: false,
     });
   } catch (err) {
-    // The invite service surfaces "caller is not a speaker" as
-    // `ForbiddenError`. The web wire prefers `NotFoundError` to avoid
-    // leaking chat existence to non-members — collapse the two failure
-    // modes (chat-in-other-org, caller-not-speaker) into a single 404.
-    if (err instanceof ForbiddenError && /not a speaker/i.test(err.message)) {
+    // The invite service surfaces "caller is not a speaker" as a typed
+    // `CallerNotSpeakerError` (subclass of `ForbiddenError`). The web wire
+    // prefers `NotFoundError` to avoid leaking chat existence to non-members
+    // — collapse the two failure modes (chat-in-other-org, caller-not-speaker)
+    // into a single 404. Matching on the error class instead of the message
+    // string means renaming the underlying error text can't silently regress
+    // this remap into a 403 leak.
+    if (err instanceof CallerNotSpeakerError) {
       throw new NotFoundError(`Chat "${chatId}" not found`);
     }
     throw err;
@@ -781,14 +784,15 @@ export async function markMeChatUnread(
 export async function joinMeChat(db: Database, chatId: string, humanAgentId: string): Promise<void> {
   const membership = await resolveChatMembership(db, chatId, humanAgentId);
   ensureCanJoin(membership);
+  // `joinAsParticipant` encloses the post-commit `invalidateChatAudience`
+  // call so any future caller automatically gets the cache-coherency step.
   await joinAsParticipant(db, chatId, humanAgentId);
-  invalidateChatAudience(chatId);
 }
 
 export async function leaveMeChat(db: Database, chatId: string, humanAgentId: string): Promise<MeChatLeaveResponse> {
-  const result = await leaveAsParticipant(db, chatId, humanAgentId);
-  invalidateChatAudience(chatId);
-  return result;
+  // `leaveAsParticipant` encloses the post-commit `invalidateChatAudience`
+  // call — same canonical-bundle pattern as join.
+  return leaveAsParticipant(db, chatId, humanAgentId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -29,9 +29,12 @@
  *   - return shape (Layer 3 chooses what to read back, if anything)
  *
  * Hard-wired contract here:
- *   - caller MUST be a chat speaker (else ForbiddenError) — the only
- *     authorisation gate; no admin override path (admins use the same
- *     chat-membership rows as everyone else).
+ *   - caller MUST be a chat speaker (else `CallerNotSpeakerError`, a
+ *     subclass of `ForbiddenError`) — the only authorisation gate; no admin
+ *     override path (admins use the same chat-membership rows as everyone
+ *     else). Web shells match on the subclass to remap into 404
+ *     probing-protection; do NOT downgrade the throw site to a plain
+ *     `ForbiddenError` without updating those callers in lockstep.
  *   - every target must exist (else BadRequestError listing the missing
  *     ids).
  *   - every target must be in the chat's organization (else BadRequestError).
@@ -50,7 +53,7 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { BadRequestError, CallerNotSpeakerError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { applyMembershipWrite } from "./participant-mode.js";
 
 export type InviteParticipantsArgs = {
@@ -116,7 +119,7 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     )
     .limit(1);
   if (!callerRow) {
-    throw new ForbiddenError(`Caller "${callerAgentId}" is not a speaker of chat "${chatId}"`);
+    throw new CallerNotSpeakerError(callerAgentId, chatId);
   }
   const callerMemberId = callerRow.ownerMemberId;
 

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -1,0 +1,218 @@
+/**
+ * Single Layer-2 entry for "speaker A invites agent B (or many Bs) into chat C".
+ *
+ * Both the agent-JWT path (`chat.ts::addParticipant` — single target by uuid
+ * or by name) and the user-JWT web path (`me-chat.ts::addMeChatParticipants`
+ * — batch by uuid) collapse onto this service. The previous arrangement —
+ * two near-identical services with mirrored cross-org / owner-exclusive
+ * checks — is what let PR #393's silent-context backfill regress when the
+ * web path drifted past the agent path (see PR #545 + follow-up). Anchoring
+ * the invite rules to a single function closes the whole class of
+ * "duplicate writers go out of sync" bug.
+ *
+ * Caller-side adapter shells (Layer 3) keep their wire-shape responsibilities:
+ *   - `chat.ts::addParticipant` resolves a single `{ agentId | agentName }`
+ *     to a uuid, then calls this service with `targetAgentIds: [uuid]` and
+ *     `errorOnAlreadySpeaker: true` (the agent SDK contract treats "already
+ *     in the chat" as a hard 409 with a recognisable name).
+ *   - `me-chat.ts::addMeChatParticipants` does the web-path "chat in caller's
+ *     org" probing-protection 404 pre-check, then calls this service with
+ *     `targetAgentIds: body.participantIds` and `errorOnAlreadySpeaker:
+ *     false` (the batch UI is partial-idempotent: re-adding someone already
+ *     in the chat is silent).
+ *
+ * What this service does NOT do — by design:
+ *   - by-name target lookup (Layer 3 concern; only the agent-JWT path
+ *     surfaces it)
+ *   - probing-protection 404 swap (Layer 3 concern; only the web path
+ *     surfaces it, see `assertChatVisibleInOrg` for the helper)
+ *   - return shape (Layer 3 chooses what to read back, if anything)
+ *
+ * Hard-wired contract here:
+ *   - caller MUST be a chat speaker (else ForbiddenError) — the only
+ *     authorisation gate; no admin override path (admins use the same
+ *     chat-membership rows as everyone else).
+ *   - every target must exist (else BadRequestError listing the missing
+ *     ids).
+ *   - every target must be in the chat's organization (else BadRequestError).
+ *   - private targets only land if the caller's owning member matches the
+ *     target's owning member ("owner-exclusive" / "邀请即同意"; see
+ *     `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.4.2 / §4.5).
+ *     Self-add (`targetAgentId === callerAgentId`) is exempt.
+ *   - the actual write goes through `applyMembershipWrite`, which encloses
+ *     the silent-context backfill + watcher recompute invariants and the
+ *     post-commit audience-cache invalidation.
+ */
+
+import { AGENT_VISIBILITY } from "@first-tree/shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { applyMembershipWrite } from "./participant-mode.js";
+
+export type InviteParticipantsArgs = {
+  chatId: string;
+  /** Caller agent uuid. MUST currently be a speaker of the chat. */
+  callerAgentId: string;
+  /** Targets to invite, by uuid. by-name resolution is a Layer-3 concern. */
+  targetAgentIds: ReadonlyArray<string>;
+  /**
+   * Behaviour for targets that already hold an `access_mode='speaker'` row
+   * in the chat:
+   *   - `true`  → throw `ConflictError` on the first such target. Used by
+   *               the agent-JWT path where the wire contract is "one target,
+   *               409 if already in".
+   *   - `false` → silently skip the already-speaker targets and proceed with
+   *               the rest. Used by the web batch path which is partial-
+   *               idempotent (the UI treats re-adding someone as a no-op).
+   *
+   * Either way, the underlying `addChatParticipants` call is already
+   * idempotent on already-speaker rows — this flag controls only whether
+   * the service surfaces a 409 to the caller.
+   */
+  errorOnAlreadySpeaker: boolean;
+};
+
+/**
+ * Invite one or more agents into a chat. See the file-level comment for the
+ * contract and the rationale for which checks live here vs. in Layer-3
+ * adapter shells.
+ */
+export async function inviteParticipantsToChat(db: Database, args: InviteParticipantsArgs): Promise<void> {
+  const { chatId, callerAgentId, targetAgentIds, errorOnAlreadySpeaker } = args;
+  const distinctTargets = [...new Set(targetAgentIds)];
+  if (distinctTargets.length === 0) {
+    throw new BadRequestError("At least one participant required");
+  }
+
+  // 1. Chat exists.
+  const [chat] = await db
+    .select({ id: chats.id, organizationId: chats.organizationId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+  if (!chat) {
+    throw new NotFoundError(`Chat "${chatId}" not found`);
+  }
+
+  // 2. Caller is a speaker. Join `chatMembership` × `agents` so we get the
+  //    caller's owning-member id in the same query — it's the authoritative
+  //    input to the owner-exclusive check below. Deriving it from the
+  //    caller's `managerId` (vs. accepting it as a parameter) prevents an
+  //    internal caller from mismatching the two and bypassing the gate.
+  const [callerRow] = await db
+    .select({ ownerMemberId: agents.managerId })
+    .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+    .where(
+      and(
+        eq(chatMembership.chatId, chatId),
+        eq(chatMembership.agentId, callerAgentId),
+        eq(chatMembership.accessMode, "speaker"),
+      ),
+    )
+    .limit(1);
+  if (!callerRow) {
+    throw new ForbiddenError(`Caller "${callerAgentId}" is not a speaker of chat "${chatId}"`);
+  }
+  const callerMemberId = callerRow.ownerMemberId;
+
+  // 3. Targets exist + cross-org.
+  const targetRows = await db
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+    })
+    .from(agents)
+    .where(inArray(agents.uuid, distinctTargets));
+  if (targetRows.length !== distinctTargets.length) {
+    const foundSet = new Set(targetRows.map((r) => r.uuid));
+    const missing = distinctTargets.filter((id) => !foundSet.has(id));
+    throw new BadRequestError(`Agents not found: ${missing.join(", ")}`);
+  }
+  const crossOrg = targetRows.filter((t) => t.organizationId !== chat.organizationId);
+  if (crossOrg.length > 0) {
+    throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((t) => t.uuid).join(", ")}`);
+  }
+
+  // 4. Owner-exclusive for private targets. Self-add (target === caller) is
+  //    exempt so an agent rejoining a chat it already owns isn't blocked.
+  const privateNotOwned = targetRows.filter(
+    (t) => t.visibility === AGENT_VISIBILITY.PRIVATE && t.uuid !== callerAgentId && t.managerId !== callerMemberId,
+  );
+  if (privateNotOwned.length > 0) {
+    throw new ForbiddenError(
+      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((t) => t.uuid).join(", ")}`,
+    );
+  }
+
+  // 5. Already-speaker behaviour. `addChatParticipants` is naturally
+  //    idempotent on already-speaker rows (it identifies them and skips the
+  //    backfill); this flag only controls whether the service raises a 409
+  //    to the caller.
+  const existingSpeakers = await db
+    .select({ agentId: chatMembership.agentId })
+    .from(chatMembership)
+    .where(
+      and(
+        eq(chatMembership.chatId, chatId),
+        inArray(chatMembership.agentId, distinctTargets),
+        eq(chatMembership.accessMode, "speaker"),
+      ),
+    );
+  const existingSpeakerSet = new Set(existingSpeakers.map((e) => e.agentId));
+  if (errorOnAlreadySpeaker) {
+    const firstDup = distinctTargets.find((id) => existingSpeakerSet.has(id));
+    if (firstDup !== undefined) {
+      throw new ConflictError(`Agent "${firstDup}" is already a participant`);
+    }
+  }
+  const toWrite = distinctTargets.filter((id) => !existingSpeakerSet.has(id));
+  if (toWrite.length === 0) {
+    // All targets were already speakers and the caller opted into silent
+    // skip. No row write needed; the watcher set is already consistent with
+    // the speaker set (the most recent write that put these agents in has
+    // already run recompute). Skip the round-trip.
+    return;
+  }
+
+  // 6. Delegate to the canonical write bundle. `upgradeWatcherToSpeaker:
+  //    true` lets a pre-existing watcher row be promoted in place; for
+  //    brand-new targets it's a regular INSERT.
+  await applyMembershipWrite(
+    db,
+    chatId,
+    toWrite.map((agentId) => ({ agentId, role: "member" as const })),
+    { upgradeWatcherToSpeaker: true },
+  );
+}
+
+/**
+ * Web-path probing-protection helper. Web callers must not be able to learn
+ * "this chat exists but you can't see it" — both "chat doesn't exist" and
+ * "chat exists but not in your org" surface as the same 404.
+ *
+ * Used by the `me-chat.ts::addMeChatParticipants` shell (and any other web
+ * entrypoint that wants the same shape) before delegating to
+ * `inviteParticipantsToChat`. Kept here so the assertion lives next to the
+ * service whose error semantics it adjusts.
+ */
+export async function assertChatVisibleInOrgOrNotFound(
+  db: Database,
+  chatId: string,
+  callerOrganizationId: string,
+): Promise<void> {
+  const [chat] = await db
+    .select({ organizationId: chats.organizationId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+  if (!chat || chat.organizationId !== callerOrganizationId) {
+    throw new NotFoundError(`Chat "${chatId}" not found`);
+  }
+}

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -1,5 +1,6 @@
 /**
- * Single source of truth for writing speaker rows into `chat_membership`.
+ * Single source of truth for writing `chat_membership` speaker rows and the
+ * derived watcher set.
  *
  * **This is the ONLY place in the codebase that may INSERT speaker rows
  * (access_mode = 'speaker') into `chat_membership`.** Do not call
@@ -7,45 +8,52 @@
  * else. The original bug (docs/chat-participant-mode-fix-design.md §1.1)
  * was caused by mode-derivation logic scattered across ten insert sites;
  * keeping a single writer remains the right shape even after v2 retired
- * the `mode` field from the decision path — a future per-receiver wake
- * policy will land here too.
+ * the `mode` field from the decision path.
  *
- * Watcher rows (access_mode = 'watcher') are written from
- * `services/watcher.ts::recomputeChatWatchers` via raw SQL; they don't
- * go through this service because the historic mode rule was `full` by
- * construction for watchers (they receive but don't fan out) and v2 made
- * the column decision-inert anyway.
+ * Invariants this module owns (anchored to the row-writing helper, not to
+ * any particular service entrypoint, so any new join entrypoint inherits
+ * them for free):
  *
- * All callers that need to add a participant — `createChat`,
- * `addParticipant`, `ensureParticipant`, `joinChat`, `createMeChat`,
- * `addMeChatParticipants`, `findOrCreateChatForChannel`,
- * `joinAsParticipant`, … — go through `addChatParticipants`.
+ *   1. **Silent-context backfill** — every agent that crosses into
+ *      `accessMode='speaker'` (brand-new or watcher → speaker upgrade)
+ *      gets the chat's most recent N messages replayed as silent inbox
+ *      rows. See `backfillSilentContextForNewParticipants` (inbox.ts).
+ *
+ *   2. **Watcher set recompute** — after any speaker write, the
+ *      derived watcher set (managers of non-human speakers who are not
+ *      themselves speakers) is reconciled. See `recomputeChatWatchers`
+ *      below.
+ *
+ * A small caller-side bundle `applyMembershipWrite` is also exported here:
+ * it wraps the canonical "open tx → write rows → commit → invalidate
+ * audience cache" sequence so service entrypoints (`inviteParticipantsToChat`,
+ * `ensureParticipant`, `joinAsParticipant`, …) don't each have to spell it
+ * out and risk drifting on tx-boundary correctness.
  *
  * v2 change (proposals/hub-chat-message-v2-simplify-mode.20260520.md):
  *
  *   - `chat_membership.mode` is **decision-inert**. fan-out / enforcement
- *     / dispatcher no longer read it. The historical `defaultParticipantMode`
- *     derivation has been removed; every freshly-written speaker row gets
- *     `mode = "mention_only"` as a constant. The column itself is retained
- *     as schema scaffolding for a future per-receiver wake-policy
- *     extension (e.g. per-recipient push notifications).
+ *     / dispatcher no longer read it. Every freshly-written speaker row
+ *     gets `mode = "mention_only"` as a constant. The column itself is
+ *     retained as schema scaffolding for a future per-receiver wake-policy
+ *     extension.
  *
  *   - `chats.type` is locked to `'group'` since first-tree-context
  *     PR #465; speaker-write code no longer reads it.
  *
  * Read state (`last_read_at` / `unread_mention_count`) lives in a
  * structurally separate `chat_user_state` table whose rows survive
- * access_mode transitions untouched. A watcher → speaker promotion just
- * UPSERTs `chat_membership.access_mode`; the `chat_user_state` row (if
- * any) is unaffected — no state-carry transaction needed.
+ * access_mode transitions untouched.
  */
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
+import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { backfillSilentContextForNewParticipants } from "./inbox.js";
 
 /**
@@ -64,8 +72,7 @@ export type AddChatParticipantSpec = {
 export type AddChatParticipantsOptions = {
   /**
    * When true, `INSERT ... ON CONFLICT DO NOTHING` is used so an idempotent
-   * caller (e.g. `ensureParticipant`) doesn't blow up when the row already
-   * exists.
+   * caller doesn't blow up when the row already exists.
    */
   onConflictDoNothing?: boolean;
   /**
@@ -79,59 +86,43 @@ export type AddChatParticipantsOptions = {
   upgradeWatcherToSpeaker?: boolean;
   /**
    * When true, every passed agent must be `type === 'human'`. Used by
-   * `joinChat` / `joinAsParticipant` whose contracts only admit a manager's
-   * human agent — anything else is a programming error that should crash
-   * loudly rather than silently insert with the wrong access mode.
+   * `joinAsParticipant` whose contract only admits a manager's human agent
+   * — anything else is a programming error that should crash loudly rather
+   * than silently insert with the wrong access mode.
    */
   assertHuman?: boolean;
 };
 
 /**
- * Insert speaker rows.
+ * Insert speaker rows + maintain the two derived invariants
+ * (silent-context backfill + watcher set recompute).
  *
  * Reads:
  *   - `chats.id` for the target chat (NotFoundError on missing).
  *   - `agents.uuid`, `agents.type`, `agents.inboxId` for every requested
  *     participant (BadRequestError on missing). When `assertHuman` is set,
  *     also validates `agents.type`. `inboxId` feeds the silent-context
- *     backfill (see below).
+ *     backfill.
  *   - `chat_membership` rows for the (chatId, agentIds) tuple, to classify
  *     each input as `alreadySpeaker` (skip) / `upgradingWatcher` / `brandNew`.
  *
  * Writes:
- *   - One INSERT (multi-row) into `chat_membership` per call.
+ *   - One INSERT (multi-row) into `chat_membership`.
  *   - One INSERT (multi-row) into `inbox_entries` carrying the chat's most
- *     recent N messages as silent (notify=false) rows, for every agent whose
- *     access_mode just transitioned to `speaker` (`brandNew` ∪
- *     `upgradingWatcher`). Skipped when no such transition happens.
+ *     recent N messages as silent (notify=false) rows, for every agent
+ *     whose access_mode just transitioned to `speaker` (`brandNew` ∪
+ *     `upgradingWatcher`).
+ *   - Recomputes watcher rows for the chat (idempotent — `recomputeChatWatchers`
+ *     ONLY INSERTs or DELETEs rows where `access_mode='watcher'`, never
+ *     touches speaker rows).
  *
- * Why backfill lives here (not at the service entrypoints):
- *
- *   The "an agent crossing into `accessMode='speaker'` must be able to read
- *   prior chat history" invariant is a property of writing the membership
- *   row, not of any particular service entrypoint. Anchoring it to the
- *   single helper that owns the write means new service entrypoints
- *   (`addParticipant`, `addMeChatParticipants`, `ensureParticipant`,
- *   `joinChat`, `joinAsParticipant`, `findOrCreateChatForChannel`, …) all
- *   inherit it for free. The previous arrangement — backfill scattered at
- *   `addParticipant` only — regressed silently when the web path went
- *   through `addMeChatParticipants` instead (PR #393 follow-up).
- *
- * Watcher → speaker upgrades also backfill: watchers do not receive inbox
- * fan-out (`message.ts` filters by `access_mode='speaker'`), so the moment
- * they become speakers, everything before that moment is unreachable
- * without the silent-context replay.
- *
- * No watcher / audience-cache side effects — the caller owns those, since
- * different entrypoints have different surrounding work (watcher recompute,
- * audience invalidation). Keeping this module otherwise side-effect-free
- * makes it testable from any tx context. Backfill is the one exception
- * because, unlike watcher / audience cache, it is an invariant of writing
- * the row itself, not a choice the caller makes.
+ * Side-effect boundary: this helper runs entirely inside the caller's tx.
+ * The audience cache invalidation (which must happen AFTER commit) is the
+ * caller's responsibility — see `applyMembershipWrite` for the canonical
+ * tx-aware bundle.
  *
  * v2: `chat_membership.mode` is written as the constant `"mention_only"`.
- * No chat-type / agent-type / peer-shape derivation. See file-level
- * comment + proposals/hub-chat-message-v2-simplify-mode.20260520.md.
+ * No chat-type / agent-type / peer-shape derivation.
  */
 export async function addChatParticipants(
   tx: DbLike,
@@ -191,9 +182,6 @@ export async function addChatParticipants(
   if (options.upgradeWatcherToSpeaker) {
     // Promote watcher → speaker in place: chat_user_state row (if any) is
     // structurally separate so the user's read state survives untouched.
-    // `excluded.<col>` would reach back into the INSERT VALUES row; with
-    // the constant `mode='mention_only'` there's nothing dynamic to carry
-    // and we can spell the literal directly.
     await insert.onConflictDoUpdate({
       target: [chatMembership.chatId, chatMembership.agentId],
       set: {
@@ -208,9 +196,9 @@ export async function addChatParticipants(
     await insert;
   }
 
-  // Silent-context backfill invariant. Triggers when an agent crosses into
-  // `accessMode='speaker'` — either brand-new (no prior membership row) or
-  // promoted from watcher. Already-speaker rows are skipped because
+  // Invariant 1: silent-context backfill. Triggers when an agent crosses
+  // into `accessMode='speaker'` — either brand-new (no prior membership
+  // row) or promoted from watcher. Already-speaker rows are skipped because
   // re-inserting them was a no-op above. When `upgradeWatcherToSpeaker` is
   // not set, the watcher branch is naturally empty (the INSERT would have
   // crashed on the unique key) — defensive filtering keeps the contract
@@ -228,4 +216,111 @@ export async function addChatParticipants(
       .map((inboxId) => ({ inboxId }));
     await backfillSilentContextForNewParticipants(tx, chatId, backfillTargets);
   }
+
+  // Invariant 2: derived watcher set. Always recompute — the helper is
+  // idempotent and writes only watcher rows, so re-running it after a
+  // speaker write is safe even when the speaker set didn't actually change
+  // (the join path's no-op upgrade case). Cheaper to recompute
+  // unconditionally than to risk drifting from the invariant.
+  await recomputeChatWatchers(tx, chatId);
+}
+
+/**
+ * Recompute watcher rows for ONE chat. For every active member who:
+ *   - manages a non-human agent that speaks in the chat, AND
+ *   - whose own human agent is NOT a speaker in the chat
+ * a `(chat_id, member.agent_id)` watcher row is upserted.
+ *
+ * Strict invariant: only writes rows with access_mode = 'watcher';
+ * never updates or deletes any access_mode = 'speaker' row. The
+ * ON CONFLICT DO NOTHING clause guarantees that if a (chat, agent) row
+ * already exists as a speaker, we leave it alone.
+ *
+ * Watchers whose anchoring condition no longer holds (manager left,
+ * the managed agent was removed from the chat, the manager joined as a
+ * speaker themselves) are deleted — also gated on access_mode = 'watcher'.
+ *
+ * Idempotent: safe to call multiple times for the same chat. This is the
+ * property that lets `addChatParticipants` call it unconditionally on every
+ * speaker write without needing to know whether watchers actually need to
+ * change.
+ *
+ * Lives in this file (and not in `watcher.ts`) because watcher rows are a
+ * derived projection of the speaker set: anchoring this function next to
+ * the speaker writer is what lets us close the invariant loop.
+ * `watcher.ts::recomputeWatchersForAgent` / `recomputeWatchersForMember`
+ * delegate back here when their per-agent / per-member triggers fire.
+ */
+export async function recomputeChatWatchers(db: DbLike, chatId: string): Promise<void> {
+  // Insert the desired set of watcher rows; speaker rows are preserved by
+  // the ON CONFLICT clause + the NOT EXISTS guard in the SELECT.
+  await db.execute(sql`
+    INSERT INTO chat_membership
+      (chat_id, agent_id, role, access_mode, mode, source, joined_at)
+    SELECT DISTINCT cm.chat_id, m.agent_id, 'member', 'watcher', 'full', 'auto_manager', now()
+      FROM chat_membership cm
+      JOIN agents  a ON a.uuid = cm.agent_id
+      JOIN members m ON m.id   = a.manager_id
+     WHERE cm.chat_id = ${chatId}
+       AND cm.access_mode = 'speaker'
+       AND m.status = 'active'
+       AND a.type   <> 'human'
+       AND NOT EXISTS (
+         SELECT 1 FROM chat_membership cm2
+          WHERE cm2.chat_id  = cm.chat_id
+            AND cm2.agent_id = m.agent_id
+       )
+    ON CONFLICT (chat_id, agent_id) DO NOTHING
+  `);
+
+  // Drop watcher rows whose anchoring condition no longer holds. Speaker
+  // rows are protected by the access_mode = 'watcher' clause.
+  await db.execute(sql`
+    DELETE FROM chat_membership cm
+     WHERE cm.chat_id = ${chatId}
+       AND cm.access_mode = 'watcher'
+       AND NOT EXISTS (
+         SELECT 1
+           FROM chat_membership speakers
+           JOIN agents  a ON a.uuid = speakers.agent_id
+           JOIN members m ON m.id   = a.manager_id
+          WHERE speakers.chat_id     = cm.chat_id
+            AND speakers.access_mode = 'speaker'
+            AND m.agent_id           = cm.agent_id
+            AND m.status             = 'active'
+            AND a.type              <> 'human'
+       )
+  `);
+}
+
+/**
+ * Canonical membership write bundle: open a transaction, run
+ * `addChatParticipants` (which already encloses the silent-context backfill
+ * and watcher-set recompute invariants), commit, then invalidate the
+ * in-process WS audience cache.
+ *
+ * Why this is a separate function (and not inlined into
+ * `addChatParticipants`): `invalidateChatAudience` is a process-local
+ * cache invalidation, not a DB write — it MUST happen AFTER the
+ * transaction commits, otherwise a concurrent reader could repopulate the
+ * cache with the pre-commit speaker set. `addChatParticipants` runs inside
+ * the caller's tx and has no commit hook, so it cannot own this step. The
+ * bundle here makes the tx-boundary discipline a single decision instead
+ * of N repeated decisions at each service entrypoint.
+ *
+ * Use this from service entrypoints (`inviteParticipantsToChat`,
+ * `ensureParticipant`, the rebuild path of `joinAsParticipant`) rather
+ * than spelling the three steps out yourself.
+ */
+export async function applyMembershipWrite(
+  db: Database,
+  chatId: string,
+  participants: ReadonlyArray<AddChatParticipantSpec>,
+  options: AddChatParticipantsOptions = {},
+): Promise<void> {
+  if (participants.length === 0) return;
+  await db.transaction(async (tx) => {
+    await addChatParticipants(tx, chatId, participants, options);
+  });
+  invalidateChatAudience(chatId);
 }

--- a/packages/server/src/services/participant-mode.ts
+++ b/packages/server/src/services/participant-mode.ts
@@ -132,9 +132,22 @@ export async function addChatParticipants(
 ): Promise<void> {
   if (participants.length === 0) return;
 
-  // Confirm the chat exists. We no longer SELECT `chats.type` — it's locked
-  // to 'group' and never read for membership decisions.
-  const [chat] = await tx.select({ id: chats.id }).from(chats).where(eq(chats.id, chatId)).limit(1);
+  // Confirm the chat exists AND lock the chats row for the duration of the
+  // tx. We no longer SELECT `chats.type` — it's locked to 'group' and never
+  // read for membership decisions.
+  //
+  // Why FOR UPDATE on the parent chats row: two concurrent invites of the
+  // same brand-new agent X would otherwise both SELECT an empty
+  // `chat_membership` row for X (line below), both classify X as `brandNew`,
+  // and both fire `backfillSilentContextForNewParticipants` — duplicating
+  // the silent inbox rows. A FOR UPDATE on `chat_membership` itself can't
+  // help because brand-new agents have no row to lock. Locking the chats
+  // row serialises any speaker write into this chat, so the second tx sees
+  // the first one's INSERT after the lock releases and reclassifies X as
+  // `alreadySpeaker`. Cost: speaker writes into the same chat are
+  // chat-level serialised, which is acceptable — invite throughput is
+  // operator-paced, not message-paced.
+  const [chat] = await tx.select({ id: chats.id }).from(chats).where(eq(chats.id, chatId)).for("update").limit(1);
   if (!chat) {
     throw new NotFoundError(`Chat "${chatId}" not found`);
   }

--- a/packages/server/src/services/watcher.ts
+++ b/packages/server/src/services/watcher.ts
@@ -10,13 +10,14 @@
  *
  * Two distinct kinds of operation live here:
  *
- *   1. Set rebuilds (`recompute*`). Idempotent set-based
- *      recomputations driven by lifecycle events (chat created,
- *      participant added/removed, member status flipped, agent
- *      rebind, etc.). Strict invariant: ONLY INSERT or DELETE rows
- *      where access_mode = 'watcher'. NEVER UPDATE any row with
- *      access_mode = 'speaker' — the user's own join/leave decision
- *      must not be overwritten by ops paths.
+ *   1. Per-agent / per-member recompute fan-out
+ *      (`recomputeWatchersForAgent`, `recomputeWatchersForMember`).
+ *      These translate an agent-rebind or member-status flip into a
+ *      set of chat-scoped recomputes. The underlying chat-scoped
+ *      operation `recomputeChatWatchers` itself lives in
+ *      `participant-mode.ts` next to the speaker writer that owns
+ *      the derivation invariant; we re-export it from here so
+ *      historical callers keep working.
  *
  *   2. Speaker ↔ watcher transitions (`joinAsParticipant`,
  *      `leaveAsParticipant`). Single-table UPDATE on
@@ -24,12 +25,6 @@
  *      the (chat, agent) pair are not touched. Per §11.4 default,
  *      a fully-detached user keeps their `chat_user_state` row
  *      (read state remembered for re-add).
- *
- * File name preserved across the refactor for diff readability; may
- * be renamed in a follow-up. Public function names preserved too —
- * `recomputeChatWatchers` still describes what it does (recomputes
- * the watcher rows), so the rename to `recomputeChatMembership`
- * would obscure rather than clarify.
  */
 
 import { and, eq, ne, sql } from "drizzle-orm";
@@ -38,7 +33,13 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
-import { addChatParticipants } from "./participant-mode.js";
+import { addChatParticipants, recomputeChatWatchers } from "./participant-mode.js";
+
+// Re-export so historical callers that reach for
+// `watcher.ts::recomputeChatWatchers` keep compiling. The canonical home
+// for this function is now `participant-mode.ts` — anchored next to the
+// speaker writer whose write triggers the derivation.
+export { recomputeChatWatchers };
 
 /**
  * Structural DB type that accepts both the top-level `Database` and a
@@ -48,72 +49,10 @@ import { addChatParticipants } from "./participant-mode.js";
 type DbLike = PgDatabase<PgQueryResultHKT, any, any>;
 
 // ---------------------------------------------------------------------------
-// Recompute helpers — set rebuilds. Idempotent. Touch ONLY watcher rows.
+// Per-agent / per-member recompute fan-out. Translate an event that touches
+// one agent (rebind) or one member (status flip) into the right set of
+// chat-scoped recomputes.
 // ---------------------------------------------------------------------------
-
-/**
- * Recompute watcher rows for ONE chat. For every active member who:
- *   - manages a non-human agent that speaks in the chat, AND
- *   - whose own human agent is NOT a speaker in the chat
- * a `(chat_id, member.agent_id)` watcher row is upserted.
- *
- * Strict invariant: only writes rows with access_mode = 'watcher';
- * never updates or deletes any access_mode = 'speaker' row. The
- * ON CONFLICT DO NOTHING clause guarantees that if a (chat, agent)
- * row already exists as a speaker (the manager joined as a real
- * participant themselves), we leave it alone.
- *
- * Watchers whose anchoring condition no longer holds (manager left,
- * the managed agent was removed from the chat, the manager joined as
- * a speaker themselves) are deleted — also gated on access_mode =
- * 'watcher'.
- *
- * Idempotent: safe to call multiple times for the same chat.
- */
-export async function recomputeChatWatchers(db: DbLike, chatId: string): Promise<void> {
-  // Insert the desired set of watcher rows; speaker rows are
-  // preserved by the ON CONFLICT clause + the NOT EXISTS guard in
-  // the SELECT.
-  await db.execute(sql`
-    INSERT INTO chat_membership
-      (chat_id, agent_id, role, access_mode, mode, source, joined_at)
-    SELECT DISTINCT cm.chat_id, m.agent_id, 'member', 'watcher', 'full', 'auto_manager', now()
-      FROM chat_membership cm
-      JOIN agents  a ON a.uuid = cm.agent_id
-      JOIN members m ON m.id   = a.manager_id
-     WHERE cm.chat_id = ${chatId}
-       AND cm.access_mode = 'speaker'
-       AND m.status = 'active'
-       AND a.type   <> 'human'
-       AND NOT EXISTS (
-         SELECT 1 FROM chat_membership cm2
-          WHERE cm2.chat_id  = cm.chat_id
-            AND cm2.agent_id = m.agent_id
-       )
-    ON CONFLICT (chat_id, agent_id) DO NOTHING
-  `);
-
-  // Drop watcher rows whose anchoring condition no longer holds.
-  // Speaker rows are protected by the access_mode = 'watcher'
-  // clause — they will never be touched here regardless of join
-  // shape.
-  await db.execute(sql`
-    DELETE FROM chat_membership cm
-     WHERE cm.chat_id = ${chatId}
-       AND cm.access_mode = 'watcher'
-       AND NOT EXISTS (
-         SELECT 1
-           FROM chat_membership speakers
-           JOIN agents  a ON a.uuid = speakers.agent_id
-           JOIN members m ON m.id   = a.manager_id
-          WHERE speakers.chat_id     = cm.chat_id
-            AND speakers.access_mode = 'speaker'
-            AND m.agent_id           = cm.agent_id
-            AND m.status             = 'active'
-            AND a.type              <> 'human'
-       )
-  `);
-}
 
 /**
  * Recompute watcher rows touching ONE agent across all chats it

--- a/packages/server/src/services/watcher.ts
+++ b/packages/server/src/services/watcher.ts
@@ -132,7 +132,7 @@ export async function joinAsParticipant(db: Database, chatId: string, humanAgent
     // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
     // `chat_membership.mode` is decision-inert. Just upsert the speaker row.
     //
-    // `/me/chats/:id/join` admits only the manager's human agent.
+    // `/chats/:chatId/workspace-join` admits only the manager's human agent.
     // `assertHuman: true` makes a non-human caller surface as a 400 rather
     // than silently inserting.
     // `upgradeWatcherToSpeaker` promotes a pre-existing watcher row in
@@ -230,7 +230,7 @@ export async function leaveAsParticipant(db: Database, chatId: string, humanAgen
  * Returns one of: 'participant' (speaker), 'watching' (watcher),
  * or null (no row).
  *
- * Used by `/me/chats/:chatId/join` to refuse a join when the user
+ * Used by `/chats/:chatId/workspace-join` to refuse a join when the user
  * has neither a watcher row nor a participant row, and isn't
  * otherwise authorised (admin in the chat's org).
  */
@@ -249,7 +249,7 @@ export async function resolveChatMembership(
 }
 
 /**
- * Used by `/me/chats/:chatId/join`. Throw 409 if already a speaker
+ * Used by `/chats/:chatId/workspace-join`. Throw 409 if already a speaker
  * (no work to do) and 403 if no row at all (admin override is
  * resolved at the route layer; this helper only reports the membership
  * state).

--- a/packages/server/src/services/watcher.ts
+++ b/packages/server/src/services/watcher.ts
@@ -33,6 +33,7 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
+import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { addChatParticipants, recomputeChatWatchers } from "./participant-mode.js";
 
 // Re-export so historical callers that reach for
@@ -116,9 +117,16 @@ export type JoinResult = {
  * Caller is expected to have verified the user is authorised to join
  * (admin override OR an existing watcher row); this helper does not
  * gate on visibility.
+ *
+ * Tx boundary: opens its own transaction (the `JoinResult` shape needs to
+ * report whether a fresh row was inserted, which we compute from a SELECT
+ * inside the tx). Audience-cache invalidation is enclosed here — after the
+ * tx commits, `invalidateChatAudience` runs so the next `chat:message`
+ * dispatch reflects the new speaker without waiting for the TTL window.
+ * Callers do NOT need to call `invalidateChatAudience` themselves.
  */
 export async function joinAsParticipant(db: Database, chatId: string, humanAgentId: string): Promise<JoinResult> {
-  return db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx) => {
     const [existing] = await tx
       .select({ accessMode: chatMembership.accessMode })
       .from(chatMembership)
@@ -126,7 +134,7 @@ export async function joinAsParticipant(db: Database, chatId: string, humanAgent
       .limit(1);
 
     if (existing?.accessMode === "speaker") {
-      return { chatId, inserted: false, carried: null };
+      return { chatId, inserted: false, carried: null, mutated: false };
     }
 
     // v2: no chat-type flip needed — `chats.type` is locked to 'group' and
@@ -143,8 +151,17 @@ export async function joinAsParticipant(db: Database, chatId: string, humanAgent
       upgradeWatcherToSpeaker: true,
     });
 
-    return { chatId, inserted: !existing, carried: null };
+    return { chatId, inserted: !existing, carried: null, mutated: true };
   });
+
+  // Enclosed post-commit step: drop the cached audience for this chat so the
+  // newly-promoted speaker starts receiving `chat:message` pushes
+  // immediately. Skipped on the no-op path (already a speaker) to avoid
+  // pointlessly busting the cache.
+  if (result.mutated) {
+    invalidateChatAudience(chatId);
+  }
+  return { chatId: result.chatId, inserted: result.inserted, carried: result.carried };
 }
 
 export type LeaveResult = {
@@ -163,9 +180,15 @@ export type LeaveResult = {
  *      - If no  → DELETE the chat_membership row entirely.
  *   3. `chat_user_state` row (if any) is preserved either way per
  *      §11.4 default — read state is remembered for re-add.
+ *
+ * Tx boundary: opens its own transaction. Audience-cache invalidation is
+ * enclosed here — after the tx commits, `invalidateChatAudience` runs so
+ * subsequent `chat:message` dispatches stop pushing to the (now-departed)
+ * speaker's WS connection. Callers do NOT need to call
+ * `invalidateChatAudience` themselves.
  */
 export async function leaveAsParticipant(db: Database, chatId: string, humanAgentId: string): Promise<LeaveResult> {
-  return db.transaction(async (tx) => {
+  const outcome = await db.transaction(async (tx): Promise<LeaveResult> => {
     const [existing] = await tx
       .select({ accessMode: chatMembership.accessMode })
       .from(chatMembership)
@@ -219,6 +242,14 @@ export async function leaveAsParticipant(db: Database, chatId: string, humanAgen
       .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, humanAgentId)));
     return { chatId, membershipKind: "watching" };
   });
+
+  // Enclosed post-commit step: drop the cached audience for this chat so
+  // the dispatcher stops pushing `chat:message` to the WS connection of
+  // the user who just left. Always runs — every leave path here actually
+  // mutates the row (the not-a-speaker case throws before reaching this
+  // point), unlike `joinAsParticipant`'s already-a-speaker fast path.
+  invalidateChatAudience(chatId);
+  return outcome;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Five entrypoints used to write `chat_membership.access_mode='speaker'`, each with its own copy of "cross-org check + private-owner-exclusive check + watcher recompute + audience cache bust". That duplication is what let PR #393's silent-context backfill silently regress when the web path drifted past the agent path (closed by PR #545). **This PR closes the broader class of "duplicate writers go out of sync" bug** by collapsing the duplicate writers themselves.

## Layered design

```
Layer 3 (HTTP routes)          POST /agent/.../chats/:id/participants    POST /chats/:id/participants
                                          │                                          │
Layer 2 (Service, single)      addParticipant (thin shell)     addMeChatParticipants (thin shell)
                                          │                                          │
                                          └───────────► inviteParticipantsToChat ◄───┘
                                                              │
Layer 1.5 (trusted admit)      ensureParticipant ───────► applyMembershipWrite
                                                              │
Layer 1 (single writer)        addChatParticipants
                                  ├─ silent-context backfill (PR #545)
                                  └─ recomputeChatWatchers (newly inlined)
```

`recomputeChatWatchers` itself moves from `watcher.ts` to `participant-mode.ts` so it sits next to the speaker writer it derives from. `watcher.ts` re-exports it for historical callers. `recomputeWatchersForAgent` / `recomputeWatchersForMember` (the per-agent / per-member fan-out triggers) delegate back here.

`applyMembershipWrite` wraps "open tx → addChatParticipants → commit → invalidateChatAudience". `invalidateChatAudience` stays caller-owned because it must run AFTER commit.

## Layer 2 collapse

The two near-identical service files become one. `errorOnAlreadySpeaker` is the only contract difference (agent SDK = 409 hard, web batch = silent skip). Probing-protection 404 stays on the web shell (`assertChatVisibleInOrgOrNotFound` + catch-and-remap of `ForbiddenError` from caller-not-speaker).

## v1 dead code removed

- `chat.ts::joinChat` (supervision-based service)
- `POST /chats/:id/join` route
- The web / CLI / SDK exclusively use `POST /chats/:id/workspace-join` (joinMeChat → joinAsParticipant) — the v2 watcher relationship materialised by `recomputeChatWatchers` is the true subset of v1 supervision.
- `agent-visibility.test.ts` admin-join cases migrated to `/workspace-join`
- `chat-upgrade.test.ts` joinChat case migrated to `joinMeChat` (using the admin's auto-generated watcher row)
- `docs/chat-first-workspace-product-design.md` routes synced + note about v1 `/join` removal

## Test plan

- [x] Pre-existing `add-participant-backfill.test.ts`, `me-chat-service.test.ts`, `chat-membership-invariants.test.ts` all pass unmodified — end-to-end behaviour preserved
- [x] New `participant-invite.test.ts` (14 cases) pins the Layer-2 contract directly:
  - empty-target, missing-chat, caller-not-speaker
  - unknown-target, cross-org
  - private-owner-exclusive (incl. self-add carve-out)
  - already-speaker under both `errorOnAlreadySpeaker` modes
  - true no-op when all targets are already speakers
  - silent-context backfill inherited from `addChatParticipants` (PR #545 regression case re-asserted at Layer 2)
  - `assertChatVisibleInOrgOrNotFound` shape
- [x] `pnpm typecheck` — 13/13 tasks pass
- [x] `pnpm --filter @first-tree/server test` — **1171 tests pass** (baseline 1157 + 14 new)
- [x] `pnpm check` — no new warnings

## Follow-ups out of scope

- `ensureParticipant` could be renamed to make its trusted-admit contract louder (e.g. `silentAdmitPreauthorizedCaller`). Left for a separate small PR so this one stays focused on structure.
- Joining via watcher (`joinMeChat` / `joinAsParticipant`) could likewise be renamed `joinChatAsManager` if helpful. Same reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)