### PR TITLE
feat(status): show working agent's current-turn reply text in compose status bar

### DIFF
--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
+import type { LiveActivity } from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { pendingQuestions } from "../db/schema/pending-questions.js";
-import { getChatAgentStatuses } from "../services/agent-chat-status.js";
+import { getChatAgentStatuses, withTurnNarration } from "../services/agent-chat-status.js";
 import { createMeChat, deriveFailedAgents } from "../services/me-chat.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
@@ -109,6 +110,78 @@ describe("getChatAgentStatuses", () => {
     expect(s?.working).toBe(true);
     expect(s?.main).toBe("working");
     expect(s?.activity?.label).toBe("Bash");
+  });
+
+  it("keeps the current turn's narration on turnText even after a tool_call (sticky)", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    // Narration, then a tool_call right after — the tool_call is the newest
+    // event, so without sticky narration the bar would read "Using Read".
+    await app.db.execute(sql`
+      INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+      VALUES
+        (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 1, 'assistant_text',
+          ${JSON.stringify({ text: "Let me check compose-status-bar.tsx" })}::jsonb, NOW()),
+        (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 2, 'tool_call',
+          ${JSON.stringify({ toolUseId: "t1", name: "Read", args: { file_path: "x" }, status: "pending" })}::jsonb, NOW())
+    `);
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.main).toBe("working");
+    // Base activity stays the tool — sidebar / chat-list keep "Using Read".
+    expect(s?.activity?.kind).toBe("tool_call");
+    expect(s?.activity?.label).toBe("Read");
+    // Compose bar reads the sticky narration off turnText.
+    expect(s?.activity?.turnText).toBe("Let me check compose-status-bar.tsx");
+  });
+
+  it("does not carry a previous turn's narration into a fresh turn (turnText past turn_end)", async () => {
+    const { app, peer, chatId } = await newChatWithAgent();
+    await bindPresence(peer.agent.uuid, peer.clientId);
+    await setSession(peer.agent.uuid, chatId, "active");
+    await app.db.execute(sql`
+      INSERT INTO session_events (id, agent_id, chat_id, seq, kind, payload, created_at)
+      VALUES
+        (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 1, 'assistant_text',
+          ${JSON.stringify({ text: "old turn narration" })}::jsonb, NOW()),
+        (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 2, 'turn_end',
+          ${JSON.stringify({ status: "success" })}::jsonb, NOW()),
+        (${randomUUID()}, ${peer.agent.uuid}, ${chatId}, 3, 'tool_call',
+          ${JSON.stringify({ toolUseId: "t2", name: "Bash", args: null, status: "pending" })}::jsonb, NOW())
+    `);
+
+    const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+    expect(s?.main).toBe("working");
+    expect(s?.activity?.kind).toBe("tool_call");
+    expect(s?.activity?.turnText).toBeUndefined();
+  });
+});
+
+describe("withTurnNarration — sticky narration on the working activity", () => {
+  const base: LiveActivity = {
+    agentId: "a1",
+    kind: "tool_call",
+    label: "Bash",
+    startedAt: "2026-05-25T00:00:00.000Z",
+    detail: "npm test",
+  };
+
+  it("returns null when there is no base activity", () => {
+    expect(withTurnNarration(null, "anything")).toBeNull();
+  });
+
+  it("keeps the base activity unchanged when there is no narration text", () => {
+    expect(withTurnNarration(base, null)).toBe(base);
+    expect(withTurnNarration(base, "   ")).toBe(base);
+  });
+
+  it("attaches a collapsed narration as turnText without touching kind / label / detail", () => {
+    const out = withTurnNarration(base, "  Let me   check\nthe file  ");
+    expect(out?.kind).toBe("tool_call");
+    expect(out?.label).toBe("Bash");
+    expect(out?.detail).toBe("npm test");
+    expect(out?.turnText).toBe("Let me check the file");
   });
 });
 

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -11,7 +11,7 @@ import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
-import { derivePendingQuestions, toLiveActivity } from "./me-chat.js";
+import { derivePendingQuestions, previewAssistantText, toLiveActivity } from "./me-chat.js";
 
 /**
  * Composite per-(agent,chat) status for every non-human speaker in a chat —
@@ -93,15 +93,39 @@ export async function getChatAgentStatuses(db: Database, chatId: string): Promis
 }
 
 /**
+ * Sticky narration for a working agent's live activity. Surfaces the current
+ * turn's latest `assistant_text` (what the agent is *saying*) on `turnText` so
+ * the compose status bar keeps showing the narration even after a `tool_call`
+ * arrives — without it the activity is the single newest event, and a tool call
+ * fired right after a sentence buries the prose. Leaves `turnText` absent (base
+ * activity unchanged) when the turn has produced no prose yet. Base `kind` /
+ * `label` are preserved, so the sidebar AgentRow and chat-list chip keep
+ * reading `Using <tool>`. Pure & exported for unit testing.
+ */
+export function withTurnNarration(base: LiveActivity | null, narrationText: unknown): LiveActivity | null {
+  if (!base) return null;
+  const narration = previewAssistantText(narrationText);
+  return narration ? { ...base, turnText: narration } : base;
+}
+
+/**
  * Per-agent live activity in `chatId`: the latest `session_events` row per
  * pair, mapped through `toLiveActivity` (so terminal kinds → absent) and
  * dropped when older than the stale threshold. Per-pair LATERAL seek on the
  * unique `(agent_id, chat_id, seq)` index — the same shape as
  * `deriveLiveActivity`, resolved per agent rather than collapsed per chat.
+ *
+ * A second LATERAL seeks the current turn's latest `assistant_text` (seq past
+ * the last `turn_end`); `withTurnNarration` rides it along as `turnText` so the
+ * compose status bar can show the running narration even while a tool runs.
+ * Only this focused single-chat status query pays for the extra seek; the
+ * chat-list `deriveLiveActivity` is unchanged.
  */
 async function deriveAgentActivity(db: Database, chatId: string): Promise<Map<string, LiveActivity>> {
   const rows = (await db.execute(sql`
-    SELECT acs.agent_id AS agent_id, e.kind AS kind, e.payload AS payload, e.created_at AS created_at
+    SELECT acs.agent_id AS agent_id,
+           e.kind AS kind, e.payload AS payload, e.created_at AS created_at,
+           t.text AS turn_text
       FROM agent_chat_sessions acs
       CROSS JOIN LATERAL (
         SELECT kind, payload, created_at, seq
@@ -111,20 +135,43 @@ async function deriveAgentActivity(db: Database, chatId: string): Promise<Map<st
          ORDER BY se.seq DESC
          LIMIT 1
       ) e
+      LEFT JOIN LATERAL (
+        SELECT LEFT(se.payload->>'text', 200) AS text
+          FROM session_events se
+         WHERE se.agent_id = acs.agent_id
+           AND se.chat_id  = acs.chat_id
+           AND se.kind     = 'assistant_text'
+           AND se.seq > COALESCE((
+             SELECT MAX(se2.seq)
+               FROM session_events se2
+              WHERE se2.agent_id = acs.agent_id
+                AND se2.chat_id  = acs.chat_id
+                AND se2.kind     = 'turn_end'
+           ), 0)
+         ORDER BY se.seq DESC
+         LIMIT 1
+      ) t ON TRUE
      WHERE acs.chat_id = ${chatId}
        AND acs.state <> 'evicted'
-  `)) as unknown as Array<{ agent_id: string; kind: string; payload: unknown; created_at: Date | string }>;
+  `)) as unknown as Array<{
+    agent_id: string;
+    kind: string;
+    payload: unknown;
+    created_at: Date | string;
+    turn_text: string | null;
+  }>;
   const now = Date.now();
   const out = new Map<string, LiveActivity>();
   for (const r of rows) {
     if (now - new Date(r.created_at).getTime() > LIVE_ACTIVITY_STALE_MS) continue;
-    const activity = toLiveActivity({
+    const base = toLiveActivity({
       agent_id: r.agent_id,
       chat_id: chatId,
       kind: r.kind,
       payload: r.payload,
       created_at: r.created_at,
     });
+    const activity = withTurnNarration(base, r.turn_text);
     if (activity) out.set(r.agent_id, activity);
   }
   return out;

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -150,6 +150,17 @@ export const liveActivitySchema = z.object({
    * thinking.
    */
   detail: z.string().optional(),
+  /**
+   * The current turn's latest `assistant_text`, one-line preview (collapsed +
+   * capped to {@link ASSISTANT_TEXT_PREVIEW_MAX}). Distinct from `detail`,
+   * which describes the *latest event*: `turnText` is the agent's running
+   * narration for the whole turn, so a `tool_call` fired immediately after a
+   * sentence does not bury what the agent is saying. Populated only by the
+   * per-agent chat-status path (`agent-chat-status.ts`) and rendered only by
+   * the compose status bar's sticky lead; absent on the chat-list
+   * `liveActivity`, and absent when the turn has produced no prose yet.
+   */
+  turnText: z.string().optional(),
 });
 export type LiveActivity = z.infer<typeof liveActivitySchema>;
 

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -295,11 +295,21 @@ function WorkingDetail({ activity }: { activity: LiveActivity | null }) {
   );
 }
 
-/** "Thinking" (sans), the assistant reply preview ("…what the agent is saying",
- *  falling back to "Writing" when the block is empty), or "Using <tool> · <arg>"
- *  (sans word + mono tool/arg). Both previews are already truncated server-side;
- *  the reply preview is additionally width-capped so it reads as a glance. */
+/** The current turn's running narration (`turnText`, sticky across tool calls)
+ *  when present; else "Thinking", the latest assistant reply preview (falling
+ *  back to "Writing"), or "Using <tool> · <arg>" (sans word + mono tool/arg).
+ *  The narration / reply previews are truncated server-side and width-capped
+ *  here so they read as a glance. */
 function ActivityText({ activity }: { activity: LiveActivity }) {
+  // Sticky narration: the current turn's running reply text takes precedence
+  // over the tool_call / thinking indicator, so a tool call fired right after a
+  // sentence doesn't bury what the agent is saying.
+  if (activity.turnText)
+    return (
+      <span className="truncate" style={{ maxWidth: ASSISTANT_PREVIEW_MAX_WIDTH }}>
+        {activity.turnText}
+      </span>
+    );
   if (activity.kind === "thinking") return <span className="truncate">Thinking</span>;
   if (activity.kind === "assistant_text")
     return (


### PR DESCRIPTION
## Summary

While an agent is working, the compose status bar's live activity was driven by the single newest `session_events` row. An `assistant_text` (the agent's narration) is almost always immediately followed — within the same assistant message — by a higher-`seq` `tool_call`, so the activity collapsed to `Using <tool>` and the static "Writing" / #555 reply preview almost never appeared.

This makes the bar **stick the current turn's latest narration**: while working, it shows the most recent `assistant_text` of the turn (what the agent is saying), persisting even after a tool call.

**Before** `● coder · Using Read · chat-view.tsx · 3s` → **After** `● coder · Let me check compose-status-bar.tsx · 8s`

## Approach

A new scoped `LiveActivity.turnText`, populated only by the per-agent status path and rendered only by the compose status bar:

- **shared** (`schemas/me-chat.ts`): add optional `turnText` (reuses the `ASSISTANT_TEXT_PREVIEW_MAX` 120-char cap).
- **server** (`services/agent-chat-status.ts`): `deriveAgentActivity` adds a second `LEFT JOIN LATERAL` for the current turn's latest `assistant_text` (`seq` past the last `turn_end`); new pure `withTurnNarration` attaches it as `turnText` while preserving the base `kind`/`label`/`detail`.
- **web** (`components/chat/compose-status-bar.tsx`): `ActivityText` renders `turnText` before the tool/thinking text.

**Scope is contained** — the chat-list `deriveLiveActivity`, `toLiveActivity`, and the sidebar `WorkingChip` are untouched, so they keep reading `Using <tool>` (per the #555 surface split). No client/SDK change, no DB migration (the text already lives in `session_events`).

## Tests

- `agent-chat-status.test.ts`: +5 — 2 DB (narration sticks on `turnText` after a tool_call; cleared past a `turn_end`), 3 pure `withTurnNarration` cases.

## Verification

- `pnpm typecheck` 13/13
- biome clean (16 pre-existing warnings)
- shared 272 / web 272 / server 1166 (incl. the 5 new tests)

Reviewed by codex-reviewer — no blocking findings (scope confirmed contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
