### PR TITLE
feat(status): preview assistant reply text in compose status bar

### DIFF
--- a/packages/server/src/__tests__/me-chat-engaged-and-activity.test.ts
+++ b/packages/server/src/__tests__/me-chat-engaged-and-activity.test.ts
@@ -1,6 +1,13 @@
+import { ASSISTANT_TEXT_PREVIEW_MAX } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { createMeChat, listMeChats, previewToolArgs, toLiveActivity } from "../services/me-chat.js";
+import {
+  createMeChat,
+  listMeChats,
+  previewAssistantText,
+  previewToolArgs,
+  toLiveActivity,
+} from "../services/me-chat.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -349,7 +356,7 @@ describe("toLiveActivity pure helper", () => {
     expect(a?.startedAt).toBe("2026-05-14T01:23:45.000Z");
   });
 
-  it("tool_call carries a `detail` arg preview; thinking/writing have none", () => {
+  it("tool_call carries a `detail` arg preview; thinking has none", () => {
     const bash = toLiveActivity({
       ...baseRow,
       kind: "tool_call",
@@ -361,6 +368,40 @@ describe("toLiveActivity pure helper", () => {
       toLiveActivity({ ...baseRow, kind: "tool_call", payload: { name: "Bash", args: {} } })?.detail,
     ).toBeUndefined();
     expect(toLiveActivity({ ...baseRow, kind: "thinking" })?.detail).toBeUndefined();
+  });
+
+  it("assistant_text carries a collapsed reply preview; empty text → none", () => {
+    const writing = toLiveActivity({
+      ...baseRow,
+      kind: "assistant_text",
+      payload: { text: "Let me check\n the  schema first" },
+    });
+    expect(writing?.label).toBe("Writing");
+    expect(writing?.detail).toBe("Let me check the schema first");
+    // Empty / whitespace-only / missing block → no detail (status bar falls
+    // back to the static "Writing").
+    expect(toLiveActivity({ ...baseRow, kind: "assistant_text", payload: { text: "   " } })?.detail).toBeUndefined();
+    expect(toLiveActivity({ ...baseRow, kind: "assistant_text", payload: {} })?.detail).toBeUndefined();
+  });
+});
+
+describe("previewAssistantText", () => {
+  it("returns undefined for non-string / empty / whitespace-only", () => {
+    expect(previewAssistantText(undefined)).toBeUndefined();
+    expect(previewAssistantText(null)).toBeUndefined();
+    expect(previewAssistantText(123)).toBeUndefined();
+    expect(previewAssistantText("")).toBeUndefined();
+    expect(previewAssistantText("   \n  ")).toBeUndefined();
+  });
+
+  it("collapses whitespace to a single line", () => {
+    expect(previewAssistantText("foo   bar\nbaz")).toBe("foo bar baz");
+  });
+
+  it("hard-caps to ASSISTANT_TEXT_PREVIEW_MAX chars without an ellipsis", () => {
+    const out = previewAssistantText("x".repeat(ASSISTANT_TEXT_PREVIEW_MAX + 50));
+    expect(out).toHaveLength(ASSISTANT_TEXT_PREVIEW_MAX);
+    expect(out).not.toContain("…");
   });
 });
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -20,6 +20,8 @@ import { randomUUID } from "node:crypto";
 import {
   type AddMeChatParticipants,
   AGENT_VISIBILITY,
+  ASSISTANT_TEXT_PREVIEW_MAX,
+  type AssistantTextEventPayload,
   CHAT_ENGAGEMENT_STATUSES,
   type ChatEngagementStatus,
   type ChatEngagementView,
@@ -723,6 +725,21 @@ export function previewToolArgs(args: unknown): string | undefined {
 }
 
 /**
+ * One-line preview of an assistant text block for the compose status bar's
+ * liveness detail. Whitespace-collapsed and hard-capped to
+ * {@link ASSISTANT_TEXT_PREVIEW_MAX} — no trailing "…" is added, since the
+ * rail's CSS owns the visible ellipsis. Returns undefined for an empty /
+ * whitespace-only block so the status bar falls back to the static "Writing".
+ * Exported for unit testing.
+ */
+export function previewAssistantText(text: unknown): string | undefined {
+  if (typeof text !== "string") return undefined;
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  if (oneLine.length === 0) return undefined;
+  return oneLine.slice(0, ASSISTANT_TEXT_PREVIEW_MAX);
+}
+
+/**
  * Translate a `session_events` row into a `LiveActivity`, or null when the
  * kind is terminal (`turn_end` / `error`) or unrecognised. Pure & exported
  * for unit testing.
@@ -744,8 +761,17 @@ export function toLiveActivity(row: {
     }
     case "thinking":
       return { agentId: row.agent_id, kind: "thinking", label: "Thinking", startedAt };
-    case "assistant_text":
-      return { agentId: row.agent_id, kind: "assistant_text", label: "Writing", startedAt };
+    case "assistant_text": {
+      const payload = (row.payload ?? {}) as Partial<AssistantTextEventPayload>;
+      const detail = previewAssistantText(payload.text);
+      return {
+        agentId: row.agent_id,
+        kind: "assistant_text",
+        label: "Writing",
+        startedAt,
+        ...(detail ? { detail } : {}),
+      };
+    }
     default:
       // turn_end / error / unknown → no live indicator
       return null;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -319,6 +319,7 @@ export {
 } from "./schemas/invitation.js";
 export {
   type AddMeChatParticipants,
+  ASSISTANT_TEXT_PREVIEW_MAX,
   addMeChatParticipantsSchema,
   CHAT_ENGAGEMENT_VIEWS,
   type ChatEngagementView,

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -137,12 +137,17 @@ export const liveActivitySchema = z.object({
   /** ISO timestamp of the originating event; web uses this as the ticker base. */
   startedAt: z.string(),
   /**
-   * Optional truncated context for a tool call — a preview of the tool's args
-   * (e.g. "npm test" for Bash, a path for Read), already trimmed to a short
-   * length server-side. Only the compose status bar (the focal "what's
-   * happening now" strip) renders it; the chat-row WorkingChip and the
-   * AgentRow second line intentionally stay at `Using <tool> · <timer>`
-   * without it. Absent for thinking / writing and when there are no args.
+   * Optional truncated context for the activity, already trimmed server-side:
+   *   - tool_call → a preview of the tool's args (e.g. "npm test" for Bash, a
+   *     path for Read). Absent when there are no useful args.
+   *   - assistant_text → a one-line preview of the reply body the model is
+   *     writing (collapsed + capped to {@link ASSISTANT_TEXT_PREVIEW_MAX}), so
+   *     the compose status bar can read out *what* the agent is saying instead
+   *     of a static "Writing". Absent when the text block is empty.
+   * Only the compose status bar (the focal "what's happening now" strip)
+   * renders it; the chat-row WorkingChip and the AgentRow second line
+   * intentionally stay at `Using <tool> · <timer>` without it. Absent for
+   * thinking.
    */
   detail: z.string().optional(),
 });
@@ -150,6 +155,15 @@ export type LiveActivity = z.infer<typeof liveActivitySchema>;
 
 /** Stale threshold (ms) past which a `session_events` row stops driving liveActivity. */
 export const LIVE_ACTIVITY_STALE_MS = 60_000;
+
+/**
+ * Max length of the assistant-text reply preview surfaced in
+ * `LiveActivity.detail` for the compose status bar. Purely a wire bound (the
+ * stored block can be up to 8000 chars) — the visible length is capped far
+ * lower by the rail's CSS `max-width`, so this sits beyond what ever renders
+ * and the on-screen ellipsis stays CSS-driven. No trailing "…" is appended.
+ */
+export const ASSISTANT_TEXT_PREVIEW_MAX = 120;
 
 export const meChatRowSchema = z.object({
   chatId: z.string(),

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -41,6 +41,11 @@ const ATTENTION: ReadonlySet<string> = new Set(["needs_you", "failed", "working"
 const TICK_INTERVAL_MS = 1000;
 const LEAD_HOLD_MS = 4000;
 const EXPANDED_MAX_HEIGHT = 180;
+/** Visual cap (in pixels) for the assistant-text reply preview, so it reads as a
+ *  glance (one clause) on the rail instead of sprawling across the wide composer;
+ *  CSS `truncate` adds the ellipsis. Roughly 30 CJK / 55 latin chars at the
+ *  caption font size. */
+const ASSISTANT_PREVIEW_MAX_WIDTH = 300;
 
 function isAlert(s: AgentChatStatus): boolean {
   return s.main === "needs_you" || s.main === "failed";
@@ -290,11 +295,18 @@ function WorkingDetail({ activity }: { activity: LiveActivity | null }) {
   );
 }
 
-/** "Thinking" / "Writing" (sans) or "Using <tool> · <arg>" (sans word + mono
- *  tool/arg). arg preview is already truncated server-side. */
+/** "Thinking" (sans), the assistant reply preview ("…what the agent is saying",
+ *  falling back to "Writing" when the block is empty), or "Using <tool> · <arg>"
+ *  (sans word + mono tool/arg). Both previews are already truncated server-side;
+ *  the reply preview is additionally width-capped so it reads as a glance. */
 function ActivityText({ activity }: { activity: LiveActivity }) {
   if (activity.kind === "thinking") return <span className="truncate">Thinking</span>;
-  if (activity.kind === "assistant_text") return <span className="truncate">Writing</span>;
+  if (activity.kind === "assistant_text")
+    return (
+      <span className="truncate" style={{ maxWidth: ASSISTANT_PREVIEW_MAX_WIDTH }}>
+        {activity.detail ?? "Writing"}
+      </span>
+    );
   return (
     <span className="inline-flex min-w-0 items-center" style={{ gap: 4 }}>
       <span className="shrink-0">Using</span>


### PR DESCRIPTION
## Summary

While an agent is working, the composer status bar showed a static **"Writing"** for `assistant_text` activity — uninformative. This surfaces a one-line preview of the reply body the model is producing, so the rail reads out *what* the agent is saying (a liveness signal).

The text already lives in `session_events` (`assistant_text.text`), so there is **no client / storage change** — the server just stops discarding it and the web just renders it.

**Before** `● coder · Writing · 3s` → **After** `● coder · 我先看下 compose 这块怎么实现 · 8s`

## Changes

- **shared** (`schemas/me-chat.ts`, `index.ts`): add `ASSISTANT_TEXT_PREVIEW_MAX` (120) wire cap; `LiveActivity.detail` now also carries the `assistant_text` reply preview (comment updated; field reused, not new).
- **server** (`services/me-chat.ts`): new `previewAssistantText()` (whitespace-collapse + hard cap, **no** ellipsis) feeds `toLiveActivity`'s `assistant_text` branch; empty text → no `detail` so the bar falls back to "Writing".
- **web** (`components/chat/compose-status-bar.tsx`): `ComposeStatusBar` renders the preview, `max-width: 300px` so it stays a glance — CSS `truncate` owns the visible ellipsis.

## Design notes

- **Two caps, separate jobs**: server 120-char wire bound + web 300px visual bound. 300px keeps it a one-clause glance on the wide composer; CSS is the single ellipsis source (script-fair for CJK vs latin). 120 > any visible amount, so no double ellipsis.
- Only `assistant_text` gets the visual cap — tool args are already server-capped at 32, the rest are fixed short words.
- `thinking` content is still not persisted; out of scope here.

## Verification

- `pnpm typecheck` 13/13 ✓
- web vitest 272 ✓ (incl. compose-status-bar)
- server vitest 1149 ✓ (incl. new `previewAssistantText` / `toLiveActivity` cases)
- biome clean (only pre-existing unrelated warnings)

Reviewed by codex-reviewer — no blocking issues (`detail` reuse confirmed contained: only ComposeStatusBar reads it; WorkingChip/AgentRow still use `label` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
