### PR TITLE
feat(web): responsive workspace layout for mobile viewports

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
+import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
@@ -25,8 +26,25 @@ export function Layout() {
   // own width.
   const isSettings = location.pathname.startsWith("/settings");
 
+  // Top-bar progressive collapse: at `md` (768–1279) drop the right controls
+  // (cmdk / theme / user); at `narrow` (<768) also drop the brand cluster.
+  // The four nav tabs always survive — that's the minimum viable header.
+  const viewport = useWorkspaceViewport();
+  const dropControls = viewport !== "xl";
+  const dropBrand = viewport === "narrow";
+  const headerColumns = dropBrand ? "1fr" : dropControls ? "1fr auto" : "1fr auto 1fr";
+
   return (
-    <div className="flex flex-col overflow-hidden" style={{ height: "100vh", background: "var(--bg)" }}>
+    <div
+      className="flex flex-col overflow-hidden"
+      // Double height declaration: `100vh` ships first as the universal
+      // fallback; `100dvh` overrides where supported (iOS 15.4+, Chrome
+      // 108+) so the chrome stays in sync with the dynamically-resized
+      // viewport when iOS Safari's URL bar / home indicator hides on
+      // scroll. Without the dvh, the composer slips behind the toolbar
+      // on phones.
+      style={{ height: "100vh", minHeight: "100dvh", background: "var(--bg)" }}
+    >
       {/* Top bar */}
       <header
         className="relative shrink-0 grid items-center"
@@ -35,7 +53,10 @@ export function Layout() {
           // 1fr auto 1fr keeps the centre column (tabs) anchored to the
           // page midpoint regardless of how the brand cluster grows. The
           // disconnect chip can appear/disappear without shifting tabs.
-          gridTemplateColumns: "1fr auto 1fr",
+          // When the right controls collapse (md/narrow) we drop to
+          // `1fr auto`; when the brand also collapses (narrow) we go to
+          // a single column so the tabs anchor to the left edge.
+          gridTemplateColumns: headerColumns,
           gap: "var(--sp-3)",
           padding: "0 var(--sp-3)",
           borderBottom: "var(--hairline) solid var(--border)",
@@ -43,19 +64,31 @@ export function Layout() {
         }}
       >
         {/* Brand cluster: logo + name welded together, then the optional chip. */}
-        <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
-          <span className="flex items-center" style={{ gap: 10, flexShrink: 0 }}>
-            <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
-            {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
-            <span className="text-title" style={{ color: "var(--fg)" }}>
-              First Tree
+        {dropBrand ? null : (
+          <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
+            <span className="flex items-center" style={{ gap: 10, flexShrink: 0 }}>
+              <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
+              {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
+              <span className="text-title" style={{ color: "var(--fg)" }}>
+                First Tree
+              </span>
             </span>
-          </span>
-          <DisconnectChip />
-        </div>
+            <DisconnectChip />
+          </div>
+        )}
 
         {/* Tabs */}
-        <nav className="flex" style={{ gap: 2, pointerEvents: "none", justifySelf: "center" }}>
+        <nav
+          className="flex"
+          style={{
+            gap: 2,
+            pointerEvents: "none",
+            // On `narrow` the header has a single column and tabs become
+            // its sole content — anchor to the start so they don't push
+            // off the right edge.
+            justifySelf: dropBrand ? "start" : "center",
+          }}
+        >
           {navTabs.map((tab) => (
             <NavLink
               key={tab.to}
@@ -84,51 +117,53 @@ export function Layout() {
           ))}
         </nav>
 
-        {/* Right controls */}
-        <div className="flex items-center" style={{ gap: 6, justifySelf: "end" }}>
-          <button
-            type="button"
-            onClick={() => setPaletteOpen(true)}
-            aria-label="Open command palette"
-            className="inline-flex items-center transition-colors text-body"
-            style={{
-              gap: 8,
-              padding: "var(--sp-1) var(--sp-3)",
-              minWidth: 200,
-              color: "var(--fg-3)",
-              border: "var(--hairline) solid var(--border)",
-              borderRadius: "var(--radius-input)",
-              background: "var(--bg-sunken)",
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = "var(--fg)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = "var(--fg-3)";
-            }}
-          >
-            <Search className="h-4 w-4" />
-            <span>Jump to…</span>
-          </button>
-          <span
-            style={{
-              width: 1,
-              height: 18,
-              background: "var(--border)",
-              margin: "0 var(--sp-1)",
-            }}
-          />
-          <ThemeToggle />
-          <span
-            style={{
-              width: 1,
-              height: 18,
-              background: "var(--border)",
-              margin: "0 var(--sp-1)",
-            }}
-          />
-          <UserMenu />
-        </div>
+        {/* Right controls — collapse at `md` and below. */}
+        {dropControls ? null : (
+          <div className="flex items-center" style={{ gap: 6, justifySelf: "end" }}>
+            <button
+              type="button"
+              onClick={() => setPaletteOpen(true)}
+              aria-label="Open command palette"
+              className="inline-flex items-center transition-colors text-body"
+              style={{
+                gap: 8,
+                padding: "var(--sp-1) var(--sp-3)",
+                minWidth: 200,
+                color: "var(--fg-3)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-input)",
+                background: "var(--bg-sunken)",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.color = "var(--fg)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.color = "var(--fg-3)";
+              }}
+            >
+              <Search className="h-4 w-4" />
+              <span>Jump to…</span>
+            </button>
+            <span
+              style={{
+                width: 1,
+                height: 18,
+                background: "var(--border)",
+                margin: "0 var(--sp-1)",
+              }}
+            />
+            <ThemeToggle />
+            <span
+              style={{
+                width: 1,
+                height: 18,
+                background: "var(--border)",
+                margin: "0 var(--sp-1)",
+              }}
+            />
+            <UserMenu />
+          </div>
+        )}
       </header>
 
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />

--- a/packages/web/src/hooks/use-viewport.ts
+++ b/packages/web/src/hooks/use-viewport.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Workspace responsive breakpoint used by `Layout` (top-bar collapse) and
+ * `WorkspacePage` (conversation-list + chat-details overlay behavior).
+ *
+ *   - `xl`     ≥ 80rem  : top bar + conv list + chat details all visible.
+ *   - `md`     48–80rem : top bar drops right controls; chat details
+ *                          collapse (still summon-able via its toggle).
+ *   - `narrow` < 48rem  : top bar drops brand too (tabs only); both
+ *                          side rails collapse; conv list is summon-able
+ *                          via a hamburger in chat-view's header.
+ *
+ * Breakpoints align with Tailwind defaults (`md` = 48rem, `xl` = 80rem) —
+ * the same values already used elsewhere in the dashboard. Expressed in
+ * rem so the design-token guardrail (no raw `Npx`) stays clean.
+ *
+ * SPA-only: the SSR fallback seeds `xl` so the chrome lays out the wide
+ * three-pane structure on first paint. SSR consumers (none today) would
+ * need to override the seed to avoid a narrow-device hydration flicker.
+ */
+export type WorkspaceViewport = "xl" | "md" | "narrow";
+
+const XL_QUERY = "(min-width: 80rem)";
+const MD_QUERY = "(min-width: 48rem)";
+
+function readViewport(): WorkspaceViewport {
+  if (typeof window === "undefined") return "xl";
+  if (window.matchMedia(XL_QUERY).matches) return "xl";
+  if (window.matchMedia(MD_QUERY).matches) return "md";
+  return "narrow";
+}
+
+export function useWorkspaceViewport(): WorkspaceViewport {
+  const [viewport, setViewport] = useState<WorkspaceViewport>(readViewport);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const xlQuery = window.matchMedia(XL_QUERY);
+    const mdQuery = window.matchMedia(MD_QUERY);
+    const update = () => setViewport(readViewport());
+    xlQuery.addEventListener("change", update);
+    mdQuery.addEventListener("change", update);
+    return () => {
+      xlQuery.removeEventListener("change", update);
+      mdQuery.removeEventListener("change", update);
+    };
+  }, []);
+
+  return viewport;
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1373,3 +1373,14 @@ tr[data-interactive]:hover {
     animation: none;
   }
 }
+
+/* Hide the third-party hearback-widget feedback FAB on narrow viewports.
+   Matches the workspace's `narrow` breakpoint (use-viewport.ts) — at <48rem
+   the chrome collapses to tabs-only and the bottom-right bubble would
+   overlap the composer / sit on top of the home-indicator zone. The widget
+   element is injected at the end of <body> by widget.js (see index.html). */
+@media (max-width: 47.999rem) {
+  hearback-widget {
+    display: none;
+  }
+}

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -36,7 +36,15 @@ function pickPrimaryAgent(participants: { agentId: string; type: string }[], myA
   return nonSelf[0]?.agentId ?? null;
 }
 
-export function ChatByIdView({ chatId }: { chatId: string }) {
+export function ChatByIdView({
+  chatId,
+  narrow,
+  onShowConversations,
+}: {
+  chatId: string;
+  narrow: boolean;
+  onShowConversations: (() => void) | null;
+}) {
   const queryClient = useQueryClient();
   const { agentId: myAgentId } = useAuth();
 
@@ -140,9 +148,11 @@ export function ChatByIdView({ chatId }: { chatId: string }) {
           joining: joinMut.isPending,
           error: joinMut.isError ? (joinMut.error instanceof Error ? joinMut.error.message : "Failed to join") : null,
         }}
+        narrow={narrow}
+        onShowConversations={onShowConversations}
       />
     );
   }
 
-  return <ChatView agentId={primaryAgent} chatId={chatId} />;
+  return <ChatView agentId={primaryAgent} chatId={chatId} narrow={narrow} onShowConversations={onShowConversations} />;
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -9,7 +9,18 @@ import {
   type QuestionMessageContent,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, AtSign, Check, ExternalLink, Eye, MessageSquare, MoreHorizontal, Paperclip, X } from "lucide-react";
+import {
+  ArrowUp,
+  AtSign,
+  Check,
+  ExternalLink,
+  Eye,
+  Menu,
+  MessageSquare,
+  MoreHorizontal,
+  Paperclip,
+  X,
+} from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -727,6 +738,8 @@ export function ChatView({
   readOnly = false,
   titleFallback,
   joinAction,
+  narrow = false,
+  onShowConversations = null,
 }: {
   agentId: string;
   chatId: string;
@@ -745,6 +758,15 @@ export function ChatView({
     joining: boolean;
     error: string | null;
   };
+  /** Workspace shell is in narrow-viewport mode (<768). Two effects:
+   *  (1) `onShowConversations` is non-null, so we render a hamburger in
+   *  the chat header; (2) the right rail, when shown, renders as an
+   *  absolute-positioned overlay over the chat instead of an inline
+   *  shrink-0 column — at 375 px logical there isn't room for both. */
+  narrow?: boolean;
+  /** Non-null only in narrow mode. Invoking it summons the conversation-
+   *  list overlay (which lives in `WorkspacePage`). */
+  onShowConversations?: (() => void) | null;
 }) {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -2060,8 +2082,11 @@ export function ChatView({
           Putting the header inside the left column makes its reading-
           column centre share the same base as timeline/composer, so the
           title's left edge naturally aligns with the message avatars
-          regardless of whether the right rail is open. */}
-      <div className="flex-1 flex overflow-hidden">
+          regardless of whether the right rail is open. `relative` is the
+          anchor for the narrow-viewport overlay variants of the right
+          rail and its scrim — no effect on wider viewports where both
+          render as inline siblings. */}
+      <div className="flex-1 flex overflow-hidden relative">
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
           {/* Chat header — content centred in a reading column that's now
           measured against the left column rather than the full panel.
@@ -2097,6 +2122,31 @@ export function ChatView({
                 gap: 10,
               }}
             >
+              {/* Narrow-viewport summon: header lost the brand cluster and
+                  the conversation list collapsed out of the inline shell.
+                  This hamburger is the only way to get back to the chat
+                  list, so it sits at the very left of the chat header
+                  (i.e. the visible left edge of the workspace). */}
+              {onShowConversations ? (
+                <button
+                  type="button"
+                  onClick={onShowConversations}
+                  aria-label="Show conversations"
+                  title="Show conversations"
+                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                  style={{
+                    width: 28,
+                    height: 28,
+                    border: 0,
+                    background: "transparent",
+                    borderRadius: "var(--radius-input)",
+                    color: "var(--fg-3)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <Menu size={16} strokeWidth={2.25} />
+                </button>
+              ) : null}
               {/* Identity — title is the sole click-to-rename affordance
               (Slack / Linear pattern). The hover-only ✏️ pencil was
               dropped after the title itself became clickable: two
@@ -2471,11 +2521,13 @@ export function ChatView({
           Composer card inside is capped via `maxWidth` and centered, so it
           aligns vertically with the timeline column above — eye tracks
           from last message into textarea without a horizontal jump
-          (Slack / ChatGPT / Linear DM all do this). */}
+          (Slack / ChatGPT / Linear DM all do this). On phones, the
+          bottom padding extends past `env(safe-area-inset-bottom)` so
+          the home-indicator doesn't overlap the send button. */}
           <div
             className="shrink-0"
             style={{
-              padding: "var(--sp-2_5) var(--sp-6) var(--sp-3)",
+              padding: "var(--sp-2_5) var(--sp-6) calc(var(--sp-3) + env(safe-area-inset-bottom, 0))",
             }}
           >
             <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
@@ -2820,15 +2872,43 @@ export function ChatView({
           </div>
         </div>
         {showSidebar ? (
-          <ChatRightSidebar
-            chatId={chatId}
-            participants={chatDetail?.participants ?? []}
-            participantsLoading={chatDetailLoading}
-            managedByMe={managedByMeMap}
-            onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
-            onClose={() => setShowSidebar(false)}
-            readOnly={readOnly}
-          />
+          narrow ? (
+            // Narrow viewport: rail floats over the chat instead of
+            // pushing it aside. A scrim catches outside-clicks for
+            // dismissal — Esc still works via the existing key handler
+            // bound earlier in this component.
+            <>
+              <button
+                type="button"
+                aria-label="Dismiss"
+                onClick={() => setShowSidebar(false)}
+                className="absolute inset-0 z-20"
+                style={{ background: "var(--overlay-scrim)", border: 0, cursor: "default" }}
+              />
+              <div className="absolute top-0 bottom-0 right-0 z-30 flex" style={{ boxShadow: "var(--shadow-md)" }}>
+                <ChatRightSidebar
+                  chatId={chatId}
+                  participants={chatDetail?.participants ?? []}
+                  participantsLoading={chatDetailLoading}
+                  managedByMe={managedByMeMap}
+                  onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
+                  onClose={() => setShowSidebar(false)}
+                  readOnly={readOnly}
+                  width="min(88vw, 20rem)"
+                />
+              </div>
+            </>
+          ) : (
+            <ChatRightSidebar
+              chatId={chatId}
+              participants={chatDetail?.participants ?? []}
+              participantsLoading={chatDetailLoading}
+              managedByMe={managedByMeMap}
+              onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
+              onClose={() => setShowSidebar(false)}
+              readOnly={readOnly}
+            />
+          )
         ) : null}
       </div>
     </div>

--- a/packages/web/src/pages/workspace/center/index.tsx
+++ b/packages/web/src/pages/workspace/center/index.tsx
@@ -19,9 +19,19 @@ import { NoChatView } from "./no-chat-view.js";
 export function CenterPanel({
   selectedChatId,
   onSelectChat,
+  narrow,
+  onShowConversations,
 }: {
   selectedChatId: string | null;
   onSelectChat: (chatId: string) => void;
+  /** True when the workspace shell is in narrow-viewport mode (<768).
+   *  Propagated to `ChatView` so it can swap the right rail to an
+   *  overlay and surface the conv-list summon button. */
+  narrow: boolean;
+  /** Non-null only in narrow mode — invoking this opens the
+   *  conversation-list overlay. ChatView renders a hamburger button
+   *  in its header when provided. */
+  onShowConversations: (() => void) | null;
 }) {
   const { organizationId } = useAuth();
 
@@ -33,11 +43,17 @@ export function CenterPanel({
     // a uuid from the previous org could stay in the cache and silently
     // resolve a new-org `@bob` to a stranger; the server then 4xxs the
     // chat create with a confusing visibility error.
-    return <NewChatDraft key={organizationId ?? "no-org"} onCreated={onSelectChat} />;
+    return (
+      <NewChatDraft
+        key={organizationId ?? "no-org"}
+        onCreated={onSelectChat}
+        onShowConversations={onShowConversations}
+      />
+    );
   }
 
   if (selectedChatId) {
-    return <ChatByIdView chatId={selectedChatId} />;
+    return <ChatByIdView chatId={selectedChatId} narrow={narrow} onShowConversations={onShowConversations} />;
   }
 
   return <NoChatView onNewChat={() => onSelectChat(DRAFT_CHAT_ID)} />;

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -96,6 +96,7 @@ export function ConversationList({
   onClearFilters,
   group,
   onGroupChange,
+  width = 320,
 }: {
   selectedChatId: string | null;
   onSelectChat: (chatId: string) => void;
@@ -106,6 +107,11 @@ export function ConversationList({
   onUnreadChange: (next: boolean) => void;
   watching: boolean;
   onWatchingChange: (next: boolean) => void;
+  /** Override the default 20rem aside width. Used by `WorkspacePage`'s
+   *  narrow-viewport overlay branch to cap to `min(88vw, 20rem)` so the
+   *  inner aside doesn't overflow the wrapper on phones narrower than
+   *  ~23rem logical (e.g. compact Android handsets). */
+  width?: number | string;
   /**
    * Multi-select origin filter. Phase B's filter popover (forthcoming
    * in the next commit) will mount its checkbox group against this
@@ -355,7 +361,7 @@ export function ConversationList({
     <aside
       className="shrink-0 flex flex-col overflow-hidden"
       style={{
-        width: 320,
+        width,
         background: "var(--bg-raised)",
         borderRight: "var(--hairline) solid var(--border)",
       }}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -1,6 +1,6 @@
 import { type Agent, extractMentions, type MentionParticipant } from "@first-tree/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, Check, Paperclip, Plus, X } from "lucide-react";
+import { ArrowUp, Check, Menu, Paperclip, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { readFileAsBase64, sendChatMessage, sendFileMessage } from "../../../api/chats.js";
 import { putImage } from "../../../api/image-store.js";
@@ -59,7 +59,17 @@ import { cn } from "../../../lib/utils.js";
  * (a non-empty body or ≥1 image).
  */
 
-export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => void }) {
+export function NewChatDraft({
+  onCreated,
+  onShowConversations = null,
+}: {
+  onCreated: (chatId: string) => void;
+  /** Non-null only in narrow-viewport mode — renders a hamburger in the
+   *  top-left corner that summons the conversation-list overlay. Without
+   *  it, narrow users who land on a draft URL have no path back to their
+   *  chats (the inline rail is collapsed). */
+  onShowConversations?: (() => void) | null;
+}) {
   const queryClient = useQueryClient();
   const { agentId: myAgentId, memberId: myMemberId } = useAuth();
   const agentIdentity = useAgentIdentityMap();
@@ -413,7 +423,32 @@ export function NewChatDraft({ onCreated }: { onCreated: (chatId: string) => voi
   };
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden" style={{ background: "var(--bg-base)" }}>
+    <div className="flex-1 flex flex-col overflow-hidden relative" style={{ background: "var(--bg-base)" }}>
+      {/* Narrow-viewport summon: parallels the hamburger in chat-view's
+          header. Anchored absolutely so we don't disturb the existing
+          centred composer layout. */}
+      {onShowConversations ? (
+        <button
+          type="button"
+          onClick={onShowConversations}
+          aria-label="Show conversations"
+          title="Show conversations"
+          className="absolute z-10 inline-flex items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+          style={{
+            top: "var(--sp-2)",
+            left: "var(--sp-2)",
+            width: 28,
+            height: 28,
+            border: 0,
+            background: "transparent",
+            borderRadius: "var(--radius-input)",
+            color: "var(--fg-3)",
+            cursor: "pointer",
+          }}
+        >
+          <Menu size={16} strokeWidth={2.25} />
+        </button>
+      ) : null}
       <div className="flex-1 flex flex-col items-center justify-center" style={{ padding: "var(--sp-6)" }}>
         <div style={{ width: "100%", maxWidth: "clamp(55rem, 75%, 70rem)" }}>
           <p className="text-title" style={{ color: "var(--fg)", textAlign: "center", marginBottom: "var(--sp-5)" }}>

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -121,6 +121,17 @@ export function WorkspacePage() {
   useEffect(() => {
     if (!isNarrow) setConvOverlayOpen(false);
   }, [isNarrow]);
+  // Esc closes the conversation-list overlay — parallels the existing
+  // Esc handler ChatView uses for its right-rail overlay, so both
+  // overlays behave the same for keyboard users.
+  useEffect(() => {
+    if (!convOverlayOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setConvOverlayOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [convOverlayOpen]);
 
   // One-shot legacy redirects, all batched into a single setSearchParams so
   // they don't race on stale `searchParams` snapshots. Each branch returns
@@ -236,6 +247,20 @@ export function WorkspacePage() {
     return <Navigate to="/onboarding" replace />;
   }
 
+  // Pick the width prop based on what role the rail is playing:
+  //   - narrow + no chat → full-bleed (100% of the wrapper) so the list
+  //     covers the whole screen as the main view.
+  //   - narrow + overlay → fluid cap so the inner aside doesn't overflow
+  //     the wrapper on phones narrower than ~23rem logical (same pattern
+  //     ChatRightSidebar uses for its overlay variant).
+  //   - otherwise (inline rail on md/xl) → leave undefined, default 20rem.
+  const conversationListWidth = !isNarrow
+    ? undefined
+    : !selectedChatId
+      ? "100%"
+      : convOverlayOpen
+        ? "min(88vw, 20rem)"
+        : undefined;
   const conversationList = (
     <ConversationList
       selectedChatId={selectedChatId}
@@ -254,6 +279,7 @@ export function WorkspacePage() {
       onClearFilters={clearFilters}
       group={group}
       onGroupChange={setGroup}
+      width={conversationListWidth}
     />
   );
 

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -1,9 +1,10 @@
 import { CHAT_SOURCES, type ChatEngagementView, type ChatSource, chatEngagementViewSchema } from "@first-tree/shared";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Navigate, useSearchParams } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { DocPreviewDrawer } from "../../components/doc-preview-drawer.js";
 import { useAdminWs } from "../../hooks/use-admin-ws.js";
+import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { CenterPanel } from "./center/index.js";
 import { type GroupMode, parseGroupMode } from "./conversations/group-rows.js";
@@ -108,6 +109,19 @@ export function WorkspacePage() {
 
   useAdminWs();
 
+  // Viewport-driven layout: at `narrow` (<768) the conversation list
+  // collapses out of the inline three-pane shell and becomes a summon-able
+  // overlay anchored to the workspace's left edge. State is plain React
+  // (not URL) so the back button still navigates chats, not drawer state.
+  const viewport = useWorkspaceViewport();
+  const isNarrow = viewport === "narrow";
+  const [convOverlayOpen, setConvOverlayOpen] = useState(false);
+  // When the viewport widens back out, drop the overlay flag so we don't
+  // re-show the rail in two places once it returns to inline rendering.
+  useEffect(() => {
+    if (!isNarrow) setConvOverlayOpen(false);
+  }, [isNarrow]);
+
   // One-shot legacy redirects, all batched into a single setSearchParams so
   // they don't race on stale `searchParams` snapshots. Each branch returns
   // after staging its mutation; the effect re-runs once the URL settles.
@@ -149,6 +163,10 @@ export function WorkspacePage() {
       next.set("c", chatId);
       clearDocPreviewParams(next);
       setSearchParams(next);
+      // Auto-dismiss the conversation-list overlay on narrow viewports —
+      // the user picked a chat, they want the chat view, not the rail.
+      // No-op on `md`/`xl` where the rail renders inline.
+      setConvOverlayOpen(false);
     },
     [searchParams, setSearchParams],
   );
@@ -218,31 +236,83 @@ export function WorkspacePage() {
     return <Navigate to="/onboarding" replace />;
   }
 
+  const conversationList = (
+    <ConversationList
+      selectedChatId={selectedChatId}
+      onSelectChat={selectChat}
+      onNewChat={openDraft}
+      engagement={engagement}
+      onEngagementChange={setEngagement}
+      unread={unread}
+      onUnreadChange={setUnread}
+      watching={watching}
+      onWatchingChange={setWatching}
+      origin={origin}
+      onOriginChange={setOrigin}
+      participants={participants}
+      onParticipantsChange={setParticipants}
+      onClearFilters={clearFilters}
+      group={group}
+      onGroupChange={setGroup}
+    />
+  );
+
+  // Narrow + no selection: the conversation list IS the main view, not an
+  // overlay. Avoids trapping the user on NoChatView with no way back to
+  // their chats (the inline rail is hidden, the hamburger only renders
+  // inside ChatView). Same component reused, just stretched full-bleed.
+  if (isNarrow && !selectedChatId) {
+    return (
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 flex">{conversationList}</div>
+        <DocPreviewDrawer />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-1 overflow-hidden">
-      <ConversationList
-        selectedChatId={selectedChatId}
-        onSelectChat={selectChat}
-        onNewChat={openDraft}
-        engagement={engagement}
-        onEngagementChange={setEngagement}
-        unread={unread}
-        onUnreadChange={setUnread}
-        watching={watching}
-        onWatchingChange={setWatching}
-        origin={origin}
-        onOriginChange={setOrigin}
-        participants={participants}
-        onParticipantsChange={setParticipants}
-        onClearFilters={clearFilters}
-        group={group}
-        onGroupChange={setGroup}
-      />
+    <div className="flex flex-1 overflow-hidden relative">
+      {/* Inline rail at `md`/`xl`. On `narrow` the rail collapses out
+          of the row and gets summoned as an overlay (below). */}
+      {isNarrow ? null : conversationList}
 
       <main className="flex-1 flex flex-col overflow-hidden min-w-0" style={{ background: "var(--bg)" }}>
-        <CenterPanel selectedChatId={selectedChatId} onSelectChat={selectChat} />
+        <CenterPanel
+          selectedChatId={selectedChatId}
+          onSelectChat={selectChat}
+          narrow={isNarrow}
+          onShowConversations={isNarrow ? () => setConvOverlayOpen(true) : null}
+        />
       </main>
       <DocPreviewDrawer />
+
+      {/* Conversation-list overlay (narrow viewports only). Same
+          component rendered above for inline mode — just wrapped in an
+          absolute-positioned shell with a scrim. The rail itself is a
+          shrink-0 20rem-wide aside; we cap to `min(88vw, 20rem)` so it
+          doesn't bleed past the screen edge on phones narrower than
+          ~23rem logical. Scrim click closes; selecting a chat also
+          closes (see `selectChat` above). */}
+      {isNarrow && convOverlayOpen ? (
+        <>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={() => setConvOverlayOpen(false)}
+            className="absolute inset-0 z-20"
+            style={{ background: "var(--overlay-scrim)", border: 0, cursor: "default" }}
+          />
+          <div
+            className="absolute top-0 bottom-0 left-0 z-30 flex"
+            style={{
+              maxWidth: "min(88vw, 20rem)",
+              boxShadow: "var(--shadow-md)",
+            }}
+          >
+            {conversationList}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -30,6 +30,7 @@ export function ChatRightSidebar({
   onAdded,
   onClose,
   readOnly,
+  width = 320,
 }: {
   chatId: string;
   participants: ChatParticipantDetail[];
@@ -40,13 +41,17 @@ export function ChatRightSidebar({
   /** Watcher mode: hide write surfaces. Currently gates the inline
    *  "Add participant" affordance inside ParticipantsSection. */
   readOnly: boolean;
+  /** Override the default 20rem width. Used by the narrow-viewport
+   *  overlay branch in `ChatView` to cap to `min(88vw, 20rem)` so
+   *  the rail doesn't overflow a ~23rem logical viewport. */
+  width?: number | string;
 }) {
   return (
     <aside
       aria-label="Chat details"
       className="relative flex shrink-0 flex-col overflow-hidden animate-in fade-in slide-in-from-right-4 duration-150"
       style={{
-        width: 320,
+        width,
         background: "var(--bg-raised)",
         borderLeft: "var(--hairline) solid var(--border)",
       }}


### PR DESCRIPTION
## Summary

Makes the web dashboard usable down to ~375px logical. Adds a three-bucket viewport hook (`xl` ≥80rem / `md` 48–80rem / `narrow` <48rem) and rewires `Layout`, `WorkspacePage`, `ChatView`, and `NewChatDraft` so each viewport gets sensible chrome.

### Behavior by breakpoint

| Surface | xl (≥1280) | md (768–1279) | narrow (<768) |
|---|---|---|---|
| Top bar | brand + tabs + cmdk/theme/user | brand + tabs | tabs only |
| Conversation list | inline rail | inline rail | full-bleed view (no chat) / scrim+drawer summoned by hamburger (chat or draft selected) |
| Chat right details | inline column | inline column | scrim+drawer (capped `min(88vw, 20rem)`) |
| Composer | normal | normal | adds `env(safe-area-inset-bottom)` so the iOS home indicator doesn't overlap the send button |
| `hearback-widget` FAB | shown | shown | hidden via CSS (would overlap composer) |

Layout uses `min-height: 100dvh` over `100vh` so the chrome syncs with iOS Safari's URL-bar resize.

### Overlay anchoring (intentional difference)

The two narrow-viewport overlays have different scrim anchors on purpose:

- **Conversation list overlay** is anchored to `WorkspacePage` — the scrim covers the chat area only, the top tab bar stays interactive so the user can still switch sections.
- **Chat-right-details overlay** is anchored to `ChatView`'s inner row — the scrim covers the timeline + composer only, the chat header (title, status, controls) stays visible above it.

Both overlays accept Esc and scrim click to dismiss; the conversation-list one is closed automatically when the viewport widens back to `md`/`xl`.

### Files

- `packages/web/src/hooks/use-viewport.ts` *(new)* — `useWorkspaceViewport()` driven by two `matchMedia` queries
- `packages/web/src/components/layout.tsx` — top-bar progressive collapse + dvh fallback
- `packages/web/src/pages/workspace/index.tsx` — narrow + no chat → list as main view; otherwise scrim+drawer summon (Esc + scrim click both dismiss)
- `packages/web/src/pages/workspace/center/chat-view.tsx` — right-rail overlay branch + composer safe-area + summon hamburger
- `packages/web/src/pages/workspace/center/index.tsx` + `center/chat-by-id.tsx` — prop pass-through for `narrow` / `onShowConversations`
- `packages/web/src/pages/workspace/conversations/index.tsx` — accepts `width` prop so the inner aside follows the wrapper (default 320 preserved)
- `packages/web/src/pages/workspace/conversations/new-chat-draft.tsx` — hamburger in narrow mode so the draft view isn't a dead-end
- `packages/web/src/pages/workspace/right-sidebar/index.tsx` — accepts `width` prop for the narrow overlay
- `packages/web/src/index.css` — hide `hearback-widget` at narrow

No server / shared / DB / migrations touched. No new dependencies. `pnpm typecheck` clean, biome clean on touched files.

## Test plan

- [x] xl (≥1280): three-pane layout unchanged
- [x] md (768–1279): top-bar right controls drop; rest unchanged
- [x] narrow (<768) with no chat selected: full-bleed conversation list visible
- [x] narrow with chat selected: hamburger summons list overlay, scrim and Esc both dismiss
- [x] narrow with `?c=draft`: hamburger present on NewChatDraft
- [x] narrow chat-details (`?` toggle): renders as right overlay with `min(88vw, 20rem)` width
- [x] iOS Safari: composer padding clears the home indicator
- [x] Breakpoint flips at 768 / 1280 close their respective overlays cleanly
- [x] `hearback-widget` hidden below 768
- [ ] CI green