### PR TITLE
docs(cli-reference): rewrite end-to-end against the shipped CLI

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -342,7 +342,7 @@ calls `daemon status` internally and adds server/auth/agent rows.
 ## config
 
 Read and write this machine's `client.yaml`. The file lives at
-`~/.first-tree/hub/config/client.yaml` (or the staging/dev channel's
+`~/.first-tree/config/client.yaml` (or the staging/dev channel's
 equivalent — see [docs/development/local-dev-isolation.md](development/local-dev-isolation.md)).
 
 ```bash
@@ -543,7 +543,7 @@ See [observability.md](observability.md) for the full config reference, backend 
 ## Directory layout (CLI home)
 
 ```
-~/.first-tree/hub/                                 # FIRST_TREE_HOME default for the prod channel
+~/.first-tree/                                     # FIRST_TREE_HOME default for the prod channel
 ├── config/
 │   ├── client.yaml                                # this machine's client config (server.url, client.id)
 │   ├── credentials.json                           # access + refresh JWT (mode 0600)
@@ -559,7 +559,7 @@ See [observability.md](observability.md) for the full config reference, backend 
 └── logs/                                          # daemon stderr / stdout (macOS)
 ```
 
-When `FIRST_TREE_HOME` is set, replace `~/.first-tree/hub/` with that location. Staging and dev channels use `~/.first-tree-staging/` and `~/.first-tree-dev/` respectively.
+When `FIRST_TREE_HOME` is set, replace `~/.first-tree/` with that location. Staging and dev channels use `~/.first-tree-staging/` and `~/.first-tree-dev/` respectively as their channel-default home.
 
 ## Config resolution order
 
@@ -567,7 +567,7 @@ Priority from high to low:
 
 1. CLI arguments
 2. Environment variables (`FIRST_TREE_*`)
-3. Config files (`~/.first-tree/hub/config/client.yaml`)
+3. Config files (`~/.first-tree/config/client.yaml`, or the staging/dev channel's equivalent)
 4. Built-in defaults
 
 ## Verification after upgrade

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,417 +1,581 @@
-# First Tree Hub CLI Reference
+# CLI Reference
 
-## Prerequisites
+The full command surface for `first-tree`. Every command listed here is in
+the shipped binary — `first-tree --help` (and `first-tree <namespace>
+--help`) are the canonical source of truth, this document is a
+human-friendly index over them.
+
+> **Keeping this file current.** Any PR that changes the command surface
+> (adds, renames, removes, or re-flags a verb / namespace) must update
+> this file in the same PR. The grep checks that gate `Forbid legacy CLI
+> / env names` only catch a handful of retired identifiers; the broader
+> *"what commands exist and what do they do"* contract is enforced by
+> humans against this document.
+
+## Install
 
 ```bash
 npm install -g first-tree
 first-tree --version
 ```
 
-- Node.js `>= 22.16`
-- `gh` authenticated when using `onboard`
+The binary lives at `first-tree`; the short alias `ft` is also installed.
+Requirements: Node.js ≥ 22.16 (24 recommended).
 
-## Commands
+## Global flags
+
+| Flag | Effect |
+|---|---|
+| `--json` | Emit only machine-readable JSON on stdout; silence human status lines on stderr. |
+| `--verbose` | Raise the log level to debug (overrides `FIRST_TREE_LOG_LEVEL`). |
+| `--version` | Print the CLI version and exit. |
+| `--help` | Print help for the command or namespace. |
+
+## Top-level command tree
 
 ```
 first-tree
-├── connect <token> [--no-start]
-├── client
-│   ├── start [--no-interactive] [--foreground]
-│   ├── stop
-│   ├── restart
-│   ├── status
-│   ├── doctor
-│   ├── list
-│   ├── disconnect <clientId>
-│   ├── claim [--confirm]
-│   └── config
-│       ├── show [key] [--show-secrets]
-│       ├── set <key> <value>
-│       └── get <key> [--show-secrets]
-├── agent
-│   ├── add [--agent-id <uuid>]
-│   ├── remove <name>
-│   ├── prune [--yes] [--dry-run] [--server]
-│   ├── list [--remote] [--org <id>]
-│   ├── create <name> --type <t> --client-id <id> [--runtime] [--display-name] [--org] [--server]
-│   ├── claim <agentName>
-│   ├── status [name]
-│   ├── reset <name>
-│   ├── session list <agent-name> [--state]
-│   ├── session suspend <agent-name> <chat-id>
-│   ├── session terminate <agent-name> <chat-id>
-│   ├── config show <agent>
-│   ├── config set-model <agent> <model>
-│   ├── config append-prompt <agent> [-f <file>]
-│   ├── config add-mcp <agent> --name --transport [--command --args | --url]
-│   ├── config set-env <agent> <KEY=VALUE> [--sensitive]
-│   ├── config add-repo <agent> <url> [--ref] [--path]
-│   ├── config dry-run <agent> -f <patch.json>
-│   ├── bind client <agentName> --client-id
-│   ├── bind bot --platform feishu --app-id --app-secret
-│   ├── bind user <humanAgentId> --platform feishu --feishu-id
-│   └── workspace clean [agent-name] [--ttl]
-├── chat
-│   ├── list [-l <limit>] [--cursor] [--agent]
-│   ├── history <chatId> [-l <limit>] [--cursor] [--agent]
-│   ├── send <agentName> [message] [-f format] [-m <json>] [--agent]
-│   ├── invite <agentName> [--agent]
-│   └── open <agent-name> [--server]
-├── org
-│   └── bind-tree <url> [--org]
-├── onboard [--check] [--continue]
-│   [--id] [--type] [--display-name] [--role] [--domains]
-│   [--delegate-mention]
-│   [--assistant] [--server] [--feishu-bot-app-id] [--feishu-bot-app-secret]
-└── update [--check] [--no-restart]
+├── login <token>            Sign this computer in
+├── logout                   Stop the daemon and clear credentials
+├── status                   CLI + daemon + server + auth + agent overview
+├── doctor                   Cross-subsystem readiness check
+├── upgrade                  Self-update + restart the daemon
+├── agent ...                Agent management (config, bindings, sessions, messaging)
+├── chat ...                 Chats and messaging (send, list, history, open)
+├── org ...                  Organization-level operations
+├── daemon ...               Background daemon (start, stop, status, doctor)
+├── config ...               View/modify this machine's client.yaml
+├── tree ...                 Context Tree onboarding, validation, automation
+└── github scan ...          GitHub Scan daemon and inbox runtime
 ```
 
-## connect
+---
 
-Single entry point. Paste the connect token your Hub web console shows
-in *Connect your computer*; the CLI decodes the token's `iss` claim to
-derive the hub URL — no `--server-url` argument needed.
+## login
 
-```bash
-first-tree login eyJhbGciOi...           # default: install background service
-first-tree login eyJhbGciOi... --no-start   # run inline until Ctrl+C
+```
+first-tree login <token> [--no-start] [--override]
 ```
 
-Hard-fails (no fallback) when the token is missing an `iss` claim or the
-claim is not an `http(s)` URL — that prevents stale tokens from one
-environment from accidentally re-targeting another.
+Sign this computer in using a connect token from the web console. The
+token's `iss` claim carries the server URL — no `--server` flag needed,
+and switching to a different deployment only requires a fresh token.
 
-## client
+| Flag | Effect |
+|---|---|
+| `--no-start` | Write credentials and exit without installing/starting the background daemon. |
+| `--override` | Transfer ownership of this client from a different account (folds in what the retired `client claim` did). |
 
-Client runtime — connects all configured agents to the server. First-time
-setup happens via the top-level `first-tree login <token>` (see
-above); the commands below cover ongoing operation.
+## logout
 
-```bash
-# Service lifecycle (delegates to systemd / launchd when a service is installed)
-first-tree daemon start          # Start the background service
-first-tree daemon start --foreground   # Run inline instead (debug / no-service users)
-first-tree daemon stop           # Stop the service (preserves auto-start on next login)
-first-tree daemon restart        # Restart the service
-
-# Check environment readiness (includes background-service state)
-first-tree daemon doctor
-
-# One-screen overview: CLI version, service state, hub URL, configured agents
-first-tree daemon status
-
-# Hub-side client inventory and administration is exposed in the web admin UI
-# (Computers tab). The legacy `client list` / `client disconnect` CLI verbs
-# have been removed.
-
-# View / modify this machine's client.yaml
-first-tree config show
-first-tree config show update.policy
-first-tree config set update.policy auto
-
-# Transfer ownership of this machine's client.yaml to the currently
-# logged-in user (run after a 4403 CLIENT_USER_MISMATCH on `daemon start`).
-# Unpins the previous owner's agents from this machine in a single
-# transaction.
-first-tree login <token> --override
+```
+first-tree logout [--purge]
 ```
 
-`login <token>` automatically installs a background service on macOS (launchd) and Linux (`systemd --user`) so the computer stays online across reboots. Use `--no-start` to skip this and run inline (Ctrl+C to stop). Windows is not supported — `login` falls back to inline mode.
+Stop the daemon and clear credentials. `--purge` additionally removes
+`client.yaml` (server URL, generated `client.id`); the default keeps it
+so the next `login` reuses the same `client.id`.
 
-### Sharing a machine across users (`login --override`)
+## status
 
-A `client.yaml` is bound to exactly one user. When a different user logs in
-and runs `daemon start`, the WebSocket handshake refuses with code
-`CLIENT_USER_MISMATCH` (close 4403) and the CLI prints a guide pointing at
-`first-tree login <token> --override`. Running override:
-
-1. Updates `clients.user_id` to the calling JWT's user.
-2. Unpins every agent whose manager belonged to the previous owner
-   (`agents.client_id` ← NULL, presence reset to offline) — atomic.
-3. Logs `event=client.owner_transfer` with the previous/new owner ids.
-
-After override, `daemon start` reconnects without further prompts. The
-`--override` flag is the explicit consent — a typo cannot strip the
-previous owner's machine because the verb must be requested by name. See
-[`agent-hub/claim-agent.md`](https://github.com/agent-team-foundation/first-tree-context/blob/main/agent-hub/claim-agent.md) and [`agent-hub/client-identity-binding.md`](https://github.com/agent-team-foundation/first-tree-context/blob/main/agent-hub/client-identity-binding.md).
-
-### Manual service operations
-
-`daemon start / stop / restart` cover day-to-day service control. Install happens during `first-tree login <token>`; uninstall is a manual OS-level step (see *Decommission* below). `daemon status` and `daemon doctor` report state.
-
-**Tail logs:**
-
-```bash
-# Linux: journald is authoritative under the new unit (StandardOutput=journal)
-journalctl --user -u first-tree-client -f
-
-# Or read the rotating NDJSON file the client itself writes:
-tail -f ~/.first-tree/logs/client.log
-
-# Rotated files: .log + .log.1 ... .log.7, max 10 MB each
-ls -lt ~/.first-tree/logs/
+```
+first-tree status
 ```
 
-Logs are NDJSON; pipe through `jq` for filtering by level/time.
+Single-screen overview: CLI version, daemon state, server reachability,
+auth health, and the agents this client manages.
 
-**Decommission this machine (remove the background service + local credentials):**
+## doctor
 
-```bash
-# macOS
-launchctl bootout gui/$UID/dev.first-tree.client 2>/dev/null
-rm -f ~/Library/LaunchAgents/dev.first-tree.client.plist
-
-# Linux
-systemctl --user disable --now first-tree-client.service
-rm -f ~/.config/systemd/user/first-tree-client.service
-systemctl --user daemon-reload
-
-# Both: clear local credentials and config
-rm -rf ~/.first-tree
+```
+first-tree doctor
 ```
 
-To force-disconnect a client from the server side, use the Hub web admin UI (Computers tab → "Disconnect"). The CLI no longer ships an admin verb for this — it's a destructive cross-machine operation that lives in the admin surface.
+Cross-subsystem readiness check covering the daemon, server reachability,
+WebSocket, and configured agents. Use this when `status` flags something
+red and you want a guided drill-down.
 
-**Repair after Node upgrade or binary move** (plist still points at the old path): re-run `first-tree login <token>` — re-authentication is required (paste a fresh connect token from the Hub web console), but the command rewrites the unit file with the current binary path.
+## upgrade
+
+```
+first-tree upgrade [--check] [--no-restart]
+```
+
+Self-update for the CLI: query npm for the latest published version,
+install it globally, refresh the systemd unit / launchd plist on top of
+the new bits, then restart the client service.
+
+| Flag | Effect |
+|---|---|
+| `--check` | Only check for an available version; print "update available" or "already on latest". Do not install. |
+| `--no-restart` | Install the new version and refresh the unit file, but leave the running service alone. Used for staged rollouts. |
+
+Refusing to run from a source checkout (anywhere under a `.git`
+ancestor) is intentional — keeps a dev build from accidentally
+`npm i -g`-overwriting a prod global. For local development use
+`scripts/dev-install.sh` (see [docs/development/local-dev-isolation.md](development/local-dev-isolation.md)).
+
+---
 
 ## agent
 
-Agent management — configuration, tokens, bindings, and messaging.
+Agent management — local config, bindings, sessions, messaging
+debug helpers.
 
-### Configuration
+```
+first-tree agent
+├── list [--remote] [--org <id>]
+├── add --agent-id <uuid>
+├── create <name> --type <t> --client-id <id> [--runtime <r>] [--display-name <s>] [--org <id>]
+├── claim <agentName>
+├── remove <name>
+├── prune [--yes] [--dry-run]
+├── status [name]
+├── reset <name>
+├── config <subcommand>
+├── bind <subcommand>
+├── workspace <subcommand>
+└── session <subcommand>
+```
 
-```bash
-# Register an existing Hub agent on this client (interactive or --agent-id).
-# Optional: a running `first-tree daemon start` auto-registers any agent
-# the admin pins to this clientId via the Hub UI / API, so this command is
-# only needed for unattended setups or scripted seeding.
-#
-# The local config dir is always keyed by the agent's name on the Hub —
-# there is no separate "local alias" concept.
-first-tree agent add
+### agent list
+
+```
+first-tree agent list                    # locally-configured agents on this client
+first-tree agent list --remote           # every agent the signed-in user manages on the server
+first-tree agent list --remote --org <id>  # cross-org view (multi-org operators)
+```
+
+### agent create
+
+```
+first-tree agent create <name> --type <human|personal_assistant|autonomous_agent> --client-id <thisClient> [--runtime claude-code|codex]
+```
+
+Creates the agent row on the server and binds it to the given client
+machine. The local `agents/<name>/agent.yaml` is written by the running
+daemon via the server-pushed `agent:pinned` frame; no second command
+needed if the daemon is already up.
+
+### agent add
+
+```
 first-tree agent add --agent-id <uuid>
-
-# List / remove (name = Hub agent name)
-first-tree agent list                           # locally configured agents on this machine
-first-tree agent list --remote                  # every agent you manage on the Hub (cross-org)
-first-tree agent list --org <organizationId>    # restrict the remote list to one org
-first-tree agent remove <name>
-
-# Workspace cleanup
-first-tree agent workspace clean              # all agents
-first-tree agent workspace clean my-agent      # specific agent
-first-tree agent workspace clean --ttl 14       # custom TTL (days)
 ```
 
-### Bindings (Feishu)
+Register an existing server-side agent on this client. Use this when the
+daemon was not running at the moment the agent was pinned, or when
+moving an agent to a second computer that's already signed into the
+same user.
 
-```bash
-# Bind Feishu bot to an agent
-first-tree agent bind bot --platform feishu --app-id <id> --app-secret <secret>
+### agent claim
 
-# Bind Feishu user to a human agent
-first-tree agent bind user <humanAgentId> --platform feishu --feishu-id <ou_xxx>
+```
+first-tree agent claim <agentName>
 ```
 
-### Messaging — see the `chat` command group
+Become the manager of an agent. Admins can reassign any agent in their
+org; non-admins can self-claim an unmanaged agent.
 
-Day-to-day messaging lives under `first-tree chat`. See the
-[chat](#chat) section below. Low-level SDK debugging (`register` / `pull`)
-moved to the hidden `agent debug` subgroup; run `first-tree agent
-debug --help` to list those.
+### agent remove / agent prune
 
-### Agent → user structured questions (Claude runtime)
+```
+first-tree agent remove <name>     # delete local config dir, workspace, session state
+first-tree agent prune [--yes] [--dry-run]  # remove every local alias the server no longer pins to you
+```
 
-Claude-runtime agents can pause execution mid-turn and prompt the operator with a structured `AskUserQuestion` (single- or multi-select, up to 4 parallel questions, optional HTML / Markdown previews per option). The Hub bridges this through the inbox so the question lands on the Web chat as a clickable card; the operator's choice is then fed back to the agent and the turn continues.
+`prune` is the counterpart to `daemon doctor`'s "stale aliases" warning.
 
-- **Activation**: automatic for any agent on `runtimeProvider: claude-code` — no CLI flag.
-- **UI**: the question renders inline in the chat timeline as a card with three states (pending / answered / superseded).
-- **Lifecycle**: a pending question is auto-superseded when the chat session is archived (`agent session terminate`) or when the owning client is reclaimed by a different user (`first-tree login <token> --override`). The agent receives a clean deny in either case.
+### agent status / agent reset
+
+```
+first-tree agent status               # all agents this client manages
+first-tree agent status <name>        # one agent's runtime view from the server
+first-tree agent reset <name>         # reset agent error state to idle
+```
+
+### agent config
+
+Mutate the agent's server-side runtime configuration (model, prompt,
+MCP servers, env, repos). Edits the `agent_configs.payload` JSONB row
+through the Admin API.
+
+```
+first-tree agent config
+├── show <agent>
+├── set-model <agent> <model>                       # alias: opus | sonnet | haiku, or full id (e.g. claude-opus-4-7)
+├── append-prompt <agent> [-f <file>]               # reads stdin if no file
+├── add-mcp <agent> --name <id> --transport <t> [--command <c> --args <a>... | --url <u>]
+├── set-env <agent> KEY=VALUE [--sensitive]
+├── add-repo <agent> <url> [--ref <branch>] [--path <local>]
+└── dry-run <agent> -f <patch.json>                 # validate + diff, no persist
+```
+
+### agent bind
+
+```
+first-tree agent bind
+├── client <agentName> --client-id <id>             # first-time bind only; id is immutable once set
+├── bot --platform feishu --app-id <id> --app-secret <s> --agent <name>
+└── user <humanAgentId> --platform feishu --feishu-id <ou_xxx>
+```
+
+### agent workspace
+
+```
+first-tree agent workspace clean [agent-name] [--ttl <days>]
+```
+
+Remove stale workspace directories (older than the TTL with no active
+session). Without an agent name, sweeps every local agent.
+
+### agent session
+
+```
+first-tree agent session
+├── list <agent-name> [--state <active|suspended|evicted|errored>]
+├── suspend <agent-name> <chat-id>
+└── terminate <agent-name> <chat-id>
+```
+
+---
 
 ## chat
 
-Day-to-day messaging — send messages, list chats, view history, open an interactive REPL.
+Day-to-day messaging.
+
+```
+first-tree chat
+├── send <agentName> [message]                       # message via positional or stdin
+├── invite <agentName>                               # add to FIRST_TREE_CHAT_ID before send
+├── list
+├── history <chatId>
+└── open <agent-name>                                # interactive REPL
+```
 
 ```bash
-# Send a message to an agent (positional is the agent name).
-# The recipient MUST already be a participant of your current chat.
-first-tree chat send <agentName> "hello"
-echo "piped message" | first-tree chat send <agentName>
+# Inline
+first-tree chat send code-agent "ship the PR"
 
-# Pull a non-member into your current chat first, then send normally.
-# Replaces the retired `chat send --direct` escape hatch — Hub keeps a single
-# group-chat model, so there is no side-conversation fallback.
-first-tree chat invite <agentName>
-first-tree chat send <agentName> "now we can talk"
+# Stdin (multiline, markdown, special chars)
+echo "long body" | first-tree chat send code-agent -f markdown
 
-# Attach metadata
-first-tree chat send <agentName> "hello" -m '{"priority":"high"}'
+# Pull a non-member into the current chat first, then send normally.
+first-tree chat invite code-agent
+first-tree chat send code-agent "now we can talk"
 
-# List chats / view history
+# Browse
 first-tree chat list
 first-tree chat history <chatId>
 
-# Open an interactive REPL chat with an agent
-first-tree chat open <agent-name>
+# Interactive
+first-tree chat open code-agent
 ```
 
-`chat invite <agentName>` adds the named agent to the chat identified by
-`FIRST_TREE_CHAT_ID` (the chat the running agent session is bound to).
-The lookup is org-scoped, so the named agent must live in the same
-organization as the chat; cross-org adds return 404. The command only
-works inside an agent session — there is no `--chat` override.
+`chat send` / `chat invite` operate on the chat identified by
+`FIRST_TREE_CHAT_ID`, which the runtime injects into the agent's session
+environment. The recipient must be a participant of that chat; if not,
+`invite` first.
 
-`--agent <name>` selects the SENDER when multiple agents are configured
-locally (single-agent installs can omit it). The recipient is always the
-positional argument.
-- **Codex runtime**: not supported. The Codex SDK has no ask-user surface; codex-runtime agents that try to emit a question are rejected with HTTP 403 by the server (`assertSenderMayEmitQuestion`).
+### Agent-to-operator structured questions (Claude runtime)
 
-No CLI command is required to use the feature — it shows up automatically when a Claude-runtime agent calls `AskUserQuestion` during a turn.
+Claude-runtime agents can pause execution mid-turn and prompt the
+operator with a structured `AskUserQuestion` (single- or multi-select,
+up to 4 parallel questions, optional HTML/Markdown previews per option).
+The question lands on the web chat as a clickable card; the operator's
+choice is fed back to the agent and the turn continues.
 
-## client config
+- **Activation**: automatic for any agent on `runtimeProvider: claude-code`.
+- **Lifecycle**: a pending question is auto-superseded when the chat
+  session is archived (`agent session terminate`) or when the owning
+  client is reclaimed by `first-tree login <token> --override`.
+- **Codex runtime**: not supported. The Codex SDK has no ask-user
+  surface; codex-runtime agents that try to emit a question are
+  rejected with HTTP 403 by the server.
 
-Read / write the local `client.yaml` for this machine. Scope is implicit
-(this client's YAML at `~/.first-tree/config/client.yaml`).
+No CLI command is required to use the feature.
+
+---
+
+## org
+
+```
+first-tree org
+└── bind-tree <url>                                  # record this org's Context Tree repo URL
+```
+
+`bind-tree` records the team's Context Tree URL in
+`organization_settings(context_tree)`. Used by the onboarding flow's
+"create new tree" path, where the agent calls back into the server
+after scaffolding the tree.
+
+---
+
+## daemon
+
+The background service that holds the client WebSocket and runs every
+configured agent on this machine. Installed automatically by `first-tree
+login` on macOS / Linux.
+
+```
+first-tree daemon
+├── start [--no-interactive] [--foreground]
+├── stop
+├── restart
+├── status
+└── doctor
+```
+
+| Subcommand | Purpose |
+|---|---|
+| `start` | Start the daemon and connect every configured agent to the server. **Fail-closed**: exits 1 with `NO_CREDENTIALS` if no `credentials.json` exists; run `login` first. `--foreground` runs in the current shell (for debugging); the default installs/starts the service. |
+| `stop` | Stop the service (preserves auto-start; bring it back with `start`). |
+| `restart` | Restart the service. |
+| `status` | Local service state + server binding + auth health. Runs in well under a second. |
+| `doctor` | Walk Node version, config, server reachability, WS, agent registrations, and the installed service file; report each step. |
+
+The top-level `first-tree status` is the cross-subsystem overview that
+calls `daemon status` internally and adds server/auth/agent rows.
+
+---
+
+## config
+
+Read and write this machine's `client.yaml`. The file lives at
+`~/.first-tree/hub/config/client.yaml` (or the staging/dev channel's
+equivalent — see [docs/development/local-dev-isolation.md](development/local-dev-isolation.md)).
 
 ```bash
-first-tree config show                    # print every key/value
-first-tree config show update.policy      # print a single dotted key
-first-tree config show --show-secrets     # un-mask secret fields
+first-tree config show                    # every key/value
+first-tree config show server.url         # dotted-key read
+first-tree config show --show-secrets     # un-mask sensitive fields
 first-tree config set update.policy auto
 first-tree config get update.policy       # alias for `show <key>`
 ```
 
-Agent-side runtime configuration (model / prompt / MCP / env / repos)
-lives in `first-tree agent config ...` and mutates the Hub database
-via the admin API.
+Agent-side runtime configuration (model / prompt / MCP / env / repos) is
+not here — it lives in `first-tree agent config ...` and mutates the
+server-side `agent_configs` row through the Admin API.
 
-## Onboarding a new agent
+---
 
-The dedicated `onboard` command was retired in favor of explicit `agent`
-verbs. Today onboarding is a sequence:
+## tree
 
-```bash
-# 1. Log this machine into the Hub (one-time)
-first-tree login <connect-token>
+Context Tree onboarding, validation, automation, and skill management.
 
-# 2. Create the agent record on the Hub + bind it to this client
-first-tree agent create alice --type human --client-id <this-client-id>
-
-# 3. Start the daemon (auto-installs on macOS/Linux via `login`)
-first-tree daemon start
+```
+first-tree tree
+├── inspect                                 # report metadata for the current folder
+├── status                                  # workspace status
+├── init                                    # onboard a repo or workspace to a Context Tree
+├── bootstrap                               # bootstrap an explicit tree repo checkout
+├── bind                                    # bind current repo/workspace to an existing tree
+├── integrate                               # local integration without mutating the tree repo
+├── verify                                  # validate a Context Tree repo
+├── upgrade                                 # refresh integration and metadata
+├── publish                                 # publish a tree repo and refresh bound source repos
+├── codeowners                              # generate CODEOWNERS from ownership data
+├── claude-hook                             # install the Claude Code hook
+├── inject                                  # emit SessionStart payload from NODE.md
+├── review                                  # tree PR review helper
+├── workspace sync                          # bind newly added child repos to the shared tree
+├── automation install                      # install Context Tree GitHub automation
+└── skill <install|upgrade|list|doctor|link>  # manage installed first-tree skill payloads
 ```
 
-For Feishu bot / user bindings see `first-tree agent bind`.
+Run `first-tree tree help` for the in-CLI topic index, or
+`first-tree tree <verb> --help` for each subcommand's options.
 
-## upgrade
+---
 
-Self-update for the CLI. Queries the npm registry for the latest published version, installs it globally, refreshes the systemd unit / launchd plist on top of the new bits, then restarts the client service.
+## github scan
 
-```bash
-first-tree upgrade              # Install latest + refresh unit + restart service
-first-tree upgrade --check      # Only check; print "update available" or "already on latest"
-first-tree upgrade --no-restart # Install latest + refresh unit, but leave the running service alone
+The GitHub notification daemon. Polls allowed repositories, keeps a
+local inbox under `~/.first-tree/github-scan/`, and dispatches work to
+per-task agent runners.
+
+```
+first-tree github scan
+├── install                  # first-run setup; requires a tree binding and --allow-repo
+├── start                    # launch the daemon in the background
+├── stop                     # stop the daemon and remove its lock
+├── status                   # daemon lock + runtime status
+├── doctor                   # diagnose the local install
+├── watch                    # live TUI (status board + activity feed)
+├── poll                     # poll GitHub notifications once (no daemon needed)
+├── run | daemon             # foreground broker loop (humans use `start` instead)
+├── run-once                 # one poll cycle, wait for drain, exit
+└── cleanup                  # remove stale workspaces + expired claims (run only if doctor suggests)
 ```
 
-`--no-restart` is for staged rollouts where the operator wants to time the cutover. Refusing to run from a source checkout (anywhere with a `.git` ancestor) is intentional — keeps a dev build from accidentally `npm i -g`-overwriting a prod global.
+Run `first-tree github scan help <command>` for command details.
 
-## Environment Variables
+---
 
-Most environment variables use the `FIRST_TREE_` prefix. `onboard` also accepts `FEISHU_APP_ID` and `FEISHU_APP_SECRET`. When set, interactive prompts automatically skip the corresponding field.
+## Environment variables
 
-### Global
+Most environment variables use the `FIRST_TREE_` prefix.
+
+### CLI — operator-facing
 
 | Variable | Purpose | Default |
-|---------|------|--------|
-| `FIRST_TREE_HOME` | Override the CLI home directory for config, data, cloned Context Tree, and onboard resume state | channel-dependent: `~/.first-tree` (prod), `~/.first-tree-staging` (staging), `~/.first-tree-dev` (dev) |
+|---|---|---|
+| `FIRST_TREE_HOME` | Override the CLI home directory for config, data, and Context Tree mirrors. | Channel-dependent: `~/.first-tree` (prod), `~/.first-tree-staging` (staging), `~/.first-tree-dev` (dev). |
+| `FIRST_TREE_SERVER_URL` | Server URL (alternative to the connect token's `iss` claim). | — |
+| `FIRST_TREE_LOG_LEVEL` | Log level (`trace` / `debug` / `info` / `warn` / `error` / `fatal`). | `info` |
+| `FIRST_TREE_JSON` | JSON output mode (equivalent to `--json`). | — |
+
+### CLI — internal (set by the CLI for its own subprocesses)
+
+These are mentioned for completeness; operators don't set them in shell rc.
+
+| Variable | Purpose |
+|---|---|
+| `FIRST_TREE_SERVICE_MODE` | Supervisor → child flag baked into the launchd plist and systemd unit templates. |
+| `FIRST_TREE_COMMAND_VERSION` | CLI build version stamped at package time. |
+| `FIRST_TREE_UPDATE_POLL_INTERVAL_MINUTES` | How often the running daemon polls npm for a newer version. |
+| `FIRST_TREE_UPDATE_REGISTRY_URL` | npm registry override for the update check. |
+| `FIRST_TREE_UPDATE_RESTART_CHECK_INTERVAL_SECONDS` | Frequency of the upgrade-restart watchdog. |
+| `FIRST_TREE_UPDATE_RESTART_QUIET_SECONDS` | Quiet window the upgrade flow waits for before restarting. |
+| `FIRST_TREE_UPDATE_PROMPT_TIMEOUT_SECONDS` | Interactive upgrade prompt timeout. |
+| `FIRST_TREE_UPDATE_POLICY` | `auto` / `prompt` / `off`. Persisted via `first-tree config set update.policy ...`. |
+
+### Agent runtime (injected by the daemon into agent processes)
+
+Per-agent bearer tokens are gone — every agent on a signed-in machine
+authenticates as the signed-in member. The runtime injects these so an
+agent process can talk to the server without extra setup:
+
+| Variable | Purpose |
+|---|---|
+| `FIRST_TREE_ACCESS_TOKEN` | The signed-in member's access JWT (short-lived). |
+| `FIRST_TREE_AGENT_ID` | The agent's own UUID — the CLI uses it to identify the sender. |
+| `FIRST_TREE_CLIENT_ID` | The client (machine) the agent is bound to. |
+| `FIRST_TREE_CHAT_ID` | The chat the current session is bound to. Used by `chat send` / `chat invite`. |
+| `FIRST_TREE_SERVER_URL` | Server URL override; falls back to client config. |
 
 ### Server (SaaS internal)
 
-These vars configure the SaaS-hosted server and are not exercised by the
-public CLI. They are listed here for reference only — the `server` runtime
-runs in the SaaS Docker image (`packages/server/dist/index.mjs`).
+These configure the SaaS server image (`packages/server/dist/index.mjs`)
+and are not used by the CLI. They are listed here for ops reference.
+
+**Identity / channel:**
 
 | Variable | Purpose | Default |
-|---------|------|--------|
-| `FIRST_TREE_DATABASE_URL` | PostgreSQL connection URL | — (required) |
-| `FIRST_TREE_PORT` | Server port | `8000` |
-| `FIRST_TREE_HOST` | Bind address | `0.0.0.0` |
-| `FIRST_TREE_JWT_SECRET` | JWT signing key | — (required) |
-| `FIRST_TREE_ENCRYPTION_KEY` | Adapter credential encryption key | — (required) |
-| `FIRST_TREE_WEB_DIST_PATH` | Web static files path. The Docker image presets this to `/app/packages/server/web-dist`. | — |
-| `FIRST_TREE_PUBLIC_URL` | Public-facing hub URL. Stamped as the `iss` claim on connect tokens (so `connect <token>` derives the hub URL with no extra arg) and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | request `Host` (dev only) |
-| `FIRST_TREE_GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App client ID. Enables `/signup` + `/auth/github/start`. Both client id AND secret must be set together. | — |
-| `FIRST_TREE_GITHUB_OAUTH_CLIENT_SECRET` | GitHub OAuth App client secret. | — |
-| `FIRST_TREE_GITHUB_OAUTH_DEV_CALLBACK` | Opt-in to the `/auth/github/dev-callback` shortcut (no-op github round-trip, dev only). Always disabled when `NODE_ENV=production`. | `false` |
+|---|---|---|
+| `FIRST_TREE_CHANNEL` | Deployment channel (`prod` / `staging` / `dev`). | `dev` |
+| `FIRST_TREE_DATABASE_URL` | PostgreSQL connection URL. | — (required) |
+| `FIRST_TREE_PORT` | HTTP listen port. | `8000` |
+| `FIRST_TREE_HOST` | Bind address. | `127.0.0.1` |
+| `FIRST_TREE_PUBLIC_URL` | Public-facing server URL. Stamped as the `iss` claim on connect tokens and used to build invite-link URLs + the GitHub OAuth callback. **Required in production.** | — |
+| `FIRST_TREE_CORS_ORIGIN` | Allowed origin for the web console. | — |
+| `FIRST_TREE_TRUST_PROXY` | Trust the reverse-proxy `X-Forwarded-*` headers. | `false` |
+| `FIRST_TREE_WORKSPACES_ROOT` | Where agent worktrees are materialised on the host. | derived from `FIRST_TREE_HOME` |
 
-### Client
-
-| Variable | Purpose | Default |
-|---------|------|--------|
-| `FIRST_TREE_SERVER_URL` | Server URL | interactive prompt |
-| `FIRST_TREE_LOG_LEVEL` | Log level (`debug`/`info`/`warn`/`error`) | `info` |
-
-### Agent (messaging commands)
-
-Auth is the signed-in member's JWT — no per-agent token env vars. The
-runtime injects these so an agent process can talk to the Hub without
-extra setup:
+**Secrets:**
 
 | Variable | Purpose |
-|---------|------|
-| `FIRST_TREE_ACCESS_TOKEN` | User member access JWT (short-lived). Injected by the runtime. |
-| `FIRST_TREE_AGENT_ID` | The agent's own UUID — the CLI uses it to identify the SENDER. |
-| `FIRST_TREE_CHAT_ID` | The chat the agent session is bound to. |
-| `FIRST_TREE_SERVER_URL` | Server URL override for `chat send` / `chat list` / `chat history`. Falls back to client config. |
+|---|---|
+| `FIRST_TREE_JWT_SECRET` | JWT signing key. |
+| `FIRST_TREE_ENCRYPTION_KEY` | Adapter credential encryption key. |
 
-Per-agent bearer tokens are gone — logging in writes a member JWT to
-`credentials.json` and every agent on that machine authenticates as
-the signed-in member.
+**Auth lifetimes:**
 
-### Onboard
+| Variable | Default |
+|---|---|
+| `FIRST_TREE_AUTH_ACCESS_TOKEN_EXPIRY` | `30m` |
+| `FIRST_TREE_AUTH_REFRESH_TOKEN_EXPIRY` | `30d` |
+| `FIRST_TREE_AUTH_CONNECT_TOKEN_EXPIRY` | `10m` |
+
+**GitHub App / OAuth:**
 
 | Variable | Purpose |
-|---------|------|
-| `FIRST_TREE_SERVER_URL` | Hub server URL alternative to `--server` |
-| `FEISHU_APP_ID` | Feishu bot App ID alternative to `--feishu-bot-app-id` |
-| `FEISHU_APP_SECRET` | Feishu bot App Secret alternative to `--feishu-bot-app-secret` |
+|---|---|
+| `FIRST_TREE_GITHUB_APP_ID` | GitHub App numeric id. |
+| `FIRST_TREE_GITHUB_APP_CLIENT_ID` | GitHub App OAuth client id. |
+| `FIRST_TREE_GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth client secret. |
+| `FIRST_TREE_GITHUB_APP_PRIVATE_KEY` | GitHub App signing key (PEM body). |
+| `FIRST_TREE_GITHUB_APP_WEBHOOK_SECRET` | Webhook HMAC secret. |
+| `FIRST_TREE_GITHUB_APP_SLUG` | Optional explicit slug override. |
 
-### Observability (server)
+**Rate limits:**
+
+| Variable | Default |
+|---|---|
+| `FIRST_TREE_RATE_LIMIT_MAX` | `100` |
+| `FIRST_TREE_RATE_LIMIT_LOGIN_MAX` | `5` |
+| `FIRST_TREE_RATE_LIMIT_WEBHOOK_MAX` | `600` |
+| `FIRST_TREE_RATE_LIMIT_AGENT_MESSAGE_MAX` | `30` |
+| `FIRST_TREE_RATE_LIMIT_CONTEXT_TREE_SNAPSHOT_MAX` | `6` |
+
+**Inbox / WS / archive sweeper:**
+
+| Variable | Default |
+|---|---|
+| `FIRST_TREE_INBOX_MAX_IN_FLIGHT_PER_AGENT` | server-tuned |
+| `FIRST_TREE_INBOX_TIMEOUT_SECONDS` | server-tuned |
+| `FIRST_TREE_WS_MAX_PAYLOAD` | `262144` (256 KiB) |
+| `FIRST_TREE_ARCHIVE_SWEEP_INTERVAL_SECONDS` | `300` (set `0` to disable) |
+| `FIRST_TREE_ARCHIVE_MAPPED_IDLE_SECONDS` | `3600` |
+| `FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS` | `43200` |
+
+**Observability:**
 
 | Variable | Purpose | Default |
-|---------|------|--------|
-| `FIRST_TREE_LOG_LEVEL` | Log level (`trace`/`debug`/`info`/`warn`/`error`/`fatal`) | `info` |
-| `FIRST_TREE_OTEL_ENDPOINT` | OTLP/HTTP traces endpoint. Non-empty value enables tracing | `""` (disabled) |
-| `FIRST_TREE_OTEL_HEADERS` | OTLP headers in `key1=val1,key2=val2` format (secret — typically holds the write token) | `""` |
-| `FIRST_TREE_OTEL_ENVIRONMENT` | Deployment environment label (`development` / `staging` / `production` / …) — emitted as `deployment.environment.name` | `development` |
+|---|---|---|
+| `FIRST_TREE_LOG_LEVEL` | Server log level. | `info` |
+| `FIRST_TREE_OTEL_ENDPOINT` | OTLP/HTTP traces endpoint. Non-empty enables tracing. | `""` |
+| `FIRST_TREE_OTEL_HEADERS` | OTLP headers as `key1=val1,key2=val2`. Typically holds the write token. | `""` |
+| `FIRST_TREE_OTEL_ENVIRONMENT` | Deployment label emitted as `deployment.environment.name`. | `development` |
+| `FIRST_TREE_OTEL_CAPTURE_CLIENT_IP` | Capture client IP attribute on traces. | `false` |
 
 See [observability.md](observability.md) for the full config reference, backend cheat sheet, and troubleshooting recipes.
 
-## Directory Structure
+### Feishu (used by `agent bind bot`)
+
+| Variable | Purpose |
+|---|---|
+| `FEISHU_APP_ID` | Feishu bot App ID (alternative to `--app-id`). |
+| `FEISHU_APP_SECRET` | Feishu bot App Secret (alternative to `--app-secret`). |
+
+---
+
+## Directory layout (CLI home)
 
 ```
-~/.first-tree/
-├── .onboard-state.json           # Saved args for onboard resume
-├── config/                      # Configuration (human-edited)
-│   ├── client.yaml
+~/.first-tree/hub/                                 # FIRST_TREE_HOME default for the prod channel
+├── config/
+│   ├── client.yaml                                # this machine's client config (server.url, client.id)
+│   ├── credentials.json                           # access + refresh JWT (mode 0600)
 │   └── agents/
-│       ├── my-agent/agent.yaml
-│       └── another/agent.yaml
-└── data/                        # Runtime data (system-managed)
-    ├── context-tree-repos/       # Server-managed readonly Context Tree mirrors
-    ├── sessions/                # Agent session registry
-    └── workspaces/              # Per-chat isolated workspaces
-        └── <agent-name>/
-            └── <chatId>/
+│       └── <name>/
+│           └── agent.yaml                         # agentId + runtime
+├── data/
+│   ├── context-tree-repos/                        # server-managed read-only Context Tree mirrors
+│   ├── sessions/                                  # per-agent session registry
+│   └── workspaces/
+│       └── <agent-name>/                          # per-agent home (cwd is shared across chats)
+│           └── worktrees/                         # ad-hoc agent-spawned worktrees
+└── logs/                                          # daemon stderr / stdout (macOS)
 ```
 
-If `FIRST_TREE_HOME` is set, replace `~/.first-tree/` with that location.
+When `FIRST_TREE_HOME` is set, replace `~/.first-tree/hub/` with that location. Staging and dev channels use `~/.first-tree-staging/` and `~/.first-tree-dev/` respectively.
 
-## Config Resolution Order
+## Config resolution order
 
 Priority from high to low:
 
 1. CLI arguments
 2. Environment variables (`FIRST_TREE_*`)
-3. Config files (`~/.first-tree/config/client.yaml`)
+3. Config files (`~/.first-tree/hub/config/client.yaml`)
 4. Built-in defaults
+
+## Verification after upgrade
+
+After `first-tree upgrade` or after running `logout` + `login <token>` on a deployment-bump cycle:
+
+```bash
+first-tree status          # CLI version + service + server + auth + agents
+first-tree daemon doctor   # service + agent configs + WS reachability
+first-tree --help          # top-level verbs + namespaces
+```


### PR DESCRIPTION
Reshape \`docs/cli-reference.md\` so it matches what \`first-tree --help\` actually prints today.

## What changed

Per the design doc §4.2 (T2.1 – T2.5):

- **T2.1** Walked \`first-tree --help\` and every namespace's help, captured the actual command tree.
- **T2.2** Documented the top-level commands plus the 12 namespace subcommand trees, cross-checked against \`apps/cli/src/cli/index.ts\` registration.
- **T2.3** Rebuilt the env-var section from \`packages/shared/src/config/\` — grouped as CLI operator-facing / CLI internal / Agent runtime / Server (SaaS internal — auth lifetimes, GitHub App, rate limits, inbox + WS + archive sweeper, observability) / Feishu binding.
- **T2.4** Verification-after-upgrade snippet kept, but trimmed to commands that still exist.
- **T2.5** Added a maintenance contract paragraph at the top:

  > Any PR that changes the command surface (adds, renames, removes, or re-flags a verb / namespace) must update this file in the same PR. The grep checks that gate \`Forbid legacy CLI / env names\` only catch a handful of retired identifiers; the broader *"what commands exist and what do they do"* contract is enforced by humans against this document.

## Retired commands cleared

Every reference to pre-Phase-1A surface is gone:

- \`connect\` → \`login\`
- \`client start|stop|restart|status|doctor|list|disconnect|claim|config\` → \`daemon\` and top-level equivalents, \`config\` promoted out
- \`update\` → \`upgrade\`
- \`onboard\` → explicit \`login\` + \`agent create\` + \`daemon start\` sequence

## Hub branding cleared

This is the file PR-1 and PR-1-followup deferred to PR-2. After this PR:

\`\`\`
$ grep -nE "First Tree Hub|first-tree-hub|Hub server|Hub URL|\bHub\b" docs/cli-reference.md
(none)
\`\`\`

## Verification

\`\`\`
$ grep -nE "first-tree\s+(connect|onboard|update|client\s+(start|stop|restart|status|doctor|list|disconnect|claim|config))" \
    docs/cli-reference.md
(none)

$ for cmd in login logout status doctor upgrade agent chat org daemon config tree "github scan"; do
    first-tree $cmd --help
  done
✓ every namespace exists

$ markdown-link sweep over docs/cli-reference.md
no broken internal links
\`\`\`

## Diff

\`+454 / -290\` across one file. Net larger than the prior version because every nested namespace (agent config / agent bind / agent workspace / agent session / tree workspace / tree automation / tree skill) gets its own annotated entry instead of a flat one-line stub.

## Test plan

- [x] Local CLI walk against every documented namespace.
- [x] Five-check verification clean.
- [ ] Owner sign-off / reviewer pass.