### PR TITLE
fix(server): widen appendEvent seq retry budget + jitter to absorb concurrent bursts

### DIFF
--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -19,7 +19,17 @@ const log = createLogger("SessionEvent");
 
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 1000;
-const MAX_SEQ_RETRIES = 3;
+// Worst-case under READ COMMITTED, N concurrent appendEvent calls on the same
+// (agent, chat) all snapshot `MAX(seq)` together and lock-step into the same
+// candidate seq — each round eliminates exactly one loser, so up to N retries
+// can be needed before the last caller finds a free slot. 8 leaves slack for
+// the realistic burst ceiling (production is ~1 concurrent per session); a
+// CI herd at N=5 with the old budget of 3 flaked.
+const MAX_SEQ_RETRIES = 8;
+// Spread retriers so they don't re-read `MAX(seq)` in lock-step after losing
+// the previous round. Skipped on the first attempt — the happy path stays
+// zero-latency.
+const RETRY_JITTER_MS = 20;
 
 export type SessionEventRow = {
   id: string;
@@ -61,6 +71,9 @@ export async function appendEvent(
   const validated = sessionEventSchema.parse(event);
 
   for (let attempt = 0; attempt < MAX_SEQ_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await new Promise((r) => setTimeout(r, Math.random() * RETRY_JITTER_MS));
+    }
     const id = uuidv7();
     // PG JSONB rejects U+0000 outright. Strip the escaped sequence from the
     // serialized JSON so a binary preview (e.g. ZIP bytes from


### PR DESCRIPTION
## Summary

- `MAX_SEQ_RETRIES` 3 → 8 in `packages/server/src/services/session-event.ts` — the previous budget was strictly insufficient for the existing 5-way contention test, which surfaced as a flaky `Error: session_events seq contention` on the [main CI run for #564](https://github.com/agent-team-foundation/first-tree/actions/runs/26433730931/job/77811958133) (one failed test out of 1197; unrelated to that PR's changes).
- Added 0–20 ms jitter between retries so concurrent losers don't re-read `MAX(seq)` in lock-step after losing the previous round.

## Why the old budget was too small

`appendEvent` writes `seq` via `INSERT … SELECT COALESCE(MAX(seq), 0) + 1 … ON CONFLICT (agent_id, chat_id, seq) DO NOTHING` with a bounded retry loop. Under READ COMMITTED, when N concurrent callers on the same `(agent, chat)` snapshot `MAX(seq)` together, each retry round eliminates exactly one loser — so up to **N** retries can be needed before the last caller finds a free slot. The session-event contention test issues 5 concurrent appends, so a budget of 3 leaves 2 callers no retries left in the worst case.

| Round | callers still racing | MAX seen | candidate seq | winner | losers |
|------:|---:|---:|---:|---:|---:|
| #1 | 5 | 0 | 1 | 1 | 4 |
| #2 | 4 | 1 | 2 | 1 | 3 |
| #3 | 3 | 2 | 3 | 1 | **2 ← out of retries** |

The test usually passes because OS scheduling staggers the inserts; CI hit the herd case and flaked.

8 leaves slack for any plausible per-(agent, chat) burst (production is ~1 concurrent per session, so the happy path stays zero-latency — jitter only kicks in after a lost attempt).

## Test plan

- [x] `pnpm check` (biome) — clean
- [x] `pnpm --filter @first-tree/server typecheck` — clean
- [x] `resolves contention via ON CONFLICT + retry` — passes 10/10 in isolation
- [x] Full `@first-tree/server` suite — 1197/1197 pass locally
- [ ] CI Test job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)