### PR TITLE
fix(web): re-land chat-open scroll after late-arriving events

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -984,7 +984,7 @@ export function ChatView({
   // needs to call `scrollToBottom` — and sendMut is declared
   // shortly after this point. The hook only depends on
   // `scrollContainerRef`, which is just a ref.
-  const { scrollToBottomImmediate, scrollToMessageImmediate, scrollToBottom, isAtBottom } =
+  const { scrollToBottomImmediate, scrollToMessageImmediate, scrollToBottom, scrollToMessage, isAtBottom } =
     useChatScroll(scrollContainerRef);
 
   // Auto-grow the composer up to the CSS `max-height` cap (10.5rem ≈ 8
@@ -1835,6 +1835,22 @@ export function ChatView({
   // commit but before paint, so the first frame the user sees is
   // already at the right scroll position.
   //
+  // Each branch fires two scrolls:
+  //   1. *Immediate — synchronous, lands the first paint at the
+  //      current scrollHeight floor (no top-then-bottom flash).
+  //   2. Non-immediate (ResizeObserver-debounced) — re-lands once
+  //      the container's height has been stable for `stabilityDelay`
+  //      (200 ms). `messagesData` and `eventsData` arrive in two
+  //      independent React Query fetches, and messages typically
+  //      land first; without this follow-up the immediate scroll
+  //      lands at "messages end" and any in-progress `tool_call`
+  //      workgroups arriving moments later end up below the fold
+  //      (and `isAtBottom` flips to `false` as `scrollHeight` grows,
+  //      so the streaming auto-follow effect below ALSO bails).
+  //      The follow-up call is also why this useLayoutEffect doesn't
+  //      need to wait for both queries — first paint stays correct,
+  //      and the stable callback handles the late-arriving events.
+  //
   // Earlier rounds:
   //  - PR 286 review M1 round → answersByCorrelationId source fix.
   //  - PR 286 review M2 round → Bug 1 (hard reload landed at top
@@ -1845,6 +1861,10 @@ export function ChatView({
   //    "last-read marker" to "bottom-visible-on-leave snapshot",
   //    so coming back to a chat lands you where you were visually,
   //    not at "the bottom of all content I've ever seen here".
+  //  - baixiaohang manual report → on chat open the viewport landed
+  //    at the last message's bottom, leaving in-progress tool_call
+  //    workgroups (events that arrived after messages) below the
+  //    fold. Added the stable follow-up scroll.
   const landedForChatRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     if (itemCount === 0) return;
@@ -1855,13 +1875,23 @@ export function ChatView({
       // newer than the anchor sit below the fold; the pill will
       // surface them.
       scrollToMessageImmediate(bottomVisibleResolution.anchorId, "end", "auto");
+      scrollToMessage(bottomVisibleResolution.anchorId, "end", "auto");
     } else {
       // No prior snapshot (first-time visit, or the stored anchor
       // is gone): preserve the M1-era "open scrolls to bottom"
       // behavior.
       scrollToBottomImmediate("auto");
+      scrollToBottom("auto");
     }
-  }, [chatId, itemCount, bottomVisibleResolution, scrollToMessageImmediate, scrollToBottomImmediate]);
+  }, [
+    chatId,
+    itemCount,
+    bottomVisibleResolution,
+    scrollToMessageImmediate,
+    scrollToBottomImmediate,
+    scrollToMessage,
+    scrollToBottom,
+  ]);
 
   // Watches the scroll position and persists the bottom-visible
   // message id per chat. Distinct from the prior monotonic-marker


### PR DESCRIPTION
## Summary

- Opening a chat whose active turn is mid-flight landed the viewport at the last forwarded message, with the live `tool_call` workgroups left below the fold.
- Root cause: `messagesData` and `eventsData` are independent React Query fetches. `messagesData` typically resolves first, the chat-open `useLayoutEffect` (`chat-view.tsx:1849`) fires `scrollToBottomImmediate(\"auto\")` against the messages-only scrollHeight, then events append below — `scrollHeight` grows, `isAtBottom` flips to `false`, and the streaming auto-follow at `chat-view.tsx:2053` no longer matches (`isAtBottom` is gone).
- Fix: after the immediate scroll, also call the ResizeObserver-debounced version (`scrollToBottom` / `scrollToMessage`). It waits for the container height to be stable for `stabilityDelay` (200 ms) and re-anchors — absorbing the late event commit without gating the layout effect on both queries having resolved.
- First paint is unchanged (the `*Immediate` calls still fire under `useLayoutEffect`), so there's no top-then-bottom flash.

## Test plan

- [ ] Open a chat with an active agent turn (many `tool_call` rows trailing the last forwarded message). Viewport should land at the **bottom** of the tool_call list, not at the last message.
- [ ] Hard reload on a chat URL while an agent is mid-turn — same expectation as above.
- [ ] Open a chat where the stored `bottomVisibleMessageId` is still in the rendered window — viewport lands on that message at its bottom, unchanged by this PR.
- [ ] Scroll up partway, switch to another chat, switch back — the snapshot restore still works (no regression in the M2 path).
- [ ] No top-then-bottom flash on chat open.

## Context

- Original PR #585 (now closed) attempted a parallel stick-to-bottom mechanism on the pre-PR-286 timeline. PR 286 (M2/M3) introduced the `useChatScroll` + `useReadTracker` + pill + divider stack — this PR is a 32-line follow-up on that foundation, not a competing implementation.
- Discovered by @baixiaohang during manual testing after PR 286 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)