### PR TITLE
fix(status): drive composite working from per-chat runtime (not a decaying event proxy)

### DIFF
--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -59,6 +59,7 @@ function createSessionManager(opts: {
   concurrency?: number;
   log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
+  onSessionRuntimeChange?: (chatId: string, state: "idle" | "working" | "blocked" | "error") => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -86,8 +87,83 @@ function createSessionManager(opts: {
     log: opts.log ?? silentLogger(),
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     onRuntimeStateChange: opts.onRuntimeStateChange,
+    onSessionRuntimeChange: opts.onSessionRuntimeChange,
   });
 }
+
+describe("SessionManager — per-chat runtime reporting (D-axis)", () => {
+  it("reports per-chat runtime to onSessionRuntimeChange when a handler sets it", async () => {
+    const reports: Array<{ chatId: string; state: string }> = [];
+    let ctx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_m, c) {
+        ctx = c;
+        return "s-rt-1";
+      },
+    });
+    const sm = createSessionManager({
+      handler,
+      onSessionRuntimeChange: (chatId, state) => reports.push({ chatId, state }),
+    });
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-x" }));
+    defined(ctx, "ctx").setRuntimeState("working");
+
+    expect(reports).toContainEqual({ chatId: "chat-x", state: "working" });
+    await sm.shutdown();
+  });
+
+  it("getSessionRuntimeStates returns the per-chat runtime of active sessions", async () => {
+    let ctx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_m, c) {
+        ctx = c;
+        return "s-rt-2";
+      },
+    });
+    const sm = createSessionManager({ handler });
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-y" }));
+    defined(ctx, "ctx").setRuntimeState("working");
+
+    expect(sm.getSessionRuntimeStates()).toContainEqual({ chatId: "chat-y", runtimeState: "working" });
+    await sm.shutdown();
+  });
+
+  it("re-affirms working sessions on an interval (server freshness) but not idle ones", async () => {
+    vi.useFakeTimers();
+    try {
+      const reports: Array<{ chatId: string; state: string }> = [];
+      let ctx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_m, c) {
+          ctx = c;
+          return "s-rt-3";
+        },
+      });
+      const sm = createSessionManager({
+        handler,
+        // Large idle_timeout so evictIdle's suspend path doesn't interfere.
+        session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+        onSessionRuntimeChange: (chatId, state) => reports.push({ chatId, state }),
+      });
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-z" }));
+      defined(ctx, "ctx").setRuntimeState("working");
+      reports.length = 0; // drop the transition report; we now want the re-affirm
+
+      await vi.advanceTimersByTimeAsync(25_000);
+      expect(reports.some((r) => r.chatId === "chat-z" && r.state === "working")).toBe(true);
+
+      // Going idle stops the re-affirm: an idle session needs no freshness.
+      defined(ctx, "ctx").setRuntimeState("idle");
+      reports.length = 0;
+      await vi.advanceTimersByTimeAsync(25_000);
+      expect(reports.some((r) => r.chatId === "chat-z")).toBe(false);
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("SessionManager: runtime state aggregation", () => {
   it("fires onRuntimeStateChange when a session sets working state", async () => {

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -466,6 +466,14 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.ws.send(JSON.stringify({ type: "runtime:state", agentId, runtimeState }));
   }
 
+  /** Report the per-(agent,chat) runtime (D-axis) — the authority the server
+   *  persists for the composite status. Distinct from the agent-global
+   *  `runtime:state` frame above. */
+  reportSessionRuntime(agentId: string, chatId: string, runtimeState: RuntimeState): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "session:runtime", agentId, chatId, runtimeState }));
+  }
+
   reportSessionEvent(agentId: string, chatId: string, event: SessionEvent): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     const sanitized = sanitizeSessionEventForTransport(event);

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -187,6 +187,7 @@ export class AgentSlot {
       onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
       onRuntimeStateChange: (state) => this.reportRuntimeState(state),
       onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
+      onSessionRuntimeChange: (chatId, state) => this.reportSessionRuntime(chatId, state),
     });
 
     const onCommand = (cmd: { agentId: string; chatId: string; type: string }) => {
@@ -232,10 +233,23 @@ export class AgentSlot {
     this.clientConnection.reportSessionEvent(this.config.agentId, chatId, event);
   }
 
+  private reportSessionRuntime(chatId: string, state: RuntimeState): void {
+    this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, state);
+  }
+
   private fullStateSync(): void {
     if (!this.sessionManager) return;
     for (const { chatId, state } of this.sessionManager.getSessionStates()) {
       this.clientConnection.reportSessionState(this.config.agentId, chatId, state);
+    }
+    // Re-report the *real* per-chat runtime of every still-live session. On a
+    // network reconnect (process intact) a session mid-turn is still `working`
+    // and must stay so — this is what distinguishes a reconnect from a process
+    // restart (where `sessions` is empty, so nothing here reports `working` and
+    // the evicted loop below + the agent-global reset settle everything to
+    // idle/suspended).
+    for (const { chatId, runtimeState } of this.sessionManager.getSessionRuntimeStates()) {
+      this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, runtimeState);
     }
     // After a process restart `sessions` is empty but SessionRegistry just
     // hydrated every persisted (chatId → claudeSessionId) row into

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -153,6 +153,15 @@ type SessionManagerConfig = {
   onRuntimeStateChange?: (state: RuntimeState) => void;
   /** Callback when a session emits a structured event (tool_call / error). */
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
+  /**
+   * Callback when a session's per-(agent,chat) runtime state changes (the
+   * D-axis: idle/working/blocked/error). Distinct from `onRuntimeStateChange`,
+   * which reports the lossy agent-global aggregate; this carries the chatId so
+   * the server can persist the D-axis at per-chat granularity. Also fired on a
+   * periodic re-affirm for working/blocked sessions so a long turn keeps the
+   * server-side freshness stamp current.
+   */
+  onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
 };
 
 /**
@@ -167,6 +176,14 @@ type SessionManagerConfig = {
  */
 /** Maximum number of evicted session mappings to retain for resume recovery. */
 const MAX_EVICTED_MAPPINGS = 500;
+
+/**
+ * How often to re-affirm working/blocked sessions' per-chat runtime to the
+ * server (refreshing `runtime_state_at`). Kept well under the server's
+ * `RUNTIME_STALE_MS` (60s) so a single dropped frame doesn't let a live turn
+ * flap to idle.
+ */
+const RUNTIME_REAFFIRM_INTERVAL_MS = 20_000;
 
 export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
@@ -187,12 +204,17 @@ export class SessionManager {
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
+  private runtimeReaffirmTimer: ReturnType<typeof setInterval> | null = null;
   private _activeCount = 0;
 
   constructor(config: SessionManagerConfig) {
     this.config = config;
     this.registry = config.registryPath ? new SessionRegistry(config.registryPath) : null;
     this.idleTimer = setInterval(() => this.evictIdle(), 10_000);
+    // Independent of `evictIdle` (which early-continues on freshly-active
+    // sessions): re-affirm working/blocked sessions so the server-side
+    // `runtime_state_at` stays inside the freshness window during a long turn.
+    this.runtimeReaffirmTimer = setInterval(() => this.reaffirmRuntimeStates(), RUNTIME_REAFFIRM_INTERVAL_MS);
 
     // Load persisted sessions (all start as suspended)
     this.loadPersistedSessions();
@@ -357,6 +379,10 @@ export class SessionManager {
       clearInterval(this.idleTimer);
       this.idleTimer = null;
     }
+    if (this.runtimeReaffirmTimer) {
+      clearInterval(this.runtimeReaffirmTimer);
+      this.runtimeReaffirmTimer = null;
+    }
 
     const shutdowns = [...this.sessions.values()].map((s) =>
       s.status === "active" ? s.handler.shutdown() : Promise.resolve(),
@@ -415,6 +441,23 @@ export class SessionManager {
       chatId,
       state: entry.status,
     }));
+  }
+
+  /**
+   * Per-chat runtime (D-axis) of all active sessions, for full-state-sync after
+   * reconnect. Lets the agent-slot re-report the *real* per-chat runtime on a
+   * network reconnect (a session still mid-turn reports `working`), rather than
+   * blanket-idling everything — only a process restart (empty `sessions`)
+   * legitimately has nothing to report. Sessions with no recorded runtime
+   * default to `idle`.
+   */
+  getSessionRuntimeStates(): Array<{ chatId: string; runtimeState: RuntimeState }> {
+    const out: Array<{ chatId: string; runtimeState: RuntimeState }> = [];
+    for (const [chatId, entry] of this.sessions) {
+      if (entry.status !== "active") continue;
+      out.push({ chatId, runtimeState: this.sessionRuntimeStates.get(chatId) ?? "idle" });
+    }
+    return out;
   }
 
   /**
@@ -978,7 +1021,28 @@ export class SessionManager {
     const session = this.sessions.get(chatId);
     if (!session || session.status !== "active") return;
     this.sessionRuntimeStates.set(chatId, state);
+    // Report the per-chat D-axis (the authority the server persists), then the
+    // agent-global aggregate (legacy; retained for admin overview / fault
+    // notifications until the global path is retired).
+    this.config.onSessionRuntimeChange?.(chatId, state);
     this.recomputeRuntimeState();
+  }
+
+  /**
+   * Re-affirm working/blocked sessions' per-chat runtime so the server-side
+   * freshness stamp doesn't lapse mid-turn. Reports only — does NOT touch
+   * `lastActivity` (that governs idle eviction and must not be reset by a
+   * liveness ping). Runs on its own timer, outside `evictIdle`'s early-continue.
+   */
+  private reaffirmRuntimeStates(): void {
+    if (!this.config.onSessionRuntimeChange) return;
+    for (const [chatId, session] of this.sessions) {
+      if (session.status !== "active") continue;
+      const runtimeState = this.sessionRuntimeStates.get(chatId);
+      if (runtimeState === "working" || runtimeState === "blocked") {
+        this.config.onSessionRuntimeChange(chatId, runtimeState);
+      }
+    }
   }
 
   /** Aggregate per-session runtime states: error > blocked > working > idle. */

--- a/packages/server/drizzle/0049_agent_chat_session_runtime_state.sql
+++ b/packages/server/drizzle/0049_agent_chat_session_runtime_state.sql
@@ -1,0 +1,23 @@
+-- Per-(agent,chat) D-axis runtime state. Historically the runtime state
+-- (idle/working/blocked/error) lived only agent-global on
+-- `agent_presence.runtime_state`; that granularity is unusable for the
+-- per-chat composite status (an agent working in chat A would light chat B —
+-- #366), so the composite reconstructed "working" from a decaying
+-- `session_events` proxy that fails for long silent turns and for runtimes
+-- that emit no intermediate events (codex). These columns give the D-axis its
+-- correct per-chat home so the composite can read it directly.
+--
+-- `runtime_state` defaults to 'idle' so existing rows are well-defined.
+--
+-- `runtime_state_at` is intentionally NULLABLE with NO default: a NULL marks
+-- "this client has never reported per-chat runtime" (an old client), which is
+-- the sole signal the composite uses to fall back to the legacy event proxy
+-- for one release cycle. A now() default would be indistinguishable from a
+-- real report and would defeat that fallback.
+
+ALTER TABLE "agent_chat_sessions"
+  ADD COLUMN IF NOT EXISTS "runtime_state" text NOT NULL DEFAULT 'idle';
+
+--> statement-breakpoint
+ALTER TABLE "agent_chat_sessions"
+  ADD COLUMN IF NOT EXISTS "runtime_state_at" timestamp with time zone;

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0048_github_entity_state
+0049_agent_chat_session_runtime_state

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1779926400000,
       "tag": "0048_github_entity_state",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0049_agent_chat_session_runtime_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -1,5 +1,7 @@
+import { RUNTIME_STALE_MS } from "@first-tree/shared";
+import { sql } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
-import { upsertSessionState } from "../services/activity.js";
+import { setSessionRuntime, upsertSessionState } from "../services/activity.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import type { Notifier } from "../services/notifier.js";
@@ -116,10 +118,12 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
+      notifySessionRuntime: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
       onSessionStateChange: vi.fn(),
       onSessionEvent: vi.fn(),
+      onSessionRuntime: vi.fn(),
       onRuntimeStateChange: vi.fn(),
       onChatMessage: vi.fn(),
       start: vi.fn(async () => {}),
@@ -152,10 +156,12 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
+      notifySessionRuntime: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
       onSessionStateChange: vi.fn(),
       onSessionEvent: vi.fn(),
+      onSessionRuntime: vi.fn(),
       onRuntimeStateChange: vi.fn(),
       onChatMessage: vi.fn(),
       start: vi.fn(async () => {}),
@@ -171,5 +177,99 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       "suspended",
       admin.organizationId,
     );
+  });
+});
+
+describe("setSessionRuntime — notify conditions (D-axis freshness)", () => {
+  const getApp = useTestApp();
+
+  function makeNotifier(): Notifier {
+    return {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      notify: vi.fn(async () => {}),
+      notifyConfigChange: vi.fn(async () => {}),
+      notifySessionStateChange: vi.fn(async () => {}),
+      notifyRuntimeStateChange: vi.fn(async () => {}),
+      notifyChatMessage: vi.fn(async () => {}),
+      notifySessionEvent: vi.fn(async () => {}),
+      notifySessionRuntime: vi.fn(async () => {}),
+      pushFrameToInbox: vi.fn(async () => 0),
+      onConfigChange: vi.fn(),
+      onSessionStateChange: vi.fn(),
+      onSessionEvent: vi.fn(),
+      onSessionRuntime: vi.fn(),
+      onRuntimeStateChange: vi.fn(),
+      onChatMessage: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    } satisfies Notifier;
+  }
+
+  async function setupActive() {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `sr-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `sr-target-${crypto.randomUUID().slice(0, 6)}`,
+      type: "autonomous_agent",
+      displayName: "SR target",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
+    // Create the (agent,chat) session row as active. runtime_state defaults to
+    // 'idle', runtime_state_at defaults to NULL (an old-client-shaped row).
+    await upsertSessionState(app.db, agent.uuid, chat.id, "active", admin.organizationId);
+    return { app, admin, agent, chat };
+  }
+
+  /** Stamp runtime_state + runtime_state_at. `ageMs === null` → NULL stamp. */
+  async function setRuntimeAt(
+    app: Awaited<ReturnType<typeof setupActive>>["app"],
+    agentId: string,
+    chatId: string,
+    runtimeState: string,
+    ageMs: number | null,
+  ) {
+    const stamp = ageMs === null ? sql`NULL` : sql`NOW() - make_interval(secs => ${ageMs} / 1000.0)`;
+    await app.db.execute(sql`
+      UPDATE agent_chat_sessions SET runtime_state = ${runtimeState}, runtime_state_at = ${stamp}
+       WHERE agent_id = ${agentId} AND chat_id = ${chatId}
+    `);
+  }
+
+  it("notifies when the runtime value changes", async () => {
+    const { app, admin, agent, chat } = await setupActive();
+    await setRuntimeAt(app, agent.uuid, chat.id, "idle", 0); // fresh idle
+    const notifier = makeNotifier();
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "working", admin.organizationId, notifier);
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT notify on a fresh same-value re-affirm (no spam)", async () => {
+    const { app, admin, agent, chat } = await setupActive();
+    await setRuntimeAt(app, agent.uuid, chat.id, "working", 0); // fresh working
+    const notifier = makeNotifier();
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "working", admin.organizationId, notifier);
+    expect(notifier.notifySessionRuntime).not.toHaveBeenCalled();
+  });
+
+  it("notifies on the first authoritative report (runtime_state_at was NULL) even at the same value", async () => {
+    const { app, admin, agent, chat } = await setupActive();
+    await setRuntimeAt(app, agent.uuid, chat.id, "idle", null); // old-client NULL stamp
+    const notifier = makeNotifier();
+    // Same value 'idle', but NULL→non-null flips the composite from the legacy
+    // event-proxy path to the authoritative path — must invalidate.
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "idle", admin.organizationId, notifier);
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies when a same-value report refreshes a stale stamp (Idle→Working flip)", async () => {
+    const { app, admin, agent, chat } = await setupActive();
+    await setRuntimeAt(app, agent.uuid, chat.id, "working", RUNTIME_STALE_MS + 5_000); // stale working
+    const notifier = makeNotifier();
+    // Same value 'working', but stale→fresh flips the composite Idle→Working.
+    await setSessionRuntime(app.db, agent.uuid, chat.id, "working", admin.organizationId, notifier);
+    expect(notifier.notifySessionRuntime).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
+import { RUNTIME_STALE_MS } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { pendingQuestions } from "../db/schema/pending-questions.js";
 import { getChatAgentStatuses } from "../services/agent-chat-status.js";
-import { createMeChat, deriveFailedAgents } from "../services/me-chat.js";
+import { createMeChat, deriveFailedAgents, deriveWorkingAgents } from "../services/me-chat.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 describe("getChatAgentStatuses", () => {
@@ -35,6 +36,98 @@ describe("getChatAgentStatuses", () => {
       ON CONFLICT (agent_id, chat_id) DO UPDATE SET state = EXCLUDED.state
     `);
   }
+
+  /** Stamp the per-chat D-axis runtime (as the new `session:runtime` frame would).
+   *  `ageMs` ages `runtime_state_at` into the past to exercise the freshness gate. */
+  async function setSessionRuntime(agentId: string, chatId: string, runtimeState: string, ageMs = 0): Promise<void> {
+    await getApp().db.execute(sql`
+      UPDATE agent_chat_sessions
+         SET runtime_state = ${runtimeState},
+             runtime_state_at = NOW() - make_interval(secs => ${ageMs} / 1000.0)
+       WHERE agent_id = ${agentId} AND chat_id = ${chatId}
+    `);
+  }
+
+  async function insertFreshToolCall(agentId: string, chatId: string): Promise<void> {
+    await getApp().db.execute(sql`
+      INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+      VALUES (${randomUUID()}, ${agentId}, ${chatId}, 1, 'tool_call',
+              ${JSON.stringify({ toolUseId: "t1", name: "Bash", args: null, status: "pending" })}::jsonb, NOW())
+    `);
+  }
+
+  it("a fresh per-chat runtime 'working' reads as working even with NO session_events (codex case)", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await setSessionRuntime(peer.agent.uuid, chatId, "working", 0); // fresh, and zero events exist
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(true);
+    expect(s?.main).toBe("working");
+    expect(s?.activity).toBeNull(); // no event → no description, but still authoritatively working
+  });
+
+  it("a per-chat runtime 'working' older than the freshness window does NOT read as working", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await setSessionRuntime(peer.agent.uuid, chatId, "working", RUNTIME_STALE_MS + 5_000);
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(false);
+    expect(s?.main).toBe("ready");
+  });
+
+  it("a per-chat runtime 'working' on a suspended session does NOT read as working (paused wins)", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "suspended");
+    await setSessionRuntime(peer.agent.uuid, chatId, "working", 0);
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(false);
+    expect(s?.main).toBe("paused");
+  });
+
+  it("per-chat runtime is authoritative: a reported 'idle' wins over a fresh session_event", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await insertFreshToolCall(peer.agent.uuid, chatId); // a fresh event would have lit the old proxy
+    await setSessionRuntime(peer.agent.uuid, chatId, "idle", 0); // but the client says idle
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(false);
+    expect(s?.main).toBe("ready");
+  });
+
+  it("old client (runtime_state_at NULL) falls back to the legacy event proxy", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await insertFreshToolCall(peer.agent.uuid, chatId);
+    // NOTE: no setSessionRuntime() → runtime_state_at stays NULL (old client)
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(true);
+    expect(s?.main).toBe("working");
+    expect(s?.activity?.label).toBe("Bash");
+  });
+
+  it("old client fallback respects the active gate: suspended session + fresh event is NOT working", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "suspended");
+    await insertFreshToolCall(peer.agent.uuid, chatId);
+    // no setSessionRuntime → runtime_state_at NULL → legacy fallback path, which
+    // must still gate on an active session (a suspended session is Paused, not
+    // Working, even with a fresh event).
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.working).toBe(false);
+    expect(s?.main).toBe("paused");
+  });
 
   it("folds reachability + active session + pending question into needs_you, and excludes humans", async () => {
     const { app, admin, peer, chatId } = await newChatWithAgent();
@@ -177,6 +270,100 @@ describe("deriveFailedAgents — chat-list failed signal", () => {
     await setSession(peer.agent.uuid, chatId, "active");
 
     expect((await deriveFailedAgents(app.db, [chatId])).has(chatId)).toBe(false);
+  });
+});
+
+describe("deriveWorkingAgents — chat-list working signal (lockstep with getChatAgentStatuses)", () => {
+  const getApp = useTestApp();
+
+  async function bindPresence(agentId: string, clientId: string): Promise<void> {
+    await getApp().db.execute(sql`
+      INSERT INTO agent_presence (agent_id, status, client_id, runtime_state, last_seen_at)
+      VALUES (${agentId}, 'online', ${clientId}, 'idle', NOW())
+      ON CONFLICT (agent_id) DO UPDATE SET status = 'online', client_id = EXCLUDED.client_id
+    `);
+  }
+  async function setSession(agentId: string, chatId: string, state: string): Promise<void> {
+    await getApp().db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, updated_at)
+      VALUES (${agentId}, ${chatId}, ${state}, NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE SET state = EXCLUDED.state
+    `);
+  }
+  async function setSessionRuntime(agentId: string, chatId: string, runtimeState: string, ageMs = 0): Promise<void> {
+    await getApp().db.execute(sql`
+      UPDATE agent_chat_sessions
+         SET runtime_state = ${runtimeState}, runtime_state_at = NOW() - make_interval(secs => ${ageMs} / 1000.0)
+       WHERE agent_id = ${agentId} AND chat_id = ${chatId}
+    `);
+  }
+  async function insertFreshToolCall(agentId: string, chatId: string): Promise<void> {
+    await getApp().db.execute(sql`
+      INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+      VALUES (${randomUUID()}, ${agentId}, ${chatId}, 1, 'tool_call',
+              ${JSON.stringify({ toolUseId: "t1", name: "Bash", args: null, status: "pending" })}::jsonb, NOW())
+    `);
+  }
+  async function newChatWithAgent() {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `dw-${randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    return { app, peer, chatId };
+  }
+
+  it("returns an empty map for no chatIds", async () => {
+    expect((await deriveWorkingAgents(getApp().db, [])).size).toBe(0);
+  });
+
+  it("includes an agent with a fresh per-chat runtime 'working' even with no events (codex case)", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await setSessionRuntime(peer.agent.uuid, chatId, "working", 0);
+
+    expect((await deriveWorkingAgents(app.db, [chatId])).get(chatId)).toEqual([peer.agent.uuid]);
+  });
+
+  it("is authoritative: reported 'idle' excludes the agent even with a fresh event", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await insertFreshToolCall(peer.agent.uuid, chatId);
+    await setSessionRuntime(peer.agent.uuid, chatId, "idle", 0);
+
+    expect((await deriveWorkingAgents(app.db, [chatId])).has(chatId)).toBe(false);
+  });
+
+  it("excludes a stale per-chat runtime 'working'", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await setSessionRuntime(peer.agent.uuid, chatId, "working", RUNTIME_STALE_MS + 5_000);
+
+    expect((await deriveWorkingAgents(app.db, [chatId])).has(chatId)).toBe(false);
+  });
+
+  it("old client (runtime_state_at NULL) falls back to the event proxy", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await insertFreshToolCall(peer.agent.uuid, chatId);
+
+    expect((await deriveWorkingAgents(app.db, [chatId])).get(chatId)).toEqual([peer.agent.uuid]);
+  });
+
+  it("old client fallback respects the active gate: suspended session + fresh event is NOT busy", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "suspended");
+    await insertFreshToolCall(peer.agent.uuid, chatId);
+    // runtime_state_at NULL → fallback; suspended must not count as busy (lockstep
+    // with getChatAgentStatuses).
+
+    expect((await deriveWorkingAgents(app.db, [chatId])).has(chatId)).toBe(false);
   });
 });
 

--- a/packages/server/src/__tests__/pulse-aggregator.test.ts
+++ b/packages/server/src/__tests__/pulse-aggregator.test.ts
@@ -29,10 +29,12 @@ function makeMockNotifier(): {
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
     notifySessionEvent: vi.fn(async () => {}),
+    notifySessionRuntime: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
     onSessionStateChange: vi.fn(),
     onSessionEvent: vi.fn(),
+    onSessionRuntime: vi.fn(),
     onRuntimeStateChange: vi.fn((handler: RuntimeStateChangeHandler) => {
       handlers.push(handler);
     }),

--- a/packages/server/src/__tests__/ws-session-runtime.test.ts
+++ b/packages/server/src/__tests__/ws-session-runtime.test.ts
@@ -1,0 +1,368 @@
+import { RUNTIME_STALE_MS } from "@first-tree/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import { createAgent } from "../services/agent.js";
+import { getChatAgentStatuses } from "../services/agent-chat-status.js";
+import { createMeChat, deriveWorkingAgents } from "../services/me-chat.js";
+import { resolveDefaultOrgId } from "../services/organization.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestApp } from "./helpers.js";
+
+/**
+ * WS frame-level harness for the per-chat D-axis runtime ("working but shows
+ * idle" fix). Drives the FULL real pipeline — agent WS frame → ws-client handler
+ * → chainSessionOp → activity.setSessionRuntime → DB + notifier → org WS
+ * broadcast — against a real Fastify server + real Postgres (testcontainers),
+ * WITHOUT a real LLM. It simulates exactly the frames a real runtime emits.
+ *
+ * Coverage vs the 5 manual cases:
+ *   1. long-working freshness + ~20s re-affirm (simulated by re-sending the
+ *      working frame; staleness simulated by ageing `runtime_state_at`);
+ *   2. codex "working with zero session_events";
+ *   3. #366 — per-chat isolation;
+ *   4. reconnect re-asserts working / disconnect → offline;
+ *   5. org WS realtime delivery + the same-value notify rules.
+ *
+ * NOT covered here (covered by code review + client unit tests): the client
+ * runtime actually deciding to emit these frames (handler emit cadence, codex
+ * no-event behavior, the SessionManager re-affirm timer, fullStateSync).
+ */
+describe("Agent WS — per-chat runtime (D-axis) pipeline harness", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+  let orgWsBase: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signMemberJwt(
+    userId: string,
+    memberId: string,
+    organizationId: string,
+    role: string,
+  ): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({ sub: userId, memberId, organizationId, role, type: "access" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(secret);
+  }
+
+  async function seedBoundAgent(suffix: string) {
+    const orgId = await resolveDefaultOrgId(app.db);
+    const userId = uuidv7();
+    const memberId = uuidv7();
+    const clientId = `cli-rt-${suffix}-${crypto.randomUUID().slice(0, 6)}`;
+    const role = "admin";
+
+    const { agent, humanAgentUuid } = await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: userId,
+        username: `rt-user-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        passwordHash: "x",
+        displayName: `RT User ${suffix}`,
+      });
+      const humanAgent = await createAgent(tx as unknown as typeof app.db, {
+        name: `rt-human-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        displayName: `RT Human ${suffix}`,
+        source: "admin-api",
+        managerId: memberId,
+        organizationId: orgId,
+      });
+      await tx.insert(members).values({ id: memberId, userId, organizationId: orgId, agentId: humanAgent.uuid, role });
+      await tx.insert(clients).values({ id: clientId, userId, organizationId: orgId, status: "connected" });
+      const a = await createAgent(tx as unknown as typeof app.db, {
+        name: `rt-agent-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
+        type: "autonomous_agent",
+        displayName: `RT Agent ${suffix}`,
+        source: "admin-api",
+        managerId: memberId,
+        clientId,
+        organizationId: orgId,
+      });
+      return { agent: a, humanAgentUuid: humanAgent.uuid };
+    });
+
+    const token = await signMemberJwt(userId, memberId, orgId, role);
+    return { agent, humanAgentUuid, token, clientId, organizationId: orgId };
+  }
+
+  function waitForFrame(ws: WebSocket, match: (m: unknown) => boolean, timeoutMs = 5000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for frame (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          if (match(msg)) {
+            clearTimeout(timer);
+            ws.off("message", onMessage);
+            resolve(msg);
+          }
+        } catch {
+          // ignore non-JSON
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  async function waitForCondition<T>(fn: () => Promise<T | null>, timeoutMs = 4000, stepMs = 50): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const value = await fn();
+      if (value !== null && value !== undefined) return value;
+      await new Promise((r) => setTimeout(r, stepMs));
+    }
+    throw new Error(`condition not met within ${timeoutMs}ms`);
+  }
+
+  async function openBoundSocket(seed: Awaited<ReturnType<typeof seedBoundAgent>>): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(JSON.stringify({ type: "auth", token: seed.token }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:ok");
+    ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:registered");
+    ws.send(
+      JSON.stringify({
+        type: "agent:bind",
+        agentId: seed.agent.uuid,
+        ref: "bind-1",
+        runtimeType: "claude-code",
+        runtimeVersion: "0.0.0",
+      }),
+    );
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "agent:bound");
+    return ws;
+  }
+
+  async function closeSocket(ws: WebSocket): Promise<void> {
+    ws.close();
+    await new Promise<void>((r) => ws.once("close", () => r()));
+  }
+
+  /** Create a chat the agent speaks in, then drive `session:state active` so the
+   *  agent_chat_sessions row exists and is active. */
+  async function activeChat(seed: Awaited<ReturnType<typeof seedBoundAgent>>, ws: WebSocket): Promise<string> {
+    const { chatId } = await createMeChat(app.db, seed.humanAgentUuid, seed.organizationId, {
+      participantIds: [seed.agent.uuid],
+    });
+    ws.send(JSON.stringify({ type: "session:state", agentId: seed.agent.uuid, chatId, state: "active" }));
+    await waitForCondition(async () => {
+      const [row] = await app.db
+        .select({ state: agentChatSessions.state })
+        .from(agentChatSessions)
+        .where(and(eq(agentChatSessions.agentId, seed.agent.uuid), eq(agentChatSessions.chatId, chatId)))
+        .limit(1);
+      return row?.state === "active" ? true : null;
+    });
+    return chatId;
+  }
+
+  function sendRuntime(ws: WebSocket, agentId: string, chatId: string, runtimeState: string): void {
+    ws.send(JSON.stringify({ type: "session:runtime", agentId, chatId, runtimeState }));
+  }
+
+  /** Age `runtime_state_at` into the past to simulate "no re-affirm landed". */
+  async function ageRuntimeStamp(agentId: string, chatId: string, ageMs: number): Promise<void> {
+    await app.db.execute(sql`
+      UPDATE agent_chat_sessions SET runtime_state_at = NOW() - make_interval(secs => ${ageMs} / 1000.0)
+       WHERE agent_id = ${agentId} AND chat_id = ${chatId}
+    `);
+  }
+
+  async function statusOf(chatId: string, agentId: string) {
+    const all = await getChatAgentStatuses(app.db, chatId);
+    return all.find((s) => s.agentId === agentId);
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+    orgWsBase = `ws://127.0.0.1:${addr.port}/api/v1/orgs`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  // Case 2 (headline): codex emits NO intermediate session_events, only the
+  // per-chat runtime. v1's event-proxy showed idle the whole turn; v2 is working.
+  it("case 2 — `session:runtime=working` with ZERO session_events still reads working", async () => {
+    const seed = await seedBoundAgent("codex");
+    const ws = await openBoundSocket(seed);
+    try {
+      const chatId = await activeChat(seed, ws);
+      sendRuntime(ws, seed.agent.uuid, chatId, "working");
+
+      const s = await waitForCondition(async () => {
+        const st = await statusOf(chatId, seed.agent.uuid);
+        return st?.working === true ? st : null;
+      });
+      expect(s.main).toBe("working");
+      expect(s.activity).toBeNull(); // no event → no detail, but authoritatively working
+
+      const busy = await deriveWorkingAgents(app.db, [chatId]);
+      expect(busy.get(chatId)).toEqual([seed.agent.uuid]);
+
+      const [eventCount] = await app.db.execute<{ n: number }>(
+        sql`SELECT count(*)::int AS n FROM session_events WHERE agent_id = ${seed.agent.uuid} AND chat_id = ${chatId}`,
+      );
+      expect(eventCount?.n).toBe(0);
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 20000);
+
+  // Case 1: a long turn with no new events stays working as long as the runtime
+  // is re-affirmed; once re-affirm stops and the stamp ages past TTL → idle; a
+  // fresh re-affirm brings it back — all without any session_events.
+  it("case 1 — freshness window: stale (no re-affirm) → idle; re-affirm → working again", async () => {
+    const seed = await seedBoundAgent("fresh");
+    const ws = await openBoundSocket(seed);
+    try {
+      const chatId = await activeChat(seed, ws);
+      sendRuntime(ws, seed.agent.uuid, chatId, "working");
+      await waitForCondition(async () => ((await statusOf(chatId, seed.agent.uuid))?.working ? true : null));
+
+      // Simulate "no re-affirm landed for > TTL".
+      await ageRuntimeStamp(seed.agent.uuid, chatId, RUNTIME_STALE_MS + 10_000);
+      expect((await statusOf(chatId, seed.agent.uuid))?.working).toBe(false);
+      expect((await statusOf(chatId, seed.agent.uuid))?.main).toBe("ready");
+
+      // A re-affirm (same value) refreshes the stamp → working again.
+      sendRuntime(ws, seed.agent.uuid, chatId, "working");
+      const back = await waitForCondition(async () => {
+        const st = await statusOf(chatId, seed.agent.uuid);
+        return st?.working === true ? st : null;
+      });
+      expect(back.main).toBe("working");
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 20000);
+
+  // Case 3: #366 — working in chat A must not light chat B.
+  it("case 3 — #366: working in chat A leaves chat B idle (per-chat isolation)", async () => {
+    const seed = await seedBoundAgent("366");
+    const ws = await openBoundSocket(seed);
+    try {
+      const chatA = await activeChat(seed, ws);
+      const chatB = await activeChat(seed, ws);
+      sendRuntime(ws, seed.agent.uuid, chatA, "working");
+
+      await waitForCondition(async () => ((await statusOf(chatA, seed.agent.uuid))?.working ? true : null));
+      expect((await statusOf(chatA, seed.agent.uuid))?.main).toBe("working");
+      expect((await statusOf(chatB, seed.agent.uuid))?.working).toBe(false);
+      expect((await statusOf(chatB, seed.agent.uuid))?.main).toBe("ready");
+
+      const busy = await deriveWorkingAgents(app.db, [chatA, chatB]);
+      expect(busy.get(chatA)).toEqual([seed.agent.uuid]);
+      expect(busy.has(chatB)).toBe(false);
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 20000);
+
+  // Case 4: reconnect re-asserts working; a hard disconnect → offline (the
+  // reachability gate, not stuck-working).
+  it("case 4 — reconnect re-asserts working; disconnect → offline", async () => {
+    const seed = await seedBoundAgent("recon");
+    let ws = await openBoundSocket(seed);
+    let chatId: string;
+    try {
+      chatId = await activeChat(seed, ws);
+      sendRuntime(ws, seed.agent.uuid, chatId, "working");
+      await waitForCondition(async () => ((await statusOf(chatId, seed.agent.uuid))?.working ? true : null));
+    } finally {
+      await closeSocket(ws);
+    }
+
+    // Hard disconnect → presence loses its client → reachable=false → offline.
+    const offline = await waitForCondition(async () => {
+      const st = await statusOf(chatId, seed.agent.uuid);
+      return st && st.reachable === false ? st : null;
+    });
+    expect(offline.main).toBe("offline");
+
+    // Reconnect (process alive → fullStateSync re-asserts active + working).
+    ws = await openBoundSocket(seed);
+    try {
+      ws.send(JSON.stringify({ type: "session:state", agentId: seed.agent.uuid, chatId, state: "active" }));
+      sendRuntime(ws, seed.agent.uuid, chatId, "working");
+      const back = await waitForCondition(async () => {
+        const st = await statusOf(chatId, seed.agent.uuid);
+        return st?.working === true ? st : null;
+      });
+      expect(back.main).toBe("working");
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 25000);
+
+  // Case 5: org WS realtime delivery + same-value notify rules. A working
+  // transition broadcasts `session:runtime`; a fresh same-value re-affirm does
+  // NOT (no invalidation spam); a stale→fresh same-value report DOES.
+  it("case 5 — org WS broadcasts on real composite change, stays silent on a fresh re-affirm", async () => {
+    const seed = await seedBoundAgent("orgws");
+    const agentWs = await openBoundSocket(seed);
+    const adminWs = new WebSocket(
+      `${orgWsBase}/${encodeURIComponent(seed.organizationId)}/ws/?token=${encodeURIComponent(seed.token)}`,
+    );
+    const runtimeFrames: Array<{ chatId?: string }> = [];
+    try {
+      await new Promise<void>((resolve, reject) => {
+        adminWs.once("open", () => resolve());
+        adminWs.once("error", reject);
+      });
+      await waitForFrame(adminWs, (m) => (m as { type?: string }).type === "admin:connected");
+      adminWs.on("message", (raw) => {
+        try {
+          const msg = JSON.parse(raw.toString()) as { type?: string; chatId?: string };
+          if (msg.type === "session:runtime") runtimeFrames.push({ chatId: msg.chatId });
+        } catch {
+          // ignore
+        }
+      });
+
+      const chatId = await activeChat(seed, agentWs);
+
+      // (a) idle → working = value change → broadcast.
+      sendRuntime(agentWs, seed.agent.uuid, chatId, "working");
+      await waitForCondition(async () => (runtimeFrames.some((f) => f.chatId === chatId) ? true : null));
+      const afterFirst = runtimeFrames.length;
+
+      // (b) fresh same-value re-affirm → NO new broadcast.
+      sendRuntime(agentWs, seed.agent.uuid, chatId, "working");
+      await new Promise((r) => setTimeout(r, 600));
+      expect(runtimeFrames.length).toBe(afterFirst);
+
+      // (c) stale → fresh same-value → broadcast again (Idle→Working flip).
+      await ageRuntimeStamp(seed.agent.uuid, chatId, RUNTIME_STALE_MS + 10_000);
+      sendRuntime(agentWs, seed.agent.uuid, chatId, "working");
+      await waitForCondition(async () => (runtimeFrames.length > afterFirst ? true : null));
+      expect(runtimeFrames.length).toBeGreaterThan(afterFirst);
+    } finally {
+      await closeSocket(agentWs);
+      adminWs.close();
+      await new Promise<void>((r) => adminWs.once("close", () => r())).catch(() => {});
+    }
+  }, 25000);
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -10,6 +10,7 @@ import {
   runtimeStateMessageSchema,
   sessionEventMessageSchema,
   sessionReconcileRequestSchema,
+  sessionRuntimeMessageSchema,
   sessionStateMessageSchema,
   WS_AUTH_FRAME_TIMEOUT_MS,
   wsAuthFrameSchema,
@@ -692,14 +693,32 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
               const boundAgentInfo = boundAgents.get(agentId);
               if (!boundAgentInfo) return;
-              await activityService.upsertSessionState(
-                app.db,
-                agentId,
-                payloadResult.data.chatId,
-                payloadResult.data.state,
-                boundAgentInfo.organizationId,
-                notifier,
-              );
+              // Run on the per-(agent,chat) FIFO so a `session:runtime` update
+              // (which only touches an `active` row) can't be reordered ahead of
+              // the `session:state active` that creates/activates that row. The
+              // op MUST catch internally (like the `session:event` op): a thrown
+              // upsert would otherwise reject the queued promise with no handler
+              // (the chain only consumes the prior op's rejection when a *next*
+              // op is enqueued), surfacing as an unhandled rejection.
+              await chainSessionOp(agentId, payloadResult.data.chatId, async () => {
+                try {
+                  await activityService.upsertSessionState(
+                    app.db,
+                    agentId,
+                    payloadResult.data.chatId,
+                    payloadResult.data.state,
+                    boundAgentInfo.organizationId,
+                    notifier,
+                  );
+                } catch (err) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "error",
+                      message: `Failed to persist session state: ${err instanceof Error ? err.message : String(err)}`,
+                    }),
+                  );
+                }
+              });
             } else if (type === "session:reconcile") {
               const agentId = parsed.data.agentId;
               if (!agentId || !boundAgents.has(agentId)) {
@@ -763,6 +782,42 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               } else if (payload.runtimeState === "idle" || payload.runtimeState === "working") {
                 notificationService.markAgentFaultsResolved(app.db, agentId).catch(() => {});
               }
+            } else if (type === "session:runtime") {
+              const agentId = parsed.data.agentId;
+              if (!agentId || !boundAgents.has(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
+
+              const payloadResult = sessionRuntimeMessageSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                socket.send(JSON.stringify({ type: "error", message: "Malformed session:runtime frame" }));
+                return;
+              }
+              const boundInfo = boundAgents.get(agentId);
+              if (!boundInfo) return;
+              const { chatId, runtimeState } = payloadResult.data;
+              // Same per-(agent,chat) FIFO as session:state/session:event so the
+              // active-gated read-then-write stays ordered behind the state write.
+              await chainSessionOp(agentId, chatId, async () => {
+                try {
+                  await activityService.setSessionRuntime(
+                    app.db,
+                    agentId,
+                    chatId,
+                    runtimeState,
+                    boundInfo.organizationId,
+                    notifier,
+                  );
+                } catch (err) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "error",
+                      message: `Failed to persist session runtime: ${err instanceof Error ? err.message : String(err)}`,
+                    }),
+                  );
+                }
+              });
             } else if (type === "session:event") {
               const agentId = parsed.data.agentId;
               if (!agentId || !boundAgents.has(agentId)) {

--- a/packages/server/src/api/orgs/ws.ts
+++ b/packages/server/src/api/orgs/ws.ts
@@ -82,6 +82,13 @@ export function orgWsRoutes(notifier: Notifier, jwtSecret: string) {
     broadcastOrgScoped({ type: "session:event", ...payload });
   });
 
+  notifier.onSessionRuntime((payload) => {
+    // The D-axis authority changed for one (agent, chat). Admin WS consumers
+    // invalidate `chat-agent-status` + `me/chats` off this (NOT `session-events`,
+    // since no event was appended). Routing-only payload, same as session:event.
+    broadcastOrgScoped({ type: "session:runtime", ...payload });
+  });
+
   notifier.onChatMessage(({ chatId }) => {
     void dispatchChatMessage(chatId);
   });

--- a/packages/server/src/db/schema/agent-chat-sessions.ts
+++ b/packages/server/src/db/schema/agent-chat-sessions.ts
@@ -13,6 +13,24 @@ export const agentChatSessions = pgTable(
       .notNull()
       .references(() => chats.id, { onDelete: "cascade" }),
     state: text("state").notNull(),
+    /**
+     * D-axis: is a turn in flight for THIS (agent, chat) right now. Mirrors the
+     * client's per-chat `sessionRuntimeStates`. One of `idle|working|blocked|
+     * error`. This is the per-chat home of the runtime state that historically
+     * only lived agent-global on `agent_presence.runtime_state` — the composite
+     * status reads this so it no longer has to reconstruct "working" from a
+     * decaying `session_events` proxy.
+     */
+    runtimeState: text("runtime_state").notNull().default("idle"),
+    /**
+     * Freshness stamp for `runtime_state`, bumped on every per-chat runtime
+     * report (transition + ~20s re-affirm). NULLABLE on purpose: a NULL means
+     * "this client has never reported per-chat runtime" (old client) — the
+     * sole signal the composite uses to fall back to the legacy event proxy.
+     * Never default it to now(): a fresh default is indistinguishable from a
+     * real report and would defeat that fallback.
+     */
+    runtimeStateAt: timestamp("runtime_state_at", { withTimezone: true }),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [primaryKey({ columns: [table.agentId, table.chatId] })],

--- a/packages/server/src/services/activity.ts
+++ b/packages/server/src/services/activity.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from "@first-tree/shared";
+import { RUNTIME_STALE_MS, type RuntimeState, type SessionState } from "@first-tree/shared";
 import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
@@ -105,6 +105,64 @@ export async function upsertSessionState(
 
   if (stateChanged && notifier) {
     notifier.notifySessionStateChange(agentId, chatId, state, organizationId).catch(() => {});
+  }
+}
+
+/**
+ * Persist the per-(agent,chat) D-axis runtime state reported by a client
+ * (`session:runtime` frame, plus the ~20s re-affirm). Always bumps
+ * `runtime_state_at` so a long working turn stays fresh; kicks the admin WS
+ * only when the *effective composite status could change* — i.e. the runtime
+ * value changed, OR a same-value report flips the derivation (NULL→non-null:
+ * legacy-proxy path → authoritative path; stale→fresh: Idle→Working). A fresh
+ * same-value re-affirm changes nothing, so it stays silent (no invalidation spam).
+ *
+ * Only an `active` session is touched: the suspend/evict paths own the
+ * lifecycle, and a runtime report for a non-active (or missing) session is
+ * stale — skip it (the next re-affirm recovers once the session goes active,
+ * covering the startup-order race where a `working` report can beat the
+ * `session:state active` report). Callers MUST invoke this inside the
+ * per-(agent,chat) `chainSessionOp` queue so the read-then-write is race-free
+ * and ordered behind the `session:state` write.
+ */
+export async function setSessionRuntime(
+  db: Database,
+  agentId: string,
+  chatId: string,
+  runtimeState: RuntimeState,
+  organizationId: string,
+  notifier?: Notifier,
+): Promise<void> {
+  const [prev] = await db
+    .select({
+      runtimeState: agentChatSessions.runtimeState,
+      runtimeStateAt: agentChatSessions.runtimeStateAt,
+      state: agentChatSessions.state,
+    })
+    .from(agentChatSessions)
+    .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)))
+    .limit(1);
+  if (!prev || prev.state !== "active") return;
+
+  await db
+    .update(agentChatSessions)
+    .set({ runtimeState, runtimeStateAt: new Date() })
+    .where(and(eq(agentChatSessions.agentId, agentId), eq(agentChatSessions.chatId, chatId)));
+
+  // Notify when the composite `working` could have flipped — not only on a
+  // value change, but also on the two same-value transitions that still move
+  // the composite (else the UI sticks until the 30s poll):
+  //   - runtime_state_at NULL → non-null: old-client legacy-proxy path becomes
+  //     the authoritative path;
+  //   - stale → fresh: a `working` that had aged out (read as Idle) is live
+  //     again (Idle → Working).
+  // A fresh same-value re-affirm changes nothing, so it stays silent (no spam).
+  const valueChanged = prev.runtimeState !== runtimeState;
+  const wasNull = prev.runtimeStateAt == null;
+  // Inline the null check (not `!wasNull`) so TS narrows `runtimeStateAt`.
+  const wasStale = prev.runtimeStateAt != null && Date.now() - prev.runtimeStateAt.getTime() > RUNTIME_STALE_MS;
+  if ((valueChanged || wasNull || wasStale) && notifier) {
+    notifier.notifySessionRuntime(agentId, chatId, runtimeState, organizationId).catch(() => {});
   }
 }
 

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -4,6 +4,7 @@ import {
   buildAgentChatStatus,
   LIVE_ACTIVITY_STALE_MS,
   type LiveActivity,
+  RUNTIME_STALE_MS,
 } from "@first-tree/shared";
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
@@ -35,12 +36,21 @@ export async function getChatAgentStatuses(db: Database, chatId: string): Promis
   const agentIds = speakers.map((s) => s.agentId);
   if (agentIds.length === 0) return [];
 
-  // Per-(agent,chat) session lifecycle (C).
+  // Per-(agent,chat) session lifecycle (C) + the per-chat D-axis runtime state.
+  // `runtimeStateAt` is the authority/fallback discriminator: non-null means a
+  // client has reported per-chat runtime, so `working` reads it directly; null
+  // means an old client that only reports agent-global runtime, so `working`
+  // falls back to the legacy `session_events` proxy (one release cycle).
   const sessions = await db
-    .select({ agentId: agentChatSessions.agentId, state: agentChatSessions.state })
+    .select({
+      agentId: agentChatSessions.agentId,
+      state: agentChatSessions.state,
+      runtimeState: agentChatSessions.runtimeState,
+      runtimeStateAt: agentChatSessions.runtimeStateAt,
+    })
     .from(agentChatSessions)
     .where(and(eq(agentChatSessions.chatId, chatId), inArray(agentChatSessions.agentId, agentIds)));
-  const sessionState = new Map(sessions.map((s) => [s.agentId, s.state]));
+  const sessionByAgent = new Map(sessions.map((s) => [s.agentId, s]));
 
   // Reachability (A): a non-null bound client (mirrors the web
   // `resolveAgentState` rule — no client ⇒ offline). Also carries the
@@ -62,16 +72,35 @@ export async function getChatAgentStatuses(db: Database, chatId: string): Promis
   const pendingByChat = await derivePendingQuestions(db, [chatId]);
   const pendingAgents = new Set(pendingByChat.get(chatId) ?? []);
 
-  // Activity (D): per-agent live activity (fresh, non-terminal latest event).
-  // `working` is derived from its presence; the activity itself rides along so
-  // AgentRow / compose can render the "Using <tool> · 12s" detail.
+  // Activity (D), DESCRIPTION layer: per-agent live activity (fresh, non-terminal
+  // latest event). This no longer *decides* `working` — it only supplies the
+  // "Using <tool> · 12s" detail when the agent is working. The boolean comes
+  // from the per-chat runtime state below (with a legacy fallback).
   const activityByAgent = await deriveAgentActivity(db, chatId);
 
+  const now = Date.now();
   return agentIds.map((agentId) => {
-    const state = sessionState.get(agentId);
+    const sess = sessionByAgent.get(agentId);
+    const state = sess?.state;
     const p = presenceById.get(agentId);
     const activity = activityByAgent.get(agentId) ?? null;
     const engagement: AgentEngagement = state === "active" ? "active" : state === "suspended" ? "suspended" : "none";
+
+    // D-axis `working`: authoritative per-chat runtime when the client reports
+    // it (`runtime_state_at` non-null), else the legacy event proxy. Gated on an
+    // active session so a stale `runtime_state` left on a suspended row (the
+    // suspend path doesn't reset it) cannot read as working.
+    const working =
+      sess?.runtimeStateAt != null
+        ? engagement === "active" &&
+          sess.runtimeState === "working" &&
+          now - sess.runtimeStateAt.getTime() <= RUNTIME_STALE_MS
+        : // Legacy event-proxy fallback (old client, never reported per-chat
+          // runtime). Gate on `active` too — lockstep with the authoritative
+          // path and with `deriveWorkingAgents` — so a suspended session with a
+          // still-fresh event reads as Paused, not Working.
+          engagement === "active" && activity != null;
+
     return buildAgentChatStatus({
       agentId,
       reachable: p?.clientId != null,
@@ -85,9 +114,11 @@ export async function getChatAgentStatuses(db: Database, chatId: string): Promis
       // indirection costs more than it saves, so we keep the duplicated literal.
       errored: state === "errored" || p?.runtimeState === "error",
       needsYou: pendingAgents.has(agentId),
-      working: activity != null,
+      working,
       engagement,
-      activity,
+      // The activity is a descriptor of in-flight work — carry it only while
+      // working, matching the schema's "null when not working" contract.
+      activity: working ? activity : null,
     });
   });
 }

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -37,6 +37,7 @@ import {
   type MeChatRow,
   type MeChatSourceCounts,
   type MeChatUnreadResponse,
+  RUNTIME_STALE_MS,
   type ToolCallEventPayload,
 } from "@first-tree/shared";
 import { and, eq, inArray, isNotNull, ne, or, type SQL, sql } from "drizzle-orm";
@@ -474,6 +475,13 @@ export async function listMeChats(
   // needs-you signal so the list can pin failed chats above needs-you.
   const failedByChat = await deriveFailedAgents(db, chatIds);
 
+  // working — per-chat set of agents whose composite status is `working` (the
+  // D-axis), derived in lockstep with `getChatAgentStatuses`. Drives the list
+  // activity indicator directly so it lights even when a runtime emits no
+  // intermediate `session_events` (codex). `liveActivity` (below) stays as the
+  // description; this set is the authority for "working".
+  const workingByChat = await deriveWorkingAgents(db, chatIds);
+
   // First-message lookup for auto-title fallback. Mirrors
   // `session.ts:listAgentSessions`'s `selectDistinctOn` pattern. The
   // logic is the same as before the schema refactor — first-message
@@ -526,6 +534,7 @@ export async function listMeChats(
       liveActivity: liveActivityByChat.get(r.chat_id) ?? null,
       pendingQuestionAgentIds: pendingByChat.get(r.chat_id) ?? [],
       failedAgentIds: failedByChat.get(r.chat_id) ?? [],
+      busyAgentIds: workingByChat.get(r.chat_id) ?? [],
     };
   });
 
@@ -595,6 +604,67 @@ export async function deriveFailedAgents(db: Database, chatIds: string[]): Promi
     const set = sets.get(row.chatId);
     if (set) set.add(row.agentId);
     else sets.set(row.chatId, new Set([row.agentId]));
+  }
+  const out = new Map<string, string[]>();
+  for (const [chatId, set] of sets) out.set(chatId, [...set]);
+  return out;
+}
+
+/**
+ * Per-chat set of non-human speaker agents whose composite status is `working`
+ * — the D-axis "a turn is in flight in THIS chat right now" boolean. Derived in
+ * lockstep with `getChatAgentStatuses` (agent-chat-status.ts): when the client
+ * has reported per-chat runtime (`runtime_state_at` non-null) it is the
+ * authority — `state='active' AND runtime_state='working' AND fresh within
+ * RUNTIME_STALE_MS`; otherwise (old client) it falls back to the legacy proxy —
+ * the latest non-terminal `session_events` row within LIVE_ACTIVITY_STALE_MS.
+ * The `state='active'` gate matters: the suspend path doesn't reset
+ * `runtime_state`, so a stale `working` on a suspended row must not light up.
+ * Chats with no working agent are absent from the map (caller treats absence as
+ * []). LATERAL seek mirrors `deriveLiveActivity`'s index usage.
+ */
+export async function deriveWorkingAgents(db: Database, chatIds: string[]): Promise<Map<string, string[]>> {
+  if (chatIds.length === 0) return new Map();
+  const chatIdInClause = sql.join(
+    chatIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  const rows = (await db.execute(sql`
+    SELECT acs.agent_id AS agent_id, acs.chat_id AS chat_id
+      FROM agent_chat_sessions acs
+      JOIN agents a
+        ON a.uuid = acs.agent_id AND a.type <> 'human'
+      JOIN chat_membership cm
+        ON cm.chat_id = acs.chat_id AND cm.agent_id = acs.agent_id AND cm.access_mode = 'speaker'
+      LEFT JOIN LATERAL (
+        SELECT kind, created_at
+          FROM session_events se
+         WHERE se.agent_id = acs.agent_id
+           AND se.chat_id  = acs.chat_id
+         ORDER BY se.seq DESC
+         LIMIT 1
+      ) e ON true
+     WHERE acs.chat_id IN (${chatIdInClause})
+       AND acs.state <> 'evicted'
+       AND CASE
+         WHEN acs.runtime_state_at IS NOT NULL THEN
+           acs.state = 'active'
+           AND acs.runtime_state = 'working'
+           AND acs.runtime_state_at > NOW() - make_interval(secs => ${RUNTIME_STALE_MS} / 1000.0)
+         ELSE
+           -- Legacy event-proxy fallback (old client). Gate on active too, in
+           -- lockstep with the authoritative path and getChatAgentStatuses, so
+           -- a suspended session with a fresh event is not counted as working.
+           acs.state = 'active'
+           AND e.kind IN ('tool_call', 'thinking', 'assistant_text')
+           AND e.created_at > NOW() - make_interval(secs => ${LIVE_ACTIVITY_STALE_MS} / 1000.0)
+       END
+  `)) as unknown as Array<{ agent_id: string; chat_id: string }>;
+  const sets = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const set = sets.get(row.chat_id);
+    if (set) set.add(row.agent_id);
+    else sets.set(row.chat_id, new Set([row.agent_id]));
   }
   const out = new Map<string, string[]>();
   for (const [chatId, set] of sets) out.set(chatId, [...set]);

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -6,6 +6,8 @@ const CONFIG_CHANNEL = "config_changes";
 const SESSION_STATE_CHANNEL = "session_state_changes";
 const SESSION_EVENT_CHANNEL = "session_event_changes";
 const RUNTIME_STATE_CHANNEL = "runtime_state_changes";
+/** Per-(agent,chat) D-axis runtime change. Carries `<agentId>:<chatId>:<state>:<organizationId>`. */
+const SESSION_RUNTIME_CHANNEL = "session_runtime_changes";
 /**
  * Chat-first workspace cross-process kick. Carries `<chatId>:<messageId>`.
  * Lets admin WS sockets translate every chat message (speaker AND watcher
@@ -36,6 +38,19 @@ export type SessionEventChangeHandler = (payload: {
   organizationId: string;
 }) => void;
 export type RuntimeStateChangeHandler = (payload: { agentId: string; state: string; organizationId: string }) => void;
+/**
+ * Per-(agent,chat) runtime change — fired when a client reports the D-axis
+ * runtime state for a specific chat (`session:runtime` frame / ~20s re-affirm).
+ * Lets admin WS consumers invalidate `chat-agent-status` + `me/chats` in
+ * realtime instead of waiting for the 30s poll. Same routing-only payload shape
+ * as the session-state channel.
+ */
+export type SessionRuntimeChangeHandler = (payload: {
+  agentId: string;
+  chatId: string;
+  state: string;
+  organizationId: string;
+}) => void;
 export type ChatMessageChangeHandler = (payload: { chatId: string; messageId: string }) => void;
 
 /**
@@ -66,6 +81,8 @@ export type Notifier = {
   notifySessionStateChange(agentId: string, chatId: string, state: string, organizationId: string): Promise<void>;
   /** Notify that a session event was appended (used to invalidate `liveActivity`). */
   notifySessionEvent(agentId: string, chatId: string, kind: string, organizationId: string): Promise<void>;
+  /** Notify that a per-(agent,chat) runtime state changed (D-axis: idle/working/…). */
+  notifySessionRuntime(agentId: string, chatId: string, state: string, organizationId: string): Promise<void>;
   /** Notify that an agent runtime state has changed (idle/working/error/…). Payload is org-scoped so admin consumers can filter. */
   notifyRuntimeStateChange(agentId: string, state: string, organizationId: string): Promise<void>;
   /** Chat-first workspace: kick admin WS sockets to invalidate ["me","chats"] and the timeline of `chatId`. */
@@ -84,6 +101,8 @@ export type Notifier = {
   onSessionStateChange(handler: SessionStateChangeHandler): void;
   /** Register a handler for session-event notifications (per-chat liveActivity). */
   onSessionEvent(handler: SessionEventChangeHandler): void;
+  /** Register a per-(agent,chat) runtime change handler. */
+  onSessionRuntime(handler: SessionRuntimeChangeHandler): void;
   /** Register a handler for runtime state change notifications */
   onRuntimeStateChange(handler: RuntimeStateChangeHandler): void;
   /** Register a handler for chat:message change notifications. */
@@ -99,12 +118,14 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   const configChangeHandlers: ConfigChangeHandler[] = [];
   const sessionStateChangeHandlers: SessionStateChangeHandler[] = [];
   const sessionEventHandlers: SessionEventChangeHandler[] = [];
+  const sessionRuntimeHandlers: SessionRuntimeChangeHandler[] = [];
   const runtimeStateChangeHandlers: RuntimeStateChangeHandler[] = [];
   const chatMessageHandlers: ChatMessageChangeHandler[] = [];
   let unlistenInboxFn: (() => Promise<void>) | null = null;
   let unlistenConfigFn: (() => Promise<void>) | null = null;
   let unlistenSessionStateFn: (() => Promise<void>) | null = null;
   let unlistenSessionEventFn: (() => Promise<void>) | null = null;
+  let unlistenSessionRuntimeFn: (() => Promise<void>) | null = null;
   let unlistenRuntimeStateFn: (() => Promise<void>) | null = null;
   let unlistenChatMessageFn: (() => Promise<void>) | null = null;
 
@@ -195,6 +216,16 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       }
     },
 
+    async notifySessionRuntime(agentId: string, chatId: string, state: string, organizationId: string) {
+      try {
+        // `<agentId>:<chatId>:<state>:<organizationId>` — same shape as the
+        // session-state channel so the listen-side split is reused verbatim.
+        await listenClient`SELECT pg_notify(${SESSION_RUNTIME_CHANNEL}, ${`${agentId}:${chatId}:${state}:${organizationId}`})`;
+      } catch {
+        // fire-and-forget — admin UI's 30s agent-status poll re-syncs.
+      }
+    },
+
     async notifyChatMessage(chatId: string, messageId: string) {
       try {
         await listenClient`SELECT pg_notify(${CHAT_MESSAGE_CHANNEL}, ${`${chatId}:${messageId}`})`;
@@ -233,6 +264,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
 
     onSessionEvent(handler: SessionEventChangeHandler) {
       sessionEventHandlers.push(handler);
+    },
+
+    onSessionRuntime(handler: SessionRuntimeChangeHandler) {
+      sessionRuntimeHandlers.push(handler);
     },
 
     onRuntimeStateChange(handler: RuntimeStateChangeHandler) {
@@ -301,6 +336,30 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       });
       unlistenSessionEventFn = sessionEventResult.unlisten;
 
+      const sessionRuntimeResult = await listenClient.listen(SESSION_RUNTIME_CHANNEL, (payload) => {
+        if (payload) {
+          // payload format: "agentId:chatId:state:organizationId" — mirrors the
+          // session-state channel split.
+          const firstSep = payload.indexOf(":");
+          const secondSep = payload.indexOf(":", firstSep + 1);
+          const thirdSep = payload.indexOf(":", secondSep + 1);
+          if (firstSep > 0 && secondSep > firstSep && thirdSep > secondSep) {
+            const agentId = payload.slice(0, firstSep);
+            const chatId = payload.slice(firstSep + 1, secondSep);
+            const state = payload.slice(secondSep + 1, thirdSep);
+            const organizationId = payload.slice(thirdSep + 1);
+            for (const handler of sessionRuntimeHandlers) {
+              try {
+                handler({ agentId, chatId, state, organizationId });
+              } catch {
+                // swallow — handler errors must not poison fan-out
+              }
+            }
+          }
+        }
+      });
+      unlistenSessionRuntimeFn = sessionRuntimeResult.unlisten;
+
       const runtimeStateResult = await listenClient.listen(RUNTIME_STATE_CHANNEL, (payload) => {
         if (payload) {
           // payload format: "agentId:state:organizationId"
@@ -353,6 +412,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       if (unlistenSessionEventFn) {
         await unlistenSessionEventFn();
         unlistenSessionEventFn = null;
+      }
+      if (unlistenSessionRuntimeFn) {
+        await unlistenSessionRuntimeFn();
+        unlistenSessionRuntimeFn = null;
       }
       if (unlistenRuntimeStateFn) {
         await unlistenRuntimeStateFn();

--- a/packages/shared/src/__tests__/session-runtime-message.test.ts
+++ b/packages/shared/src/__tests__/session-runtime-message.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { sessionRuntimeMessageSchema } from "../schemas/presence.js";
+
+// The per-(agent,chat) runtime report (client → server). Distinct from the
+// agent-global `runtimeStateMessageSchema` (no chatId) — this one carries the
+// chatId so the server can persist the D-axis at per-chat granularity.
+describe("sessionRuntimeMessageSchema", () => {
+  it("parses a valid per-chat runtime report", () => {
+    const r = sessionRuntimeMessageSchema.safeParse({ chatId: "c1", runtimeState: "working" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts every runtime state value", () => {
+    for (const runtimeState of ["idle", "working", "blocked", "error"] as const) {
+      expect(sessionRuntimeMessageSchema.safeParse({ chatId: "c1", runtimeState }).success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown runtimeState", () => {
+    const r = sessionRuntimeMessageSchema.safeParse({ chatId: "c1", runtimeState: "busy" });
+    expect(r.success).toBe(false);
+  });
+
+  it("requires a non-empty chatId (this is what distinguishes it from the global runtime:state frame)", () => {
+    expect(sessionRuntimeMessageSchema.safeParse({ runtimeState: "working" }).success).toBe(false);
+    expect(sessionRuntimeMessageSchema.safeParse({ chatId: "", runtimeState: "working" }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,6 +122,7 @@ export {
   type DeriveMainStatusInput,
   deriveMainStatus,
   MAIN_STATUS_PRIORITY,
+  RUNTIME_STALE_MS,
 } from "./schemas/agent-status.js";
 export {
   type ConnectTokenExchange,
@@ -509,8 +510,10 @@ export {
   runtimeStateMessageSchema,
   runtimeStateSchema,
   SESSION_STATES,
+  type SessionRuntimeMessage,
   type SessionState,
   type SessionStateMessage,
+  sessionRuntimeMessageSchema,
   sessionStateMessageSchema,
   sessionStateSchema,
 } from "./schemas/presence.js";

--- a/packages/shared/src/schemas/agent-status.ts
+++ b/packages/shared/src/schemas/agent-status.ts
@@ -65,6 +65,16 @@ export const AGENT_ENGAGEMENTS = {
 export const agentEngagementSchema = z.enum(["active", "suspended", "none"]);
 export type AgentEngagement = z.infer<typeof agentEngagementSchema>;
 
+/**
+ * Freshness window (ms) for the per-(agent,chat) D-axis runtime state. The
+ * client re-affirms `working`/`blocked` sessions on an interval (~20s) so a
+ * long turn keeps `runtime_state_at` fresh; if no re-affirm lands within this
+ * window the server stops treating the session as `working` (self-heals after
+ * a silent client death where the `idle` transition was never received).
+ * Kept >= 2x the re-affirm interval so a single dropped frame doesn't flap.
+ */
+export const RUNTIME_STALE_MS = 60_000;
+
 /** Inputs to the projection — one field per status axis. */
 export type DeriveMainStatusInput = {
   /** Reachability (A): is the agent's runtime/client reachable at all? */

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -243,6 +243,24 @@ export const meChatRowSchema = z.object({
    * for version skew, same rationale as `pendingQuestionAgentIds`.
    */
   failedAgentIds: z.array(z.string()).default([]),
+  /**
+   * Speakers in this chat whose composite status is `working` — the D-axis
+   * "is a turn in flight right now in THIS chat" signal. Drives the chat-list
+   * activity indicator (the scrolling `•••`) directly, so it lights up even
+   * when a runtime emits no intermediate `session_events` (e.g. codex tools
+   * that only emit on completion) — the case `liveActivity` alone cannot
+   * cover. `liveActivity` stays as the *description* ("Using Bash · 12s");
+   * this set is the authority for "working". Derived at query time from
+   * `agent_chat_sessions.runtime_state` (per-chat), in lockstep with
+   * `getChatAgentStatuses`. `.default([])` for version skew, same rationale as
+   * `pendingQuestionAgentIds`.
+   *
+   * NAME: deliberately NOT `workingAgentIds` — that name was a retired
+   * agent-global misnomer (the #366 cross-chat false-positive) since renamed
+   * to `engagedAgentIds`; a regression test pins its absence. `busyAgentIds`
+   * is the per-chat D-axis set and avoids resurrecting the poisoned name.
+   */
+  busyAgentIds: z.array(z.string()).default([]),
 });
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 

--- a/packages/shared/src/schemas/presence.ts
+++ b/packages/shared/src/schemas/presence.ts
@@ -57,6 +57,20 @@ export const runtimeStateMessageSchema = z.object({
 });
 export type RuntimeStateMessage = z.infer<typeof runtimeStateMessageSchema>;
 
+/**
+ * Client-reported runtime state at **per-(agent, chat)** granularity
+ * (client → server). The agent-global `runtimeStateMessageSchema` (no chatId)
+ * is a lossy aggregate that the per-chat composite cannot consume safely
+ * (an agent working in chat A would light chat B — #366). This frame carries
+ * the chatId so the server can persist the D-axis (`agent_chat_sessions.
+ * runtime_state`) at the granularity the status surfaces actually need.
+ */
+export const sessionRuntimeMessageSchema = z.object({
+  chatId: z.string().min(1),
+  runtimeState: runtimeStateSchema,
+});
+export type SessionRuntimeMessage = z.infer<typeof sessionRuntimeMessageSchema>;
+
 // -- Agent Bind Payload (client → server) --
 // v2: token removed; authorization derives from the WS-level JWT and the
 // client_id pinned to the agent (Rule R-RUN).

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -208,6 +208,15 @@ function broadcast(msg: WsMessage) {
       if (agentId && chatId) {
         latestQc.invalidateQueries({ queryKey: ["session-events", agentId, chatId] });
       }
+    } else if (msg.type === "session:runtime") {
+      // The per-(agent,chat) D-axis authority changed (api/orgs/ws.ts spreads
+      // the notifier payload). It drives composite `working` on the right
+      // sidebar (`chat-agent-status`) and the chat-list `busyAgentIds`
+      // (`me/chats`). Re-uses the same throttle as session:state/event.
+      // Deliberately NOT invalidating `session-events`: no event was appended,
+      // and the runtime change carries no timeline content.
+      meChatsInvalidator.invalidate(latestQc);
+      chatAgentStatusInvalidator.invalidate(latestQc);
     } else if (msg.type === "chat:message") {
       // Best-effort realtime nudge for the chat-first workspace. The frame
       // carries `{ type, chatId }` (see shared/me-chat.ts:chatMessageFrameSchema);

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -39,6 +39,7 @@ function row(overrides: Partial<MeChatRow>): MeChatRow {
     liveActivity: overrides.liveActivity ?? null,
     pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? [],
     failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
   };
 }
 

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -28,6 +28,7 @@ function row(overrides: Partial<MeChatRow> & { id: string; lastMessageAt: string
     liveActivity: overrides.liveActivity ?? null,
     pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? [],
     failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
   };
 }
 

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -639,13 +639,20 @@ export function ConversationList({
                               {row.title}
                             </span>
                             {(() => {
-                              const slot = row.liveActivity ? (
-                                <ActivityDots />
-                              ) : row.lastMessageAt ? (
-                                <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
-                                  {formatRowTime(row.lastMessageAt)}
-                                </span>
-                              ) : null;
+                              // `busyAgentIds` is the authoritative D-axis
+                              // "is anyone working in this chat" signal — it
+                              // lights the activity dots even when the runtime
+                              // emits no intermediate `session_events` (codex
+                              // tools that only report on completion), which
+                              // `liveActivity` alone would miss.
+                              const slot =
+                                row.busyAgentIds.length > 0 ? (
+                                  <ActivityDots />
+                                ) : row.lastMessageAt ? (
+                                  <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
+                                    {formatRowTime(row.lastMessageAt)}
+                                  </span>
+                                ) : null;
                               return slot ? (
                                 <span className="shrink-0 transition-opacity group-hover:opacity-0 group-has-aria-expanded:opacity-0">
                                   {slot}


### PR DESCRIPTION
## Problem
Agents showed **"Idle" while actually working**: any single silent operation >60s (long `Bash`/`npm test`/build, long reasoning) and **codex-runtime long tools** (which emit no intermediate `session_events`) read as idle for the whole turn.

## Root cause + fix
The D-axis runtime state (idle/working/blocked/error) was persisted **only at agent-global granularity** (`agent_presence.runtime_state`), unusable for the per-(agent,chat) composite — an agent working in chat A would light chat B (#366). So the composite reconstructed "working" from a **`session_events` freshness proxy** that decays after `LIVE_ACTIVITY_STALE_MS` (60s) and is empty for completion-only runtimes (codex).

This PR **relocates the D-axis to per-chat** ("D′"): clients report runtime per `(agent,chat)` via a new `session:runtime` frame, stored on `agent_chat_sessions.runtime_state` + `runtime_state_at`; the composite reads it directly. `session_events` is demoted to pure description; a ~20s client re-affirm keeps a long turn fresh. Old clients (`runtime_state_at IS NULL`) fall back to the event proxy for **one release cycle**. Agent-global runtime is kept **double-written** (not removed) this PR.

### Changes by layer
- **shared**: `session:runtime` WS frame; `RUNTIME_STALE_MS`; `MeChatRow.busyAgentIds` (named to avoid the retired `workingAgentIds` wire name).
- **db (migration `0049`)**: `runtime_state` (`NOT NULL DEFAULT 'idle'`) + `runtime_state_at` (**NULLABLE, no default** — the new/old-client discriminator).
- **server**: `ws-client` routes `session:runtime` + `session:state` through the per-(agent,chat) FIFO queue (each op catches internally); `activity.setSessionRuntime` updates only `active` rows and notifies when the *effective composite* could change (value change / NULL→non-null / stale→fresh) but stays silent on a fresh same-value re-affirm; `notifier` + org WS broadcast `session:runtime`; `getChatAgentStatuses` and `deriveWorkingAgents` read per-chat runtime (authoritative) with a `runtime_state_at IS NULL` fallback, both gated on an active session.
- **client**: per-chat runtime report on change + ~20s re-affirm (independent of `evictIdle`, doesn't touch `lastActivity`); `getSessionRuntimeStates` so `fullStateSync` re-asserts real working on a network reconnect; `agent-slot`/`client-connection` wiring.
- **web**: `use-admin-ws` invalidates `chat-agent-status` + `me/chats` on `session:runtime` (throttled, not `session-events`); chat-list dots read `busyAgentIds`; components tolerate `working` with no live activity.

## Related
- Tree proposal: agent-team-foundation/first-tree-context#333 (merged).

## Verification
- `pnpm typecheck` 13/13, `pnpm check` (biome) clean.
- Tests: **server 1173** / shared 277 / web 272; client unit suite (re-affirm, `getSessionRuntimeStates`, fullStateSync) — pre-existing env-only `first-tree-cli-contract` failure is unrelated.
- Migration `0049` applied on real Postgres (testcontainers + dev-stack boot).
- **WS frame-level integration harness** (`ws-session-runtime.test.ts`): drives agent WS → server → org WS → DB for all 5 behavioral cases (long-working freshness, codex no-events working, #366 isolation, reconnect/disconnect, org WS realtime + same-value notify rules) — all green.
- Review: codex two design rounds + one code-level round → **"可提交"**; its non-blocking comment note already addressed.

## Backlog (NOT in this PR)
- Retire agent-global `agent_presence.runtime_state` (drop column; admin overview + fault notifications → per-chat).
- Human-eyes gold-standard pass (real agent in a browser) — can be done at staging/PR stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
