### PR TITLE
feat(client,server): widen doc-preview self-fence to cover agent on-demand worktrees

### DIFF
--- a/apps/cli/src/__tests__/doc-capture.test.ts
+++ b/apps/cli/src/__tests__/doc-capture.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -54,5 +54,63 @@ describe("captureOutboundDocs (chat send L3 capture)", () => {
     const out = await captureOutboundDocs("just a plain message", { FIRST_TREE_DOC_BASE: base });
     expect(out.content).toBe("just a plain message");
     expect(out.documentContext).toBeUndefined();
+  });
+
+  describe("wide-fence env (FIRST_TREE_DOC_AGENT_HOME + optional FIRST_TREE_DOC_REPO_LOCAL_PATH)", () => {
+    let agentHome: string;
+
+    beforeAll(async () => {
+      // Layout mirrors the post-#506 production tree:
+      //   <agentHome>/<localPath>/         predeclared source repo
+      //   <agentHome>/worktrees/<task>/    on-demand worktree the LLM `git worktree add`s
+      agentHome = await mkdtemp(join(tmpdir(), "cli-doc-capture-agent-home-"));
+      await mkdir(join(agentHome, "first-tree", "docs"), { recursive: true });
+      await writeFile(join(agentHome, "first-tree", "docs", "intro.md"), "# intro\n", "utf8");
+      await mkdir(join(agentHome, "worktrees", "task-x", "docs"), { recursive: true });
+      await writeFile(join(agentHome, "worktrees", "task-x", "docs", "design.md"), "# design\n", "utf8");
+    });
+
+    afterAll(async () => {
+      await rm(agentHome, { recursive: true, force: true });
+    });
+
+    it("snapshots a worktree-scoped absolute path when AGENT_HOME widens the fence", async () => {
+      // The pre-fix narrow fence (source-repo top only) would have dropped this
+      // mention to plain text; the wide fence now produces an agent-home-relative
+      // snapshot key.
+      const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
+      const out = await captureOutboundDocs(`wrote ${abs} now`, {
+        FIRST_TREE_DOC_AGENT_HOME: agentHome,
+        FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree",
+      });
+      expect(out.content).toBe(`wrote [worktrees/task-x/docs/design.md](worktrees/task-x/docs/design.md) now`);
+      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
+      expect(ctx?.docs?.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+    });
+
+    it("promotes a relative source-repo mention to a shared agent-home-relative key", async () => {
+      // `docs/intro.md` written relatively must share its canonical key with the
+      // absolute form `<agentHome>/<localPath>/docs/intro.md` — otherwise the same
+      // file produces two snapshot entries and web cache lookup splits.
+      const out = await captureOutboundDocs("see docs/intro.md please", {
+        FIRST_TREE_DOC_AGENT_HOME: agentHome,
+        FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree",
+      });
+      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
+      expect(ctx?.docs?.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
+      expect(out.content).toBe("see [first-tree/docs/intro.md](first-tree/docs/intro.md) please");
+    });
+
+    it("ignores the legacy FIRST_TREE_DOC_BASE when FIRST_TREE_DOC_AGENT_HOME is present", async () => {
+      // The wide-fence env takes precedence so a runtime that emits BOTH (during
+      // upgrade) routes through the new path.
+      const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
+      const out = await captureOutboundDocs(`wrote ${abs} now`, {
+        FIRST_TREE_DOC_AGENT_HOME: agentHome,
+        FIRST_TREE_DOC_BASE: join(agentHome, "first-tree"),
+      });
+      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
+      expect(ctx?.docs?.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+    });
   });
 });

--- a/apps/cli/src/core/doc-capture.ts
+++ b/apps/cli/src/core/doc-capture.ts
@@ -1,4 +1,4 @@
-import { buildMessageDocumentSnapshots, type WorkspaceFence } from "@first-tree/client";
+import { buildMessageDocumentSnapshots, type SelfFence, type WorkspaceFence } from "@first-tree/client";
 import { documentContextSchema } from "@first-tree/shared";
 
 /**
@@ -7,15 +7,27 @@ import { documentContextSchema } from "@first-tree/shared";
  * (L3: unify doc-preview capture across ALL send paths, not just final-text).
  *
  * The runtime injects the resolved doc context into the agent's environment
- * (`buildAgentEnv` → `FIRST_TREE_DOC_BASE` / `_WORKSPACES_ROOT` /
- * `_AGENT_SLUG`); we read it here so the CLI sub-process resolves against the
- * exact same base + cross-agent fence as the runtime — no config reconstruction,
- * no server round-trip.
+ * (`buildAgentEnv`); we read it here so the CLI sub-process resolves against
+ * the exact same fence as the runtime — no config reconstruction, no server
+ * round-trip.
+ *
+ * Two wire forms, in priority order:
+ *
+ *  1. `FIRST_TREE_DOC_AGENT_HOME` (+ optional `_DOC_REPO_LOCAL_PATH`) — the
+ *     wide self-fence introduced alongside the worktrees-fence widening. The
+ *     full {@link SelfFence} is rebuilt so absolute `.md` paths in the agent's
+ *     on-demand `worktrees/<task>/` checkouts also snapshot.
+ *
+ *  2. `FIRST_TREE_DOC_BASE` (legacy) — set by pre-fix runtimes. We treat it
+ *     as `agentHome` so the snapshot pipeline still produces relative-key
+ *     output, but no `singleRepoLocalPath` is available so the wider
+ *     containment that #498's worktrees idiom relies on is not active. This
+ *     branch keeps an old runtime + new chat-send combo working at pre-fix
+ *     fidelity (no worktree preview, source-repo paths still resolve).
  *
  * Returns the (possibly rewritten) content + a validated `documentContext` to
  * merge into message metadata. When no doc base is present (not in an agent
- * session, or the runtime predates this wiring) it is a pure pass-through, so
- * `chat send` keeps working unchanged.
+ * session) it is a pure pass-through, so `chat send` keeps working unchanged.
  *
  * Capture failure NEVER blocks the send: any error degrades to passing the
  * original content through with no `documentContext`.
@@ -24,8 +36,8 @@ export async function captureOutboundDocs(
   content: string,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ content: string; documentContext?: unknown }> {
-  const base = env.FIRST_TREE_DOC_BASE;
-  if (!base) return { content };
+  const self = resolveSelfFenceFromEnv(env);
+  if (!self) return { content };
 
   const chatId = env.FIRST_TREE_CHAT_ID;
   const workspacesRoot = env.FIRST_TREE_WORKSPACES_ROOT;
@@ -34,7 +46,7 @@ export async function captureOutboundDocs(
     workspacesRoot && selfSlug && chatId ? { workspacesRoot, chatId, selfSlug } : undefined;
 
   try {
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(content, base, fence);
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(content, self, fence);
     if (docs.length === 0) return { content: rewrittenText };
     // Validate through the shared schema (same as result-sink) so a malformed
     // doc can never be lodged into immutable message history; on a parse error
@@ -44,4 +56,14 @@ export async function captureOutboundDocs(
   } catch {
     return { content };
   }
+}
+
+function resolveSelfFenceFromEnv(env: NodeJS.ProcessEnv): SelfFence | null {
+  const agentHome = env.FIRST_TREE_DOC_AGENT_HOME;
+  if (agentHome) {
+    const singleRepoLocalPath = env.FIRST_TREE_DOC_REPO_LOCAL_PATH;
+    return singleRepoLocalPath ? { agentHome, singleRepoLocalPath } : { agentHome };
+  }
+  const legacyBase = env.FIRST_TREE_DOC_BASE;
+  return legacyBase ? { agentHome: legacyBase } : null;
 }

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -286,7 +286,10 @@ describe("buildAgentEnv", () => {
     expect(env.FIRST_TREE_CHAT_ID).toBe("chat-right");
   });
 
-  it("injects doc-preview context (base + workspaces root + slug) when provided, for `chat send` capture", () => {
+  it("injects BOTH wide (agent home) and narrow (legacy base) doc fences + workspaces root + slug for `chat send`", () => {
+    // Wide-fence vars enable the new worktree-fence behaviour; the legacy
+    // `FIRST_TREE_DOC_BASE` is kept emitting so a stale pre-fix `chat send`
+    // binary inherited from this process still snapshots like it used to.
     const env = buildAgentEnv({} as NodeJS.ProcessEnv, {
       sdk: { serverUrl: "http://hub" },
       agent: {
@@ -298,11 +301,40 @@ describe("buildAgentEnv", () => {
         metadata: {},
       },
       chatId: "chat-1",
-      docContext: { base: "/ws/coder/chat-1", workspacesRoot: "/ws", selfSlug: "coder" },
+      docContext: {
+        base: "/ws/coder/first-tree",
+        agentHome: "/ws/coder",
+        singleRepoLocalPath: "first-tree",
+        workspacesRoot: "/ws",
+        selfSlug: "coder",
+      },
     });
-    expect(env.FIRST_TREE_DOC_BASE).toBe("/ws/coder/chat-1");
+    expect(env.FIRST_TREE_DOC_BASE).toBe("/ws/coder/first-tree");
+    expect(env.FIRST_TREE_DOC_AGENT_HOME).toBe("/ws/coder");
+    expect(env.FIRST_TREE_DOC_REPO_LOCAL_PATH).toBe("first-tree");
     expect(env.FIRST_TREE_WORKSPACES_ROOT).toBe("/ws");
     expect(env.FIRST_TREE_AGENT_SLUG).toBe("coder");
+  });
+
+  it("omits FIRST_TREE_DOC_REPO_LOCAL_PATH when the agent has no single declared source repo", () => {
+    // Zero / multi-repo agents have nothing to promote — the env var is
+    // suppressed so chat-send doesn't try to derive a promotion prefix from
+    // garbage and accidentally widen the fence in a different way.
+    const env = buildAgentEnv({} as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://hub" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "autonomous_agent",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      docContext: { base: "/ws/coder", agentHome: "/ws/coder", workspacesRoot: "/ws", selfSlug: "coder" },
+    });
+    expect(env.FIRST_TREE_DOC_AGENT_HOME).toBe("/ws/coder");
+    expect(env.FIRST_TREE_DOC_REPO_LOCAL_PATH).toBeUndefined();
   });
 
   it("omits doc-preview env vars when no docContext is provided (self-only / non-agent shells)", () => {
@@ -319,6 +351,8 @@ describe("buildAgentEnv", () => {
       chatId: "chat-1",
     });
     expect(env.FIRST_TREE_DOC_BASE).toBeUndefined();
+    expect(env.FIRST_TREE_DOC_AGENT_HOME).toBeUndefined();
+    expect(env.FIRST_TREE_DOC_REPO_LOCAL_PATH).toBeUndefined();
     expect(env.FIRST_TREE_WORKSPACES_ROOT).toBeUndefined();
     expect(env.FIRST_TREE_AGENT_SLUG).toBeUndefined();
   });

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -254,3 +254,140 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
     );
   });
 });
+
+/**
+ * Worktree-fence widening (this PR): the self fence now extends to the FULL
+ * agent home, not just the source-repo top, so absolute paths into the
+ * agent's on-demand `<agentHome>/worktrees/<task>/` checkouts also snapshot
+ * (PR #498's workflow). Relative mentions in a single-repo workspace are
+ * promoted to `<localPath>/<rel>` so the abs + rel forms of a source-repo
+ * file share one canonical key.
+ */
+describe("buildMessageDocumentSnapshots — wide self-fence over agent home", () => {
+  let agentHome: string;
+
+  beforeAll(async () => {
+    // Layout mirrors the post-#506 production tree:
+    //   <agentHome>/first-tree/          predeclared source repo (top level)
+    //   <agentHome>/worktrees/<task>/    agent-on-demand worktree
+    //   <agentHome>/docs/                agent-home-scoped notes
+    //   <agentHome>/.agent/              MUST stay rejected via hidden-segment check
+    agentHome = await mkdtemp(join(tmpdir(), "doc-snap-agenthome-"));
+    await mkdir(join(agentHome, "first-tree", "docs"), { recursive: true });
+    await writeFile(join(agentHome, "first-tree", "docs", "intro.md"), "# intro\n", "utf8");
+    await mkdir(join(agentHome, "worktrees", "task-x", "docs"), { recursive: true });
+    await writeFile(join(agentHome, "worktrees", "task-x", "docs", "design.md"), "# design\n", "utf8");
+    await mkdir(join(agentHome, "docs"), { recursive: true });
+    await writeFile(join(agentHome, "docs", "note.md"), "# note\n", "utf8");
+    await mkdir(join(agentHome, ".agent"), { recursive: true });
+    await writeFile(join(agentHome, ".agent", "secret.md"), "# secret\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(agentHome, { recursive: true, force: true });
+  });
+
+  it("snapshots a worktree-scoped absolute .md (#506+#498 idiom — the bug this PR fixes)", async () => {
+    // Pre-fix the snapshot scanner gated absolute paths on the source-repo top
+    // and dropped this mention back to plain text. Wide fence + agent-home-
+    // relative key restores the preview.
+    const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`wrote ${abs} just now`, {
+      agentHome,
+      singleRepoLocalPath: "first-tree",
+    });
+
+    expect(docs.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+    expect(docs[0]?.content).toBe("# design\n");
+    expect(rewrittenText).toBe("wrote [worktrees/task-x/docs/design.md](worktrees/task-x/docs/design.md) just now");
+  });
+
+  it("promotes a relative source-repo mention to `<localPath>/<rel>` so abs + rel share one key", async () => {
+    // `docs/intro.md` written relatively was the pre-#506 idiom; we keep it
+    // resolving against the source-repo top so the agent's old habits still
+    // work. The snapshot key is PROMOTED so the absolute form
+    // `<agentHome>/first-tree/docs/intro.md` produces the same canonical key —
+    // web cache stays single-keyed per file.
+    const abs = join(agentHome, "first-tree", "docs", "intro.md");
+    const text = `relative docs/intro.md and absolute ${abs}`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
+      agentHome,
+      singleRepoLocalPath: "first-tree",
+    });
+
+    expect(docs.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
+    expect(rewrittenText).toBe(
+      "relative [first-tree/docs/intro.md](first-tree/docs/intro.md) and " +
+        "absolute [first-tree/docs/intro.md](first-tree/docs/intro.md)",
+    );
+  });
+
+  it("snapshots an agent-home-scoped absolute .md (sibling of the source repo)", async () => {
+    // `<agentHome>/docs/note.md` is in neither the source repo nor a worktree;
+    // it's an agent-home note (CLAUDE.md, README, scratch). The wide fence
+    // accepts it as a valid snapshot target.
+    const abs = join(agentHome, "docs", "note.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs}`, {
+      agentHome,
+      singleRepoLocalPath: "first-tree",
+    });
+
+    expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
+    expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
+  });
+
+  it("rejects an absolute path outside the agent home — wide fence is not a free-for-all", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "doc-snap-outside-wide-"));
+    try {
+      await writeFile(join(outside, "external.md"), "# external\n", "utf8");
+      const abs = join(outside, "external.md");
+      const text = `out-of-home ${abs}`;
+      const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
+        agentHome,
+        singleRepoLocalPath: "first-tree",
+      });
+
+      expect(docs).toEqual([]);
+      expect(rewrittenText).toBe(text);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("still rejects a hidden-segment mention inside the agent home (.agent/secret.md)", async () => {
+    const abs = join(agentHome, ".agent", "secret.md");
+    const text = `secret ${abs}`;
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
+      agentHome,
+      singleRepoLocalPath: "first-tree",
+    });
+
+    expect(docs).toEqual([]);
+    expect(rewrittenText).toBe(text);
+  });
+
+  it("falls back to agent-home resolution when singleRepoLocalPath is absent (zero/multi-repo)", async () => {
+    // No promotion: relative `first-tree/docs/intro.md` is interpreted directly
+    // against the agent home and resolves cleanly without prefixing.
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("see first-tree/docs/intro.md please", {
+      agentHome,
+    });
+
+    expect(docs.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
+    expect(rewrittenText).toBe("see [first-tree/docs/intro.md](first-tree/docs/intro.md) please");
+  });
+
+  it("gracefully degrades when singleRepoLocalPath points outside the agent home (no promotion)", async () => {
+    // Defence in depth: a misconfigured `localPath: "../escape"` must not let
+    // docBase wander outside the fence. The resolver silently drops the
+    // promotion and falls back to agent-home resolution.
+    const abs = join(agentHome, "docs", "note.md");
+    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs}`, {
+      agentHome,
+      singleRepoLocalPath: "../escape",
+    });
+
+    expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
+    expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
+  });
+});

--- a/packages/client/src/__tests__/document-base-path.test.ts
+++ b/packages/client/src/__tests__/document-base-path.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { documentBasePathFromRuntimeConfig, resolveSessionDocRoot } from "../runtime/session-manager.js";
+import {
+  documentBasePathFromRuntimeConfig,
+  resolveSessionDocRoot,
+  selfFenceFromRuntimeConfig,
+  singleRepoLocalPathFromPayload,
+} from "../runtime/session-manager.js";
 
 function payload(gitRepos: AgentRuntimeConfigPayload["gitRepos"]): AgentRuntimeConfigPayload {
   return { kind: "claude-code", prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos };
@@ -80,5 +85,39 @@ describe("resolveSessionDocRoot — per-agent-home vs legacy per-chat layout", (
       resolveSessionDocRoot(workspaceRoot, "another-new-chat"),
     );
     expect(base).toBe(join(workspaceRoot, "first-tree"));
+  });
+});
+
+describe("singleRepoLocalPathFromPayload + selfFenceFromRuntimeConfig", () => {
+  it("returns null for zero-repo and multi-repo payloads — no promotion path", () => {
+    expect(singleRepoLocalPathFromPayload(payload([]))).toBeNull();
+    expect(
+      singleRepoLocalPathFromPayload(payload([{ url: "https://x/y.git" }, { url: "https://x/z.git" }])),
+    ).toBeNull();
+  });
+
+  it("derives the localPath from the repo URL when explicit localPath is absent", () => {
+    expect(singleRepoLocalPathFromPayload(payload([{ url: "https://github.com/a/first-tree.git" }]))).toBe(
+      "first-tree",
+    );
+  });
+
+  it("honours an explicit localPath; treats a blank string as no promotion", () => {
+    expect(singleRepoLocalPathFromPayload(payload([{ url: "https://x/y.git", localPath: "nested/repo" }]))).toBe(
+      "nested/repo",
+    );
+    expect(singleRepoLocalPathFromPayload(payload([{ url: "https://x/y.git", localPath: "   " }]))).toBeNull();
+  });
+
+  it("selfFenceFromRuntimeConfig packs agentHome + optional singleRepoLocalPath for the snapshot pipeline", () => {
+    expect(selfFenceFromRuntimeConfig(payload([{ url: "https://github.com/a/first-tree.git" }]), "/ws/coder")).toEqual({
+      agentHome: "/ws/coder",
+      singleRepoLocalPath: "first-tree",
+    });
+    expect(selfFenceFromRuntimeConfig(payload([]), "/ws/coder")).toEqual({ agentHome: "/ws/coder" });
+  });
+
+  it("returns agentHome-only when no payload is cached yet (very first message)", () => {
+    expect(selfFenceFromRuntimeConfig(null, "/ws/coder")).toEqual({ agentHome: "/ws/coder" });
   });
 });

--- a/packages/client/src/__tests__/result-sink-capture-failure.test.ts
+++ b/packages/client/src/__tests__/result-sink-capture-failure.test.ts
@@ -39,7 +39,7 @@ describe("createResultSink — capture/parse failure preserves the original body
       getTrigger: () => null,
       clearTrigger: () => {},
       log: () => {},
-      getDocumentBasePath: vi.fn().mockResolvedValue("/ws/coder/chat-1"),
+      getSelfFence: vi.fn().mockResolvedValue({ agentHome: "/ws/coder/chat-1" }),
       workspacesRoot: "/ws",
       selfSlug: "coder",
     });

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { SelfFence } from "../runtime/doc-snapshots.js";
 import { createResultSink, type Trigger } from "../runtime/result-sink.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
@@ -24,7 +25,7 @@ const ME = "agent-me";
 type SinkFixtures = {
   trigger: Trigger | null;
   sendMessage?: ReturnType<typeof vi.fn>;
-  getDocumentBasePath?: () => Promise<string | null>;
+  getSelfFence?: () => Promise<SelfFence | null>;
 };
 
 function buildSink(fx: SinkFixtures) {
@@ -53,7 +54,7 @@ function buildSink(fx: SinkFixtures) {
       trigger = null;
     },
     log: (msg) => logs.push(msg),
-    getDocumentBasePath: fx.getDocumentBasePath,
+    getSelfFence: fx.getSelfFence,
   });
 
   return { sink, sendMessage, logs };
@@ -102,7 +103,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     // documentContext at all (and still no auto-mentions array).
     const { sink, sendMessage } = buildSink({
       trigger: { messageId: "m1", senderId: "agent-peer" },
-      getDocumentBasePath: vi.fn().mockResolvedValue("first-tree"),
+      getSelfFence: vi.fn().mockResolvedValue({ agentHome: "first-tree" } satisfies SelfFence),
     });
 
     await sink("see [design](docs/design.md)");
@@ -137,7 +138,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     it("emits kind=snapshot when basePath resolves and the text references a real .md", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see [design](design.md)");
@@ -165,7 +166,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       // the same canonical key so the click hits the snapshot in cache.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("created design.md just now");
@@ -180,7 +181,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     it("strips :line[:col] from bare paths so snapshot keys match what the click handler resolves", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see docs/intro.md:42:1 for details");
@@ -194,7 +195,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     it("rejects dotfiles / hidden dirs and attaches NO documentContext when no docs survive", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("hidden: [secret](.agent/secret.md)");
@@ -213,7 +214,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       // matching what `docPreviewPathFromHref` produces for a click.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see [a](./docs/intro.md) and [b](./other/../docs/intro.md)");
@@ -234,7 +235,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       // would pass; realpath-relative segments must fail.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see [public](public.md)");
@@ -264,7 +265,7 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see [broken](broken.md)");
@@ -294,7 +295,7 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("see [evil](https://x.com/api.md) and [also](//x.com/a.md) and [mail](mailto:a@b.md)");
@@ -310,7 +311,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     it("ignores escaped link `\\[...](path.md)` and image link `![alt](path.md)`", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       await sink("escaped: \\[design](design.md) and image: ![diagram](api.md)");
@@ -328,7 +329,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       // web renders a native link whose href is the snapshot key.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
-        getDocumentBasePath: vi.fn().mockResolvedValue(worktree),
+        getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
 
       const abs = join(worktree, "design.md");

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -25,7 +25,7 @@ export { probeCapabilities } from "./runtime/capabilities/index.js";
 export type { AgentSlotYamlConfig, RuntimeConfig, SessionConfig } from "./runtime/config.js";
 export { loadRuntimeConfig } from "./runtime/config.js";
 export { Deduplicator } from "./runtime/deduplicator.js";
-export type { WorkspaceFence } from "./runtime/doc-snapshots.js";
+export type { SelfFence, WorkspaceFence } from "./runtime/doc-snapshots.js";
 export { buildMessageDocumentSnapshots } from "./runtime/doc-snapshots.js";
 export type { GitMirrorManager, GitMirrorManagerOptions } from "./runtime/git-mirror-manager.js";
 export { createGitMirrorManager, GitMirrorError } from "./runtime/git-mirror-manager.js";

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -32,11 +32,34 @@ export function buildAgentEnv(
      * Resolved doc-preview context for this session, so a `first-tree
      * chat send` sub-process can snapshot referenced `.md` the same way
      * `result-sink` does for final-text (L3: unify capture across send
-     * paths). Absent → `chat send` skips snapshotting (self-only fallback /
-     * no doc base). All three are required together for cross-agent
-     * resolution; `base` alone still enables self snapshots.
+     * paths). Absent → `chat send` skips snapshotting.
+     *
+     * Two boundaries are exported:
+     *  - `agentHome` — the WIDE fence: per-agent home (or legacy per-chat
+     *    dir for pre-#506 chats). Covers on-demand `worktrees/<task>/`
+     *    checkouts that #498's idiom puts here. New chat-send binaries read
+     *    `FIRST_TREE_DOC_AGENT_HOME`.
+     *  - `base` — the NARROW fence: source repo top (`<agentHome>/<localPath>`
+     *    for single-repo, `agentHome` otherwise). Kept emitting under the
+     *    legacy `FIRST_TREE_DOC_BASE` name so a stale pre-fix `chat send`
+     *    binary still snapshots like it used to (graceful degradation: no
+     *    worktree preview, but source-repo docs work).
+     *
+     * Cross-agent resolution needs `workspacesRoot` + `selfSlug` + chatId;
+     * `agentHome` alone (or `base` alone for legacy) still enables self
+     * snapshots.
      */
-    docContext?: { base: string; workspacesRoot: string; selfSlug: string };
+    docContext?: {
+      /** Legacy narrow fence (source-repo top); ridden by pre-fix `chat send`. */
+      base: string;
+      /** Wide fence (agent home / legacy per-chat dir). */
+      agentHome: string;
+      /** Single declared source-repo `localPath` — promotes relative `docs/foo.md`
+       *  to the same canonical key as the absolute form. */
+      singleRepoLocalPath?: string;
+      workspacesRoot: string;
+      selfSlug: string;
+    };
   },
 ): NodeJS.ProcessEnv {
   return {
@@ -48,6 +71,10 @@ export function buildAgentEnv(
     ...(ctx.docContext
       ? {
           FIRST_TREE_DOC_BASE: ctx.docContext.base,
+          FIRST_TREE_DOC_AGENT_HOME: ctx.docContext.agentHome,
+          ...(ctx.docContext.singleRepoLocalPath
+            ? { FIRST_TREE_DOC_REPO_LOCAL_PATH: ctx.docContext.singleRepoLocalPath }
+            : {}),
           FIRST_TREE_WORKSPACES_ROOT: ctx.docContext.workspacesRoot,
           FIRST_TREE_AGENT_SLUG: ctx.docContext.selfSlug,
         }

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -90,7 +90,7 @@ export type SelfFence = {
    *  for pre-#506 chats. Absolute paths must realpath inside this; snapshot
    *  keys are emitted relative to this root. */
   agentHome: string;
-  /** Single declared source-repo `localPath` — e.g. "first-tree-hub". Set when
+  /** Single declared source-repo `localPath` — e.g. `"first-tree"`. Set when
    *  `payload.gitRepos.length === 1` and its localPath is non-empty. */
   singleRepoLocalPath?: string;
 };

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -64,11 +64,56 @@ export type WorkspaceFence = {
   selfSlug: string;
 };
 
+/**
+ * Self-fence config: the agent's own workspace root + an optional source-repo
+ * `localPath` for relative-path promotion.
+ *
+ * Why two roots: after #506 the agent's cwd is the per-agent home and the
+ * `git worktree add` workflow (#498) puts task-scoped checkouts at
+ * `<agentHome>/worktrees/<task>/`. Those are **siblings** of the predeclared
+ * source repo at `<agentHome>/<localPath>/`. Containment-checking absolute
+ * paths against the source repo alone (the pre-#535 behaviour, restored by
+ * #535 to the right root but not widened) drops every worktree mention back to
+ * plain text. The fix is to gate absolute paths on the wider `agentHome`
+ * boundary while keeping relative paths resolving against the source repo top
+ * (where "docs/foo.md" has always meant "in the source repo").
+ *
+ * `singleRepoLocalPath`, when set, is used both to RESOLVE relative mentions
+ * (against `<agentHome>/<localPath>`) AND to **promote** the resulting snapshot
+ * key to `<localPath>/<rel>` so a file written two ways (relative
+ * `docs/foo.md` and absolute `<agentHome>/<localPath>/docs/foo.md`) ends up
+ * with one shared canonical key. Zero / multi-repo agents skip the promotion;
+ * relative mentions resolve against `agentHome` directly.
+ */
+export type SelfFence = {
+  /** Per-agent home (`acquireAgentHome` return value) or legacy per-chat dir
+   *  for pre-#506 chats. Absolute paths must realpath inside this; snapshot
+   *  keys are emitted relative to this root. */
+  agentHome: string;
+  /** Single declared source-repo `localPath` — e.g. "first-tree-hub". Set when
+   *  `payload.gitRepos.length === 1` and its localPath is non-empty. */
+  singleRepoLocalPath?: string;
+};
+
+type ResolvedRoots = {
+  agentHomeReal: string;
+  /** Where relative paths resolve. Equals `agentHomeReal` when no singleRepo
+   *  localPath; equals `<agentHomeReal>/<localPath>` realpath'd otherwise. May
+   *  fall back to `agentHomeReal` when the localPath dir doesn't yet exist. */
+  docBaseReal: string;
+  /** `<localPath>` as a POSIX-canonical key prefix (or null when no promotion).
+   *  Used to promote a relative `docs/foo.md` into agent-home-relative form
+   *  `<localPath>/docs/foo.md`. */
+  promotePrefix: string | null;
+};
+
 type ResolvedOccurrence = DocPathOccurrence & {
   kind: "self" | "cross" | null;
-  /** Snapshot key: bare base-relative for self, global `<slug>/<chatId>/<rel>` for cross. */
+  /** Snapshot key: agent-home-relative for self (key collisions with cross
+   *  ruled out because cross keys are global `<slug>/<chatId>/<rel>`). */
   key: string | null;
-  /** Realpath of the file to read (cross only; self resolves against `root`). */
+  /** Realpath of the file to read (cross only; self resolves against
+   *  `agentHomeReal`). */
   file: string | null;
   /** Rewrite replacement for a cross mention: short `<ownerSlug>/<rel>`. */
   shortForm: string;
@@ -76,29 +121,31 @@ type ResolvedOccurrence = DocPathOccurrence & {
 
 export async function buildMessageDocumentSnapshots(
   text: string,
-  root: string,
+  self: string | SelfFence,
   fence?: WorkspaceFence,
 ): Promise<{ docs: SnapshotDoc[]; skipped: number; rewrittenText: string }> {
   const occurrences = collectDocPathOccurrences(text);
   if (occurrences.length === 0) return { docs: [], skipped: 0, rewrittenText: text };
 
-  const rootReal = await safeRealpath(root);
-  if (!rootReal) return { docs: [], skipped: occurrences.length, rewrittenText: text };
+  const selfConfig: SelfFence = typeof self === "string" ? { agentHome: self } : self;
+  const roots = await resolveSelfRoots(selfConfig);
+  if (!roots) return { docs: [], skipped: occurrences.length, rewrittenText: text };
 
   const workspacesRootReal = fence ? await safeRealpath(fence.workspacesRoot) : null;
 
   // Pass 1 — resolve every occurrence to a snapshot plan:
-  //   self  → bare key relative to `root` (unchanged from #474/#480); the
-  //           absolute-in-root case canonicalises to the same relative key web
-  //           derives once the text is rewritten.
+  //   self  → key relative to `agentHomeReal`; relative mentions in single-
+  //           repo workspaces are PROMOTED to `<localPath>/<rel>` so the abs
+  //           and rel forms of the same source-repo file share one canonical
+  //           key.
   //   cross → global key `<ownerSlug>/<chatId>/<rel>` for a file that realpaths
   //           into ANOTHER agent's workspace under the shared common root.
   const resolved: ResolvedOccurrence[] = await Promise.all(
     occurrences.map(async (occ): Promise<ResolvedOccurrence> => {
-      const selfKey = await canonicalizeWorkspacePath(rootReal, occ.writtenPath);
+      const selfKey = await canonicalizeWorkspacePath(roots, occ.writtenPath);
       if (selfKey) return { ...occ, kind: "self", key: selfKey, file: null, shortForm: "" };
-      // Only an ABSOLUTE path can escape the sender's own root into a sibling
-      // workspace; a relative mention always resolves under `root`.
+      // Only an ABSOLUTE path can escape the sender's own home into a sibling
+      // workspace; a relative mention always resolves under the self roots.
       if (workspacesRootReal && fence && isAbsolute(occ.writtenPath)) {
         const cross = await resolveCrossWorkspaceDoc(workspacesRootReal, fence, occ.writtenPath);
         if (cross) return { ...occ, kind: "cross", key: cross.key, file: cross.file, shortForm: cross.shortForm };
@@ -130,9 +177,9 @@ export async function buildMessageDocumentSnapshots(
       continue;
     }
 
-    // Self keys resolve back against `root`; cross keys already carry the
-    // realpath'd file from the fenced lookup.
-    const file = occ.kind === "cross" ? occ.file : await resolveWorkspaceFile(rootReal, key);
+    // Self keys resolve back against `agentHomeReal`; cross keys already
+    // carry the realpath'd file from the fenced lookup.
+    const file = occ.kind === "cross" ? occ.file : await resolveWorkspaceFile(roots.agentHomeReal, key);
     if (!file) {
       skipped += 1;
       continue;
@@ -294,27 +341,101 @@ function scanInlineMarkdownLinks(text: string): InlineLinkMatch[] {
 }
 
 /**
- * Resolve the canonical workspace-relative key for a written `.md` path,
- * accepting BOTH relative paths and absolute paths that land inside the
- * workspace root.
+ * Realpath the two self roots up-front so every occurrence in `Pass 1` shares
+ * the same containment-check fixtures. Returns null when `agentHome` itself is
+ * unrealpath'able — there is no workspace to snapshot against, so every
+ * occurrence is "skipped" by the caller.
+ *
+ * `docBaseReal` falls back to `agentHomeReal` when `singleRepoLocalPath` is
+ * unset OR points to a directory that doesn't physically exist yet (e.g. the
+ * source repo hasn't been materialised when the very first message goes out).
+ * In both cases the promotion is silently dropped — relative mentions still
+ * resolve, just against the agent home directly, matching the legacy
+ * zero/multi-repo path.
+ */
+async function resolveSelfRoots(self: SelfFence): Promise<ResolvedRoots | null> {
+  const agentHomeReal = await safeRealpath(self.agentHome);
+  if (!agentHomeReal) return null;
+  const localPath = self.singleRepoLocalPath?.trim();
+  if (!localPath) {
+    return { agentHomeReal, docBaseReal: agentHomeReal, promotePrefix: null };
+  }
+  const docBaseReal = await safeRealpath(resolve(agentHomeReal, localPath));
+  if (!docBaseReal) {
+    return { agentHomeReal, docBaseReal: agentHomeReal, promotePrefix: null };
+  }
+  // Defence in depth: the localPath dir must still be inside the agent home.
+  // A misconfigured `localPath: "../escape"` would otherwise let the docBase
+  // wander outside the fence and accept files we don't intend to snapshot.
+  const prefix = agentHomeReal.endsWith(sep) ? agentHomeReal : agentHomeReal + sep;
+  if (docBaseReal !== agentHomeReal && !docBaseReal.startsWith(prefix)) {
+    return { agentHomeReal, docBaseReal: agentHomeReal, promotePrefix: null };
+  }
+  // Promote relative keys to `<localPath>/<rel>` so abs + rel forms of the
+  // same source-repo file share one canonical key. `normalizeDocLinkPath`
+  // canonicalises here too, so a stray leading "/" or "./" in the operator's
+  // config doesn't leak through into snapshot keys.
+  const promote = normalizeDocLinkPath(relative(agentHomeReal, docBaseReal));
+  return {
+    agentHomeReal,
+    docBaseReal,
+    promotePrefix: promote && promote.length > 0 ? promote : null,
+  };
+}
+
+/**
+ * Resolve the canonical agent-home-relative snapshot key for a written `.md`
+ * path. Accepts BOTH relative paths (resolved against `docBaseReal` — the
+ * source repo top for single-repo agents, the agent home otherwise) and
+ * absolute paths (containment-checked against the wider `agentHomeReal` so
+ * `<agentHome>/worktrees/<task>/foo.md` and `<agentHome>/<localPath>/docs/foo.md`
+ * both land inside the fence).
  *
  * Absolute paths are `realpath`'d FIRST, then checked for containment — so an
- * ancestor symlink cannot be used to claim a path is "inside" the root when
- * its real target is not. The relative result is run back through
- * `normalizeDocLinkPath` so the key is POSIX-canonical and any hidden segment
- * exposed by the realpath (`<root>/.agent/x.md` reached via a symlink) is
- * rejected — matching what web's re-scan derives from the rewritten relative
- * token. Returns null when the path escapes the root, hides, or cannot be
- * realpath'd; the caller then leaves the text untouched and embeds no snapshot.
+ * ancestor symlink cannot be used to claim a path is "inside" the home when
+ * its real target is not. The result is run back through `normalizeDocLinkPath`
+ * so the key is POSIX-canonical and any hidden segment exposed by the realpath
+ * (`<agentHome>/.agent/x.md` reached via a symlink) is rejected — matching
+ * what web's re-scan derives from the rewritten token. Returns null when the
+ * path escapes the home, hides, or cannot be realpath'd; the caller then leaves
+ * the text untouched and embeds no snapshot.
+ *
+ * Relative paths get a second pass: `<docBaseReal>/<rel>` is realpath'd to
+ * confirm the file physically exists inside the fence (so the snapshot key
+ * agrees with what `resolveWorkspaceFile` will read) and to derive the
+ * agent-home-relative form. A relative mention that points at a non-existent
+ * file falls back to the un-promoted `normalizeDocLinkPath` so we don't change
+ * pre-#535 behaviour for tokens that were always dropped anyway.
  */
-async function canonicalizeWorkspacePath(rootReal: string, writtenPath: string): Promise<string | null> {
-  if (!isAbsolute(writtenPath)) return normalizeDocLinkPath(writtenPath);
+async function canonicalizeWorkspacePath(roots: ResolvedRoots, writtenPath: string): Promise<string | null> {
+  if (isAbsolute(writtenPath)) {
+    const real = await safeRealpath(writtenPath);
+    if (!real) return null;
+    const prefix = roots.agentHomeReal.endsWith(sep) ? roots.agentHomeReal : roots.agentHomeReal + sep;
+    if (real !== roots.agentHomeReal && !real.startsWith(prefix)) return null;
+    return normalizeDocLinkPath(relative(roots.agentHomeReal, real));
+  }
 
-  const real = await safeRealpath(writtenPath);
-  if (!real) return null;
-  const prefix = rootReal.endsWith(sep) ? rootReal : rootReal + sep;
-  if (real !== rootReal && !real.startsWith(prefix)) return null;
-  return normalizeDocLinkPath(relative(rootReal, real));
+  // Relative path. Try to land it inside the fence so abs and rel forms agree
+  // on the same key; if it can't be realpath'd, fall back to the bare
+  // normalized form (legacy: caller's resolveWorkspaceFile will still drop it).
+  const normalized = normalizeDocLinkPath(writtenPath);
+  if (!normalized) return null;
+  const real = await safeRealpath(resolve(roots.docBaseReal, normalized));
+  if (!real) {
+    // The file may not exist yet (or the path leaves the fence via `..`); the
+    // pre-promotion key remains valid for the legacy single-root resolve in
+    // resolveWorkspaceFile, where promotePrefix is null. With a promotePrefix
+    // we still need agent-home-relative output, so synthesise it from the
+    // normalized rel form.
+    if (roots.promotePrefix) {
+      return normalizeDocLinkPath(`${roots.promotePrefix}/${normalized}`);
+    }
+    return normalized;
+  }
+  const prefix = roots.agentHomeReal.endsWith(sep) ? roots.agentHomeReal : roots.agentHomeReal + sep;
+  if (real !== roots.agentHomeReal && !real.startsWith(prefix)) return null;
+  return normalizeDocLinkPath(relative(roots.agentHomeReal, real));
 }
 
 /**

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -1,6 +1,6 @@
 import { documentContextSchema } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
-import { buildMessageDocumentSnapshots } from "./doc-snapshots.js";
+import { buildMessageDocumentSnapshots, type SelfFence } from "./doc-snapshots.js";
 import type { AgentIdentity } from "./handler.js";
 
 /**
@@ -46,11 +46,19 @@ export type ResultSinkDeps = {
   clearTrigger: () => void;
   log: (msg: string) => void;
   /**
-   * Optional repo-local base path for markdown document links emitted by the
-   * handler. When present, web preview resolves `docs/foo.md` inside that
-   * worktree instead of the per-chat workspace root.
+   * Resolved self-fence for snapshot capture. `agentHome` is the wide
+   * containment boundary for absolute paths — covers the predeclared source
+   * repo, the agent's on-demand `worktrees/<task>/` checkouts, and anything
+   * else the agent writes inside its home. `singleRepoLocalPath` (optional)
+   * enables relative-path promotion so `docs/foo.md` and the absolute form
+   * `<agentHome>/<localPath>/docs/foo.md` share one canonical key. Absent →
+   * no snapshotting (legacy / test path).
+   *
+   * Returned via a callback (not a static field) because the agent's git-repo
+   * config can refresh mid-session; the runtime exposes the latest payload via
+   * its config cache.
    */
-  getDocumentBasePath?: () => Promise<string | null>;
+  getSelfFence?: () => Promise<SelfFence | null>;
   /**
    * Shared `workspaces/` common root (parent of every `<agentSlug>/<chatId>`).
    * Set alongside `selfSlug` to enable cross-agent doc snapshots: an absolute
@@ -74,8 +82,8 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
   async function prepareOutbound(text: string): Promise<{ content: string; metadata?: Record<string, unknown> }> {
     const metadata: Record<string, unknown> = {};
     let content = text;
-    const documentBasePath = await deps.getDocumentBasePath?.();
-    if (documentBasePath) {
+    const selfFence = await deps.getSelfFence?.();
+    if (selfFence) {
       // Embed the inline-snapshot variant only. This is the cloud-friendly
       // form: web gets the bytes straight from the message, no second server
       // round-trip and no dependency on the server having access to the
@@ -97,7 +105,7 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
           deps.workspacesRoot && deps.selfSlug
             ? { workspacesRoot: deps.workspacesRoot, chatId: deps.chatId, selfSlug: deps.selfSlug }
             : undefined;
-        const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, documentBasePath, fence);
+        const { docs, skipped, rewrittenText } = await buildMessageDocumentSnapshots(text, selfFence, fence);
         // Validate BEFORE committing the rewritten body: `rewrittenText`
         // contains explicit `[display](key)` links that only make sense paired
         // with their snapshots. If schema validation throws, the catch must

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -16,6 +16,7 @@ import type { AgentConfigCache } from "./agent-config-cache.js";
 import { buildAgentEnv, createParticipantCache, formatInboundContent, resolveSenderLabel } from "./agent-io.js";
 import type { SessionConfig } from "./config.js";
 import { Deduplicator } from "./deduplicator.js";
+import type { SelfFence } from "./doc-snapshots.js";
 import type {
   AgentHandler,
   AgentIdentity,
@@ -118,12 +119,42 @@ export function resolveSessionDocRoot(workspaceRoot: string, chatId: string): st
  *  - zero or multiple repos → the session doc root.
  */
 export function documentBasePathFromRuntimeConfig(payload: AgentRuntimeConfigPayload, sessionRoot: string): string {
-  if (payload.gitRepos.length === 1) {
-    const repo = payload.gitRepos[0];
-    const localPath = repo ? repoLocalPath(repo).trim() : "";
-    if (localPath.length > 0) return join(sessionRoot, localPath);
-  }
-  return sessionRoot;
+  const localPath = singleRepoLocalPathFromPayload(payload);
+  return localPath ? join(sessionRoot, localPath) : sessionRoot;
+}
+
+/**
+ * Extract the lone declared source-repo `localPath` for snapshot self-fence
+ * promotion. Returns null when the agent has zero or multiple repos, or when
+ * the single repo's localPath is blank — both cases bypass promotion so a
+ * relative `docs/foo.md` resolves against the agent home directly.
+ *
+ * Centralised here (rather than reimplemented in {@link documentBasePathFromRuntimeConfig})
+ * so the env-path / sessionRoot / SelfFence all derive from one source.
+ */
+export function singleRepoLocalPathFromPayload(payload: AgentRuntimeConfigPayload): string | null {
+  if (payload.gitRepos.length !== 1) return null;
+  const repo = payload.gitRepos[0];
+  if (!repo) return null;
+  const localPath = repoLocalPath(repo).trim();
+  return localPath.length > 0 ? localPath : null;
+}
+
+/**
+ * Build the {@link SelfFence} the snapshot pipeline gates absolute paths on.
+ * `agentHome` is whatever `resolveSessionDocRoot` picked (per-agent home for
+ * new chats, legacy per-chat dir for pre-#506 chats); the optional
+ * `singleRepoLocalPath` enables relative-path promotion so the abs and rel
+ * forms of a source-repo doc share a single snapshot key.
+ *
+ * Mirrors {@link documentBasePathFromRuntimeConfig} but exposes the agent home
+ * itself, not the narrower source-repo top — so on-demand `worktrees/<task>/`
+ * checkouts (PR #498's idiom) also resolve.
+ */
+export function selfFenceFromRuntimeConfig(payload: AgentRuntimeConfigPayload | null, sessionRoot: string): SelfFence {
+  if (!payload) return { agentHome: sessionRoot };
+  const singleRepoLocalPath = singleRepoLocalPathFromPayload(payload);
+  return singleRepoLocalPath ? { agentHome: sessionRoot, singleRepoLocalPath } : { agentHome: sessionRoot };
 }
 
 function repoLocalPath(repo: GitRepo): string {
@@ -911,16 +942,19 @@ export class SessionManager {
     // config surface (decision: config-ascent).
     const workspacesRoot = dirname(this.config.handlerConfig.workspaceRoot);
     const selfSlug = basename(this.config.handlerConfig.workspaceRoot);
-    // Resolve the doc base SYNCHRONOUSLY from the already-populated config
+    // Resolve the self-fence SYNCHRONOUSLY from the already-populated config
     // cache so it can ride the agent's env (`buildAgentEnv` is sync). This
     // lets a `first-tree chat send` sub-process snapshot referenced docs
     // exactly like result-sink does (L3: unify capture across send paths).
-    // result-sink keeps its own async `getDocumentBasePath`; both read the
-    // same cache (`refreshIfNewer(_, 0)` returns the cached payload), so the
-    // base they compute agrees. Falls back to the session doc root when the
-    // cache has no payload yet (== the single/zero-repo default).
+    // result-sink keeps its own async `getSelfFence`; both read the same cache
+    // (`refreshIfNewer(_, 0)` returns the cached payload), so the fence they
+    // compute agrees. The legacy `base` env var (`FIRST_TREE_DOC_BASE`) is
+    // kept emitting the OLD source-repo-top semantics so a stale pre-fix
+    // `chat send` binary inherited from this process still snapshots like it
+    // used to — see `agent-io.ts` for the wire-compat plumbing.
     const sessionRoot = resolveSessionDocRoot(this.config.handlerConfig.workspaceRoot, chatId);
-    const cachedPayload = this.config.agentConfigCache?.get(this.config.agentIdentity.agentId)?.payload;
+    const cachedPayload = this.config.agentConfigCache?.get(this.config.agentIdentity.agentId)?.payload ?? null;
+    const selfFence = selfFenceFromRuntimeConfig(cachedPayload, sessionRoot);
     const docBase = cachedPayload ? documentBasePathFromRuntimeConfig(cachedPayload, sessionRoot) : sessionRoot;
 
     const forwardResult = createResultSink({
@@ -932,7 +966,7 @@ export class SessionManager {
         this.currentTrigger.delete(chatId);
       },
       log,
-      getDocumentBasePath: () => this.resolveDocumentBasePath(log, chatId),
+      getSelfFence: () => this.resolveSelfFence(log, chatId),
       workspacesRoot,
       selfSlug,
     });
@@ -941,7 +975,13 @@ export class SessionManager {
       sdk: this.config.sdk,
       agent: this.config.agentIdentity,
       chatId,
-      docContext: { base: docBase, workspacesRoot, selfSlug },
+      docContext: {
+        base: docBase,
+        agentHome: selfFence.agentHome,
+        singleRepoLocalPath: selfFence.singleRepoLocalPath,
+        workspacesRoot,
+        selfSlug,
+      },
     };
 
     return {
@@ -968,21 +1008,21 @@ export class SessionManager {
     };
   }
 
-  private async resolveDocumentBasePath(log: (msg: string) => void, chatId: string): Promise<string> {
+  private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {
     // Session doc root: the dir the handler actually hands the agent as cwd —
     // the per-agent home for new chats, the legacy `<workspaceRoot>/<chatId>/`
     // dir for pre-#506 chats. See `resolveSessionDocRoot` (read-only existsSync;
     // no acquire* side effects on every outbound message).
     const sessionRoot = resolveSessionDocRoot(this.config.handlerConfig.workspaceRoot, chatId);
-    if (!this.config.agentConfigCache) return sessionRoot;
+    if (!this.config.agentConfigCache) return { agentHome: sessionRoot };
     try {
       const { payload } = await this.config.agentConfigCache.refreshIfNewer(this.config.agentIdentity.agentId, 0);
-      return documentBasePathFromRuntimeConfig(payload, sessionRoot);
+      return selfFenceFromRuntimeConfig(payload, sessionRoot);
     } catch (err) {
       log(
-        `document preview base path: config unavailable, using session doc root: ${err instanceof Error ? err.message : String(err)}`,
+        `document preview self-fence: config unavailable, using agent home only: ${err instanceof Error ? err.message : String(err)}`,
       );
-      return sessionRoot;
+      return { agentHome: sessionRoot };
     }
   }
 

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -139,7 +139,13 @@ describe("validateDocumentContext", () => {
   });
 
   describe("cross-agent provenance (chatScope)", () => {
-    const scope = (slugs: string[]) => ({ chatId: "chat-1", participantSlugs: new Set(slugs) });
+    // Real chat ids are UUIDs (services/chat.ts uses `randomUUID()`). Tests use
+    // canonical UUID-shaped strings so the cross-chat fence (which gates on
+    // `looksLikeChatId`) discriminates correctly — a non-UUID second segment
+    // is treated as a deep self path, NOT a cross-chat attempt.
+    const CHAT_ID = "11111111-1111-4111-8111-111111111111";
+    const OTHER_CHAT_ID = "22222222-2222-4222-8222-222222222222";
+    const scope = (slugs: string[]) => ({ chatId: CHAT_ID, participantSlugs: new Set(slugs) });
 
     it("accepts a cross-agent global key when the owner is a chat participant", () => {
       expect(() =>
@@ -147,7 +153,7 @@ describe("validateDocumentContext", () => {
           {
             documentContext: {
               kind: "snapshot",
-              docs: [snapshotDoc("assistant/chat-1/design.md", "# theirs\n")],
+              docs: [snapshotDoc(`assistant/${CHAT_ID}/design.md`, "# theirs\n")],
             },
           },
           scope(["coder", "assistant"]),
@@ -161,7 +167,7 @@ describe("validateDocumentContext", () => {
           {
             documentContext: {
               kind: "snapshot",
-              docs: [snapshotDoc("intruder/chat-1/secret.md", "# leak\n")],
+              docs: [snapshotDoc(`intruder/${CHAT_ID}/secret.md`, "# leak\n")],
             },
           },
           scope(["coder", "assistant"]),
@@ -184,15 +190,16 @@ describe("validateDocumentContext", () => {
     });
 
     it("rejects a participant-owned global key that names a DIFFERENT chat (chatId fence — P1)", () => {
-      // `assistant` is a participant, so `assistant/other-chat/design.md` is a
-      // cross key shape pointing at another chat's workspace — it must not slip
-      // past the `workspaces/*/<currentChatId>/` fence.
+      // `assistant` is a participant, the second segment is a uuid-shaped
+      // chatId different from `scope.chatId` — this is a cross key shape
+      // pointing at another chat's workspace and must not slip past the
+      // `workspaces/*/<currentChatId>/` fence.
       expect(() =>
         validateDocumentContext(
           {
             documentContext: {
               kind: "snapshot",
-              docs: [snapshotDoc("assistant/other-chat/design.md", "# x\n")],
+              docs: [snapshotDoc(`assistant/${OTHER_CHAT_ID}/design.md`, "# x\n")],
             },
           },
           scope(["coder", "assistant"]),
@@ -216,12 +223,52 @@ describe("validateDocumentContext", () => {
       ).not.toThrow();
     });
 
+    it("treats a participant-named first segment as SELF when the second segment is not uuid-shaped", () => {
+      // Worktree-fence regression guard: a single-repo agent whose source-repo
+      // `localPath` happens to coincide with another participant's slug emits
+      // promoted self keys like `assistant/docs/intro.md` for relative
+      // mentions. Without the `looksLikeChatId` discriminator, the
+      // participant-owned-different-chat branch would reject these as a
+      // cross-chat leak — but `docs` is not a uuid, so no real chat can be
+      // named `docs` and the leak path is structurally impossible. Treat the
+      // key as a deep self path and let it through.
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("assistant/docs/intro.md", "# self with colliding prefix\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).not.toThrow();
+    });
+
+    it("allows a worktree self key whose first segment is not a participant slug", () => {
+      // The wide self-fence emits agent-home-relative keys for files outside
+      // the source repo (e.g. on-demand `git worktree add`). When the first
+      // segment is `worktrees` and no participant is named `worktrees`, the
+      // path is straightforward self — never trips the cross check.
+      expect(() =>
+        validateDocumentContext(
+          {
+            documentContext: {
+              kind: "snapshot",
+              docs: [snapshotDoc("worktrees/553-fix/docs/design.md", "# worktree doc\n")],
+            },
+          },
+          scope(["coder", "assistant"]),
+        ),
+      ).not.toThrow();
+    });
+
     it("skips the provenance check entirely when no chatScope is supplied (back-compat)", () => {
       expect(() =>
         validateDocumentContext({
           documentContext: {
             kind: "snapshot",
-            docs: [snapshotDoc("intruder/chat-1/secret.md", "# leak\n")],
+            docs: [snapshotDoc(`intruder/${CHAT_ID}/secret.md`, "# leak\n")],
           },
         }),
       ).not.toThrow();

--- a/packages/server/src/services/doc-snapshots.ts
+++ b/packages/server/src/services/doc-snapshots.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import {
   documentContextSchema,
+  looksLikeChatId,
   MAX_DOC_SNAPSHOT_BYTES,
   MAX_TOTAL_DOC_SNAPSHOT_BYTES,
   parseWorkspaceDocKey,
@@ -66,12 +67,23 @@ export function validateDocumentContext(
               "doc_snapshot.owner_slug": key.agentSlug,
             });
           }
-        } else if (ownerIsParticipant) {
+        } else if (ownerIsParticipant && looksLikeChatId(key.chatId)) {
           // Owner-shaped global key naming a DIFFERENT chat. A participant-owned
           // key whose chat segment isn't this chat would pull another chat's
           // private workspace doc past the `workspaces/*/<currentChatId>/` fence
-          // — reject it (review P1). A deep SELF path whose first segment isn't
-          // a participant slug (e.g. `docs/api/design.md`) is left alone.
+          // — reject it (review P1).
+          //
+          // The `looksLikeChatId` gate disambiguates a real cross-chat attempt
+          // (`<participant>/<some-uuid>/<rel>`) from a deep SELF path whose
+          // first segment HAPPENS to be a participant slug. After the
+          // worktree-fence widening (this PR), a single-repo agent emits
+          // promoted self keys shaped `<localPath>/<rel>` (e.g.
+          // `assistant/docs/intro.md`); without the uuid check, those would be
+          // rejected here whenever `<localPath>` collides with a participant
+          // name, breaking otherwise valid sends. chatIds are minted by
+          // `createChat` as canonical UUIDs (services/chat.ts), so any
+          // non-uuid second segment cannot reference a real chat — the leak
+          // protection is meaningless in that branch.
           throw new BadRequestError("Document snapshot references another chat's agent workspace", {
             "doc_snapshot.path": doc.path,
             "doc_snapshot.owner_slug": key.agentSlug,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } fro
 export {
   buildWorkspaceDocKey,
   isCanonicalDocLinkPath,
+  looksLikeChatId,
   normalizeDocLinkPath,
   parseWorkspaceDocKey,
 } from "./lib/doc-path.js";

--- a/packages/shared/src/lib/__tests__/doc-path.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-path.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildWorkspaceDocKey,
   isCanonicalDocLinkPath,
+  looksLikeChatId,
   normalizeDocLinkPath,
   parseWorkspaceDocKey,
 } from "../doc-path.js";
@@ -135,5 +136,37 @@ describe("parseWorkspaceDocKey", () => {
   it("round-trips with buildWorkspaceDocKey", () => {
     const key = buildWorkspaceDocKey("assistant", "chat-1", "docs/design.md") as string;
     expect(parseWorkspaceDocKey(key)).toEqual({ agentSlug: "assistant", chatId: "chat-1", rel: "docs/design.md" });
+  });
+});
+
+describe("looksLikeChatId", () => {
+  it("accepts canonical UUID v4 / v7 chat ids (the shape `randomUUID` mints)", () => {
+    // Real chat ids — services/chat.ts uses `randomUUID()` from node:crypto.
+    expect(looksLikeChatId("11111111-1111-4111-8111-111111111111")).toBe(true);
+    // UUID v7 (time-ordered) — used elsewhere in the project for message ids;
+    // chatIds may rotate to v7 in the future, so the check must accept it.
+    expect(looksLikeChatId("018f8f3c-8c4f-7f5a-9a4b-1a2b3c4d5e6f")).toBe(true);
+    // Mixed case is canonical too.
+    expect(looksLikeChatId("ABCDEF12-3456-7890-ABCD-EF1234567890")).toBe(true);
+  });
+
+  it("rejects everyday subdir names — the disambiguator's whole purpose", () => {
+    // Without this rejection, the server validator would over-reject promoted
+    // self keys like `<localPath>/docs/intro.md` whenever `<localPath>`
+    // collides with a participant slug (worktree-fence-widening codex P2).
+    expect(looksLikeChatId("docs")).toBe(false);
+    expect(looksLikeChatId("worktrees")).toBe(false);
+    expect(looksLikeChatId("api")).toBe(false);
+    expect(looksLikeChatId("chat-1")).toBe(false);
+    expect(looksLikeChatId("other-chat")).toBe(false);
+  });
+
+  it("rejects strings that are uuid-like but structurally off", () => {
+    expect(looksLikeChatId("")).toBe(false);
+    expect(looksLikeChatId("11111111-1111-4111-8111-11111111111")).toBe(false); // 35 chars
+    expect(looksLikeChatId("11111111-1111-4111-8111-1111111111111")).toBe(false); // 37 chars
+    expect(looksLikeChatId("11111111-1111-9111-8111-111111111111")).toBe(false); // version=9 (invalid)
+    expect(looksLikeChatId("11111111-1111-4111-c111-111111111111")).toBe(false); // variant=c (invalid)
+    expect(looksLikeChatId("g1111111-1111-4111-8111-111111111111")).toBe(false); // non-hex
   });
 });

--- a/packages/shared/src/lib/doc-path.ts
+++ b/packages/shared/src/lib/doc-path.ts
@@ -115,3 +115,30 @@ export function parseWorkspaceDocKey(key: string): { agentSlug: string; chatId: 
   if (!agentSlug || !chatId || rel.length === 0) return null;
   return { agentSlug, chatId, rel };
 }
+
+/**
+ * Heuristic: does this string have the shape of a Hub chat id?
+ *
+ * Chats are minted with `randomUUID()` (services/chat.ts), so a real chatId is
+ * always a 36-char canonical UUID — `xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx`
+ * where M is the version nibble and N is the variant nibble. We accept any
+ * canonical UUID (v1-v7) so the check stays correct if the project rotates
+ * the version field in the future.
+ *
+ * Why this matters: {@link parseWorkspaceDocKey} is structurally ambiguous —
+ * a 3+ segment self path (`<localPath>/docs/foo.md`, `worktrees/<task>/x.md`)
+ * also splits cleanly into `agentSlug / chatId / rel`. Callers that need to
+ * distinguish "real cross-agent global key" from "deep self path that happens
+ * to start with a participant slug" use this check: only when the second
+ * segment IS a uuid-shaped chatId is the path treated as a cross key (see
+ * server `validateDocumentContext` cross-chat fence). Without this, a
+ * single-repo agent whose source-repo `localPath` collides with another
+ * participant's slug (e.g. both literally `assistant`) would have every
+ * relative `docs/x.md` rejected as a cross-chat leak — codex-review P2 on
+ * the worktree-fence-widening PR.
+ */
+const CHAT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function looksLikeChatId(s: string): boolean {
+  return CHAT_ID_RE.test(s);
+}


### PR DESCRIPTION
## Summary

After #498 encouraged `git worktree add worktrees/<task>/` and #506 moved cwd to per-agent home, every doc inside an on-demand worktree fell outside the snapshot self-fence and stayed plain text in chat — referencing a design doc you just wrote produced no preview. #535 fixed the docBase null path but kept the fence narrow at the source-repo top.

This PR widens the self-fence to the full agent home (`<workspaceRoot>` for new chats; legacy `<workspaceRoot>/<chatId>/` for pre-#506 chats). Absolute paths gate on the wide boundary; relative paths still resolve against the source-repo top (single-repo idiom) but their snapshot key is **promoted** to `<localPath>/<rel>` so abs + rel forms of one file share a single canonical key.

## Key changes

- **`SelfFence` type** carries `agentHome` + optional `singleRepoLocalPath`. `buildMessageDocumentSnapshots(text, self, fence?)` accepts either the new SelfFence object or the legacy string root (backward compat).
- **`ResultSinkDeps.getDocumentBasePath`** → `getSelfFence`. SelfFence flows from `session-manager` (new `selfFenceFromRuntimeConfig`) through result-sink to the snapshot builder.
- **New env vars**: `FIRST_TREE_DOC_AGENT_HOME` + `FIRST_TREE_DOC_REPO_LOCAL_PATH`. Legacy `FIRST_TREE_DOC_BASE` kept emitting so a stale pre-fix `chat send` sub-process degrades gracefully (no worktree preview, source-repo docs still resolve).
- **Server-side cross-fence regression guard**: a promoted self key shaped `<localPath>/<rel>` parses through `parseWorkspaceDocKey` (3+ segments → structurally ambiguous self/cross). The cross-chat-leak branch of `validateDocumentContext` would reject these whenever `<localPath>` collides with a participant slug. Added `looksLikeChatId` (canonical UUID v1-v7 regex) — chatIds are minted by `randomUUID()` so a non-uuid second segment can't reference a real chat. Found via codex review.

## Test plan

- [x] `pnpm typecheck` — 13 packages clean
- [x] `pnpm check` — 0 errors (16 pre-existing warnings only)
- [x] `pnpm --filter @first-tree/client test` — 541 passed
- [x] `pnpm --filter first-tree-dev test` — 236 passed (incl. 3 new doc-capture wide-fence cases)
- [x] `pnpm --filter @first-tree/server test` — 1190 passed (incl. new participant-collision + worktree-key cases)
- [x] `pnpm --filter @first-tree/shared test` — 275 passed (incl. 3 new `looksLikeChatId` cases)
- [x] 2 rounds of `codex review --uncommitted` — round 1 caught the `<localPath>`-collides-with-participant-slug bug (fixed via server uuid gate); round 2 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)