### PR TITLE
docs: follow-up — remove residual Hub brand mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run `first-tree <namespace> --help` for the full list under any namespace.
 - `packages/e2e/` — black-box e2e harness (`@first-tree/e2e`)
 - `skills/` — per-skill markdown payloads (`first-tree`, `first-tree-cloud`,
   `first-tree-github-scan`, `first-tree-sync`, `first-tree-write`,
-  `first-tree-onboarding`)
+  `first-tree-onboarding`, `github-scan`)
 
 ## Documentation
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -47,7 +47,7 @@ first-tree
 - `packages/web/` — React 管理后台（`@first-tree/web`）
 - `packages/github-scan/` — GitHub Scan daemon（`@first-tree/github-scan`）
 - `packages/e2e/` — 黑盒 e2e 测试框架（`@first-tree/e2e`）
-- `skills/` — 单 skill 的 markdown payload（`first-tree`、`first-tree-cloud`、`first-tree-github-scan`、`first-tree-sync`、`first-tree-write`、`first-tree-onboarding`）
+- `skills/` — 单 skill 的 markdown payload（`first-tree`、`first-tree-cloud`、`first-tree-github-scan`、`first-tree-sync`、`first-tree-write`、`first-tree-onboarding`、`github-scan`）
 
 ## 文档
 

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -28,7 +28,7 @@ const program = new Command();
 
 program
   .name(channelConfig.binName)
-  .description("First Tree — Context Tree, GitHub Scan, and Hub agent collaboration in one CLI")
+  .description("First Tree — Context Tree, GitHub Scan, and agent collaboration in one CLI")
   .version(COMMAND_VERSION)
   .option("--json", "emit only machine-readable JSON on stdout; silence human status lines on stderr")
   .option("--verbose", "raise log level to debug (overrides FIRST_TREE_LOG_LEVEL)")

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -19,7 +19,7 @@ already have.
 | staging | `npm i -g first-tree-staging` | `first-tree-staging` / `fts` | `~/.first-tree-staging/` | `first-tree-staging.service` |
 | prod | `npm i -g first-tree` | `first-tree` / `ft` | `~/.first-tree/` | `first-tree.service` |
 
-Each install registers as a separate `clientId` on whichever hub it
+Each install registers as a separate `clientId` on whichever server it
 connects to (dev → local server, staging → `dev.cloud.first-tree.ai`,
 prod → `cloud.first-tree.ai`), so server-side state stays cleanly
 partitioned too.
@@ -30,7 +30,7 @@ partitioned too.
 # from repo root, first-time use
 ./scripts/dev-install.sh
 
-# Start your local hub server (any way you like — e.g. `pnpm --filter @first-tree/server dev`)
+# Start your local server (any way you like — e.g. `pnpm --filter @first-tree/server dev`)
 
 first-tree-dev login <connect-token>   # token from http://127.0.0.1:8000/clients
 first-tree-dev daemon status
@@ -110,7 +110,7 @@ first-tree-staging login <staging-token>
 
 ## What `dev-install.sh` does NOT isolate
 
-- The PostgreSQL database. Hub server uses one shared DB by default. If
+- The PostgreSQL database. The server uses one shared DB by default. If
   you also run an in-tree server (`pnpm --filter @first-tree/server dev`),
   use a separate DB URL via `FIRST_TREE_DATABASE_URL`.
 - Global npm packages. If you have both staging and prod installed,

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -13,19 +13,19 @@ external IM integration, then `daemon start` to bring everything online.
 - **Node.js** ≥ 22.16 (24 recommended).
 - **The CLI** — `npm install -g first-tree && first-tree --version`.
 - **A connect token** — generated from the web console's *Computers → New
-  Connection* dialog. The token's `iss` claim carries the hub URL, so the
-  CLI does not need a server flag.
-- **A server you can reach** — either a SaaS hub or a locally running
-  server.
+  Connection* dialog. The token's `iss` claim carries the server URL, so
+  the CLI does not need a server flag.
+- **A server you can reach** — either the hosted SaaS or a locally
+  running server.
 
 ## End-to-end flow
 
 ```bash
-# 1. Sign this machine into the hub. Persists credentials and installs
-#    the background daemon on macOS / Linux.
+# 1. Sign this machine in. Persists credentials and installs the
+#    background daemon on macOS / Linux.
 first-tree login <connect-token>
 
-# 2. Create the agent record on the hub and bind it to this client.
+# 2. Create the agent record on the server and bind it to this client.
 #    The same JWT signs every request — no per-agent token.
 first-tree agent create alice \
   --type human \
@@ -77,8 +77,8 @@ first-tree agent add --agent-id <agent-uuid>
 first-tree agent list
 ```
 
-The local config directory is keyed by the agent's canonical name on the
-hub — there is no separate "local alias" to invent.
+The local config directory is keyed by the agent's canonical server-side
+name — there is no separate "local alias" to invent.
 
 ## Inspecting and recovering
 
@@ -88,7 +88,7 @@ hub — there is no separate "local alias" to invent.
 | Daemon readiness check | `first-tree daemon doctor` |
 | Cross-subsystem readiness check | `first-tree doctor` |
 | List local agent bindings | `first-tree agent list` |
-| List every agent you manage on the hub | `first-tree agent list --remote` |
+| List every agent you manage on the server | `first-tree agent list --remote` |
 | Take over a machine bound to another user | `first-tree login <token> --override` |
 | Send a chat message | `first-tree chat send <agent-name> "message"` |
 | List chats | `first-tree chat list` |
@@ -113,7 +113,7 @@ retained as a read-only debug endpoint.
 | Variable | Purpose |
 |---|---|
 | `FIRST_TREE_HOME` | Override config/data home directory (default: `~/.first-tree/hub`) |
-| `FIRST_TREE_SERVER_URL` | Hub server URL (alternative to the token's `iss` claim) |
+| `FIRST_TREE_SERVER_URL` | Server URL (alternative to the token's `iss` claim) |
 
 Feishu credentials (`--app-id` / `--app-secret`) are only needed when
 binding a Feishu bot via `agent bind bot`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,7 @@
 A walkthrough that takes a brand-new account from signup to a working
 chat with your first agent.
 
-## 1. Open the hub
+## 1. Open the web console
 
 <https://first-tree.ai>
 
@@ -11,9 +11,9 @@ Sign in with GitHub. A personal team is auto-created for you on first
 sign-in; you confirm or rename it in the first-run onboarding stepper.
 
 > **Self-hosting?** Replace the URL above with your own deployment. The
-> rest of this guide is identical — every connect token carries its hub
-> URL in its `iss` claim, so the CLI follows the token rather than a
-> baked-in server name.
+> rest of this guide is identical — every connect token carries its
+> server URL in its `iss` claim, so the CLI follows the token rather
+> than a baked-in server name.
 
 ## 2. Install the CLI
 
@@ -36,9 +36,9 @@ first-tree login <connect-token>
 
 `first-tree login`:
 
-- Decodes the token's `iss` claim to derive the hub URL. **No `--server`
-  flag needed**, and switching to a different hub only requires a new
-  token, not a new command.
+- Decodes the token's `iss` claim to derive the server URL. **No
+  `--server` flag needed**, and switching to a different server only
+  requires a new token, not a new command.
 - Persists the member JWT (access + refresh) at
   `~/.first-tree/hub/config/credentials.json` (mode `0600`).
 - Writes `server.url` and a fresh `client.id` to


### PR DESCRIPTION
Cleanup pass after #566 covering the 3 Blocker + 2 of 4 Minor flagged by reviewer.

## Blockers (all 3)

- **B1** \`apps/cli/src/cli/index.ts:31\` — root command description was \`"First Tree — Context Tree, GitHub Scan, and Hub agent collaboration in one CLI"\`, visible verbatim from \`first-tree --help\`. Now: \`"... and agent collaboration in one CLI"\`. (Not a code-symbol rename — just the user-facing description string.)
- **B2** \`docs/onboarding-guide.md:116\` — \`FIRST_TREE_SERVER_URL\` description \`"Hub server URL ..."\` → \`"Server URL ..."\`.
- **B3** \`docs/development/local-dev-isolation.md:113\` — \`"Hub server uses one shared DB by default"\` → \`"The server uses one shared DB by default"\` (the line missed in the \`git mv\` of #566).

## Minor

- **M1** Eight lowercase \`hub\` references as standalone nouns across \`docs/quickstart.md\`, \`docs/onboarding-guide.md\`, and \`docs/development/local-dev-isolation.md\` rewritten as \`the server\` / \`server URL\` / \`the web console\` / \`hosted SaaS\` as appropriate. Runtime paths like \`~/.first-tree/hub/...\` are kept (out of scope, §7).
- **M3** \`README.md\` + \`README_zh-CN.md\` skills list was missing \`github-scan\` (the standalone directory alongside the six \`first-tree-*\` ones). Added.

## Not addressed (PR-2 / PR-3 scope)

- **M2** SDK type name \`FirstTreeHubSDK\` in the onboarding-guide SDK example — code-symbol rename, §7 out of scope.
- **M4** Verification process improvement — this PR's description captures real grep output instead of paraphrasing (below).
- \`docs/cli-reference.md\` still has \`Hub server\` / \`hub URL\` references — that file is rewritten end-to-end in **PR-2**, so this PR intentionally leaves it alone to avoid double-edits.
- \`packages/*/README.md\`, \`.github/\` templates, \`skills/*/SKILL.md\` references — **PR-3** scope.

## Verification (actual output)

All excluding \`docs/cli-reference.md\` (PR-2 scope):

\`\`\`
$ grep -rni "first-tree-hub" \\
    README.md README_zh-CN.md AGENTS.md CONTRIBUTING.md SUPPORT.md \\
    \$(find docs -name '*.md' ! -name 'cli-reference.md')
(none)

$ grep -rniE "merges|former|unifies two|the result of merg|port-back" \\
    <same set>
(none)

$ grep -rniE "First Tree IS:|Hub / Tree / Scan|Hub agent collaboration" \\
    <same set> apps/cli/src/cli/index.ts
(none)

$ grep -rnE "Hub server|Hub URL" <same set>
(none)

$ grep -nE "\\b(the|a|saas|local|whichever)\\s+hub\\b|hub\\s+(URL|server)\\b|into\\s+the\\s+hub|on\\s+the\\s+hub|Open\\s+the\\s+hub" \\
    \$(find docs -name '*.md' ! -name 'cli-reference.md')
(none)
\`\`\`

## Diff

\`+24 / -24\` across 6 files. No source-logic changes.

## Test plan

- [x] Five-grep verification clean.
- [ ] Owner sign-off / reviewer re-review.