### PR TITLE
fix(ci): drop pnpm test from prod publish workflow

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -159,8 +159,6 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test
-
       - name: Publish to npm
         working-directory: apps/cli
         run: npm publish --tag latest --access public


### PR DESCRIPTION
## Problem

`v0.5.2` prod publish failed at `pnpm test` ([run 26435110300](https://github.com/agent-team-foundation/first-tree/actions/runs/26435110300/job/77816035349)). 5 tests failed, all asserting dev-source-tree invariants:

- `installGlobalSpec — channel guard (dev source tree)` — expects `channelConfig.channel === "dev"`, got `"prod"`
- `post-bundle channel-home isolation` — expects dist home = `~/.first-tree-dev`, service unit = `first-tree-dev.service`

## Root cause

The prod publish job rewrites `apps/cli/package.json` + `src/build-info.ts` to the prod channel (`name = first-tree`, `CHANNEL = "prod"`) **and then** runs `pnpm test`. The dev-source-tree invariant tests are correct for the source-tree (dev) context — main CI runs them in that context on every PR — but applying them to a workspace that has just been rewritten to prod is a category error.

This bug was latent until #543 (multi-env isolation) added the dev-context tests. Any future test that depends on source-tree state would trip the same wire.

## Fix

Drop `pnpm test` from the prod publish job. The job now runs:

```
rewrite → check → build → typecheck → publish
```

— matching the staging publish job, which has never run tests. Regression coverage stays on main CI (correct dev context, runs on every PR + push).

## Not in scope

If we later want a prod-rewritten smoke test (asserting `channel === "prod"`, `home === ~/.first-tree`, `service unit === first-tree.service`), that should be a separate test set explicitly designed for the prod context — not a reuse of the dev-source-tree suite.

## After merge

Delete the stale `v0.5.2` tag, then re-cut it on the merge commit to trigger a fresh prod publish run.