### PR TITLE
fix(client): defend agent-error emit paths + test retry-exhaustion branches

### DIFF
--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * When the SDK query loop crashes and the handler attempts auto-resume but
+ * `respawnQuery` itself throws (e.g. the underlying SDK rejects a `query()`
+ * call synchronously), the handler must surface that failure the same way as
+ * MAX_RETRIES exhaustion:
+ *   - emit `kind:"error"` with `source:"runtime"` describing the auto-resume
+ *     failure so the chat timeline shows an ErrorRow
+ *   - emit `kind:"turn_end"` with `status:"error"` so the turn-grouping filter
+ *     closes out the dropped turn
+ *   - flip `runtimeState` to `"error"` so the SessionManager reclaims the slot
+ *
+ * Pre-fix this branch was silent like MAX_RETRIES — it only flipped the
+ * runtime state and returned with no chat-visible signal.
+ */
+
+// First query() call returns a failing iterator (drives the consumer loop
+// into its retry-catch). respawnQuery's next query() call throws
+// SYNCHRONOUSLY, triggering the auto-resume-failed branch.
+let queryCallCount = 0;
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const makeFailingQuery = () => ({
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          throw new Error("initial sdk transport crash");
+        },
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  });
+  return {
+    query: () => {
+      queryCallCount += 1;
+      if (queryCallCount >= 2) {
+        // Synchronous throw — buildQuery has no try/catch around the `query()`
+        // call, so this surfaces as a throw out of respawnQuery and lands in
+        // the auto-resume-failed catch.
+        throw new Error("respawn build failed: sdk module unavailable");
+      }
+      return makeFailingQuery();
+    },
+  };
+});
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430db";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-auto-resume-fail-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+describe("claude-code handler — auto-resume failure surfacing", () => {
+  it("emits error + turn_end:error and flips runtimeState when respawnQuery throws", async () => {
+    queryCallCount = 0;
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const emitted: SessionEvent[] = [];
+    const runtimeStates: string[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-resume-fail",
+      log: () => {},
+      touch: () => {},
+      setRuntimeState: (state) => runtimeStates.push(state),
+      emitEvent: (e) => emitted.push(e),
+      ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
+    };
+
+    await handler.start(
+      { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    const errors = emitted.filter((e) => e.kind === "error");
+    expect(errors).toHaveLength(1);
+    const err = errors[0];
+    if (!err || err.kind !== "error") throw new Error("expected error event");
+    expect(err.payload.source).toBe("runtime");
+    expect(err.payload.message).toContain("Auto-resume failed");
+    expect(err.payload.message).toContain("respawn build failed");
+
+    const turnEnds = emitted.filter((e) => e.kind === "turn_end");
+    expect(turnEnds).toHaveLength(1);
+    const te = turnEnds[0];
+    if (!te || te.kind !== "turn_end") throw new Error("expected turn_end event");
+    expect(te.payload.status).toBe("error");
+
+    // Same emit-order contract as the other error branches: error first,
+    // turn_end:error after.
+    const errIdx = emitted.findIndex((e) => e.kind === "error");
+    const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
+    expect(errIdx).toBeLessThan(turnEndIdx);
+
+    // setRuntimeState("error") MUST run so the SessionManager can reclaim
+    // the slot even though respawnQuery never produced a working session.
+    expect(runtimeStates).toContain("error");
+  });
+});

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * When the SDK query loop throws (process crash, transport reset, etc.) and
+ * the handler exhausts its MAX_RETRIES budget, it must surface the failure
+ * the same way as the other error branches:
+ *   - emit `kind:"error"` with `source:"runtime"`, carrying the underlying
+ *     error message, so the chat timeline's ErrorRow renders the failure
+ *   - emit `kind:"turn_end"` with `status:"error"` so the turn-grouping
+ *     filter on the frontend closes out the failed turn
+ *
+ * Pre-fix this path was silent — it only flipped runtimeState to "error"
+ * (so the SessionManager could reclaim the slot) and returned, leaving the
+ * chat with no visible signal that the agent had crashed.
+ */
+
+// Every query() call returns an iterator that throws on first .next() — the
+// handler should retry up to MAX_RETRIES (= 2) times, hitting three failures
+// total, then bail through the retry-exhausted branch.
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const makeFailingQuery = () => ({
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          throw new Error("sdk transport crashed");
+        },
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  });
+  return { query: () => makeFailingQuery() };
+});
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430da";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-retry-exhausted-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+describe("claude-code handler — retry-exhausted surfacing", () => {
+  it("emits error + turn_end:error and flips runtimeState to error after MAX_RETRIES", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const emitted: SessionEvent[] = [];
+    const runtimeStates: string[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-retry",
+      log: () => {},
+      touch: () => {},
+      setRuntimeState: (state) => runtimeStates.push(state),
+      emitEvent: (e) => emitted.push(e),
+      ...mockCtxPlumbing({ sendMessage }, "chat-retry"),
+    };
+
+    await handler.start(
+      { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    // Result auto-forward never ran — every iteration threw.
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    const errors = emitted.filter((e) => e.kind === "error");
+    expect(errors).toHaveLength(1);
+    const err = errors[0];
+    if (!err || err.kind !== "error") throw new Error("expected error event");
+    expect(err.payload.source).toBe("runtime");
+    expect(err.payload.message).toContain("Query failed after 2 retries");
+    expect(err.payload.message).toContain("sdk transport crashed");
+
+    const turnEnds = emitted.filter((e) => e.kind === "turn_end");
+    expect(turnEnds).toHaveLength(1);
+    const te = turnEnds[0];
+    if (!te || te.kind !== "turn_end") throw new Error("expected turn_end event");
+    expect(te.payload.status).toBe("error");
+
+    // Emit order: error first, then turn_end:error — same contract as the
+    // SDK-subtype-error and result-forward-failure branches so the chat UI's
+    // turn-grouping filter behaves identically across error paths.
+    const errIdx = emitted.findIndex((e) => e.kind === "error");
+    const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
+    expect(errIdx).toBeLessThan(turnEndIdx);
+
+    // setRuntimeState("error") MUST run so the SessionManager's idle path
+    // can reclaim the slot. (Pre-fix this was the only signal of failure.)
+    expect(runtimeStates).toContain("error");
+  });
+
+  it("still flips runtimeState to error even when emitEvent throws", async () => {
+    // Defensive contract: if the onSessionEvent callback throws (e.g. the
+    // agent-slot reporting hits a dead WS), the handler must still run
+    // setRuntimeState("error") so the SessionManager can reclaim the slot.
+    // Without this, the session stays counted as `working` forever.
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const runtimeStates: string[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-retry-emit-throw",
+      log: () => {},
+      touch: () => {},
+      setRuntimeState: (state) => runtimeStates.push(state),
+      emitEvent: () => {
+        throw new Error("event sink down");
+      },
+      ...mockCtxPlumbing({ sendMessage }, "chat-retry-emit-throw"),
+    };
+
+    await handler.start(
+      { id: "m1", chatId: "chat-retry-emit-throw", senderId: "u", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    expect(runtimeStates).toContain("error");
+  });
+});

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -190,6 +190,35 @@ describe("SessionManager: session-start failure signalling (F2)", () => {
 
     await sm.shutdown();
   });
+
+  it("still cleans up and recovers when onSessionEvent itself throws", async () => {
+    // Defensive contract: a broken event sink (e.g. agent-slot reporting on
+    // a dropped WebSocket) must not strand the failed session locally. The
+    // cleanup that drops the entry from `sessions` runs even when the
+    // emit throws, so the next inbound message routes as a fresh start.
+    const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const failing = failingHandler();
+    const working = workingHandler("session-after-broken-emit");
+    const sm = makeSessionManager({
+      handlers: [failing, working],
+      onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      onSessionEvent: () => {
+        throw new Error("event sink down");
+      },
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-emit-throw" }));
+    expect(stateChanges).toEqual([{ chatId: "chat-emit-throw", state: "errored" }]);
+
+    // The next dispatch must route through `startNewSession` (no stale entry
+    // left behind by the throwing emit) — verified by the fresh handler's
+    // `start` being called and the state moving back to active.
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-emit-throw" }));
+    expect(working.start).toHaveBeenCalledTimes(1);
+    expect(stateChanges.at(-1)).toEqual({ chatId: "chat-emit-throw", state: "active" });
+
+    await sm.shutdown();
+  });
 });
 
 describe("SessionManager: session-resume failure signalling (F2, resume path)", () => {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -913,12 +913,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // case in particular drops the turn entirely — no result will
             // be forwarded — so without an explicit error event the chat
             // would just go quiet.
-            const preview = errMsg.slice(0, 800);
-            const reason = claudeSessionId
-              ? `Query failed after ${MAX_RETRIES} retries: ${preview}`
-              : `Query failed and no resume id available: ${preview}`;
-            sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: reason } });
-            sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+            //
+            // Wrap the emits so a broken `onSessionEvent` callback can't
+            // short-circuit the `setRuntimeState("error")` call below —
+            // if that one is skipped the SessionManager keeps the slot
+            // counted as `working` and never reclaims it.
+            try {
+              const preview = errMsg.slice(0, 800);
+              const reason = claudeSessionId
+                ? `Query failed after ${MAX_RETRIES} retries: ${preview}`
+                : `Query failed and no resume id available: ${preview}`;
+              sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: reason } });
+              sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+            } catch (emitErr) {
+              sessionCtx.log(
+                `Failed to emit retry-exhaustion error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
+              );
+            }
             sessionCtx.setRuntimeState("error");
             return;
           }
@@ -939,12 +950,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // Mirror the MAX_RETRIES branch above: leaving runtimeState at
             // `working` would block the SessionManager's idle-suspend grace
             // window from ever firing on this session, so the slot would
-            // never be reclaimed.
-            sessionCtx.emitEvent({
-              kind: "error",
-              payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
-            });
-            sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+            // never be reclaimed. Wrap the emits defensively so the
+            // setRuntimeState call still runs if the callback throws.
+            try {
+              sessionCtx.emitEvent({
+                kind: "error",
+                payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
+              });
+              sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+            } catch (emitErr) {
+              sessionCtx.log(
+                `Failed to emit auto-resume error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
+              );
+            }
             sessionCtx.setRuntimeState("error");
             return;
           }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -546,11 +546,21 @@ export class SessionManager {
       //    internals) into the chat timeline; the full error is in the
       //    structured log. The web `ErrorRow` renders these with distinct
       //    error styling and a "session start/resume failed" header.
-      const preview = errMsg.slice(0, 800);
-      ctx.emitEvent({
-        kind: "error",
-        payload: { source: "runtime", message: `Session ${phase} failed: ${preview}` },
-      });
+      //
+      //    Wrap in try/catch so a broken `onSessionEvent` callback
+      //    (e.g. agent-slot reporting fails because the WS just dropped)
+      //    can't shortcut the local cleanup that follows — leaving the
+      //    chat in a half-torn-down state would block the next inbound
+      //    message from routing as a clean fresh-start.
+      try {
+        const preview = errMsg.slice(0, 800);
+        ctx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `Session ${phase} failed: ${preview}` },
+        });
+      } catch (emitErr) {
+        this.config.log.warn({ chatId, emitErr }, "session error event emit failed");
+      }
 
       // 3) Existing local cleanup. The follow-up message routes as a fresh
       //    start once the entry is gone.
@@ -619,11 +629,18 @@ export class SessionManager {
 
       this.notifySessionState(entry.chatId, "errored");
 
-      const preview = errMsg.slice(0, 800);
-      ctx.emitEvent({
-        kind: "error",
-        payload: { source: "runtime", message: `Session resume failed: ${preview}` },
-      });
+      // Same defensive wrap as `startNewSession`: a throwing emit callback
+      // must not skip the local cleanup that follows, or the broken entry
+      // gets stranded and blocks future resume attempts.
+      try {
+        const preview = errMsg.slice(0, 800);
+        ctx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `Session resume failed: ${preview}` },
+        });
+      } catch (emitErr) {
+        this.config.log.warn({ chatId: entry.chatId, emitErr }, "session error event emit failed");
+      }
 
       this.sessions.delete(entry.chatId);
       this.sessionRuntimeStates.delete(entry.chatId);


### PR DESCRIPTION
Follow-up to #554 addressing both non-blocking nits from @baixiaohang's review.

## Summary
- **Defensive `try/catch` around `ctx.emitEvent({ kind: \"error\", … })` in all four sites** (session-manager start + resume catches, claude-code MAX_RETRIES branch, claude-code auto-resume failure branch). `onSessionEvent` is fire-and-forget in production but synchronous at the call site — a throwing callback would skip the local cleanup that immediately follows (drop the failed session entry; `setRuntimeState(\"error\")` so the SessionManager reclaims the slot). Now wrapped + logged; cleanup runs unconditionally.
- **Coverage for the new claude-code branches.** Adds two test files modelled after `claude-code-turn-end-sdk-error.test.ts`:
  - `claude-code-turn-end-retry-exhausted.test.ts` — every `query()` iterator throws → handler retries up to `MAX_RETRIES`, then emits `error{source:\"runtime\"}` + `turn_end{status:\"error\"}` + flips runtimeState to `\"error\"`.
  - `claude-code-turn-end-auto-resume-fail.test.ts` — second `query()` call throws synchronously (simulates `respawnQuery` failure) → same three-part contract.
- Adds one defensive test to `session-start-error-signaling.test.ts` confirming the session-manager still tears down and recovers when `onSessionEvent` itself throws.

## What didn't change
No behaviour on the happy path. No schema, no API, no UI. Pure defence-in-depth + tests.

## Test plan
- [x] `pnpm check` (passes — 0 errors)
- [x] `pnpm typecheck` (passes — 13/13 tasks)
- [x] `pnpm --filter @first-tree/client exec vitest run --exclude src/__tests__/first-tree-cli-contract.integration.test.ts` — 524/524 pass (the excluded integration test needs `first-tree` on PATH; pre-existing flake)
- [x] Existing `session-start-error-signaling.test.ts` still passes (7 tests)
- [x] New `claude-code-turn-end-retry-exhausted.test.ts` passes (2 tests including the throwing-emit defence)
- [x] New `claude-code-turn-end-auto-resume-fail.test.ts` passes (1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)