### PR TITLE
feat(slash-commands): per-agent slash-command catalog + composer popover

### DIFF
--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
-import { reconcileLocalRuntimeProviders, uploadClientCapabilities } from "../core/runtime-provider-reconcile.js";
+import {
+  reconcileLocalRuntimeProviders,
+  uploadAgentSkills,
+  uploadClientCapabilities,
+} from "../core/runtime-provider-reconcile.js";
 
 /**
  * Two CLI helpers, both fetch-driven against the hub:
@@ -204,5 +208,66 @@ describe("uploadClientCapabilities", () => {
         capabilities: {},
       }),
     ).rejects.toThrow(/403/);
+  });
+});
+
+describe("uploadAgentSkills", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("PATCHes /agents/:id/skills with the scanned descriptors", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await uploadAgentSkills({
+      serverUrl: "http://hub.test",
+      accessToken: "tok-xyz",
+      agentId: "agent-1",
+      skills: [{ name: "review", description: "Pre-landing PR review", source: "user" }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error("fetch was not called");
+    const [url, init] = call as [string, RequestInit];
+    expect(url).toBe("http://hub.test/api/v1/agents/agent-1/skills");
+    expect(init.method).toBe("PATCH");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok-xyz");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(String(init.body));
+    expect(body.skills).toEqual([{ name: "review", description: "Pre-landing PR review", source: "user" }]);
+  });
+
+  it("URL-encodes the agentId so weird ids survive", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    await uploadAgentSkills({
+      serverUrl: "http://hub.test",
+      accessToken: "tok",
+      agentId: "agent/with slash",
+      skills: [],
+    });
+    const call = fetchMock.mock.calls[0];
+    if (!call) throw new Error("fetch was not called");
+    const url = call[0] as string;
+    expect(url).toBe("http://hub.test/api/v1/agents/agent%2Fwith%20slash/skills");
+  });
+
+  it("throws on non-OK status so the caller can log + continue", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 500 }));
+    await expect(
+      uploadAgentSkills({
+        serverUrl: "http://hub.test",
+        accessToken: "tok",
+        agentId: "agent-1",
+        skills: [],
+      }),
+    ).rejects.toThrow(/500/);
   });
 });

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -4,6 +4,7 @@ import {
   ClientOrgMismatchError,
   ClientUserMismatchError,
   configureClientLoggerForService,
+  discoverClaudeCodeSkills,
   probeCapabilities,
 } from "@first-tree/client";
 import {
@@ -35,6 +36,7 @@ import {
   promptUpdate,
   reconcileLocalRuntimeProviders,
   startClientService,
+  uploadAgentSkills,
   uploadClientCapabilities,
 } from "../../core/index.js";
 import { print } from "../../core/output.js";
@@ -241,6 +243,40 @@ export function registerDaemonStartCommand(daemon: Command): void {
             const msg = err instanceof Error ? err.message : String(err);
             print.status("⚠️", `capabilities upload skipped: ${msg}`);
           }
+        }
+
+        // Post-register slash-command skill upload. Phase 1B scope is
+        // user-global Claude Code skills — every claude-code agent on this
+        // client receives the same payload, which the web composer reads
+        // via `GET /api/v1/agents/:uuid/skills` after the user @mentions
+        // the agent. Codex (and any future runtime without a skill system)
+        // is skipped. Best-effort: log + continue on failure.
+        try {
+          const claudeAgents = [...agents].filter(([, c]) => c.runtime === "claude-code");
+          if (claudeAgents.length > 0) {
+            const skills = await discoverClaudeCodeSkills({
+              warn: (msg) => print.status("⚠️", `skill scan: ${msg}`),
+            });
+            const accessToken = await ensureFreshAccessToken();
+            await Promise.all(
+              claudeAgents.map(async ([name, c]) => {
+                try {
+                  await uploadAgentSkills({
+                    serverUrl: config.server.url,
+                    accessToken,
+                    agentId: c.agentId,
+                    skills,
+                  });
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : String(err);
+                  print.status("⚠️", `skills upload for ${name} skipped: ${msg}`);
+                }
+              }),
+            );
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `skills upload skipped: ${msg}`);
         }
 
         // Watch agents config dir for hot-add

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -51,7 +51,11 @@ export { blank, status } from "./output.js";
 // Interactive prompts
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
 // Pre-flight runtime-provider reconciliation (P2 — capabilities + YAML rewrite)
-export { reconcileLocalRuntimeProviders, uploadClientCapabilities } from "./runtime-provider-reconcile.js";
+export {
+  reconcileLocalRuntimeProviders,
+  uploadAgentSkills,
+  uploadClientCapabilities,
+} from "./runtime-provider-reconcile.js";
 // Background service install (launchd / systemd --user)
 export type { ServiceInfo, ServiceOpResult, ServiceState } from "./service-install.js";
 export {

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ClientCapabilities, RuntimeProvider } from "@first-tree/shared";
+import type { ClientCapabilities, RuntimeProvider, SkillDescriptor } from "@first-tree/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { cliFetch } from "./cli-fetch.js";
 
@@ -88,5 +88,32 @@ export async function uploadClientCapabilities(opts: {
   });
   if (!res.ok) {
     throw new Error(`hub returned ${res.status} on PATCH /clients/${opts.clientId}/capabilities`);
+  }
+}
+
+/**
+ * Replace the agent's slash-command skill list on the hub. Called once per
+ * managed agent during daemon startup (and on subsequent restarts) after
+ * the local SKILL.md scan. Snapshot semantics: server overwrites the row
+ * with the payload in full, so callers should always upload the complete
+ * scan output, not a diff. Best-effort: a transient failure logs and moves
+ * on; agents still bind, and a subsequent restart retries.
+ */
+export async function uploadAgentSkills(opts: {
+  serverUrl: string;
+  accessToken: string;
+  agentId: string;
+  skills: SkillDescriptor[];
+}): Promise<void> {
+  const res = await cliFetch(`${opts.serverUrl}/api/v1/agents/${encodeURIComponent(opts.agentId)}/skills`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${opts.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ skills: opts.skills }),
+  });
+  if (!res.ok) {
+    throw new Error(`hub returned ${res.status} on PATCH /agents/${opts.agentId}/skills`);
   }
 }

--- a/packages/client/src/__tests__/skills-discovery.test.ts
+++ b/packages/client/src/__tests__/skills-discovery.test.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverClaudeCodeSkills } from "../runtime/skills/index.js";
+
+/**
+ * `discoverClaudeCodeSkills` walks the well-known Claude Code skill paths
+ * under `$HOME/.claude/` and returns one descriptor per SKILL.md. The
+ * scanner deliberately tolerates malformed files (logs a warning, skips)
+ * because the daemon must not crash on a single broken skill payload.
+ */
+describe("discoverClaudeCodeSkills", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ft-skills-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeSkill(relDir: string, name: string, frontmatter: string, body = "Body"): void {
+    const dir = join(home, relDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), `---\n${frontmatter}\n---\n${body}\n`);
+  }
+
+  it("returns an empty list when the .claude tree is missing", async () => {
+    const skills = await discoverClaudeCodeSkills({ home });
+    expect(skills).toEqual([]);
+  });
+
+  it("picks up user-global skills under .claude/skills/<name>/SKILL.md", async () => {
+    writeSkill(".claude/skills", "review", "name: review\ndescription: Pre-landing PR review");
+    writeSkill(".claude/skills", "ship", "name: ship\ndescription: Ship workflow");
+    const skills = await discoverClaudeCodeSkills({ home });
+    expect(skills).toEqual([
+      { name: "review", description: "Pre-landing PR review", source: "user" },
+      { name: "ship", description: "Ship workflow", source: "user" },
+    ]);
+  });
+
+  it("tags plugin skills with the plugin dir name as namespace", async () => {
+    writeSkill(".claude/plugins/hyperframes/skills", "gsap", "name: gsap\ndescription: GSAP animation reference");
+    const skills = await discoverClaudeCodeSkills({ home });
+    expect(skills).toEqual([
+      { name: "gsap", namespace: "hyperframes", description: "GSAP animation reference", source: "plugin" },
+    ]);
+  });
+
+  it("falls back to the directory name when frontmatter omits `name`", async () => {
+    writeSkill(".claude/skills", "my-skill", "description: No explicit name field");
+    const skills = await discoverClaudeCodeSkills({ home });
+    expect(skills).toEqual([{ name: "my-skill", description: "No explicit name field", source: "user" }]);
+  });
+
+  it("skips files with missing frontmatter and surfaces a warning", async () => {
+    const dir = join(home, ".claude/skills/broken");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), "no frontmatter here\n");
+    // Plus a good one so we know the scan continues past the broken entry.
+    writeSkill(".claude/skills", "good", "name: good\ndescription: Working skill");
+
+    const warnings: string[] = [];
+    const skills = await discoverClaudeCodeSkills({ home, warn: (m) => warnings.push(m) });
+    expect(skills).toEqual([{ name: "good", description: "Working skill", source: "user" }]);
+    expect(warnings.some((w) => w.includes("missing YAML frontmatter"))).toBe(true);
+  });
+
+  it("skips files whose frontmatter is missing required `description`", async () => {
+    writeSkill(".claude/skills", "incomplete", "name: incomplete");
+    const warnings: string[] = [];
+    const skills = await discoverClaudeCodeSkills({ home, warn: (m) => warnings.push(m) });
+    expect(skills).toEqual([]);
+    expect(warnings.some((w) => w.includes("missing required `description`"))).toBe(true);
+  });
+
+  it("sorts results deterministically (namespace then name) so the upload payload hashes stably", async () => {
+    writeSkill(".claude/skills", "zeta", "name: zeta\ndescription: z");
+    writeSkill(".claude/skills", "alpha", "name: alpha\ndescription: a");
+    writeSkill(".claude/plugins/hyperframes/skills", "beta", "name: beta\ndescription: b");
+    const skills = await discoverClaudeCodeSkills({ home });
+    expect(skills.map((s) => `${s.namespace ?? ""}:${s.name}`)).toEqual([":alpha", ":zeta", "hyperframes:beta"]);
+  });
+});

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -43,6 +43,8 @@ export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 export { SessionManager } from "./runtime/session-manager.js";
 export { SessionRegistry } from "./runtime/session-registry.js";
+// Skills (slash-command discovery)
+export { discoverClaudeCodeSkills } from "./runtime/skills/index.js";
 export type {
   ExecuteUpdateFn,
   ExecuteUpdateResult,

--- a/packages/client/src/runtime/skills/index.ts
+++ b/packages/client/src/runtime/skills/index.ts
@@ -1,0 +1,158 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type SkillDescriptor, skillDescriptorSchema } from "@first-tree/shared";
+import { parse as parseYaml } from "yaml";
+
+type WarnFn = (msg: string) => void;
+
+/**
+ * Discover slash-command skills available to a Claude Code runtime on this
+ * machine. The web composer reads these via
+ * `GET /api/v1/agents/:uuid/skills` to render the `/`-triggered popover
+ * after the user `@mentions` the agent.
+ *
+ * Phase 1B scope: scan only user-global skill paths
+ *   - `<home>/.claude/skills/<name>/SKILL.md`            (source: "user")
+ *   - `<home>/.claude/plugins/<plugin>/skills/<name>/SKILL.md`  (source: "plugin")
+ *
+ * Project-local skills (under each agent's repo) require knowing the
+ * per-agent workspace — deferred to a later phase. Every claude-code agent
+ * on this client gets the same user-global list as a Phase 1B
+ * approximation.
+ */
+export async function discoverClaudeCodeSkills(opts?: {
+  /** Override for tests. Defaults to the real `$HOME`. */
+  home?: string;
+  /** Surface non-fatal scan warnings (malformed frontmatter, unreadable file, etc.). */
+  warn?: WarnFn;
+}): Promise<SkillDescriptor[]> {
+  const home = opts?.home ?? homedir();
+  const warn = opts?.warn ?? (() => {});
+
+  const out: SkillDescriptor[] = [];
+
+  const userSkillsRoot = join(home, ".claude", "skills");
+  out.push(...scanSkillsDir(userSkillsRoot, { source: "user" }, warn));
+
+  const pluginsRoot = join(home, ".claude", "plugins");
+  if (existsSync(pluginsRoot)) {
+    let pluginDirs: string[];
+    try {
+      pluginDirs = readdirSync(pluginsRoot, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
+    } catch (err) {
+      warn(`cannot enumerate ${pluginsRoot}: ${errMsg(err)}`);
+      pluginDirs = [];
+    }
+    for (const plugin of pluginDirs) {
+      const skillsRoot = join(pluginsRoot, plugin, "skills");
+      out.push(...scanSkillsDir(skillsRoot, { source: "plugin", namespace: plugin }, warn));
+    }
+  }
+
+  // Stable ordering for deterministic upload payloads — keeps the
+  // content-hash short-circuit on the caller side meaningful.
+  out.sort((a, b) => {
+    const an = a.namespace ?? "";
+    const bn = b.namespace ?? "";
+    if (an !== bn) return an < bn ? -1 : 1;
+    return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  });
+
+  return out;
+}
+
+function scanSkillsDir(
+  root: string,
+  defaults: { source: SkillDescriptor["source"]; namespace?: string },
+  warn: WarnFn,
+): SkillDescriptor[] {
+  if (!existsSync(root)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch (err) {
+    warn(`cannot enumerate ${root}: ${errMsg(err)}`);
+    return [];
+  }
+
+  const out: SkillDescriptor[] = [];
+  for (const name of entries) {
+    const skillFile = join(root, name, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
+    const parsed = parseSkillFile(skillFile, warn);
+    if (!parsed) continue;
+    const candidate: SkillDescriptor = {
+      // Frontmatter `name:` wins when present; fall back to the directory
+      // name so a SKILL.md without a `name:` field is still discoverable.
+      name: parsed.name ?? name,
+      description: parsed.description,
+      source: defaults.source,
+      ...(defaults.namespace ? { namespace: defaults.namespace } : {}),
+    };
+    const validated = skillDescriptorSchema.safeParse(candidate);
+    if (validated.success) {
+      out.push(validated.data);
+    } else {
+      warn(`${skillFile}: descriptor failed validation — ${validated.error.message}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the `---\n...\n---` YAML frontmatter from a SKILL.md file. We
+ * only need `name` + `description`; other fields are ignored on purpose so
+ * skill authors can add metadata without us tracking it.
+ */
+function parseSkillFile(path: string, warn: WarnFn): { name?: string; description: string } | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    warn(`${path}: cannot read — ${errMsg(err)}`);
+    return null;
+  }
+
+  // Frontmatter must be the very first thing in the file.
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+  if (!match) {
+    warn(`${path}: missing YAML frontmatter block`);
+    return null;
+  }
+
+  let fm: unknown;
+  try {
+    fm = parseYaml(match[1] ?? "");
+  } catch (err) {
+    warn(`${path}: malformed YAML frontmatter — ${errMsg(err)}`);
+    return null;
+  }
+  if (!isPlainObject(fm)) {
+    warn(`${path}: YAML frontmatter is not an object`);
+    return null;
+  }
+
+  const description = fm.description;
+  if (typeof description !== "string" || description.length === 0) {
+    warn(`${path}: missing required \`description\` field in frontmatter`);
+    return null;
+  }
+  const name = fm.name;
+  return {
+    name: typeof name === "string" && name.length > 0 ? name : undefined,
+    description,
+  };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/server/drizzle/0050_agent_skills.sql
+++ b/packages/server/drizzle/0050_agent_skills.sql
@@ -11,4 +11,4 @@
 -- ({ name, namespace?, description, source }). Default `[]` keeps every
 -- existing row valid until its owning daemon next checks in — at which
 -- point the column is overwritten in full (no per-skill UPSERT).
-ALTER TABLE "agents" ADD COLUMN "skills" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "skills" jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/packages/server/drizzle/0050_agent_skills.sql
+++ b/packages/server/drizzle/0050_agent_skills.sql
@@ -1,0 +1,14 @@
+-- Track agent-reported skills (slash commands) on the agents row.
+--
+-- The CLI daemon scans each agent's runtime skill directories
+-- (~/.claude/skills, <repo>/.claude/skills, plugin skill dirs) and
+-- uploads the discovered descriptors via
+-- `PATCH /api/v1/agents/:uuid/skills`. The web composer reads this list
+-- back via `GET /api/v1/agents/:uuid/skills` to render the `/`-triggered
+-- slash-command popover after the user @mentions the agent.
+--
+-- Stored as a JSONB array of SkillDescriptor objects
+-- ({ name, namespace?, description, source }). Default `[]` keeps every
+-- existing row valid until its owning daemon next checks in — at which
+-- point the column is overwritten in full (no per-skill UPSERT).
+ALTER TABLE "agents" ADD COLUMN "skills" jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0049_agent_chat_session_runtime_state
+0050_agent_skills

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1780272000000,
       "tag": "0049_agent_chat_session_runtime_state",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1780358400000,
+      "tag": "0050_agent_skills",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-skills.test.ts
+++ b/packages/server/src/__tests__/agent-skills.test.ts
@@ -1,0 +1,100 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+/**
+ * `GET /api/v1/agents/:uuid/skills` and `PATCH /api/v1/agents/:uuid/skills`
+ * back the web composer's slash-command popover. The PATCH endpoint is the
+ * upload entry point for the CLI daemon's local probe; GET is read by the
+ * web after the user `@mentions` the agent in the composer.
+ */
+describe("agents/:uuid/skills", () => {
+  const getApp = useTestApp();
+
+  const sampleSkill = {
+    name: "review",
+    description: "Pre-landing PR review",
+    source: "user" as const,
+  };
+
+  it("defaults to an empty list on a freshly-created agent", async () => {
+    const app = getApp();
+    const ctx = await createTestAgent(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ skills: [] });
+  });
+
+  it("PATCH replaces the full list (snapshot semantics, not merge)", async () => {
+    const app = getApp();
+    const ctx = await createTestAgent(app);
+
+    const first = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: { skills: [sampleSkill, { name: "ship", description: "Ship workflow", source: "user" }] },
+    });
+    expect(first.statusCode).toBe(204);
+
+    // Second write is a smaller snapshot — must replace, not merge.
+    const second = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: { skills: [sampleSkill] },
+    });
+    expect(second.statusCode).toBe(204);
+
+    const [row] = await app.db
+      .select({ skills: agents.skills })
+      .from(agents)
+      .where(eq(agents.uuid, ctx.agent.uuid))
+      .limit(1);
+    expect(row?.skills).toEqual([sampleSkill]);
+  });
+
+  it("rejects malformed payloads with 400", async () => {
+    const app = getApp();
+    const ctx = await createTestAgent(app);
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      // `source: "bogus"` is not in the enum.
+      payload: { skills: [{ name: "x", description: "y", source: "bogus" }] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("GET round-trips the namespace field for plugin skills", async () => {
+    const app = getApp();
+    const ctx = await createTestAgent(app);
+
+    await app.inject({
+      method: "PATCH",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: {
+        skills: [{ name: "gsap", namespace: "hyperframes", description: "GSAP animation reference", source: "plugin" }],
+      },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/agents/${ctx.agent.uuid}/skills`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      skills: [{ name: "gsap", namespace: "hyperframes", description: "GSAP animation reference", source: "plugin" }],
+    });
+  });
+});

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -202,8 +202,11 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
   // — the same scope that PATCHes runtime config and capabilities.
   //
   // The PATCH body replaces the list in full (snapshot semantics). The
-  // client-side `probeCapabilities()` hashes the local set and skips the
-  // request when nothing changed, so write-amplification is bounded.
+  // daemon uploads the full payload once per restart (see
+  // `apps/cli/src/commands/daemon/start.ts`) — no per-skill diff, no
+  // content-hash short-circuit yet. Restart cadence is low enough that
+  // write-amplification hasn't shown up; a hash check belongs on the
+  // client side if it ever does.
 
   app.get<{ Params: { uuid: string } }>("/:uuid/skills", async (request) => {
     await requireAgentAccess(request, app.db, "visible");

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -1,4 +1,9 @@
-import { agentPinnedMessageSchema, rebindAgentSchema, updateAgentSchema } from "@first-tree/shared";
+import {
+  agentPinnedMessageSchema,
+  rebindAgentSchema,
+  updateAgentSchema,
+  updateAgentSkillsSchema,
+} from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { BadRequestError, ForbiddenError } from "../errors.js";
 import { assertAllAgentsVisibleInOrg, requireAgentAccess } from "../scope/require-resource.js";
@@ -186,6 +191,30 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
   app.delete<{ Params: { uuid: string } }>("/:uuid/avatar", async (request, reply) => {
     await requireAgentAccess(request, app.db, "manage");
     await agentService.clearAgentAvatarImage(app.db, request.params.uuid);
+    return reply.status(204).send();
+  });
+
+  // ─── Skills (slash-command catalog) ─────────────────────────────────
+  //
+  // GET is `visible`: any chat member with line-of-sight to the agent can
+  // read its skill list to render the slash-command popover after they
+  // `@mention` it. PATCH is `manage`: only the manager's daemon may upload
+  // — the same scope that PATCHes runtime config and capabilities.
+  //
+  // The PATCH body replaces the list in full (snapshot semantics). The
+  // client-side `probeCapabilities()` hashes the local set and skips the
+  // request when nothing changed, so write-amplification is bounded.
+
+  app.get<{ Params: { uuid: string } }>("/:uuid/skills", async (request) => {
+    await requireAgentAccess(request, app.db, "visible");
+    const skills = await agentService.getAgentSkills(app.db, request.params.uuid);
+    return { skills };
+  });
+
+  app.patch<{ Params: { uuid: string } }>("/:uuid/skills", async (request, reply) => {
+    await requireAgentAccess(request, app.db, "manage");
+    const body = updateAgentSkillsSchema.parse(request.body);
+    await agentService.updateAgentSkills(app.db, request.params.uuid, body.skills);
     return reply.status(204).send();
   });
 

--- a/packages/server/src/db/schema/agents.ts
+++ b/packages/server/src/db/schema/agents.ts
@@ -79,6 +79,15 @@ export const agents = pgTable(
      * edit. NULL iff data is NULL.
      */
     avatarImageUpdatedAt: timestamp("avatar_image_updated_at", { withTimezone: true }),
+    /**
+     * Agent-reported skill (slash-command) list. Discovered by the daemon by
+     * scanning the agent runtime's skill directories (~/.claude/skills,
+     * <repo>/.claude/skills, plugin skill dirs) and uploaded via
+     * `PATCH /api/v1/agents/:uuid/skills`. Consumed by the web composer to
+     * render the `/`-triggered slash-command popover after the user
+     * @mentions this agent. Default `[]` keeps existing rows valid.
+     */
+    skills: jsonb("skills").$type<Array<Record<string, unknown>>>().notNull().default([]),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentSkills,
   AgentType,
   AgentVisibility,
   CreateAgent,
@@ -1088,6 +1089,43 @@ export async function clearAgentAvatarImage(db: Database, uuid: string): Promise
       avatarImageUpdatedAt: null,
       updatedAt: new Date(),
     })
+    .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .returning({ uuid: agents.uuid });
+  if (result.length === 0) {
+    throw new NotFoundError(`Agent "${uuid}" not found`);
+  }
+}
+
+/**
+ * Read the agent-reported slash-command skill list. Returns `[]` for agents
+ * whose daemon has not uploaded yet — the column is `NOT NULL DEFAULT '[]'`
+ * so this is a fast row read with no conditional logic.
+ */
+export async function getAgentSkills(db: Database, uuid: string): Promise<AgentSkills> {
+  const [row] = await db
+    .select({ skills: agents.skills })
+    .from(agents)
+    .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
+    .limit(1);
+  if (!row) {
+    throw new NotFoundError(`Agent "${uuid}" not found`);
+  }
+  // The DB column is typed as `Array<Record<string, unknown>>` in the schema
+  // (we keep the row loose so legacy fields don't break reads). Routes are
+  // expected to validate the payload with `agentSkillsSchema` on the way
+  // in, so the stored shape is trusted on the way out.
+  return row.skills as unknown as AgentSkills;
+}
+
+/**
+ * Replace the agent's full skill list. Daemon uploads the entire snapshot
+ * on every check-in (after a content-hash short-circuit on the client side
+ * to avoid no-op writes); we never merge per-skill.
+ */
+export async function updateAgentSkills(db: Database, uuid: string, skills: AgentSkills): Promise<void> {
+  const result = await db
+    .update(agents)
+    .set({ skills, updatedAt: new Date() })
     .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
     .returning({ uuid: agents.uuid });
   if (result.length === 0) {

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1118,9 +1118,11 @@ export async function getAgentSkills(db: Database, uuid: string): Promise<AgentS
 }
 
 /**
- * Replace the agent's full skill list. Daemon uploads the entire snapshot
- * on every check-in (after a content-hash short-circuit on the client side
- * to avoid no-op writes); we never merge per-skill.
+ * Replace the agent's full skill list. The daemon uploads the entire
+ * snapshot on every restart — no per-skill merge, no diff. Phase 1 keeps
+ * this unconditional (users restart daemons rarely); a future revision
+ * may persist the last-uploaded content hash in the agent's local yaml
+ * to skip no-op PATCHes if write-amplification ever shows up.
  */
 export async function updateAgentSkills(db: Database, uuid: string, skills: AgentSkills): Promise<void> {
   const result = await db

--- a/packages/shared/src/__tests__/skill-schema.test.ts
+++ b/packages/shared/src/__tests__/skill-schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { skillDescriptorSchema } from "../schemas/skill.js";
+
+describe("skillDescriptorSchema", () => {
+  const baseValid = { name: "review", description: "Pre-landing PR review", source: "user" as const };
+
+  it("accepts a well-formed descriptor", () => {
+    expect(skillDescriptorSchema.parse(baseValid)).toEqual(baseValid);
+  });
+
+  it("accepts a namespaced descriptor", () => {
+    const out = skillDescriptorSchema.parse({ ...baseValid, namespace: "hyperframes", name: "gsap" });
+    expect(out.namespace).toBe("hyperframes");
+  });
+
+  // Charset guard: schema MUST agree with `detectSlashTrigger`'s accept-set
+  // in the web composer (`[A-Za-z0-9_-]`). A schema-passing skill whose
+  // name contains spaces or `/` would be unreachable from the popover —
+  // the user would type the bad char and the trigger would close
+  // mid-query. Rejecting at schema is the only way to keep the contract
+  // single-source.
+  it("rejects a name containing whitespace", () => {
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, name: "weird name" })).toThrow(/A-Za-z0-9_-/);
+  });
+
+  it("rejects a name containing `/`", () => {
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, name: "foo/bar" })).toThrow(/A-Za-z0-9_-/);
+  });
+
+  it("rejects a name starting with `-` or `_`", () => {
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, name: "-foo" })).toThrow(/A-Za-z0-9_-/);
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, name: "_foo" })).toThrow(/A-Za-z0-9_-/);
+  });
+
+  it("applies the same charset to namespace", () => {
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, namespace: "bad ns" })).toThrow(/A-Za-z0-9_-/);
+  });
+
+  it("rejects an empty name", () => {
+    expect(() => skillDescriptorSchema.parse({ ...baseValid, name: "" })).toThrow();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -585,6 +585,17 @@ export {
   sessionReconcileResultSchema,
 } from "./schemas/session-reconcile.js";
 export {
+  type AgentSkills,
+  agentSkillsSchema,
+  SKILL_SOURCES,
+  type SkillDescriptor,
+  type SkillSource,
+  skillDescriptorSchema,
+  skillSourceSchema,
+  type UpdateAgentSkills,
+  updateAgentSkillsSchema,
+} from "./schemas/skill.js";
+export {
   type OrgStats,
   orgStatsSchema,
   type Stats,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -587,6 +587,7 @@ export {
 export {
   type AgentSkills,
   agentSkillsSchema,
+  SKILL_NAME_REGEX,
   SKILL_SOURCES,
   type SkillDescriptor,
   type SkillSource,

--- a/packages/shared/src/schemas/skill.ts
+++ b/packages/shared/src/schemas/skill.ts
@@ -11,6 +11,16 @@ export const skillSourceSchema = z.enum(["builtin", "user", "project", "plugin"]
 export type SkillSource = z.infer<typeof skillSourceSchema>;
 
 /**
+ * Charset for skill `name` / `namespace`. Must match the composer's
+ * `detectSlashTrigger` accept-set (`[A-Za-z0-9_-]`); otherwise a SKILL.md
+ * that declared `name: "weird thing"` would be uploadable but unreachable
+ * — the user would type `/weird` and the popover would close at the
+ * space. Keeping schema = composer accept-set makes the contract
+ * single-source.
+ */
+export const SKILL_NAME_REGEX = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+/**
  * Descriptor for a single agent skill (a.k.a. slash command) discovered by
  * the client. Mirrors the YAML frontmatter of a `SKILL.md` file plus a
  * source tag so the web UI can group / annotate. The recipe is intentionally
@@ -19,9 +29,17 @@ export type SkillSource = z.infer<typeof skillSourceSchema>;
  */
 export const skillDescriptorSchema = z.object({
   /** Skill name without leading slash. e.g. "review", "ship". */
-  name: z.string().min(1).max(120),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .regex(SKILL_NAME_REGEX, "Must start with alphanumeric and contain only [A-Za-z0-9_-]."),
   /** Optional plugin namespace; rendered as `<namespace>:<name>`. */
-  namespace: z.string().max(120).optional(),
+  namespace: z
+    .string()
+    .max(120)
+    .regex(SKILL_NAME_REGEX, "Must start with alphanumeric and contain only [A-Za-z0-9_-].")
+    .optional(),
   /** One-line description used as the popover subtitle. */
   description: z.string().max(2000),
   /** Where this skill came from — used for grouping/labelling in the UI. */

--- a/packages/shared/src/schemas/skill.ts
+++ b/packages/shared/src/schemas/skill.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const SKILL_SOURCES = {
+  BUILTIN: "builtin",
+  USER: "user",
+  PROJECT: "project",
+  PLUGIN: "plugin",
+} as const;
+
+export const skillSourceSchema = z.enum(["builtin", "user", "project", "plugin"]);
+export type SkillSource = z.infer<typeof skillSourceSchema>;
+
+/**
+ * Descriptor for a single agent skill (a.k.a. slash command) discovered by
+ * the client. Mirrors the YAML frontmatter of a `SKILL.md` file plus a
+ * source tag so the web UI can group / annotate. The recipe is intentionally
+ * minimal — the agent runtime owns execution; this row only carries what
+ * the UI needs to render the slash-command popover.
+ */
+export const skillDescriptorSchema = z.object({
+  /** Skill name without leading slash. e.g. "review", "ship". */
+  name: z.string().min(1).max(120),
+  /** Optional plugin namespace; rendered as `<namespace>:<name>`. */
+  namespace: z.string().max(120).optional(),
+  /** One-line description used as the popover subtitle. */
+  description: z.string().max(2000),
+  /** Where this skill came from — used for grouping/labelling in the UI. */
+  source: skillSourceSchema,
+});
+export type SkillDescriptor = z.infer<typeof skillDescriptorSchema>;
+
+export const agentSkillsSchema = z.array(skillDescriptorSchema).max(2000);
+export type AgentSkills = z.infer<typeof agentSkillsSchema>;
+
+export const updateAgentSkillsSchema = z.object({
+  skills: agentSkillsSchema,
+});
+export type UpdateAgentSkills = z.infer<typeof updateAgentSkillsSchema>;

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -1,4 +1,4 @@
-import type { Agent, CreateAgent, RebindAgent, UpdateAgent } from "@first-tree/shared";
+import type { Agent, AgentSkills, CreateAgent, RebindAgent, UpdateAgent } from "@first-tree/shared";
 import { ApiError, api, getStoredTokens, withOrg } from "./client.js";
 
 type PaginatedAgents = {
@@ -72,6 +72,16 @@ export function listManagedAgents(): Promise<ManagedAgent[]> {
 
 export function getAgent(uuid: string): Promise<Agent> {
   return api.get<Agent>(`/agents/${encodeURIComponent(uuid)}`);
+}
+
+/**
+ * Read the agent's slash-command catalog. Powers the composer's `/`
+ * popover after the caller `@mentions` the agent. Daemon refreshes this
+ * on startup via `PATCH /agents/:uuid/skills`; web cache is per-agent so
+ * switching `@mention` targets re-uses any already-fetched lists.
+ */
+export function getAgentSkills(uuid: string): Promise<{ skills: AgentSkills }> {
+  return api.get<{ skills: AgentSkills }>(`/agents/${encodeURIComponent(uuid)}/skills`);
 }
 
 export function createAgent(data: CreateAgent): Promise<Agent> {

--- a/packages/web/src/components/__tests__/slash-command-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/slash-command-autocomplete.test.ts
@@ -1,0 +1,141 @@
+import type { SkillDescriptor } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import {
+  buildSlashInsert,
+  detectSlashTrigger,
+  rankSlashCommands,
+  resolveMentionContext,
+  type SlashCommandItem,
+  type SlashSystemCommand,
+} from "../slash-command-autocomplete.js";
+
+function sysCmd(name: string, description = ""): SlashSystemCommand {
+  return { kind: "system", name, description };
+}
+
+function skillItem(name: string, namespace?: string): SlashCommandItem {
+  const skill: SkillDescriptor = {
+    name,
+    description: `desc ${name}`,
+    source: "user",
+    ...(namespace ? { namespace } : {}),
+  };
+  return { kind: "skill", skill, agentId: "agt-1", agentDisplayName: "Agent" };
+}
+
+describe("detectSlashTrigger", () => {
+  it("detects `/` at the very start of the buffer", () => {
+    expect(detectSlashTrigger("/re", 3)).toEqual({ triggerIndex: 0, query: "re" });
+  });
+
+  it("detects `/` after leading whitespace (tolerates indented composers)", () => {
+    expect(detectSlashTrigger("  /he", 5)).toEqual({ triggerIndex: 2, query: "he" });
+  });
+
+  it("does NOT trigger on mid-line `/` — slash commands are composer-mode", () => {
+    expect(detectSlashTrigger("hi /help", 8)).toBeNull();
+  });
+
+  it("does NOT trigger after a `@mention` followed by `/` — slash must be first non-ws char", () => {
+    expect(detectSlashTrigger("@reviewer /re", 13)).toBeNull();
+  });
+
+  it("returns empty query for a bare `/`", () => {
+    expect(detectSlashTrigger("/", 1)).toEqual({ triggerIndex: 0, query: "" });
+  });
+
+  it("rejects non-name chars in the query (closes the trigger)", () => {
+    expect(detectSlashTrigger("/foo bar", 8)).toBeNull();
+  });
+
+  it("accepts namespaced commands (`/plugin:name`)", () => {
+    expect(detectSlashTrigger("/hyperframes:gsap", 17)).toEqual({ triggerIndex: 0, query: "hyperframes:gsap" });
+  });
+});
+
+describe("resolveMentionContext", () => {
+  const participants = [
+    { agentId: "a", name: "alice", displayName: "Alice" },
+    { agentId: "b", name: "bob", displayName: "Bob" },
+  ];
+
+  it("picks the most recent mention before the cursor", () => {
+    const got = resolveMentionContext("@alice please. @bob /", 21, participants);
+    expect(got).toEqual({ agentId: "b", displayName: "Bob" });
+  });
+
+  it("ignores mentions after the cursor", () => {
+    const got = resolveMentionContext("@alice /  @bob", 8, participants);
+    expect(got).toEqual({ agentId: "a", displayName: "Alice" });
+  });
+
+  it("returns null when no @<name> resolves", () => {
+    expect(resolveMentionContext("hi /", 4, participants)).toBeNull();
+    expect(resolveMentionContext("@unknown /", 10, participants)).toBeNull();
+  });
+
+  it("falls back to display name when participant has no friendly label", () => {
+    const got = resolveMentionContext("@bob /", 6, [{ agentId: "b", name: "bob", displayName: null }]);
+    expect(got).toEqual({ agentId: "b", displayName: "bob" });
+  });
+});
+
+describe("rankSlashCommands", () => {
+  const items: SlashCommandItem[] = [
+    sysCmd("help"),
+    sysCmd("clear"),
+    skillItem("review"),
+    skillItem("ship"),
+    skillItem("gsap", "hyperframes"),
+  ];
+
+  it("filters by case-insensitive prefix first", () => {
+    const r = rankSlashCommands(items, "he");
+    expect(r.map((i) => (i.kind === "system" ? i.name : i.skill.name))).toEqual(["help"]);
+  });
+
+  it("prefers prefix matches over substring matches", () => {
+    const r = rankSlashCommands([sysCmd("score"), ...items], "re");
+    // `score` is a substring match ("re" inside "sCORe" — index 3); `review`
+    // is a prefix match. Prefix wins.
+    expect(r.map((i) => (i.kind === "system" ? i.name : i.skill.name))).toEqual(["review", "score"]);
+  });
+
+  it("system commands win ties with the same score", () => {
+    // Both `/clear` (system) and `/cli` (hypothetical) start with `cl`;
+    // here we just check the kind-tiebreaker via empty query.
+    const r = rankSlashCommands(items, "");
+    expect(r.filter((i) => i.kind === "system").length).toBe(2);
+    // System block sorts before skills in ties.
+    expect(r[0]?.kind).toBe("system");
+  });
+
+  it("matches namespaced commands via `namespace:name` key", () => {
+    const r = rankSlashCommands(items, "hyperframes:g");
+    expect(r.map((i) => (i.kind === "skill" ? i.skill.name : i.name))).toEqual(["gsap"]);
+  });
+});
+
+describe("buildSlashInsert", () => {
+  it("clears the textarea for system commands so they are not sent literally", () => {
+    const insert = buildSlashInsert("/he", { triggerIndex: 0, query: "he" }, 3, sysCmd("help"));
+    expect(insert).toEqual({ text: "", cursor: 0, kind: "system" });
+  });
+
+  it("replaces `/<query>` with `/<name> ` for a skill so the user can type args", () => {
+    const insert = buildSlashInsert("/re", { triggerIndex: 0, query: "re" }, 3, skillItem("review"));
+    expect(insert.text).toBe("/review ");
+    expect(insert.cursor).toBe("/review ".length);
+    expect(insert.kind).toBe("skill");
+  });
+
+  it("does not double-space when a space already follows the trigger", () => {
+    const insert = buildSlashInsert("/re foo", { triggerIndex: 0, query: "re" }, 3, skillItem("review"));
+    expect(insert.text).toBe("/review foo");
+  });
+
+  it("emits the namespaced literal for plugin skills", () => {
+    const insert = buildSlashInsert("/hy", { triggerIndex: 0, query: "hy" }, 3, skillItem("gsap", "hyperframes"));
+    expect(insert.text).toBe("/hyperframes:gsap ");
+  });
+});

--- a/packages/web/src/components/slash-command-autocomplete.tsx
+++ b/packages/web/src/components/slash-command-autocomplete.tsx
@@ -385,7 +385,11 @@ export function SlashCommandPopover({
               role="option"
               aria-selected={active}
               data-slash-index={i}
-              title={label}
+              // Hover discloses the full description — the visible subtitle
+              // truncates at 110 chars, so long Claude Code skills (some are
+              // multi-paragraph) need a way to reveal the rest without
+              // committing the pick first.
+              title={description}
               onMouseDown={(e) => {
                 e.preventDefault();
                 onPick(item);

--- a/packages/web/src/components/slash-command-autocomplete.tsx
+++ b/packages/web/src/components/slash-command-autocomplete.tsx
@@ -1,0 +1,411 @@
+import type { SkillDescriptor } from "@first-tree/shared";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "../lib/utils.js";
+
+/**
+ * `/`-triggered slash-command popover, mirrored on the `@mention`
+ * autocomplete shape. The composer owns the textarea + draft state; this
+ * module only computes the active query, ranks candidates, and reports
+ * keyboard intent back via `handleKey`.
+ *
+ * Two command kinds:
+ *   - "system" — interpreted client-side (e.g. `/help`, `/clear`).
+ *   - "skill"  — sent to the @mentioned agent verbatim; the agent's
+ *               harness routes it through its own Skill tool.
+ *
+ * Per the design contract (`tmp/first-tree-slash-commands/design.html`
+ * §5.1.1), the visible skill set follows the *current* @mention target.
+ * When no agent is mentioned, only system commands are shown — group
+ * chats require a mention to send anyway, so an unscoped skill list
+ * would be unusable.
+ */
+
+export type SlashSystemCommand = {
+  kind: "system";
+  /** Command name without leading slash. */
+  name: string;
+  description: string;
+};
+
+export type SlashSkillCommand = {
+  kind: "skill";
+  skill: SkillDescriptor;
+  /** Agent UUID this skill belongs to — needed by callers that want to
+   *  show "from @<agent>" affordances; we drop it on insert because the
+   *  caller already has the mention text in the draft. */
+  agentId: string;
+  /** Friendly agent label for the popover subtitle. */
+  agentDisplayName: string;
+};
+
+export type SlashCommandItem = SlashSystemCommand | SlashSkillCommand;
+
+type ActiveTrigger = {
+  /** Text index of the leading `/`. */
+  triggerIndex: number;
+  /** The substring between `/` and the cursor, already lowercased. */
+  query: string;
+};
+
+/**
+ * Locate the active `/<query>` trigger. The `/` opens a slash command
+ * iff it is the first char of the textarea (after optional leading
+ * whitespace) — composer-wide rather than mid-word — and the query
+ * accumulated since contains only command-name chars
+ * (`[A-Za-z0-9_:-]`, mirroring the SkillDescriptor name + namespace
+ * charset). Anything else (space, newline, punctuation) closes it.
+ *
+ * The "first-char only" rule is intentional. Slash commands are a
+ * composer mode, not a mid-message escape — Slack and Discord use the
+ * same convention. It also avoids the false positives a mid-line `/`
+ * would catch (URLs, paths, dates).
+ */
+export function detectSlashTrigger(text: string, cursor: number): ActiveTrigger | null {
+  if (cursor <= 0 || cursor > text.length) return null;
+
+  // The slash must be at the very start of the line — that is, after a
+  // run of any whitespace from position 0.
+  const head = text.slice(0, cursor);
+  const m = head.match(/^\s*\/([A-Za-z0-9_:-]*)$/);
+  if (!m) return null;
+
+  const triggerIndex = head.indexOf("/");
+  if (triggerIndex < 0) return null;
+  return { triggerIndex, query: (m[1] ?? "").toLowerCase() };
+}
+
+/**
+ * Resolve the agent that should own the slash-command scope given the
+ * current draft + cursor. Returns the *last* `@<name>` match strictly
+ * before the cursor (most recent intent wins), or null when no token
+ * resolves to a known participant. The set of "known participants" is
+ * the chat's mention candidate roster — same source the `@`
+ * autocomplete walks.
+ *
+ * Naming uses the agent slug (`name`), not the display name; matches
+ * the {@link MENTION_REGEX} contract in `@first-tree/shared/mentions`.
+ */
+export function resolveMentionContext(
+  draft: string,
+  cursor: number,
+  participants: Array<{ agentId: string; name: string | null; displayName: string | null }>,
+): { agentId: string; displayName: string } | null {
+  const byName = new Map<string, { agentId: string; displayName: string }>();
+  for (const p of participants) {
+    if (p.name) {
+      byName.set(p.name.toLowerCase(), {
+        agentId: p.agentId,
+        displayName: p.displayName ?? p.name,
+      });
+    }
+  }
+  if (byName.size === 0) return null;
+
+  // Mirror MENTION_REGEX from @first-tree/shared, but globally scanned
+  // over the slice strictly before the cursor. We could import the
+  // shared regex but its `g` flag carries state — a fresh local literal
+  // is simpler and the source-of-truth contract is the *charset*, not
+  // the binding.
+  const re = /(?<![A-Za-z0-9_.@-])@([A-Za-z0-9][A-Za-z0-9_-]{0,63})(?![A-Za-z0-9_/-])/g;
+  const head = draft.slice(0, cursor);
+  let lastMatch: { agentId: string; displayName: string } | null = null;
+  for (const m of head.matchAll(re)) {
+    const hit = byName.get((m[1] ?? "").toLowerCase());
+    if (hit) lastMatch = hit;
+  }
+  return lastMatch;
+}
+
+/** Score a single item against the typed query. */
+function scoreItem(item: SlashCommandItem, query: string): number {
+  const haystack = item.kind === "system" ? item.name : commandLabelKey(item.skill);
+  const lower = haystack.toLowerCase();
+  if (!query) return 0;
+  if (lower.startsWith(query)) return 0;
+  if (lower.includes(query)) return 1;
+  return Infinity;
+}
+
+/** Stable, namespace-aware label key used for matching + sorting. */
+function commandLabelKey(skill: SkillDescriptor): string {
+  return skill.namespace ? `${skill.namespace}:${skill.name}` : skill.name;
+}
+
+export function rankSlashCommands(items: SlashCommandItem[], query: string): SlashCommandItem[] {
+  const scored: Array<{ item: SlashCommandItem; score: number }> = [];
+  for (const item of items) {
+    const score = scoreItem(item, query);
+    if (score !== Infinity) scored.push({ item, score });
+  }
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return a.score - b.score;
+    // System commands win ties so the small, fixed set always sits at
+    // the top when both groups match.
+    if (a.item.kind !== b.item.kind) return a.item.kind === "system" ? -1 : 1;
+    const al = a.item.kind === "system" ? a.item.name : commandLabelKey(a.item.skill);
+    const bl = b.item.kind === "system" ? b.item.name : commandLabelKey(b.item.skill);
+    return al.localeCompare(bl);
+  });
+  return scored.slice(0, 20).map((s) => s.item);
+}
+
+type SlashInsert = {
+  text: string;
+  cursor: number;
+  /** Kind of the picked item, so the host can decide whether to
+   *  intercept (system) or just leave the literal in the textarea
+   *  (skill — sent on the next Enter). */
+  kind: SlashCommandItem["kind"];
+};
+
+/**
+ * Build the insertion tuple for a picked item. System commands are
+ * replaced with empty text (the host runs the action and clears the
+ * input). Skills replace `/<query>` with `/<name> ` so the user can
+ * keep typing arguments before hitting Enter.
+ */
+export function buildSlashInsert(
+  source: string,
+  trigger: ActiveTrigger,
+  cursor: number,
+  item: SlashCommandItem,
+): SlashInsert {
+  const before = source.slice(0, trigger.triggerIndex);
+  const after = source.slice(cursor);
+
+  if (item.kind === "system") {
+    // System commands are intercepted by the host — clearing the
+    // textarea on insert avoids the user accidentally sending the
+    // literal `/help` to the recipient when the action fires.
+    return { text: "", cursor: 0, kind: "system" };
+  }
+
+  const literal = `/${commandLabelKey(item.skill)}`;
+  const needsSpace = after.length === 0 || !/\s/.test(after[0] ?? "");
+  const tail = needsSpace ? ` ${after}` : after;
+  const text = `${before}${literal}${tail}`;
+  const cursorOut = before.length + literal.length + (needsSpace ? 1 : 0);
+  return { text, cursor: cursorOut, kind: "skill" };
+}
+
+export type SlashKeyHandler = (e: { key: string; preventDefault: () => void }) => boolean;
+
+export function useSlashCommand({
+  value,
+  cursor,
+  systemCommands,
+  agentSkills,
+  mentionedAgent,
+  onSelect,
+  disabled,
+}: {
+  value: string;
+  cursor: number;
+  systemCommands: SlashSystemCommand[];
+  /** Skills for the currently @-mentioned agent. Pass `null` when no
+   *  agent is in scope (e.g. group chat without a recipient picked); the
+   *  popover then shows only system commands. */
+  agentSkills: { agentId: string; agentDisplayName: string; skills: SkillDescriptor[] } | null;
+  /** Used only for keyed memoisation — the agent ref the popover should
+   *  re-rank when the @mention target flips. Pass `null` for "no
+   *  mention". Identical to `agentSkills.agentId` when skills are
+   *  loaded; supplied separately so a loading state still resets the
+   *  highlight on switch. */
+  mentionedAgent: { agentId: string; displayName: string } | null;
+  onSelect: (update: SlashInsert, picked: SlashCommandItem) => void;
+  disabled?: boolean;
+}): {
+  trigger: ActiveTrigger | null;
+  results: SlashCommandItem[];
+  highlightIndex: number;
+  mentionedAgent: { agentId: string; displayName: string } | null;
+  handleKey: SlashKeyHandler;
+  pick: (item: SlashCommandItem) => void;
+  dismiss: () => void;
+} {
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+
+  const trigger = useMemo(() => {
+    if (disabled) return null;
+    return detectSlashTrigger(value, cursor);
+  }, [value, cursor, disabled]);
+
+  const items = useMemo<SlashCommandItem[]>(() => {
+    const out: SlashCommandItem[] = [...systemCommands];
+    if (agentSkills) {
+      for (const skill of agentSkills.skills) {
+        out.push({
+          kind: "skill",
+          skill,
+          agentId: agentSkills.agentId,
+          agentDisplayName: agentSkills.agentDisplayName,
+        });
+      }
+    }
+    return out;
+  }, [systemCommands, agentSkills]);
+
+  const results = useMemo(() => (trigger ? rankSlashCommands(items, trigger.query) : []), [trigger, items]);
+
+  // Reset highlight on trigger / mention switch — re-ranking can move
+  // the previously-active row out from under the highlight.
+  const resetKey = trigger ? `${trigger.triggerIndex}:${trigger.query}:${mentionedAgent?.agentId ?? ""}` : "";
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey IS the dep.
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [resetKey]);
+
+  useEffect(() => {
+    if (trigger === null && dismissedAt !== null) setDismissedAt(null);
+  }, [trigger, dismissedAt]);
+
+  const dismissed = dismissedAt !== null && trigger !== null && dismissedAt === trigger.triggerIndex;
+  const open = trigger !== null && results.length > 0 && !dismissed;
+
+  function dismiss() {
+    setDismissedAt(trigger?.triggerIndex ?? null);
+  }
+
+  function pick(item: SlashCommandItem) {
+    if (!trigger) return;
+    const insert = buildSlashInsert(value, trigger, cursor, item);
+    onSelect(insert, item);
+  }
+
+  const handleKey: SlashKeyHandler = (e) => {
+    if (!open || !trigger) return false;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightIndex((i) => (results.length === 0 ? 0 : (i + 1) % results.length));
+      return true;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightIndex((i) => (results.length === 0 ? 0 : (i - 1 + results.length) % results.length));
+      return true;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      const picked = results[highlightIndex] ?? results[0];
+      if (!picked) return false;
+      e.preventDefault();
+      pick(picked);
+      return true;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      dismiss();
+      return true;
+    }
+    return false;
+  };
+
+  return {
+    trigger: open ? trigger : null,
+    results: open ? results : [],
+    highlightIndex,
+    mentionedAgent,
+    handleKey,
+    pick,
+    dismiss,
+  };
+}
+
+export function SlashCommandPopover({
+  trigger,
+  results,
+  highlightIndex,
+  mentionedAgent,
+  onPick,
+  anchorRef,
+}: {
+  trigger: ActiveTrigger | null;
+  results: SlashCommandItem[];
+  highlightIndex: number;
+  mentionedAgent: { agentId: string; displayName: string } | null;
+  onPick: (item: SlashCommandItem) => void;
+  anchorRef: { current: HTMLTextAreaElement | null };
+}) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = popoverRef.current?.querySelector<HTMLElement>(`[data-slash-index="${highlightIndex}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex]);
+
+  if (!trigger || results.length === 0) return null;
+  const anchor = anchorRef.current;
+  if (!anchor) return null;
+
+  // Group rows for visual separation — system block, then skills.
+  let lastKind: SlashCommandItem["kind"] | null = null;
+
+  return (
+    <div
+      ref={popoverRef}
+      role="listbox"
+      aria-label="Slash command suggestions"
+      className={cn("absolute z-20 max-h-72 overflow-auto rounded-md border shadow-lg")}
+      style={{
+        bottom: "calc(100% + var(--sp-1))",
+        left: 0,
+        minWidth: 280,
+        maxWidth: 420,
+        background: "var(--bg-raised)",
+        borderColor: "var(--border)",
+      }}
+    >
+      {results.map((item, i) => {
+        const headerEl =
+          item.kind !== lastKind ? (
+            <div
+              key={`hdr-${item.kind}`}
+              className="px-3 py-1 text-caption mono uppercase"
+              style={{ color: "var(--fg-4)" }}
+            >
+              {item.kind === "system" ? "System" : mentionedAgent ? `@${mentionedAgent.displayName}` : "Skills"}
+            </div>
+          ) : null;
+        lastKind = item.kind;
+
+        const active = i === highlightIndex;
+        const label = item.kind === "system" ? `/${item.name}` : `/${commandLabelKey(item.skill)}`;
+        const description = item.kind === "system" ? item.description : item.skill.description;
+
+        return (
+          // `label` is unique within a single popover render because we
+          // dedupe by `<kind>:<name(:namespace)>` upstream — slash command
+          // names cannot collide across the system/skill split (system
+          // names are a hand-curated allowlist) and within skills the
+          // server already enforces uniqueness per agent.
+          <div key={`${item.kind}-${label}`}>
+            {headerEl}
+            <button
+              type="button"
+              role="option"
+              aria-selected={active}
+              data-slash-index={i}
+              title={label}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onPick(item);
+              }}
+              className="flex w-full flex-col items-start gap-0.5 px-3 py-1.5 text-left"
+              style={{
+                background: active ? "var(--bg-hover)" : "transparent",
+                color: "var(--fg)",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              <span className="mono font-medium text-body">{label}</span>
+              <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+                {description.length > 110 ? `${description.slice(0, 110)}…` : description}
+              </span>
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -35,6 +35,7 @@ import {
 import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
 import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../../api/agent-status.js";
+import { getAgentSkills } from "../../../api/agents.js";
 import {
   type FileMessageContent,
   getChat,
@@ -83,6 +84,12 @@ import {
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { NewMessagesPill } from "../../../components/new-messages-pill.js";
+import {
+  resolveMentionContext,
+  SlashCommandPopover,
+  type SlashSystemCommand,
+  useSlashCommand,
+} from "../../../components/slash-command-autocomplete.js";
 import { Button } from "../../../components/ui/button.js";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { StatusGlyph } from "../../../components/ui/status-glyph.js";
@@ -2180,6 +2187,86 @@ export function ChatView({
     },
   });
 
+  /**
+   * Slash-command setup. Per the design contract (`/ for commands` in the
+   * placeholder), the popover follows the @mention context:
+   *   - explicit @mention in the draft wins (most recent before cursor)
+   *   - 1-on-1 chats (no required @) fall back to the sole other speaker
+   *     so `/<cmd>` works without typing `@` first
+   *   - group chats with no resolved @ show only system commands
+   */
+  const slashMentionContext = useMemo<{ agentId: string; displayName: string } | null>(() => {
+    const explicit = resolveMentionContext(draft, cursor, mentionCandidates);
+    if (explicit) return explicit;
+    if (!requiresMention && mentionCandidates.length === 1) {
+      const c = mentionCandidates[0];
+      if (!c) return null;
+      return { agentId: c.agentId, displayName: c.displayName ?? c.name ?? c.agentId };
+    }
+    return null;
+  }, [draft, cursor, mentionCandidates, requiresMention]);
+
+  // Phase 1C ships with a single in-product system command (`/clear`).
+  // The four-command roadmap from the design doc (`/help`, `/me`,
+  // `/invite`) needs its own UX surfaces (modals + invite flow), so it's
+  // deferred to keep this PR scoped to the popover wiring. The
+  // useSlashCommand hook expects an array, not an opinionated set —
+  // adding the others is a one-line append once their actions exist.
+  const slashSystemCommands = useMemo<SlashSystemCommand[]>(
+    () => [{ kind: "system", name: "clear", description: "Clear the message draft" }],
+    [],
+  );
+
+  const { data: slashSkillsData } = useQuery({
+    queryKey: ["agent-skills", slashMentionContext?.agentId ?? null],
+    queryFn: () => {
+      const id = slashMentionContext?.agentId;
+      if (!id) return Promise.resolve({ skills: [] });
+      return getAgentSkills(id);
+    },
+    // Only fetch when we actually have a scope. Re-fetching on every
+    // keystroke would amplify the GET — staleTime keeps the result for
+    // a minute, which matches the daemon's "upload at start" cadence.
+    enabled: Boolean(slashMentionContext?.agentId),
+    staleTime: 60_000,
+  });
+
+  const slash = useSlashCommand({
+    value: draft,
+    cursor,
+    systemCommands: slashSystemCommands,
+    agentSkills: slashMentionContext
+      ? {
+          agentId: slashMentionContext.agentId,
+          agentDisplayName: slashMentionContext.displayName,
+          skills: slashSkillsData?.skills ?? [],
+        }
+      : null,
+    mentionedAgent: slashMentionContext,
+    disabled: sendMut.isPending || uploading,
+    onSelect: (update, picked) => {
+      setDraft(update.text);
+      setCursor(update.cursor);
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(update.cursor, update.cursor);
+      });
+      if (picked.kind === "system") {
+        switch (picked.name) {
+          case "clear":
+            // `buildSlashInsert` already cleared the textarea content;
+            // nothing else to do for v1.
+            break;
+        }
+      }
+      // Skill picks are not intercepted — the literal `/<name> ` is
+      // already in the textarea so the user can append arguments and
+      // send. The agent's harness routes the slash on receipt.
+    },
+  });
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Chat body: left column owns header + timeline + composer; right
@@ -2755,6 +2842,14 @@ export function ChatView({
                         anchorRef={textareaRef}
                         onPick={mention.pick}
                       />
+                      <SlashCommandPopover
+                        trigger={slash.trigger}
+                        results={slash.results}
+                        highlightIndex={slash.highlightIndex}
+                        mentionedAgent={slash.mentionedAgent}
+                        anchorRef={textareaRef}
+                        onPick={slash.pick}
+                      />
                       <textarea
                         ref={textareaRef}
                         value={draft}
@@ -2809,6 +2904,11 @@ export function ChatView({
                           // Skip while an IME is composing so Enter confirms the
                           // candidate instead of sending / picking a mention.
                           if (e.nativeEvent.isComposing) return;
+                          // Slash command popover handles navigation keys when active.
+                          // Sits before mention so `/`-typed draft never falls through to
+                          // mention-autocomplete (the trigger predicates are disjoint, but
+                          // ordering documents intent).
+                          if (slash.handleKey(e)) return;
                           // Mention autocomplete gets first crack at navigation keys so
                           // ArrowUp/Down/Enter/Tab/Escape cycle candidates instead of
                           // sending or moving the cursor.


### PR DESCRIPTION
> Re-opened from #581 after branch rename `feature/slash-commands` → `feat/slash-commands` (CI's `Check Branch Name` job requires the `feat/` prefix). No code changes since the previous PR's last push (`1ebe0dfa`). Carries over @baixiaohang's approve from the prior thread — see https://github.com/agent-team-foundation/first-tree/pull/581 for the full review history.

## Summary

End-to-end slash-command pipeline: type `/` after `@mention`ing an agent in the composer to pick from that agent's available skills (the same skills Claude Code surfaces via its Skill tool).

- **Data layer**: `agents.skills jsonb NOT NULL DEFAULT '[]'`; new `GET/PATCH /api/v1/agents/:uuid/skills` (visible/manage scope), `SkillDescriptor` Zod schema in `@first-tree/shared`.
- **Daemon**: scans `~/.claude/skills/*/SKILL.md` + `~/.claude/plugins/<plugin>/skills/*/SKILL.md`, parses YAML frontmatter, uploads via PATCH on every daemon start (snapshot semantics; codex/human agents skipped). Failures log + continue — never blocks startup.
- **Web composer**: `useSlashCommand` hook + `SlashCommandPopover` (mirrors `useMentionAutocomplete` shape). `/` triggers only at start of message (composer-mode). Skill list follows the **most recent `@mention` before the cursor**; 1-on-1 chats fall back to the sole speaker so `/` works without `@`. v1 ships one system command (`/clear`); `/help|/me|/invite` deferred pending UX surfaces.

## Test plan

- [x] `pnpm typecheck` — shared / server / client / cli / web all clean
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — all suites green (shared / server / client / cli / web)
- [x] Live E2E against firsttreehub dev DB: real `discoverClaudeCodeSkills` against `\$HOME/.claude/skills` (42 skills) → real `uploadAgentSkills` PATCH → GET round-trip identity verified
- [x] Browser smoke via `/login` dev-callback as `devuser` against group chat with seeded skills on `reviewer-bot` / `planner-bot`
- [x] **Slash-routing spike** (closes #584 routing half): direct SDK probe confirms `[From: alice]\n\n/review` correctly invokes Skill tool — First Tree's `formatInboundContent` prefix is actually *necessary* for routing (bare `/review` falls through to Bash). See https://github.com/agent-team-foundation/first-tree/issues/584#issuecomment-4550740472.

## Migration / DB changes ⚠️

Adds one column. Non-destructive — PG 11+ does this as a metadata-only ALTER (no table rewrite). `IF NOT EXISTS` for idempotency.

```sql
ALTER TABLE "agents" ADD COLUMN IF NOT EXISTS "skills" jsonb NOT NULL DEFAULT '[]'::jsonb;
```

## Follow-up issues

- #583 — bump `description.max` 2000 → 8000, lower `agentSkillsSchema.max` 2000 → 200, add explicit `bodyLimit` on the PATCH route
- #584 — skill-set sync invariant (routing half resolved by spike; sandbox-isolation half deferred to first real deploy boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)