### PR TITLE
test(web): polish chat-cache primitives — symmetric resolve + tests (#129 N1+N4)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.5.0",
+    "fake-indexeddb": "^6.2.5",
     "tailwindcss": "^4.2.2",
     "tailwindcss-animate": "^1.0.7",
     "vite": "^6.3.0",

--- a/packages/web/src/api/__tests__/message-store.test.ts
+++ b/packages/web/src/api/__tests__/message-store.test.ts
@@ -1,0 +1,118 @@
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageWithDelivery } from "../chats.js";
+
+function msg(id: string, createdAt: string, overrides: Partial<MessageWithDelivery> = {}): MessageWithDelivery {
+  return {
+    id,
+    chatId: "chat-1",
+    senderId: "user-1",
+    format: "text",
+    content: { text: id },
+    metadata: {},
+    inReplyTo: null,
+    source: "web",
+    createdAt,
+    ...overrides,
+  };
+}
+
+const T = (s: number) => new Date(2026, 0, 1, 0, 0, s).toISOString();
+
+// `message-store` caches its DB open across calls (module-scoped
+// `dbPromise`). Reset the module + give each test a fresh fake IDB so the
+// cache-from-prior-test does not leak into the next.
+async function loadStore() {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  return import("../message-store.js");
+}
+
+describe("message-store / getCachedMessages", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("returns [] on cold cache", async () => {
+    const { getCachedMessages } = await loadStore();
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+
+  it("returns [] when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    // Simulate a browser without IndexedDB — `typeof indexedDB === "undefined"`.
+    // Use `delete` rather than assigning `undefined` so the typeof check fires.
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { getCachedMessages, cacheMessages } = await import("../message-store.js");
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+
+  it("returns rows ordered ascending by createdAt regardless of insert order", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("c", T(3)), msg("a", T(1)), msg("b", T(2))]);
+    const rows = await getCachedMessages("chat-1");
+    expect(rows.map((m) => m.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("scopes results to the requested chatId", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+    await cacheMessages("chat-2", [msg("b", T(2), { chatId: "chat-2" })]);
+    expect((await getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["a"]);
+    expect((await getCachedMessages("chat-2")).map((m) => m.id)).toEqual(["b"]);
+  });
+});
+
+describe("message-store / cacheMessages", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("is a no-op on empty input", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", []);
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+
+  it("upserts idempotently — repeated writes overwrite", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1), { content: { text: "v1" } })]);
+    await cacheMessages("chat-1", [msg("a", T(1), { content: { text: "v2" } })]);
+    const rows = await getCachedMessages("chat-1");
+    expect(rows).toHaveLength(1);
+    const [row] = rows;
+    expect(row).toBeDefined();
+    expect((row?.content as { text: string }).text).toBe("v2");
+  });
+
+  it("defensively skips messages whose chatId doesn't match the call's chatId", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1)), msg("rogue", T(2), { chatId: "chat-other" })]);
+    const rows = await getCachedMessages("chat-1");
+    expect(rows.map((m) => m.id)).toEqual(["a"]);
+    expect(await getCachedMessages("chat-other")).toEqual([]);
+  });
+});
+
+describe("message-store / clearChatCache", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("removes only the targeted chat's rows", async () => {
+    const { cacheMessages, clearChatCache, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1)), msg("b", T(2))]);
+    await cacheMessages("chat-2", [msg("c", T(3), { chatId: "chat-2" })]);
+    await clearChatCache("chat-1");
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+    expect((await getCachedMessages("chat-2")).map((m) => m.id)).toEqual(["c"]);
+  });
+
+  it("is a no-op when the chat has no cached rows", async () => {
+    const { clearChatCache, getCachedMessages } = await loadStore();
+    await clearChatCache("chat-1");
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+});

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -98,15 +98,13 @@ export async function getCachedMessages(chatId: string): Promise<MessageWithDeli
     const req = index.openCursor(range);
     req.onsuccess = () => {
       const cursor = req.result;
-      if (!cursor) {
-        resolve(out);
-        return;
-      }
+      if (!cursor) return;
       const row = cursor.value as StoredMessage;
       out.push(row.payload);
       cursor.continue();
     };
-    req.onerror = () => resolve(out);
+    tx.oncomplete = () => resolve(out);
+    tx.onerror = () => resolve(out);
     tx.onabort = () => resolve(out);
   });
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -78,6 +78,7 @@ import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
 import { cn } from "../../../lib/utils.js";
+import { findGapAfterMessageId } from "../../../utils/chat-gap.js";
 import { computeRequiresMention } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 import { ChatRightSidebar } from "../right-sidebar/index.js";
@@ -1311,34 +1312,10 @@ export function ChatView({
     return Array.from(byId.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }, [cachedMessages, messagesData]);
 
-  // Detect a known gap between the cache range and the server's "last 50"
-  // window: if there's no overlap and the server's oldest fetched message
-  // is strictly newer than the cache's newest, the user was away long
-  // enough that more than 50 messages went past in between, and we have
-  // no way to fill them in until cursor pagination ships. Render a banner
-  // after the message id returned here. Returns null when there's overlap
-  // (the common case) or when either side is empty.
-  const gapAfterMessageId = useMemo<string | null>(() => {
-    const fromCache = cachedMessages ?? [];
-    const fromServer = messagesData?.items ?? [];
-    const firstCached = fromCache[0];
-    const firstServer = fromServer[0];
-    if (!firstCached || !firstServer) return null;
-    const serverIds = new Set(fromServer.map((m) => m.id));
-    for (const cached of fromCache) {
-      if (serverIds.has(cached.id)) return null;
-    }
-    let newestCached = firstCached;
-    for (const m of fromCache) {
-      if (m.createdAt > newestCached.createdAt) newestCached = m;
-    }
-    let oldestServer = firstServer;
-    for (const m of fromServer) {
-      if (m.createdAt < oldestServer.createdAt) oldestServer = m;
-    }
-    if (oldestServer.createdAt <= newestCached.createdAt) return null;
-    return newestCached.id;
-  }, [cachedMessages, messagesData]);
+  const gapAfterMessageId = useMemo<string | null>(
+    () => findGapAfterMessageId(cachedMessages ?? [], messagesData?.items ?? []),
+    [cachedMessages, messagesData],
+  );
 
   const items: TimelineItem[] = useMemo(() => {
     const rawEvents = eventsData?.items ?? [];

--- a/packages/web/src/utils/__tests__/chat-gap.test.ts
+++ b/packages/web/src/utils/__tests__/chat-gap.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { MessageWithDelivery } from "../../api/chats.js";
+import { findGapAfterMessageId } from "../chat-gap.js";
+
+function msg(id: string, createdAt: string): MessageWithDelivery {
+  return {
+    id,
+    chatId: "chat-1",
+    senderId: "user-1",
+    format: "text",
+    content: { text: id },
+    metadata: {},
+    inReplyTo: null,
+    source: "web",
+    createdAt,
+  };
+}
+
+const T = (s: number) => new Date(2026, 0, 1, 0, 0, s).toISOString();
+
+describe("findGapAfterMessageId", () => {
+  it("returns null when the cache side is empty", () => {
+    expect(findGapAfterMessageId([], [msg("a", T(1))])).toBeNull();
+  });
+
+  it("returns null when the server side is empty", () => {
+    expect(findGapAfterMessageId([msg("a", T(1))], [])).toBeNull();
+  });
+
+  it("returns null when both sides are empty", () => {
+    expect(findGapAfterMessageId([], [])).toBeNull();
+  });
+
+  it("returns null when cache and server overlap by id", () => {
+    const cache = [msg("a", T(1)), msg("b", T(2)), msg("c", T(3))];
+    const server = [msg("b", T(2)), msg("c", T(3)), msg("d", T(4))];
+    expect(findGapAfterMessageId(cache, server)).toBeNull();
+  });
+
+  it("returns the newest cached id when strictly disjoint and server is newer", () => {
+    const cache = [msg("a", T(1)), msg("b", T(2))];
+    const server = [msg("c", T(3)), msg("d", T(4))];
+    expect(findGapAfterMessageId(cache, server)).toBe("b");
+  });
+
+  it("picks the newest cached id by createdAt, not insertion order", () => {
+    const cache = [msg("a", T(2)), msg("b", T(1))];
+    const server = [msg("c", T(5))];
+    expect(findGapAfterMessageId(cache, server)).toBe("a");
+  });
+
+  it("uses the oldest server message (not the first one) when checking for overlap window", () => {
+    const cache = [msg("a", T(1)), msg("b", T(5))];
+    const server = [msg("c", T(10)), msg("d", T(7))];
+    expect(findGapAfterMessageId(cache, server)).toBe("b");
+  });
+
+  it("returns null when the server's oldest message is the same time as the cache's newest (no real gap)", () => {
+    const cache = [msg("a", T(2))];
+    const server = [msg("c", T(2)), msg("d", T(3))];
+    expect(findGapAfterMessageId(cache, server)).toBeNull();
+  });
+
+  it("returns null in the reverse case where server is older than cache", () => {
+    const cache = [msg("a", T(10))];
+    const server = [msg("b", T(1)), msg("c", T(2))];
+    expect(findGapAfterMessageId(cache, server)).toBeNull();
+  });
+});

--- a/packages/web/src/utils/chat-gap.ts
+++ b/packages/web/src/utils/chat-gap.ts
@@ -1,0 +1,39 @@
+import type { MessageWithDelivery } from "../api/chats.js";
+
+/**
+ * Detect a known gap between the IDB cache range and the server's "last 50"
+ * window. If there is no id-overlap and the server's oldest fetched message
+ * is strictly newer than the cache's newest, the user was away long enough
+ * that more than 50 messages went past in between and there is no way to
+ * fill them in until cursor pagination ships.
+ *
+ * Returns the id of the newest cached message (= the anchor before which the
+ * gap banner should render) when a gap is detected. Returns `null` when
+ * there is overlap (the common case), when either side is empty, or when
+ * the server window already reaches at least as far back as the cache.
+ */
+export function findGapAfterMessageId(
+  fromCache: readonly MessageWithDelivery[],
+  fromServer: readonly MessageWithDelivery[],
+): string | null {
+  const firstCached = fromCache[0];
+  const firstServer = fromServer[0];
+  if (!firstCached || !firstServer) return null;
+
+  const serverIds = new Set(fromServer.map((m) => m.id));
+  for (const cached of fromCache) {
+    if (serverIds.has(cached.id)) return null;
+  }
+
+  let newestCached = firstCached;
+  for (const m of fromCache) {
+    if (m.createdAt > newestCached.createdAt) newestCached = m;
+  }
+  let oldestServer = firstServer;
+  for (const m of fromServer) {
+    if (m.createdAt < oldestServer.createdAt) oldestServer = m;
+  }
+
+  if (oldestServer.createdAt <= newestCached.createdAt) return null;
+  return newestCached.id;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.0
         version: 4.7.0(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -3414,6 +3417,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -7972,6 +7979,8 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-decode-uri-component@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Follow-up polish for [`agent-team-foundation/first-tree-all#129`](https://github.com/agent-team-foundation/first-tree-all/issues/129) (PR #286 / M1 review nits). In scope: **N1 + N4**. Out of scope: N2 (user-driven cache cleanup, deferred), N3 (already shipped), N5 (timeline helper extraction, skipped).

Parent issue: [`agent-team-foundation/first-tree-all#118`](https://github.com/agent-team-foundation/first-tree-all/issues/118).

### N4 — Symmetric `resolve` in cache primitives

`packages/web/src/api/message-store.ts`: `getCachedMessages` used to resolve eagerly inside the cursor-end branch, while `cacheMessages` and `clearChatCache` settle via `tx.oncomplete`. Standardised on the `tx.oncomplete/onerror/onabort` pattern across all three so the file reads the same way end to end. Semantically equivalent for a readonly transaction — the cursor has already produced every row by the time `oncomplete` fires.

### N1 — Unit tests for cache + gap detection

- Lifted the `gapAfterMessageId` `useMemo` out of `chat-view.tsx` into a pure helper `utils/chat-gap.ts` (`findGapAfterMessageId(cache, server)`) so it can be unit-tested without rendering React.
- Added `packages/web/src/utils/__tests__/chat-gap.test.ts` (9 cases): empty sides, id overlap, strict-disjoint, out-of-order `createdAt` on either side, equal-boundary, reverse case.
- Added `packages/web/src/api/__tests__/message-store.test.ts` (9 cases, `fake-indexeddb`):
  - `getCachedMessages` — cold cache, IDB unavailable (`typeof indexedDB === "undefined"`), ordering, per-chat scoping
  - `cacheMessages` — empty-input no-op, idempotent upsert, defensive cross-chat skip
  - `clearChatCache` — targeted purge, no-op when nothing to clear

`fake-indexeddb ^6.2.5` added to `packages/web` devDeps.

## Test plan

- [x] `pnpm --filter @first-tree/web test` — 290 pass (18 new)
- [x] `pnpm --filter @first-tree/web typecheck` — clean
- [x] `pnpm check` — exit 0 (the 16 `noNonNullAssertion` warnings under `packages/github-scan` are pre-existing on `main`)
- [x] `pnpm test` (full monorepo) — all 6 packages pass

Closes: `agent-team-foundation/first-tree-all#129`