### PR TITLE
feat(computers): 4-state status pill + connect dialog hardening

### DIFF
--- a/packages/server/src/__tests__/me-clients-list.test.ts
+++ b/packages/server/src/__tests__/me-clients-list.test.ts
@@ -1,4 +1,6 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
@@ -86,5 +88,140 @@ describe("GET /me/clients", () => {
     const app = getApp();
     const res = await app.inject({ method: "GET", url: "/api/v1/me/clients" });
     expect(res.statusCode).toBe(401);
+  });
+
+  /**
+   * Computer status pill derivation (web) needs to know if any runtime
+   * capability is `ok` to distinguish "Ready" from "Setup incomplete". The
+   * full capability snapshot lives at `clients.metadata.capabilities`; the
+   * list response surfaces it so the pill can be computed client-side
+   * without fanning out one `GET /clients/:id` per row.
+   */
+  it("includes the reported capabilities snapshot in each row", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+
+    const capabilities = {
+      "claude-code": {
+        state: "ok",
+        available: true,
+        authenticated: true,
+        sdkVersion: "0.8.1",
+        authMethod: "oauth",
+        detectedAt: new Date().toISOString(),
+      },
+      codex: {
+        state: "missing",
+        available: false,
+        authenticated: false,
+        sdkVersion: null,
+        authMethod: "none",
+        detectedAt: new Date().toISOString(),
+      },
+    } as const;
+
+    await app.db.update(clients).set({ metadata: { capabilities } }).where(eq(clients.id, ctx.clientId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{
+      id: string;
+      capabilities: Record<string, { state: string; sdkVersion: string | null }>;
+    }>;
+    const row = body.find((c) => c.id === ctx.clientId);
+    expect(row).toBeDefined();
+    expect(row?.capabilities["claude-code"]?.state).toBe("ok");
+    expect(row?.capabilities["claude-code"]?.sdkVersion).toBe("0.8.1");
+    expect(row?.capabilities.codex?.state).toBe("missing");
+  });
+
+  /**
+   * Brand-new clients that have never run the capability probe land in
+   * the DB with `metadata = NULL` (or no `capabilities` sub-key). The
+   * response must still expose `capabilities` as an empty object — never
+   * `undefined` / `null` — so the web pill derivation can treat the value
+   * as a stable map without conditional access.
+   */
+  it("returns an empty capabilities object when the client has never reported any", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    // seedClient leaves metadata NULL; do not touch it.
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; capabilities: Record<string, unknown> }>;
+    const row = body.find((c) => c.id === ctx.clientId);
+    expect(row).toBeDefined();
+    expect(row?.capabilities).toEqual({});
+  });
+});
+
+/**
+ * Admin team listing — same capability surfacing as `/me/clients`, but for
+ * cross-user audit view. The pill derivation is shared between member
+ * self-view and admin team-view; both endpoints must carry the same
+ * payload shape. The admin's own client is part of the team list (joined
+ * via `members.userId = clients.userId`), so we cover the wiring without
+ * needing a separate teammate row.
+ */
+describe("GET /orgs/:orgId/clients (admin team view)", () => {
+  const getApp = useTestApp();
+
+  it("includes capabilities for clients in the team listing", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    const capabilities = {
+      "claude-code": {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion: "0.8.1",
+        authMethod: "none",
+        detectedAt: new Date().toISOString(),
+      },
+    } as const;
+
+    await app.db.update(clients).set({ metadata: { capabilities } }).where(eq(clients.id, admin.clientId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/clients`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{
+      id: string;
+      capabilities: Record<string, { state: string; sdkVersion: string | null }>;
+    }>;
+    const row = body.find((c) => c.id === admin.clientId);
+    expect(row).toBeDefined();
+    expect(row?.capabilities["claude-code"]?.state).toBe("unauthenticated");
+    expect(row?.capabilities["claude-code"]?.sdkVersion).toBe("0.8.1");
+  });
+
+  it("returns an empty capabilities object for clients that have not reported any", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    // seedClient (via createAdminContext) leaves metadata NULL.
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/clients`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; capabilities: Record<string, unknown> }>;
+    const row = body.find((c) => c.id === admin.clientId);
+    expect(row).toBeDefined();
+    expect(row?.capabilities).toEqual({});
   });
 });

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -428,6 +428,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       agentCount: c.agentCount,
       connectedAt: serializeDate(c.connectedAt),
       lastSeenAt: c.lastSeenAt.toISOString(),
+      capabilities: clientService.extractCapabilities(c.metadata),
       lastUpdateAttempt: clientService.extractLastUpdateAttempt(c.metadata),
     }));
   });

--- a/packages/server/src/api/orgs/clients.ts
+++ b/packages/server/src/api/orgs/clients.ts
@@ -26,6 +26,7 @@ export async function orgClientRoutes(app: FastifyInstance): Promise<void> {
       agentCount: c.agentCount,
       connectedAt: serializeDate(c.connectedAt),
       lastSeenAt: c.lastSeenAt.toISOString(),
+      capabilities: clientService.extractCapabilities(c.metadata),
       lastUpdateAttempt: clientService.extractLastUpdateAttempt(c.metadata),
     }));
   });

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -234,6 +234,19 @@ export function extractLastUpdateAttempt(metadata: unknown): UpdateAttempt | nul
 }
 
 /**
+ * Pull the capability snapshot out of a client row's `metadata` jsonb.
+ * Returns `{}` (never `null` / `undefined`) so the web pill derivation
+ * can treat the value as a stable map without a conditional access.
+ * Mirrors {@link extractLastUpdateAttempt}; same defensive shape.
+ */
+export function extractCapabilities(metadata: unknown): ClientCapabilities {
+  if (!metadata || typeof metadata !== "object") return {};
+  const sub = (metadata as Record<string, unknown>).capabilities;
+  const parsed = clientCapabilitiesSchema.safeParse(sub);
+  return parsed.success ? parsed.data : {};
+}
+
+/**
  * List the active agents currently pinned to a client. Used by the WS
  * registration handshake to backfill `agent:pinned` notifications missed while
  * the client was offline — without it, an admin who pinned an agent during a

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -44,6 +44,14 @@ export type HubClient = {
   agentCount: number;
   connectedAt: string | null;
   lastSeenAt: string;
+  /**
+   * Runtime-provider capability snapshot. Empty object when the client
+   * has never reported any (fresh machine, pre-capability-probe SDK).
+   * Consumed by the client-side pill derivation in
+   * `pages/clients/derive-status.ts` to distinguish Ready
+   * (≥1 capability `state=ok`) from Setup incomplete (all `≠ ok`).
+   */
+  capabilities: ClientCapabilities;
 };
 
 export function retireClient(clientId: string): Promise<void> {
@@ -74,17 +82,14 @@ export function getClient(clientId: string): Promise<HubClient> {
 }
 
 /**
- * Fetch this client's reported runtime-provider capabilities. Returns the
- * client's full row plus its `metadata.capabilities` blob (Option C). Used
- * by the Computers page to surface SDK install + auth state
- * per provider.
+ * Fetch this client's reported runtime-provider capabilities via the
+ * single-row endpoint. Returns the same `HubClient` shape as
+ * {@link listClients}; the dedicated endpoint stays as a force-refresh
+ * path for surfaces that want the freshest capability state immediately
+ * after a UX action (e.g. onboarding waits for the first probe).
  */
-export type ClientWithCapabilities = HubClient & {
-  capabilities: ClientCapabilities;
-};
-
-export function getClientCapabilities(clientId: string): Promise<ClientWithCapabilities> {
-  return api.get<ClientWithCapabilities>(`/clients/${clientId}`);
+export function getClientCapabilities(clientId: string): Promise<HubClient> {
+  return api.get<HubClient>(`/clients/${clientId}`);
 }
 
 export function disconnectClient(clientId: string): Promise<{ disconnected: boolean; agentIds: string[] }> {

--- a/packages/web/src/components/connect-stuck-panel.tsx
+++ b/packages/web/src/components/connect-stuck-panel.tsx
@@ -1,0 +1,54 @@
+import { COPY } from "../pages/onboarding/copy.js";
+
+/**
+ * Wait this long on the connect command before a caller surfaces this
+ * panel. Exported so both surfaces (Onboarding `StepConnectComputer`
+ * and Settings → Computers `NewConnectionDialog`) share one source of
+ * truth — drift between them was the silent UX regression the panel
+ * was introduced to prevent.
+ */
+export const STUCK_AFTER_MS = 75_000;
+
+/**
+ * "Stuck?" recovery panel for the Connect-computer flow. Pure
+ * presentational — the parent owns the timer that flips this on / off
+ * because the conditions for clearing it differ by surface (onboarding
+ * clears on `connectedClient`; the daily dialog clears on phase changes
+ * or modal close). Sharing the visuals + copy keeps the two surfaces
+ * showing the same recovery advice without forcing one of them to
+ * implement an unnatural timer reset.
+ */
+export function ConnectStuckPanel() {
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-3)",
+        borderRadius: "var(--radius-input)",
+        background: "color-mix(in oklch, var(--bg-raised) 40%, transparent)",
+        border: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+        {COPY.connectComputer.stuckTitle}
+      </p>
+      <ul className="flex flex-col" style={{ gap: "var(--sp-1_5)", margin: 0, paddingLeft: "var(--sp-4)" }}>
+        {COPY.connectComputer.stuckReasons.map((reason) => (
+          <li key={reason} className="text-label" style={{ color: "var(--fg-3)" }}>
+            {reason}
+          </li>
+        ))}
+      </ul>
+      <a
+        href={COPY.connectComputer.nodeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-label font-medium self-start"
+        style={{ color: "var(--accent)" }}
+      >
+        {COPY.connectComputer.nodeLinkLabel} →
+      </a>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
+++ b/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
@@ -23,6 +23,7 @@ function client(overrides: Partial<HubClient>): HubClient {
     agentCount: 1,
     connectedAt: null,
     lastSeenAt: new Date().toISOString(),
+    capabilities: {},
     ...overrides,
   };
 }

--- a/packages/web/src/lib/__tests__/format-relative.test.ts
+++ b/packages/web/src/lib/__tests__/format-relative.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelative } from "../utils.js";
+
+/**
+ * `formatRelative` powers the "Last seen N units ago" cell on the
+ * Settings → Computers page. Fake timers are used to pin "now" so the
+ * unit boundaries are deterministic.
+ */
+describe("formatRelative", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns '—' for null", () => {
+    expect(formatRelative(null)).toBe("—");
+  });
+
+  it("returns '—' for undefined", () => {
+    expect(formatRelative(undefined)).toBe("—");
+  });
+
+  it("returns '—' for an invalid timestamp string", () => {
+    expect(formatRelative("not-a-date")).toBe("—");
+  });
+
+  it("formats seconds-ago for very recent timestamps", () => {
+    expect(formatRelative("2026-05-01T11:59:48Z")).toMatch(/12 seconds? ago/);
+  });
+
+  it("formats minutes-ago when offset is at least a minute", () => {
+    expect(formatRelative("2026-05-01T11:55:00Z")).toMatch(/5 minutes? ago/);
+  });
+
+  it("formats hours-ago when offset is at least an hour", () => {
+    expect(formatRelative("2026-05-01T10:00:00Z")).toMatch(/2 hours? ago/);
+  });
+
+  it("formats days-ago when offset is at least a day", () => {
+    expect(formatRelative("2026-04-23T12:00:00Z")).toMatch(/8 days? ago/);
+  });
+
+  it("uses 'yesterday' for the one-day boundary (numeric: auto)", () => {
+    expect(formatRelative("2026-04-30T12:00:00Z")).toBe("yesterday");
+  });
+
+  it("clamps future-dated timestamps to 'now' to defend against server clock skew", () => {
+    // 3 seconds in the future. Without the clamp, Intl.RelativeTimeFormat
+    // would render "in 3 seconds" — jarring next to a "Last seen" header.
+    expect(formatRelative("2026-05-01T12:00:03Z")).toBe("now");
+  });
+
+  it("renders 'now' for the exactly-zero offset", () => {
+    expect(formatRelative("2026-05-01T12:00:00Z")).toBe("now");
+  });
+});

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -29,3 +29,67 @@ export function formatDay(date: string | null | undefined): string {
     day: "2-digit",
   }).format(new Date(date));
 }
+
+const SECOND_MS = 1000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+/**
+ * Relative-time formatter for "last seen" timestamps. Returns strings
+ * like "12 seconds ago", "8 days ago", "yesterday". Native
+ * `Intl.RelativeTimeFormat` — no extra dependency. Returns "—" for
+ * null/undefined or invalid dates so callers don't have to branch.
+ *
+ * Unit picking favours days through the first 30 days (mockup Variant
+ * B-1 calls out "8 days ago" — `Intl.RelativeTimeFormat` with the
+ * coarsest-available unit would collapse 7-13 days to "last week",
+ * which loses precision the operator cares about when chasing an
+ * agent-offline incident).
+ *
+ * Locale is "en" intentionally: the Settings → Computers surface is
+ * English-first ("first-tree", "Last seen", "Connect computer") and
+ * `numeric: "auto"` produces idiomatic English ("yesterday" / "now")
+ * that machine-translates poorly. When the wider app gains i18n we can
+ * swap the locale here.
+ *
+ * @param iso ISO 8601 timestamp (server returns `lastSeenAt.toISOString()`).
+ */
+export function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  // Clamp future-dated timestamps (mild server clock skew can put
+  // `lastSeenAt` a few seconds ahead) so the cell never reads "in 3
+  // seconds". A clamp here is safer than letting "now" land in some
+  // surfaces and "in N seconds" in others.
+  const diffMs = Math.min(0, t - Date.now());
+  const abs = Math.abs(diffMs);
+
+  let unit: Intl.RelativeTimeFormatUnit;
+  let unitMs: number;
+  if (abs < MINUTE_MS) {
+    unit = "second";
+    unitMs = SECOND_MS;
+  } else if (abs < HOUR_MS) {
+    unit = "minute";
+    unitMs = MINUTE_MS;
+  } else if (abs < DAY_MS) {
+    unit = "hour";
+    unitMs = HOUR_MS;
+  } else if (abs < MONTH_MS) {
+    unit = "day";
+    unitMs = DAY_MS;
+  } else if (abs < YEAR_MS) {
+    unit = "month";
+    unitMs = MONTH_MS;
+  } else {
+    unit = "year";
+    unitMs = YEAR_MS;
+  }
+  return RELATIVE_FORMATTER.format(Math.round(diffMs / unitMs), unit);
+}

--- a/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
@@ -5,9 +5,9 @@ import {
   RUNTIME_PROVIDERS,
   type RuntimeProvider,
 } from "@first-tree/shared";
-import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
-import { type ClientWithCapabilities, getClientCapabilities, type HubClient, listClients } from "../../api/activity.js";
+import { type HubClient, listClients } from "../../api/activity.js";
 import { rebindAgent } from "../../api/agents.js";
 import { ApiError } from "../../api/client.js";
 import { Button } from "../../components/ui/button.js";
@@ -50,25 +50,17 @@ export function ReBindDialog({ open, onOpenChange, agent }: Props) {
 
   const candidateClients = clientsQuery.data ?? [];
 
-  // Lazily fetch full capabilities for every candidate client so the runtime
-  // picker can grey-out missing providers.
-  const capabilityQueries = useQueries({
-    queries: candidateClients.map((c) => ({
-      queryKey: ["client-capabilities", c.id],
-      queryFn: () => getClientCapabilities(c.id),
-      enabled: open,
-    })),
-  });
+  // Capability snapshots ride along on every list row now (`/me/clients`
+  // includes the `metadata.capabilities` blob), so the runtime picker
+  // greys-out missing providers without fanning out N `GET /clients/:id`
+  // requests when the dialog opens. The data freshness is bounded by the
+  // list refetch cadence (5s while the dialog is mounted via react-query),
+  // which is plenty for the "is Codex installed on machine X" question.
   const capabilitiesByClient = useMemo(() => {
     const map = new Map<string, ClientCapabilities>();
-    capabilityQueries.forEach((q, idx) => {
-      const c = candidateClients[idx];
-      if (!c) return;
-      const data = q.data as ClientWithCapabilities | undefined;
-      if (data?.capabilities) map.set(c.id, data.capabilities);
-    });
+    for (const c of candidateClients) map.set(c.id, c.capabilities);
     return map;
-  }, [capabilityQueries, candidateClients]);
+  }, [candidateClients]);
 
   useEffect(() => {
     if (!open) {

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -8,10 +8,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
-  type ClientWithCapabilities,
   disconnectClient,
   getActivityOverview,
-  getClientCapabilities,
   type HubClient,
   listClients,
   listOrgClients,
@@ -35,7 +33,9 @@ import { PresenceChip, runtimeStateToPresence } from "../components/ui/presence-
 import { RowActionsMenu } from "../components/ui/row-actions-menu.js";
 import { UppercaseLabel } from "../components/ui/section-header.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
-import { formatDate } from "../lib/utils.js";
+import { formatDate, formatRelative } from "../lib/utils.js";
+import { ComputerStatusPill } from "./clients/computer-status-pill.js";
+import { compareByPillPriority, deriveComputerStatus, summarizeComputers } from "./clients/derive-status.js";
 import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
 
 /**
@@ -106,7 +106,6 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // computers instead of a broken page.
   const grouped = isAdmin && !orgClientsQuery.isError;
   const teamLoadError = isAdmin && orgClientsQuery.isError;
-  const clients = grouped ? orgClientsQuery.data : meClientsQuery.data;
 
   const { data: activity } = useQuery({
     queryKey: ["activity"],
@@ -151,22 +150,31 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const getClientAgents = (clientId: string): RuntimeAgent[] => agentsByClient.get(clientId) ?? [];
 
   // admin grouped view: split the single org-scoped list into the viewer's
-  // own machines vs everyone else's, each sorted by recency. `userId === null`
-  // (legacy clients that pre-date user binding) lands in the team block — the
-  // viewer isn't its owner, so it doesn't belong in "yours".
+  // own machines vs everyone else's. Each group sorts by status pill priority
+  // (auth_expired → setup_incomplete → offline → ready) with lastSeenAt as
+  // tie-break — surfaces problem rows at the top without forcing the viewer
+  // to scan the full list. `userId === null` (legacy clients that pre-date
+  // user binding) lands in the team block.
   const mineList = useMemo<HubClient[]>(() => {
     if (!grouped || !orgClientsQuery.data || !user) return [];
-    return [...orgClientsQuery.data]
-      .filter((c) => c.userId === user.id)
-      .sort((a, b) => (a.lastSeenAt > b.lastSeenAt ? -1 : a.lastSeenAt < b.lastSeenAt ? 1 : 0));
+    return [...orgClientsQuery.data].filter((c) => c.userId === user.id).sort(compareByPillPriority);
   }, [grouped, orgClientsQuery.data, user]);
 
   const teamList = useMemo<HubClient[]>(() => {
     if (!grouped || !orgClientsQuery.data || !user) return [];
-    return [...orgClientsQuery.data]
-      .filter((c) => c.userId !== user.id)
-      .sort((a, b) => (a.lastSeenAt > b.lastSeenAt ? -1 : a.lastSeenAt < b.lastSeenAt ? 1 : 0));
+    return [...orgClientsQuery.data].filter((c) => c.userId !== user.id).sort(compareByPillPriority);
   }, [grouped, orgClientsQuery.data, user]);
+
+  /**
+   * Member-mode list (non-admin): the `/me/clients` payload arrives in
+   * server-default order (no explicit ORDER BY). Sort by pill priority so
+   * an Auth expired row cannot hide below a Ready one. This is a
+   * deliberate UX change vs. the prior table — see PR description.
+   */
+  const memberList = useMemo<HubClient[] | undefined>(() => {
+    if (grouped || !meClientsQuery.data) return meClientsQuery.data;
+    return [...meClientsQuery.data].sort(compareByPillPriority);
+  }, [grouped, meClientsQuery.data]);
 
   const membersById = useMemo<Map<string, string>>(() => {
     const map = new Map<string, string>();
@@ -189,27 +197,25 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
     return { text: client.userId.slice(0, 8), title: client.userId };
   };
 
-  const connectedCount = (clients ?? []).filter((c) => c.status === "connected").length;
-  const totalAgentsBound = (clients ?? []).reduce((n, c) => n + c.agentCount, 0);
-  const authBrokenCount = (clients ?? []).filter((c) => c.authState !== "ok").length;
+  // Single source of truth for "what the user is looking at right now": admin
+  // grouped mode → the org-scoped list (covers both mineList + teamList);
+  // member mode → the pill-sorted memberList. Driving the subtitle and the
+  // empty-state branch off this list keeps the two display modes in sync.
+  const clients = grouped ? orgClientsQuery.data : memberList;
+
+  // Subtitle is the pure-function output of `summarizeComputers` — single
+  // headline for one row owned by the viewer ("Your computer is ready"),
+  // neutral phrasing when admin is looking at a teammate's lone row, and a
+  // zero-suppressed pill-count breakdown for multi-row views. The `· N
+  // agents bound` suffix restores the power-user signal the old subtitle
+  // surfaced. See `clients/derive-status.ts` for the pure logic + tests.
+  const subtitle = useMemo(() => summarizeComputers(clients, user?.id), [clients, user?.id]);
 
   return (
     <div className={embedded ? "" : "-m-6"}>
       <PageHeader
         title="Computers"
-        subtitle={
-          clients && clients.length > 0 ? (
-            <>
-              {clients.length} total · {connectedCount} connected · {totalAgentsBound} agents bound
-              {authBrokenCount > 0 && (
-                <>
-                  {" · "}
-                  <span style={{ color: "var(--state-error)" }}>{authBrokenCount} need re-auth</span>
-                </>
-              )}
-            </>
-          ) : null
-        }
+        subtitle={subtitle}
         right={
           <div className="flex items-center gap-1.5">
             <Button size="xs" onClick={() => setNewConnectionOpen(true)}>
@@ -366,9 +372,9 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                   <DenseTableHead>Hostname</DenseTableHead>
                   {grouped && <DenseTableHead>Owner</DenseTableHead>}
                   <DenseTableHead>OS</DenseTableHead>
-                  <DenseTableHead>SDK</DenseTableHead>
+                  <DenseTableHead>first-tree</DenseTableHead>
                   <DenseTableHead>Agents</DenseTableHead>
-                  <DenseTableHead>Connected</DenseTableHead>
+                  <DenseTableHead>Last seen</DenseTableHead>
                   <DenseTableHead>Status</DenseTableHead>
                   <DenseTableHead aria-hidden />
                 </DenseTableRow>
@@ -506,37 +512,24 @@ const PROVIDER_UNAUTH_HINT: Record<RuntimeProvider, string> = {
 };
 
 /**
- * Lazy-loaded runtime-provider capability matrix shown inside the expanded
- * row of the Computers table. We only fetch when the row is open so the
- * /clients listing stays cheap on large fleets — capabilities are reported by
- * the client at startup and stored under `clients.metadata.capabilities`.
+ * Runtime-provider capability matrix shown inside the expanded row of the
+ * Computers table. The snapshot is pre-loaded with the list response now
+ * (single-source via `/me/clients` / `/orgs/:orgId/clients`), so the
+ * matrix renders synchronously — no extra round-trip when a row opens.
  */
-function CapabilityMatrix({ clientId, enabled }: { clientId: string; enabled: boolean }) {
-  const { data, isLoading } = useQuery({
-    queryKey: ["client-capabilities", clientId],
-    queryFn: () => getClientCapabilities(clientId),
-    enabled,
-  });
-  const capabilities: ClientCapabilities | null = (data as ClientWithCapabilities | undefined)?.capabilities ?? null;
+function CapabilityMatrix({ capabilities }: { capabilities: ClientCapabilities }) {
+  const empty = Object.keys(capabilities).length === 0;
   return (
     <>
       <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>Runtimes</UppercaseLabel>
-      {isLoading && !capabilities ? (
-        <div className="text-body" style={{ color: "var(--fg-3)" }}>
-          Loading…
-        </div>
-      ) : capabilities && Object.keys(capabilities).length === 0 ? (
+      {empty ? (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>
           Capabilities not yet reported. Reconnect this computer to refresh.
         </div>
       ) : (
         <div className="flex flex-col gap-1">
           {PROVIDER_ORDER.map((provider) => (
-            <ProviderRow
-              key={provider}
-              provider={provider}
-              entry={capabilities ? (capabilities[provider] ?? null) : null}
-            />
+            <ProviderRow key={provider} provider={provider} entry={capabilities[provider] ?? null} />
           ))}
         </div>
       )}
@@ -607,34 +600,9 @@ function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: Ca
   }
 }
 
-/**
- * Distinguishes "credentials died" from "machine offline". Server derives
- * the state from offline duration vs configured refresh-token TTL, so the
- * pill flips on its own once the row has been disconnected long enough.
- */
-function AuthExpiredChip() {
-  return (
-    <span
-      className="mono inline-flex items-center gap-1.5 uppercase text-caption"
-      style={{ color: "var(--state-error)" }}
-    >
-      <span
-        style={{
-          width: 7,
-          height: 7,
-          borderRadius: "50%",
-          background: "var(--state-error)",
-          display: "inline-block",
-        }}
-      />
-      AUTH EXPIRED
-    </span>
-  );
-}
-
-// Column count in member mode — `chevron | Hostname | OS | SDK | Agents |
-// Connected | Status | Actions`. admin mode inserts an Owner column between
-// Hostname and OS, bumping the count by 1.
+// Column count in member mode — `chevron | Hostname | OS | first-tree |
+// Agents | Last seen | Status | Actions`. admin mode inserts an Owner column
+// between Hostname and OS, bumping the count by 1.
 const MEMBER_COLSPAN = 8;
 const ADMIN_COLSPAN = MEMBER_COLSPAN + 1;
 
@@ -737,14 +705,12 @@ function ClientRow({
   // `isExpanded` for owner rows and is forced to false for team rows so a
   // stale collapsed-set never accidentally opens one.
   const effectiveExpanded = restricted ? false : isExpanded;
-  // Auth health takes priority over the connection state when rendering the
-  // row's status pill: "auth expired" must outrank the plain "offline" so
-  // the user knows it isn't going to come back without intervention.
-  const authBroken = client.authState !== "ok";
-  // The Computer row's connection pill collapses the richer `HubClient.status`
-  // enum (connected/disconnected/…) into the two-state reachability vocabulary
-  // shared with agent presence — same visual element, different data source.
-  const presenceForChip = client.status === "connected" ? "online" : "offline";
+  // Row status pill is computed by `deriveComputerStatus` — pure function
+  // over (status, authState, capabilities). Encodes the priority rules
+  // ("auth expired wins over offline") that previously lived in this
+  // component, and unlocks `setup_incomplete` which the prior visuals
+  // could not express. See `clients/derive-status.ts`.
+  const status = deriveComputerStatus(client);
   return (
     <>
       <DenseTableRow interactive={!restricted} selected={effectiveExpanded} onClick={restricted ? undefined : onToggle}>
@@ -768,10 +734,16 @@ function ClientRow({
         <DenseTableCell>
           <span className="mono tnum text-label">{client.agentCount}</span>
         </DenseTableCell>
-        <DenseTableCell className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-          {client.connectedAt ? formatDate(client.connectedAt) : "—"}
+        <DenseTableCell
+          className="mono text-caption"
+          style={{ color: "var(--fg-4)" }}
+          title={formatDate(client.lastSeenAt)}
+        >
+          {formatRelative(client.lastSeenAt)}
         </DenseTableCell>
-        <DenseTableCell>{authBroken ? <AuthExpiredChip /> : <PresenceChip status={presenceForChip} />}</DenseTableCell>
+        <DenseTableCell>
+          <ComputerStatusPill pill={status.pill} />
+        </DenseTableCell>
         {/* Overflow menu for row actions. Reconnect / Disconnect / Retire
             are all low-frequency operations (Retire is destructive and
             once-off, Disconnect is rare, Reconnect only matters when offline)
@@ -798,7 +770,7 @@ function ClientRow({
         <tr style={{ background: "var(--bg-sunken)" }}>
           <DenseTableCell />
           <DenseTableCell colSpan={colSpan - 1} style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-3_5)" }}>
-            <CapabilityMatrix clientId={client.id} enabled={effectiveExpanded} />
+            <CapabilityMatrix capabilities={client.capabilities} />
             {boundAgents.length > 0 && (
               <>
                 <UppercaseLabel style={{ display: "block", marginTop: "var(--sp-3)", marginBottom: 6 }}>

--- a/packages/web/src/pages/clients/__tests__/computer-status-pill.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/computer-status-pill.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { PILL_VIEW } from "../computer-status-pill.js";
+
+/**
+ * The pill chip itself is a thin presentational wrapper around
+ * `PILL_VIEW`. We pin the view-model contract (label + color token per
+ * pill) so a label rewrite or palette swap is a deliberate change, not
+ * a regression. Matches the convention used by `presence-chip.test.ts`.
+ */
+describe("PILL_VIEW — 4-state computer pill view model", () => {
+  it("ready maps to 'Ready' + idle (green) color", () => {
+    expect(PILL_VIEW.ready).toEqual({ label: "Ready", color: "var(--state-idle)" });
+  });
+
+  it("auth_expired maps to 'Auth expired' + error (red) color", () => {
+    expect(PILL_VIEW.auth_expired).toEqual({ label: "Auth expired", color: "var(--state-error)" });
+  });
+
+  it("setup_incomplete maps to 'Setup incomplete' + blocked (amber) color", () => {
+    expect(PILL_VIEW.setup_incomplete).toEqual({ label: "Setup incomplete", color: "var(--state-blocked)" });
+  });
+
+  it("offline maps to 'Offline' + muted (gray) color", () => {
+    expect(PILL_VIEW.offline).toEqual({ label: "Offline", color: "var(--fg-3)" });
+  });
+});

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import type { HubClient } from "../../../api/activity.js";
+import { compareByPillPriority, deriveComputerStatus, PILL_PRIORITY, summarizeComputers } from "../derive-status.js";
+
+/**
+ * Pure-function unit tests for the 4-state Settings → Computers status
+ * pill. The pill is computed entirely from existing server fields
+ * (`status`, `authState`, `capabilities`) — no new server columns, no
+ * thresholds. Ordering of the if/else ladder matters: see the comments
+ * on `deriveComputerStatus` itself.
+ */
+
+const T = new Date("2026-05-01T00:00:00Z").toISOString();
+
+function client(overrides: Partial<HubClient>): HubClient {
+  return {
+    id: "c-1",
+    userId: "u-1",
+    status: "connected",
+    authState: "ok",
+    sdkVersion: "v1.3.2",
+    hostname: "MacBook-Pro.local",
+    os: "macOS",
+    agentCount: 0,
+    connectedAt: T,
+    lastSeenAt: T,
+    capabilities: {},
+    ...overrides,
+  };
+}
+
+function capability(state: "ok" | "missing" | "unauthenticated" | "error") {
+  return {
+    state,
+    available: state === "ok",
+    authenticated: state === "ok",
+    sdkVersion: state === "ok" ? "0.8.1" : null,
+    authMethod: state === "ok" ? ("oauth" as const) : ("none" as const),
+    detectedAt: T,
+  };
+}
+
+describe("deriveComputerStatus", () => {
+  it("returns Ready when connected, auth ok, and at least one capability is ok", () => {
+    const c = client({ capabilities: { "claude-code": capability("ok") } });
+    expect(deriveComputerStatus(c).pill).toBe("ready");
+    expect(deriveComputerStatus(c).headline).toBe("Your computer is ready");
+  });
+
+  it("returns Ready when at least one capability is ok and others are missing", () => {
+    const c = client({
+      capabilities: { "claude-code": capability("ok"), codex: capability("missing") },
+    });
+    expect(deriveComputerStatus(c).pill).toBe("ready");
+  });
+
+  it("auth_expired wins over offline (server contract: expired ⊂ disconnected)", () => {
+    const c = client({ status: "disconnected", authState: "expired" });
+    expect(deriveComputerStatus(c).pill).toBe("auth_expired");
+    expect(deriveComputerStatus(c).headline).toBe("Your computer needs to log in again");
+  });
+
+  it("auth_expired wins even when capabilities are ok (last-reported snapshot)", () => {
+    // Server snapshots capability state during 'connected'; after going offline
+    // long enough for the refresh token to lapse, the row carries
+    // authState=expired but the capability snapshot is still 'ok'. The pill
+    // must surface the credential death, not the stale runtime detail.
+    const c = client({
+      status: "disconnected",
+      authState: "expired",
+      capabilities: { "claude-code": capability("ok") },
+    });
+    expect(deriveComputerStatus(c).pill).toBe("auth_expired");
+  });
+
+  it("returns Offline when disconnected with auth still ok", () => {
+    const c = client({ status: "disconnected", authState: "ok" });
+    expect(deriveComputerStatus(c).pill).toBe("offline");
+    expect(deriveComputerStatus(c).headline).toBe("Your computer is offline");
+  });
+
+  it("returns Setup incomplete when connected + auth ok but no capability is ok", () => {
+    const c = client({
+      capabilities: { "claude-code": capability("missing"), codex: capability("missing") },
+    });
+    expect(deriveComputerStatus(c).pill).toBe("setup_incomplete");
+    expect(deriveComputerStatus(c).headline).toBe("Finish setting up your computer");
+  });
+
+  it("treats an empty capabilities map as Setup incomplete (no runtime probed)", () => {
+    const c = client({ capabilities: {} });
+    expect(deriveComputerStatus(c).pill).toBe("setup_incomplete");
+  });
+
+  it("treats unauthenticated or error capabilities as not-ok (still Setup incomplete)", () => {
+    const c = client({
+      capabilities: { "claude-code": capability("unauthenticated"), codex: capability("error") },
+    });
+    expect(deriveComputerStatus(c).pill).toBe("setup_incomplete");
+  });
+
+  it("is tolerant of a malformed capability entry (defensive optional chain)", () => {
+    // A wire-shape drift / malformed jsonb could yield an entry missing `state`.
+    // The pill derivation must not throw; treat the entry as not-ok.
+    const c = client({
+      // biome-ignore lint/suspicious/noExplicitAny: simulating a malformed payload
+      capabilities: { "claude-code": {} as any },
+    });
+    expect(deriveComputerStatus(c).pill).toBe("setup_incomplete");
+  });
+});
+
+describe("PILL_PRIORITY", () => {
+  it("orders pills auth_expired < setup_incomplete < offline < ready (problems first)", () => {
+    expect(PILL_PRIORITY.auth_expired).toBeLessThan(PILL_PRIORITY.setup_incomplete);
+    expect(PILL_PRIORITY.setup_incomplete).toBeLessThan(PILL_PRIORITY.offline);
+    expect(PILL_PRIORITY.offline).toBeLessThan(PILL_PRIORITY.ready);
+  });
+});
+
+describe("compareByPillPriority", () => {
+  it("sorts auth_expired ahead of ready", () => {
+    const expired = client({ id: "exp", status: "disconnected", authState: "expired" });
+    const ready = client({ id: "rdy", capabilities: { "claude-code": capability("ok") } });
+    const sorted = [ready, expired].sort(compareByPillPriority);
+    expect(sorted[0]?.id).toBe("exp");
+    expect(sorted[1]?.id).toBe("rdy");
+  });
+
+  it("ties on pill priority break by lastSeenAt descending (most recent first)", () => {
+    const newer = client({ id: "new", lastSeenAt: "2026-05-01T10:00:00Z" });
+    const older = client({ id: "old", lastSeenAt: "2026-05-01T05:00:00Z" });
+    // Both are setup_incomplete (no caps); the more recently-seen one wins.
+    const sorted = [older, newer].sort(compareByPillPriority);
+    expect(sorted[0]?.id).toBe("new");
+    expect(sorted[1]?.id).toBe("old");
+  });
+
+  it("is stable when both pill and lastSeenAt match (returns 0)", () => {
+    const a = client({ id: "a" });
+    const b = client({ id: "b" });
+    expect(compareByPillPriority(a, b)).toBe(0);
+  });
+});
+
+describe("summarizeComputers — page subtitle pure helper", () => {
+  it("returns null for an empty list", () => {
+    expect(summarizeComputers([], "u-1")).toBeNull();
+  });
+
+  it("returns null for undefined input (loading state)", () => {
+    expect(summarizeComputers(undefined, "u-1")).toBeNull();
+  });
+
+  it("uses the possessive headline when the viewer owns the single row", () => {
+    const c = client({ userId: "u-1", capabilities: { "claude-code": capability("ok") } });
+    expect(summarizeComputers([c], "u-1")).toBe("Your computer is ready");
+  });
+
+  it("uses neutral phrasing when admin views someone else's single row", () => {
+    const c = client({ userId: "u-other", capabilities: { "claude-code": capability("ok") }, agentCount: 0 });
+    expect(summarizeComputers([c], "u-1")).toBe("1 computer is ready");
+  });
+
+  it("uses neutral phrasing when there is no viewer id (server-rendered fallback)", () => {
+    const c = client({ userId: "u-other" });
+    expect(summarizeComputers([c], null)).toBe("1 computer needs setup");
+  });
+
+  it("appends an agents-bound suffix when agents are present (single computer)", () => {
+    const c = client({
+      userId: "u-1",
+      agentCount: 3,
+      capabilities: { "claude-code": capability("ok") },
+    });
+    expect(summarizeComputers([c], "u-1")).toBe("Your computer is ready · 3 agents bound");
+  });
+
+  it("uses the singular 'agent' when exactly one agent is bound", () => {
+    const c = client({
+      userId: "u-1",
+      agentCount: 1,
+      capabilities: { "claude-code": capability("ok") },
+    });
+    expect(summarizeComputers([c], "u-1")).toBe("Your computer is ready · 1 agent bound");
+  });
+
+  it("breaks down pills in priority order and omits zero-count pills for multi-row views", () => {
+    const c1 = client({ id: "c1", status: "disconnected", authState: "expired", agentCount: 1 });
+    const c2 = client({ id: "c2", capabilities: { "claude-code": capability("ok") }, agentCount: 2 });
+    const c3 = client({ id: "c3", capabilities: { "claude-code": capability("ok") }, agentCount: 0 });
+    expect(summarizeComputers([c1, c2, c3], "u-1")).toBe("1 auth expired · 2 ready · 3 agents bound");
+  });
+
+  it("omits the agents-bound suffix entirely when no agents are bound", () => {
+    const c1 = client({ id: "c1", agentCount: 0 });
+    const c2 = client({ id: "c2", agentCount: 0 });
+    expect(summarizeComputers([c1, c2], "u-1")).toBe("2 setup incomplete");
+  });
+});

--- a/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
+++ b/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
@@ -28,6 +28,7 @@ function client(overrides: Partial<HubClient>): HubClient {
     agentCount: 0,
     connectedAt: new Date(T0).toISOString(),
     lastSeenAt: new Date(T0).toISOString(),
+    capabilities: {},
     ...overrides,
   };
 }

--- a/packages/web/src/pages/clients/computer-status-pill.tsx
+++ b/packages/web/src/pages/clients/computer-status-pill.tsx
@@ -1,0 +1,49 @@
+import { StatusGlyph } from "../../components/ui/status-glyph.js";
+import { cn } from "../../lib/utils.js";
+import type { ComputerStatusPill as PillName } from "./derive-status.js";
+
+type ComputerStatusPillProps = {
+  pill: PillName;
+  className?: string;
+};
+
+/**
+ * Per-pill view model: label string + color token. Exported so tests
+ * (and any future consumer that wants the same vocabulary without the
+ * chip's DOM) can drive the same normalization.
+ */
+export const PILL_VIEW: Record<PillName, { label: string; color: string }> = {
+  ready: { label: "Ready", color: "var(--state-idle)" },
+  auth_expired: { label: "Auth expired", color: "var(--state-error)" },
+  setup_incomplete: { label: "Setup incomplete", color: "var(--state-blocked)" },
+  offline: { label: "Offline", color: "var(--fg-3)" },
+};
+
+/**
+ * Four-state computer reachability pill for Settings → Computers.
+ *
+ * Replaces the previous mixed visuals (separate AUTH EXPIRED chip +
+ * generic PresenceChip) with a single chip that conveys the user's
+ * actionable answer: "can my agent run on this machine right now?"
+ *
+ * Driven by `deriveComputerStatus` — a pure function over the existing
+ * `status` / `authState` / `capabilities` fields. No new server signal,
+ * no time thresholds.
+ */
+export function ComputerStatusPill({ pill, className }: ComputerStatusPillProps) {
+  const view = PILL_VIEW[pill];
+  // role="status" + aria-label make this announce as a state region for
+  // screen readers and ensure colorblind users still receive the label
+  // text (the StatusGlyph dot is decorative, the prose is the truth).
+  return (
+    <span
+      role="status"
+      aria-label={`Computer status: ${view.label}`}
+      className={cn("mono inline-flex items-center gap-1.5 text-caption", className)}
+      style={{ color: view.color }}
+    >
+      <StatusGlyph shape="dot" colorVar={view.color} size={7} />
+      {view.label}
+    </span>
+  );
+}

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -1,0 +1,138 @@
+import type { HubClient } from "../../api/activity.js";
+
+export type ComputerStatusPill = "ready" | "auth_expired" | "setup_incomplete" | "offline";
+
+export type ComputerStatus = {
+  pill: ComputerStatusPill;
+  /** Headline copy for the top-of-page sentence. */
+  headline: string;
+};
+
+/**
+ * Pure 4-state pill derivation for a computer row.
+ *
+ * Inputs come entirely from existing server fields — `status`,
+ * `authState`, and `capabilities` — so the pill costs zero new server
+ * columns and zero thresholds.
+ *
+ * Ordering of the checks below is by user-actionable severity, most
+ * actionable first:
+ *
+ *   1. `auth_expired` — credentials are dead, the user must rerun
+ *      `first-tree login` on the machine.
+ *   2. `offline`      — credentials are alive but the machine is not.
+ *   3. `ready`        — connected and at least one runtime is `ok`.
+ *   4. `setup_incomplete` — connected but no runtime is `ok` yet.
+ *
+ * Note on the relationship between `auth_expired` and `offline`: the
+ * server contract in `services/client.ts:deriveAuthState` only returns
+ * `expired` when `status=disconnected` AND offline duration exceeds
+ * the refresh-token TTL. So `expired ⊂ disconnected` today and the
+ * step-2 `status !== "connected"` branch is unreachable when step 1
+ * matched. Both are kept as defensive ordering in case the server
+ * grows admin-driven revocation (auth could go expired while the
+ * row is still `connected`).
+ */
+export function deriveComputerStatus(client: HubClient): ComputerStatus {
+  if (client.authState === "expired") {
+    return { pill: "auth_expired", headline: "Your computer needs to log in again" };
+  }
+  if (client.status !== "connected") {
+    return { pill: "offline", headline: "Your computer is offline" };
+  }
+  const caps = client.capabilities ?? {};
+  const anyOk = Object.values(caps).some((entry) => entry?.state === "ok");
+  if (anyOk) {
+    return { pill: "ready", headline: "Your computer is ready" };
+  }
+  return { pill: "setup_incomplete", headline: "Finish setting up your computer" };
+}
+
+/**
+ * Priority order — smaller is "more urgent / sorts earlier". The list
+ * page sorts rows by this so problem rows bubble to the top without the
+ * viewer needing to scan a long table.
+ */
+export const PILL_PRIORITY: Record<ComputerStatusPill, number> = {
+  auth_expired: 0,
+  setup_incomplete: 1,
+  offline: 2,
+  ready: 3,
+};
+
+/**
+ * Sort comparator: pill priority ascending (problems first), then
+ * `lastSeenAt` descending (most recently active wins the tie). Stable
+ * w.r.t. the underlying `Array.prototype.sort`.
+ */
+export function compareByPillPriority(a: HubClient, b: HubClient): number {
+  const pa = PILL_PRIORITY[deriveComputerStatus(a).pill];
+  const pb = PILL_PRIORITY[deriveComputerStatus(b).pill];
+  if (pa !== pb) return pa - pb;
+  if (a.lastSeenAt > b.lastSeenAt) return -1;
+  if (a.lastSeenAt < b.lastSeenAt) return 1;
+  return 0;
+}
+
+/**
+ * Build the per-page-header subtitle for the Computers page.
+ *
+ * Inputs:
+ *   - `clients`: the rows currently on screen (member: own; admin: org-wide)
+ *   - `viewerUserId`: caller's user id — drives whether the single-row
+ *     branch uses the possessive headline ("Your computer is ready") or
+ *     the neutral phrasing ("1 computer is ready") so admins reading a
+ *     teammate's lone row do not get a copy bug.
+ *
+ * Returns null when there are zero rows. Returns either the per-status
+ * headline (single-row, owned by viewer) or a `· `-joined per-pill count
+ * with zero-suppression, suffixed by `· N agents bound` to restore the
+ * power-user signal that the prior subtitle carried.
+ *
+ * Pure; exported for testing without rendering React.
+ */
+export function summarizeComputers(
+  clients: HubClient[] | undefined,
+  viewerUserId: string | null | undefined,
+): string | null {
+  if (!clients || clients.length === 0) return null;
+  const totalAgents = clients.reduce((n, c) => n + c.agentCount, 0);
+  const agentsSuffix = totalAgents > 0 ? ` · ${totalAgents} ${totalAgents === 1 ? "agent" : "agents"} bound` : "";
+
+  if (clients.length === 1) {
+    const only = clients[0];
+    // biome-ignore lint/style/noNonNullAssertion: length === 1 guards above
+    const status = deriveComputerStatus(only!);
+    // biome-ignore lint/style/noNonNullAssertion: length === 1 guards above
+    if (viewerUserId && only!.userId === viewerUserId) {
+      return status.headline + agentsSuffix;
+    }
+    // Neutral phrasing — admin viewing someone else's lone row.
+    const neutral: Record<ComputerStatusPill, string> = {
+      ready: "1 computer is ready",
+      auth_expired: "1 computer needs to log in again",
+      setup_incomplete: "1 computer needs setup",
+      offline: "1 computer is offline",
+    };
+    return neutral[status.pill] + agentsSuffix;
+  }
+
+  const counts: Record<ComputerStatusPill, number> = {
+    ready: 0,
+    auth_expired: 0,
+    setup_incomplete: 0,
+    offline: 0,
+  };
+  for (const c of clients) counts[deriveComputerStatus(c).pill] += 1;
+  const labels: Record<ComputerStatusPill, string> = {
+    ready: "ready",
+    auth_expired: "auth expired",
+    setup_incomplete: "setup incomplete",
+    offline: "offline",
+  };
+  const segments = (Object.keys(PILL_PRIORITY) as ComputerStatusPill[])
+    .sort((a, b) => PILL_PRIORITY[a] - PILL_PRIORITY[b])
+    .filter((pill) => counts[pill] > 0)
+    .map((pill) => `${counts[pill]} ${labels[pill]}`);
+  return segments.join(" · ") + agentsSuffix;
+}

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -1,8 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectTokenResponse, generateConnectToken, type HubClient, listClients } from "../../api/activity.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { ConnectCommandPanel, type ConnectPhase } from "../../components/connect-command-panel.js";
+import { ConnectStuckPanel, STUCK_AFTER_MS } from "../../components/connect-stuck-panel.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { runVisibilityAwareInterval } from "../../lib/visibility-interval.js";
@@ -39,19 +40,31 @@ const SUCCESS_HOLD_MS = 1_200;
 // between the browser and the server (or a connect handshake that races a
 // hair ahead of the open) still falls inside the "after open" window.
 const CONNECT_DETECT_FUDGE_MS = 1_000;
+// Buffer subtracted from the server-reported expiry so the modal flips to
+// `error` slightly before the token is actually rejected by the connect-token
+// exchange endpoint — keeps the "expired" UX strictly aligned with the
+// server, never narrower.
+const TOKEN_EXPIRY_BUFFER_MS = 2_000;
 
 /**
  * "Connect computer" modal — replaces the always-on ConnectStrip.
  *
  * Lifecycle:
  *   1. open=true        → record open timestamp → mint a connect token
- *   2. phase="waiting"  → poll /clients every 3s; first client owned by the
+ *   2. phase="waiting"  → poll /clients every 5s; first client owned by the
  *                         caller with status="connected" and connectedAt
  *                         AFTER the open timestamp wins. Timestamp-based so
  *                         re-pairing a machine that already has a client_id
  *                         row (status flips disconnected→connected, id is
  *                         reused) is still detected.
+ *                         A `STUCK_AFTER_MS` timer surfaces the recovery
+ *                         panel for users who hit the install/firewall wall.
+ *                         A token-expiry timer flips to phase=error once the
+ *                         server-issued token can no longer be exchanged.
  *   3. phase="success"  → brief hold (~1.2s), then close + invalidate
+ *   4. phase="error"    → either mint failed or the token expired before the
+ *                         CLI landed. A "Generate new token" button re-runs
+ *                         the mint inline without closing the modal.
  *
  * Cancel / backdrop close: drops the unused token (server expires it on TTL).
  */
@@ -62,39 +75,55 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
   const [token, setToken] = useState<ConnectTokenResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [arrivedHostname, setArrivedHostname] = useState<string | null>(null);
+  const [stuck, setStuck] = useState(false);
   const openedAtRef = useRef<number>(0);
+  // Tracks whether a mint cycle owned by *this* call is still relevant.
+  // Bumped on every new mint (open and regenerate). Stale async settlements
+  // compare their snapshot to the live ref before touching state.
+  const mintCycleRef = useRef(0);
 
-  // 1. On open: stamp open time, mint, switch to waiting. Reset all state on close.
+  /** Generate a fresh connect token and arm the waiting loop. */
+  const mintToken = useCallback(async () => {
+    const cycle = ++mintCycleRef.current;
+    setStuck(false);
+    setArrivedHostname(null);
+    setPhase("loading");
+    setToken(null);
+    setErrorMessage(null);
+    try {
+      const t = await generateConnectToken();
+      if (mintCycleRef.current !== cycle) return;
+      // Stamp the arrival baseline AFTER the token is in hand. A slow mint
+      // shouldn't leave `openedAtRef` pointing several seconds into the past
+      // — the arrival detector compares `client.connectedAt >= openedAt`,
+      // and a too-old baseline lets stale CLI handshakes from unrelated
+      // sessions count as "arrived".
+      openedAtRef.current = Date.now() - CONNECT_DETECT_FUDGE_MS;
+      setToken(t);
+      setPhase("waiting");
+    } catch (err) {
+      if (mintCycleRef.current !== cycle) return;
+      setErrorMessage(err instanceof Error ? err.message : "Failed to generate connect token");
+      setPhase("error");
+    }
+  }, []);
+
+  // 1. On open: mint a token. On close: reset all transient state. The
+  //    mint cycle bump in mintToken ensures any in-flight resolve from a
+  //    previous open() can't bleed into the new lifecycle.
   useEffect(() => {
     if (!open) {
+      mintCycleRef.current += 1;
       setPhase("loading");
       setToken(null);
       setErrorMessage(null);
       setArrivedHostname(null);
+      setStuck(false);
       openedAtRef.current = 0;
       return;
     }
-
-    let cancelled = false;
-    openedAtRef.current = Date.now() - CONNECT_DETECT_FUDGE_MS;
-
-    (async () => {
-      try {
-        const t = await generateConnectToken();
-        if (cancelled) return;
-        setToken(t);
-        setPhase("waiting");
-      } catch (err) {
-        if (cancelled) return;
-        setErrorMessage(err instanceof Error ? err.message : "Failed to generate connect token");
-        setPhase("error");
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
+    void mintToken();
+  }, [open, mintToken]);
 
   // 2. While waiting: poll for a client whose handshake landed AFTER the modal
   //    opened. Timestamp comparison (not id-set diff) is what lets us catch a
@@ -119,6 +148,46 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
     return runVisibilityAwareInterval(tick, POLL_MS);
   }, [open, phase, queryClient, user]);
 
+  // 2b. Token expiry: server returns `expiresIn` (seconds). When that
+  //     elapses, flip to error so the user sees the dead-token state
+  //     instead of an indefinite spinner. `open` is in deps to defend
+  //     against close→reopen-with-cached-token race (cleanup runs on
+  //     close, clearing the previous timer before the next open arms a
+  //     new one). The TOKEN_EXPIRY_BUFFER_MS subtraction keeps the UX
+  //     strictly aligned with the server contract (never showing the
+  //     token as valid past the point the server rejects it).
+  useEffect(() => {
+    if (!open || !token || phase !== "waiting") return;
+    const ms = token.expiresIn * 1_000 - TOKEN_EXPIRY_BUFFER_MS;
+    if (ms <= 0) {
+      // Server returned a token with no remaining validity (malformed
+      // response, or we mis-parsed expiresIn). Flip to error
+      // synchronously instead of arming a 0-delay timeout that would
+      // race React's render queue.
+      setErrorMessage("This token has no remaining validity. Generate a new one to continue.");
+      setPhase("error");
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      setErrorMessage("This token expired before the computer connected. Generate a new one to continue.");
+      setPhase("error");
+    }, ms);
+    return () => window.clearTimeout(handle);
+  }, [open, token, phase]);
+
+  // 2c. Stuck recovery: if the waiting phase drags past STUCK_AFTER_MS,
+  //     surface the same recovery panel onboarding shows. Resets the
+  //     moment we leave waiting (success or error) so a Regenerate that
+  //     also stalls re-arms the panel cleanly.
+  useEffect(() => {
+    if (!open || phase !== "waiting") {
+      setStuck(false);
+      return;
+    }
+    const handle = window.setTimeout(() => setStuck(true), STUCK_AFTER_MS);
+    return () => window.clearTimeout(handle);
+  }, [open, phase]);
+
   // 3. On success: brief hold so the user sees the green confirmation, then close.
   useEffect(() => {
     if (phase !== "success") return;
@@ -134,11 +203,14 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Connect computer</DialogTitle>
-          <DialogDescription>Run this command on the machine you want to pair with this Hub.</DialogDescription>
+          <DialogDescription>
+            Run this command on the machine you want to pair with this Hub. If first-tree isn't installed yet, the
+            command includes the install step.
+          </DialogDescription>
         </DialogHeader>
 
         <ConnectCommandPanel
-          command={token?.command ?? null}
+          command={token?.bootstrapCommand ?? null}
           expiresInSeconds={token?.expiresIn}
           phase={phase}
           successContent={
@@ -147,9 +219,17 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
             </>
           }
           errorContent={errorMessage}
+          copyButtonPlacement="bottom"
         />
 
+        {stuck && phase === "waiting" && <ConnectStuckPanel />}
+
         <div className="flex justify-end" style={{ gap: "var(--sp-2)" }}>
+          {phase === "error" && (
+            <Button variant="outline" size="sm" onClick={() => void mintToken()}>
+              Generate new token
+            </Button>
+          )}
           <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
@@ -1,16 +1,11 @@
 import { ArrowRight } from "lucide-react";
 import { useEffect, useState } from "react";
+import { ConnectStuckPanel, STUCK_AFTER_MS } from "../../../components/connect-stuck-panel.js";
 import { Button } from "../../../components/ui/button.js";
 import { COPY } from "../copy.js";
 import { CommandBox, FlowNote, StatusRow } from "../flow-ui.js";
 import { ShowMeHow, TerminalGuide } from "../guides.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
-
-// How long to wait on the command before surfacing the "stuck?" panel. The
-// happy path is seconds; this only fires for the true-beginner wall (no
-// Node, wrong machine, firewall). We keep polling underneath, so it still
-// auto-advances the moment the computer connects.
-const STUCK_AFTER_MS = 75_000;
 
 /**
  * Connect the computer the agent will run on. The user pastes a
@@ -50,7 +45,7 @@ export function StepConnectComputer() {
           ) : (
             <StatusRow state="waiting" label={COPY.connectComputer.waiting} />
           )}
-          {stuck && <StuckPanel />}
+          {stuck && <ConnectStuckPanel />}
           <ShowMeHow>
             <TerminalGuide />
           </ShowMeHow>
@@ -82,41 +77,6 @@ export function StepConnectComputer() {
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
-    </div>
-  );
-}
-
-function StuckPanel() {
-  return (
-    <div
-      className="flex flex-col"
-      style={{
-        gap: "var(--sp-2)",
-        padding: "var(--sp-3)",
-        borderRadius: "var(--radius-input)",
-        background: "color-mix(in oklch, var(--bg-raised) 40%, transparent)",
-        border: "var(--hairline) solid var(--border-faint)",
-      }}
-    >
-      <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
-        {COPY.connectComputer.stuckTitle}
-      </p>
-      <ul className="flex flex-col" style={{ gap: "var(--sp-1_5)", margin: 0, paddingLeft: "var(--sp-4)" }}>
-        {COPY.connectComputer.stuckReasons.map((reason) => (
-          <li key={reason} className="text-label" style={{ color: "var(--fg-3)" }}>
-            {reason}
-          </li>
-        ))}
-      </ul>
-      <a
-        href={COPY.connectComputer.nodeUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-label font-medium self-start"
-        style={{ color: "var(--accent)" }}
-      >
-        {COPY.connectComputer.nodeLinkLabel} →
-      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase A of the **Settings → Computers** optimization. Replaces the mixed status chips with a deterministic 4-state pill, surfaces the onboarding "stuck" recovery in the daily connect dialog, and lets new users with no CLI installed paste one command instead of two.

Background design docs (gandy-s-assistant's proposals): `proposals/connect-computer-optimization.md` and `proposals/connect-computer-default-view-mockup.md`. Implementation plan (gandy-developer's): `proposals/connect-computer-implementation-plan.md`. Three rounds of design reflection + two rounds of independent code review applied before this PR — see plan §11 for the trail.

### 4-state status pill

Pill is derived client-side via a pure function (`packages/web/src/pages/clients/derive-status.ts`) over the existing `(status, authState, capabilities)` fields — no new server columns, no time thresholds, no aging logic.

| Pill | Trigger | Headline |
|---|---|---|
| 🟢 Ready | `connected` + auth ok + ≥1 capability `state="ok"` | Your computer is ready |
| 🔴 Auth expired | `authState=="expired"` | Your computer needs to log in again |
| 🟡 Setup incomplete | `connected` + auth ok + no capability is `ok` | Finish setting up your computer |
| ⚪ Offline | `disconnected` + auth ok | Your computer is offline |

Rows sort by pill priority so problem machines surface at the top. Admin team view uses neutral phrasing ("1 computer is ready") when a single lone row isn't owned by the viewer.

### Server: capabilities on the list endpoints

`/me/clients` and `/orgs/:orgId/clients` now include the `capabilities` snapshot. The data already lives at `clients.metadata.capabilities`; the change is a response-shape extension only — no schema change, no migration. The expanded-row `CapabilityMatrix` and the agent-detail `ReBindDialog` both consume this list snapshot now, dropping one round-trip per row open / dialog open.

### NewConnectionDialog hardening

- **Bootstrap command**: uses the server's pre-existing `bootstrapCommand` (double-line `npm install -g first-tree\nfirst-tree login <token>`) so a fresh machine doesn't fail with `command not found` on copy-paste.
- **Token expiry**: a `setTimeout` keyed off `token.expiresIn` flips to `phase="error"` with a "Generate new token" button that re-mints inline without closing the modal.
- **Stuck panel**: 75-second timer surfaces the same recovery panel onboarding uses. Extracted to `packages/web/src/components/connect-stuck-panel.tsx` and shared with `StepConnectComputer`; both callers keep their own timer with the `STUCK_AFTER_MS` constant.
- **Race defense**: `mintCycleRef` defeats stale promise settlements across rapid open → close → reopen and Regenerate cycles. `openedAtRef` is stamped after mint resolves (not before) so a slow mint can't widen the arrival-detection window.

### Column tweaks

- "SDK" → "first-tree" (column shows the hub CLI version)
- "Connected" → "Last seen" (relative time via `Intl.RelativeTimeFormat`, clamped to past-only)
- Subtitle: status sentence + `· N agents bound` suffix; both signals survive

### Accessibility

The pill renders with `role="status"` + `aria-label` so the state is announced to screen readers and colorblind users get the label text alongside the dot.

## What's NOT in this PR (deferred to Phase B / C per the plan)

- **Phase B (P0-3 IA overhaul)**: card-based single-device view, responsive 2-up multi-card layout, "+Connect" button downgrade. Builds on this PR's pill. Web-only, zero migration.
- **Phase C (P0-1 server hygiene)**: `registerClient` soft-dedup on `(user_id, hostname, os)`, orphan archival sweep, daemon ↔ yaml binding. Schema + CLI changes. Riskiest piece, isolated PR.
- `getClientCapabilities` is still called by `new-agent-dialog.tsx` and `use-computer-connection.ts` — they have non-trivial pickedClientId state machinery and rebinding them widens scope; a follow-up cleanup PR can fold them onto the list snapshot.
- The dialog's poll uses `["clients"]` while the page reads `["clients", "me"]` — pre-existing cache-key split, the post-success `invalidateQueries({queryKey:["clients"]})` already covers it but a unified key would be cleaner. Out of scope.

## Sorting behavior change

The non-admin (member) view previously rendered rows in `/me/clients` API order (unsorted). This PR sorts by `compareByPillPriority` so an Auth expired row can't hide below a Ready one. Deliberate UX improvement; flagged here so reviewers can ack the change in row order.

## Test plan

- [x] `pnpm --filter @first-tree/server test` — 1218 tests green (147 files), includes new coverage for `/me/clients` and `/orgs/:orgId/clients` capabilities surfacing + empty-object fallback
- [x] `pnpm --filter @first-tree/web test` — 372 tests green (37 files), includes:
  - `derive-status.test.ts` — 4 pill states, ordering invariants, defensive optional-chain, sort comparator, summarize helper
  - `computer-status-pill.test.tsx` — PILL_VIEW label + color tokens
  - `format-relative.test.ts` — unit boundaries, future-date clamp, invalid-input handling
- [x] `pnpm typecheck` — all 13 packages clean
- [x] `pnpm check` (biome) — no new lint errors in changed files

### Manual verification suggested before merge

- [x] Single Ready computer: subtitle reads "Your computer is ready · N agent(s) bound", row pill is green
- [x] Auth expired: subtitle reads "Your computer needs to log in again", red pill
- [x] Setup incomplete: subtitle reads "Finish setting up your computer", amber pill
- [x] Offline: gray pill
- [x] Multi-computer (≥2): subtitle reads "N ready · M offline · ..." with zero-suppression
- [x] Admin team view: someone else's lone row reads neutrally ("1 computer is ready"), not "Your"
- [ ] NewConnectionDialog: command shown is double-line `npm install -g first-tree\nfirst-tree login <token>`
- [ ] NewConnectionDialog: wait 75 seconds without running the command → stuck panel appears
- [ ] NewConnectionDialog: wait past token expiry (~10 min) → phase=error, "Generate new token" button re-mints inline

## Review trail

Three rounds of design reflection (writing-plans self-review, plan-eng-review framework analysis, adversarial subagent challenge) before any code change, then two rounds of independent code review on the diff before commit. All 34 findings triaged: 9 actionable applied, 25 documented in plan §11 as accepted trade-offs or deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)