### PR TITLE
feat(client,web): show agent runtime errors as distinct timeline events

### DIFF
--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from "@first-tree/shared";
+import type { SessionEvent, SessionState } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
@@ -12,14 +12,19 @@ import { mockEntry } from "./test-helpers.js";
  *
  * When `handler.start` or `handler.resume` throws, the SessionManager must
  *   1) emit `session:state=errored` to the server so admin / UI see it,
- *   2) forward a user-visible chat message via the result-sink so the chat
- *      doesn't go silent, and
+ *   2) emit a structured `error` session event so the chat timeline renders
+ *      the failure with its distinct ErrorRow styling (NOT a plain text
+ *      message — that would be indistinguishable from a normal agent reply),
  *   3) recover so the next inbound message for the same chat can start a
  *      fresh session.
  *
- * Pre-fix the catch block only torn local state down — the server still
- * thought the session was `active`, and no chat message surfaced the
- * failure to the user.
+ * Historical note: pre-2026-05 this path forwarded a `⚠️ Session ... failed`
+ * **text** message via the result-sink. That worked but rendered identical
+ * to a normal agent reply in the chat timeline, so users couldn't tell the
+ * agent had crashed vs replied "I failed". The forward path was replaced
+ * with a `kind: "error"` session event; the web `ErrorRow` component
+ * renders these with a red left-border + tinted background + `error · ...`
+ * header so the failure is visually distinguishable.
  */
 
 function mockSdk(): {
@@ -45,6 +50,7 @@ function mockSdk(): {
 function makeSessionManager(opts: {
   handlers: AgentHandler[];
   onStateChange?: (chatId: string, state: SessionState) => void;
+  onSessionEvent?: (chatId: string, event: SessionEvent) => void;
   sdk?: FirstTreeHubSDK;
 }) {
   const factory: HandlerFactory = () => {
@@ -69,6 +75,7 @@ function makeSessionManager(opts: {
     log: silentLogger(),
     ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
     onStateChange: opts.onStateChange,
+    onSessionEvent: opts.onSessionEvent,
   });
 }
 
@@ -107,40 +114,56 @@ describe("SessionManager: session-start failure signalling (F2)", () => {
     await sm.shutdown();
   });
 
-  it("forwards a user-visible error message via the result sink", async () => {
+  it("emits a structured error session event (not a plain text message)", async () => {
     const { sdk, sendMessage } = mockSdk();
-    const sm = makeSessionManager({ handlers: [failingHandler()], sdk });
+    const events: Array<{ chatId: string; event: SessionEvent }> = [];
+    const sm = makeSessionManager({
+      handlers: [failingHandler()],
+      sdk,
+      onSessionEvent: (chatId, event) => events.push({ chatId, event }),
+    });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-fail" }));
 
-    // sendMessage gets called once — the forwarded user-visible error.
-    // The chat shows `Session start failed (<agent>): <truncated err>`.
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const [, payload] = sendMessage.mock.calls[0] ?? [];
-    const content = (payload as { content?: string })?.content ?? "";
-    expect(content).toContain("Session start failed");
-    expect(content).toContain("Test Agent");
-    expect(content).toContain("git worktree add failed");
+    // No plain text forward — errors do NOT round-trip through sendMessage
+    // anymore; otherwise they'd be indistinguishable from a normal reply.
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    const errorEvents = events.filter((e) => e.event.kind === "error");
+    expect(errorEvents).toHaveLength(1);
+    const errorEvent = errorEvents[0];
+    expect(errorEvent?.chatId).toBe("chat-fail");
+    expect(errorEvent?.event.kind).toBe("error");
+    if (errorEvent?.event.kind === "error") {
+      expect(errorEvent.event.payload.source).toBe("runtime");
+      expect(errorEvent.event.payload.message).toContain("Session start failed");
+      expect(errorEvent.event.payload.message).toContain("git worktree add failed");
+    }
 
     await sm.shutdown();
   });
 
-  it("truncates the forwarded error to ~800 characters to keep stderr out of the chat", async () => {
-    const { sdk, sendMessage } = mockSdk();
+  it("truncates the error preview to ~800 characters to keep stderr out of the chat", async () => {
     const giant = `boom: ${"x".repeat(2000)}`;
     const handler = workingHandler();
     handler.start = vi.fn().mockRejectedValue(new Error(giant));
-    const sm = makeSessionManager({ handlers: [handler], sdk });
+    const events: SessionEvent[] = [];
+    const sm = makeSessionManager({
+      handlers: [handler],
+      onSessionEvent: (_chatId, event) => events.push(event),
+    });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-huge-err" }));
 
-    const [, payload] = sendMessage.mock.calls[0] ?? [];
-    const content = (payload as { content?: string })?.content ?? "";
-    // The forwarded body keeps a short prefix ("Session start failed (…): "),
-    // then up to 800 chars of the original message. Headers + prefix put a
-    // floor on total length but the bulk of `xxx…` cap is 800.
-    expect(content.length).toBeLessThan(900);
-    expect(content).toContain("boom: ");
+    const errEvent = events.find((e) => e.kind === "error");
+    expect(errEvent).toBeDefined();
+    if (errEvent?.kind === "error") {
+      // The event message keeps a short prefix ("Session start failed: "),
+      // then up to 800 chars of the original message. Prefix + the 800-char
+      // cap puts a hard ceiling well under 900.
+      expect(errEvent.payload.message.length).toBeLessThan(900);
+      expect(errEvent.payload.message).toContain("boom: ");
+    }
   });
 
   it("allows the next inbound message for the same chat to start a fresh session", async () => {
@@ -179,6 +202,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
   function makeSerializedManager(opts: {
     handlerQueue: AgentHandler[];
     onStateChange?: (chatId: string, state: SessionState) => void;
+    onSessionEvent?: (chatId: string, event: SessionEvent) => void;
     sdk?: FirstTreeHubSDK;
   }) {
     const queue = [...opts.handlerQueue];
@@ -199,13 +223,15 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       log: silentLogger(),
       ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
       onStateChange: opts.onStateChange,
+      onSessionEvent: opts.onSessionEvent,
     });
   }
 
-  it("emits onStateChange('errored') and forwards a chat-visible error when handler.resume throws", async () => {
+  it("emits onStateChange('errored') and a structured error event when handler.resume throws", async () => {
     // Stage: handlerA.start() succeeds; chat-B start preempts chat-A to
     // suspended; the third dispatch then hits resume on chat-A which throws.
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const events: Array<{ chatId: string; event: SessionEvent }> = [];
     const { sdk, sendMessage } = mockSdk();
     const handlerA: AgentHandler = {
       start: vi.fn().mockResolvedValue("session-A"),
@@ -218,6 +244,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       handlerQueue: [handlerA, workingHandler("session-B")],
       sdk,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      onSessionEvent: (chatId, event) => events.push({ chatId, event }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" })); // start succeeds
@@ -226,10 +253,25 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
     expect(chatAStates.at(-1)).toBe("errored");
-    const resumeFwd = sendMessage.mock.calls.find((call) =>
-      ((call[1] as { content?: string })?.content ?? "").includes("Session resume failed"),
+
+    const resumeErrEvent = events.find(
+      (e) =>
+        e.chatId === "chat-A" && e.event.kind === "error" && e.event.payload.message.includes("Session resume failed"),
     );
-    expect(resumeFwd).toBeDefined();
+    expect(resumeErrEvent).toBeDefined();
+    if (resumeErrEvent?.event.kind === "error") {
+      expect(resumeErrEvent.event.payload.source).toBe("runtime");
+      expect(resumeErrEvent.event.payload.message).toContain("git mirror fetch failed");
+    }
+
+    // sendMessage should NOT carry the error — that's the regression we're
+    // guarding against. (It may be called for unrelated bookkeeping, so we
+    // only check that no call references the error string.)
+    for (const call of sendMessage.mock.calls) {
+      const content = (call[1] as { content?: string })?.content ?? "";
+      expect(content).not.toContain("Session resume failed");
+    }
+
     expect(handlerA.resume).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -908,6 +908,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
           if (retryCount >= MAX_RETRIES || !claudeSessionId) {
             sessionCtx.log("Exhausted retries, session will be suspended");
+            // Surface to the chat timeline so the user sees the failure and
+            // doesn't think the agent silently stalled. The MAX_RETRIES
+            // case in particular drops the turn entirely — no result will
+            // be forwarded — so without an explicit error event the chat
+            // would just go quiet.
+            const preview = errMsg.slice(0, 800);
+            const reason = claudeSessionId
+              ? `Query failed after ${MAX_RETRIES} retries: ${preview}`
+              : `Query failed and no resume id available: ${preview}`;
+            sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: reason } });
+            sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             sessionCtx.setRuntimeState("error");
             return;
           }
@@ -923,11 +934,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           try {
             respawnQuery(claudeSessionId, sessionCtx);
           } catch (resumeErr) {
-            sessionCtx.log(`Auto-resume failed: ${resumeErr instanceof Error ? resumeErr.message : String(resumeErr)}`);
+            const resumeMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+            sessionCtx.log(`Auto-resume failed: ${resumeMsg}`);
             // Mirror the MAX_RETRIES branch above: leaving runtimeState at
             // `working` would block the SessionManager's idle-suspend grace
             // window from ever firing on this session, so the slot would
             // never be reclaimed.
+            sessionCtx.emitEvent({
+              kind: "error",
+              payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
+            });
+            sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             sessionCtx.setRuntimeState("error");
             return;
           }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -526,10 +526,12 @@ export class SessionManager {
       // server's `agent_chat_sessions.state` stayed `active`, no chat
       // message was emitted, and the agent looked silently failed to
       // every observer. F2 (chat-participant-mode-fix-design.md §3.3)
-      // signals the failure three ways: structured log (existing),
-      // `session:state=errored` to the server (so admin/UI see it), and
-      // a single user-visible chat message via the result-sink (so the
-      // requester knows the agent didn't drop their message on purpose).
+      // signals the failure two ways: structured log (existing), and a
+      // `session:state=errored` to the server (so admin/UI see it).
+      // A user-visible signal goes out as a structured `error` session
+      // event (rendered by the web ErrorRow), not as a plain text
+      // message — otherwise it's indistinguishable from a normal agent
+      // reply in the timeline.
       const errMsg = err instanceof Error ? err.message : String(err);
       const phase: "start" | "resume" = evicted ? "resume" : "start";
       this.config.log.error({ chatId, err, phase }, "session start/resume failed");
@@ -539,21 +541,18 @@ export class SessionManager {
       //    for this chat, this `errored` transition will go through.
       this.notifySessionState(chatId, "errored");
 
-      // 2) User-visible chat message. Truncate to 800 chars so we don't
-      //    leak full stderr (which may include FS paths or git internals)
-      //    into the chat timeline; the full error is in the structured log.
-      try {
-        const preview = errMsg.slice(0, 800);
-        const agentLabel = this.config.agentIdentity.displayName ?? this.config.agentIdentity.agentId;
-        const userMsg = `⚠️ Session ${phase} failed (${agentLabel}): ${preview}`;
-        await ctx.forwardResult(userMsg);
-      } catch (forwardErr) {
-        this.config.log.warn({ chatId, forwardErr }, "session error forward failed");
-      }
+      // 2) User-visible structured error event. Truncate to 800 chars so
+      //    we don't leak full stderr (which may include FS paths or git
+      //    internals) into the chat timeline; the full error is in the
+      //    structured log. The web `ErrorRow` renders these with distinct
+      //    error styling and a "session start/resume failed" header.
+      const preview = errMsg.slice(0, 800);
+      ctx.emitEvent({
+        kind: "error",
+        payload: { source: "runtime", message: `Session ${phase} failed: ${preview}` },
+      });
 
-      // 3) Existing local cleanup. Forward first, tear down second —
-      //    keeps the order obviously safe regardless of future cleanup-
-      //    block refactors. The follow-up message routes as a fresh
+      // 3) Existing local cleanup. The follow-up message routes as a fresh
       //    start once the entry is gone.
       this.sessions.delete(chatId);
       this.sessionRuntimeStates.delete(chatId);
@@ -613,21 +612,18 @@ export class SessionManager {
       // throws is not the same shape as a suspend (the entry is unusable,
       // not just idle), so leaving `status = "suspended"` would lie to the
       // server and let the broken entry persist locally. Notify `errored`,
-      // forward a chat-visible error, then drop the entry so the next
+      // emit a chat-visible error event, then drop the entry so the next
       // inbound message routes through `startNewSession` for a clean restart.
       const errMsg = err instanceof Error ? err.message : String(err);
       this.config.log.error({ chatId: entry.chatId, err }, "resume failed");
 
       this.notifySessionState(entry.chatId, "errored");
 
-      try {
-        const preview = errMsg.slice(0, 800);
-        const agentLabel = this.config.agentIdentity.displayName ?? this.config.agentIdentity.agentId;
-        const userMsg = `⚠️ Session resume failed (${agentLabel}): ${preview}`;
-        await ctx.forwardResult(userMsg);
-      } catch (forwardErr) {
-        this.config.log.warn({ chatId: entry.chatId, forwardErr }, "session error forward failed");
-      }
+      const preview = errMsg.slice(0, 800);
+      ctx.emitEvent({
+        kind: "error",
+        payload: { source: "runtime", message: `Session resume failed: ${preview}` },
+      });
 
       this.sessions.delete(entry.chatId);
       this.sessionRuntimeStates.delete(entry.chatId);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -203,9 +203,12 @@ function AssistantTextRow({
   );
 }
 
-function ErrorRow({ event }: { event: SessionEventRow }) {
+function ErrorRow({ event, agentNameFn }: { event: SessionEventRow; agentNameFn?: (id: string) => string }) {
   const payload = asErrorPayload(event.payload);
   const ts = formatClockTime(event.createdAt);
+  // Resolve the emitting agent so the header reads "error · <agent> · runtime · …".
+  // Falls back gracefully if the lookup function isn't provided (legacy callers).
+  const agentName = agentNameFn ? agentNameFn(event.agentId) : null;
   return (
     <div
       // Anchor for the compose rail's jump-to-timeline (failed → this agent's error).
@@ -218,7 +221,7 @@ function ErrorRow({ event }: { event: SessionEventRow }) {
       }}
     >
       <div className="mono uppercase text-caption" style={{ color: "var(--state-error)" }}>
-        error · {payload?.source ?? "unknown"} · {ts}
+        error{agentName ? ` · ${agentName}` : ""} · {payload?.source ?? "unknown"} · {ts}
       </div>
       <div
         className="text-label"
@@ -2414,7 +2417,7 @@ export function ChatView({
                           );
                           break;
                         case "error":
-                          node = <ErrorRow key={item.key} event={ev} />;
+                          node = <ErrorRow key={item.key} event={ev} agentNameFn={chatScopedAgentName} />;
                           break;
                         default:
                           // tool_call / thinking are folded into the workgroup


### PR DESCRIPTION
## Summary
- Agent runtime errors (session start/resume failures, claude-code query-loop retry exhaustion, auto-resume failures) used to be forwarded as plain text chat messages prefixed with `⚠️ Session ... failed`. In the chat timeline they were indistinguishable from a normal agent reply, so users couldn't tell the agent had crashed vs replied.
- Migrate all these paths to emit `kind: "error"` session events. The existing web `ErrorRow` component renders them with a red left-border, tinted background, and `error · ...` header — a visually distinct row. The existing `filterEventsForTimeline` already keeps error events visible across turn boundaries.
- `ErrorRow` also now resolves and shows the emitting agent's name in its header (`error · <agent> · runtime · <ts>`), helpful in group chats with multiple agents.

## What changed
- `packages/client/src/runtime/session-manager.ts` — `startNewSession` and `resumeSession` catch blocks now call `ctx.emitEvent({ kind: "error", payload: { source: "runtime", message: "Session start/resume failed: …" } })` instead of `ctx.forwardResult("⚠️ …")`.
- `packages/client/src/handlers/claude-code.ts` — MAX_RETRIES exhaustion and respawn failure branches now emit a `kind: "error"` event + a closing `kind: "turn_end"` with `status: "error"` before setting `runtimeState("error")`. Previously the timeline went silent after the retry loop gave up.
- `packages/web/src/pages/workspace/center/chat-view.tsx` — `ErrorRow` accepts `agentNameFn` and renders the emitting agent's name in its header.
- `packages/client/src/__tests__/session-start-error-signaling.test.ts` — updated to assert the new contract (event emitted via `onSessionEvent`, no plain-text message via `sendMessage`).

## Out of scope
Retry mechanics. The user noted retry will be handled in a separate PR.

## Test plan
- [x] `pnpm check` (passes — 0 errors)
- [x] `pnpm typecheck` (passes — 13/13 tasks successful)
- [x] `pnpm --filter @first-tree/client test --run` (520 / 523 pass; the 3 failing tests in `first-tree-cli-contract.integration.test.ts` fail identically on `main` because they require the `first-tree` CLI to be installed on PATH in the test environment)
- [x] `pnpm --filter @first-tree/web test --run` (272/272 pass)
- [x] `pnpm --filter @first-tree/shared test --run` (272/272 pass)
- [x] `pnpm --filter @first-tree/server test --run` (1157/1157 pass)
- [ ] Manual UI smoke: trigger a session start failure (e.g. invalid git repo config) and confirm the timeline shows a red ErrorRow with the agent name + error message, not a normal-looking message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)