### PR TITLE
fix(client): narrow SSH auth heuristic so network failures don't trigger HTTPS retry

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -665,8 +665,11 @@ describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailur
     "git@github.com: Permission denied (publickey).",
     "Permission denied, please try again.",
     "Permission denied (publickey,password,keyboard-interactive).",
-    "fatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
-    "Host key verification failed.\nfatal: Could not read from remote repository.",
+    // Real multi-line stderr: host-key reject still classifies as auth
+    // (matched by `Host key verification failed`, not by the trailing
+    // `Could not read from remote repository` line — that line on its own
+    // is no longer a signal).
+    "Host key verification failed.\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
     "Unable to negotiate with 1.2.3.4 port 22: no matching host key type found.",
     "Unable to negotiate: no mutual signature algorithm",
   ])("matches SSH credential-shaped error: %s", (msg) => {
@@ -679,6 +682,18 @@ describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailur
     "ssh: connect to host github.com port 22: Connection timed out",
     "ssh: Could not resolve hostname github.com: Name or service not known",
     "fatal: couldn't find remote ref refs/heads/missing",
+    // `fatal: Could not read from remote repository.` on its own is not an
+    // auth signal — git appends it to every SSH transport failure, including
+    // network ones. Matching it would re-classify the multi-line network
+    // cases below as auth failures and trigger a useless HTTPS retry.
+    "fatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
+    // Real multi-line stderr observed when port 22 is blocked / GitHub SSH
+    // is briefly unreachable. The `Connection timed out` (or refused / DNS)
+    // line carries the real cause; the `Could not read from remote` tail
+    // is git's generic post-failure boilerplate, not an auth fingerprint.
+    "ssh: connect to host github.com port 22: Connection timed out\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
+    "ssh: connect to host github.com port 22: Connection refused\nfatal: Could not read from remote repository.",
+    "ssh: Could not resolve hostname github.com: Name or service not known\nfatal: Could not read from remote repository.",
     // HTTPS-side failures — should NOT be misclassified as SSH.
     "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
     "fatal: could not read Username for 'https://github.com'",
@@ -707,6 +722,13 @@ describe("GitMirrorManager — transient network error heuristic (isLikelyTransi
     "GnuTLS recv error (-110): The TLS connection was non-properly terminated.",
     "transfer closed with outstanding read data remaining",
     "ssh: connect to host github.com port 22: Network is unreachable",
+    // Multi-line SSH transport timeout (port 22 blocked or briefly
+    // unreachable). Real chat-reported failure shape. Used to be hidden
+    // behind the over-broad SSH auth heuristic (`Could not read from
+    // remote repository` matched as auth, suppressing transient retry);
+    // now flows through this path so the next attempt sees the network
+    // recover instead of surfacing as a `Session resume failed` to chat.
+    "ssh: connect to host github.com port 22: Connection timed out\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.",
     // Raw OpenSSL form for a TLS connection the peer closed mid-stream —
     // distinct from `SSL_ERROR_SYSCALL` and distinct from the cert-verify
     // failures (negative case below). Narrow pattern by design.

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -309,8 +309,15 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     // shells it would block the request indefinitely instead of failing fast
     // (defeating the ssh-fallback path below). Callers can still override by
     // passing an `env` that sets `GIT_TERMINAL_PROMPT` explicitly.
+    // Force `LC_ALL=C` so git/ssh stderr stays in English regardless of the
+    // caller's locale — the credential-shape and transient-network heuristics
+    // below match against stderr substrings, and a localized message would
+    // silently break classification (and the protocol-fallback decision that
+    // hangs off it). Placed after the spread so it overrides any inherited
+    // LC_ALL from `process.env`; `GIT_TERMINAL_PROMPT` stays before the spread
+    // so tests can opt back into prompting if they need to.
     const baseEnv = env ?? process.env;
-    const finalEnv = { GIT_TERMINAL_PROMPT: "0", ...baseEnv };
+    const finalEnv = { GIT_TERMINAL_PROMPT: "0", ...baseEnv, LC_ALL: "C" };
     return await new Promise<{ stdout: string; stderr: string; elapsedMs: number }>((resolveExec, rejectExec) => {
       const proc = spawn("git", args, {
         cwd: cwd ?? undefined,
@@ -1012,11 +1019,20 @@ export function isLikelyHttpsAuthFailure(message: string): boolean {
  * Heuristic for SSH-side credential failures (no key on disk, key not
  * accepted by remote, agent has nothing usable, host key mismatch).
  *
- * Negative space (intentionally NOT matched): SSH-level network errors
- * (`Could not resolve hostname`, `Connection refused`, `Connection timed out`).
- * Those are network reachability issues — switching to HTTPS won't help
- * unless the network policy specifically blocks port 22, which is rare
- * enough that we'd rather surface the original error than guess.
+ * Negative space (intentionally NOT matched):
+ *   - SSH-level network errors (`Could not resolve hostname`,
+ *     `Connection refused`, `Connection timed out`). Those are reachability
+ *     issues — switching to HTTPS won't help unless the network policy
+ *     specifically blocks port 22, which is rare enough that we'd rather
+ *     surface the original error than guess.
+ *   - `fatal: Could not read from remote repository.` on its own. Git
+ *     appends that line to *every* SSH transport failure regardless of
+ *     cause (auth reject, timeout, DNS, refused, …), so it carries no
+ *     classification signal — matching it would re-classify network errors
+ *     as auth failures and trigger a noisy HTTPS retry that fails again on
+ *     SSH-only hosts. The real auth fingerprints below (`Permission denied`,
+ *     `Host key verification failed`, host-key/algorithm negotiation) are
+ *     specific enough on their own.
  *
  * Exported for unit testing.
  */
@@ -1029,7 +1045,6 @@ export function isLikelySshAuthFailure(message: string): boolean {
   // forms only occur in ssh auth failure context.
   return (
     /Permission denied\s*(?:\(|,)/i.test(message) ||
-    /Could not read from remote repository/i.test(message) ||
     /Host key verification failed/i.test(message) ||
     /no matching host key type/i.test(message) ||
     /no mutual signature algorithm/i.test(message)


### PR DESCRIPTION
## Summary

`isLikelySshAuthFailure` matched `fatal: Could not read from remote repository.` as a credential-shaped failure, but git appends that line to **every** SSH transport failure regardless of cause — auth reject, timeout, DNS, refused. The line carries no classification signal.

On SSH-only hosts (no HTTPS credential helper configured — a documented scenario PR #291 itself targets) this caused two stacked failures whenever GitHub's port 22 had a network blip:

1. SSH network blip (timeout / refused / DNS) → misclassified as auth failure
2. Protocol-fallback path retries via HTTPS → fails immediately with `terminal prompts disabled`
3. User sees `⚠️ Session resume failed: Could not fetch ... over SSH or HTTPS. SSH attempt failed: ... Connection timed out HTTPS retry (https://github.com/) failed: could not read Username ...` in chat

The misclassification also shadowed `isLikelyTransientNetworkError` (`git-mirror-manager.ts:1102` short-circuits on credential-shaped failures), so the same SSH-side transient errors that **would have** been auto-retried with exponential backoff were instead promoted straight to a chat-visible failure on the first attempt.

### Fix

- **Drop** `/Could not read from remote repository/i` from `isLikelySshAuthFailure`. The four remaining fingerprints (`Permission denied`, `Host key verification failed`, `no matching host key type`, `no mutual signature algorithm`) are specific to genuine auth/handshake failures and fully cover the original PR #291 cases.
- **Force `LC_ALL=C`** on every spawned git subprocess so stderr stays in English regardless of operator locale. The credential-shape and transient-network heuristics all match stderr substrings; localized git output would silently break classification. Placed *after* the env spread so it overrides any inherited `LC_ALL`.
- **Doc updates** on `isLikelySshAuthFailure` and the `git()` helper explaining the new invariants.

### Why this is a real bug, not just cosmetic

Bug introduced by `9fd95439` (PR #291 — SSH support + bidirectional protocol fallback). The over-broad regex made SSH-only hosts a permanent landmine: any SSH-side network blip surfaces as a confusing dual-failure to end users instead of being retried silently. Reported by an operator with chat error matching the canonical shape above.

### Tests

- `isLikelySshAuthFailure` **negative** cases added: bare git boilerplate tail alone, plus three real multi-line stderr forms (`Connection timed out` / `Connection refused` / `Could not resolve hostname`, each combined with the trailing git boilerplate). All used to be misclassified.
- `isLikelySshAuthFailure` **positive** case updated: the `Host key verification failed` example now uses the full multi-line form (with trailing boilerplate) to confirm genuine auth errors still classify correctly even when the tail line is present.
- `isLikelyTransientNetworkError` **positive** case added: multi-line SSH timeout stderr — verifies the connected good behavior unlocked by this fix (these errors now go through transient retry instead of the credential-fallback path).

## Test plan

- [x] \`pnpm --filter @first-tree/client test\` — 528 passed, `git-mirror-manager.test.ts` 136 tests pass
- [x] \`pnpm check\` — exit 0 (only pre-existing warnings in `packages/github-scan/tests/`, unrelated)
- [x] \`pnpm typecheck\` — 13 tasks pass
- [ ] Manual validation: on an SSH-only host, observe that occasional GitHub port 22 timeouts during session resume no longer surface as `⚠️ Session resume failed: Could not fetch ... over SSH or HTTPS` in chat (the transient retry path swallows them; only persistent unreachability surfaces, and with a clean network-error message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)