### PR TITLE
refactor(me-chat): scope "Needs attention" to caller-relevant chats

### DIFF
--- a/docs/development/needs-attention-scoping-plan.20260526.md
+++ b/docs/development/needs-attention-scoping-plan.20260526.md
@@ -1,0 +1,956 @@
+# Needs-Attention Scoping — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scope the Agent Hub Web me-chat "Needs attention" bucket to chats that are actually relevant to the caller — narrow the existing wire fields to "agents I manage", add one boolean to cover the speaker-in-chat-with-question fallback, and extend the frontend predicate to also include unread @-mentions.
+
+**Architecture:**
+- **Backend** (`me-chat.ts`): one extra indexed lookup for the caller's managed-agent set; narrow the existing `failedAgentIds` / `pendingQuestionAgentIds` projection by that set; emit a new `chatHasOpenQuestion: boolean`.
+- **Shared schema** (`me-chat.ts` zod): add `chatHasOpenQuestion` with `.default(false)` for version skew.
+- **Frontend** (`group-rows.ts`): replace the 2-condition attention predicate with a 4-rule one (R1 mine-failed, R2 mine-pending, R3 speaker-in-chat-with-question, R4 unread-mention) and a local `ATTENTION_PRIORITY = ["failed","needs_you","mention"]` sort ladder.
+- **No DB migration**, **no changes to the shared `resolveAgentChatStatuses` producer**, **no UI toggle**.
+
+**Tech Stack:** TypeScript · Postgres (Drizzle ORM) · Fastify · React · Vitest · pnpm workspaces.
+
+**Design doc**: `docs/development/needs-attention-scoping.20260526.md`
+
+**Worktree**: `/Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping`
+**Branch**: `refactor/needs-attention-predicate` (off origin/main @ 3992f98)
+
+---
+
+## File Plan
+
+| File | Change | Responsibility |
+|---|---|---|
+| `packages/shared/src/schemas/me-chat.ts` | Modify (`meChatRowSchema`) | Add `chatHasOpenQuestion` field |
+| `packages/server/src/services/me-chat.ts` | Modify (`listMeChats`) | New `callerMemberId` param; fetch managed-agent set; narrow `failed`/`pending`; emit `chatHasOpenQuestion` |
+| `packages/server/src/api/orgs/chats.ts` | Modify (1 call site) | Pass `scope.memberId` |
+| `packages/server/src/__tests__/me-chat-activity.test.ts` | Modify | Add `callerMemberId` to `listMeChats` calls |
+| `packages/server/src/__tests__/me-chat-source-tags.test.ts` | Modify | Same |
+| `packages/server/src/__tests__/me-chat-service.test.ts` | Modify | Same |
+| `packages/server/src/__tests__/direct-chat-auto-mention.test.ts` | Modify | Same |
+| `packages/server/src/__tests__/cross-org-chat-pollution.test.ts` | Modify | Same |
+| `packages/server/src/__tests__/me-chat-attention.test.ts` | Create | New integration tests B1–B10 (manager × membership × failed/pending matrix) |
+| `packages/web/src/pages/workspace/conversations/group-rows.ts` | Modify | New `rowAttentionReason` / `ATTENTION_PRIORITY`; updated `rowIsFailed` / `rowNeedsYou` / `splitAttentionRows` |
+| `packages/web/src/pages/workspace/__tests__/group-rows.test.ts` | Modify | Add 11 new cases under `splitAttentionRows — predicate` |
+
+`chat-row-avatar-preview.tsx` / `conversations/index.tsx` are unchanged: they call `rowIsFailed`/`rowNeedsYou`, whose external signatures are preserved (internal logic adjusts).
+
+---
+
+## Pre-flight
+
+- [ ] **Verify worktree state**
+
+Run:
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+git status -sb
+```
+Expected: `## refactor/needs-attention-predicate...origin/main` and no untracked files except `docs/development/needs-attention-scoping*.md`.
+
+- [ ] **Install workspace deps** (idempotent — skips if already current)
+
+Run:
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm install
+```
+
+---
+
+## Task 1 — Add `callerMemberId` to `listMeChats` (signature plumbing)
+
+**Goal:** non-functional refactor — adds the new parameter end-to-end so subsequent tasks can use it. No behavior change yet.
+
+**Files:**
+- Modify: `packages/server/src/services/me-chat.ts` (signature only; body unchanged this task)
+- Modify: `packages/server/src/api/orgs/chats.ts:94` (pass `scope.memberId`)
+- Modify (each adds a `memberId` arg): `packages/server/src/__tests__/me-chat-activity.test.ts`, `me-chat-source-tags.test.ts`, `me-chat-service.test.ts`, `direct-chat-auto-mention.test.ts`, `cross-org-chat-pollution.test.ts`
+
+- [ ] **Step 1.1: Update `listMeChats` signature**
+
+Edit `packages/server/src/services/me-chat.ts` — the `listMeChats` function declaration:
+
+```ts
+export async function listMeChats(
+  db: Database,
+  humanAgentId: string,
+  callerMemberId: string,
+  organizationId: string,
+  query: ListMeChatsQuery,
+): Promise<ListMeChatsResponse> {
+  // body unchanged in Task 1.
+  ...
+}
+```
+
+(Insert `callerMemberId: string,` after `humanAgentId: string,` and before `organizationId: string,`.)
+
+- [ ] **Step 1.2: Update the route call site**
+
+Edit `packages/server/src/api/orgs/chats.ts:94`:
+
+```ts
+return listMeChats(app.db, scope.humanAgentId, scope.memberId, scope.organizationId, query);
+```
+
+- [ ] **Step 1.3: Update all 5 test files to pass `memberId`**
+
+Each test file already creates an admin via `createTestAdmin` (which returns `{ memberId, humanAgentUuid, organizationId, ... }`). For every `listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, ...)` call, insert `admin.memberId` between `humanAgentUuid` and `organizationId`.
+
+Run a sanity grep first to enumerate the call sites:
+
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+grep -n "listMeChats(" packages/server/src/__tests__/me-chat-*.test.ts packages/server/src/__tests__/direct-chat-auto-mention.test.ts packages/server/src/__tests__/cross-org-chat-pollution.test.ts
+```
+
+Apply this transform at every match:
+```
+- listMeChats(app.db, <humanAgentVar>, <orgVar>, ...)
++ listMeChats(app.db, <humanAgentVar>, <memberVar>, <orgVar>, ...)
+```
+
+Where `<memberVar>` is the corresponding `admin.memberId` / `member.id` for that test's admin context (look one or two lines up — every test owns its admin handle).
+
+Note: `me-chat-activity.test.ts` has a `rowFor(chatId, viewerAgentId, organizationId)` helper around line 59 that currently shadows the same signature. If found, update its signature too:
+```ts
+async function rowFor(chatId: string, viewerAgentId: string, viewerMemberId: string, organizationId: string) {
+  const { rows } = await listMeChats(app.db, viewerAgentId, viewerMemberId, organizationId, { ... });
+  ...
+}
+```
+and update all `rowFor(...)` callers in that file to thread the memberId through.
+
+- [ ] **Step 1.4: Typecheck — confirm signature plumbing is clean**
+
+Run:
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm typecheck 2>&1 | tail -20
+```
+Expected: no type errors. If any test file still calls the old 4-arg form, fix it.
+
+- [ ] **Step 1.5: Backend tests still green (no behavior change yet)**
+
+Run:
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm --filter @first-tree/server test -- me-chat 2>&1 | tail -30
+```
+Expected: all existing me-chat tests pass.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+git add packages/server/src/services/me-chat.ts packages/server/src/api/orgs/chats.ts packages/server/src/__tests__/me-chat-*.test.ts packages/server/src/__tests__/direct-chat-auto-mention.test.ts packages/server/src/__tests__/cross-org-chat-pollution.test.ts
+git commit -m "refactor(me-chat): thread callerMemberId into listMeChats signature
+
+Plumbing only — no behavior change. Sets up the subsequent
+manager-filter projection for the Needs-Attention bucket fix."
+```
+
+---
+
+## Task 2 — Backend: fetch managed-agent set, narrow `failedAgentIds` / `pendingQuestionAgentIds`
+
+**Goal:** introduce the manager filter inside the projection loop. After this task, R1 + R2 of the new predicate are satisfied on the wire.
+
+**File:** `packages/server/src/services/me-chat.ts:438-478` (the section between `resolveAgentChatStatuses(...)` and the row build).
+
+- [ ] **Step 2.1: Write the first failing integration test (B1 — mine-failed)**
+
+Create `packages/server/src/__tests__/me-chat-attention.test.ts`:
+
+```ts
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { createMeChat, listMeChats } from "../services/me-chat.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+describe("listMeChats: needs-attention scoping (R1–R3 backend projection)", () => {
+  const getApp = useTestApp();
+
+  async function markErrored(agentId: string, chatId: string): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, runtime_state_at, updated_at)
+      VALUES (${agentId}, ${chatId}, 'errored', 'error', NOW(), NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE
+        SET state = EXCLUDED.state,
+            runtime_state = EXCLUDED.runtime_state,
+            runtime_state_at = EXCLUDED.runtime_state_at
+    `);
+  }
+
+  async function rowFor(chatId: string, admin: Awaited<ReturnType<typeof createTestAdmin>>) {
+    const app = getApp();
+    const { rows } = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    return rows.find((r) => r.chatId === chatId) ?? null;
+  }
+
+  it("B1: mine-failed → failedAgentIds contains the agent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    // createTestAgent(app, { managerMemberId: admin.memberId }) — agent under THIS admin.
+    const mine = await createTestAgent(app, { name: `mine-${crypto.randomUUID().slice(0, 6)}` });
+    // createTestAgent has its own internal admin; bind the agent's manager to ours instead.
+    // Use a raw UPDATE: managerId is the only thing we need to flip.
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${admin.memberId} WHERE uuid = ${mine.agent.uuid}`);
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await markErrored(mine.agent.uuid, chatId);
+    const row = await rowFor(chatId, admin);
+    expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
+  });
+});
+```
+
+(Helper note: `createTestAgent` internally creates a fresh admin and sets `managerId = that admin's memberId`. To simulate "mine vs theirs" we either (a) raw-UPDATE the `manager_id` post-creation as above, or (b) compose a single test admin and create multiple agents via `seedAgentFactory(app)`. Option a keeps each test self-describing; if `seedAgentFactory` proves cleaner across the test matrix, refactor at Step 2.6.)
+
+- [ ] **Step 2.2: Run B1 — verify it fails**
+
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm --filter @first-tree/server test -- me-chat-attention 2>&1 | tail -20
+```
+Expected: B1 fails. (It will likely PASS today by accident because the current implementation also returns the agent; the manager filter only changes behavior in B2/B3 etc. We add B2 next to drive the real change.)
+
+Actually — re-confirm by adding **B2 alongside B1 in the same step** before running, so the failing case is exercised:
+
+```ts
+  it("B2: someone-else's failed agent, caller is speaker → failedAgentIds empty", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    // 'theirs' is created under `them`'s admin context — managerId already = them.memberId.
+    // Build it via the same low-level pattern createTestAgent uses but anchored to `them`.
+    const theirs = await createTestAgent(app, { name: `theirs-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${them.memberId} WHERE uuid = ${theirs.agent.uuid}`);
+    // me + theirs in a chat — me is speaker (creator).
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await markErrored(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);  // <-- THIS is the regression today returns [theirs.uuid].
+  });
+```
+
+Re-run; expect **B2 fails** with the current code returning `[theirs.uuid]`.
+
+- [ ] **Step 2.3: Implement — fetch managed-agent set + apply filter**
+
+Edit `packages/server/src/services/me-chat.ts:438-478`. Between `const statusByChat = await resolveAgentChatStatuses(...)` and the `for (const [chatId, statuses] of statusByChat) { ... }` loop, insert:
+
+```ts
+  // Manager-scope: agent UUIDs the caller manages (`agents.manager_id = caller.member_id`).
+  // Drives the "mine" narrowing on the `failedAgentIds` / `pendingQuestionAgentIds`
+  // projections — so a watcher (or peer speaker) is no longer pinned by someone
+  // else's broken / waiting agent. The caller's own human agent is self-managed
+  // (manager_id = caller.member_id); harmless because humans never produce
+  // failed sessions or pending questions.
+  //
+  // One indexed read via `idx_agents_manager`, scoped to the same org as the
+  // chat list. Result is materialised into an in-memory Set so the per-chat
+  // projection loop below stays a single-pass walk over `statusByChat`.
+  const managedRows = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(and(eq(agents.managerId, callerMemberId), eq(agents.organizationId, organizationId)));
+  const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
+```
+
+Then update the projection inside the existing loop. Replace the body of `for (const [chatId, statuses] of statusByChat)` with:
+
+```ts
+  for (const [chatId, statuses] of statusByChat) {
+    const speakers = nonHumanSpeakersByChat.get(chatId);
+    let freshest: { activity: LiveActivity; startedMs: number } | null = null;
+    const failed: string[] = [];
+    const pending: string[] = [];
+    const busy: string[] = [];
+    for (const s of statuses) {
+      const isSpeaker = speakers?.has(s.agentId) ?? false;
+      const isMine = managedAgentIds.has(s.agentId);
+      if (isSpeaker && s.activity) {
+        const startedMs = new Date(s.activity.startedAt).getTime();
+        if (!freshest || startedMs > freshest.startedMs) freshest = { activity: s.activity, startedMs };
+      }
+      // failed — speaker-filtered AND narrowed to mine (R1).
+      if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
+      // busy — speaker-filtered, NOT narrowed (informational, not attention).
+      if (isSpeaker && s.working) busy.push(s.agentId);
+      // pending — NOT speaker-filtered (a pending agent that has left still counts);
+      // NARROWED to mine (R2). The frontend covers R3 (caller-is-speaker) via the
+      // separate `chatHasOpenQuestion` boolean emitted below.
+      if (s.needsYou && isMine) pending.push(s.agentId);
+    }
+    if (freshest) liveActivityByChat.set(chatId, freshest.activity);
+    if (failed.length > 0) failedByChat.set(chatId, failed);
+    if (pending.length > 0) pendingByChat.set(chatId, pending);
+    if (busy.length > 0) busyByChat.set(chatId, busy);
+  }
+```
+
+Update the JSDoc on `pendingQuestionAgentIds` field in the row build (a few lines below) so the wire-contract narrowing is documented at the projection site:
+
+```ts
+    // Comment block above the row build:
+    // `pendingQuestionAgentIds` / `failedAgentIds` are narrowed to "agents I
+    // manage" — drives the chat-list "Needs attention" pin without bleeding
+    // peer / watcher chats into it. See docs/development/needs-attention-scoping.20260526.md.
+```
+
+- [ ] **Step 2.4: Run B1 + B2 — verify they pass**
+
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm --filter @first-tree/server test -- me-chat-attention 2>&1 | tail -20
+```
+Expected: both pass.
+
+- [ ] **Step 2.5: Confirm no regressions on the rest of the me-chat suite**
+
+```bash
+pnpm --filter @first-tree/server test -- me-chat 2>&1 | tail -30
+```
+Expected: all green (existing tests use `admin.memberId` from Task 1.3, so the narrowing is a no-op for them — every agent they create is under the same admin).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add packages/server/src/services/me-chat.ts packages/server/src/__tests__/me-chat-attention.test.ts
+git commit -m "feat(me-chat): narrow failed/pending projections to caller-managed agents
+
+Fixes the Needs-Attention badcase where a watcher (or peer speaker) was
+pinned by someone else's broken / waiting agent. R1 (mine-failed) and
+R2 (mine-pending) of the chat-granularity predicate. R3 (speaker-in-chat-
+with-question) and R4 (mention) ship in subsequent commits.
+
+Doc: docs/development/needs-attention-scoping.20260526.md"
+```
+
+---
+
+## Task 3 — Backend: emit `chatHasOpenQuestion` boolean
+
+**Goal:** add the new wire field so the frontend can implement R3 (caller-is-speaker fallback).
+
+**Files:**
+- Modify: `packages/shared/src/schemas/me-chat.ts` — zod schema
+- Modify: `packages/server/src/services/me-chat.ts` — emit the field
+
+- [ ] **Step 3.1: Write failing test B6 (someone-else's pending, caller is speaker)**
+
+Append to `me-chat-attention.test.ts`:
+
+```ts
+  it("B6: someone-else's pending question, caller is speaker → pending empty but chatHasOpenQuestion=true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `theirs-pq-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${them.memberId} WHERE uuid = ${theirs.agent.uuid}`);
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    // Seed a pending question by `theirs` in this chat.
+    await app.db.execute(sql`
+      INSERT INTO pending_questions (id, agent_id, chat_id, message_id, status, created_at)
+      VALUES (
+        ${crypto.randomUUID()},
+        ${theirs.agent.uuid},
+        ${chatId},
+        ${crypto.randomUUID()},
+        'pending',
+        NOW()
+      )
+    `);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);            // narrowed away (R2 fail)
+    expect(row?.chatHasOpenQuestion).toBe(true);                  // raw bit fires (R3 fuel)
+  });
+```
+
+Run:
+```bash
+pnpm --filter @first-tree/server test -- me-chat-attention 2>&1 | tail -20
+```
+Expected: B6 fails (field doesn't exist yet — likely a parse error or `undefined`).
+
+- [ ] **Step 3.2: Add `chatHasOpenQuestion` to the wire schema**
+
+Edit `packages/shared/src/schemas/me-chat.ts`, inside `meChatRowSchema`, after the `busyAgentIds` field:
+
+```ts
+  /**
+   * True iff this chat has at least one non-human agent with a pending
+   * AskUserQuestion (`pending_questions.status === 'pending'`), regardless
+   * of whether that agent is managed by the caller. Drives the
+   * "speaker-in-chat-with-question" fallback on the front-end
+   * (`splitAttentionRows` R3) without re-broadening
+   * `pendingQuestionAgentIds`, which stays narrowed to caller-managed.
+   *
+   * `.default(false)` for version skew: an older server build that predates
+   * this field would otherwise produce `undefined`, which would silently
+   * disable R3 — exactly the conservative degradation we want during a
+   * web-ahead-of-server rollout (R1/R2/R4 continue to fire correctly).
+   *
+   * See `docs/development/needs-attention-scoping.20260526.md` §4 / §5.
+   */
+  chatHasOpenQuestion: z.boolean().default(false),
+```
+
+- [ ] **Step 3.3: Emit the field from the projection**
+
+Edit `packages/server/src/services/me-chat.ts`. Add a fourth map alongside the existing three (just before the projection loop):
+
+```ts
+  const liveActivityByChat = new Map<string, LiveActivity>();
+  const failedByChat = new Map<string, string[]>();
+  const pendingByChat = new Map<string, string[]>();
+  const busyByChat = new Map<string, string[]>();
+  const hasOpenQuestionByChat = new Map<string, boolean>();   // NEW
+```
+
+Inside the inner `for (const s of statuses)` loop, add the raw bit:
+
+```ts
+      // chatHasOpenQuestion — raw "any agent in this chat has a pending
+      // question" bit; unfiltered by speaker / manager. The front-end uses
+      // it together with `r.access_mode === 'speaker'` to implement R3.
+      if (s.needsYou) hasOpenQuestionByChat.set(chatId, true);
+```
+
+In the row build at the bottom (`rows: MeChatRow[] = pageRaw.map((r) => { ... return { ... } })`), add the field:
+
+```ts
+      busyAgentIds: busyByChat.get(r.chat_id) ?? [],
+      chatHasOpenQuestion: hasOpenQuestionByChat.get(r.chat_id) ?? false,   // NEW
+```
+
+- [ ] **Step 3.4: Run B6 — verify pass**
+
+```bash
+pnpm --filter @first-tree/server test -- me-chat-attention 2>&1 | tail -20
+```
+Expected: B6 passes.
+
+- [ ] **Step 3.5: Add the rest of the backend matrix (B3/B4/B5/B7/B8/B9/B10)**
+
+Append to `me-chat-attention.test.ts`:
+
+```ts
+  it("B3: someone-else's failed agent, caller is watcher → failedAgentIds empty", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `theirs-w-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${them.memberId} WHERE uuid = ${theirs.agent.uuid}`);
+    // chat created by `them` so `me` joins later as a watcher.
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    // Make `me` a watcher of that chat. (chat_membership row with access_mode='watcher'.)
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source, joined_at)
+      VALUES (${chatId}, ${me.humanAgentUuid}, 'member', 'watcher', 'mention_only', 'manual', NOW())
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
+    await markErrored(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+  });
+
+  it("B4: my failed agent, caller is watcher → failedAgentIds still contains it (boundary A)", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const mine = await createTestAgent(app, { name: `mine-w-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${me.memberId} WHERE uuid = ${mine.agent.uuid}`);
+    // `them` creates the chat; `me` watches.
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source, joined_at)
+      VALUES (${chatId}, ${me.humanAgentUuid}, 'member', 'watcher', 'mention_only', 'manual', NOW())
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
+    await markErrored(mine.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
+  });
+
+  it("B5: my pending question → pendingQuestionAgentIds + chatHasOpenQuestion both true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const mine = await createTestAgent(app, { name: `mine-pq-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${me.memberId} WHERE uuid = ${mine.agent.uuid}`);
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await app.db.execute(sql`
+      INSERT INTO pending_questions (id, agent_id, chat_id, message_id, status, created_at)
+      VALUES (${crypto.randomUUID()}, ${mine.agent.uuid}, ${chatId}, ${crypto.randomUUID()}, 'pending', NOW())
+    `);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([mine.agent.uuid]);
+    expect(row?.chatHasOpenQuestion).toBe(true);
+  });
+
+  it("B7: someone-else's pending question, caller is watcher → pending empty, chatHasOpenQuestion still true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `theirs-pqw-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${them.memberId} WHERE uuid = ${theirs.agent.uuid}`);
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source, joined_at)
+      VALUES (${chatId}, ${me.humanAgentUuid}, 'member', 'watcher', 'mention_only', 'manual', NOW())
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
+    await app.db.execute(sql`
+      INSERT INTO pending_questions (id, agent_id, chat_id, message_id, status, created_at)
+      VALUES (${crypto.randomUUID()}, ${theirs.agent.uuid}, ${chatId}, ${crypto.randomUUID()}, 'pending', NOW())
+    `);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(true);    // raw bit still true; FE will gate R3 on speaker.
+  });
+
+  it("B8: nothing failed / no pending → all new attention fields empty/false", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `quiet-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(false);
+  });
+
+  it("B10: chat with only my own human agent → no false positives", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    // Create a chat containing only me (loopback). createMeChat rejects
+    // self-only chats — instead seed a membership row to model the empty-1:1
+    // shape if/when it appears in prod.
+    const peer = await createTestAgent(app, { name: `peer-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(false);
+  });
+
+  it("B9: multi-chat listMeChats — B1-style + B2-style chats coexist with independent projections", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    // Chat A — my failed agent.
+    const mineFailed = await createTestAgent(app, { name: `mf-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${me.memberId} WHERE uuid = ${mineFailed.agent.uuid}`);
+    const { chatId: chatA } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [mineFailed.agent.uuid],
+    });
+    await markErrored(mineFailed.agent.uuid, chatA);
+    // Chat B — their failed agent (me as speaker).
+    const theirsFailed = await createTestAgent(app, { name: `tf-${crypto.randomUUID().slice(0, 6)}` });
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${them.memberId} WHERE uuid = ${theirsFailed.agent.uuid}`);
+    const { chatId: chatB } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirsFailed.agent.uuid],
+    });
+    await markErrored(theirsFailed.agent.uuid, chatB);
+
+    const { rows } = await listMeChats(app.db, me.humanAgentUuid, me.memberId, me.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    const rowA = rows.find((r) => r.chatId === chatA);
+    const rowB = rows.find((r) => r.chatId === chatB);
+    expect(rowA?.failedAgentIds).toEqual([mineFailed.agent.uuid]);
+    expect(rowB?.failedAgentIds).toEqual([]);
+  });
+```
+
+Run:
+```bash
+pnpm --filter @first-tree/server test -- me-chat-attention 2>&1 | tail -40
+```
+Expected: all 10 cases (B1–B10) pass.
+
+- [ ] **Step 3.6: Full server suite check**
+
+```bash
+pnpm --filter @first-tree/server test 2>&1 | tail -10
+```
+Expected: green. (If any unrelated test fails, isolate before continuing.)
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add packages/shared/src/schemas/me-chat.ts packages/server/src/services/me-chat.ts packages/server/src/__tests__/me-chat-attention.test.ts
+git commit -m "feat(me-chat): emit chatHasOpenQuestion boolean for R3 fallback
+
+New wire field on MeChatRow — defaults to false for version-skew safety.
+Carries the raw 'any agent in this chat has a pending question' bit so
+the front-end can implement the R3 caller-is-speaker fallback without
+re-broadening pendingQuestionAgentIds (which stays manager-narrowed)."
+```
+
+---
+
+## Task 4 — Frontend: new attention predicate
+
+**Goal:** update `splitAttentionRows` and friends to apply R1–R4 with the priority ladder.
+
+**File:** `packages/web/src/pages/workspace/conversations/group-rows.ts:184-225`
+
+- [ ] **Step 4.1: Write the failing frontend tests**
+
+Edit `packages/web/src/pages/workspace/__tests__/group-rows.test.ts`. Update the test row fixture factory to include the new field (default false):
+
+```ts
+function row(overrides: Partial<MeChatRow> & { id: string; lastMessageAt: string | null }): MeChatRow {
+  return {
+    chatId: overrides.id,
+    type: overrides.type ?? "direct",
+    membershipKind: overrides.membershipKind ?? "participant",
+    source: overrides.source ?? "manual",
+    entityType: overrides.entityType ?? null,
+    title: overrides.title ?? overrides.id,
+    topic: overrides.topic ?? null,
+    participants: overrides.participants ?? [],
+    participantCount: overrides.participantCount ?? 0,
+    lastMessageAt: overrides.lastMessageAt,
+    lastMessagePreview: overrides.lastMessagePreview ?? null,
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    liveActivity: overrides.liveActivity ?? null,
+    pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? [],
+    failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? false,
+  };
+}
+```
+
+Append a new `describe`:
+
+```ts
+describe("splitAttentionRows — predicate (R1–R4)", () => {
+  it("R1: mine-failed → attention bucket, failed tier", () => {
+    const rows = [row({ id: "r1", lastMessageAt: null, failedAgentIds: ["mine"] })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r1"]);
+    expect(rowIsFailed(attention[0]!)).toBe(true);
+  });
+
+  it("R2: mine-pending → attention bucket, needs_you tier", () => {
+    const rows = [row({ id: "r2", lastMessageAt: null, pendingQuestionAgentIds: ["mine"] })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r2"]);
+    expect(rowNeedsYou(attention[0]!)).toBe(true);
+  });
+
+  it("R3: chatHasOpenQuestion=true + caller is speaker → attention bucket, needs_you tier", () => {
+    const rows = [
+      row({
+        id: "r3",
+        lastMessageAt: null,
+        chatHasOpenQuestion: true,
+        membershipKind: "participant",
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r3"]);
+    expect(rowNeedsYou(attention[0]!)).toBe(true);
+  });
+
+  it("R3 watcher: chatHasOpenQuestion=true + caller is watcher → NOT attention", () => {
+    const rows = [
+      row({
+        id: "r3w",
+        lastMessageAt: null,
+        chatHasOpenQuestion: true,
+        membershipKind: "watching",
+      }),
+    ];
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["r3w"]);
+  });
+
+  it("R4: unread mention → attention bucket (no failed / pending)", () => {
+    const rows = [row({ id: "r4", lastMessageAt: null, unreadMentionCount: 3 })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r4"]);
+  });
+
+  it("quiet row → NOT attention", () => {
+    const rows = [row({ id: "quiet", lastMessageAt: null })];
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["quiet"]);
+  });
+
+  it("priority: failed beats mention", () => {
+    const rows = [row({ id: "fm", lastMessageAt: null, failedAgentIds: ["a"], unreadMentionCount: 1 })];
+    const { attention } = splitAttentionRows(rows);
+    expect(rowIsFailed(attention[0]!)).toBe(true);
+  });
+
+  it("priority: needs_you beats mention (R2 + mention)", () => {
+    const rows = [row({ id: "pm", lastMessageAt: null, pendingQuestionAgentIds: ["a"], unreadMentionCount: 1 })];
+    const { attention } = splitAttentionRows(rows);
+    expect(rowIsFailed(attention[0]!)).toBe(false);
+    expect(rowNeedsYou(attention[0]!)).toBe(true);
+  });
+
+  it("sort: failed > needs_you > mention", () => {
+    const rows = [
+      row({ id: "m", lastMessageAt: null, unreadMentionCount: 1 }),
+      row({ id: "n", lastMessageAt: null, pendingQuestionAgentIds: ["x"] }),
+      row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f", "n", "m"]);
+  });
+
+  it("R2 + R3 simultaneously → single needs_you tier, no double-count", () => {
+    const rows = [
+      row({
+        id: "r23",
+        lastMessageAt: null,
+        pendingQuestionAgentIds: ["mine"],
+        chatHasOpenQuestion: true,
+        membershipKind: "participant",
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention).toHaveLength(1);
+    expect(rowNeedsYou(attention[0]!)).toBe(true);
+  });
+
+  it("stable sort within failed tier preserves input order", () => {
+    const rows = [
+      row({ id: "f1", lastMessageAt: null, failedAgentIds: ["a"] }),
+      row({ id: "f2", lastMessageAt: null, failedAgentIds: ["b"] }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f1", "f2"]);
+  });
+});
+```
+
+Run:
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm --filter @first-tree/web test -- group-rows 2>&1 | tail -30
+```
+Expected: the new cases fail (`chatHasOpenQuestion` is set in fixtures but `splitAttentionRows` doesn't read it yet; R3-watcher test expects NOT attention but current code with the old predicate ignores `membershipKind` for R3).
+
+- [ ] **Step 4.2: Implement the new predicate**
+
+Replace lines 184-225 of `packages/web/src/pages/workspace/conversations/group-rows.ts` with:
+
+```ts
+// ---------------------------------------------------------------------------
+// attention pinning (failed + needs-you + mention)
+// ---------------------------------------------------------------------------
+//
+// Chat-granularity predicate — see docs/development/needs-attention-scoping.20260526.md.
+// A chat enters the "Needs attention" bucket when ANY of:
+//   R1. failedAgentIds.length > 0
+//       (server-narrowed to agents the caller manages — see me-chat.ts)
+//   R2. pendingQuestionAgentIds.length > 0
+//       (same narrowing)
+//   R3. chatHasOpenQuestion && membershipKind === "participant"
+//       (anyone has a pending question and the caller is a human speaker in the chat —
+//        covers "someone else's agent is asking in a chat I'm in")
+//   R4. unreadMentionCount > 0
+//       (someone @-mentioned the caller)
+//
+// Sort priority inside the bucket: failed > needs_you > mention.
+//
+// This is a separate ladder from the agent-status `compareMainStatus`
+// (`failed`, `needs_you`, `working`, ...). `mention` is a chat-level signal,
+// not an agent main status — overloading the shared comparator would couple
+// two ladders that should evolve independently.
+
+const ATTENTION_PRIORITY = ["failed", "needs_you", "mention"] as const;
+type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
+
+/**
+ * Highest-priority attention reason for this row, or null when not in attention.
+ * Order matters: a row that satisfies multiple rules sorts under the highest tier.
+ */
+function rowAttentionReason(r: MeChatRow): AttentionReason | null {
+  if (r.failedAgentIds.length > 0) return "failed";
+  if (
+    r.pendingQuestionAgentIds.length > 0 ||
+    (r.chatHasOpenQuestion && r.membershipKind === "participant")
+  ) {
+    return "needs_you";
+  }
+  if (r.unreadMentionCount > 0) return "mention";
+  return null;
+}
+
+/** A chat is currently in the failed tier of attention. */
+export function rowIsFailed(r: MeChatRow): boolean {
+  return rowAttentionReason(r) === "failed";
+}
+
+/** A chat is currently in the needs-you tier of attention. */
+export function rowNeedsYou(r: MeChatRow): boolean {
+  return rowAttentionReason(r) === "needs_you";
+}
+
+/**
+ * Partition rows into the pinned "Needs attention" set and the rest. Within
+ * attention, sort by `ATTENTION_PRIORITY` (stable within tier).
+ *
+ * ⚠️ Operates on the already-loaded rows only: an attention chat outside the
+ * loaded page(s) is not pinned (page-local v1; cross-page pinned query is
+ * a follow-up).
+ */
+export function splitAttentionRows(rows: ReadonlyArray<MeChatRow>): {
+  attention: MeChatRow[];
+  rest: MeChatRow[];
+} {
+  const attention: MeChatRow[] = [];
+  const rest: MeChatRow[] = [];
+  for (const r of rows) {
+    if (rowAttentionReason(r) !== null) attention.push(r);
+    else rest.push(r);
+  }
+  attention.sort((a, b) => {
+    // Non-null by construction — only rows with a reason entered `attention`.
+    const ra = rowAttentionReason(a) as AttentionReason;
+    const rb = rowAttentionReason(b) as AttentionReason;
+    return ATTENTION_PRIORITY.indexOf(ra) - ATTENTION_PRIORITY.indexOf(rb);
+  });
+  return { attention, rest };
+}
+```
+
+Note: the previous import of `compareMainStatus` at the top of the file may no longer be used. Remove from the import statement if so (typecheck will report).
+
+- [ ] **Step 4.3: Run frontend tests — verify pass**
+
+```bash
+pnpm --filter @first-tree/web test -- group-rows 2>&1 | tail -30
+```
+Expected: all green (existing cases + new 11 cases).
+
+- [ ] **Step 4.4: Confirm consumers still compile**
+
+```bash
+pnpm typecheck 2>&1 | tail -20
+```
+Expected: no errors.
+
+If `chat-row-avatar-preview.tsx` had test fixtures that omit `chatHasOpenQuestion`, the schema default (`false`) keeps zod parsing safe but a literal TS object will need the field. Check by:
+
+```bash
+grep -rn "pendingQuestionAgentIds: " packages/web/src --include="*.test.ts" --include="*.test.tsx"
+```
+At every match in a literal `MeChatRow` object, add `chatHasOpenQuestion: false,` to keep the type complete.
+
+- [ ] **Step 4.5: Full web suite**
+
+```bash
+pnpm --filter @first-tree/web test 2>&1 | tail -10
+```
+Expected: green.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add packages/web/src/pages/workspace/conversations/group-rows.ts packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+git commit -m "feat(web): apply R1–R4 attention predicate with mention tier
+
+R1 mine-failed and R2 mine-pending narrow to caller-managed (server
+provides). R3 covers 'someone else's agent asking in my speaker chat'
+via the new chatHasOpenQuestion bit + access_mode check. R4 surfaces
+unread @-mentions into the Needs Attention bucket. Sort priority is
+failed > needs_you > mention via a local ATTENTION_PRIORITY ladder
+(separate from the agent-status compareMainStatus)."
+```
+
+---
+
+## Task 5 — Final verification + ship
+
+- [ ] **Step 5.1: Full repo check**
+
+```bash
+cd /Users/gandy/.first-tree-staging/data/workspaces/gandy-developer/worktrees/needs-attention-scoping
+pnpm check 2>&1 | tail -20
+pnpm typecheck 2>&1 | tail -20
+pnpm test 2>&1 | tail -30
+```
+Expected: all green.
+
+- [ ] **Step 5.2: Confirm the badcase is fixed (smoke check)**
+
+Re-read the badcase: "non-self-related agent broke → appears in my Needs Attention".
+
+Walk through `me-chat-attention.test.ts` B2 (peer-managed agent failed, caller is speaker) — covered.
+Walk through B3 (peer-managed agent failed, caller is watcher) — covered.
+
+- [ ] **Step 5.3: Diff review**
+
+```bash
+git log origin/main..HEAD --oneline
+git diff origin/main..HEAD --stat
+```
+Expected: 4 commits, ~5 files modified + 1 new test file + 1 design doc + 1 plan doc.
+
+- [ ] **Step 5.4: Report back to gandy-s-assistant for confirmation**
+
+Send a `fts chat send gandy-s-assistant` message with:
+- Worktree path + branch
+- Commit shas
+- Pasted test output (B1–B10 + frontend predicate cases)
+- Ask whether to push / open PR
+
+(Do NOT push without confirmation per the project's chat protocol.)
+
+---
+
+## Self-Review Checklist (already applied)
+
+- ✅ Every step has exact code or exact commands.
+- ✅ No placeholders (`TODO`, "implement later", "fill in details").
+- ✅ Type / method names consistent across tasks (`rowAttentionReason`, `ATTENTION_PRIORITY`, `chatHasOpenQuestion`, `callerMemberId`).
+- ✅ TDD: each behavior change has a failing test before implementation.
+- ✅ Frequent commits — one per task boundary, on the same logical change.
+- ✅ Spec coverage: R1 (B1, B4, R1 frontend), R2 (B5, R2 frontend), R3 (B6, B7, R3 + R3-watcher frontend), R4 (R4 frontend), Boundaries A/B/C all covered (B4 = A, B6 = B, "multi-speaker" = C accepted via R3-frontend test).
+
+---
+
+## Risks / Open Items
+
+- **`createTestAgent` post-create UPDATE of `manager_id`**: works because `agents.manager_id` is plain `text` (no FK / trigger). If the test helper grows a manager-update API later, switch to it.
+- **R3 across multiple humans in one chat**: accepted noise (boundary C). When `pending_questions.addressed_user_id` lands (future M3), R3 narrows automatically — no client change needed; `chatHasOpenQuestion` is replaced by a per-caller-addressed bit and the predicate stays structurally identical.

--- a/docs/development/needs-attention-scoping.20260526.md
+++ b/docs/development/needs-attention-scoping.20260526.md
@@ -1,0 +1,348 @@
+# Needs-Attention Scoping — Technical Design (2026-05-26)
+
+> Status: **draft — pending review by gandy-s-assistant + gandy2025**
+> Author: gandy-developer
+> Scope: chat-granularity attention predicate (no item-level, no inbox, no dismiss/snooze, no schema migration).
+
+## 1. Problem & Locked Rules (recap)
+
+The Agent Hub Web me-chat list pins a chat into the "Needs attention" bucket when *any* speaker agent is `failed` or *any* agent has a pending `AskUserQuestion`. There is no "is this related to me?" filter — so a watcher (or even a speaker peer) sees attention pins for other people's broken / waiting agents.
+
+Discussion with the user has locked the new predicate:
+
+```
+chat ∈ Needs Attention ⇔ any of:
+  R1. agent ∈ chat has main = failed       AND  agent.manager = caller_member
+  R2. agent ∈ chat has pending question    AND  agent.manager = caller_member
+  R3. agent ∈ chat has pending question    AND  caller is a human SPEAKER in chat
+  R4. unread_mention_count(chat, caller) > 0
+```
+
+Boundaries already locked: A (manager wins over watcher/speaker membership for R1+R2), B (R3 fires even for someone else's agent), C (R3 fires for every speaker when there are multiple humans — accepted as noise vs precision tradeoff). No UI toggle.
+
+## 2. Current State — Verified
+
+| Concern                                | File                                                                              | Notes                                                                  |
+|----------------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| Backend per-chat status producer       | `packages/server/src/services/agent-chat-status.ts:314-455`                       | `resolveAgentChatStatuses` — viewpoint-agnostic; should stay that way. |
+| Backend per-row projection (caller-scoped) | `packages/server/src/services/me-chat.ts:442-478`                            | `failedAgentIds` is speaker-filtered; `pendingQuestionAgentIds` is NOT. Neither is manager-filtered. |
+| Route handler (knows caller identity)  | `packages/server/src/api/orgs/chats.ts:94`                                        | Already has `scope.memberId` and `scope.humanAgentId`. Passes only the latter.        |
+| Frontend attention predicate           | `packages/web/src/pages/workspace/conversations/group-rows.ts:189-225`            | `splitAttentionRows` consumes `failedAgentIds.length`, `pendingQuestionAgentIds.length`. |
+| Wire schema                            | `packages/shared/src/schemas/me-chat.ts:188-287`                                  | Two zod arrays with `.default([])` for version skew.                   |
+| Agent → manager link                   | `packages/server/src/db/schema/agents.ts:47` (`managerId text NOT NULL`)          | Indexed: `idx_agents_manager`. `managerId` = `members.id` (not `users.id`). |
+| Caller speaker / watcher per chat      | `chat_membership.access_mode` — already selected as `r.access_mode` in the main JOIN | No extra join needed.                                                  |
+| Mention count                          | `chat_user_state.unread_mention_count` — already selected as `r.unread_mention_count` | No extra join needed.                                                  |
+| `pending_questions` schema             | `packages/server/src/db/schema/pending-questions.ts`                              | No addressee field — out of scope for this fix.                        |
+
+## 3. Design Decisions
+
+### 3.1 Where does the manager filter live?
+
+`resolveAgentChatStatuses` returns full per-chat status arrays and is shared with `GET /chats/:id/agent-status` (panel view, where every speaker should show regardless of manager). **Keep it viewpoint-agnostic.** The manager filter belongs to the *caller-scoped projection* — i.e. inside `me-chat.ts:listMeChats`.
+
+### 3.2 Field semantics — narrow the existing fields, add ONE small new field
+
+**Narrow** `failedAgentIds` and `pendingQuestionAgentIds` semantics: they become **"agents I manage in this chat that …"**.
+
+**Add** `chatHasOpenQuestion: boolean` — pure raw "ANY agent in this chat has a pending question". Drives R3 alone.
+
+Why narrow vs add a parallel "mine" field?
+
+- The badges on the chat row (`failed` red dot, `needsYou` orange dot — see `chat-row-avatar-preview.tsx:275-276`) **should** also narrow to "mine". Today a watcher sees a red dot for someone else's broken agent — exactly the same badcase pattern. Narrowing the field repairs the badge for free.
+- A parallel `myFailedAgentIds` would double the wire footprint, and we'd have to also decide what `failedAgentIds` is supposed to communicate after the fix. Cleaner to repurpose.
+- `chatHasOpenQuestion` is a single bit, only consulted by R3. The cost is negligible.
+
+Rejected alternatives:
+
+- **Single computed `needsAttention` boolean from server.** Tempting (one bit replaces all the logic), but the front-end still needs the failed-vs-needs-you priority for sort ordering inside the bucket, AND the row badges need to know individually. So the front-end loses fidelity. Skip.
+- **Pass `memberId` to `resolveAgentChatStatuses` and have it filter.** Couples viewpoint to the shared producer; would force `GET /chats/:id/agent-status` to acquire a viewpoint param too. Skip.
+
+### 3.3 Caller-is-speaker check (R3 needs it)
+
+Already available **for free** in the existing per-row data: `r.access_mode` is selected from `cm.access_mode` where `cm.agent_id = humanAgentId`. So:
+
+```ts
+const callerIsHumanSpeaker = r.access_mode === "speaker";
+```
+
+(Humans never have `access_mode` other than speaker / watcher; no other check needed.)
+
+### 3.4 Mention (R4) — where does the predicate live?
+
+`unreadMentionCount` is already on `MeChatRow`. The cleanest place to add R4 is the **frontend** `splitAttentionRows` (same place as R1/R2/R3 consumption), not a new server field. Front-end already reads `r.unreadMentionCount` for the unread bold styling.
+
+### 3.5 Attention bucket sort priority (3-tier now)
+
+Today: `failed` > `needs_you`, delegated to shared `compareMainStatus`.
+
+After: `failed` > `needs_you` > `mention`. `compareMainStatus` is keyed on agent main-status enum (failed/needs_you/working/…); `mention` is a chat-level signal that doesn't fit that ladder. Add a local `ATTENTION_PRIORITY` const in `group-rows.ts` rather than overload the shared comparator.
+
+Sort rule: a chat that triggers multiple reasons sorts under its highest-priority reason. A chat that is both failed AND has a mention sorts as failed.
+
+## 4. Field Changes
+
+### 4.1 `MeChatRow` (`packages/shared/src/schemas/me-chat.ts`)
+
+```ts
+// SEMANTIC NARROW — no schema shape change.
+failedAgentIds: z.array(z.string()).default([]),
+  // Was: every failed non-human SPEAKER in this chat.
+  // Now: every failed non-human SPEAKER in this chat that the CALLER manages
+  //      (agents.manager_id = caller.member_id).
+
+pendingQuestionAgentIds: z.array(z.string()).default([]),
+  // Was: every non-human agent in this chat with a PENDING AskUserQuestion
+  //      (NOT speaker-filtered — preserved).
+  // Now: every non-human agent in this chat with a PENDING AskUserQuestion
+  //      that the CALLER manages.
+
+// NEW FIELD.
+chatHasOpenQuestion: z.boolean().default(false),
+  // True iff ANY non-human agent in this chat has a PENDING question
+  // (raw, unfiltered). Drives R3 (caller-is-speaker fallback) on the front-end.
+  // .default(false) for version skew: old server → new web reads `false`,
+  // which keeps the conservative R1/R2/R4 behaviour while the deploy progresses.
+```
+
+`busyAgentIds` is **not** narrowed — `busy` is a live-activity indicator, not an attention signal, and a watcher seeing "someone is working" is correct, not noise.
+
+### 4.2 No schema migration
+
+`agents.manager_id` exists and is indexed. `chat_membership.access_mode` exists. `chat_user_state.unread_mention_count` exists. No DB changes.
+
+## 5. Backend Implementation Plan
+
+### 5.1 Route — `packages/server/src/api/orgs/chats.ts:94`
+
+```diff
+- return listMeChats(app.db, scope.humanAgentId, scope.organizationId, query);
++ return listMeChats(app.db, scope.humanAgentId, scope.memberId, scope.organizationId, query);
+```
+
+The "Class B → mine-scope" route already builds `scope` via `requireOrgMembership`, which produces both `humanAgentId` and `memberId`.
+
+### 5.2 Service signature
+
+```ts
+export async function listMeChats(
+  db: Database,
+  humanAgentId: string,
+  callerMemberId: string,     // NEW
+  organizationId: string,
+  query: ListMeChatsQuery,
+): Promise<ListMeChatsResponse> { ... }
+```
+
+(Existing tests pass `humanAgentId` and `organizationId` only — they'll need a `callerMemberId` arg too. Helpers already track `admin.memberId`, so the diff is trivial.)
+
+### 5.3 Within `listMeChats` — the projection loop
+
+After the existing participant lookup, but before the per-chat projection (`for (const [chatId, statuses] of statusByChat)`):
+
+```ts
+// Set of agent UUIDs the caller manages — used to narrow failed/pending
+// projections to "mine". One indexed read (`idx_agents_manager`); the
+// chat-list is necessarily org-scoped so we add organization_id for
+// belt-and-braces. Caller's own human agent has manager_id = caller's
+// own member_id (Phase 2 of agent-naming refactor), so the set is
+// self-inclusive — harmless because human agents never produce
+// pending questions or failed sessions.
+const managedRows = await db
+  .select({ uuid: agents.uuid })
+  .from(agents)
+  .where(and(eq(agents.managerId, callerMemberId), eq(agents.organizationId, organizationId)));
+const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
+```
+
+Inside the existing projection loop, refine the field builders:
+
+```ts
+const failed: string[] = [];
+const pending: string[] = [];
+const busy: string[] = [];
+let chatHasOpenQuestion = false;
+for (const s of statuses) {
+  const isSpeaker = speakers?.has(s.agentId) ?? false;
+  const isMine = managedAgentIds.has(s.agentId);
+  // live-dot / busy — unchanged semantics
+  if (isSpeaker && s.activity) { /* ... */ }
+  if (isSpeaker && s.working) busy.push(s.agentId);
+  // failed — speaker-filtered AND narrowed to mine (R1).
+  if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
+  // pending — NOT speaker-filtered (matches existing behaviour for a
+  // pending agent that has since left). NARROWED to mine (R2).
+  if (s.needsYou && isMine) pending.push(s.agentId);
+  // chatHasOpenQuestion — raw bit feeding R3 on the front-end. Computed
+  // over the same union (non-human speakers + non-human pending) that
+  // resolveAgentChatStatuses returns, so a pending agent that has left
+  // still flips this true (parity with the current `pending` field).
+  if (s.needsYou) chatHasOpenQuestion = true;
+}
+```
+
+Wire the new boolean into the row:
+
+```ts
+return {
+  ...,
+  pendingQuestionAgentIds: pendingByChat.get(r.chat_id) ?? [],
+  failedAgentIds: failedByChat.get(r.chat_id) ?? [],
+  busyAgentIds: busyByChat.get(r.chat_id) ?? [],
+  chatHasOpenQuestion: hasOpenQuestionByChat.get(r.chat_id) ?? false,
+};
+```
+
+(One new `Map<string, boolean>` alongside the three existing maps.)
+
+### 5.4 SQL impact
+
+| Query                              | Before        | After       | Notes                                       |
+|------------------------------------|---------------|-------------|---------------------------------------------|
+| main `chats` JOIN                  | unchanged     | unchanged   | No new joins / filters.                     |
+| `participantRows` lookup           | unchanged     | unchanged   |                                             |
+| `resolveAgentChatStatuses` reads   | unchanged     | unchanged   | Viewpoint-agnostic by design.               |
+| **NEW** `managedAgentIds` lookup   | n/a           | 1 indexed scan on `idx_agents_manager`. Bounded by caller's managed-agent count (typically <50). One round-trip. |
+
+Negligible. The managed-agents set is a per-request constant; it's cheaper than the participants lookup that already happens.
+
+## 6. Frontend Implementation Plan
+
+`packages/web/src/pages/workspace/conversations/group-rows.ts:189-225`:
+
+```ts
+const ATTENTION_PRIORITY = ["failed", "needs_you", "mention"] as const;
+type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
+
+function rowAttentionReason(r: MeChatRow): AttentionReason | null {
+  // R1 — mine failed in chat.
+  if (r.failedAgentIds.length > 0) return "failed";
+  // R2 — mine pending in chat.   OR
+  // R3 — any pending in chat, AND I'm a speaker.
+  if (
+    r.pendingQuestionAgentIds.length > 0 ||
+    (r.chatHasOpenQuestion && r.membershipKind === "participant")
+  ) {
+    return "needs_you";
+  }
+  // R4 — unread @-mention.
+  if (r.unreadMentionCount > 0) return "mention";
+  return null;
+}
+
+export function rowIsFailed(r: MeChatRow): boolean {
+  return rowAttentionReason(r) === "failed";
+}
+export function rowNeedsYou(r: MeChatRow): boolean {
+  return rowAttentionReason(r) === "needs_you";
+}
+// (Optional, only if any caller needs it — current consumers don't.)
+// export function rowIsMention(r: MeChatRow): boolean { ... }
+
+export function splitAttentionRows(rows: ReadonlyArray<MeChatRow>): {
+  attention: MeChatRow[];
+  rest: MeChatRow[];
+} {
+  const attention: MeChatRow[] = [];
+  const rest: MeChatRow[] = [];
+  for (const r of rows) {
+    if (rowAttentionReason(r) !== null) attention.push(r);
+    else rest.push(r);
+  }
+  attention.sort((a, b) => {
+    const ra = rowAttentionReason(a);
+    const rb = rowAttentionReason(b);
+    // Both are non-null inside this bucket; non-null assert via index.
+    return ATTENTION_PRIORITY.indexOf(ra!) - ATTENTION_PRIORITY.indexOf(rb!);
+  });
+  return { attention, rest };
+}
+```
+
+Side effects on existing consumers:
+
+- `chat-row-avatar-preview.tsx:275-276` (`needsYou={row.pendingQuestionAgentIds.length > 0}` / `failed={row.failedAgentIds.length > 0}`) — these badges **narrow** to "mine". This is **intentional and desired** (manager-noise reduction also for the indicator dots, not just the bucket). Confirmed by the design discussion — a watcher seeing a red `!` on someone else's broken agent is the same badcase pattern.
+- `conversations/index.tsx:633-634` — same.
+
+**Bucket vs. badge — important asymmetry:** R3 (peer's agent asking in a chat where I'm a speaker) ENTERS the bucket but does NOT light the `rowNeedsYou` badge. The badge stays specific to R2 ("an agent I manage is waiting on me"). Rationale: `pendingQuestionAgentIds` is now server-narrowed to caller-managed; lighting the orange `?` for a row where the caller manages nothing would contradict the field's wire semantics. The bucket position alone signals R3-only rows; the row's last-message preview surfaces the actual question. The exported `rowAttentionReason(r)` returns the bucket tier (so any future consumer can branch on it without re-deriving) while `rowNeedsYou` stays a badge predicate.
+
+`compareMainStatus` is **not** touched (it's the shared agent-status ladder; mention isn't an agent status).
+
+## 7. Test Matrix
+
+### 7.1 Frontend unit — `packages/web/src/pages/workspace/__tests__/group-rows.test.ts`
+
+Append a new `describe("splitAttentionRows — predicate")` block. Each case is a single fixture row with the boolean fields set; assert `rowAttentionReason` / bucket membership / ordering.
+
+| # | Setup                                                                                          | Expected                                |
+|---|------------------------------------------------------------------------------------------------|-----------------------------------------|
+| 1 | `failedAgentIds: ["mine"]`                                                                     | attention; reason=failed                |
+| 2 | `pendingQuestionAgentIds: ["mine"]`                                                            | attention; reason=needs_you             |
+| 3 | `chatHasOpenQuestion: true, membershipKind: "participant"`, mine empty                         | attention; reason=needs_you (R3 path)   |
+| 4 | `chatHasOpenQuestion: true, membershipKind: "watching"`, mine empty                            | NOT attention (watcher → R3 not fired)  |
+| 5 | `unreadMentionCount: 3`, all else empty                                                        | attention; reason=mention               |
+| 6 | All empty / zero                                                                               | NOT attention                           |
+| 7 | `failedAgentIds:["x"]` + `unreadMentionCount: 1`                                               | attention; reason=failed (priority wins)|
+| 8 | `pendingQuestionAgentIds:["x"]` + `chatHasOpenQuestion: true, membershipKind: participant`     | attention; reason=needs_you (R2 wins over R3, but both produce needs_you; just don't double-count) |
+| 9 | Three rows: f, n, m; assert ordered `[f, n, m]` after `splitAttentionRows`                     | sort order honors `ATTENTION_PRIORITY`  |
+| 10| `chatHasOpenQuestion: false`, `membershipKind: "participant"`, `pendingQuestionAgentIds: []`   | NOT attention (no question anywhere)    |
+| 11| Stable sort within tier: two `failed` rows in input order → preserved in output                | failed-tier order preserved             |
+
+Boundary mapping (from the discussion):
+- Boundary A: case 1 with `membershipKind: "watching"` and `failedAgentIds: ["mine"]` → still attention (manager wins over watcher).
+- Boundary B: case 3 (1:1 chat shape) and case 4 (watcher) — covered above.
+- Boundary C: a single row with `chatHasOpenQuestion: true, membershipKind: "participant"` is enough; the "multiple speakers" replication is a fan-out of the same single-row rule.
+
+### 7.2 Backend integration — new file `packages/server/src/__tests__/me-chat-attention.test.ts`
+
+Patterns adapted from `me-chat-activity.test.ts` (uses `createTestAdmin` / `createTestAgent`). `createTestAgent` creates an admin behind the scenes and sets `managerId = that admin's memberId` — meaning we can simulate "someone else's agent" by calling `createTestAgent(app, ...)` instead of `createTestAgent(app, { ... })` from the current admin's perspective.
+
+Test cases:
+
+| # | Scenario                                                                                                  | Expected projection           |
+|---|-----------------------------------------------------------------------------------------------------------|-------------------------------|
+| B1 | Caller manages agent A; A is in a chat with caller, A `errored` via session.                              | `failedAgentIds == ["A"]`     |
+| B2 | Someone else manages agent X; caller is **speaker** in the chat with X; X `errored`.                      | `failedAgentIds == []`        |
+| B3 | Someone else manages agent X; caller is **watcher**; X `errored`.                                         | `failedAgentIds == []`        |
+| B4 | Caller manages A; caller is **watcher** of the chat; A `errored`.                                         | `failedAgentIds == ["A"]` (boundary A) |
+| B5 | Caller manages A; A has pending question; caller is speaker.                                              | `pendingQuestionAgentIds == ["A"]`, `chatHasOpenQuestion == true` |
+| B6 | Someone else manages X; X has pending question; caller is **speaker**.                                    | `pendingQuestionAgentIds == []`, `chatHasOpenQuestion == true` (R3 raw bit) |
+| B7 | Someone else manages X; X has pending question; caller is **watcher**.                                    | `pendingQuestionAgentIds == []`, `chatHasOpenQuestion == true` (frontend filters R3) |
+| B8 | No agents failed / no pending; caller has a chat with non-zero `unread_mention_count`.                    | All three new fields empty/false (mention is frontend-only). |
+| B9 | Multi-chat list: B1 + B2 + B5 + B6 returned in one `listMeChats` call.                                    | Each row independent — no cross-contamination. |
+| B10| Caller is in chat with their own human agent only (no others).                                            | All fields empty/false (no false positive from self). |
+
+### 7.3 Existing regressions to keep green
+
+- `me-chat-activity.test.ts` — `liveActivity` is unaffected (busyAgentIds / live dot unchanged).
+- `me-chat-source-tags.test.ts` — source counts unaffected.
+- `cross-org-chat-pollution.test.ts` — org scoping unaffected.
+- `direct-chat-auto-mention.test.ts` — mention logic unaffected.
+- `me-chat-service.test.ts` — basic CRUD unaffected; signature change requires passing the new `callerMemberId` arg (small diff).
+
+### 7.4 Static / lint
+
+`pnpm check && pnpm typecheck` from the repo root. The narrowed semantics are documented in the zod schema comments — no signature changes user-visible on the wire.
+
+## 8. Rollout / Version Skew
+
+- `chatHasOpenQuestion` defaults to `false` in the zod schema → old server + new web reads `false` → R3 silently degrades to "off". R1, R2, R4 still fire correctly. Acceptable transient (the only case it affects is "I'm in chat with someone else's agent that asked a question").
+- Field semantic narrow on `failedAgentIds` / `pendingQuestionAgentIds` is the BADCASE fix itself — new web + old server would still over-pin (because the old server still returns un-narrowed sets), which is the same buggy behaviour we have today. Acceptable since the web rolls before the server in this codebase.
+- No DB migration → instant rollback safe.
+
+## 9. Out of Scope (explicitly)
+
+- `pending_questions.addressee_user_id` — would refine R3 from "any speaker" to "the actual addressee". Deferred (would require schema migration + SDK contract change). The current R3 noise (multi-speaker group chats) is accepted per boundary C.
+- Per-user `dismiss` / `snooze` state. Item-level inbox view. Cross-surface unification (GitHub, Adapter). Per the Aha conversation, these are M2-M5; this PR is M1.
+- "Show all" UI toggle (declined by user).
+- Treating mention as a distinct on-row badge (today it already drives the unread bold styling — bucket inclusion is enough).
+
+## 10. Questions for Reviewer
+
+1. **Field semantic narrow vs adding `myFailedAgentIds` / `myPendingQuestionAgentIds`** — design picks narrow (rationale §3.2). If reviewer prefers parallel "mine" fields (keeping the existing fields raw for some panel UI we don't yet have), say so before implementation.
+2. **Mention as 3rd attention tier** — design adds `mention` to `ATTENTION_PRIORITY`. If you'd rather mention NOT sort *inside* the attention bucket (e.g. mention rows stay in their normal recency / source bucket but get a different visual cue), say so — that's a smaller frontend-only change but a different product feel.
+3. **`busyAgentIds`** — design keeps it un-narrowed (a watcher seeing "someone is working" is informational, not attention). Confirm.
+4. **Doc location** — placed under `docs/development/` to fit existing repo layout. If a `proposals/` directory is preferred (matches in-repo code-comment references like `proposals/chat-data-model-restructure.20260512.md` — those resolve in a sibling first-tree-context repo, not here), I'll move it.
+
+---
+
+On approval I'll convert this into a step-by-step implementation plan (`docs/superpowers/plans/2026-05-26-needs-attention-scoping.md`) following the `writing-plans` skill format, then execute.

--- a/packages/server/src/__tests__/cross-org-chat-pollution.test.ts
+++ b/packages/server/src/__tests__/cross-org-chat-pollution.test.ts
@@ -84,7 +84,7 @@ describe("cross-org chat pollution — read-side guard rails", () => {
       .where(eq(chatMembership.agentId, admin.humanAgentUuid));
     expect(participantRow?.chatId).toBe(dirtyChatId);
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",

--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -37,9 +37,14 @@ import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 describe("direct-chat auto-mention for chat-list unread counter", () => {
   const getApp = useTestApp();
 
-  async function loadUnread(chatId: string, agentUuid: string, organizationId: string): Promise<number> {
+  async function loadUnread(
+    chatId: string,
+    agentUuid: string,
+    memberId: string,
+    organizationId: string,
+  ): Promise<number> {
     const app = getApp();
-    const { rows } = await listMeChats(app.db, agentUuid, organizationId, {
+    const { rows } = await listMeChats(app.db, agentUuid, memberId, organizationId, {
       limit: 10,
       filter: "all",
       engagement: "all",
@@ -87,7 +92,7 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
       content: "hi, no explicit @ here",
     });
 
-    expect(await loadUnread(chatId, peer.agent.uuid, peer.organizationId)).toBeGreaterThanOrEqual(1);
+    expect(await loadUnread(chatId, peer.agent.uuid, peer.memberId, peer.organizationId)).toBeGreaterThanOrEqual(1);
   });
 
   it("agent → human DM: human's unread counter bumps on plain text", async () => {
@@ -104,7 +109,9 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
       content: "ack",
     });
 
-    expect(await loadUnread(chatId, admin.humanAgentUuid, admin.organizationId)).toBeGreaterThanOrEqual(1);
+    expect(await loadUnread(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId)).toBeGreaterThanOrEqual(
+      1,
+    );
   });
 
   it("agent ↔ agent DM: counter bumps AND inbox wakes the peer (v2 1:1 implicit wake)", async () => {
@@ -128,7 +135,7 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
     });
 
     // Counter side unchanged.
-    expect(await loadUnread(chat.id, a2.uuid, a1.organizationId)).toBeGreaterThanOrEqual(1);
+    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBeGreaterThanOrEqual(1);
 
     // Inbox side: 1:1 implicit wake fires → exactly one notify=true row.
     expect(await notifyInboxRows(chat.id, a2.uuid)).toHaveLength(1);
@@ -174,7 +181,7 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
       content: `@${peer.agent.name}`,
     });
 
-    expect(await loadUnread(chatId, peer.agent.uuid, peer.organizationId)).toBe(0);
+    expect(await loadUnread(chatId, peer.agent.uuid, peer.memberId, peer.organizationId)).toBe(0);
   });
 
   it("group chat: plain text still produces zero counter bumps (no auto-mention)", async () => {
@@ -194,7 +201,7 @@ describe("direct-chat auto-mention for chat-list unread counter", () => {
       content: "anyone around",
     });
 
-    expect(await loadUnread(chat.id, a2.uuid, a1.organizationId)).toBe(0);
-    expect(await loadUnread(chat.id, a3.uuid, a1.organizationId)).toBe(0);
+    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBe(0);
+    expect(await loadUnread(chat.id, a3.uuid, a1.memberId, a1.organizationId)).toBe(0);
   });
 });

--- a/packages/server/src/__tests__/me-chat-activity.test.ts
+++ b/packages/server/src/__tests__/me-chat-activity.test.ts
@@ -56,9 +56,9 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
     `);
   }
 
-  async function rowFor(chatId: string, viewerAgentId: string, organizationId: string) {
+  async function rowFor(chatId: string, viewerAgentId: string, viewerMemberId: string, organizationId: string) {
     const app = getApp();
-    const { rows } = await listMeChats(app.db, viewerAgentId, organizationId, {
+    const { rows } = await listMeChats(app.db, viewerAgentId, viewerMemberId, organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -73,7 +73,7 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
     const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [peer.agent.uuid],
     });
-    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId);
     expect(row?.liveActivity).toBeNull();
   });
 
@@ -90,7 +90,7 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
       args: {},
       status: "pending",
     });
-    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId);
     expect(row?.liveActivity).toMatchObject({
       agentId: peer.agent.uuid,
       kind: "tool_call",
@@ -107,14 +107,18 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
       participantIds: [a.agent.uuid],
     });
     await appendEvent(a.agent.uuid, chatA, "thinking", {});
-    expect((await rowFor(chatA, admin.humanAgentUuid, admin.organizationId))?.liveActivity?.label).toBe("Thinking");
+    expect((await rowFor(chatA, admin.humanAgentUuid, admin.memberId, admin.organizationId))?.liveActivity?.label).toBe(
+      "Thinking",
+    );
 
     const b = await createTestAgent(app, { name: `la-write-${crypto.randomUUID().slice(0, 6)}` });
     const { chatId: chatB } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [b.agent.uuid],
     });
     await appendEvent(b.agent.uuid, chatB, "assistant_text", { text: "hello" });
-    expect((await rowFor(chatB, admin.humanAgentUuid, admin.organizationId))?.liveActivity?.label).toBe("Writing");
+    expect((await rowFor(chatB, admin.humanAgentUuid, admin.memberId, admin.organizationId))?.liveActivity?.label).toBe(
+      "Writing",
+    );
   });
 
   it("turn_end as the newest event → null (turn is over)", async () => {
@@ -126,7 +130,7 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
     });
     await appendEvent(peer.agent.uuid, chatId, "tool_call", { toolUseId: "t1", name: "Read", args: {}, status: "ok" });
     await appendEvent(peer.agent.uuid, chatId, "turn_end", { status: "success" });
-    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId);
     expect(row?.liveActivity).toBeNull();
   });
 
@@ -138,7 +142,7 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
       participantIds: [peer.agent.uuid],
     });
     await appendEvent(peer.agent.uuid, chatId, "error", { source: "runtime", message: "boom" });
-    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId);
     expect(row?.liveActivity).toBeNull();
   });
 
@@ -157,7 +161,7 @@ describe("listMeChats: liveActivity derivation from session_events", () => {
       { toolUseId: "t1", name: "Read", args: {}, status: "pending" },
       oldTs,
     );
-    const row = await rowFor(chatId, admin.humanAgentUuid, admin.organizationId);
+    const row = await rowFor(chatId, admin.humanAgentUuid, admin.memberId, admin.organizationId);
     expect(row?.liveActivity).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/me-chat-attention.test.ts
+++ b/packages/server/src/__tests__/me-chat-attention.test.ts
@@ -1,0 +1,277 @@
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { createMeChat, listMeChats } from "../services/me-chat.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * Chat-granularity "Needs attention" scoping — server projection.
+ *
+ * The chat-list pinning rule has four parts; the server is responsible for
+ * R1 (mine-failed), R2 (mine-pending), and the raw R3 bit
+ * (`chatHasOpenQuestion`). R4 (unread mention) and the R3 speaker check both
+ * live on the front-end — see `packages/web/.../group-rows.ts`.
+ *
+ * Matrix:
+ *   B1  mine failed, caller is speaker          → failedAgentIds = [mine]
+ *   B2  theirs failed, caller is speaker        → failedAgentIds = []
+ *   B3  theirs failed, caller is watcher        → failedAgentIds = []
+ *   B4  mine failed, caller is watcher          → failedAgentIds = [mine]   (boundary A)
+ *   B5  mine pending question                    → pending = [mine], chatHasOpenQuestion = true
+ *   B6  theirs pending, caller is speaker        → pending = [], chatHasOpenQuestion = true
+ *   B7  theirs pending, caller is watcher        → pending = [], chatHasOpenQuestion = true
+ *   B8  nothing pending / failed                → all new fields empty/false
+ *   B9  multi-chat list mixing B1 + B2          → projections per-row independent
+ *   B10 chat with only my own human + a peer     → no false positives on quiet
+ *
+ * See docs/development/needs-attention-scoping.20260526.md.
+ */
+describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () => {
+  const getApp = useTestApp();
+
+  // Make an agent reachable by mirroring its `agents.client_id` into
+  // `agent_presence`. `deriveMainStatus` returns "offline" when
+  // `reachable=false`, gating ALL other states — so without a presence row,
+  // `markErrored` alone would promote main to "offline" instead of "failed"
+  // and the projection would emit `[]` even for mine-failed (false-pass).
+  //
+  // Reuses the client the agent is already pinned to (seeded by
+  // `createTestAgent`) instead of allocating a parallel client row — keeps
+  // the FK chain consistent with how the real runtime binds presence.
+  async function makeReachable(agentId: string): Promise<void> {
+    const app = getApp();
+    const [row] = await app.db.execute<{ client_id: string | null }>(sql`
+      SELECT client_id FROM agents WHERE uuid = ${agentId}
+    `);
+    if (!row?.client_id) {
+      throw new Error(`agents.client_id is null for ${agentId} — non-human test agents need a pinned client`);
+    }
+    await app.db.execute(sql`
+      INSERT INTO agent_presence (agent_id, status, client_id, last_seen_at)
+      VALUES (${agentId}, 'online', ${row.client_id}, NOW())
+      ON CONFLICT (agent_id) DO UPDATE
+        SET status = EXCLUDED.status,
+            client_id = EXCLUDED.client_id,
+            last_seen_at = EXCLUDED.last_seen_at
+    `);
+  }
+
+  // Mark an `(agent,chat)` pair as failed by writing an `agent_chat_sessions`
+  // row with `state='errored'`. `computeErrored` in `agent-chat-status.ts`
+  // promotes this into `errored=true`, and `deriveMainStatus` promotes that
+  // (gated on `reachable`) into `main === "failed"`. Pair with `makeReachable`.
+  async function markErrored(agentId: string, chatId: string): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, runtime_state_at, updated_at)
+      VALUES (${agentId}, ${chatId}, 'errored', 'error', NOW(), NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE
+        SET state = EXCLUDED.state,
+            runtime_state = EXCLUDED.runtime_state,
+            runtime_state_at = EXCLUDED.runtime_state_at
+    `);
+    await makeReachable(agentId);
+  }
+
+  // Seed a pending AskUserQuestion row for the given agent in the chat.
+  async function markPending(agentId: string, chatId: string): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO pending_questions (id, agent_id, chat_id, message_id, status, created_at)
+      VALUES (${crypto.randomUUID()}, ${agentId}, ${chatId}, ${crypto.randomUUID()}, 'pending', NOW())
+    `);
+  }
+
+  // `createTestAgent` always creates an internal admin and binds the agent's
+  // managerId to that admin's memberId. Re-anchor to a chosen memberId via a
+  // direct UPDATE — `agents.manager_id` is plain text with no FK / trigger,
+  // and re-targeting it is exactly what a future "transfer manager" admin
+  // action would do.
+  async function setManager(agentId: string, memberId: string): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`UPDATE agents SET manager_id = ${memberId} WHERE uuid = ${agentId}`);
+  }
+
+  // Add the caller's human agent as a *watcher* of a chat that someone else
+  // created. The chat membership table has no FK / trigger; an INSERT with
+  // `access_mode='watcher'` is sufficient to flip the row's
+  // `membershipKind` to "watching" in the listMeChats projection.
+  async function addAsWatcher(chatId: string, humanAgentUuid: string): Promise<void> {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO chat_membership (chat_id, agent_id, role, access_mode, mode, source, joined_at)
+      VALUES (${chatId}, ${humanAgentUuid}, 'member', 'watcher', 'mention_only', 'manual', NOW())
+      ON CONFLICT (chat_id, agent_id) DO NOTHING
+    `);
+  }
+
+  async function rowFor(chatId: string, caller: Awaited<ReturnType<typeof createTestAdmin>>) {
+    const app = getApp();
+    const { rows } = await listMeChats(app.db, caller.humanAgentUuid, caller.memberId, caller.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    return rows.find((r) => r.chatId === chatId) ?? null;
+  }
+
+  it("B1: my failed agent, caller is speaker → failedAgentIds = [mine]", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const mine = await createTestAgent(app, { name: `b1-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(mine.agent.uuid, me.memberId);
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await markErrored(mine.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
+  });
+
+  it("B2: peer's failed agent, caller is speaker → failedAgentIds = []", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `b2-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(theirs.agent.uuid, them.memberId);
+    // `me` creates the chat so `me` is the speaker.
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await markErrored(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+  });
+
+  it("B3: peer's failed agent, caller is watcher → failedAgentIds = []", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `b3-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(theirs.agent.uuid, them.memberId);
+    // `them` creates the chat; `me` watches.
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await addAsWatcher(chatId, me.humanAgentUuid);
+    await markErrored(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+  });
+
+  it("B4: my failed agent, caller is watcher → failedAgentIds = [mine] (boundary A)", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const mine = await createTestAgent(app, { name: `b4-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(mine.agent.uuid, me.memberId);
+    // `them` creates the chat; `me` watches.
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await addAsWatcher(chatId, me.humanAgentUuid);
+    await markErrored(mine.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
+  });
+
+  it("B5: my pending question → pending = [mine] AND chatHasOpenQuestion = true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const mine = await createTestAgent(app, { name: `b5-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(mine.agent.uuid, me.memberId);
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [mine.agent.uuid],
+    });
+    await markPending(mine.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([mine.agent.uuid]);
+    expect(row?.chatHasOpenQuestion).toBe(true);
+  });
+
+  it("B6: peer's pending question, caller is speaker → pending = [] AND chatHasOpenQuestion = true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `b6-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(theirs.agent.uuid, them.memberId);
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await markPending(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(true);
+  });
+
+  it("B7: peer's pending question, caller is watcher → pending = [] AND chatHasOpenQuestion = true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    const theirs = await createTestAgent(app, { name: `b7-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(theirs.agent.uuid, them.memberId);
+    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
+      participantIds: [theirs.agent.uuid],
+    });
+    await addAsWatcher(chatId, me.humanAgentUuid);
+    await markPending(theirs.agent.uuid, chatId);
+    const row = await rowFor(chatId, me);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(true);
+  });
+
+  it("B8: nothing failed / no pending → all attention fields empty / false", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `b8-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(false);
+  });
+
+  it("B9: multi-chat list — mine-failed + peer-failed are projected independently per row", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
+    // Chat A — my failed agent.
+    const mineFailed = await createTestAgent(app, { name: `b9-mf-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(mineFailed.agent.uuid, me.memberId);
+    const { chatId: chatA } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [mineFailed.agent.uuid],
+    });
+    await markErrored(mineFailed.agent.uuid, chatA);
+    // Chat B — their failed agent (me as speaker).
+    const theirsFailed = await createTestAgent(app, { name: `b9-tf-${crypto.randomUUID().slice(0, 6)}` });
+    await setManager(theirsFailed.agent.uuid, them.memberId);
+    const { chatId: chatB } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [theirsFailed.agent.uuid],
+    });
+    await markErrored(theirsFailed.agent.uuid, chatB);
+
+    const { rows } = await listMeChats(app.db, me.humanAgentUuid, me.memberId, me.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    const rowA = rows.find((r) => r.chatId === chatA);
+    const rowB = rows.find((r) => r.chatId === chatB);
+    expect(rowA?.failedAgentIds).toEqual([mineFailed.agent.uuid]);
+    expect(rowB?.failedAgentIds).toEqual([]);
+  });
+
+  it("B10: chat with only a quiet peer agent → no false positives", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `b10-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.failedAgentIds).toEqual([]);
+    expect(row?.pendingQuestionAgentIds).toEqual([]);
+    expect(row?.chatHasOpenQuestion).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -47,7 +47,7 @@ describe("chat-first workspace service layer", () => {
   it("listMeChats: empty when user has no participations", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -93,7 +93,7 @@ describe("chat-first workspace service layer", () => {
     });
 
     // admin (manager of `managed`) should now see this chat as a watcher
-    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -173,7 +173,7 @@ describe("chat-first workspace service layer", () => {
     expect(projRow?.last_message_preview).toContain("Please review");
 
     // watcher counter incremented for admin (manager of `managed`)
-    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 10,
       filter: "all",
       engagement: "all",
@@ -407,7 +407,7 @@ describe("chat-first workspace service layer", () => {
     const result = await leaveMeChat(app.db, chatId, admin.humanAgentUuid);
     expect(result.membershipKind).toBe("watching");
 
-    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -585,7 +585,7 @@ describe("chat-first workspace service layer", () => {
 
     // Page size 2: first page is [c1, one of c2/c3]; second page returns
     // exactly the missing one.
-    const page1 = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const page1 = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 2,
       filter: "all",
       engagement: "all",
@@ -594,7 +594,7 @@ describe("chat-first workspace service layer", () => {
     expect(page1.nextCursor).not.toBeNull();
     expect(page1.rows[0]?.chatId).toBe(c1.chatId); // most-recent message wins
 
-    const page2 = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const page2 = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 2,
       filter: "all",
       engagement: "all",
@@ -629,7 +629,7 @@ describe("chat-first workspace service layer", () => {
       VALUES ('nested-x', ${admin.humanAgentUuid}, 'member', 'speaker')
     `);
 
-    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -660,7 +660,7 @@ describe("chat-first workspace service layer", () => {
     await setChatEngagement(app.db, hides.chatId, admin.humanAgentUuid, "archived");
     await setChatEngagement(app.db, gone.chatId, admin.humanAgentUuid, "deleted");
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -684,7 +684,7 @@ describe("chat-first workspace service layer", () => {
     });
     await setChatEngagement(app.db, archived.chatId, admin.humanAgentUuid, "archived");
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "archived",
@@ -711,7 +711,7 @@ describe("chat-first workspace service layer", () => {
     await setChatEngagement(app.db, archived.chatId, admin.humanAgentUuid, "archived");
     await setChatEngagement(app.db, deleted.chatId, admin.humanAgentUuid, "deleted");
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
@@ -776,7 +776,7 @@ describe("chat-first workspace service layer", () => {
     );
     expect(stateRows[0]?.count).toBe(0);
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",

--- a/packages/server/src/__tests__/me-chat-source-tags.test.ts
+++ b/packages/server/src/__tests__/me-chat-source-tags.test.ts
@@ -115,7 +115,7 @@ describe("conversation-list source tags", () => {
     );
 
     // Default (no source param) returns all four.
-    const all = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const all = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -124,7 +124,7 @@ describe("conversation-list source tags", () => {
 
     // manual: must NOT leak github / feishu chats — that was the regression
     // risk when this filter was first wired.
-    const manualOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const manualOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -135,7 +135,7 @@ describe("conversation-list source tags", () => {
     // origin collapses PR + Issue into a single `github` bucket — the
     // per-entity granularity now rides on `row.entityType` for the
     // leading-icon renderer, not on the filter dimension.
-    const githubOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const githubOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -150,7 +150,7 @@ describe("conversation-list source tags", () => {
     expect(prRow?.entityType).toBe("pull_request");
     expect(issueRow?.entityType).toBe("issue");
 
-    const feishuOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const feishuOnly = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -247,7 +247,7 @@ describe("conversation-list source tags", () => {
     expect(counts.github).toEqual({ chatCount: 1, unreadChatCount: 0 });
     expect(counts.manual).toEqual({ chatCount: 0, unreadChatCount: 0 });
 
-    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",
@@ -288,7 +288,7 @@ describe("conversation-list source tags", () => {
       { chatId: issueUnread, agentId: admin.humanAgentUuid, unreadMentionCount: 1 },
     ]);
 
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "unread",
       engagement: "active",
@@ -335,7 +335,7 @@ describe("conversation-list source tags", () => {
     expect(archivedCounts.counts.github).toEqual({ chatCount: 1, unreadChatCount: 0 });
 
     // Sanity: the list query mirrors the same engagement view.
-    const archivedList = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const archivedList = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "archived",
@@ -402,7 +402,7 @@ describe("conversation-list source tags", () => {
     // Filtering by origin AND `watching=true` surfaces the watcher row.
     // Phase B lifted `watching` out of the filter enum into an
     // independent boolean — the two now compose freely.
-    const watchingPr = await listMeChats(app.db, admin.humanAgentUuid, admin.organizationId, {
+    const watchingPr = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "active",

--- a/packages/server/src/api/orgs/chats.ts
+++ b/packages/server/src/api/orgs/chats.ts
@@ -91,7 +91,7 @@ export async function orgChatRoutes(app: FastifyInstance): Promise<void> {
 
     // Default: workspace conversation list for the caller's HUMAN agent.
     const query = listMeChatsQuerySchema.parse(request.query);
-    return listMeChats(app.db, scope.humanAgentId, scope.organizationId, query);
+    return listMeChats(app.db, scope.humanAgentId, scope.memberId, scope.organizationId, query);
   });
 
   /**

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -37,7 +37,7 @@ import {
   type MeChatSourceCounts,
   type MeChatUnreadResponse,
 } from "@first-tree/shared";
-import { and, eq, inArray, type SQL, sql } from "drizzle-orm";
+import { and, eq, inArray, ne, type SQL, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -442,25 +442,34 @@ export async function listMeChats(
   // (only the compose status bar does). Each signal is projected below.
   const statusByChat = await resolveAgentChatStatuses(db, chatIds, { withTurnText: false });
 
-  // Manager-scope: agent UUIDs the caller manages
+  // Manager-scope: non-human agent UUIDs the caller manages
   // (`agents.manager_id = caller.member_id`). Drives the "mine" narrowing on
   // the `failedAgentIds` / `pendingQuestionAgentIds` projections below — so a
   // watcher (or peer speaker) is no longer pinned into "Needs attention" by
-  // someone else's broken / waiting agent. The caller's own human agent has
-  // `manager_id = caller.member_id` (self-managed); harmless because human
-  // agents never produce failed sessions or pending questions.
+  // someone else's broken / waiting agent.
+  //
+  // The `ne(type, 'human')` guard excludes the caller's own human agent (which
+  // is self-managed, `manager_id = caller.member_id` per `createTestAdmin` /
+  // `createMember`). Today the downstream projection is safe regardless —
+  // `resolveAgentChatStatuses` already filters non-human, so a human agent in
+  // this set never reaches the loop. The guard is defensive: if a future
+  // change ever surfaces human statuses (e.g. an "adapter offline" signal),
+  // we don't want the caller's own human agent's main accidentally flowing
+  // into `failedAgentIds`. Belt-and-braces flagged in PR #579 review.
   //
   // One indexed read via `idx_agents_manager`. Filtering by `manager_id` alone
-  // is sufficient — `members.id` is unique per (user, org) so any agent whose
-  // manager is `callerMemberId` is necessarily in the caller's org. An extra
-  // `organization_id` clause was deliberately removed: in the (rare) case where
-  // the create-time invariant `agents.organization_id == manager.organization_id`
-  // was broken by a buggy admin path, an extra clause would silently drop a
-  // legitimate "mine" agent from attention. The read-side trusts the invariant;
-  // the write-side is where it should be enforced.
+  // (no `organization_id` clause) is sufficient — `members.id` is unique per
+  // (user, org) so any agent whose manager is `callerMemberId` is necessarily
+  // in the caller's org. An extra `organization_id` clause would silently drop
+  // a legitimate "mine" agent in the (rare) case where the create-time
+  // invariant `agents.organization_id == manager.organization_id` was broken
+  // by a buggy admin path. Read-side trusts the invariant; write-side guards.
   //
   // See docs/development/needs-attention-scoping.20260526.md.
-  const managedRows = await db.select({ uuid: agents.uuid }).from(agents).where(eq(agents.managerId, callerMemberId));
+  const managedRows = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(and(eq(agents.managerId, callerMemberId), ne(agents.type, "human")));
   const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
 
   const liveActivityByChat = new Map<string, LiveActivity>();

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -290,6 +290,7 @@ function participantsFilterSql(agentIds: ReadonlyArray<string>): SQL {
 export async function listMeChats(
   db: Database,
   humanAgentId: string,
+  callerMemberId: string,
   organizationId: string,
   query: ListMeChatsQuery,
 ): Promise<ListMeChatsResponse> {
@@ -441,10 +442,32 @@ export async function listMeChats(
   // (only the compose status bar does). Each signal is projected below.
   const statusByChat = await resolveAgentChatStatuses(db, chatIds, { withTurnText: false });
 
+  // Manager-scope: agent UUIDs the caller manages
+  // (`agents.manager_id = caller.member_id`). Drives the "mine" narrowing on
+  // the `failedAgentIds` / `pendingQuestionAgentIds` projections below — so a
+  // watcher (or peer speaker) is no longer pinned into "Needs attention" by
+  // someone else's broken / waiting agent. The caller's own human agent has
+  // `manager_id = caller.member_id` (self-managed); harmless because human
+  // agents never produce failed sessions or pending questions.
+  //
+  // One indexed read via `idx_agents_manager`. Filtering by `manager_id` alone
+  // is sufficient — `members.id` is unique per (user, org) so any agent whose
+  // manager is `callerMemberId` is necessarily in the caller's org. An extra
+  // `organization_id` clause was deliberately removed: in the (rare) case where
+  // the create-time invariant `agents.organization_id == manager.organization_id`
+  // was broken by a buggy admin path, an extra clause would silently drop a
+  // legitimate "mine" agent from attention. The read-side trusts the invariant;
+  // the write-side is where it should be enforced.
+  //
+  // See docs/development/needs-attention-scoping.20260526.md.
+  const managedRows = await db.select({ uuid: agents.uuid }).from(agents).where(eq(agents.managerId, callerMemberId));
+  const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
+
   const liveActivityByChat = new Map<string, LiveActivity>();
   const failedByChat = new Map<string, string[]>();
   const pendingByChat = new Map<string, string[]>();
   const busyByChat = new Map<string, string[]>();
+  const hasOpenQuestionByChat = new Map<string, boolean>();
   for (const [chatId, statuses] of statusByChat) {
     const speakers = nonHumanSpeakersByChat.get(chatId);
     // live-dot: freshest activity among non-human SPEAKERS. (Narrowed from the
@@ -456,20 +479,34 @@ export async function listMeChats(
     const busy: string[] = [];
     for (const s of statuses) {
       const isSpeaker = speakers?.has(s.agentId) ?? false;
+      const isMine = managedAgentIds.has(s.agentId);
       if (isSpeaker && s.activity) {
         const startedMs = new Date(s.activity.startedAt).getTime();
         if (!freshest || startedMs > freshest.startedMs) freshest = { activity: s.activity, startedMs };
       }
-      if (isSpeaker && s.main === "failed") failed.push(s.agentId);
+      // failed — speaker-filtered AND narrowed to "mine" (R1). A peer's broken
+      // agent in a chat I'm in no longer pins my row to "Needs attention".
+      if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
       // busy = speakers with composite `working` (the D-axis truth from
       // `agent_chat_sessions.runtime_state`). Drives the chat-list activity
       // indicator authoritatively, so it lights even when a runtime emits
       // no intermediate session_events (codex no-events case) — the gap
-      // `liveActivity` alone can never cover.
+      // `liveActivity` alone can never cover. NOT narrowed to mine — "someone
+      // is working" is informational, not an attention signal.
       if (isSpeaker && s.working) busy.push(s.agentId);
-      // pending is NOT speaker-filtered (matches the prior derivePendingQuestions
-      // surface: a pending agent that has since left the chat still counts).
-      if (s.needsYou) pending.push(s.agentId);
+      // pending — NOT speaker-filtered (a pending agent that has since left
+      // the chat still counts, matching the prior `derivePendingQuestions`
+      // surface), AND narrowed to "mine" (R2). The front-end covers R3
+      // (caller-is-speaker fallback) via the separate `chatHasOpenQuestion`
+      // boolean below — which stays raw, unfiltered.
+      if (s.needsYou && isMine) pending.push(s.agentId);
+      // chatHasOpenQuestion — raw "any agent in this chat has a pending
+      // question" bit. Feeds the front-end R3 rule (a speaker in a chat with
+      // an open question is in attention even if the asking agent is someone
+      // else's). Computed over the same union (non-human speakers + non-human
+      // pending) that `resolveAgentChatStatuses` returns, so a pending agent
+      // that has left still flips this true.
+      if (s.needsYou) hasOpenQuestionByChat.set(chatId, true);
     }
     if (freshest) liveActivityByChat.set(chatId, freshest.activity);
     if (failed.length > 0) failedByChat.set(chatId, failed);
@@ -529,6 +566,7 @@ export async function listMeChats(
       pendingQuestionAgentIds: pendingByChat.get(r.chat_id) ?? [],
       failedAgentIds: failedByChat.get(r.chat_id) ?? [],
       busyAgentIds: busyByChat.get(r.chat_id) ?? [],
+      chatHasOpenQuestion: hasOpenQuestionByChat.get(r.chat_id) ?? false,
     };
   });
 

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -284,6 +284,25 @@ export const meChatRowSchema = z.object({
    * poisoned identifier.
    */
   busyAgentIds: z.array(z.string()).default([]),
+  /**
+   * True iff this chat has at least one non-human agent with a pending
+   * `AskUserQuestion` (`pending_questions.status === 'pending'`), regardless
+   * of whether that agent is managed by the caller. Drives the chat-list
+   * "Needs attention" speaker-fallback rule (R3) on the front-end: a chat
+   * with an open question pins for callers who are HUMAN speakers in it,
+   * even when the asking agent belongs to a peer manager. Keeps
+   * `pendingQuestionAgentIds` cleanly narrowed to caller-managed so the
+   * row's needs-you indicator stays specific to "agents I manage".
+   *
+   * Derived at query time (no schema migration). `.default(false)` for
+   * version skew: an older server build that predates this field would
+   * otherwise produce `undefined`, which silently disables R3 on the new
+   * web — exactly the conservative degradation we want during a
+   * web-ahead-of-server rollout (R1/R2/R4 continue to fire correctly).
+   *
+   * See docs/development/needs-attention-scoping.20260526.md §4 / §5.
+   */
+  chatHasOpenQuestion: z.boolean().default(false),
 });
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -39,6 +39,7 @@ function row(overrides: Partial<MeChatRow>): MeChatRow {
     pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? [],
     failedAgentIds: overrides.failedAgentIds ?? [],
     busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? false,
   };
 }
 

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -1,6 +1,12 @@
-import { compareMainStatus, type MeChatRow } from "@first-tree/shared";
+import type { MeChatRow } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { groupRows, splitAttentionRows } from "../conversations/group-rows.js";
+import {
+  groupRows,
+  rowAttentionReason,
+  rowIsFailed,
+  rowNeedsYou,
+  splitAttentionRows,
+} from "../conversations/group-rows.js";
 
 // Fixed reference "now" — picked to be mid-week so the
 // `startOfWeek` (Monday) maths is exercised non-trivially. UTC noon
@@ -28,6 +34,7 @@ function row(overrides: Partial<MeChatRow> & { id: string; lastMessageAt: string
     pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? [],
     failedAgentIds: overrides.failedAgentIds ?? [],
     busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? false,
   };
 }
 
@@ -216,10 +223,9 @@ describe("splitAttentionRows — pinned failed + needs-you partition", () => {
     expect(rest.map((r) => r.chatId)).toEqual(["x"]);
   });
 
-  it("orders the attention bucket via compareMainStatus, not a hardcoded concat", () => {
-    // Interleaved failed / needs-you; the bucket order must equal sorting their
-    // composite mains by compareMainStatus — so a future MAIN_STATUS_PRIORITY
-    // change flows through here automatically (no parallel hardcoded order).
+  it("orders the attention bucket by ATTENTION_PRIORITY (failed > needs_you), stable within tier", () => {
+    // Interleaved failed / needs-you; the bucket order must put every failed
+    // row before every needs-you row, preserving source order inside each tier.
     const rows = [
       row({ id: "n1", lastMessageAt: offsetIso(-1), pendingQuestionAgentIds: ["a"] }),
       row({ id: "f1", lastMessageAt: offsetIso(-2), failedAgentIds: ["b"] }),
@@ -227,9 +233,151 @@ describe("splitAttentionRows — pinned failed + needs-you partition", () => {
       row({ id: "f2", lastMessageAt: offsetIso(-4), failedAgentIds: ["d"] }),
     ];
     const { attention } = splitAttentionRows(rows);
-    const mains = attention.map((r): "failed" | "needs_you" => (r.failedAgentIds.length > 0 ? "failed" : "needs_you"));
-    expect(mains).toEqual([...mains].sort((x, y) => compareMainStatus(x, y)));
-    // failed tier first (stable within tier), then needs-you tier (stable).
     expect(attention.map((r) => r.chatId)).toEqual(["f1", "f2", "n1", "n2"]);
+  });
+});
+
+// Chat-granularity scoping predicate — R1 (mine-failed), R2 (mine-pending),
+// R3 (chatHasOpenQuestion AND caller is a HUMAN speaker), R4 (unread mention).
+// See docs/development/needs-attention-scoping.20260526.md.
+describe("splitAttentionRows — predicate (R1–R4)", () => {
+  it("R1: mine-failed → attention bucket, failed tier", () => {
+    const rows = [row({ id: "r1", lastMessageAt: null, failedAgentIds: ["mine"] })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r1"]);
+    expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
+  });
+
+  it("R2: mine-pending → attention bucket, needs_you tier", () => {
+    const rows = [row({ id: "r2", lastMessageAt: null, pendingQuestionAgentIds: ["mine"] })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r2"]);
+    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
+  });
+
+  it("R3: chatHasOpenQuestion + caller is speaker → attention bucket, needs_you tier (but badge stays narrow)", () => {
+    const rows = [
+      row({
+        id: "r3",
+        lastMessageAt: null,
+        chatHasOpenQuestion: true,
+        membershipKind: "participant",
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r3"]);
+    // Bucket placement: needs_you tier (so it sorts between failed and mention).
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("needs_you");
+    // Row badge: stays specific to caller-managed (R2 only). R3 enters the
+    // bucket but does NOT light the orange ? indicator — `pendingQuestionAgentIds`
+    // is server-narrowed to "mine", and this peer-question row has [].
+    expect(attention[0] && rowNeedsYou(attention[0])).toBe(false);
+  });
+
+  it("R3 watcher: chatHasOpenQuestion + caller is watcher → NOT attention", () => {
+    const rows = [
+      row({
+        id: "r3w",
+        lastMessageAt: null,
+        chatHasOpenQuestion: true,
+        membershipKind: "watching",
+      }),
+    ];
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["r3w"]);
+  });
+
+  it("R4: unread @-mention → attention bucket (no failed/pending)", () => {
+    const rows = [row({ id: "r4", lastMessageAt: null, unreadMentionCount: 3 })];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r4"]);
+  });
+
+  it("quiet row → NOT attention", () => {
+    const rows = [row({ id: "quiet", lastMessageAt: null })];
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["quiet"]);
+  });
+
+  it("priority: failed beats mention", () => {
+    const rows = [
+      row({
+        id: "fm",
+        lastMessageAt: null,
+        failedAgentIds: ["a"],
+        unreadMentionCount: 1,
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
+  });
+
+  it("priority: needs_you beats mention (R2 + mention)", () => {
+    const rows = [
+      row({
+        id: "pm",
+        lastMessageAt: null,
+        pendingQuestionAgentIds: ["a"],
+        unreadMentionCount: 1,
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention[0] && rowIsFailed(attention[0])).toBe(false);
+    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
+  });
+
+  it("sort: failed > needs_you > mention across all three tiers", () => {
+    const rows = [
+      row({ id: "m", lastMessageAt: null, unreadMentionCount: 1 }),
+      row({ id: "n", lastMessageAt: null, pendingQuestionAgentIds: ["x"] }),
+      row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f", "n", "m"]);
+  });
+
+  it("R2 + R3 simultaneously → single needs_you tier row (no double-count), badge fires for R2", () => {
+    const rows = [
+      row({
+        id: "r23",
+        lastMessageAt: null,
+        pendingQuestionAgentIds: ["mine"],
+        chatHasOpenQuestion: true,
+        membershipKind: "participant",
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention).toHaveLength(1);
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("needs_you");
+    // Badge DOES fire here because mine-pending (R2) is true on this row.
+    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
+  });
+
+  it("stable sort within failed tier preserves input order", () => {
+    const rows = [
+      row({ id: "f1", lastMessageAt: null, failedAgentIds: ["a"] }),
+      row({ id: "f2", lastMessageAt: null, failedAgentIds: ["b"] }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f1", "f2"]);
+  });
+
+  it("boundary A: my failed agent, caller is watcher → still attention (manager wins over membership)", () => {
+    // Server already narrows `failedAgentIds` to mine regardless of membership.
+    // The front-end predicate stays membership-agnostic for R1, so the row
+    // pins even when membershipKind is "watching" — boundary A locked.
+    const rows = [
+      row({
+        id: "rA",
+        lastMessageAt: null,
+        failedAgentIds: ["mine"],
+        membershipKind: "watching",
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["rA"]);
+    expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
   });
 });

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -1,4 +1,4 @@
-import { type ChatSource, compareMainStatus, type MeChatRow } from "@first-tree/shared";
+import type { ChatSource, MeChatRow } from "@first-tree/shared";
 
 export type GroupMode = "recency" | "source" | "type" | "none";
 
@@ -182,44 +182,105 @@ function groupByType(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket>
 }
 
 // ---------------------------------------------------------------------------
-// attention pinning (failed + needs-you)
+// attention pinning (failed + needs-you + mention)
 // ---------------------------------------------------------------------------
+//
+// Chat-granularity predicate — see docs/development/needs-attention-scoping.20260526.md.
+// A chat enters the "Needs attention" bucket when ANY of:
+//   R1. `failedAgentIds.length > 0`
+//       (server-narrowed to agents the caller manages — see services/me-chat.ts)
+//   R2. `pendingQuestionAgentIds.length > 0`
+//       (same narrowing)
+//   R3. `chatHasOpenQuestion && membershipKind === "participant"`
+//       (anyone has a pending question AND the caller is a HUMAN speaker in the
+//        chat — covers "someone else's agent is asking in a chat I'm in")
+//   R4. `unreadMentionCount > 0`
+//       (someone @-mentioned the caller)
+//
+// Sort priority inside the bucket: `failed > needs_you > mention`.
+//
+// This ladder is INTENTIONALLY separate from the shared agent-status
+// `compareMainStatus` (`failed`, `needs_you`, `working`, ...). `mention` is a
+// chat-level signal, not an agent main status — overloading the shared
+// comparator would couple two ladders that should evolve independently.
 
-/** A chat has a failed agent (composite `failed`) — see `MeChatRow.failedAgentIds`. */
+const ATTENTION_PRIORITY = ["failed", "needs_you", "mention"] as const;
+type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
+
+/**
+ * Highest-priority attention reason for this row, or `null` when the row is
+ * NOT in the attention bucket. Order matters: a row that satisfies multiple
+ * rules sorts under its highest tier (e.g. failed + mention → failed).
+ *
+ * Exported because external surfaces sometimes need the tier (e.g. for
+ * a per-row visual treatment), but the row-level indicator helpers
+ * (`rowIsFailed` / `rowNeedsYou`) are deliberately NOT just thin wrappers
+ * over this — they project the narrower "mine" semantics so the badges
+ * stay specific to caller-managed agents even when R3 fires.
+ */
+export function rowAttentionReason(r: MeChatRow): AttentionReason | null {
+  if (r.failedAgentIds.length > 0) return "failed";
+  // `chatHasOpenQuestion === true` (not just truthy) because the web client
+  // does NOT run the row through `meChatRowSchema.parse` — it casts the
+  // response as-is. So the Zod `.default(false)` only applies server-side;
+  // an old server skewed with new web returns `undefined` here, and `&&` on
+  // an unknown shape should not silently coerce. Explicit boolean check
+  // keeps the R3 fallback off until the server actually emits the bit.
+  if (r.pendingQuestionAgentIds.length > 0 || (r.chatHasOpenQuestion === true && r.membershipKind === "participant")) {
+    return "needs_you";
+  }
+  if (r.unreadMentionCount > 0) return "mention";
+  return null;
+}
+
+/**
+ * The row's "failed" indicator (red `!` / left border). Lights ONLY for
+ * caller-managed failed agents — server already narrows `failedAgentIds`.
+ * Equivalent to "this row is in the failed tier of the attention bucket".
+ */
 export function rowIsFailed(r: MeChatRow): boolean {
   return r.failedAgentIds.length > 0;
 }
 
-/** A chat has an agent with a pending AskUserQuestion (composite `needs_you`). */
+/**
+ * The row's "needs-you" indicator (orange `?` / left border). Lights ONLY
+ * for caller-managed agents with a pending question (R2). The R3 fallback
+ * (someone else's agent asking in a chat where I'm a speaker) DOES enter
+ * the attention bucket but does NOT light this badge — the indicator stays
+ * specific to "an agent I manage is waiting on me", matching the field's
+ * narrowed wire semantics. The bucket position alone signals R3-only rows;
+ * the row's last-message preview surfaces the actual question.
+ */
 export function rowNeedsYou(r: MeChatRow): boolean {
   return r.pendingQuestionAgentIds.length > 0;
 }
 
 /**
- * Partition rows into the pinned "Needs attention" set and the rest. Attention
- * rows are ordered by delegating to the shared `compareMainStatus`
- * (`MAIN_STATUS_PRIORITY`) — failed ranks above needs-you, matching the sidebar
- * / composer — rather than a hardcoded concat with no link to the priority
- * ladder. `Array.sort` is stable, so source order within a tier is preserved. A
- * chat that is both failed AND needs-you sorts under the failed tier. The caller
- * hoists `attention` into a single pinned bucket at the top and groups `rest`
- * normally, so a chat appears in exactly one place.
+ * Partition rows into the pinned "Needs attention" set and the rest. Within
+ * the attention bucket, sort by `ATTENTION_PRIORITY` (stable within tier,
+ * so source order is preserved among rows of the same reason). The caller
+ * hoists `attention` into a single pinned bucket at the top and groups
+ * `rest` normally, so a chat appears in exactly one place.
  *
  * ⚠️ Operates on the already-loaded rows only: an attention chat outside the
  * loaded page(s) is not pinned (page-local v1; the cross-page pinned query is
- * the §8.1#2 follow-up).
+ * a follow-up).
  */
 export function splitAttentionRows(rows: ReadonlyArray<MeChatRow>): { attention: MeChatRow[]; rest: MeChatRow[] } {
   const attention: MeChatRow[] = [];
   const rest: MeChatRow[] = [];
   for (const r of rows) {
-    if (rowIsFailed(r) || rowNeedsYou(r)) attention.push(r);
+    if (rowAttentionReason(r) !== null) attention.push(r);
     else rest.push(r);
   }
-  // The maintenance point for attention ordering: a contributor adding a new
-  // pinned status updates MAIN_STATUS_PRIORITY and the literal here, nothing else.
-  attention.sort((a, b) =>
-    compareMainStatus(rowIsFailed(a) ? "failed" : "needs_you", rowIsFailed(b) ? "failed" : "needs_you"),
-  );
+  attention.sort((a, b) => {
+    const ra = rowAttentionReason(a);
+    const rb = rowAttentionReason(b);
+    // Defensive guard — both are non-null by construction (only rows with a
+    // reason entered `attention`), but a runtime check is cheaper than a TS
+    // `as` cast and respects the repo's "no `as` assertions" rule (CLAUDE.md).
+    if (ra === null || rb === null) return 0;
+    return ATTENTION_PRIORITY.indexOf(ra) - ATTENTION_PRIORITY.indexOf(rb);
+  });
   return { attention, rest };
 }


### PR DESCRIPTION
## Summary

- Adds a 4-rule chat-granularity predicate so the me-chat **Needs attention** bucket only pins chats the caller is actually responsible for (no more peer-managed agent failures bleeding into your list).
- Threads `callerMemberId` through `listMeChats`, adds one indexed `agents.manager_id` lookup, narrows `failedAgentIds`/`pendingQuestionAgentIds` to "mine", and emits a new `chatHasOpenQuestion: boolean` so the front-end can cover the speaker-fallback case (R3).
- No DB migration. No changes to the shared `resolveAgentChatStatuses` producer.

## New predicate (chat in attention ⇔ any of)

- **R1** — agent I manage is failed in this chat
- **R2** — agent I manage has a pending `AskUserQuestion`
- **R3** — any agent has a pending question AND I am a human speaker
- **R4** — unread @-mention

Sort priority inside the bucket: `failed > needs_you > mention` (local ladder, deliberately separate from `compareMainStatus` since mention is a chat-level signal).

## Important UX nuance

R3 (peer's agent asking in a chat where I'm a speaker) **enters the bucket** but does **NOT** light the orange `?` badge on the row — the badge tracks the now-narrowed `pendingQuestionAgentIds` (mine only). Bucket position alone signals R3-only rows; the row's last-message preview surfaces the actual question. See design doc §6 for the rationale.

## Reviews completed pre-commit

- **Round 1 — `codex review`** (high reasoning): 1× [P2] — `rowNeedsYou` was conflating bucket and badge for R3 rows. **Fixed**: split the helper so `rowAttentionReason` covers the bucket and `rowNeedsYou` stays narrow to R2.
- **Round 2 — fresh independent agent**: 4× actionable findings; 3 folded into this PR:
  1. Web client doesn't run `meChatRowSchema.parse`, so the Zod `.default(false)` doesn't fire on read. **Fixed**: explicit `r.chatHasOpenQuestion === true` check in `rowAttentionReason`.
  2. `as AttentionReason` violated the repo's no-`as` rule. **Fixed**: runtime guard instead.
  3. Manager-filter had an extra `organization_id` clause that could silently drop legitimate "mine" agents if the create-time invariant broke. **Fixed**: dropped the clause; `members.id` is already unique per (user, org).
- 1 finding deferred (potential admin-flow assertion in `agent.ts` to enforce `manager.organizationId === data.organizationId` at create time) — out of scope for this PR.

## Test coverage

- **Server** `me-chat-attention.test.ts` — 10 new integration tests (B1-B10) for the matrix manager × speaker/watcher × failed/pending.
- **Frontend** `group-rows.test.ts` — 11 new predicate cases covering all 4 rules, boundary A (manager wins for watcher), priority ordering, and the bucket-vs-badge asymmetry.
- 5 existing me-chat test files threaded with the new `callerMemberId` arg.

## Design + plan docs

- `docs/development/needs-attention-scoping.20260526.md`
- `docs/development/needs-attention-scoping-plan.20260526.md`

## Test plan

- [x] `pnpm typecheck` (full)
- [x] `pnpm check` (full — 0 errors)
- [x] `pnpm --filter @first-tree/server test` (1224/1224 ✓)
- [x] `pnpm --filter @first-tree/web test` (348/348 ✓)
- [ ] Manual smoke on staging: confirm watcher chats with peer-managed failed agent no longer pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)