### PR TITLE
release: bump apps/cli to v0.5.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
Minor release covering 30 commits since v0.5.1.

Re-opened from #567 with the correct `chore/` branch prefix (CI requires `feat|fix|refactor|test|docs|chore`). Same commit, same review state — yuezengwu's LGTM on #567 still applies.

## Highlights

- New beginner-first onboarding flow at `/onboarding` (#529)
- Instant chat switching via IndexedDB caching (#286)
- Unified agent work-status across chat list, sidebar, and composer (#524)
- Agent runtime errors now surface as structured session events (#554)

## Notable fixes

- Auto-retry transient `git fetch` / `set-head` failures (#548)
- Auto-recover worktree after orphaned dev-server leftovers (#527)
- Forward shell proxy env into launchd / systemd units (#526)
- Server: route GitHub events by human; UUID v7 message IDs (#544, #549)

Tag `v0.5.2` will be cut on the merge commit.