### PR TITLE
docs: peripheral cleanup after the main repo docs reshape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,6 @@ jobs:
           # Legitimate residues (allow-listed and filtered out via the trailing
           # `grep -v` pipeline):
           # - docs/migration/**                          : migration tables show old↔new
-          # - docs/development/git-history.md            : merge anchor doc cites legacy repo URL
           # - .github/workflows/ci.yml                   : this file's own regex literals (self-immunity via [f])
           # - packages/server/drizzle/*.sql              : SQL migrations are immutable historical artifacts
           hits=$(grep -rEn \
@@ -234,7 +233,7 @@ jobs:
             --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' --include='*.cjs' \
             --include='*.json' --include='*.yaml' --include='*.yml' --include='*.md' --include='*.sh' \
             "[f]irst-tree-hub" packages apps scripts docs skills .github \
-            | grep -v -E '^docs/development/git-history\.md:|^\.github/workflows/ci\.yml:' \
+            | grep -v -E '^\.github/workflows/ci\.yml:' \
             || true)
           if [ -n "$hits" ]; then
             echo "::error::found a 'first-tree-hub' literal outside the documented allow-list — see N-1 in PR-1 description"
@@ -250,9 +249,9 @@ jobs:
           #
           # The `[F]` self-immunity trick keeps this file's own comments
           # (which must spell out the forbidden literal) from tripping the
-          # check. Same allow-list as the broad sweep above; docs/ is also
-          # currently allow-listed until the N-4 design-docs sweep lands —
-          # see PR-1 description "First Tree Hub product-name residues".
+          # check. Same allow-list as the broad sweep above; docs/ stays
+          # excluded because the migration tables and cli-reference may
+          # still mention the three-word form historically.
           hits=$(grep -rEn \
             --exclude-dir=migration \
             --exclude-dir=node_modules \
@@ -261,7 +260,7 @@ jobs:
             --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' --include='*.cjs' \
             --include='*.json' --include='*.yaml' --include='*.yml' --include='*.md' --include='*.sh' \
             "[F]irst Tree Hub" packages apps scripts docs skills .github \
-            | grep -v -E '^docs/development/git-history\.md:|^\.github/workflows/ci\.yml:' \
+            | grep -v -E '^\.github/workflows/ci\.yml:' \
             || true)
           if [ -n "$hits" ]; then
             echo "::error::found a 'First Tree Hub' three-word product-name literal outside the allow-list — N-3 brand retirement"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,10 +92,10 @@ jobs:
           ACTIONS_FEISHU_TAG: "v1.3.1"
           INPUT_WEBHOOK: ${{ secrets.RELEASE_BOT_URL }}
           INPUT_MESSAGE_TYPE: "post"
-          INPUT_TITLE: Hub 测试环境更新 ✅ 成功
+          INPUT_TITLE: first-tree 测试环境更新 ✅ 成功
           INPUT_CONTENT: |
             部署结果: ✅ 成功
-            环境: Hub 测试环境
+            环境: first-tree 测试环境
             Image: ghcr.io/${{ github.repository }}:${{ github.sha }}
             Commit: ${{ github.sha }}
             Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/apps/cli/src/commands/daemon/_shared/wsl-dbus.ts
+++ b/apps/cli/src/commands/daemon/_shared/wsl-dbus.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
  * WSL2 + WSLg over-mounts a mode=755 tmpfs onto /run/user/$UID, hiding the
  * systemd user-bus socket beneath. `systemctl --user` then fails with
  * "Failed to connect to bus: No such file or directory" even though the
- * user manager is happily running. See docs/wsl2-troubleshooting.md.
+ * user manager is happily running. See docs/troubleshooting/wsl2.md.
  */
 export function isWslDbusOvermount(reason: string): boolean {
   if (process.platform !== "linux") return false;

--- a/apps/cli/src/commands/org/index.ts
+++ b/apps/cli/src/commands/org/index.ts
@@ -8,7 +8,7 @@ import { registerOrgBindTreeCommand } from "./bind-tree.js";
  * create a fresh context-tree GitHub repo so the Hub records the binding in
  * the org's `context_tree` settings namespace. The verb mirrors first-tree
  * CLI's own `tree bind` vocabulary so agents reading "bind-tree" know what
- * it means without translation. See docs/new-user-onboarding-design.md §7.4
+ * it means without translation. See first-tree-context:agent-hub/onboarding.md §7.4
  * (Path B).
  */
 export function registerOrgCommands(program: Command): void {

--- a/apps/cli/src/core/migrate-agent-dirs.ts
+++ b/apps/cli/src/core/migrate-agent-dirs.ts
@@ -5,7 +5,7 @@ import { cliFetch } from "./cli-fetch.js";
 import { print } from "./output.js";
 
 /**
- * Phase 3 of the agent-naming refactor (docs/agent-naming-design.md §3.4 + §4):
+ * Phase 3 of the agent-naming refactor (first-tree-context:agent-hub/agent-naming.md §3.4 + §4):
  * reconcile every local agent directory name with the server-authoritative
  * `agent.name` slug. The free-form local alias concept is gone — the Hub is
  * the only namespace authority — so on every client startup we walk the

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -748,7 +748,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       // reconnect with the same clientId would just re-trigger the rejection.
       // The caller (CLI) is expected to surface the mismatch to the user,
       // abandon the local clientId, and start a fresh connection with a new
-      // one. See docs/multi-tenancy-hardening-design.md (B4).
+      // one. See first-tree-context:agent-hub/multi-tenancy.md (B4).
       this.closing = true;
       const err =
         code === "CLIENT_USER_MISMATCH"

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -1,6 +1,6 @@
 # `@first-tree/e2e` — cross-process E2E framework
 
-Real-process E2E for Hub: each run boots a fresh PostgreSQL (Docker), spawns
+Real-process E2E for first-tree: each run boots a fresh PostgreSQL (Docker), spawns
 the built server and the unified CLI as **separate Node processes**, and
 talks to them over real HTTP + WS. Distinct from the in-process
 `packages/server/src/__tests__/*` suite (which uses `fastify.inject` and stays
@@ -123,9 +123,9 @@ packages/e2e/
     │   │   └── dev-callback.ts  # M3: mint extra user JWTs via the dev-callback bypass
     │   ├── cli-driver/
     │   │   ├── exec.ts          # M3: execCli (one-shot) + spawnCli (long-running) + ambient FIRST_TREE_* sanitization
-    │   │   └── client-foreground.ts # M3: thin spawnCli wrapper for `client start --foreground`
+    │   │   └── client-foreground.ts # M3: thin spawnCli wrapper for `daemon start --foreground`
     │   ├── credentials.ts       # M5 fixture: single-user PG seed for tests (paired with setup-devuser.ts; one is the fixture, the other is the live-seed)
-    │   ├── setup-devuser.ts     # M5 dev-user seed: dev-callback → connect-token → CLI client start → agent/chat/message (driven from up.ts, not tests)
+    │   ├── setup-devuser.ts     # M5 dev-user seed: dev-callback → connect-token → CLI daemon start → agent/chat/message (driven from up.ts, not tests)
     │   ├── github-mock.ts       # M4: signs + delivers webhooks, stubs /api/*
     │   ├── github-app-fixture.ts# M4: GitHub App key + installation token fixture
     │   └── agent-mock.ts        # M4: stand-in for the agent runtime side

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -20,7 +20,7 @@
  *      to 3, and watcher rows are flipped to speaker for newly-joined
  *      speakers (orthogonal axes: role + access_mode).
  *
- * See docs/chat-first-workspace-product-design.md for the contract under test.
+ * See first-tree-context:agent-hub/web-console.md for the contract under test.
  */
 
 import { sql } from "drizzle-orm";

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -43,7 +43,7 @@ describe("GitHub OAuth onboarding flow", () => {
     const orgRow = orgs[0];
     if (!orgRow) throw new Error("expected default org row");
     // Default team display name is `${login}'s team` — collective-space
-    // reading per docs/new-user-onboarding-design.md §5.5; user can rename
+    // reading per first-tree-context:agent-hub/onboarding.md (was §5.5 in source design); user can rename
     // in onboarding Step 1.
     expect(orgRow.displayName).toBe("octocat's team");
 

--- a/packages/server/src/__tests__/route-conventions.test.ts
+++ b/packages/server/src/__tests__/route-conventions.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 /**
  * Invariant tests for the route naming conventions documented in
- * `docs/http-path-conventions.md`. They replace the old
+ * `docs/development/http-path-conventions.md`. They replace the old
  * `admin-routes-org-scope-invariant.test.ts` (deleted with the JWT-ambient-
  * scope refactor) and pin three layers of defense:
  *

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -406,7 +406,7 @@ async function completeOauthFlow(
       const personal = await createPersonalTeam(app.db, {
         userId,
         loginSeed: profile.login,
-        // Per docs/new-user-onboarding-design.md §5.5, default team name is
+        // Per first-tree-context:agent-hub/onboarding.md (was §5.5 in source design), default team name is
         // `${login}'s team` — reads as a collective space, matches Linear's
         // convention. The user can rename in Step 1 of onboarding.
         teamDisplayName: `${profile.login}'s team`,

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -117,7 +117,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
    * Stamping NOW() server-side avoids client-clock skew. Idempotent: a
    * second PATCH leaves the original timestamp in place.
    *
-   * See docs/new-user-onboarding-design.md §8.4.
+   * See first-tree-context:agent-hub/onboarding.md §8.4.
    */
   app.patch("/me/onboarding", async (request, reply) => {
     const { userId } = requireUser(request);

--- a/packages/server/src/db/schema/clients.ts
+++ b/packages/server/src/db/schema/clients.ts
@@ -15,7 +15,7 @@ import { users } from "./users.js";
  * authenticated JWT's org claim and never changes thereafter. Re-registering
  * the same clientId under a JWT for a different org is rejected with
  * `CLIENT_ORG_MISMATCH` — the CLI responds by abandoning the local clientId
- * and registering a new one instead (see docs/multi-tenancy-hardening-design.md).
+ * and registering a new one instead (see first-tree-context:agent-hub/multi-tenancy.md).
  */
 export const clients = pgTable(
   "clients",

--- a/packages/server/src/db/schema/users.ts
+++ b/packages/server/src/db/schema/users.ts
@@ -14,7 +14,7 @@ export const users = pgTable("users", {
    * `onboardingStep` so the stepper can keep rendering across all three
    * UI steps (server-side onboardingStep flips to `completed` at the end of
    * Step 2 — Step 3 is purely client-driven). NULL = stepper renders.
-   * See docs/new-user-onboarding-design.md §8.
+   * See first-tree-context:agent-hub/onboarding.md (was §8. in source design)
    */
   onboardingDismissedAt: timestamp("onboarding_dismissed_at", { withTimezone: true }),
   /**

--- a/packages/server/src/services/chat-projection.ts
+++ b/packages/server/src/services/chat-projection.ts
@@ -21,7 +21,7 @@
  *      so admin WS sockets can translate it into a `chat:message` frame.
  *      Failure is swallowed — durable persistence is the correctness path.
  *
- * Strict invariants (see docs/chat-first-workspace-product-design.md
+ * Strict invariants (see first-tree-context:agent-hub/web-console.md
  * "Risk Constraints"):
  *   - This module appends ONLY. Never edits existing fan-out / inbox /
  *     mention-extraction code.

--- a/packages/server/src/services/github-entity-extractor.ts
+++ b/packages/server/src/services/github-entity-extractor.ts
@@ -4,7 +4,7 @@ import type { ToolCallEventPayload } from "@first-tree/shared";
  * Phase 1 fallback path for chat ↔ GitHub entity binding.
  *
  * The long-term direction is *not* to extend this whitelist indefinitely —
- * see `docs/github-entity-chat-binding-design.md` for the four-family
+ * see `first-tree-context:agent-hub/github-entity-chat-binding.md` for the four-family
  * framing (declaration / outbound proxy / webhook backfill / stdout
  * extraction). Stdout extraction is the cheapest first cut, not the
  * canonical entry point; once an explicit `bind_chat_to_github_entity`

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -111,7 +111,7 @@ type CreatePersonalTeamInput = {
  *   - On collision: append a 4-char hex disambiguator
  *
  * Default team display name is `${login}'s team` (set by the caller — see
- * docs/new-user-onboarding-design.md §5.5). Reads as "this is a collective
+ * first-tree-context:agent-hub/onboarding.md (was §5.5 in source design)). Reads as "this is a collective
  * space" from day one so a later teammate-invite doesn't surface a label
  * that looks like a private sandbox. Users can rename via Step 1 of the
  * onboarding flow or Settings.

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -567,7 +567,7 @@ async function sendMessageInner(
     // 6. Chat-first workspace projection (append-only, post-fan-out).
     //    Updates chats.last_message_*, increments speaker + watcher mention
     //    counters. New code; no existing path is modified — see
-    //    docs/chat-first-workspace-product-design.md "Risk Constraints".
+    //    first-tree-context:agent-hub/web-console.md "Risk Constraints".
     const previewText = typeof outboundContent === "string" ? outboundContent.trim() : "";
     await applyAfterFanOut(tx, {
       chatId,

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -11,7 +11,7 @@ import {
 
 /**
  * Pins the tightened agent-name rules introduced in Phase 1 of the
- * agent-naming refactor (see docs/agent-naming-design.md §3.1). These
+ * agent-naming refactor (see first-tree-context:agent-hub/agent-naming.md §3.1). These
  * constraints align `createAgentSchema` with `MENTION_REGEX` so every
  * valid name can be @-mentioned and CLI-flag-parsed.
  */

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -49,7 +49,7 @@ export const agentStatusSchema = z.enum(["active", "suspended"]);
 export type AgentStatus = z.infer<typeof agentStatusSchema>;
 
 /**
- * Agent-name rules (see docs/agent-naming-design.md §3.1):
+ * Agent-name rules (see first-tree-context:agent-hub/agent-naming.md §3.1):
  *   - Lowercase ASCII slug, hyphens + underscores allowed.
  *   - Must start with alphanumeric: `-` / `_` as first char collide with
  *     CLI flag parsing and markdown list syntax.

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -4,7 +4,7 @@ import { chatSourceSchema, githubEntityTypeSchema } from "./chat-metadata.js";
 
 /**
  * Member-facing chat APIs (`/me/chats*`) for the chat-first workspace.
- * See docs/chat-first-workspace-product-design.md "API Contract".
+ * See first-tree-context:agent-hub/web-console.md "API Contract".
  */
 
 /**

--- a/packages/shared/src/schemas/me-extras.ts
+++ b/packages/shared/src/schemas/me-extras.ts
@@ -33,7 +33,7 @@ export type CreateOrgFromMe = z.infer<typeof createOrgFromMeSchema>;
 /**
  * Body for `PATCH /me/onboarding`. v1 only mutates `dismissed` — true to
  * hide the onboarding stepper (server stamps `users.onboarding_dismissed_at
- * = NOW()`), false to restore it. See docs/new-user-onboarding-design.md
+ * = NOW()`), false to restore it. See first-tree-context:agent-hub/onboarding.md
  * §8.4.
  */
 export const patchOnboardingSchema = z.object({

--- a/packages/web/src/components/agent-chip.tsx
+++ b/packages/web/src/components/agent-chip.tsx
@@ -7,7 +7,7 @@ import { cn } from "../lib/utils.js";
  * dropdown, mention previews). Collapses the three previous ad-hoc
  * renderings into a single component so tweaks only happen once.
  *
- * Display contract (see docs/agent-naming-design.md §3.3):
+ * Display contract (see first-tree-context:agent-hub/agent-naming.md §3.3):
  *   - `displayName` is the primary (human) label.
  *   - `name` is shown as the @-prefixed mention target, in monospace, dim.
  *   - When only one of the two is set, the chip still reads naturally:

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -8,7 +8,7 @@ import { cn } from "../lib/utils.js";
  * reports back (a) visibility, (b) the currently highlighted candidate,
  * and (c) the final replacement when the user picks one.
  *
- * See docs/agent-naming-design.md §3.5. Intentionally not a rich
+ * See first-tree-context:agent-hub/agent-naming.md §3.5. Intentionally not a rich
  * editor — we match by typing a `@`, then filtering a static list.
  *
  * Matching policy:

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -44,7 +44,7 @@ function issuesToFieldErrors(issues: ValidationIssue[] | undefined): FieldErrors
 /**
  * Simplified agent creation dialog for the onboarding flow.
  *
- * Display-name-first layout (see docs/agent-naming-design.md §3.6):
+ * Display-name-first layout (see first-tree-context:agent-hub/agent-naming.md §3.6):
  *   - "Display name" is the primary input at the top (required-feeling, unicode).
  *   - The derived @handle previews under the display name as a quiet
  *     `@my-dev-assistant · permanent · Edit` line. Most users never need to

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1057,7 +1057,7 @@ export function ChatView({
       // `active` agent_chat_sessions row, so the new chat now satisfies the
       // listAgentSessions INNER JOIN. Without this invalidate the user would
       // wait up to 10s for the polling refetch. See M plan Step 3 in
-      // docs/session-creation-on-first-message.md.
+      // first-tree-context:agent-hub/messaging.md.
       queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
       // Persist the own-send advance to chat-A's read-state row
       // both in the React Query cache and in IndexedDB, keyed by

--- a/packages/web/src/pages/workspace/roster/index.tsx
+++ b/packages/web/src/pages/workspace/roster/index.tsx
@@ -63,7 +63,7 @@ export function AgentRoster({
       // No sessions invalidate here: at chat-creation time the
       // agent_chat_sessions row does NOT yet exist (server only writes it
       // after the user sends a first message — see M plan Step 1b in
-      // docs/session-creation-on-first-message.md). The list refresh is
+      // first-tree-context:agent-hub/messaging.md). The list refresh is
       // therefore moved to chat-view's sendMut.onSuccess.
       onSelectChat(agentId, result.id);
     },

--- a/skills/first-tree-cloud/SKILL.md
+++ b/skills/first-tree-cloud/SKILL.md
@@ -34,8 +34,7 @@ This shape drives almost every command: `daemon` and `config` target this machin
    - `config show/set/get` to read or write `client.yaml`, instead of hand-editing it
 3. **Read the canonical repo docs when the task becomes specialized.**
    - `docs/cli-reference.md` — every flag and env var in one place
-   - `docs/onboarding-guide.md` — full onboarding walkthrough
-   - `docs/claim-agent-guide.md` — agent claim + Feishu binding
+   - `docs/onboarding-guide.md` — full onboarding walkthrough, including agent claim + Feishu binding
 4. **On a fresh machine, verify prerequisites before proposing a flow.**
    - Node.js `>= 22.16`
    - Install: `npm install -g first-tree`

--- a/skills/first-tree-cloud/references/command-surface.md
+++ b/skills/first-tree-cloud/references/command-surface.md
@@ -190,5 +190,4 @@ Useful when debugging or when a user wants to script around the CLI. All calls a
 ## When to Read Other Docs
 
 - `docs/cli-reference.md` — the canonical public flag/env reference.
-- `docs/onboarding-guide.md` — end-to-end onboarding walkthrough and type-specific notes.
-- `docs/claim-agent-guide.md` — claim + Feishu binding details.
+- `docs/onboarding-guide.md` — end-to-end onboarding walkthrough, type-specific notes, claim + Feishu binding details.

--- a/skills/first-tree-cloud/references/developer-map.md
+++ b/skills/first-tree-cloud/references/developer-map.md
@@ -5,8 +5,7 @@
 - `AGENTS.md` — architecture rules, conventions, package map, development workflow.
 - `README.md` — product framing, quick start, top-level documentation links.
 - `docs/cli-reference.md` — public command and environment variable reference.
-- `docs/onboarding-guide.md` — end-to-end onboarding flow.
-- `docs/claim-agent-guide.md` — claim + Feishu binding details.
+- `docs/onboarding-guide.md` — end-to-end onboarding flow, including agent claim + Feishu binding.
 
 ## CLI Source Map
 
@@ -93,7 +92,7 @@ The single-shot `onboard` command was retired in Phase 1A; onboarding is now a s
 1. `commands/login.ts` for token exchange / `--override` flow.
 2. `commands/agent/create.ts` for the Hub-side create + local bind step.
 3. `commands/agent/bind/{bot,user}.ts` for IM bindings.
-4. `docs/onboarding-guide.md` and `docs/claim-agent-guide.md` for user-facing changes.
+4. `docs/onboarding-guide.md` for user-facing changes.
 
 ### Change the background daemon
 


### PR DESCRIPTION
Sweep §4.3 (T3.1 – T3.5) targets that PR-1 deferred. The main repo docs reshape (#566 + #568) landed; this PR cleans up the references those PRs left untouched by design.

## T3.1 — packages/*/README.md

- \`packages/e2e/README.md\`: \`"Real-process E2E for Hub"\` → \`"for first-tree"\`; tree-printed \`client start --foreground\` comment updated to \`daemon start --foreground\` (the actual command the helpers invoke; the underlying source files already used \`daemon start\`).
- \`packages/github-scan/README.md\`: clean, no changes.

## T3.2 — .github/

- \`workflows/docker.yml\`: Feishu deploy notification title/content \`"Hub 测试环境"\` → \`"first-tree 测试环境"\`.
- \`workflows/ci.yml\`: dropped \`docs/development/git-history.md\` from the three-grep CI allow-list (the file was deleted in #566); refreshed the "First Tree Hub" three-word check's rationale comment now that the design-doc sweep landed.
- Issue + PR templates: no changes needed.

## T3.3 — skills/*/SKILL.md + references/

- \`first-tree-cloud/SKILL.md\`, \`references/developer-map.md\`, \`references/command-surface.md\`: redirected \`docs/claim-agent-guide.md\` references to \`docs/onboarding-guide.md\` (the claim guide was merged into onboarding in #566).
- \`Hub\` prose inside skill payloads left in place. §4.3 T3.3 scopes this task to **doc-path references** only; the wider skill prose rewrite is out of scope.

## T3.4 — assets/

\`README.md\` does not reference \`assets/\`; banner + logo images carry no Hub branding. No changes.

## T3.5 — apps/cli/src/cli/index.ts + broader source-comment doc references

The visible \`--help\` description was already fixed in PR-1-followup (#568). The remaining work in this category was inline-comment doc references across \`packages/server/\`, \`packages/client/\`, \`packages/web/\`, \`packages/shared/\`, and \`apps/cli/\` that pointed at design markdowns deleted in #566.

Each one now redirects to the corresponding \`first-tree-context:agent-hub/<node>.md\` destination so future maintainers can still follow the breadcrumb:

| Old | New |
|---|---|
| \`docs/new-user-onboarding-design.md\` | \`first-tree-context:agent-hub/onboarding.md\` |
| \`docs/session-creation-on-first-message.md\` | \`first-tree-context:agent-hub/messaging.md\` |
| \`docs/agent-naming-design.md\` | \`first-tree-context:agent-hub/agent-naming.md\` |
| \`docs/multi-tenancy-hardening-design.md\` | \`first-tree-context:agent-hub/multi-tenancy.md\` |
| \`docs/chat-first-workspace-product-design.md\` | \`first-tree-context:agent-hub/web-console.md\` |
| \`docs/github-entity-chat-binding-design.md\` | \`first-tree-context:agent-hub/github-entity-chat-binding.md\` |
| \`docs/decouple-client-from-identity-design-zh.md\` | \`first-tree-context:agent-hub/client-identity-binding.md\` |
| \`docs/http-path-conventions.md\` | \`docs/development/http-path-conventions.md\` (moved in #566) |
| \`docs/wsl2-troubleshooting.md\` | \`docs/troubleshooting/wsl2.md\` (moved in #566) |

## Verification

\`\`\`
$ grep -rnE "docs/(claim-agent-guide|wsl2-troubleshooting|quickstart-zh|tree/|design/|decouple|agent-naming-design|chat-first-workspace|github-entity-chat-binding-design|multi-tenancy-hardening|new-user-onboarding|runtime-provider-design|session-creation-on|team-page|user-facing-context-tree|migration/from-first-tree-hub|development/git-history)" \\
    --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=migration --exclude-dir=docs \\
    packages apps skills scripts .github

# only hits left are 'docs/design/overview.md' string literals inside
# packages/web/src/lib/__tests__/doc-preview-links.test.ts — those are
# unit-test fixtures exercising relative-path resolution, not real refs.
\`\`\`

## Diff

\`+38 / -42\` across 30 files. No source-logic changes — only comments and config strings.

## Race notes

- This PR overlaps with **PR-2 (#572 — CLI Reference rewrite)** only on \`apps/cli/src/cli/index.ts\` if PR-2 also touches comment lines. The two PRs change disjoint code paths in that file (PR-2 owns \`docs/cli-reference.md\`; this PR did not touch \`cli/index.ts\` in this commit because PR-1-followup already fixed the only visible description). No predicted conflict.
- This PR's \`ci.yml\` allow-list trim depends on \`docs/development/git-history.md\` being absent — it is, on \`main\` (deleted in #566). Safe.

## Test plan

- [x] All grep checks clean per the snippet above.
- [ ] Owner sign-off / reviewer pass.
- [ ] CI green (no source logic changed, but the \`Forbid legacy CLI / env names\` grep should re-run with the tightened allow-list).