### PR TITLE
feat(computers): server-side soft dedup + 30-day orphan archival + CLI redirect protocol

### DIFF
--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,22 +1,80 @@
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { defaultConfigDir } from "@first-tree/shared/config";
+import { select } from "@inquirer/prompts";
 import type { Command } from "commander";
 import { getClientServiceStatus, isServiceSupported, stopClientService } from "../core/index.js";
 import { print } from "../core/output.js";
 
 /**
+ * Two-step confirmation prompt before `--purge` wipes `client.yaml`. The
+ * operator commonly types `logout` by muscle memory; a quiet `--purge` flag
+ * pushed onto the end (or pasted from a runbook) would silently destroy the
+ * machine's identity. This prompt forces a deliberate selection.
+ *
+ * Non-TTY guard: `select` from `@inquirer/prompts` hangs forever when stdin
+ * is not a TTY (systemd ExecStart, cron, CI, piped). Detect that case and
+ * refuse with a clear message pointing at `--yes`. Exits the process with
+ * code 1 so a caller script sees the failure rather than waiting for input
+ * that will never come.
+ *
+ * Returns `true` if the operator confirmed purge, `false` if they cancelled.
+ * Exported for testing — the prompt is otherwise impossible to drive from
+ * a unit test without mocking `@inquirer/prompts` directly.
+ */
+export async function confirmPurge(): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    print.line("\n  ✗ --purge requires interactive confirmation, but stdin is not a TTY.\n");
+    print.line("    Re-run with --yes to skip the prompt (only if you've confirmed the consequences).\n\n");
+    process.exit(1);
+  }
+  print.line("\n  ⚠️  --purge will permanently remove this computer's identity (client.yaml).\n");
+  print.line("     Next `first-tree login` will register a brand-new computer row on the Hub.\n");
+  print.line("     The existing row will become an orphan until the server's dedup merges it back\n");
+  print.line("     (only if the same user reconnects from the same hostname + OS).\n\n");
+  const choice = await select<"purge" | "cancel">({
+    message: "How would you like to continue?",
+    choices: [
+      { name: "Cancel — keep client.yaml", value: "cancel" },
+      { name: "Purge — I want to lose this computer's identity", value: "purge" },
+    ],
+  });
+  return choice === "purge";
+}
+
+/**
  * `first-tree logout` — symmetric counterpart to `login`. Stops the
  * background daemon and removes persisted credentials. `client.yaml` is
  * kept by default (it carries harmless config like `server.url` and the
- * stable `client.id`); `--purge` opts in to wiping that too.
+ * stable `client.id`); `--purge` opts in to wiping that too, after a
+ * two-step confirmation to protect against muscle-memory mistakes.
  */
 export function registerLogoutCommand(program: Command): void {
   program
     .command("logout")
     .description("Disconnect from the Hub — stop daemon and clear credentials (symmetric to `login`)")
     .option("--purge", "Also remove client.yaml (server.url etc.); default keeps it")
-    .action((options: { purge?: boolean }) => {
+    .option("--yes", "Skip the interactive --purge confirmation (required in non-TTY environments)")
+    .action(async (options: { purge?: boolean; yes?: boolean }) => {
+      // 0. --purge guardrail: explicit confirmation unless --yes is set.
+      // Done BEFORE stopping the daemon so a cancel leaves the install in
+      // exactly the state we found it.
+      if (options.purge && !options.yes) {
+        try {
+          const confirmed = await confirmPurge();
+          if (!confirmed) {
+            print.line("\n  Cancelled. client.yaml retained.\n\n");
+            return;
+          }
+        } catch (err) {
+          // Inquirer throws `ExitPromptError` on Ctrl+C — same UX as cancel.
+          if ((err as { name?: string }).name === "ExitPromptError") {
+            print.line("\n  Cancelled. client.yaml retained.\n\n");
+            return;
+          }
+          throw err;
+        }
+      }
       // 1. Stop daemon (best-effort).
       if (isServiceSupported()) {
         const svc = getClientServiceStatus();

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -14,7 +14,13 @@ import {
 } from "@first-tree/client";
 import type { AgentPinnedMessage } from "@first-tree/shared";
 import type { AgentConfig } from "@first-tree/shared/config";
-import { agentConfigSchema, defaultDataDir, loadAgents } from "@first-tree/shared/config";
+import {
+  agentConfigSchema,
+  defaultConfigDir,
+  defaultDataDir,
+  loadAgents,
+  setConfigValue,
+} from "@first-tree/shared/config";
 import { stringify as stringifyYaml } from "yaml";
 import { ensureFreshAccessToken } from "./bootstrap.js";
 import { print } from "./output.js";
@@ -139,6 +145,17 @@ export class ClientRuntime {
     this.connection.on("agent:pinned", (message) => {
       this.handleAgentPinned(message);
     });
+
+    // Soft-dedup redirect: the server merged our local clientId into an
+    // existing canonical `(user, host, os)` row. Persist the canonical id
+    // to yaml + cleanly shut down so the supervisor restarts us under the
+    // new identity. queueMicrotask defers off the WS-event-handler frame so
+    // the close handler and any in-flight cleanup can settle first.
+    this.connection.on("client:redirect", (canonicalId) => {
+      queueMicrotask(() => {
+        void this.handleClientRedirect(canonicalId);
+      });
+    });
   }
 
   addAgent(name: string, config: AgentConfig): void {
@@ -260,6 +277,64 @@ export class ClientRuntime {
     this.updateManager = null;
     await Promise.allSettled(this.agents.map((a) => a.slot.stop()));
     await this.connection.disconnect();
+  }
+
+  /**
+   * Soft-dedup redirect handler. Persists the canonical clientId to
+   * `client.yaml` and exits cleanly so the supervisor (systemd/launchd)
+   * restarts the process under the canonical identity.
+   *
+   * Why exit-and-restart instead of in-process re-attach:
+   * `ClientConnection.clientId` is readonly — a soft-dedup redirect
+   * literally changes the identity this process speaks for. Re-attaching
+   * in place would require re-running login bootstrap, re-acquiring git
+   * mirror handles, and reconciling agent slots. The exit path reuses
+   * the bootstrap we already trust.
+   *
+   * Failure mode: if `setConfigValue` throws (disk full, EACCES, read-
+   * only FS), the process exits with TEMPFAIL (75) so the supervisor
+   * applies its backoff instead of looping at 1Hz. Silently swallowing
+   * the failure would re-trigger the redirect on every restart and
+   * never make progress.
+   *
+   * `protected` for testability: a subclass can override and capture
+   * the canonicalId without actually writing yaml / exiting.
+   */
+  protected async handleClientRedirect(canonicalId: string): Promise<void> {
+    const yamlPath = join(defaultConfigDir(), "client.yaml");
+    try {
+      setConfigValue(yamlPath, "client.id", canonicalId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.check(false, "failed to persist canonical client id to yaml", msg);
+      print.status("", "Recovery: ensure the config directory is writable, then re-run the command.");
+      await this.stop().catch(() => {});
+      process.exit(75);
+    }
+
+    print.status("✓", `merged with existing computer record on this hub (id: ${canonicalId})`);
+    print.status("", "restarting to pick up the new identity...");
+
+    // Graceful shutdown — same path SIGINT triggers in login.ts. Without
+    // this, agent.slot.stop() never fires and git mirror worktree refs
+    // could leak. Bounded by a hard timeout so a wedged handler (e.g.,
+    // an agent subprocess ignoring SIGTERM) cannot trap us in the stale
+    // identity forever: after the timeout the supervisor restart wins.
+    const STOP_TIMEOUT_MS = 10_000;
+    const stopWithTimeout = Promise.race([
+      this.stop().catch((err) => {
+        print.status("⚠️", `runtime.stop() during redirect threw: ${err instanceof Error ? err.message : String(err)}`);
+      }),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => {
+          print.status("⚠️", `runtime.stop() exceeded ${STOP_TIMEOUT_MS}ms during redirect — forcing exit`);
+          resolve("timeout");
+        }, STOP_TIMEOUT_MS),
+      ),
+    ]);
+    await stopWithTimeout;
+
+    process.exit(0);
   }
 
   private aggregateQuietGate(): { activeCount: number; lastActivityMs: number } {

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -135,6 +135,15 @@ type ClientConnectionEvents = {
    */
   "auth:fatal": [error: Error];
   "server:welcome": [welcome: ServerWelcome];
+  /**
+   * Server soft-dedupped this register into a canonical clientId that
+   * differs from the local one. The consumer should persist the new id
+   * to yaml, dispose this `ClientConnection`, and either spawn a fresh
+   * one with the canonical id or exit cleanly so a supervisor restarts.
+   * The current connection has already set `closing = true` and the WS
+   * has been closed — reconnection is suppressed.
+   */
+  "client:redirect": [canonicalClientId: string];
 };
 
 /**
@@ -164,6 +173,26 @@ export class ClientUserMismatchError extends Error {
   constructor(message = "Client belongs to a different user") {
     super(message);
     this.name = "ClientUserMismatchError";
+  }
+}
+
+/**
+ * Thrown when the server refuses `client:register` because the
+ * `(user_id, hostname, os)` canonical row is currently held by a
+ * different live socket. The dedup soft-merge would silently steal the
+ * canonical slot from the live CLI, so the server refuses instead.
+ *
+ * Recovery is automatic: the CLI's reconnect backoff will retry, and
+ * once the live CLI disconnects the dedup succeeds. No operator action
+ * required — emitted on the connection's `error` event so the CLI logs
+ * the cause but does NOT exit on this code (distinct from
+ * `auth:fatal`).
+ */
+export class ClientDedupConflictError extends Error {
+  readonly code = "CLIENT_DEDUP_CONFLICT";
+  constructor(message = "Another client holds the canonical row for this machine") {
+    super(message);
+    this.name = "ClientDedupConflictError";
   }
 }
 
@@ -757,18 +786,21 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     if (type === "client:register:rejected") {
       const code = typeof msg.code === "string" ? msg.code : undefined;
       const message = typeof msg.message === "string" ? msg.message : "unknown";
-      // Mark closing so the WS `close` handler does not auto-reconnect — a
-      // reconnect with the same clientId would just re-trigger the rejection.
-      // The caller (CLI) is expected to surface the mismatch to the user,
-      // abandon the local clientId, and start a fresh connection with a new
-      // one. See first-tree-context:agent-hub/multi-tenancy.md (B4).
-      this.closing = true;
+      const isDedupConflict = code === "CLIENT_DEDUP_CONFLICT";
+      // CLIENT_DEDUP_CONFLICT is *transient* — another live CLI holds the
+      // canonical row right now; backoff and retry will succeed once that
+      // CLI disconnects. Don't mark `closing = true` for this code so the
+      // reconnect loop kicks in. All other rejections (USER/ORG mismatch,
+      // generic) are terminal — the same clientId would re-trigger them.
+      if (!isDedupConflict) this.closing = true;
       const err =
         code === "CLIENT_USER_MISMATCH"
           ? new ClientUserMismatchError(message)
           : code === "CLIENT_ORG_MISMATCH"
             ? new ClientOrgMismatchError(message)
-            : new Error(`client:register rejected: ${message}`);
+            : code === "CLIENT_DEDUP_CONFLICT"
+              ? new ClientDedupConflictError(message)
+              : new Error(`client:register rejected: ${message}`);
       this.lastHandshakeError = err;
       this.wsLogger.error({ code, message }, "client register rejected");
       this.emit("error", err);
@@ -777,6 +809,24 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
 
     if (type === "client:registered") {
+      // Soft-dedup redirect: server returned a canonical id that differs
+      // from ours, meaning a `(user_id, hostname, os)` row already exists
+      // and our local clientId was merged into it. Persist the new id +
+      // bounce out — reconnect is suppressed (the canonical id is
+      // server-side truth; reconnecting with our stale local id would
+      // just trigger the same redirect every cycle).
+      const responseClientId = typeof msg.clientId === "string" ? msg.clientId : null;
+      if (responseClientId && responseClientId !== this.clientId) {
+        this.wsLogger.info(
+          { local: this.clientId, canonical: responseClientId },
+          "server soft-dedup redirect — clientId reassigned",
+        );
+        this.closing = true;
+        this.emit("client:redirect", responseClientId);
+        this.ws?.close(1000, "client redirect");
+        return;
+      }
+
       const isReconnect = this.boundAgents.size > 0 || this.desiredBindings.size > 0;
       this.registered = true;
       // Application-layer success — only now is it safe to reset the backoff

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -187,6 +187,11 @@ export class ClientUserMismatchError extends Error {
  * required — emitted on the connection's `error` event so the CLI logs
  * the cause but does NOT exit on this code (distinct from
  * `auth:fatal`).
+ *
+ * Mirror of the server-side class:
+ * `packages/server/src/services/client.ts::ClientDedupConflictError`.
+ * Both carry the same `code = "CLIENT_DEDUP_CONFLICT"` wire constant.
+ * Update both when changing the protocol code.
  */
 export class ClientDedupConflictError extends Error {
   readonly code = "CLIENT_DEDUP_CONFLICT";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,7 +4,12 @@ export type {
   ServerWelcome,
   SessionCommand,
 } from "./client-connection.js";
-export { ClientConnection, ClientOrgMismatchError, ClientUserMismatchError } from "./client-connection.js";
+export {
+  ClientConnection,
+  ClientDedupConflictError,
+  ClientOrgMismatchError,
+  ClientUserMismatchError,
+} from "./client-connection.js";
 // Handlers
 export { registerBuiltinHandlers } from "./handlers/index.js";
 export {

--- a/packages/server/drizzle/0051_clients_archived_at.sql
+++ b/packages/server/drizzle/0051_clients_archived_at.sql
@@ -1,0 +1,22 @@
+-- Soft-delete column for orphan-row archival.
+--
+-- - NULL → active row; surfaces in all read paths
+--   (/me/clients, /orgs/:orgId/clients, GET /clients/:id, agent:bind joins).
+-- - non-NULL → archived; excluded from read paths but the row stays for
+--   audit / recovery. Set by the hourly archiveAbandonedClients sweep when
+--   (status='disconnected', last_seen_at > 30d ago, zero pinned agents)
+--   all hold. Cleared on reconnect by registerClient's same-id upsert.
+--
+-- Partial index idx_clients_sweep supports the sweep's WHERE clause:
+-- (status, last_seen_at) leading keys line up with the equality + range
+-- predicates; the `archived_at IS NULL` partial keeps the index lean as
+-- archived rows accumulate.
+
+-- Idempotent variants of ADD COLUMN / CREATE INDEX so the migration is
+-- safe to re-apply on a DB where a partial of this change ran out-of-band
+-- (e.g., manual schema repair). Drizzle's `__drizzle_migrations` table
+-- already gates re-application; these guards are defense in depth.
+
+ALTER TABLE "clients" ADD COLUMN IF NOT EXISTS "archived_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_clients_sweep" ON "clients" USING btree ("status","last_seen_at") WHERE archived_at IS NULL;

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0050_agent_skills
+0051_clients_archived_at

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1780358400000,
       "tag": "0050_agent_skills",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1780444800000,
+      "tag": "0051_clients_archived_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/client-archival.test.ts
+++ b/packages/server/src/__tests__/client-archival.test.ts
@@ -1,0 +1,183 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { createAgent } from "../services/agent.js";
+import { archiveAbandonedClients, listClients } from "../services/client.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Orphan-row archival tests for `archiveAbandonedClients` + the read-path
+ * filters that consume `archived_at`.
+ *
+ * The sweep archives a `clients` row when ALL of:
+ *   - status = 'disconnected'
+ *   - last_seen_at < NOW() - 30 days
+ *   - zero non-deleted agents pinned
+ *   - archived_at IS NULL (idempotency guard)
+ *
+ * 30 days is the locked-in product decision (2026-05-27). Tests pin the
+ * threshold by manipulating `last_seen_at` to either side of the cutoff.
+ */
+describe("archiveAbandonedClients — sweep", () => {
+  const getApp = useTestApp();
+
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  it("archives a disconnected row with no agents and last_seen > 30 days ago", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `arch-${crypto.randomUUID().slice(0, 8)}` });
+
+    const oldId = `cli-old-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: oldId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 31 * DAY_MS),
+    });
+
+    const archived = await archiveAbandonedClients(app.db);
+    expect(archived).toBeGreaterThanOrEqual(1);
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, oldId)).limit(1);
+    expect(row?.archivedAt).not.toBeNull();
+  });
+
+  it("does NOT archive a row that's only 29 days old (boundary)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `boundary-${crypto.randomUUID().slice(0, 8)}` });
+
+    const id = `cli-young-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 29 * DAY_MS),
+    });
+
+    await archiveAbandonedClients(app.db);
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, id)).limit(1);
+    expect(row?.archivedAt).toBeNull();
+  });
+
+  it("does NOT archive a connected row even if last_seen is ancient (status guard)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `conn-${crypto.randomUUID().slice(0, 8)}` });
+
+    const id = `cli-conn-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "connected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 365 * DAY_MS),
+    });
+
+    await archiveAbandonedClients(app.db);
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, id)).limit(1);
+    expect(row?.archivedAt).toBeNull();
+  });
+
+  it("does NOT archive a row with pinned agents even if it's stale", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `pinned-${crypto.randomUUID().slice(0, 8)}` });
+
+    const id = `cli-pinned-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 365 * DAY_MS),
+    });
+    const [adminMember] = await app.db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.userId, admin.userId))
+      .limit(1);
+    if (!adminMember) throw new Error("admin member missing");
+    await createAgent(app.db, {
+      name: `pinned-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Pinned",
+      managerId: adminMember.id,
+      organizationId: admin.organizationId,
+      clientId: id,
+      runtimeProvider: "claude-code",
+    });
+
+    await archiveAbandonedClients(app.db);
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, id)).limit(1);
+    expect(row?.archivedAt).toBeNull();
+  });
+
+  it("is idempotent — re-running on an already-archived row is a no-op", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `idem-${crypto.randomUUID().slice(0, 8)}` });
+
+    const id = `cli-already-${crypto.randomUUID().slice(0, 8)}`;
+    const archivedAt = new Date(Date.now() - 10 * DAY_MS);
+    await app.db.insert(clients).values({
+      id,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 100 * DAY_MS),
+      archivedAt,
+    });
+
+    const archived = await archiveAbandonedClients(app.db);
+    // Doesn't matter how many other rows other tests created; what
+    // matters is OUR row's archived_at didn't change.
+    expect(archived).toBeGreaterThanOrEqual(0);
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, id)).limit(1);
+    expect(row?.archivedAt?.toISOString()).toBe(archivedAt.toISOString());
+  });
+});
+
+describe("read paths exclude archived rows", () => {
+  const getApp = useTestApp();
+
+  it("listClients omits archived rows from /me/clients results", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `listfilter-${crypto.randomUUID().slice(0, 8)}` });
+
+    const activeId = `cli-active-${crypto.randomUUID().slice(0, 8)}`;
+    const archivedId = `cli-arch-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values([
+      {
+        id: activeId,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        status: "connected",
+        hostname: "host-a",
+        os: "darwin",
+      },
+      {
+        id: archivedId,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        status: "disconnected",
+        hostname: "host-b",
+        os: "darwin",
+        archivedAt: new Date(),
+      },
+    ]);
+
+    const list = await listClients(app.db, { userId: admin.userId });
+    const ids = list.map((c) => c.id);
+    expect(ids).toContain(activeId);
+    expect(ids).not.toContain(archivedId);
+  });
+});

--- a/packages/server/src/__tests__/client-register-dedup.test.ts
+++ b/packages/server/src/__tests__/client-register-dedup.test.ts
@@ -253,6 +253,46 @@ describe("registerClient — soft dedup", () => {
     expect(row?.status).toBe("connected");
   });
 
+  it("refuses to first-time-claim an archived legacy (user_id NULL) row", async () => {
+    // Security regression test (review finding #1). The (A) same-id path
+    // allows legacy NULL → caller's userId promotion as documented in the
+    // claim semantics, BUT archived legacy rows must NOT be claimable —
+    // client.id can leak via logs / shared FS, and silently transferring
+    // ownership of an archived row would be the attack window.
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `legacy-${crypto.randomUUID().slice(0, 8)}` });
+
+    const archivedLegacyId = `cli-legacy-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: archivedLegacyId,
+      userId: null,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "Stranger.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+      archivedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+
+    await expect(
+      registerClient(app.db, {
+        clientId: archivedLegacyId,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        instanceId: "test-instance",
+        hostname: "MacBook-Pro.local",
+        os: "darwin",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_USER_MISMATCH" });
+
+    // Row was NOT mutated — userId stays NULL, archived_at stays set,
+    // hostname unchanged. No silent ownership transfer.
+    const [unchanged] = await app.db.select().from(clients).where(eq(clients.id, archivedLegacyId)).limit(1);
+    expect(unchanged?.userId).toBeNull();
+    expect(unchanged?.archivedAt).not.toBeNull();
+    expect(unchanged?.hostname).toBe("Stranger.local");
+  });
+
   it("prefers a canonical with pinned agents over one without (pickCanonical priority)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `priority-${crypto.randomUUID().slice(0, 8)}` });

--- a/packages/server/src/__tests__/client-register-dedup.test.ts
+++ b/packages/server/src/__tests__/client-register-dedup.test.ts
@@ -1,0 +1,314 @@
+import { and, eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { createAgent } from "../services/agent.js";
+import { ClientDedupConflictError, registerClient } from "../services/client.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Soft-dedup tests for `registerClient`.
+ *
+ * The dedup branch runs only when the caller's `clientId` is brand new (no
+ * row for that id yet) AND `hostname` + `os` are both present. It looks for
+ * a canonical `(user_id, hostname, os)` row and, when one exists, merges the
+ * new connection's runtime info onto that row instead of inserting a new
+ * one — preventing the orphan-row accumulation seen in production before
+ * PR-C.
+ *
+ * Coordination invariants tested here:
+ *   - Empty candidate set → plain INSERT (no dedup).
+ *   - Existing canonical (disconnected) → redirect-merge, original id wins.
+ *   - Existing canonical (connected) + the slot is held by a different live
+ *     socket → `ClientDedupConflictError` (refuse to steal).
+ *   - Caller's id already exists → existing same-id upsert path; dedup
+ *     query never runs.
+ *   - Missing hostname/os → no dedup (we need a stable anchor to merge).
+ *   - Archived canonical → still wins as canonical, and the merge clears
+ *     `archived_at` (unarchive on return).
+ */
+describe("registerClient — soft dedup", () => {
+  const getApp = useTestApp();
+
+  it("returns canonicalClientId = caller's id + redirected=false when no canonical exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `nope-${crypto.randomUUID().slice(0, 8)}` });
+
+    const clientId = `cli-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await registerClient(app.db, {
+      clientId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    expect(result).toEqual({ canonicalClientId: clientId, redirected: false });
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId)).limit(1);
+    expect(row?.id).toBe(clientId);
+    expect(row?.status).toBe("connected");
+  });
+
+  it("redirects to canonical when a disconnected (user, host, os) row already exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `dup-${crypto.randomUUID().slice(0, 8)}` });
+
+    const oldId = `cli-old-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: oldId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      lastSeenAt: new Date(Date.now() - 60_000),
+    });
+
+    const newId = `cli-new-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await registerClient(app.db, {
+      clientId: newId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance-2",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      sdkVersion: "0.5.2-alpha.30",
+    });
+
+    expect(result.redirected).toBe(true);
+    expect(result.canonicalClientId).toBe(oldId);
+
+    // Old row absorbed the new connection info.
+    const [merged] = await app.db.select().from(clients).where(eq(clients.id, oldId)).limit(1);
+    expect(merged?.status).toBe("connected");
+    expect(merged?.sdkVersion).toBe("0.5.2-alpha.30");
+    expect(merged?.instanceId).toBe("test-instance-2");
+
+    // The new id was never inserted as a fresh row.
+    const newRow = await app.db.select().from(clients).where(eq(clients.id, newId)).limit(1);
+    expect(newRow).toEqual([]);
+  });
+
+  it("falls back to plain INSERT when hostname is missing (no safe anchor for dedup)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `nohost-${crypto.randomUUID().slice(0, 8)}` });
+
+    // Pre-seed a row with NULL hostname to make sure we don't accidentally
+    // match across NULL anchors (which would over-merge unrelated rows).
+    const existingId = `cli-exist-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: existingId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: null,
+      os: null,
+    });
+
+    const newId = `cli-anon-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await registerClient(app.db, {
+      clientId: newId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance",
+      // hostname/os intentionally omitted
+    });
+
+    expect(result.redirected).toBe(false);
+    expect(result.canonicalClientId).toBe(newId);
+
+    // Both rows live independently when there's no anchor to merge on.
+    const [newRow] = await app.db.select().from(clients).where(eq(clients.id, newId)).limit(1);
+    expect(newRow?.id).toBe(newId);
+  });
+
+  it("same-id reconnect runs the existing upsert path with no dedup query", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `same-${crypto.randomUUID().slice(0, 8)}` });
+
+    const clientId = `cli-same-${crypto.randomUUID().slice(0, 8)}`;
+    await registerClient(app.db, {
+      clientId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "first",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    const result = await registerClient(app.db, {
+      clientId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "second",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    expect(result).toEqual({ canonicalClientId: clientId, redirected: false });
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId)).limit(1);
+    expect(row?.instanceId).toBe("second");
+  });
+
+  it("throws ClientDedupConflictError when the canonical slot is held by a different live socket", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `conflict-${crypto.randomUUID().slice(0, 8)}` });
+
+    const liveId = `cli-live-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: liveId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "connected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    const newId = `cli-new-${crypto.randomUUID().slice(0, 8)}`;
+    await expect(
+      registerClient(
+        app.db,
+        {
+          clientId: newId,
+          userId: admin.userId,
+          organizationId: admin.organizationId,
+          instanceId: "test-instance",
+          hostname: "MacBook-Pro.local",
+          os: "darwin",
+        },
+        () => true, // simulate "canonical slot is held by another live socket"
+      ),
+    ).rejects.toBeInstanceOf(ClientDedupConflictError);
+
+    // The live canonical row was NOT mutated.
+    const [unchanged] = await app.db.select().from(clients).where(eq(clients.id, liveId)).limit(1);
+    expect(unchanged?.instanceId).toBeNull();
+
+    // New id was NOT inserted.
+    const newRow = await app.db.select().from(clients).where(eq(clients.id, newId)).limit(1);
+    expect(newRow).toEqual([]);
+  });
+
+  it("unarchives the canonical row when dedup picks an archived candidate", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `unarch-${crypto.randomUUID().slice(0, 8)}` });
+
+    const oldId = `cli-arch-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: oldId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      archivedAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+    });
+
+    const newId = `cli-new-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await registerClient(app.db, {
+      clientId: newId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    expect(result.redirected).toBe(true);
+    expect(result.canonicalClientId).toBe(oldId);
+
+    const [resurrected] = await app.db.select().from(clients).where(eq(clients.id, oldId)).limit(1);
+    expect(resurrected?.archivedAt).toBeNull();
+    expect(resurrected?.status).toBe("connected");
+  });
+
+  it("same-id reconnect of an archived row clears archived_at (unarchive on return)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `same-arch-${crypto.randomUUID().slice(0, 8)}` });
+
+    const clientId = `cli-arch-same-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: clientId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      status: "disconnected",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+      archivedAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+    });
+
+    const result = await registerClient(app.db, {
+      clientId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    expect(result).toEqual({ canonicalClientId: clientId, redirected: false });
+    const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId)).limit(1);
+    expect(row?.archivedAt).toBeNull();
+    expect(row?.status).toBe("connected");
+  });
+
+  it("prefers a canonical with pinned agents over one without (pickCanonical priority)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `priority-${crypto.randomUUID().slice(0, 8)}` });
+
+    const idEmpty = `cli-empty-${crypto.randomUUID().slice(0, 8)}`;
+    const idBusy = `cli-busy-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values([
+      {
+        id: idEmpty,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        status: "disconnected",
+        hostname: "MacBook-Pro.local",
+        os: "darwin",
+        lastSeenAt: new Date(),
+      },
+      {
+        id: idBusy,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        status: "disconnected",
+        hostname: "MacBook-Pro.local",
+        os: "darwin",
+        lastSeenAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      },
+    ]);
+
+    // Pin an agent to idBusy so pickCanonical favors it despite the older
+    // lastSeenAt — agentCount > lastSeenAt in the priority stack.
+    const [adminMember] = await app.db
+      .select({ id: members.id })
+      .from(members)
+      .where(and(eq(members.userId, admin.userId), eq(members.organizationId, admin.organizationId)))
+      .limit(1);
+    if (!adminMember) throw new Error("admin member missing");
+    await createAgent(app.db, {
+      name: `pinned-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Pinned",
+      managerId: adminMember.id,
+      organizationId: admin.organizationId,
+      clientId: idBusy,
+      runtimeProvider: "claude-code",
+    });
+
+    const newId = `cli-new-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await registerClient(app.db, {
+      clientId: newId,
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      instanceId: "test-instance",
+      hostname: "MacBook-Pro.local",
+      os: "darwin",
+    });
+
+    expect(result.canonicalClientId).toBe(idBusy);
+    expect(result.redirected).toBe(true);
+  });
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -523,37 +523,45 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               // admin/agents.ts only fires for live sockets. The client dedupes
               // on agentId, so re-firing on every reconnect is safe.
               //
-              // Enumerate by `canonicalClientId`, not the caller's input id —
-              // on the dedup-redirect path, agents are pinned to the canonical
-              // row, not to the (rejected) input id.
-              try {
-                const pinned = await clientService.listActiveAgentsPinnedToClient(
-                  app.db,
-                  registerResult.canonicalClientId,
-                );
-                for (const agent of pinned) {
-                  const parsed = agentPinnedMessageSchema.safeParse({
-                    type: "agent:pinned",
-                    agentId: agent.uuid,
-                    name: agent.name,
-                    displayName: agent.displayName,
-                    agentType: agent.type,
-                    runtimeProvider: agent.runtimeProvider,
-                  });
-                  if (!parsed.success) {
-                    app.log.warn(
-                      { err: parsed.error.flatten(), agentId: agent.uuid, clientId: registerResult.canonicalClientId },
-                      "agent:pinned backfill frame failed schema validation — skipping",
-                    );
-                    continue;
+              // Skip the backfill on the dedup-redirect path: the new CLI is
+              // about to set `closing=true` and close this socket, so any
+              // frames we push are wasted. The next reconnect (with the
+              // canonical id in yaml) hits the same-id (A) branch and
+              // backfills then to a stable socket.
+              if (!registerResult.redirected) {
+                try {
+                  const pinned = await clientService.listActiveAgentsPinnedToClient(
+                    app.db,
+                    registerResult.canonicalClientId,
+                  );
+                  for (const agent of pinned) {
+                    const parsed = agentPinnedMessageSchema.safeParse({
+                      type: "agent:pinned",
+                      agentId: agent.uuid,
+                      name: agent.name,
+                      displayName: agent.displayName,
+                      agentType: agent.type,
+                      runtimeProvider: agent.runtimeProvider,
+                    });
+                    if (!parsed.success) {
+                      app.log.warn(
+                        {
+                          err: parsed.error.flatten(),
+                          agentId: agent.uuid,
+                          clientId: registerResult.canonicalClientId,
+                        },
+                        "agent:pinned backfill frame failed schema validation — skipping",
+                      );
+                      continue;
+                    }
+                    socket.send(JSON.stringify(parsed.data));
                   }
-                  socket.send(JSON.stringify(parsed.data));
+                } catch (err) {
+                  app.log.error(
+                    { err, clientId: registerResult.canonicalClientId },
+                    "agent:pinned backfill on client:register failed — client may need manual `agent add`",
+                  );
                 }
-              } catch (err) {
-                app.log.error(
-                  { err, clientId: registerResult.canonicalClientId },
-                  "agent:pinned backfill on client:register failed — client may need manual `agent add`",
-                );
               }
             } else if (type === "agent:bind") {
               if (!clientId) {

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -34,6 +34,7 @@ import {
 } from "../../observability/index.js";
 import * as activityService from "../../services/activity.js";
 import * as clientService from "../../services/client.js";
+import { ClientDedupConflictError } from "../../services/client.js";
 import * as connectionManager from "../../services/connection-manager.js";
 import * as inboxService from "../../services/inbox.js";
 import * as notificationService from "../../services/notification.js";
@@ -461,17 +462,30 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 socket.close(4403, "no membership");
                 return;
               }
+              let registerResult: clientService.RegisterClientResult;
               try {
-                await clientService.registerClient(app.db, {
-                  clientId: data.clientId,
-                  userId: session.userId,
-                  organizationId: placeholderOrgId,
-                  instanceId,
-                  hostname: data.hostname,
-                  os: data.os,
-                  sdkVersion: data.sdkVersion,
-                  lastUpdateAttempt: data.lastUpdateAttempt,
-                });
+                registerResult = await clientService.registerClient(
+                  app.db,
+                  {
+                    clientId: data.clientId,
+                    userId: session.userId,
+                    organizationId: placeholderOrgId,
+                    instanceId,
+                    hostname: data.hostname,
+                    os: data.os,
+                    sdkVersion: data.sdkVersion,
+                    lastUpdateAttempt: data.lastUpdateAttempt,
+                  },
+                  // Connection-stealing guard for soft-dedup: the canonical
+                  // slot is "live" iff a DIFFERENT socket holds it and is
+                  // still OPEN. If our own socket is registered there (e.g.
+                  // an in-flight reconnect via the same id), we are NOT
+                  // stealing — let the register through.
+                  (canonicalId) => {
+                    const existing = connectionManager.getClientConnection(canonicalId);
+                    return existing !== undefined && existing !== socket && existing.readyState === existing.OPEN;
+                  },
+                );
               } catch (err) {
                 const message = err instanceof Error ? err.message : "client register failed";
                 const code =
@@ -479,7 +493,9 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     ? err.code
                     : err instanceof ClientOrgMismatchError
                       ? err.code
-                      : undefined;
+                      : err instanceof ClientDedupConflictError
+                        ? err.code
+                        : undefined;
                 socket.send(
                   JSON.stringify({
                     type: "client:register:rejected",
@@ -491,10 +507,14 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 return;
               }
 
-              clientId = data.clientId;
-              setWsConnectionAttrs(socket, { "client.id": data.clientId });
-              connectionManager.setClientConnection(data.clientId, socket);
-              socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
+              // Use the canonical id for the local session, connection
+              // manager registration, and the response frame. On the
+              // soft-dedup redirect path the caller's input id is not the
+              // identity the server tracks — see services/client.ts §B.
+              clientId = registerResult.canonicalClientId;
+              setWsConnectionAttrs(socket, { "client.id": registerResult.canonicalClientId });
+              connectionManager.setClientConnection(registerResult.canonicalClientId, socket);
+              socket.send(JSON.stringify({ type: "client:registered", clientId: registerResult.canonicalClientId }));
 
               // Backfill `agent:pinned` for any agent already bound to this
               // client at registration time. Without this, an admin who pins an
@@ -502,8 +522,15 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               // `first-tree agent add` after restart — the realtime push in
               // admin/agents.ts only fires for live sockets. The client dedupes
               // on agentId, so re-firing on every reconnect is safe.
+              //
+              // Enumerate by `canonicalClientId`, not the caller's input id —
+              // on the dedup-redirect path, agents are pinned to the canonical
+              // row, not to the (rejected) input id.
               try {
-                const pinned = await clientService.listActiveAgentsPinnedToClient(app.db, data.clientId);
+                const pinned = await clientService.listActiveAgentsPinnedToClient(
+                  app.db,
+                  registerResult.canonicalClientId,
+                );
                 for (const agent of pinned) {
                   const parsed = agentPinnedMessageSchema.safeParse({
                     type: "agent:pinned",
@@ -515,7 +542,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   });
                   if (!parsed.success) {
                     app.log.warn(
-                      { err: parsed.error.flatten(), agentId: agent.uuid, clientId: data.clientId },
+                      { err: parsed.error.flatten(), agentId: agent.uuid, clientId: registerResult.canonicalClientId },
                       "agent:pinned backfill frame failed schema validation — skipping",
                     );
                     continue;
@@ -524,7 +551,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 }
               } catch (err) {
                 app.log.error(
-                  { err, clientId: data.clientId },
+                  { err, clientId: registerResult.canonicalClientId },
                   "agent:pinned backfill on client:register failed — client may need manual `agent add`",
                 );
               }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -553,7 +553,14 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
  * org has a non-human agent — matching the user-level mental model.
  */
 async function inferOnboardingStep(app: FastifyInstance, userId: string): Promise<OnboardingStep> {
-  const [hasClient] = await app.db.select({ id: clients.id }).from(clients).where(eq(clients.userId, userId)).limit(1);
+  // Archived clients don't count toward onboarding — a user whose only
+  // computer rows are sweep-soft-deleted should be sent back to "connect",
+  // not falsely advanced to "create_agent".
+  const [hasClient] = await app.db
+    .select({ id: clients.id })
+    .from(clients)
+    .where(and(eq(clients.userId, userId), isNull(clients.archivedAt)))
+    .limit(1);
   if (!hasClient) return "connect";
 
   const [hasAgent] = await app.db

--- a/packages/server/src/db/schema/clients.ts
+++ b/packages/server/src/db/schema/clients.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { organizations } from "./organizations.js";
 import { users } from "./users.js";
@@ -37,6 +38,35 @@ export const clients = pgTable(
     connectedAt: timestamp("connected_at", { withTimezone: true }),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    /**
+     * Soft-delete timestamp for orphan-row archival.
+     *
+     * - NULL  → active row. Surfaces in all read paths
+     *   (`/me/clients`, `/orgs/:orgId/clients`, `GET /clients/:id`,
+     *   `agent:bind` joins, onboarding inference).
+     * - Non-NULL → archived (`archiveAbandonedClients` sweep judged this
+     *   row abandoned: disconnected, >30 days unseen, zero pinned
+     *   agents). Excluded from every read path but the row stays for
+     *   audit / recovery (admin SQL `UPDATE clients SET archived_at =
+     *   NULL WHERE id = '...'` resurrects).
+     *
+     * Soft-delete (not DELETE) so the dedup path can `pickCanonical` an
+     * archived row when a re-registering CLI returns; the `(A)` same-id
+     * upsert clears `archived_at` automatically on reconnect — see
+     * `services/client.ts::registerClient`.
+     */
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
   },
-  (table) => [index("idx_clients_user").on(table.userId), index("idx_clients_org").on(table.organizationId)],
+  (table) => [
+    index("idx_clients_user").on(table.userId),
+    index("idx_clients_org").on(table.organizationId),
+    /**
+     * Supports the hourly `archiveAbandonedClients` sweep — its WHERE
+     * clause scans `(status='disconnected', last_seen_at < cutoff,
+     * archived_at IS NULL)`. The partial predicate keeps the index small
+     * (archived rows excluded) and a (status, last_seen_at) leading key
+     * lines up with the equality + range predicate.
+     */
+    index("idx_clients_sweep").on(table.status, table.lastSeenAt).where(sql`archived_at IS NULL`),
+  ],
 );

--- a/packages/server/src/services/__tests__/pick-canonical.test.ts
+++ b/packages/server/src/services/__tests__/pick-canonical.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { pickCanonical } from "../client.js";
+
+/**
+ * Pure-function tests for the soft-dedup canonical selection rule.
+ *
+ * `pickCanonical` is invoked by `registerClient` inside the dedup branch
+ * after the advisory lock + candidate SELECT. The rule decides WHICH of
+ * several rows for the same `(user_id, hostname, os)` tuple wins the
+ * "canonical identity for this machine" title.
+ *
+ * Order (most preferred first):
+ *   1. Non-archived rows beat archived rows.
+ *   2. Higher `agentCount` beats lower.
+ *   3. More-recent `lastSeenAt` beats older.
+ *   4. Lexicographically smaller `id` beats larger (UUID v7 ≈ creation
+ *      time ascending — oldest row wins the final tie-break).
+ *
+ * Each rule is tested in isolation, then a couple of stacked cases pin
+ * the cascading order so a future refactor that flips two priorities is
+ * caught.
+ */
+
+type Cand = {
+  id: string;
+  status: "connected" | "disconnected";
+  lastSeenAt: Date;
+  agentCount: number;
+  archivedAt: Date | null;
+};
+
+function cand(overrides: Partial<Cand>): Cand {
+  return {
+    id: "client_default",
+    status: "disconnected",
+    lastSeenAt: new Date("2026-05-01T00:00:00Z"),
+    agentCount: 0,
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+describe("pickCanonical", () => {
+  it("returns null for an empty candidate set", () => {
+    expect(pickCanonical([])).toBeNull();
+  });
+
+  it("returns the single candidate when only one row matches", () => {
+    const only = cand({ id: "client_only" });
+    expect(pickCanonical([only])?.id).toBe("client_only");
+  });
+
+  it("prefers a non-archived row over an archived one — even if the archived row has more agents", () => {
+    // Archival is the strongest negative signal: an archived row was abandoned
+    // long enough ago that the sweep decided it was dead, so even if it
+    // historically had work pinned to it, a live row should outrank it.
+    const archived = cand({ id: "client_archived", agentCount: 5, archivedAt: new Date("2026-04-01T00:00:00Z") });
+    const active = cand({ id: "client_active", agentCount: 0, archivedAt: null });
+    expect(pickCanonical([archived, active])?.id).toBe("client_active");
+  });
+
+  it("when both rows are archived, falls through to the rest of the ordering rules", () => {
+    // Archived-vs-archived: priority 1 is a wash; agentCount decides next.
+    const a = cand({ id: "client_a", agentCount: 0, archivedAt: new Date("2026-04-01T00:00:00Z") });
+    const b = cand({ id: "client_b", agentCount: 1, archivedAt: new Date("2026-04-01T00:00:00Z") });
+    expect(pickCanonical([a, b])?.id).toBe("client_b");
+  });
+
+  it("prefers more agents pinned over fewer (within the same archival tier)", () => {
+    const lonely = cand({ id: "client_lonely", agentCount: 0 });
+    const busy = cand({ id: "client_busy", agentCount: 3 });
+    expect(pickCanonical([lonely, busy])?.id).toBe("client_busy");
+  });
+
+  it("prefers more-recent lastSeenAt when agentCount ties", () => {
+    const stale = cand({ id: "client_stale", lastSeenAt: new Date("2026-04-01T00:00:00Z") });
+    const fresh = cand({ id: "client_fresh", lastSeenAt: new Date("2026-05-01T00:00:00Z") });
+    expect(pickCanonical([stale, fresh])?.id).toBe("client_fresh");
+  });
+
+  it("breaks ties on lexicographically smallest id (UUID v7 ≈ creation order)", () => {
+    const newer = cand({ id: "client_zzz" });
+    const older = cand({ id: "client_aaa" });
+    expect(pickCanonical([newer, older])?.id).toBe("client_aaa");
+  });
+
+  it("respects the full priority stack: non-archived > agentCount > lastSeen > id", () => {
+    // Construct a 4-way race where each rule decides one pair.
+    // - winner: non-archived, 1 agent, 2026-05-01, id 'client_b'
+    // - peer A: non-archived, 1 agent, 2026-05-01, id 'client_c' (loses on id)
+    // - peer B: non-archived, 1 agent, 2026-04-01, id 'client_a' (loses on lastSeen)
+    // - peer C: non-archived, 0 agents, 2026-05-01, id 'client_a' (loses on agentCount)
+    // - peer D: archived, 5 agents, 2026-05-01, id 'client_a' (loses on archival)
+    const winner = cand({ id: "client_b", agentCount: 1, lastSeenAt: new Date("2026-05-01T00:00:00Z") });
+    const peerA = cand({ id: "client_c", agentCount: 1, lastSeenAt: new Date("2026-05-01T00:00:00Z") });
+    const peerB = cand({ id: "client_a", agentCount: 1, lastSeenAt: new Date("2026-04-01T00:00:00Z") });
+    const peerC = cand({ id: "client_a", agentCount: 0, lastSeenAt: new Date("2026-05-01T00:00:00Z") });
+    const peerD = cand({
+      id: "client_a",
+      agentCount: 5,
+      lastSeenAt: new Date("2026-05-01T00:00:00Z"),
+      archivedAt: new Date("2026-04-01T00:00:00Z"),
+    });
+    expect(pickCanonical([peerA, peerB, peerC, peerD, winner])?.id).toBe("client_b");
+  });
+
+  it("does not mutate the input array", () => {
+    const a = cand({ id: "client_a", agentCount: 5 });
+    const b = cand({ id: "client_b", agentCount: 1 });
+    const input = [b, a];
+    pickCanonical(input);
+    expect(input.map((c) => c.id)).toEqual(["client_b", "client_a"]);
+  });
+});

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -26,6 +26,7 @@ export function createBackgroundTasks(
   let adapterOutboundTimer: ReturnType<typeof setInterval> | null = null;
   let kaelOutboundTimer: ReturnType<typeof setInterval> | null = null;
   let archiveSweepTimer: ReturnType<typeof setInterval> | null = null;
+  let clientOrphanArchiveTimer: ReturnType<typeof setInterval> | null = null;
 
   return {
     start() {
@@ -94,6 +95,29 @@ export function createBackgroundTasks(
         }, 5_000);
       }
 
+      // Orphan client archival sweep — runs hourly. A `clients` row gets
+      // archived once it's been disconnected for ≥30 days AND has zero
+      // pinned non-deleted agents. The predicate is day-grained so
+      // hourly cadence is plenty; the partial index idx_clients_sweep
+      // keeps the cost bounded as the table grows. See
+      // services/client.ts::archiveAbandonedClients.
+      clientOrphanArchiveTimer = setInterval(
+        async () => {
+          try {
+            const archived = await clientService.archiveAbandonedClients(app.db);
+            if (archived > 0) {
+              log.info(
+                { archived, staleDays: clientService.ORPHAN_ARCHIVAL_STALE_DAYS },
+                "archived abandoned client rows",
+              );
+            }
+          } catch (err) {
+            log.error({ err }, "client orphan archival sweep failed");
+          }
+        },
+        60 * 60 * 1000,
+      );
+
       // Chat auto-archive sweeper — cadence comes from runtime config so
       // ops can tune (or zero-disable) without touching code. See
       // services/chat-archive.ts for the two routes and their idle
@@ -152,6 +176,10 @@ export function createBackgroundTasks(
       if (archiveSweepTimer) {
         clearInterval(archiveSweepTimer);
         archiveSweepTimer = null;
+      }
+      if (clientOrphanArchiveTimer) {
+        clearInterval(clientOrphanArchiveTimer);
+        clientOrphanArchiveTimer = null;
       }
     },
   };

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -5,7 +5,7 @@ import {
   type UpdateAttempt,
   updateAttemptSchema,
 } from "@first-tree/shared";
-import { and, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
@@ -23,30 +23,87 @@ import { markSupersededByAgents } from "./questions.js";
  * ownership transfer goes through `claimClient` in PR-B.
  */
 export async function assertClientOwner(db: Database, clientId: string, scope: { userId: string }): Promise<void> {
+  // Archived rows are 404 from the user's perspective — they were
+  // sweep-soft-deleted, so admin actions against them must go through
+  // SQL recovery, not the regular owner-scoped routes.
   const [row] = await db
-    .select({ id: clients.id, userId: clients.userId })
+    .select({ id: clients.id, userId: clients.userId, archivedAt: clients.archivedAt })
     .from(clients)
     .where(eq(clients.id, clientId))
     .limit(1);
-  if (!row || row.userId !== scope.userId) {
+  if (!row || row.userId !== scope.userId || row.archivedAt !== null) {
     throw new NotFoundError(`Client "${clientId}" not found`);
   }
 }
 
 /**
- * Upsert the clients row for a given `client_id` under an authenticated user.
+ * Outcome of {@link registerClient}.
  *
- * Claim semantics (decouple-client-from-identity §4.1.1):
- *   - New client_id → INSERT with the authenticated user_id. `organization_id`
- *     is written as a placeholder (NOT NULL legacy column; no longer consumed
- *     by any read path) sourced from the caller-supplied JWT default org.
- *   - Existing row with the same user_id → refresh runtime columns.
- *     `organization_id` is **not** updated on conflict, so the placeholder set
- *     at first insert sticks for the row's lifetime.
- *   - Existing row with a different user_id → raises
- *     {@link ClientUserMismatchError} (WS close 4403). The CLI guides the
- *     operator through `first-tree login <token> --override` to take
- *     ownership, which unpins the previous owner's agents from the machine.
+ * - `canonicalClientId` — the id the WS handler must use to track this
+ *   session going forward. Differs from the caller's `data.clientId` only
+ *   on the soft-dedup redirect path (B).
+ * - `redirected` — true iff soft-dedup picked an existing row to merge
+ *   the new connection into. The WS handler tells the CLI by setting
+ *   the `client:registered` frame's `clientId` to `canonicalClientId`;
+ *   a new-protocol CLI compares and updates yaml.
+ */
+export type RegisterClientResult = {
+  canonicalClientId: string;
+  redirected: boolean;
+};
+
+/**
+ * Soft-dedup refused because the canonical row is currently held by
+ * another live socket. The WS handler maps this to
+ * `client:register:rejected { code: "CLIENT_DEDUP_CONFLICT" }` and
+ * closes 4403 so the offending CLI does not silently steal the slot
+ * every reconnect. CLI side: error class lives in
+ * `packages/client/src/client-connection.ts` for protocol symmetry.
+ */
+export class ClientDedupConflictError extends Error {
+  readonly code = "CLIENT_DEDUP_CONFLICT";
+  constructor(canonicalId: string) {
+    super(`Another client is currently connected as canonical "${canonicalId}". Retry later.`);
+    this.name = "ClientDedupConflictError";
+  }
+}
+
+/**
+ * Upsert / soft-dedup the clients row for a given `client_id` under an
+ * authenticated user.
+ *
+ * Three branches:
+ *
+ *   (A) **Same-id path** — a row with the caller's `clientId` already
+ *       exists. Runs the existing user-mismatch + upsert logic.
+ *       `archived_at` is cleared so a returning install (rare: archived
+ *       row whose owner kept yaml) auto-resurrects. Returns the caller's
+ *       id, `redirected: false`.
+ *
+ *   (B) **Dedup path** — caller's id is brand new AND both `hostname`
+ *       and `os` are present. Acquires a transaction-scoped advisory
+ *       lock on `hash(user_id | hostname | os)` so two concurrent
+ *       first-time registers from the same machine serialize. Then
+ *       picks a canonical row via {@link pickCanonical}; if one is
+ *       found, the new connection's runtime info is merged onto the
+ *       canonical row (clearing `archived_at` on the way) and the
+ *       caller's id is never inserted. If the canonical slot is held by
+ *       a different live socket, {@link ClientDedupConflictError} is
+ *       thrown so the offending CLI bounces instead of stealing.
+ *
+ *   (C) **Plain insert** — caller's id is new and there is no anchor
+ *       (no hostname/os, or no canonical match). Inserts a fresh row.
+ *
+ * Cross-user same-id still raises {@link ClientUserMismatchError} (WS
+ * close 4403); the CLI guides the operator through `first-tree login
+ * <token> --override`.
+ *
+ * @param isCanonicalSlotLive Injected by the WS handler. Returns true
+ *   iff the canonical id currently has a live socket held by
+ *   `connectionManager` that is NOT this caller. Defaults to `() =>
+ *   false` for unit tests / service-layer callers that don't have a
+ *   `connectionManager` in scope; bypassing the guard outside the WS
+ *   handler is safe because there's no real socket to steal.
  */
 export async function registerClient(
   db: Database,
@@ -67,21 +124,9 @@ export async function registerClient(
      */
     lastUpdateAttempt?: UpdateAttempt;
   },
-) {
+  isCanonicalSlotLive: (canonicalId: string) => boolean = () => false,
+): Promise<RegisterClientResult> {
   const now = new Date();
-
-  const [existing] = await db
-    .select({ id: clients.id, userId: clients.userId })
-    .from(clients)
-    .where(eq(clients.id, data.clientId))
-    .limit(1);
-
-  if (existing?.userId && existing.userId !== data.userId) {
-    throw new ClientUserMismatchError(
-      `Client "${data.clientId}" is owned by a different user. ` +
-        "Run `first-tree login <token> --override` to transfer ownership.",
-    );
-  }
 
   // Shallow-merge `lastUpdateAttempt` into the existing metadata jsonb so
   // we don't clobber sibling keys like `capabilities` (written by
@@ -95,25 +140,78 @@ export async function registerClient(
     ? sql`COALESCE(${clients.metadata}, '{}'::jsonb) || ${JSON.stringify({ lastUpdateAttempt: data.lastUpdateAttempt })}::jsonb`
     : undefined;
 
-  await db
-    .insert(clients)
-    .values({
-      id: data.clientId,
-      userId: data.userId,
-      organizationId: data.organizationId,
-      status: "connected",
-      instanceId: data.instanceId,
-      hostname: data.hostname ?? null,
-      os: data.os ?? null,
-      sdkVersion: data.sdkVersion ?? null,
-      connectedAt: now,
-      lastSeenAt: now,
-      ...(data.lastUpdateAttempt ? { metadata: { lastUpdateAttempt: data.lastUpdateAttempt } } : {}),
-    })
-    .onConflictDoUpdate({
-      target: clients.id,
-      set: {
+  return db.transaction(async (tx) => {
+    // (A) Same-id path. No dedup query, no advisory lock — normal
+    // reconnect stays O(1).
+    const [existing] = await tx
+      .select({ id: clients.id, userId: clients.userId, archivedAt: clients.archivedAt })
+      .from(clients)
+      .where(eq(clients.id, data.clientId))
+      .limit(1);
+
+    if (existing) {
+      if (existing.userId && existing.userId !== data.userId) {
+        throw new ClientUserMismatchError(
+          `Client "${data.clientId}" is owned by a different user. ` +
+            "Run `first-tree login <token> --override` to transfer ownership.",
+        );
+      }
+      // Refuse to first-time-claim an archived legacy (user_id NULL) row.
+      // The archival sweep already judged this row abandoned; allowing any
+      // user who learns the client_id to claim it (the existing legacy-
+      // claim path) would open an attack window since `client.id` may end
+      // up in server logs, screenshots, or shared filesystems. Returning
+      // users with their own row (existing.userId === data.userId) hit
+      // the same-user branch above and are NOT affected — they retain
+      // their identity and the row unarchives below.
+      if (existing.userId === null && existing.archivedAt !== null) {
+        throw new ClientUserMismatchError(
+          `Client "${data.clientId}" is archived and cannot be claimed. ` +
+            "Generate a fresh connect token and let the server assign a new identity.",
+        );
+      }
+      await tx
+        .insert(clients)
+        .values({
+          id: data.clientId,
+          userId: data.userId,
+          organizationId: data.organizationId,
+          status: "connected",
+          instanceId: data.instanceId,
+          hostname: data.hostname ?? null,
+          os: data.os ?? null,
+          sdkVersion: data.sdkVersion ?? null,
+          connectedAt: now,
+          lastSeenAt: now,
+          ...(data.lastUpdateAttempt ? { metadata: { lastUpdateAttempt: data.lastUpdateAttempt } } : {}),
+        })
+        .onConflictDoUpdate({
+          target: clients.id,
+          set: {
+            userId: data.userId,
+            status: "connected",
+            instanceId: data.instanceId,
+            hostname: data.hostname ?? null,
+            os: data.os ?? null,
+            sdkVersion: data.sdkVersion ?? null,
+            connectedAt: now,
+            lastSeenAt: now,
+            // Unarchive on reconnect — if this row was previously
+            // archived by the sweep, returning the user to the same
+            // identity should resurrect it transparently.
+            archivedAt: null,
+            ...(metadataMerge ? { metadata: metadataMerge } : {}),
+          },
+        });
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // (C) Plain-insert path when there's no anchor to dedup on.
+    if (!data.hostname || !data.os) {
+      await tx.insert(clients).values({
+        id: data.clientId,
         userId: data.userId,
+        organizationId: data.organizationId,
         status: "connected",
         instanceId: data.instanceId,
         hostname: data.hostname ?? null,
@@ -121,9 +219,141 @@ export async function registerClient(
         sdkVersion: data.sdkVersion ?? null,
         connectedAt: now,
         lastSeenAt: now,
+        ...(data.lastUpdateAttempt ? { metadata: { lastUpdateAttempt: data.lastUpdateAttempt } } : {}),
+      });
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // (B) Dedup path. Acquire an advisory lock keyed on the dedup tuple
+    // BEFORE the candidate SELECT — `SELECT ... FOR UPDATE` would not
+    // serialize concurrent first-time registers because an empty result
+    // set locks nothing. The advisory lock is transaction-scoped (auto-
+    // released at COMMIT/ROLLBACK) and survives empty SELECTs.
+    //
+    // `hashtextextended` (64-bit, seed 0) instead of `hashtext` (32-bit):
+    // PG's int4 advisory keyspace lands ~50% collision odds around 65k
+    // distinct active tuples, causing unrelated `(user, host, os)` triples
+    // to serialize for no semantic reason. int8 keyspace is 2^64 — same
+    // protocol, ~zero false sharing.
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${data.userId} || '|' || ${data.hostname} || '|' || ${data.os}, 0))`,
+    );
+
+    // Re-check after acquiring the lock: a concurrent register that won
+    // the race may have just INSERTed the caller's id (unlikely — caller
+    // ids are freshly generated UUIDs — but the cost of a defensive
+    // re-check is one indexed lookup).
+    const [insertedConcurrently] = await tx
+      .select({ id: clients.id })
+      .from(clients)
+      .where(eq(clients.id, data.clientId))
+      .limit(1);
+    if (insertedConcurrently) {
+      // Fall through to the same-id upsert path that the (A) branch
+      // takes. Easier than re-implementing: do another tiny upsert here.
+      await tx
+        .update(clients)
+        .set({
+          userId: data.userId,
+          status: "connected",
+          instanceId: data.instanceId,
+          hostname: data.hostname,
+          os: data.os,
+          sdkVersion: data.sdkVersion ?? null,
+          connectedAt: now,
+          lastSeenAt: now,
+          archivedAt: null,
+          ...(metadataMerge ? { metadata: metadataMerge } : {}),
+        })
+        .where(eq(clients.id, data.clientId));
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    const candidateRows = await tx
+      .select({
+        id: clients.id,
+        status: clients.status,
+        lastSeenAt: clients.lastSeenAt,
+        archivedAt: clients.archivedAt,
+      })
+      .from(clients)
+      .where(and(eq(clients.userId, data.userId), eq(clients.hostname, data.hostname), eq(clients.os, data.os)));
+
+    // Two-step agent-count: GROUP BY + FOR UPDATE is invalid in PG
+    // (cannot lock through an aggregate). The advisory lock scopes ONLY
+    // to other concurrent `registerClient`s on the same (user, host, os) —
+    // it does NOT cover the `agents` table, so an admin PATCH that
+    // rebinds `agents.client_id` while we read may shift the count.
+    // Worst case: pickCanonical picks the wrong canonical (priority
+    // delta), no data loss. Acceptable under soft-dedup semantics.
+    const candidateIds = candidateRows.map((r) => r.id);
+    const agentCounts =
+      candidateIds.length > 0
+        ? await tx
+            .select({ clientId: agents.clientId, count: sql<number>`count(*)::int` })
+            .from(agents)
+            .where(
+              and(
+                sql`${agents.clientId} IS NOT NULL`,
+                inArray(agents.clientId, candidateIds),
+                ne(agents.status, "deleted"),
+              ),
+            )
+            .groupBy(agents.clientId)
+        : [];
+    const counts = new Map(agentCounts.map((c) => [c.clientId, c.count]));
+
+    const canonical = pickCanonical(
+      candidateRows.map((r) => ({
+        id: r.id,
+        status: r.status as "connected" | "disconnected",
+        lastSeenAt: r.lastSeenAt,
+        agentCount: counts.get(r.id) ?? 0,
+        archivedAt: r.archivedAt,
+      })),
+    );
+
+    if (!canonical) {
+      // No canonical to merge into — plain INSERT with the caller's id.
+      await tx.insert(clients).values({
+        id: data.clientId,
+        userId: data.userId,
+        organizationId: data.organizationId,
+        status: "connected",
+        instanceId: data.instanceId,
+        hostname: data.hostname,
+        os: data.os,
+        sdkVersion: data.sdkVersion ?? null,
+        connectedAt: now,
+        lastSeenAt: now,
+        ...(data.lastUpdateAttempt ? { metadata: { lastUpdateAttempt: data.lastUpdateAttempt } } : {}),
+      });
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // Connection-stealing guard: a different live socket is currently
+    // registered as canonical. Refuse the dedup; offending CLI gets a
+    // `CLIENT_DEDUP_CONFLICT` error and bounces with reconnect backoff.
+    if (isCanonicalSlotLive(canonical.id)) {
+      throw new ClientDedupConflictError(canonical.id);
+    }
+
+    // Redirect-merge: take the caller's connection info onto the canonical
+    // row. `archivedAt: null` resurrects archived canonicals on return.
+    await tx
+      .update(clients)
+      .set({
+        status: "connected",
+        instanceId: data.instanceId,
+        sdkVersion: data.sdkVersion ?? null,
+        connectedAt: now,
+        lastSeenAt: now,
+        archivedAt: null,
         ...(metadataMerge ? { metadata: metadataMerge } : {}),
-      },
-    });
+      })
+      .where(eq(clients.id, canonical.id));
+    return { canonicalClientId: canonical.id, redirected: true };
+  });
 }
 
 /**
@@ -209,8 +439,66 @@ export async function heartbeatClient(db: Database, clientId: string) {
 }
 
 export async function getClient(db: Database, clientId: string) {
-  const [row] = await db.select().from(clients).where(eq(clients.id, clientId)).limit(1);
+  // Filter out archived rows — they're soft-deleted from the user's
+  // perspective (sweep gave up on them). Admin SQL can resurrect by
+  // clearing `archived_at`; this read path stays simple.
+  const [row] = await db
+    .select()
+    .from(clients)
+    .where(and(eq(clients.id, clientId), isNull(clients.archivedAt)))
+    .limit(1);
   return row ?? null;
+}
+
+/**
+ * One candidate row in the soft-dedup canonical decision. Mirrors the
+ * column subset `registerClient` actually consults — kept separate from
+ * `Client` (the full DTO) so {@link pickCanonical} stays a pure function
+ * over plain data, testable without a DB.
+ */
+export type DedupCandidate = {
+  id: string;
+  status: "connected" | "disconnected";
+  lastSeenAt: Date;
+  agentCount: number;
+  archivedAt: Date | null;
+};
+
+/**
+ * Pick the canonical row for a `(user_id, hostname, os)` candidate set
+ * during soft-dedup. Pure — sorts a copy of the input, never mutates.
+ *
+ * Priority (most preferred first):
+ *   1. Non-archived rows beat archived. An archived row was abandoned
+ *      long enough ago that the sweep gave up on it; a live row should
+ *      take over the identity instead of resurrecting a dead one.
+ *   2. Higher `agentCount` beats lower. A row with pinned work is the
+ *      one that holds the user's state — losing its identity would
+ *      orphan their agents.
+ *   3. More-recent `lastSeenAt` beats older.
+ *   4. Lexicographically smaller `id` beats larger. UUID v7 sorts ≈
+ *      ascending creation time, so this stable tie-break prefers the
+ *      oldest row — keeping identity continuity for the longest-lived
+ *      install.
+ *
+ * Returns null only when the candidate set is empty.
+ */
+export function pickCanonical(candidates: DedupCandidate[]): DedupCandidate | null {
+  if (candidates.length === 0) return null;
+  return (
+    [...candidates].sort((a, b) => {
+      const aArchived = a.archivedAt !== null;
+      const bArchived = b.archivedAt !== null;
+      if (aArchived !== bArchived) return aArchived ? 1 : -1;
+      if (a.agentCount !== b.agentCount) return b.agentCount - a.agentCount;
+      const aMs = a.lastSeenAt.getTime();
+      const bMs = b.lastSeenAt.getTime();
+      if (aMs !== bMs) return bMs - aMs;
+      if (a.id < b.id) return -1;
+      if (a.id > b.id) return 1;
+      return 0;
+    })[0] ?? null
+  );
 }
 
 /**
@@ -286,7 +574,7 @@ export async function listMyPinnedAgents(
     })
     .from(agents)
     .innerJoin(clients, eq(agents.clientId, clients.id))
-    .where(and(eq(clients.userId, scope.userId), ne(agents.status, "deleted")));
+    .where(and(eq(clients.userId, scope.userId), ne(agents.status, "deleted"), isNull(clients.archivedAt)));
   return rows
     .filter((r): r is { agentId: string; clientId: string; runtimeProvider: string } => r.clientId !== null)
     .map((r) => ({
@@ -334,7 +622,10 @@ export async function updateClientCapabilities(
  * `?organizationId=` cross-user view via {@link listClientsForOrgAdmin}.
  */
 export async function listClients(db: Database, scope: { userId: string }) {
-  const rows = await db.select().from(clients).where(eq(clients.userId, scope.userId));
+  const rows = await db
+    .select()
+    .from(clients)
+    .where(and(eq(clients.userId, scope.userId), isNull(clients.archivedAt)));
   return attachAgentCounts(db, rows);
 }
 
@@ -365,7 +656,7 @@ export async function listClientsForOrgAdmin(db: Database, orgId: string) {
     })
     .from(clients)
     .innerJoin(members, eq(members.userId, clients.userId))
-    .where(and(eq(members.organizationId, orgId), eq(members.status, "active")));
+    .where(and(eq(members.organizationId, orgId), eq(members.status, "active"), isNull(clients.archivedAt)));
   return attachAgentCounts(db, rows);
 }
 
@@ -488,5 +779,56 @@ export async function cleanupStaleClients(db: Database, staleSeconds = 60): Prom
       .where(inArray(agentPresence.clientId, staleIds));
   }
 
+  return result.length;
+}
+
+/**
+ * Default threshold for the orphan-row archival sweep. A `clients` row
+ * is auto-archived when ALL of the following hold:
+ *   1. `status = 'disconnected'`
+ *   2. `last_seen_at < NOW() - ORPHAN_ARCHIVAL_STALE_DAYS days`
+ *   3. zero non-deleted agents are pinned to it
+ *   4. it is not already archived (idempotency guard)
+ *
+ * 30 days is a deliberate product decision (2026-05-27): long enough to
+ * survive a typical vacation / contractor cycle, short enough that
+ * abandoned `client.yaml` regenerations clear within a month. Decoupled
+ * from the auth refresh-token TTL — even if a row's creds are still
+ * mintable, an unused machine for 30 days with no pinned work is
+ * treated as abandoned.
+ *
+ * Returns become recoverable via admin SQL: `UPDATE clients SET
+ * archived_at = NULL WHERE id = '...'`. Or transparent unarchive when
+ * the same yaml id reconnects — see `registerClient` (A) path.
+ */
+export const ORPHAN_ARCHIVAL_STALE_DAYS = 30;
+
+/**
+ * Sweep abandoned `clients` rows: set `archived_at = NOW()` on rows
+ * meeting all four conditions above. Read paths exclude `archived_at IS
+ * NOT NULL` so the row stops surfacing in the UI / API; the row stays
+ * in the table for audit and recovery.
+ *
+ * Returns the number of rows archived. Cheap: a single indexed UPDATE
+ * via `idx_clients_sweep` (status, last_seen_at) WHERE archived_at IS
+ * NULL. Idempotent on the second sweep within the same window — the
+ * `archived_at IS NULL` guard skips rows we already archived.
+ *
+ * Driven by `services/background-tasks.ts` on an hourly timer.
+ */
+export async function archiveAbandonedClients(db: Database, staleDays = ORPHAN_ARCHIVAL_STALE_DAYS): Promise<number> {
+  const result = await db.execute<{ id: string }>(sql`
+    UPDATE clients
+    SET archived_at = NOW()
+    WHERE status = 'disconnected'
+      AND archived_at IS NULL
+      AND last_seen_at < NOW() - make_interval(days => ${staleDays})
+      AND NOT EXISTS (
+        SELECT 1 FROM agents
+        WHERE agents.client_id = clients.id
+          AND agents.status != 'deleted'
+      )
+    RETURNING id
+  `);
   return result.length;
 }

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -57,8 +57,12 @@ export type RegisterClientResult = {
  * another live socket. The WS handler maps this to
  * `client:register:rejected { code: "CLIENT_DEDUP_CONFLICT" }` and
  * closes 4403 so the offending CLI does not silently steal the slot
- * every reconnect. CLI side: error class lives in
- * `packages/client/src/client-connection.ts` for protocol symmetry.
+ * every reconnect.
+ *
+ * Mirror of the CLI-side class:
+ * `packages/client/src/client-connection.ts::ClientDedupConflictError`.
+ * Both carry the same `code = "CLIENT_DEDUP_CONFLICT"` wire constant.
+ * Update both when changing the protocol code.
  */
 export class ClientDedupConflictError extends Error {
   readonly code = "CLIENT_DEDUP_CONFLICT";
@@ -416,7 +420,13 @@ export async function claimClient(
       }
     }
 
-    await tx.update(clients).set({ userId: newUserId }).where(eq(clients.id, clientId));
+    // Also clear `archived_at` so an admin re-claiming an archived row
+    // unarchives it in one step. Without this, the row stays archived
+    // and the next `assertClientOwner` returns 404 — `archived_at IS
+    // NULL` filters that surface elsewhere would skip it too. Aligns
+    // with the same-id (A) `registerClient` upsert path that already
+    // clears the column on reconnect.
+    await tx.update(clients).set({ userId: newUserId, archivedAt: null }).where(eq(clients.id, clientId));
 
     return { previousUserId, unpinnedAgentIds, supersededChatIds };
   });
@@ -813,6 +823,13 @@ export const ORPHAN_ARCHIVAL_STALE_DAYS = 30;
  * via `idx_clients_sweep` (status, last_seen_at) WHERE archived_at IS
  * NULL. Idempotent on the second sweep within the same window — the
  * `archived_at IS NULL` guard skips rows we already archived.
+ *
+ * Concurrency with `registerClient`: this UPDATE does NOT take the dedup
+ * advisory lock, and it doesn't need to. PG's READ COMMITTED re-
+ * evaluates the WHERE clause on a row a concurrent `UPDATE` already
+ * touched, so a register that flips `status='connected'` mid-sweep
+ * causes the sweep to skip the row. There is no "archived=NOW + status=
+ * connected" intermediate state visible to other transactions.
  *
  * Driven by `services/background-tasks.ts` on an hourly timer.
  */

--- a/proposals/connect-computer-default-view-mockup.md
+++ b/proposals/connect-computer-default-view-mockup.md
@@ -1,0 +1,365 @@
+# Settings → Computers 默认视图 · 示意图
+
+配套 proposals/connect-computer-optimization.md 的 P0-3 IA 重组。
+
+布局核心原则：
+
+- **单台机器 = 详情卡片**（不是表格）
+- **顶部一句话状态描述**（不是 chip 数字堆，也不是抽象的"健康度"）
+- **状态用 4 个明确的 pill 来表达**，每个都从现有数据库字段直接派生
+- **行动按钮跟着异常状态走**——出问题就在那里给入口，不藏在 kebab
+- **"+ Add another" 永远在角落、低显眼度**
+
+---
+
+## 状态 pill 定义（4 种，互斥，按优先级判定）
+
+**所有 pill 都用现有字段计算，不引入新的 server 字段、不引入阈值。**
+
+| Pill | 触发条件 | 顶部一句话 | 含义 |
+|---|---|---|---|
+| 🟢 **Ready** | `status=connected` AND `authState=ok` AND 至少一个 `capabilities[*].state=ok` | "Your computer is ready" | 可以跑 agent |
+| 🔴 **Auth expired** | `authState=expired` | "Your computer needs to log in again" | 需要重新 `first-tree login` |
+| 🟡 **Setup incomplete** | `status=connected` AND `authState=ok` AND 所有 `capabilities[*].state ≠ ok` | "Finish setting up your computer" | 在线但没装好任何 runtime |
+| ⚪ **Offline** | `status=disconnected` AND `authState=ok` | "Your computer is offline" | 暂时没在线，没过期 |
+
+判定顺序（自上而下，命中即停）：
+1. `authState=expired` → 🔴 Auth expired
+2. `status=disconnected` → ⚪ Offline
+3. `status=connected` 且所有 capability ≠ ok → 🟡 Setup incomplete
+4. 其余 → 🟢 Ready
+
+派生来源：
+- `clients.status` — 服务端 register/disconnect/cleanupStaleClients 维护
+- `deriveAuthState(row, refreshTTL)` — 服务端纯函数，已存在
+- `clients.metadata.capabilities[*].state` — SDK 启动时探测上报
+
+无需新阈值（心跳多久 stale、SDK 多旧 outdated 都不参与判定）。
+
+---
+
+## Variant A · 🟢 Ready（最高频）
+
+> 用户机器正常运行，进来扫一眼就走
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Computer                                  [ + Add another ]│
+│  ✓ Your computer is ready                                   │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ╭─ MacBook-Pro.local ──────────────── 🟢 Ready ─╮        │
+│   │                                                │        │
+│   │  Heartbeat       12 sec ago                    │        │
+│   │  first-tree      v1.3.2                        │        │
+│   │  OS              macOS 14.4                    │        │
+│   │                                                │        │
+│   │  Runtimes                                      │        │
+│   │    ✓ Claude Code   v0.8.1 · authenticated      │        │
+│   │    ⊘ Codex         not installed   [ Install ] │        │
+│   │                                                │        │
+│   │  Agents · 3 online                             │        │
+│   │    ● code-reviewer       Online                │        │
+│   │    ● design-reviewer     Online                │        │
+│   │    ● support-bot         Online                │        │
+│   │                                                │        │
+│   │                          [ ⋯ More actions ]    │        │
+│   ╰────────────────────────────────────────────────╯        │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- 顶部 ✓ + "Your computer is ready" 是一句确认，让用户安心离开
+- Heartbeat / first-tree version / OS / Runtimes / Agents 都是事实展示，**不参与 pill 判定**
+- Codex 显示 "not installed" 但**不算问题**（只要 Claude Code 是 ok，pill 就是 Ready）
+- Codex 行末有低显眼度的 `[ Install ]` 按钮——给想"加一个 runtime"的用户一个不打眼的入口；点击展开命令复制框
+- "⋯ More actions" 收纳 Disconnect / Retire 等低频操作
+
+---
+
+## Variant B · 🔴 Auth expired（用户主动来排查最常见的一种）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Computer                                  [ + Add another ]│
+│  ⚠ Your computer needs to log in again                      │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ╭─ MacBook-Pro.local ─────────── 🔴 Auth expired ─╮      │
+│   │                                                  │      │
+│   │  This computer hasn't checked in for 8 days.     │      │
+│   │  Your access token has expired.                  │      │
+│   │                                                  │      │
+│   │  To fix, run on MacBook-Pro.local:               │      │
+│   │                                                  │      │
+│   │    first-tree login <token>                      │      │
+│   │              [ Generate new token ]              │      │
+│   │                                                  │      │
+│   │  ─────────────────────                           │      │
+│   │  Heartbeat       8 days ago                      │      │
+│   │  first-tree      v1.0.4                          │      │
+│   │  Claude Code     ✓ authenticated (last reported) │      │
+│   │  Agents · 3 offline                              │      │
+│   ╰──────────────────────────────────────────────────╯      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- Card 头部 pill 即诊断，下面紧跟"为什么 + 怎么办"
+- "Generate new token" 是行内按钮（点了在原位展开 token 文本 + 复制按钮）
+- 旧的事实数据（heartbeat / first-tree version）放在下方分隔线后，作为补充
+- Agents 显示离线影响范围，让用户理解修复后能恢复什么
+
+---
+
+## Variant B-2 · 🟡 Setup incomplete
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Computer                                      [ + Add another ]│
+│  ⚠ Finish setting up your computer                              │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│   ╭─ MacBook-Pro.local ──────── 🟡 Setup incomplete ─╮         │
+│   │                                                    │         │
+│   │  This computer is online, but no runtime is        │         │
+│   │  ready. Install one of the following on this       │         │
+│   │  computer to start running agents:                 │         │
+│   │                                                    │         │
+│   │  ┌─ Claude Code ────────────────────────┐          │         │
+│   │  │  On MacBook-Pro.local, run:           │          │         │
+│   │  │    npm install -g @anthropic-ai/      │          │         │
+│   │  │      claude-code                      │          │         │
+│   │  │    claude login                       │          │         │
+│   │  │                       [ Copy commands ]│          │        │
+│   │  └────────────────────────────────────────┘         │         │
+│   │                                                    │         │
+│   │  ┌─ Codex ────────────────────────────────┐        │         │
+│   │  │  On MacBook-Pro.local, run:             │        │         │
+│   │  │    npm install -g @openai/codex         │        │         │
+│   │  │    codex login                          │        │         │
+│   │  │                       [ Copy commands ] │        │         │
+│   │  └─────────────────────────────────────────┘        │         │
+│   │                                                    │         │
+│   │  ─────────────────────                             │         │
+│   │  Heartbeat       12 sec ago                        │         │
+│   │  first-tree      v1.3.2                            │         │
+│   │  Agents · 0                                        │         │
+│   ╰────────────────────────────────────────────────────╯         │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- **两个 runtime 对等展示**——不强推任意一个，用户按自己习惯/已有账号选
+- 每个 runtime 一个独立 box，含安装 + 登录命令 + 复制按钮
+- 全部 capability ⊘ 算严格的 "no runtime ready"——只要装好一个，pill 就跳到 Ready
+- 如果其中一个状态是 `unauthenticated` 而不是 `missing`，对应 box 文案变为 "Claude Code is installed but not logged in" + 只显示 `claude login` 命令
+
+---
+
+## Variant B-3 · ⚪ Offline
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Computer                                  [ + Add another ]│
+│  ⚠ Your computer is offline                                 │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ╭─ MacBook-Pro.local ─────────────── ⚪ Offline ─╮        │
+│   │                                                │        │
+│   │  Last seen 2 hours ago.                        │        │
+│   │  Make sure the machine is awake and connected. │        │
+│   │                                                │        │
+│   │  If the daemon isn't running, on MacBook-Pro:  │        │
+│   │                                                │        │
+│   │    first-tree daemon start                     │        │
+│   │                                                │        │
+│   │  ─────────────────────                         │        │
+│   │  first-tree      v1.3.2                        │        │
+│   │  Claude Code     ✓ authenticated (last reported)│       │
+│   │  Agents · 3 offline                            │        │
+│   ╰────────────────────────────────────────────────╯        │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- Offline 跟 Auth expired 区别：Auth expired = 凭证已死、必须重新 login；Offline = 凭证还活着，只是这台机器没在跑
+- 引导从轻到重：先确认机器是否开机、网络是否通 → 再考虑 daemon 重启
+
+---
+
+## Variant C · 双设备用户（15-25%）
+
+> 两台机器并列，浓缩卡片
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Computers                                           [ + Add another ]  │
+│  🟢 1 ready · ⚪ 1 offline                                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   ╭─ MacBook-Pro ────── 🟢 Ready ─╮  ╭─ Mac-mini ────── ⚪ Offline ─╮ │
+│   │  Heartbeat 12 sec               │  │  Last seen 2 hours ago        │ │
+│   │  Claude Code ✓                  │  │  Claude Code ✓ (last reported)│ │
+│   │  Agents 3 online                │  │  Agents 2 offline             │ │
+│   │                                 │  │                               │ │
+│   │  [ View details ]   [ ⋯ ]      │  │  [ Wake guide ]   [ ⋯ ]      │ │
+│   ╰─────────────────────────────────╯  ╰───────────────────────────────╯ │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- 顶部一句话拆分成 "N pill-name" 计数（比如 "1 ready · 1 offline"）
+- 卡片是 Variant A/B 的浓缩版，主操作 + ⋯
+- View details / 状态对应的恢复入口（Wake guide / Re-authenticate / Setup runtime）按 pill 显示
+- **布局响应式**：视口宽（≥ 1024px）2-up 并列；窄屏（< 1024px）自动堆叠为单列卡片栈，每张卡片宽度 = 视口宽 - padding
+
+---
+
+## Variant D · Admin team view（admin 切到 team tab）
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Computers                                                              │
+│  ⊙ Your computer 🟢 (active)   |   ⊙ Team computers (8)                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│  Filter:  [ All ▾ ] [ With issues ▾ ] [ Sort by: state ▾ ]              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  🔴  Alice  · alice-MBP        Auth expired                             │
+│       Heartbeat 8 days ago · Claude Code ✓ (last reported)              │
+│       2 agents offline                                                  │
+│       [ Copy suggestion → Alice ]   [ View details ]                    │
+│  ─────────────────────────────────────────────────────────────────────  │
+│  🟡  Bob    · bob-linux        Setup incomplete                         │
+│       Heartbeat 15 sec ago · No runtime ready                           │
+│       1 agent waiting                                                   │
+│       [ Copy suggestion → Bob ]   [ View details ]                      │
+│  ─────────────────────────────────────────────────────────────────────  │
+│  ⚪  Eva    · eva-MBP          Offline                                  │
+│       Last seen 4 hours ago · Claude Code ✓                             │
+│       1 agent offline                                                   │
+│       [ Copy suggestion → Eva ]   [ View details ]                      │
+│  ─────────────────────────────────────────────────────────────────────  │
+│  🟢  Cara   · cara-MBP         Ready                                    │
+│       Heartbeat 8 sec ago · Claude Code ✓ · 4 agents online             │
+│       [ View details ]                                                  │
+│  ─────────────────────────────────────────────────────────────────────  │
+│  ... (3 more ready, collapsed)                       [ Show all 8 ]    │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**说明**：
+- **默认 tab 是 "Your computer"**（更高频），admin 主动切到 "Team computers" 才进入支持模式
+- **默认按 pill 优先级排序**：🔴 → 🟡 → ⚪ → 🟢，admin 不用扫，问题自然冒上来
+- 每行一句话状态结论 + 当前事实（heartbeat、capability、agent 数）
+- 健康的成员折叠 / 简化显示，节省视觉带宽
+
+### "Copy suggestion" 消息模板
+
+**产品提供按 pill 状态的固定模板，admin 点击后弹出可编辑预览**（保证消息质量基线，同时允许个性化润色）。
+
+模板示例：
+
+#### 🔴 Auth expired
+```
+Hi {member_name}, your computer "{hostname}" needs you to re-login.
+
+On {hostname}, run:
+  first-tree login <token>
+
+Generate the token at https://{hub_host}/settings/computers
+This will bring back {agent_count} agent(s): {agent_names}.
+```
+
+#### 🟡 Setup incomplete
+```
+Hi {member_name}, your computer "{hostname}" is online but needs a runtime installed.
+
+On {hostname}, install at least one of:
+
+  Claude Code:
+    npm install -g @anthropic-ai/claude-code && claude login
+
+  Codex:
+    npm install -g @openai/codex && codex login
+
+Once installed, {agent_count} agent(s) will come online: {agent_names}.
+```
+
+#### ⚪ Offline
+```
+Hi {member_name}, your computer "{hostname}" hasn't checked in for {duration}.
+
+Please make sure the machine is awake and connected.
+If the daemon isn't running, on {hostname} run:
+  first-tree daemon start
+
+{agent_count} agent(s) are currently offline: {agent_names}.
+```
+
+模板里的 `{...}` 占位符由前端按当前行数据填好，admin 在编辑预览里看到的就是最终文本——可以原样复制、也可以改完再复制。
+
+---
+
+## 跟当前实现的对比
+
+| | 当前 | 提议 |
+|---|---|---|
+| 默认视图 | 表格（无论几台机器） | 单台→卡片、多台→卡片列表 |
+| 顶部摘要 | "X total · Y connected · Z agents bound · W need re-auth" | 一句话状态描述（"Your computer is ready" 等） |
+| 状态指示 | 多个 chip（status / authExpired 分散） | **一个 pill = 4 状态之一**（互斥优先级判定） |
+| 心跳信号 | 显示 connectedAt | 显示 lastSeenAt |
+| 版本字段名 | "SDK" | "first-tree" |
+| 版本健康 | 字符串 v1.0.4 | 字符串 v1.0.4（不参与判定，仅展示） |
+| Capability | 必须展开行才能看 | 主视图直接显示 |
+| 操作入口 | kebab 菜单（Disconnect/Retire/Reconnect） | 状态化主行动（Generate new token / Wake guide / Setup runtime）+ ⋯ More |
+| "+ Connect" 显眼度 | 页面顶部主按钮 | 角落次要按钮 |
+| Admin team view | 表格 + 行不可展开 | 一句话诊断列表 + 一键复制建议 |
+| Admin 排序 | 按 lastSeenAt | 按 pill 优先级（🔴→🟡→⚪→🟢） |
+
+---
+
+## Runtime 行为细则（横跨所有 variant）
+
+| Runtime state | 在 Ready 卡片 | 在 Setup incomplete 卡片 | 在 Auth expired / Offline 卡片 |
+|---|---|---|---|
+| `ok` | ✓ Claude Code v0.8.1 · authenticated (method)，无 action | 不出现（既然有 ok，pill 就不是 Setup incomplete） | 标 "(last reported)" 不可操作 |
+| `unauthenticated` | ⚠ installed v0.8.1, not authenticated · 行末有 [ Sign in ] 按钮 | 在 box 里独立展示，文案改成 "installed but not logged in"，只给 `claude login` 命令 | 不展示登录入口（机器没在线）|
+| `missing` | ⊘ not installed · 行末有 [ Install ] 按钮（低显眼度） | 在 box 里独立展示，给完整 install + login 命令 | 不展示安装入口 |
+| `error` | ❌ error: {message} · 文档链接 | 在 box 里独立展示 error 详情 + 文档链接 | 不展示 |
+
+**error 状态处理（C 选项）**：
+- 显示 capability.error 文字
+- 加一个 troubleshooting 文档链接
+- **不做** "Retry probe" / "Reinstall" 自动化按钮（留待后续）
+
+---
+
+## 已敲定（全部）
+
+- 4 个 pill 名称：**Ready / Auth expired / Setup incomplete / Offline**（英文）
+- Setup incomplete 严格定义：**所有 capability 都 ≠ ok 才触发**
+- Agent 状态语言：**online / offline**（沿用线上 PresenceChip）
+- 版本字段名：**first-tree**（替代 "SDK"）
+- Ready 卡片：行末给 [ Install ] / [ Sign in ] 入口（低显眼）
+- Setup incomplete 卡片：**Claude Code 与 Codex 对等展示**，用户自选
+- Runtime error 状态：error message + 文档链接，不做 retry 按钮
+- **多设备布局**：响应式（≥1024 2-up 并列，<1024 单列堆叠）
+- **Admin 默认 tab**：Your computer（更高频）
+- **Copy suggestion**：产品给按 pill 状态的固定模板，admin 点击后弹出可编辑预览
+
+## 下一步
+
+Mockup 设计部分已收尾，可以：
+
+1. **转技术 spec**：交 @gandy-developer 基于本 mockup + proposals/connect-computer-optimization.md 出技术设计文档（含数据模型变更、API 变更、UI 组件拆分、迁移计划、测试覆盖）
+2. **同步更新 proposal 主文档**：把 §5 P0-3/P0-4 里跟"健康"等含糊措辞对齐到本 mockup 的精确 pill 定义
+
+@gandy2025 拍板要先做哪个、还是两个并行交付。

--- a/proposals/connect-computer-implementation-plan.md
+++ b/proposals/connect-computer-implementation-plan.md
@@ -1,0 +1,825 @@
+# Connect Computer 体验优化 — Implementation Plan
+
+| | |
+|---|---|
+| **作者** | @gandy-developer |
+| **日期** | 2026-05-26 |
+| **基础文档** | proposals/connect-computer-optimization.md（gandy-assistant 出）<br>proposals/connect-computer-default-view-mockup.md（gandy-assistant 出） |
+| **代码 baseline** | hub-fresh worktree `3992f98`（main） |
+| **状态** | DRAFT — 待 design reflection 三轮后冻结 |
+
+---
+
+## 0. Executive Summary
+
+本计划把 proposals 中定义的 First Delivery (P0-1 ~ P0-4) 拆成**三个独立可发布、互不阻塞的 PR**，按"风险递增、可见性递减"顺序排：
+
+- **PR-A · Quick wins（首选起手）**：纯前端 + 一处 server 附加字段。P0-2 NewConnectionDialog 修正 + P0-4 4-pill 状态派生 + lastSeenAt + "first-tree" 改名。**零迁移，零 CLI 改动**，单 PR 完整可回滚。
+- **PR-B · IA 重组**：P0-3 卡片视图 + 响应式 1024px 断点 + 降权 "+Connect"。建立在 PR-A 的 pill 派生函数之上。纯前端，**零迁移**。
+- **PR-C · 服务端清理**：P0-1 register dedup + 孤儿归档 + daemon ↔ yaml 联动。涉及 schema 变更、迁移、CLI 改动、跨包契约。**最大 blast radius**，独立 PR 慎重发。
+
+**推荐先 ship PR-A**：
+- 70-80% 用户立刻能看到"机器现在能不能跑 agent"的明确答案
+- 解决"永远 connecting"死路（最常见的用户投诉）
+- 不动 DB schema、不动 CLI、不动 daemon 行为 → 回滚成本为零
+- 完成后再决定 PR-B / PR-C 的优先级
+
+---
+
+## 1. 现状代码摸底（影响 plan 的关键发现）
+
+读完 hub-fresh main 的关键代码（详见 §10 附录），把 proposals 里的假设和现实对齐：
+
+### 1.1 `bootstrapCommand` 字段服务端已实现
+
+`POST /me/connect-tokens` 已经在响应里返回：
+- `command`: 单行 `first-tree login <token>`
+- `bootstrapCommand`: 双行 `npm install -g <pkg>\nfirst-tree login <token>`（prod/staging）或同 `command`（dev，无 npm 包）
+- `npmSpec`, `binName`
+
+→ NewConnectionDialog **已经能拿到双行命令**，只是 [new-connection-dialog.tsx:141](packages/web/src/pages/clients/new-connection-dialog.tsx) 选用了 `token?.command`。**改成 `bootstrapCommand` 是一行修改**。
+
+### 1.2 `capabilities` 没暴露在列表 API
+
+- `GET /me/clients`（[api/me.ts:416-433](packages/server/src/api/me.ts)）返回 `id / userId / status / authState / sdkVersion / hostname / os / agentCount / connectedAt / lastSeenAt / lastUpdateAttempt`，**不含 capabilities**
+- `GET /clients/:id`（[api/clients.ts:15-37](packages/server/src/api/clients.ts)）返回包括 `capabilities`，但需要 row-level 拉取
+- 当前 Web `ClientsPage` 展开行触发 `getClientCapabilities`，对 1 台机器有效；列表层级要看 pill 状态需要每行各打一发请求
+
+**对 4-pill 派生的影响**：
+- 🔴 Auth expired：用 `authState`（已在列表）
+- ⚪ Offline：用 `status`（已在列表）
+- 🟢 Ready vs 🟡 Setup incomplete：**需要 capabilities**（区分点是"至少有一个 capability state=ok"）
+
+**决策**：在 PR-A 内给 `/me/clients` 加 `capabilities` 字段（来自现有的 `clients.metadata.capabilities`，零 DB 改动，纯响应映射扩展）。同时给 `/orgs/:orgId/clients`（admin 视图）加同样字段为 PR-B 备料。详见 §3.1。
+
+### 1.3 `deriveAuthState` 已经服务端纯函数化
+
+[services/client.ts:376-385](packages/server/src/services/client.ts) 把 `authState: "ok" | "expired"` 推断挪到了 server。Web 拿到的 `authState` 是服务端算好的，**前端 pill 派生直接用即可**。
+
+### 1.4 `cleanupStaleClients` 仅翻 status，不删行
+
+[services/client.ts:459-479](packages/server/src/services/client.ts) 把停跳的 client 翻成 `disconnected`，**没有任何归档/删除**。P0-1 的孤儿归档需要：
+- 新增定时 sweep（disconnected > 阈值 + agentCount=0 的行）
+- 表上加 `archivedAt` 列或新的 `status='archived'` 枚举值
+- 所有读路径排除 archived 行（`/me/clients`、`/orgs/:orgId/clients`、`GET /clients/:id`）
+
+**这件事属于 PR-C**，PR-A 不碰。
+
+### 1.5 `logout --purge` 已经正确处理 daemon
+
+[apps/cli/src/commands/logout.ts:14-44](apps/cli/src/commands/logout.ts) 默认**先停 daemon、再删 credentials**；`--purge` 才删 yaml。proposal 描述准确——**当前 logout 不是 orphan 的来源**。orphan 来自其他路径（多 channel、`rm -rf` yaml、login --override 后旧行）。
+
+### 1.6 `clients` 表 schema 已经 user-owned + org-immutable
+
+[db/schema/clients.ts](packages/server/src/db/schema/clients.ts) primary key 是 `id`，`userId` 可空但实际上每个新行都有，`organizationId` 是占位列（不消费）。没有 `(user_id, hostname, os)` unique 索引。
+
+→ PR-C 添加 soft dedup 时，**不需要 unique 约束**（应用层处理 reuse 路径），但需要 `idx_clients_user_hostname_os` 检索索引。
+
+### 1.7 现有 vitest 测试体系完整
+
+`packages/server/src/__tests__/` 下有 `me-clients-list.test.ts`、`client-auth-state.test.ts`、`client-claim.test.ts` 等 ~12 个 client 相关测试文件。`packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts` 测了 `selectArrivedClient` 纯函数。**测试体系成熟，TDD 路径清晰**。
+
+---
+
+## 2. Scope 决策与三个 PR 的边界
+
+### 2.1 为什么不一个 PR
+
+proposals/connect-computer-optimization.md §6 自己说第一交付"建议 2-3 周"。把全部塞一个 PR：
+- 单次审查负担过大，code review 质量下降
+- 服务端去重（P0-1）需要迁移和 daemon 协议改动，blast radius 跟纯 UI 改动不在一个量级
+- IA 重组（P0-3）跟 pill 派生（P0-4）虽然有依赖，但拆开有可读性收益（pill 派生函数先建立、覆盖测试，IA 再消费）
+- 若 P0-1 出问题需要回滚，纯 UI 的 P0-2/P0-4 会被一起退掉，浪费已经验证可用的工作
+
+### 2.2 PR 边界
+
+| PR | 涵盖 proposal 项 | 修改文件包 | 迁移 | CLI 改动 | Schema 改动 |
+|---|---|---|---|---|---|
+| **PR-A** | P0-2 + P0-4 (+ `/me/clients` 加 capabilities 字段) | web + server（一处）| 否 | 否 | 否 |
+| **PR-B** | P0-3 | web | 否 | 否 | 否 |
+| **PR-C** | P0-1 | server + cli + shared | **是** | **是** | **是** |
+
+### 2.3 风险递增
+
+- PR-A：纯展示+一处 server response shape 加字段。可视化的 diff 一目了然。失败模式：pill 派生逻辑误判 → 用户看到错误状态。回滚 = 还原 PR。
+- PR-B：仅 IA。失败模式：响应式 broken / 单设备 vs 多设备分支处理错。回滚 = 还原 PR。
+- PR-C：跨服务、跨进程、含 DB 迁移。失败模式：dedup 误合并、归档了不该归档的行、daemon 自杀逻辑误伤。**必须先有 staging 验证**。
+
+### 2.4 推荐执行顺序
+
+1. **PR-A 先发**（本 plan 详细覆盖到 task 级别）
+2. PR-A merge 后立刻评估 PR-B（IA 重组）—— PR-B 的 mockup 已经在 proposal 里定型，只是 React 组件重组
+3. PR-C 独立排期 ——  staging 灰度先验证 dedup 不误合并
+
+---
+
+## 3. PR-A 架构设计
+
+### 3.1 数据流：`/me/clients` 携带 capabilities
+
+**现状**：
+```ts
+type HubClient = {
+  id; userId; status; authState; sdkVersion;
+  hostname; os; agentCount; connectedAt; lastSeenAt;
+  // 不含 capabilities
+};
+```
+
+**改动**：
+```ts
+type HubClient = {
+  ...same as above...
+  /**
+   * Runtime-provider capabilities snapshot (server reads from
+   * clients.metadata.capabilities). Empty object when never reported.
+   * Used by the client-side pill derivation to distinguish Ready
+   * (≥1 capability state=ok) from Setup incomplete (all ≠ ok).
+   */
+  capabilities: ClientCapabilities;
+};
+```
+
+**实现要点**：
+- 服务端 [api/me.ts:420-432](packages/server/src/api/me.ts) 的 `.map(c => ...)` 加一行：`capabilities: ((c.metadata?.capabilities) as ClientCapabilities | undefined) ?? {}`
+- 与 [api/clients.ts:21](packages/server/src/api/clients.ts)（`GET /clients/:id`）的处理一致
+- **Member path**：`listClients`（[services/client.ts:323-325](packages/server/src/services/client.ts) `.select().from(clients)`）拉所有列含 `metadata`。**响应映射可直接读 `c.metadata.capabilities`**
+- ⚠️ **Admin path**：`listClientsForOrgAdmin`（[services/client.ts:338-356](packages/server/src/services/client.ts)）用 explicit column select，**不含 `metadata`**。Task A1 必须在此 select 中加入 `metadata: clients.metadata`，否则 admin 视图收不到 capabilities，pill 在 admin 模式会全错（误判成 setup_incomplete）。这是 adversarial review 抓到的 P0 项
+
+**响应大小影响**：capability 是 `Record<provider, entry>`，目前两个 provider（claude-code、codex），每个 entry 几个 string 字段。1 个 client ≤ 1KB。70-80% 用户 1 台 client → 总响应 < 2KB，可忽略。
+
+### 3.2 4-Pill 派生（前端纯函数）
+
+**文件**：`packages/web/src/pages/clients/derive-status.ts`（新建）
+
+```ts
+import type { ClientCapabilities } from "@first-tree/shared";
+import type { HubClient } from "../../api/activity.js";
+
+export type ComputerStatusPill = "ready" | "auth_expired" | "setup_incomplete" | "offline";
+
+export type ComputerStatus = {
+  pill: ComputerStatusPill;
+  /** Headline copy for the top-of-page sentence. */
+  headline: string;
+};
+
+/**
+ * Pure 4-state pill derivation for the Settings → Computers row.
+ *
+ * Order is by user-actionable severity (most actionable first). All
+ * inputs come from existing fields — no new server columns, no thresholds.
+ *
+ * NOTE on `expired` vs `disconnected`: the server contract in
+ * `services/client.ts:376-385` returns `authState=expired` ONLY when
+ * `status=disconnected` AND offline duration exceeds the refresh-token
+ * TTL. So `expired` ⊂ `disconnected` — the step-2 disconnected branch is
+ * unreachable when step 1 matched. Keep both as defensive ordering in
+ * case the server contract changes (e.g., adds admin-driven revocation).
+ */
+export function deriveComputerStatus(client: HubClient): ComputerStatus {
+  // 1. authState=expired wins — credentials are dead, user must re-login.
+  if (client.authState === "expired") {
+    return { pill: "auth_expired", headline: "Your computer needs to log in again" };
+  }
+  // 2. Disconnected (but auth still ok — token alive, machine just offline).
+  if (client.status !== "connected") {
+    return { pill: "offline", headline: "Your computer is offline" };
+  }
+  // 3. Connected + at least one capability with state=ok → Ready.
+  const caps = client.capabilities ?? {};
+  const anyOk = Object.values(caps).some((entry) => entry?.state === "ok");
+  if (anyOk) {
+    return { pill: "ready", headline: "Your computer is ready" };
+  }
+  // 4. Connected + zero ok capabilities → Setup incomplete.
+  return { pill: "setup_incomplete", headline: "Finish setting up your computer" };
+}
+
+/** Priority order — used by both row sorting and top-of-page summary. */
+export const PILL_PRIORITY: Record<ComputerStatusPill, number> = {
+  auth_expired: 0,
+  setup_incomplete: 1,
+  offline: 2,
+  ready: 3,
+};
+```
+
+**特性**：
+- 零 server 字段、零阈值（符合 mockup §"状态 pill 定义"硬约束）
+- 完全纯函数，pinpoint TDD：表格驱动测试 N 个 input → expected pill
+- 不依赖时间（mockup 明确不引入 stale heartbeat 阈值）
+
+### 3.3 `ComputerStatusPill` 组件
+
+**文件**：`packages/web/src/pages/clients/computer-status-pill.tsx`（新建）
+
+复用现有 PresenceChip 的视觉语言（dot + label），但加 4 个 pill 状态色：
+- 🟢 Ready → `var(--state-idle)` 绿
+- 🔴 Auth expired → `var(--state-error)` 红（已有）
+- 🟡 Setup incomplete → `var(--state-blocked)` 琥珀
+- ⚪ Offline → `var(--fg-4)` 灰
+
+Pill 文案是固定字符串。组件接收 `pill: ComputerStatusPill`。
+
+### 3.4 表格列改动（不重组 IA，那是 PR-B 的事）
+
+[clients.tsx](packages/web/src/pages/clients.tsx) 当前表头：
+```
+| chevron | Hostname | (Owner) | OS | SDK | Agents | Connected | Status | actions |
+```
+
+PR-A 改成：
+```
+| chevron | Hostname | (Owner) | OS | first-tree | Agents | Last seen | Status | actions |
+                                       ↑↑↑↑↑↑↑↑↑↑               ↑↑↑↑↑↑↑↑↑   ↑↑↑↑↑↑
+                                       仅文案改名              relative time   单 pill
+```
+
+具体：
+1. SDK 列表头改 "first-tree"，单元格还显示 `client.sdkVersion`（mockup §"已敲定"决定不引入版本健康对比）
+2. Connected 列改名 Last seen，单元格从 `formatDate(connectedAt)` 改为 `formatRelative(lastSeenAt)`，title 仍带绝对时间
+3. Status 列：原来分支渲染 `AuthExpiredChip` 或 `PresenceChip`，改成统一 `<ComputerStatusPill pill={status.pill} />`
+4. 顶部 subtitle：
+   - 当 `clients.length === 1` → 单 headline (`status.headline`)
+   - 当 `clients.length > 1` → "N ready · M offline · ..." 计数（不引入新字段就能算）
+   - **Zero-suppression**：计数为 0 的 pill 不显示，避免 "1 ready · 0 setup_incomplete · 0 offline" 这种噪音。仅显示出现过的 pill
+5. 行排序按 `PILL_PRIORITY` 升序（红色冒到最上面），同 pill tie-break `lastSeenAt` 降序
+   - **Member 模式 (non-admin) 当前没有显式 sort**（按 API 返回顺序）— PR-A 引入 pill-priority sort 会**改变现有用户视野中的行顺序**。这是有意 UX 改进（问题机器冒头）。在 PR description 中显式 call out
+   - **Admin 模式**当前按 `lastSeenAt` 降序排（[clients.tsx:159-169](packages/web/src/pages/clients.tsx)）；PR-A 改成 pill-priority + lastSeenAt 联合排序
+
+### 3.5 NewConnectionDialog 三件套修正
+
+**文件**：[packages/web/src/pages/clients/new-connection-dialog.tsx](packages/web/src/pages/clients/new-connection-dialog.tsx)
+
+#### 3.5.1 改用 `bootstrapCommand`
+
+```ts
+<ConnectCommandPanel
+  command={token?.bootstrapCommand ?? null}  // was token?.command
+  ...
+/>
+```
+
+Onboarding 已经在用 `bootstrapCommand`（[step-connect-computer.tsx](packages/web/src/pages/onboarding/steps/step-connect-computer.tsx) 通过 `useOnboardingFlow().computer.cliCommand`）。一致化即 fix。
+
+#### 3.5.2 Token 过期 → error phase
+
+`token.expiresIn` 已经返回（秒数，~10 分钟默认）。在 mint 成功后启动一个 setTimeout：
+
+```ts
+useEffect(() => {
+  if (!open || !token || phase !== "waiting") return;
+  const ms = token.expiresIn * 1_000;
+  const handle = setTimeout(() => {
+    setErrorMessage("This token expired. Generate a new one to continue.");
+    setPhase("error");
+  }, ms);
+  return () => clearTimeout(handle);
+}, [open, token, phase]);
+```
+
+**`open` 在 deps 里很关键**：modal 关闭时，前一个 effect 的 cleanup（return 函数）跑，timer 被 clearTimeout。否则 close + reopen with same token cache 会让旧 timer 在新 modal 上 fire（adversarial review finding #3）。
+
+**Race 分析**：
+- 用户拷贝命令在 t=9min，切到 terminal 跑，CLI 在 t=10:30s 连上
+- 前端 timer 在 t=10min fire → phase=error
+- Polling tick 在 t=10:05min 看到 arrived client → 想 setPhase=success
+- 但 polling useEffect 的 guard `phase !== "waiting"` 会让 tick 直接 return（已经在 error phase）
+- **正确行为**：server 已经在 t=10min 把 connect-token 标记 expired，CLI 跑会被 server 拒绝（AUTH_ERROR）—— 永远不会有"过期 token 的 CLI 成功落地"这种状态
+
+→ 边界一致。**额外测试**：用 fake timers 模拟该序列，验证 phase 始终 error 不被 polling 翻回 success。
+
+并在 error phase 加一个 "Generate new token" 按钮 → 触发 `mintToken()` 重新走 loading→waiting（实现详见 §3.13）。
+
+#### 3.5.3 StuckPanel 抽出共用
+
+[step-connect-computer.tsx:89-122](packages/web/src/pages/onboarding/steps/step-connect-computer.tsx) 的 `StuckPanel` 是个纯 presentational 组件（无 timer）。**75 秒触发逻辑是在父组件 `StepConnectComputer` 的 [useEffect](packages/web/src/pages/onboarding/steps/step-connect-computer.tsx:30-38) 里管理的**（`stuck` boolean state + setTimeout）。
+
+**修订设计（避免 adversarial review finding #4 的耦合问题）**：
+
+1. 把 `StuckPanel` 抽出到 `packages/web/src/components/connect-stuck-panel.tsx` —— **保持纯 presentational**，无 internal timer。文案仍走 `COPY.connectComputer.*`（onboarding copy 也由 NewConnectionDialog import — 当前 dialog 已经间接使用 `ConnectCommandPanel` 共享 panel，加 `import { COPY } from "../onboarding/copy.js"` 是接受的轻耦合，避免大规模 copy 重组）
+2. 75 秒触发逻辑**各 caller 自己管**：
+   - Onboarding `StepConnectComputer` 保留 `stuck` state（不变）
+   - NewConnectionDialog 加同样模式的 `stuck` state + useEffect（waiting phase 时启动 75s timer，phase 变化或 unmount 时 clear）
+3. 共享常量：`packages/web/src/components/connect-stuck-panel.tsx` 顶部 `export const STUCK_AFTER_MS = 75_000;` 让 onboarding 和 dialog 同时 import，确保两端漂移不掉
+4. **DRY trade-off**：两处各写一份 small useEffect（~5 行 each）总比让 ConnectStuckPanel 把 timer 内置然后被 parent 通过 `triggerKey`/`reset` prop 隔空控制更清晰。Explicit over clever
+
+→ **不动 onboarding 的行为**（重要：当前 onboarding 在 `connectedClient` 到达时清 stuck，NewConnectionDialog 在 phase 变化时清 stuck，逻辑分别在 parent 里写，互不干扰）
+
+### 3.6 测试策略
+
+#### 3.6.1 单元（pure-fn / vitest）
+
+- **`derive-status.test.ts`**: 矩阵覆盖 4 个 pill × 关键边界条件
+  - authState expired 强势压制 status / capabilities
+  - status disconnected + authState ok → offline
+  - connected + zero capability ok → setup_incomplete
+  - connected + 至少一个 capability ok → ready
+  - capabilities 为空对象（从未上报）→ setup_incomplete
+  - capabilities 含 missing / unauthenticated / error 但没有 ok → setup_incomplete
+  - **edge**: `capabilities` 字段缺失（undefined）→ 视同 `{}`，setup_incomplete
+  - **edge**: capability entry `state` 字段缺失（malformed）→ optional chain 跳过该 entry，等同 ≠ ok
+
+- **`new-connection-dialog.test.ts`**（已有的扩展）:
+  - 现有 `selectArrivedClient` 测试保留
+  - 新增：token expiresIn 到点切 phase=error（用 `vi.useFakeTimers()`）
+  - 新增：使用 `bootstrapCommand` 而非 `command`
+  - 新增：mint 失败时 phase=error 显示 error 消息（点击 Generate 按钮重试也走 mint）
+  - 新增：error phase 下点击 "Generate new token" 按钮 → 触发 mintToken 重新走 loading→waiting
+
+- **`connect-stuck-panel.test.tsx`** (新):
+  - 默认 75s 后渲染 StuckPanel 内容
+  - `afterMs={500}` prop 缩短测试时长
+  - 用 `vi.useFakeTimers()` 跳过 setTimeout
+
+- **`clients-sort.test.ts`** (新或集成在 clients.test.ts):
+  - 抽出 `compareByPillPriority(a, b)` helper（在 clients.tsx 或 derive-status.ts）
+  - 测试：🔴 排在 🟡 前面；同 pill 按 lastSeenAt 降序 tie-break
+  - 测试：admin 双分组各自独立排序，不跨组
+
+#### 3.6.2 集成（server vitest）
+
+- **`me-clients-list.test.ts`** 扩展：
+  - `/me/clients` 响应包含 `capabilities` 字段
+  - 已上报 capabilities 的 client 返回完整 map
+  - 从未上报的 client 返回 `{}`
+  - admin 模式同样断言 `/orgs/:orgId/clients` 含 capabilities
+
+#### 3.6.3 端到端（手测）
+
+PR-A 是纯展示+一处字段补充，没有需要 e2e 框架的 happy path。手测清单写入 PR 描述：
+
+- [ ] 单 ready computer：顶部"Your computer is ready"，Status 列绿点
+- [ ] Auth expired computer：顶部"...needs to log in again"，红 pill
+- [ ] 没装 runtime 的 computer：黄 setup_incomplete pill
+- [ ] 双 computer 一 ready 一 offline：顶部"1 ready · 1 offline"，offline 行排上面
+- [ ] NewConnectionDialog 双行命令可见
+- [ ] NewConnectionDialog 等 10 分钟（token 过期）→ 自动切红色 error + Generate new token 按钮
+- [ ] NewConnectionDialog 75s 不连 → 出现 stuck panel
+
+### 3.7 PR-A 不做的事（明确排除）
+
+- ❌ 单设备卡片视图（→ PR-B P0-3）
+- ❌ 响应式 2-up 多卡片（→ PR-B P0-3）
+- ❌ "+Connect computer" 按钮降权位置（→ PR-B P0-3）
+- ❌ 服务端 register dedup（→ PR-C P0-1）
+- ❌ 孤儿归档（→ PR-C P0-1）
+- ❌ daemon ↔ yaml binding（→ PR-C P0-1）
+- ❌ Admin team view 解锁诊断（→ 后续 P1 PR，不在 First Delivery）
+- ❌ Copy suggestion 模板（→ 后续 P1 PR）
+- ❌ 行内 state-aware actions（→ PR-B 或单独 PR，跟 IA 重组耦合）
+
+### 3.8 关于 proposal P0-4 "capability matrix 主视图可见" 的部分满足
+
+proposal §5 P0-4 包含一条 "capability matrix 主视图可见，不再深埋展开行"。在 PR-A 保持 table IA 的前提下，**完整在主行渲染 runtime 矩阵会让表格过宽**。PR-A 的折中：
+
+- **主行**：4-pill 已经隐含传达 "capabilities 状况"（Ready ⇔ 至少一个 ok；Setup incomplete ⇔ 全不 ok）。具体 provider 详情**仍保留展开行**
+- **PR-B 卡片视图**才真正把 runtime 矩阵搬到卡片主体（卡片体内有空间承载详情，table 没有）
+- proposal §3 mockup variant A/B 全部基于卡片视图，是 PR-B 的目标态
+
+→ PR-A 满足 "状态信号在主视图可见"（pill 即状态结论），完整 capability 详情主视图化在 PR-B 实现。这是有意为之的拆分，不是遗漏。
+
+### 3.9 类型边界细节
+
+- `clients.metadata` 类型是 `jsonb` → TS `Record<string, unknown>`，`metadata.capabilities` 是 `unknown`。服务端 [api/clients.ts:21](packages/server/src/api/clients.ts) 已经有 typeof guard 模式（`metadata.capabilities && typeof === "object"`），Task A1 复用同一 guard
+- Web 收到的 `capabilities` 不做二次 zod parse（信任服务端） — 仅用 `Object.values(caps).some(...)` 这种 defensive 访问。`entry?.state` optional chain 处理 entry 缺失情形
+
+### 3.10 `formatRelative` 实现
+
+`packages/web/src/lib/utils.ts` 现有 `formatDate` 用于绝对时间。新增 `formatRelative` 基于 `date-fns/formatDistanceToNowStrict`（已有依赖；如未有则用 native fallback）：
+
+```ts
+import { formatDistanceToNowStrict } from "date-fns";
+
+/** "12 sec ago" / "8 days ago" / etc. Pure wrapper for grep-ability. */
+export function formatRelative(iso: string): string {
+  return `${formatDistanceToNowStrict(new Date(iso))} ago`;
+}
+```
+
+如 date-fns 不在依赖里，先确认包：`pnpm --filter @first-tree/web why date-fns`；不在的话改用 `Intl.RelativeTimeFormat` 手写一个 minimal 实现，避免新增依赖。Task A5 第一步检查并做选择。
+
+### 3.11 Stuck panel `afterMs` prop 共用
+
+`ConnectStuckPanel` 接受 `afterMs?: number` 默认 75_000 — 让 Onboarding（明示传 75000 与之前一致）和 NewConnectionDialog（用 default）共享同一常量，避免两端漂移。常量本身放 `packages/web/src/components/connect-stuck-panel.tsx` 顶部 `export const DEFAULT_STUCK_AFTER_MS = 75_000;` 让两端 import 同一 source。
+
+### 3.12.0 关于 "first-tree" 改名的语义说明
+
+PR-A 仅改 **列表头** "SDK" → "first-tree"，单元格内容继续是 `client.sdkVersion`（这是 hub CLI 自身的版本字符串，比如 `v1.3.2`）。
+
+注意：展开行里的 capability 矩阵已经显示了**每个 runtime provider 的 sdkVersion**（如 "Claude Code v0.8.1"）—— 那是 provider runtime 版本，跟 hub CLI 版本是两件事，**不重命名**。
+
+→ 用户读：顶层列叫 "first-tree" = hub CLI 版本；展开里叫 "Claude Code v0.8.1" = provider runtime 版本。两者语义清晰区分。
+
+### 3.12.1 关于 PR-A 列改动的"短命"成本
+
+PR-A 改 table 列（rename SDK / rename Connected / swap status cell），PR-B 会把整个 table 改成 card。PR-A 的这些 column-level 修改在 PR-B merge 后会被替换掉。
+
+**这个成本是有意接受的**：
+- PR-A 的列修改总共 < 10 行 diff
+- PR-A 单独发能立刻给 70-80% 用户带来可见改进
+- 等 PR-B 一起发会让 PR-A 阻塞在更大的 IA 工作上，降低首批用户感知优化的速度
+- 短命改动经过 PR-A 的测试与生产观察，让 PR-B 的卡片视图实现有更多 user data 参考
+
+### 3.12.2 ~~关于 capability 双源~~ 改为单源 (per adversarial review finding #9)
+
+**最初设计**：列表 capabilities 用于 pill；展开行继续 `GET /clients/:id` 拉详情 → **双源、cache 不同 key、polling cadence 不同步**
+
+**修订**：既然列表已经带 capabilities，**展开行直接消费 list 缓存的 capabilities，不再单独 fetch**。
+
+具体：
+- `CapabilityMatrix` 组件接口从 `{ clientId, enabled }` 改为 `{ capabilities: ClientCapabilities }`
+- ClientRow 把 `client.capabilities` 直接 pass down（client 来自 list query 缓存）
+- 移除 `useQuery(["client-capabilities", clientId])` 整个分支
+- `getClientCapabilities` API helper 仍保留（其他 caller 可能用到，未来需要 force-refresh），但 PR-A 不再从此组件调
+
+**净效果**：
+- 一处数据源（list `["clients"]`/`["clients", "org"]` 缓存）
+- 数据新鲜度 = 10s polling
+- 简化 ClientRow 组件（少一个 query）
+- **少触发一次 API 调用**（用户每展开一行原本要打一发请求）
+
+Task A5 task list 已对应更新（详见 §4 Task A5 Step ?）。
+
+### 3.13 "Generate new token" 重置流程
+
+NewConnectionDialog 的 mint 当前绑在 `useEffect(...,[open])`。要在 error 状态下点击按钮触发**重新 mint 而不关闭 modal**，需要把 mint 抽成独立函数，按钮点击 → `setPhase("loading")` + clear token + 调 mint。useEffect 内复用同一函数（解构重用，不复制）。
+
+```ts
+const mintToken = useCallback(async () => {
+  setPhase("loading");
+  setToken(null);
+  setErrorMessage(null);
+  openedAtRef.current = Date.now() - CONNECT_DETECT_FUDGE_MS;
+  try {
+    const t = await generateConnectToken();
+    setToken(t);
+    setPhase("waiting");
+  } catch (err) {
+    setErrorMessage(err instanceof Error ? err.message : "Failed to generate connect token");
+    setPhase("error");
+  }
+}, []);
+
+// open useEffect 调 mintToken；按钮 onClick 也调 mintToken
+```
+
+---
+
+## 4. PR-A · Task 分解（TDD-style）
+
+每个 task 一个 commit。**先红、后绿、再重构、再 commit**。
+
+### Task A1 · 服务端 `/me/clients` + `/orgs/:orgId/clients` 加 capabilities
+
+**Files:**
+- Modify: `packages/server/src/api/me.ts:416-433`
+- Modify: `packages/server/src/services/client.ts:338-356` (admin select expansion)
+- Modify: `packages/server/src/__tests__/me-clients-list.test.ts`
+- Modify: `packages/server/src/__tests__/admin-*.test.ts` 中 admin clients listing 相关 test
+
+- [ ] **Step 1: Failing test (member path)** — `me-clients-list.test.ts` 加一个用例：插入 client + 写 `metadata.capabilities`，断言 `GET /me/clients` 返回的对象含 `capabilities` 且形状匹配
+- [ ] **Step 2: 运行 `pnpm --filter @first-tree/server test -- me-clients-list`** — 看红
+- [ ] **Step 3: 修改 api/me.ts** 在 `.map` 中加 `capabilities: ((c.metadata?.capabilities) as ClientCapabilities | undefined) ?? {}`
+- [ ] **Step 4: 测试转绿**
+- [ ] **Step 5: 额外断言** — 从未上报 capabilities 的 client 返回 `{}`，不是 undefined / null
+- [ ] **Step 6: Failing test (admin path)** — 找到 admin clients listing 测试（如 `admin-clients-capabilities.test.ts` 或 `admin-overview.test.ts`），加用例：admin 视角 list 中的 team client 含 capabilities 字段
+- [ ] **Step 7: 看红 + 验证根因**：当前 `listClientsForOrgAdmin` (`services/client.ts:338-356`) 的 select 子句**不含 `metadata`**，所以 admin 路径根本看不到 capabilities
+- [ ] **Step 8: 修复 `listClientsForOrgAdmin`** —— 在 select 子句中添加 `metadata: clients.metadata`；orgs admin 路由 handler 同步加 `capabilities` 映射
+- [ ] **Step 9: 整个 server pkg test pass**：`pnpm --filter @first-tree/server test`
+- [ ] **Step 10: Commit** `feat(server): include capabilities in /me/clients and admin team listing`
+
+### Task A2 · Web HubClient type 扩展
+
+**Files:**
+- Modify: `packages/web/src/api/activity.ts:35-47`
+- Modify: 测试 fixture / mock
+
+- [ ] **Step 1:** 把 `capabilities: ClientCapabilities` 加到 `HubClient` type
+- [ ] **Step 2:** 修编译错误 (`ClientCapabilities` 已经从 `@first-tree/shared` export)
+- [ ] **Step 3:** 现有 `new-connection-dialog.test.ts` 的 `client()` fixture 加 `capabilities: {}`
+- [ ] **Step 4:** `pnpm --filter @first-tree/web typecheck` + `test` 通过
+- [ ] **Step 5: Commit** `feat(web): extend HubClient type with capabilities`
+
+### Task A3 · 4-pill 派生纯函数
+
+**Files:**
+- Create: `packages/web/src/pages/clients/derive-status.ts`
+- Create: `packages/web/src/pages/clients/__tests__/derive-status.test.ts`
+
+- [ ] **Step 1:** 先写 test 文件 — 表格驱动覆盖 §3.6.1 全部 case
+- [ ] **Step 2:** `pnpm --filter @first-tree/web test -- derive-status` 红（模块不存在）
+- [ ] **Step 3:** 实现 `derive-status.ts` 按 §3.2 spec
+- [ ] **Step 4:** 测试转绿
+- [ ] **Step 5: Commit** `feat(web): derive 4-state computer status pill`
+
+### Task A4 · `ComputerStatusPill` 组件
+
+**Files:**
+- Create: `packages/web/src/pages/clients/computer-status-pill.tsx`
+- Create: `packages/web/src/pages/clients/__tests__/computer-status-pill.test.tsx`
+
+- [ ] **Step 1:** 测试断言 — pill="ready" 渲染绿圆点 + "Ready" 文字；其余三个 pill 同理 + 对应色 token
+- [ ] **Step 2:** 红
+- [ ] **Step 3:** 实现组件
+- [ ] **Step 4:** 绿
+- [ ] **Step 5: Commit** `feat(web): add ComputerStatusPill component`
+
+### Task A5 · ClientsPage 集成 pill + 列改动 + 单源 capability
+
+**Files:**
+- Modify: `packages/web/src/pages/clients.tsx`
+- Modify: `packages/web/src/lib/utils.ts` (add `formatRelative`)
+
+- [ ] **Step 1:** Status 列：删除 `AuthExpiredChip + PresenceChip` 分支，统一渲染 `<ComputerStatusPill pill={deriveComputerStatus(client).pill} />`
+- [ ] **Step 2:** SDK 表头 → "first-tree"（仅 thead 文案，cell 内容仍 `client.sdkVersion`）
+- [ ] **Step 3:** Connected 表头 → "Last seen"，cell 从 `formatDate(connectedAt)` 改为 `formatRelative(lastSeenAt)`：
+  - 第一步检查依赖：`pnpm --filter @first-tree/web why date-fns`。**有** date-fns → 用 `formatDistanceToNowStrict`；**没有** date-fns → 用 `Intl.RelativeTimeFormat` 手写最小实现（避免新增依赖）
+  - 新增 `formatRelative(iso: string): string` 到 `lib/utils.ts`，返回 "12 sec ago" 这种字符串
+  - Cell 上加 `title={absoluteTime}` tooltip 保留精确时间
+- [ ] **Step 4:** 顶部 subtitle：
+  - 单 client 时显示 `deriveComputerStatus(clients[0]).headline`
+  - 多 client 时按 pill 计数生成 "1 ready · 1 offline" —— **zero-suppression**（只显示出现过的 pill）
+  - 0 client 时不显示 subtitle，复用现有空状态文案
+- [ ] **Step 5:** 行排序 compareByPillPriority helper（写在 derive-status.ts 或 clients.tsx 顶部）：
+  ```ts
+  export function compareByPillPriority(a: HubClient, b: HubClient): number {
+    const pa = PILL_PRIORITY[deriveComputerStatus(a).pill];
+    const pb = PILL_PRIORITY[deriveComputerStatus(b).pill];
+    if (pa !== pb) return pa - pb;
+    // tie-break: lastSeenAt 降序（最近的在前）
+    return a.lastSeenAt < b.lastSeenAt ? 1 : a.lastSeenAt > b.lastSeenAt ? -1 : 0;
+  }
+  ```
+  应用：
+  - Member 模式：`clients.sort(compareByPillPriority)`（**前所未有的 sort —— 是有意的 UX 改进**，PR description 说明）
+  - Admin 模式：替换 `mineList`/`teamList` 现有的 `lastSeenAt` 排序为 `compareByPillPriority`
+- [ ] **Step 6: 单源 capability**（adversarial finding #9 修订）：
+  - `CapabilityMatrix` 组件接口从 `{ clientId, enabled }` 改为 `{ capabilities: ClientCapabilities }`
+  - 移除 `useQuery(["client-capabilities", clientId])` 整个 hook + 内部 enabled/isLoading state
+  - 展开行 `<CapabilityMatrix capabilities={client.capabilities ?? {}} />` 直接传 list 缓存数据
+- [ ] **Step 7:** 视觉手测（dev server）：单设备 Ready / 单 Auth expired / 单 Setup incomplete / 双设备
+- [ ] **Step 8:** Lint + typecheck + test 全包绿
+- [ ] **Step 9: Commit** `feat(web): replace mixed status chips with 4-pill, rename columns, sort by pill priority, drop per-id capability fetch`
+
+### Task A6 · 抽出 StuckPanel 到 shared component
+
+**Files:**
+- Create: `packages/web/src/components/connect-stuck-panel.tsx`
+- Modify: `packages/web/src/pages/onboarding/steps/step-connect-computer.tsx`
+
+- [ ] **Step 1:** 把 [step-connect-computer.tsx:89-122](packages/web/src/pages/onboarding/steps/step-connect-computer.tsx) 的 `StuckPanel` 函数和 75s 触发逻辑搬到新组件
+- [ ] **Step 2:** 接口设计：`<ConnectStuckPanel afterMs={75_000} />` 内部自己管 setTimeout
+- [ ] **Step 3:** Onboarding 改用新组件
+- [ ] **Step 4:** 视觉对比 — Onboarding 75s 后仍出现同样的 panel
+- [ ] **Step 5: Commit** `refactor(web): extract ConnectStuckPanel for reuse`
+
+### Task A7 · NewConnectionDialog 三件套
+
+**Files:**
+- Modify: `packages/web/src/pages/clients/new-connection-dialog.tsx`
+- Modify: `packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts`
+
+- [ ] **Step 1:** 测试 — token expiresIn 到点后 phase 变成 "error"
+- [ ] **Step 2:** 红（当前没有 expiry timer）
+- [ ] **Step 3:** 加 expiry useEffect 实现 §3.5.2
+- [ ] **Step 4:** 绿
+- [ ] **Step 5:** 测试 — 渲染时传给 `ConnectCommandPanel` 的 `command` prop 是 `token.bootstrapCommand`，不是 `command`
+- [ ] **Step 6:** 红
+- [ ] **Step 7:** 一行修改
+- [ ] **Step 8:** 绿
+- [ ] **Step 9:** 加 `<ConnectStuckPanel />` 在 waiting phase（与 Onboarding 一致）
+- [ ] **Step 10:** 加 "Generate new token" 按钮在 phase=error 时显示
+- [ ] **Step 11:** Lint + typecheck + test pass
+- [ ] **Step 12: Commit** `feat(web): NewConnectionDialog uses bootstrap command, handles token expiry, shows stuck panel`
+
+### Task A8 · 全包测试 + lint
+
+- [ ] **Step 1:** Repo root `pnpm test` 全绿
+- [ ] **Step 2:** `pnpm typecheck` 全绿
+- [ ] **Step 3:** `pnpm check` (biome) 全绿
+- [ ] **Step 4:** 如有失败，逐一修复
+- [ ] **Step 5: No commit** — 这一步保证下一步的提交干净
+
+### Task A9 · Code review 第一轮（gstack /review，对当前 branch diff）
+
+- [ ] 运行 `/review` 对 PR-A 分支 vs main 的 diff
+- [ ] 评估每条 finding：fix / 反驳带 rationale / 标记 won't fix
+- [ ] 修复采纳的项目，每一处 fix 单独 commit
+
+### Task A10 · Code review 第二轮（codex review）
+
+- [ ] 运行 `/codex review` 对相同 diff
+- [ ] 评估每条 finding（重点：架构和边界条件，跟 gstack review 角度不同）
+- [ ] 修复采纳，每一处 fix 单独 commit
+
+### Task A11 · Push + PR
+
+- [ ] Push 分支到 origin
+- [ ] `gh pr create` — title "feat: Settings → Computers status pill + connect dialog fixes (Phase A)"
+- [ ] PR body 含：summary、test plan（含 §3.6.3 手测清单）、scope（明确说 IA 重组在 PR-B、server dedup 在 PR-C）、引用两份 proposal
+- [ ] **DO NOT merge** — 等 gandy2025 手动 merge
+
+### Task A12 · 守 PR 直到 mergeable
+
+- [ ] 定期检查 PR comment
+- [ ] 每条 review comment 处理：fix / 反驳 / 标记需 user 决策
+- [ ] CI 失败立刻看日志修
+- [ ] 每次 fix 后 force-push 或 add commit + push
+- [ ] 直到 PR `mergeable: clean`，**仍不合**，等 user
+
+---
+
+## 5. PR-B 简表（建立在 PR-A 之上）
+
+仅给设计签合用，不展开 task 级。
+
+| 项 | 描述 |
+|---|---|
+| 单设备 → 卡片 | `clients.length === 1` 时不渲染 table；渲染 `<ComputerCard />` 包含 heartbeat / first-tree version / OS / Runtimes 矩阵 / Agents 列表 |
+| 多设备 → 卡片列表 | `length > 1` 时多卡片 grid；响应式 `@media (min-width: 1024px)` 2-up，否则 1-up |
+| "+Connect" 降权 | 从 PageHeader 主按钮挪到角落 outline 按钮，并文案改 "Add another computer" |
+| Capability matrix 主视图可见 | 原本展开行的 capability 列表从展开拉到卡片主体 |
+| Auth expired / Setup incomplete 行内引导 | 卡片体内显示 "Generate new token" / install/sign-in 命令复制框 |
+
+依赖：PR-A 的 `deriveComputerStatus` + `ComputerStatusPill` + `capabilities` 字段。
+
+**风险点**：双视图（table / card）切换逻辑要小心，admin 分组在卡片视图下怎么展现需要额外设计（草案：team computers 折叠成 collapsible section）。
+
+---
+
+## 6. PR-C 简表（最大风险）
+
+| 项 | 描述 |
+|---|---|
+| `registerClient` soft dedup | 查 `(user_id, hostname, os) AND status='connected'`，命中则**通过 WS frame 让客户端切换到旧 client_id**，旧行 reuse；客户端写回 yaml |
+| 协议改动 | `client:register` 响应增加可选 `clientId` 字段；客户端若收到与本地不同的 id，写回 yaml 后重连 |
+| `archivedAt` 列 | `clients` 表加 nullable `archived_at` timestamp，所有读路径加 `WHERE archived_at IS NULL` |
+| Orphan sweep | 新增 cron service：`disconnected > 30 天 AND agent_count = 0 AND archived_at IS NULL` → SET `archived_at = NOW()` |
+| daemon ↔ yaml 联动 | daemon 启动时 + 周期校验 `client.id` 与 yaml 一致；不一致自杀（防幽灵心跳） |
+| 迁移 | drizzle migration 新增 `archived_at` + 索引 `idx_clients_user_hostname_os` |
+
+**为什么 PR-C 单独**：
+- 协议改动（`client:register` 响应）影响 CLI 所有版本（向下兼容：旧 client 收到未知字段忽略）
+- 迁移阶段需要 staging 灰度
+- 误删 / 误归档 / 误合并的代价高（用户机器"消失"）
+
+依赖：无（独立于 PR-A / PR-B），但建议 PR-A 已经稳后再上，避免一次性回滚多东西。
+
+---
+
+## 7. 待用户拍板的（产品向）
+
+继承自 proposals/connect-computer-optimization.md §7，未变：
+
+1. **去重 key**：`(user_id, hostname, os)` 接受？hostname 不稳少数情况会误判 → **影响 PR-C**
+2. **孤儿归档阈值**：30 天 + 0 agents pinned 是否合适 → **影响 PR-C**
+3. **页面命名/路径**：`/clients` 与 `/settings/computers` 双入口是否合并 → **本期可不动**，PR-A/B 都保留双入口
+4. **`logout --purge` 警告**：是否加显式警示文案 → **可独立小 PR**，不阻塞
+
+**PR-A 不依赖任何上述决策。** PR-C 上之前需要把 1 + 2 敲定。
+
+---
+
+## 8. 风险与缓解
+
+| 风险 | PR | 缓解 |
+|---|---|---|
+| Pill 派生在 capabilities 缺失时回到 setup_incomplete，对从未上报过 capability 的旧 client 不准 | A | 旧 client 升级 SDK 后会上报；老用户少；UI 文案明确"on this computer, install one of..." 不会引起恐慌 |
+| 顶部 subtitle 单设备/多设备分支错（如 0 设备） | A | 0 设备显示既有的空状态文案 |
+| Token expiry timer 在 modal 关闭后未清理 | A | useEffect cleanup 函数显式 clearTimeout（已在 §3.5.2 设计） |
+| `formatRelative` 显示对旧时间不友好（"4 months ago" 真的友好吗） | A | mockup 已经明确 "Last seen 2 hours ago" / "Last seen 8 days ago" 的语义可用 |
+| capability map 在响应大小膨胀（如果未来 provider 多） | A | 当前 2 provider；若超 10 个再考虑 server 端做"have-any-ok"摘要 |
+| **Capability 响应 malformed（防御性）** | A | `Object.values(caps ?? {})` + `entry?.state` 双重 optional chain；Task A3 测试用例显式覆盖 |
+| **`lastSeenAt` 字段无效（理论上 server 保证 ISO）** | A | server `lastSeenAt.notNull().defaultNow()` + `.toISOString()` 保证有效；端到端测试如果发现仍可加 try/catch 兜底 |
+| **Token expiry timer 与 arrival detection race** | A | server 已经会 reject 过期 token —— 即使前端 timer 比 polling 早 fire 进 error，用户拷贝命令也会被服务端拒（CLI 报 "AUTH_ERROR"）。安全 |
+| **PR-A 列改动短命被 PR-B 重写** | A | 接受短命成本（§3.12.1）—— PR-A 单独发的可见收益值得；diff 小 |
+| PR-B 卡片视图与 admin 双栏冲突 | B | 草案先做"member-only 卡片，admin 仍用 table"，下个迭代再统一 |
+| PR-C dedup 误合并：同一 hostname 跨真机（家里 MacBook = 公司 MacBook 同名） | C | 这种情形下 user 是同一个、hostname 同名 → **会被合并**。需要 fingerprint 才能区分；当前 spec 接受这个限制（用户应该改 hostname） |
+| PR-C `archived_at` 加列对在线迁移影响 | C | drizzle migration 非阻塞 ALTER TABLE ADD COLUMN NULLABLE，PG 安全 |
+
+---
+
+## 9. 验证标准
+
+### PR-A merge 前必须满足
+- 全部 task 的 unit / integration 测试 pass
+- 全包 `pnpm test` / `pnpm typecheck` / `pnpm check` 绿
+- §3.6.3 全部手测过
+- 2 轮独立 code review（gstack /review + /codex review）已运行，发现的项已 fix 或 documented
+- PR 描述清楚说明 PR-B / PR-C 的延后理由
+
+### PR-A merge 后短期监控
+- /me/clients 响应大小变化（应该 < 2x，因为加了 capabilities）
+- 单设备用户错率（pill 错判应当极低）
+- NewConnectionDialog 报错率（token expired 占比应增加 — 因为现在能看见了）
+
+---
+
+## 10. 附录：关键代码定位（hub-fresh `3992f98` 上）
+
+### 服务端
+- [packages/server/src/api/me.ts:416-433](packages/server/src/api/me.ts) — `GET /me/clients`（PR-A capabilities 字段加这）
+- [packages/server/src/api/clients.ts:15-37](packages/server/src/api/clients.ts) — `GET /clients/:id`（已含 capabilities）
+- [packages/server/src/services/client.ts:51-127](packages/server/src/services/client.ts) — `registerClient`（PR-C dedup 改这）
+- [packages/server/src/services/client.ts:376-385](packages/server/src/services/client.ts) — `deriveAuthState`（前端 pill 派生依赖此）
+- [packages/server/src/services/client.ts:459-479](packages/server/src/services/client.ts) — `cleanupStaleClients`（PR-C 孤儿归档挂这）
+- [packages/server/src/db/schema/clients.ts](packages/server/src/db/schema/clients.ts) — schema（PR-C 加 archived_at）
+
+### Web 前端
+- [packages/web/src/pages/clients.tsx](packages/web/src/pages/clients.tsx) — ClientsPage（PR-A 列改动；PR-B IA 重组主战场）
+- [packages/web/src/pages/clients/new-connection-dialog.tsx](packages/web/src/pages/clients/new-connection-dialog.tsx) — NewConnectionDialog（PR-A 三件套）
+- [packages/web/src/pages/onboarding/steps/step-connect-computer.tsx:89-122](packages/web/src/pages/onboarding/steps/step-connect-computer.tsx) — StuckPanel（PR-A 抽出共用）
+- [packages/web/src/components/connect-command-panel.tsx](packages/web/src/components/connect-command-panel.tsx) — 共用 panel（无需改）
+- [packages/web/src/api/activity.ts:35-47](packages/web/src/api/activity.ts) — `HubClient` 类型（PR-A 加 capabilities）
+
+### Shared / CLI
+- [packages/shared/src/schemas/client-capabilities.ts](packages/shared/src/schemas/client-capabilities.ts) — `ClientCapabilities` schema
+- [packages/shared/src/config/resolver.ts:138-139](packages/shared/src/config/resolver.ts) — `auto-generate` client-id（PR-C 关联点）
+- [apps/cli/src/commands/logout.ts](apps/cli/src/commands/logout.ts) — 当前正确，不改
+- [apps/cli/src/commands/login.ts](apps/cli/src/commands/login.ts) — PR-C 可能加 yaml 校验
+
+---
+
+## 11. Design Reflection 日志（三轮）
+
+### Round 1 · writing-plans self-review
+
+发现并 inline 修复：
+- §3.8 补：proposal P0-4 "capability matrix 主视图可见" 在 PR-A 部分满足（pill 隐含状态），完整主视图化在 PR-B
+- §3.9 补：capability `metadata` 类型边界处理（typeof guard + optional chain）
+- §3.10 补：`formatRelative` 实现细节 + 依赖检查
+- §3.11 补：`STUCK_AFTER_MS` 常量共享
+- §3.13 补：`mintToken` 重置流程
+
+### Round 2 · plan-eng-review 框架分析
+
+发现并 inline 修复（5 条）：
+- §3.6.1 加 edge case 测试：capabilities undefined / malformed entry
+- §3.6.1 加测试：mint 错误路径 + Regenerate button 重新触发 mint
+- §3.6.1 加测试：ConnectStuckPanel 75s 触发（vi.useFakeTimers）
+- §3.6.1 加测试：compareByPillPriority sort helper
+- §8 补：capability malformed / lastSeenAt 无效 / timer race 三类失败模式
+
+### Round 3 · adversarial subagent challenge（独立 fresh context）
+
+13 条 finding，按严重度分级处理：
+
+**P0/P1 修订到 plan**：
+
+- ✅ **Finding 1** (P0, conf 9): `listClientsForOrgAdmin` admin select **不含 metadata** → admin 路径收不到 capabilities → admin 模式所有 team computer 都会被误判为 setup_incomplete。Task A1 Step 8 显式覆盖这一处 select 修改，新增 admin path 失败测试 Step 6-7
+- ✅ **Finding 2** (P1, conf 9): Member 模式当前**没有**显式 sort，PR-A 加 pill-priority sort 会改变现有行顺序。§3.4 Step 5 显式 call out + PR description 说明
+- ✅ **Finding 3** (P1, conf 8): 过期 timer useEffect deps 漏了 `open`，close+reopen with cached token 会让旧 timer 在新 modal 上 fire。§3.5.2 加 `open` 到 deps + 详细 race 分析
+- ✅ **Finding 4** (P1, conf 8): StuckPanel 抽出有隐藏耦合（COPY keys、parent-driven timer）。§3.5.3 改设计：保持 StuckPanel 为纯 presentational，timer 留在各 caller parent
+- ✅ **Finding 5** (P1, conf 9): `expired ⊂ disconnected` 是 server contract（`expired` 仅当 `disconnected` 才返回），prose 误导。§3.2 改注释 + 标注 step-2 是防御性 dead branch
+- ✅ **Finding 7** (P1, conf 8): PR-B 卡片视图会需要 deprecate per-id capability fetch。§3.12.2 把这个工作前移到 PR-A 单源化（简化更早，PR-B 工作量更小）
+- ✅ **Finding 9** (P1, conf 8): React Query cache 双源（list 和 per-id）。§3.12.2 改为单源 capability，移除 `useQuery(["client-capabilities", clientId])`
+- ✅ **Finding 13** (P1, conf 8): "first-tree" 列改名 + 未改值有视觉混淆风险。§3.12.0 显式说明语义（hub CLI version vs provider runtime version）
+
+**P2 noted（不修订，记录在 §8 风险表）**：
+- Finding 6: vi fake timers 对 date-fns ✓ 兼容；Intl.RelativeTimeFormat fallback 风险
+- Finding 8: PR-C 时间线建议 commit（标注在 §6 / §10）
+- Finding 10: subtitle 多 segment 在窄屏丑 — §3.4 加 zero-suppression
+- Finding 11: Regenerate token 后旧 CLI race（benign，加测试）
+- Finding 12: 红 pill + 展开行绿 capability check 视觉冲突（接受，PR-B 改）
+
+## 12. PR-A 实施结果（2026-05-27）
+
+**PR-A 已交付**：[#586](https://github.com/agent-team-foundation/first-tree/pull/586)
+- 状态：APPROVED + MERGEABLE，等用户手动 merge
+- 测试：server 1218 / web 372 全绿，typecheck + biome 干净
+- Review：3 轮设计反思 + 2 轮 adversarial code review，34 finding triage（9 落地 + 25 deferred）
+- @yuezengwu 的 3 条 non-blocker 全部已在 PR body 列为 deferred follow-ups
+
+## 13. 下个 PR 候选项 (TODO 来源于 dev 环境验收)
+
+PR-A merge 后还有几个小 TODO 项可以打包到一个 follow-up PR 或放到 PR-B 里一起做：
+
+### TODO-A1：dev channel 下 NewConnectionDialog 描述 vs 命令不一致
+
+**症状**：dev channel（`first-tree-dev` 本地构建，无 npm 包）下：
+- 服务端 `getChannelConfig().packageName === null` → 返回 `bootstrapCommand === command`（单行 `first-tree-dev login <token>`）
+- 但 dialog 描述仍写 "If first-tree isn't installed yet, the command includes the install step." → 用户在 dev 环境看到的命令是单行，描述是误导
+
+**修法**（两选一）：
+1. 简单：在 dialog 里检测 `token.npmSpec === null`，把"installed yet..."那句话替换成 "Run this command in a terminal on the target machine."
+2. 服务端：让 dev channel 也生成两行（第二行是 `cd <build-dir> && pnpm install` 之类构建提示），但这会复杂化 server config
+
+**优先级**：低（只影响 dev 调试）—— 但用户已经在 dev 环境看到了，值得修一下消除困惑。
+
+代码定位：
+- `packages/web/src/pages/clients/new-connection-dialog.tsx` description 文案
+- `packages/server/src/api/me.ts:349-358` bootstrapCommand 生成路径
+
+### TODO-A2：可选 follow-up（之前 PR-A 也已列）
+
+- `compareByPillPriority` 在每次比较中重派生 `deriveComputerStatus` —— 列表 K 行级别再做 `.map` 缓存
+- `["clients"]` vs `["clients","me"]` cache-key 分裂——pre-existing，可统一
+- `new-agent-dialog.tsx` / `use-computer-connection.ts` 仍调 `getClientCapabilities`——可改为读 list snapshot
+- `getClient` 在 `api/activity.ts:80` 已无任何调用者，可删
+
+### PR-B / PR-C（按原 plan）
+
+- **PR-B**：P0-3 IA 重组（卡片视图 + 响应式 + "+Connect" 降权），建立在 PR-A 的 pill 之上
+- **PR-C**：P0-1 服务端 dedup + 孤儿归档 + daemon ↔ yaml 联动（消除 dev 环境看到的"两个同名 GandydeMacBook-Pro.local 行"问题）

--- a/proposals/connect-computer-optimization.md
+++ b/proposals/connect-computer-optimization.md
@@ -1,0 +1,439 @@
+# Proposal — Connect Computer 体验优化
+
+| | |
+|---|---|
+| **作者** | @gandy-assistant（需求对接） |
+| **日期** | 2026-05-26 |
+| **目标实现方** | @gandy-developer |
+| **范围** | Settings → Computers 入口，包含 `/clients`、`/settings/computers`、NewConnectionDialog、相关 server 端 dedup 与孤儿治理 |
+| **优先级** | P0 必须做、P1 应该做、P2 延后 |
+
+---
+
+## 1. 背景
+
+### 1.1 这是什么页面？谁来用？
+
+Settings → Computers（实现为 `ClientsPage`，路径 `/settings/computers` 与 `/clients` 双入口）是 first-tree-hub 让用户**看到并管理"agent 在跑的那台机器"**的地方。
+
+数据层叫 client，用户面前一律叫 **Computer**——一台已通过 `first-tree login` 配对、跑着 daemon、能承载 agent 的机器。**Agent 必须钉到一台具体 computer 上才能工作**，所以这台机器的状态直接决定 agent 是死是活。
+
+按当前 1:1 简化策略，绝大多数用户在自己的物理机上**只装一台 computer**。所以这个页面对他们而言，本质是「**我那台 agent 在跑的机器现在怎么样了**」的状态面板，不是机群管理面板。
+
+### 1.2 用户什么时候来这里？
+
+按真实频率推断：
+
+1. **排查故障**（最高频）："我的 agent 没反应了，是不是机器断了？认证过期了？版本不对？"
+2. **Admin 帮成员排查**："Alice 反馈不工作，我去看看她那边状态"
+3. **新增机器**（低频）：买了新电脑，想加进来
+4. **生命周期管理**（极低频）：清理不用的旧机器、换电脑迁移
+
+### 1.3 当前用户来这里会撞到什么
+
+具体的 UX 失败（按严重度排序）：
+
+- **想加新机器，弹窗永远在 "Waiting…"**——点 "Connect computer"，命令复制粘贴跑过去如果出错（CLI 没装、token 过期、网络问题），modal **没有任何反馈**，只是一直转圈。新用户束手无策、老用户重复踩坑
+- **页面里出现两、三、五台 computer，但用户只有一台**——数据库里堆积的"孤儿行"被原样展示，用户分不清哪台是真的、哪台是历史残留，连主线诉求"看看我那台机器怎么样"都做不到
+- **agent 出问题时找不到答案**——用户来就是想知道"机器哪里坏了"，但当前列里只有 *连接时间*（不是心跳时间）、*first-tree 版本字符串*（无状态指示）、*AUTH EXPIRED 红标*（但没有"点这里恢复"的入口）。**用户能看到症状，但点不到解药**
+- **Admin 想帮成员排查，但看不到关键信息**——team view 的行**完全不能展开**，capability 详情 / 认证状态全部隐藏，admin 无法判断成员是 SDK 没装、auth 过期、还是 daemon 挂了。"帮团队排障"这个场景在 Web 上根本做不到
+- **新用户的安装阻塞无引导**——onboarding 已经有 75s "stuck panel" 兜底（提示 npm 没装、Node 版本等常见原因），但 Settings 这个 modal 完全没复用。回流的用户撞到同一面墙的同一个位置
+
+### 1.4 共同后果
+
+这个页面没有发挥它该发挥的「**我的 computer 状态面板**」作用：
+- agent 出问题时进来找不到答案
+- admin 想支持团队也找不到入口
+- 用户对产品的"机器可观测"判断会从这里开始崩塌
+
+### 1.5 为什么现在做
+
+- **孤儿行只增不减**——不修，每次用户重装/换 channel 都在累加噪音
+- **范围明确、不需要前置决策**——本期不涉及 Workspace 抽象、不涉及 cloud runtime，是一次纯局部优化，可快速交付
+- **是"agent 当员工"叙事的下限**——员工出问题至少要让经理（用户/admin）一眼看到问题在哪、点哪里能修
+
+本 proposal 梳理产品定位、用户场景、根因、优化方案，并分期落地。
+
+---
+
+## 2. 产品定位与设计原则
+
+### 2.1 Computer 是虚拟概念
+
+数据层名为 `client`（DB 表、TS 类型、API 都用此名），用户面前一律称 "Computer"。这是有意的语言分裂。
+
+身份由 `~/.first-tree/config/client.yaml` 中的 `client.id` 标识，**跟物理硬件不绑定**（当前 SDK 完全不采集硬件指纹）。
+
+### 2.2 当前 1:1 简化策略
+
+**一台物理设备 = 一个 computer**。非管理员用户在自己的物理机上只装/跑一个 computer。这是产品当前的有意简化，是为了：
+
+- 心智简单：用户不需要管理"一台机器跑几个 worker"
+- IA 简单：UI 不需要为"多 worker per machine"留位置
+
+放开 1:1 是未来选项，**当前不做**。
+
+### 2.3 用户分布预期
+
+| 用户群 | 占比（估） | computer 数 |
+|---|---|---|
+| 单设备用户 | 70-80% | 1 |
+| 双设备 | 15-25% | 2 |
+| 多设备/重度 | <5% | 3+ |
+
+**绝大多数用户在该页面只会看到 1 行**。这是页面 IA 必须服务的主线。
+
+---
+
+## 3. 用户场景
+
+按**重要性（频率 × 痛感）**排序——主线优先，边角靠后。
+
+### S1｜排查自己机器的故障（最高频、最痛，主线）
+
+普通用户「agent 没反应」时来这里找答案。每个子场景都对应一种现实异常：
+
+| 子场景 | 描述 | 用户当下心理 |
+|---|---|---|
+| S1.a | "我的 agent 不工作了，是不是机器掉线了" | 紧急、想立刻知道答案 |
+| S1.b | "我看到 AUTH EXPIRED 红标，这是什么、怎么办" | 困惑、想要明确指引 |
+| S1.c | "Claude Code 那边的 cred 过期了 / 换 key 了，怎么刷新到 hub 这边" | 知道问题在哪、想要操作入口 |
+| S1.d | "我的 CLI 提示版本旧，hub 这边怎么显示" | 想确认是不是 hub 不接受了 |
+| S1.e | "daemon 挂了我自己不知道——agent 表面上"在"，实际不响应" | 被动发现、想要主动告警 |
+| S1.f | "我笔记本重启过，agent 会自动回来吗" | 不确定、想验证 |
+
+**主线诉求**：**进来一眼看到机器状态（4-pill）+ 每个异常都有明确的下一步动作**。状态 pill 与判定见 proposals/connect-computer-default-view-mockup.md。
+
+### S2｜Admin 帮成员排障（次主线，high-impact，决定团队信任）
+
+Admin 不会主动改 team 成员的机器，但需要**看见诊断信息然后给出建议**：
+
+| 子场景 | 描述 | Admin 当下行动 |
+|---|---|---|
+| S2.a | 成员私信"我 agent 不工作"——admin 打开看成员机器状态 | 看 lastSeen / SDK / auth / capability 信息 → 翻译成"请你跑这个命令" |
+| S2.b | 主动巡检：哪些团队成员的机器有隐患 | 扫所有 team 行，按异常排序 |
+| S2.c | 推升级前确认范围："谁的 CLI 低于 v1.3"，"谁的 Claude Code 没装" | 按 SDK / capability 筛选 |
+| S2.d | 离职成员的孤儿机器需要清理（admin 视角） | 找到该用户的所有 computer + 退役 |
+
+**主线诉求**：**team view 能看到跟自己机器一样多的诊断信息**，并能一键复制"给成员的修复建议"。
+
+### S3｜首次接入（频率：每用户至多 1-2 次）
+
+| 子场景 | 描述 | 谁接 |
+|---|---|---|
+| S3.a | 新用户配置第一台机器 | **onboarding 已接住**，不是本页主线 |
+| S3.b | 跳过/中断 onboarding 后回来补 | 本页面的"+ Connect computer"应能接住 |
+
+**主线诉求**：onboarding 流的兜底（stuck panel、command 自带 install）必须**回流到本页面的 modal**，避免回流用户撞同一堵墙。
+
+### S4｜新增机器 / 生命周期（低频，每用户每年 0-2 次）
+
+| 子场景 | 描述 |
+|---|---|
+| S4.a | 买了新电脑，想加进来 |
+| S4.b | 笔记本进水/丢/换新机，想迁移 agent |
+| S4.c | 清理多月不用的旧机器 |
+
+**设计含义**：这是"+ Connect computer"和"Retire"按钮真正的服务对象，但**频率远低于 S1**——不应该作为页面顶部最显眼操作。
+
+### S5｜创建/编辑 agent 时选 computer（不在本页面）
+
+发生在 `/agent/:id` 详情页，本 proposal 范围外，但影响**本页面对外的语义契约**：本页面是 agent 的 computer 真值源，所以列表数据必须可靠。
+
+### 暂不进入本期设计视野
+
+- 多机调度 / agent fail-over / hosted runtime — 与 1:1 简化策略冲突，留待后续
+- Workspace 抽象层（agent → workspace → computer 三层）— 同上
+
+---
+
+## 4. 当前问题清单与根因
+
+### 4.1 问题清单
+
+| # | 问题 | 影响范围 | 严重度 |
+|---|---|---|---|
+| Q1 | "永远 connecting…" — NewConnectionDialog 卡死无出路 | 所有点击 "Connect computer" 的用户 | 🔴 高 |
+| Q2 | 数据库出现重复 computer 孤儿行 | 重装/换 channel/手动清理过的用户 | 🔴 高 |
+| Q3 | 页面按机群管理设计，与 1 台机器的现实不符 | 单设备用户（70-80%） | 🟡 中 |
+| Q4 | Admin team view 不能展开诊断信息 | Admin 排查团队问题时 | 🔴 高 |
+| Q5 | 用户无法识别"该升 SDK / 重新认证" | 所有出故障的用户 | 🟡 中 |
+| Q6 | "+ Connect computer" 被误点击（用户想修不想加） | S1（排查故障）用户 | 🟡 中 |
+| Q7 | install/upgrade 卡点无引导（command not found 等） | 新用户、版本旧的用户 | 🟡 中 |
+
+### 4.2 根因分析
+
+#### Q1 根因｜NewConnectionDialog 只有 "waiting" 一种出路
+
+`packages/web/src/pages/clients/new-connection-dialog.tsx` 进入 `phase=waiting` 后**只有一种成功条件**（检测 `connectedAt ≥ openedAt`），所有失败场景都表现为同一个 spinner：
+
+| 实际状态 | UI 表现 | 用户能识别吗 |
+|---|---|---|
+| 用户还没复制命令 | spinner | ✓ |
+| CLI 未装，命令报 `command not found` | spinner | ✗ |
+| Token 已过期（>10min） | spinner | ✗ |
+| 网络/防火墙问题 | spinner | ✗ |
+| 跑错 channel | spinner | ✗ |
+
+**关键缺失**：token 过期不切 error、没有 stuck 兜底面板（onboarding 75s 面板未回流）。
+
+#### Q2 根因｜重复 computer 行来自多条路径，无清理机制
+
+主要根因（已确认 code path）：
+
+1. **服务端只用 `client.id` 做 unique key**，没有 `(user_id, hostname, os)` 软去重。`packages/server/src/services/client.ts:51-127` `registerClient` 仅 ON CONFLICT on `client.id`
+2. **多 channel 各自独立 yaml**（`first-tree` / `first-tree-staging` / `first-tree-dev` 三套 channel home），登录到同一 hub 会注册成多行。详见 `packages/shared/src/config/resolver.ts:53-59`
+3. **`client.yaml` 被销毁 → 自动生成新 id**（`packages/shared/src/config/resolver.ts:138-139` + `:348-360`），旧行在 server 留下成孤儿
+4. **完全无自动清理**：`cleanupStaleClients` (`client.ts:459-479`) 只翻 status 到 disconnected，不删行
+5. **daemon 跟 yaml 没联动**：手动 rm yaml 但 daemon 还在跑会产生幽灵心跳
+
+**注意**：经过仔细排查，**`logout` 命令本身实现是正确的**（先停 daemon、默认保留 yaml；详见 `apps/cli/src/commands/logout.ts`）。重复行不是 logout 的 bug，是其他几条路径累加 + 无清理。
+
+#### Q3 根因｜表格 IA 假设 N 台机器
+
+`packages/web/src/pages/clients.tsx` 顶部 summary chip `"X total · Y connected · Z agents bound · W need re-auth"`、admin 双栏、表格列结构——这些都是面向 N 台机器的 IA。对**只有 1 台的 70-80% 用户**，这是过度设计。
+
+#### Q4 根因｜admin "看" 和 "动" 被一起 restrict
+
+代码中 `restricted = true` 同时压制了三件事：
+- 隐藏 action 按钮（合理，server 也 403）
+- 禁止行展开（**不合理**）
+- 禁止 capability matrix 请求（**不合理**）
+
+**更深层**：server `GET /clients/:id` 对非 owner 直接 403。这把"admin 不能动 team 机器"和"admin 不能看 team 机器"混在一起，跟"admin 帮 team 排查"的产品意图冲突。
+
+#### Q5 根因｜状态信号未上行
+
+- "Connected" 列实际显示 `connectedAt`，不是 `lastSeenAt`——admin 无法分辨"daemon 还活着 vs 早就挂了"
+- 多个状态信号（`status` / `authState` / 每个 `capabilities[*].state`）分散在不同列与展开行里，**没有一个汇总判定**告诉用户/admin "这台机器现在能不能跑 agent"
+- AUTH EXPIRED 是纯客户端时间推断（`deriveAuthState`），但 UI 没有把它跟 connection/capability 状态合并成单一行动结论
+
+#### Q6 根因｜入口语义与用户意图错位
+
+页面最显眼的 "+ Connect computer" 按钮假设用户主要意图是"加新机器"。**但实际访问者大多数（S1（排查故障））是来排查问题的**，期望按钮帮自己"修好"，结果它只服务"加全新机器"——用户点错后陷入 Q1 的死路。
+
+#### Q7 根因｜两条 connect 流未统一
+
+- Onboarding (`step-connect-computer.tsx`) 命令是双行 `npm install -g first-tree\nfirst-tree login <token>`，自带 install + 75s stuck 面板 + 终端引导
+- Daily NewConnectionDialog 命令是单行 `first-tree login <token>`，**假设用户已装 CLI**，无 stuck 兜底、无引导
+
+---
+
+## 5. 优化方案
+
+按优先级分三层。
+
+### P0 ｜核心治本（必须做）
+
+#### P0-1 服务端去重 + 孤儿治理
+
+**目标**：消灭重复 computer 行的产生与堆积。
+
+- **服务端 soft dedup**：`registerClient` 在 ON CONFLICT 之前先按 `(user_id, hostname, os)` 查找同一用户的 `connected` 行；存在则复用其 `client.id`，把 yaml 回写为该 id；不创建新行
+- **daemon ↔ yaml 联动**：daemon 启动 + 周期校验 yaml 里 client.id 跟它内存的是否一致，不一致自杀
+- **自动孤儿归档**：服务端定时任务，`disconnected > 30 天 + 0 agents pinned` 的行自动归档（soft delete or hide）
+
+#### P0-2 NewConnectionDialog 修正
+
+**目标**：消灭"永远 connecting"。
+
+- 到 `token.expiresIn` 自动切到 `phase=error`，提示重新生成
+- 抽取 onboarding 的 75s stuck 面板，复用到 daily modal（同一组件）
+- 命令统一为 self-bootstrapping 双行 `npm install -g first-tree\nfirst-tree login <token>`
+- modal 副标题加先决条件提示
+- 加 "我已经跑了但没反应" troubleshooting 入口
+
+#### P0-3 页面 IA 重组（详细示意见 mockup 文件）
+
+**目标**：让 70-80% 单设备用户看到适合 1 台的视图。
+
+- 1 台 computer 时显示**详情卡片视图**（不显示表格）
+- 2+ 台时退化为卡片列表（响应式：≥1024 2-up 并列，<1024 单列堆叠）
+- 顶部一句话状态描述（按 4-pill 派生），不再是 "X total · Y connected" chip 堆
+- "+ Connect computer" 按钮**降权到次要位置**
+
+详细示意见 proposals/connect-computer-default-view-mockup.md（Variant A/B-1/B-2/B-3/C）。
+
+#### P0-4 状态 pill 派生 + 信号上行
+
+**目标**：让 S1（排查故障）用户和 admin 一眼看到机器现在能不能用、坏在哪。
+
+- **引入 4-pill 状态**（前端纯函数派生，**无新 server 字段、无阈值**）：
+  - 🟢 **Ready** = `status=connected` AND `authState=ok` AND 至少一个 capability `state=ok`
+  - 🔴 **Auth expired** = `authState=expired`
+  - 🟡 **Setup incomplete** = `status=connected` AND `authState=ok` AND 所有 capability `state≠ok`
+  - ⚪ **Offline** = `status=disconnected` AND `authState=ok`
+  - 判定顺序自上而下，命中即停
+- 显示 `lastSeenAt`（"心跳 12 秒前"）替代/补充 `connectedAt`
+- `first-tree` 版本字段名替代"SDK"（不参与 pill 判定，仅展示——本期不引入版本健康对比）
+- capability matrix 主视图可见，不再深埋展开行
+
+### P1｜操作可达性（应该做）
+
+#### P1-1 行内 state-aware 操作
+
+**目标**：把"我下一步该做什么"直接呈现，不让用户猜。
+
+| 卡片 pill | 行内主操作 |
+|---|---|
+| 🟢 Ready | 无主操作；可选行末"Install Codex"/"Sign in"等次要入口 |
+| ⚪ Offline | "Start the daemon on this machine" + 复制 `first-tree daemon start` |
+| 🔴 Auth expired | **行内 "Generate new token" → 配 `first-tree login <token>` 复制框** |
+| 🟡 Setup incomplete | **Claude Code 与 Codex 对等展示**，每个独立 box 含 install + login 命令 |
+| Capability `error` | 显示 error message + troubleshooting 文档链接 |
+
+#### P1-2 Admin team view 解锁诊断
+
+**目标**：让 admin 真正能帮 team 排查。
+
+- **server 端**：admin 可读 team 机器的 capability / auth state（保留 action 限制）
+- **UI**：team 行可展开展示同样信息，仅没有 action 按钮
+- **默认 tab 是 "Your computer"**（更高频，team 是支持场景再切）
+- 每行用**单一 pill** 展示状态（🔴/🟡/⚪/🟢），按 pill 优先级排序，问题自然冒上
+- **"Copy suggestion → 成员名"按钮**：按 pill 状态选固定模板，弹可编辑预览，placeholder 自动填充（详细模板见 mockup §"Copy suggestion 消息模板"）
+- 大团队支持：按 pill / heartbeat / hostname 筛选排序
+
+#### P1-3 用户清理孤儿入口
+
+**目标**：给已经污染的 DB 一条逃生通道。
+
+- UI：检测到"看起来是同一台机器的旧记录"时提示合并/隐藏
+- CLI：`first-tree computer prune`，扫同用户名下重复+老的 disconnected 行
+
+#### P1-4 S1 排查路径梳理
+
+**目标**：每个 pill 状态都明确映射到下一步动作（详细见 mockup Variant B-1/B-2/B-3）。
+
+- 🔴 Auth expired → 行内 "Generate new token" + `first-tree login <token>` 复制框
+- ⚪ Offline → 行内说明 "Make sure the machine is awake; if daemon isn't running, run `first-tree daemon start`"
+- 🟡 Setup incomplete → 对等展示 Claude Code / Codex 两个 install box
+- Capability `error`（横跨任何 pill）→ 显示 error 详情 + 文档链接
+
+### P2｜延后（可以不做，等数据说话）
+
+- **Machine fingerprint**：仅在 P0/P1 落地后还有用户因"洗牌重来"产生重复时再做。涉及 3 个 OS API、协议变更、schema 变更、隐私评估。**当前不必要**
+- **Adopt 命令**：让新机器继承已有 client 身份。1:1 策略下主要为"换电脑"场景，频率低
+- **OS-aware 安装命令**：按 UA 区分 mac/linux/windows 安装方式
+- **Hosted runtime / cloud worker**：与 1:1 策略相关的大方向，已搁置
+
+---
+
+## 6. 实施分期
+
+### 第一交付（建议 2-3 周）
+
+**目标**：消灭"永远 connecting"和重复行 bug；让单设备用户的视图对齐现实。
+
+包含：
+- P0-1 服务端去重 + 孤儿归档 + daemon ↔ yaml 联动
+- P0-2 NewConnectionDialog 修正
+- P0-3 页面 IA 重组（单设备卡片视图 + 响应式多卡片）
+- P0-4 状态 pill 派生 + lastSeenAt + first-tree 版本字段（无版本对比）
+
+**验收信号**：
+- 单设备用户在 Settings → Computers 看到状态卡片，不是表格
+- 多次 logout/重装的用户不会再产生新孤儿行
+- "永远 connecting" 不再发生（要么成功、要么明确报错有出路）
+
+### 第二交付（建议 2-3 周）
+
+**目标**：让 admin 能在 Web 端帮成员排查；让用户清理已有孤儿。
+
+包含：
+- P1-1 行内 state-aware 操作
+- P1-2 admin team view 解锁诊断 + 修复建议复制
+- P1-3 用户/CLI 清理孤儿
+- P1-4 S1 排查路径梳理
+
+**验收信号**：
+- Admin 在 team view 能看到每个成员机器的 SDK 版本、auth 状态、capability，并能一键复制修复建议
+- 用户能在 UI 或 CLI 清理掉自己历史的重复行
+- 出现 AUTH EXPIRED 的用户能直接点行内按钮恢复，无需多步
+
+### 后续（数据说话再决定）
+
+P2 各项。在第一/第二交付落地后跑 1-2 个月数据，看：
+- 是否还有用户因"洗牌重来"产生重复（决定是否做 fingerprint）
+- 多机用户的换电脑频率（决定是否做 adopt）
+- 安装失败率分布（决定是否做 OS-aware 命令）
+
+---
+
+## 7. 待决策的产品问题
+
+UI 设计部分的决策已全部锁定（详见 proposals/connect-computer-default-view-mockup.md §"已敲定（全部）"）。
+
+**剩余需要敲定**（主要是后端/治理向）：
+
+1. **去重 key**：`(user_id, hostname, os)` 是否可接受？hostname 不稳，会有少数误判（macOS WiFi 切换偶尔加 `-2` 后缀）。备选：仍用 hostname 但加 "merge candidates" 提示让用户手动确认
+2. **孤儿归档阈值**：30 天 + 0 agents pinned 算保守。可以更激进（14 天）或更保守（90 天），看你想要的清理速度
+3. **页面命名/路径**：当前双入口 `/clients` + `/settings/computers`，是否合并/重定向？保留哪条为正？
+4. **`logout --purge` 警告**：当前实现正确（先停 daemon 再删 yaml），是否要加"这会让你失去这台机器的身份"明确警告？
+
+**已锁定**（不再讨论）：
+- UI 状态展示用 4-pill（Ready / Auth expired / Setup incomplete / Offline），无新 server 字段、无阈值
+- 不引入 SDK 版本对比（first-tree 版本只展示、不参与判定）
+- Copy suggestion 用产品提供模板 + admin 可编辑
+- Admin 默认 tab 是 Your computer
+- 多设备布局响应式（1024px 断点）
+
+---
+
+## 8. 关键代码定位（供 @gandy-developer 参考）
+
+### 服务端
+- `packages/server/src/services/client.ts:51-127` — `registerClient`（P0-1 dedup 改动入口）
+- `packages/server/src/services/client.ts:419-448` — `retireClient`
+- `packages/server/src/services/client.ts:459-479` — `cleanupStaleClients`（P0-1 孤儿归档挂这里）
+- `packages/server/src/services/client.ts:376-385` — `deriveAuthState`（P0-4 pill 派生输入之一）
+- `packages/server/src/api/clients.ts` — 客户端 HTTP 路由
+- `packages/server/src/api/orgs/clients.ts:13-31` — admin team 列表（P1-2 解锁 read 权限点）
+- `packages/server/src/api/agent/ws-client.ts:435-497` — `client:register` WS 处理
+
+### Web 前端
+- `packages/web/src/pages/clients.tsx` — ClientsPage 主视图（P0-3 IA 重组主战场）
+- `packages/web/src/pages/clients/new-connection-dialog.tsx` — NewConnectionDialog（P0-2 修正主战场）
+- `packages/web/src/pages/onboarding/steps/step-connect-computer.tsx` — 75s stuck 面板源（P0-2 复用）
+- `packages/web/src/components/connect-command-panel.tsx` — 共用 panel
+- `packages/web/src/hooks/use-disconnected-computers.ts` — disconnected chip 数据源
+- `packages/web/src/api/activity.ts` — `HubClient` 类型 + API 函数
+- `packages/web/src/pages/agent-detail/setup-section.tsx` — agent ↔ computer 绑定 UI
+
+### CLI
+- `apps/cli/src/commands/logout.ts` — **当前实现已正确**（参考但不需要改）
+- `apps/cli/src/commands/login.ts` — login 主流程
+- `apps/cli/src/commands/upgrade.ts` — upgrade 命令（P1-4 引导关联）
+
+### Shared / config
+- `packages/shared/src/config/client-config.ts:17-25` — `client.id` 字段定义
+- `packages/shared/src/config/resolver.ts:138-139` — `auto-generate` client_id（P0-1 daemon 联动关联点）
+- `packages/shared/src/config/resolver.ts:348-360` — yaml 缺失时的 auto-gen 路径
+
+---
+
+## 9. 不在本 proposal 范围内（明确排除）
+
+为了聚焦，以下议题**不在此次优化中**：
+
+- 多机 fail-over / agent 在多台机器间漂移
+- Cloud / hosted runtime
+- Workspace 抽象层（agent → workspace → computer 三层）
+- Computer 重命名（保留 "Computer" 用户面前不变）
+- 机器迁移命令（adopt）
+- Solo vs Team 的 IA 大调整
+
+这些已在前期讨论中明确推迟，待第一/第二交付的数据出来后再议。
+
+---
+
+## 10. 下一步
+
+1. 用户（@gandy2025）对 §7 待决策问题给出方向
+2. @gandy-assistant 将决策同步给 @gandy-developer
+3. @gandy-developer 针对**第一交付**出技术设计文档（含数据迁移方案、API 变更、UI 草图、测试覆盖计划）
+4. 技术方案回传 @gandy2025 确认
+5. 进入开发
+
+---
+
+*Generated by @gandy-assistant. Reviewed against latest main (`ae96016`).*

--- a/proposals/connect-computer-pr-c-plan.md
+++ b/proposals/connect-computer-pr-c-plan.md
@@ -1,0 +1,902 @@
+# PR-C Implementation Plan — Server Dedup + CLI Cleanup
+
+| | |
+|---|---|
+| **作者** | @gandy-developer |
+| **日期** | 2026-05-27 |
+| **基础** | proposals/connect-computer-optimization.md §P0-1 + 用户 2026-05-27 决策 |
+| **依赖** | PR-A 已 merge (`b48178f7`) |
+| **代码 baseline** | `feat/connect-computer-dedup` off `origin/main` |
+| **状态** | DRAFT — 待 design reflection 三轮后冻结 |
+
+---
+
+## 0. Executive Summary
+
+消灭"两个同名 GandydeMacBook-Pro.local 行"问题（PR-A dev 截图里的真实数据症状）的**根因**：服务端没有 `(user_id, hostname, os)` 软去重，每次 `client.yaml` 重新生成 → 新行累积。
+
+**用户决策（2026-05-27）**：
+- ✅ 去重 key 用 `(user_id, hostname, os)` 软去重
+- ✅ **孤儿归档：30 天 + 0 agents pinned + status=disconnected → 自动 archive**（用户 2026-05-27 二次决策）
+- ✅ `logout --purge` 加警告 + 二次确认
+
+**Scope（含 archival）**：
+
+1. Server `registerClient` 加 dedup transaction — `(user_id, hostname, os)` 软合并到 canonical 行
+2. WS `client:register` 处理器返回 canonical clientId（response.clientId 字段已存在，赋成 canonical 值）
+3. CLI `ClientConnection.handleMessage` `client:registered` 路径：检测 response.clientId 与本地 mismatch → emit redirect 事件
+4. CLI bootstrap: 收到 redirect → 写 yaml + 优雅退出（supervisor 重启自动接 canonical 身份）
+5. CLI `logout --purge`: 加交互式 2 步确认 prompt + `--yes` flag 跳过
+6. **新增**：`clients.archived_at TIMESTAMP NULL` 列 + 所有读路径加 `WHERE archived_at IS NULL` 过滤
+7. **新增**：`archiveAbandonedClients` 服务函数 + 接入 `background-tasks` 定时调度（hourly sweep）
+8. **新增**：`registerClient` (A) 同 id 路径在重连时自动 unarchive（`archived_at = NULL`），让用户带凭证回归时直接复活旧行
+
+**Excluded** (与用户决策一致):
+- ❌ `first-tree computer prune` 用户清理 CLI — 用户未要求，后续 PR
+- ❌ daemon ↔ yaml file watch — 较复杂，后续 PR
+- ❌ admin Web UI 展示 archived 行供恢复 — 后续 PR（admin 当前可用 SQL `UPDATE clients SET archived_at = NULL WHERE id = '...'` 恢复）
+
+---
+
+## 1. 现状代码摸底
+
+### 1.1 Server 端（`packages/server/src/services/client.ts`）
+
+`registerClient` 当前路径（[services/client.ts:51-127](packages/server/src/services/client.ts)）：
+
+```ts
+1. SELECT existing row by clientId
+2. If existing.userId != data.userId → throw ClientUserMismatchError
+3. INSERT ... ON CONFLICT (clients.id) DO UPDATE
+```
+
+unique key 是 `clients.id`，没有 `(user_id, hostname, os)` 查询。
+
+### 1.2 WS 处理器（`packages/server/src/api/agent/ws-client.ts`）
+
+`client:register` 帧处理（[ws-client.ts:435-497](packages/server/src/api/agent/ws-client.ts)）：
+
+```ts
+const data = clientRegisterSchema.parse(msg);
+...
+await clientService.registerClient(app.db, { clientId: data.clientId, ... });
+clientId = data.clientId;  // <-- server-side session 用 CALLER's id
+connectionManager.setClientConnection(data.clientId, socket);
+socket.send(JSON.stringify({ type: "client:registered", clientId: data.clientId }));
+```
+
+→ PR-C 需要：
+- `registerClient` 返回 canonical id
+- WS handler 用 canonical id 作为 session-local clientId + `connectionManager` key + 响应 clientId 字段
+
+### 1.3 CLI ClientConnection（`packages/client/src/client-connection.ts`）
+
+`client:registered` 处理（[client-connection.ts:779-796](packages/client/src/client-connection.ts)）：
+
+```ts
+if (type === "client:registered") {
+  // 完全不读 msg.clientId
+  this.registered = true;
+  this.startHeartbeat();
+  this.emit("connected");
+  ...
+}
+```
+
+→ PR-C 需要：
+- 读 `msg.clientId`，与 `this.clientId` 比较
+- 若 mismatch → 不进入 connected 流程，emit 新 `client:redirect` 事件（带 canonical id），cleanly close（设 `this.closing=true` 防止 reconnect loop）
+
+`this.clientId` 是 `readonly` —— 不可变。Redirect 后由 caller 重建 ClientConnection 实例。
+
+### 1.4 CLI Bootstrap（`apps/cli/src/core/client-runtime.ts`）
+
+`ClientRuntime` 构造时把 `clientId` 传入 `new ClientConnection({ clientId, ... })`（[client-runtime.ts:80-95](apps/cli/src/core/client-runtime.ts)）。Bootstrap 流程在 `apps/cli/src/commands/login.ts` 或 `daemon.ts` 中。
+
+→ PR-C 需要：
+- Bootstrap 监听 `ClientConnection.on("client:redirect")`
+- 收到事件 → 写 yaml.client.id = canonicalId → `process.exit(0)`（service 模式下 supervisor 自动重启，inline 模式下用户重跑命令）
+
+### 1.5 `logout --purge`（`apps/cli/src/commands/logout.ts`）
+
+当前实现（[commands/logout.ts:14-44](apps/cli/src/commands/logout.ts)）已正确（先停 daemon 再删 yaml），但没有交互式确认。`--purge` 是隐藏 flag，能看到 docs 的用户大概率知道在做什么；但加二次确认能拦住 copy-paste 失误。
+
+→ PR-C 需要：
+- 加 interactive `select` prompt（用现有 `@inquirer/prompts`）
+- 加 `--yes` flag 用于脚本场景
+
+---
+
+## 2. 架构设计
+
+### 2.1 服务端去重事务
+
+**新增**：`packages/server/src/services/client.ts`
+
+**关键修订（adversarial review finding #1, P0）**：原 plan 用 `SELECT ... FOR UPDATE` 想串行化并发 register，但 **FOR UPDATE 在空结果集上不锁任何行** —— 两个并发 first-time register 都看到 "no canonical"，都 INSERT，产生 dedup 想消除的同一类 orphan。修复：用 `pg_advisory_xact_lock(hashtext(key))` 在 SELECT 之前就锁住 `(user, hostname, os)` key，PG 事务级 advisory lock 是空结果集仍然有效的串行化原语，事务结束自动释放。
+
+```ts
+export type RegisterClientResult = {
+  /** Canonical clientId for this (user, hostname, os) tuple. May differ from the
+   *  caller's `data.clientId` if a soft-dedup merge happened. */
+  canonicalClientId: string;
+  /** True when soft-dedup picked a different row than the caller asked for. */
+  redirected: boolean;
+};
+
+/** Thrown when soft-dedup would steal a canonical row whose socket is still
+ *  live (i.e. another CLI is currently connected as the canonical). Caller
+ *  (WS handler) translates this to `client:register:rejected` + close 4403 so
+ *  the offending CLI does not keep stealing the slot every reconnect. */
+export class ClientDedupConflictError extends Error {
+  readonly code = "CLIENT_DEDUP_CONFLICT";
+  constructor(canonicalId: string) {
+    super(`Another client is currently connected as canonical "${canonicalId}". Retry later.`);
+    this.name = "ClientDedupConflictError";
+  }
+}
+
+export async function registerClient(
+  db: Database,
+  data: { clientId, userId, organizationId, instanceId, hostname?, os?, sdkVersion?, lastUpdateAttempt? },
+  /** Injected by the WS handler. Returns true iff the canonical id currently
+   *  has a live socket held by `connectionManager` that is NOT this caller. */
+  isCanonicalSlotLive: (canonicalId: string) => boolean,
+): Promise<RegisterClientResult> {
+  return db.transaction(async (tx) => {
+    // (A) Same-id path: if a row with caller's id exists, run the existing
+    //     user-mismatch + upsert path. No dedup query, no advisory lock —
+    //     normal reconnect path stays O(1).
+    const [bySameId] = await tx.select(...).from(clients).where(eq(clients.id, data.clientId)).limit(1);
+    if (bySameId) {
+      // existing user-mismatch check + metadataMerge upsert, returning data.clientId
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // (B) Dedup path. Caller's id is new — check (user, host, os) for a
+    //     canonical row. ADVISORY LOCK FIRST to serialize concurrent first-
+    //     time registers from the same machine, otherwise both would race
+    //     past an empty SELECT and both INSERT.
+    if (!data.hostname || !data.os) {
+      // Without hostname/os we cannot dedup safely — plain insert.
+      ...plain insert with data.clientId...
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // `pg_advisory_xact_lock(hashtext(...))` — 64-bit integer key, released
+    // automatically at COMMIT/ROLLBACK. hashtext is deterministic on the
+    // concatenated key. No new schema needed.
+    await tx.execute(sql`
+      SELECT pg_advisory_xact_lock(
+        hashtext(${data.userId} || '|' || ${data.hostname} || '|' || ${data.os})
+      )
+    `);
+
+    // Now safe to SELECT — any concurrent transaction with the same key is
+    // blocked behind us on the advisory lock.
+    const candidateRows = await tx.select({ id, status, lastSeenAt }).from(clients)
+      .where(and(
+        eq(clients.userId, data.userId),
+        eq(clients.hostname, data.hostname),
+        eq(clients.os, data.os),
+      ));
+
+    // Two-step agent-count: GROUP BY + FOR UPDATE is invalid in PG (cannot
+    // lock through aggregate). We already hold the advisory lock for this
+    // key, so a plain COUNT is race-safe within our scope.
+    const agentCounts =
+      candidateRows.length > 0
+        ? await tx.select({ clientId: agents.clientId, count: sql<number>`count(*)::int` })
+            .from(agents)
+            .where(and(
+              sql`${agents.clientId} IS NOT NULL`,
+              inArray(agents.clientId, candidateRows.map((r) => r.id)),
+              ne(agents.status, "deleted"),
+            ))
+            .groupBy(agents.clientId)
+        : [];
+    const counts = new Map(agentCounts.map((c) => [c.clientId, c.count]));
+    const candidates = candidateRows.map((r) => ({ ...r, agentCount: counts.get(r.id) ?? 0 }));
+
+    const canonical = pickCanonical(candidates);  // see §2.2
+
+    if (!canonical) {
+      ...plain insert with data.clientId...
+      return { canonicalClientId: data.clientId, redirected: false };
+    }
+
+    // (C) Connection-stealing guard (adversarial finding #3, #19). If a
+    // different live socket is currently registered as canonical, fail the
+    // dedup — do NOT silently kick the other CLI off. The WS handler maps
+    // ClientDedupConflictError to `client:register:rejected`, so the
+    // offending CLI sees a clear error instead of an invisible takeover.
+    if (isCanonicalSlotLive(canonical.id)) {
+      throw new ClientDedupConflictError(canonical.id);
+    }
+
+    // (D) Redirect path: merge caller's connection info onto canonical row.
+    // metadata merge MUST mirror the existing single-id upsert path
+    // (services/client.ts:94) — `COALESCE(metadata, '{}'::jsonb) || jsonb`
+    // — so capabilities (written by updateClientCapabilities) are NOT
+    // clobbered. Only `lastUpdateAttempt` sub-key is overwritten.
+    const metadataMerge = data.lastUpdateAttempt
+      ? sql`COALESCE(${clients.metadata}, '{}'::jsonb) || ${JSON.stringify({ lastUpdateAttempt: data.lastUpdateAttempt })}::jsonb`
+      : undefined;
+
+    await tx.update(clients).set({
+      status: "connected",
+      instanceId: data.instanceId,
+      sdkVersion: data.sdkVersion ?? null,
+      connectedAt: now,
+      lastSeenAt: now,
+      ...(metadataMerge ? { metadata: metadataMerge } : {}),
+    }).where(eq(clients.id, canonical.id));
+    return { canonicalClientId: canonical.id, redirected: true };
+  });
+}
+```
+
+### 2.2 Canonical 选择规则 (`pickCanonical`)
+
+**纯函数**，输入：`Array<{id, status, lastSeenAt, agentCount}>` （DB 查询已经预 join 好）。规则：
+
+1. **有 agents pinned** 的行优先（agentCount 降序）
+2. 同 agentCount：**最近 lastSeenAt** 在前（降序）
+3. 同时相同：取最老的 `id` （字符串升序——UUID v7 排序 ≈ 创建时间升序，稳定 tie-break）
+
+**修订（adversarial finding #5）**：原 plan 想用 `SELECT clients.* JOIN agents COUNT GROUP BY ... FOR UPDATE` 单次查询拿数据，**PG 不允许在含 GROUP BY 的聚合查询上加 FOR UPDATE**。改成两步：
+- Step 1: SELECT clients 候选（advisory lock 已在外层 holding，无需 FOR UPDATE）
+- Step 2: SELECT clientId + COUNT(*) FROM agents WHERE clientId IN (...) GROUP BY clientId
+
+两步在同一事务里、同一 advisory lock 范围内，并发安全。代码示例已在 §2.1 中体现。
+
+### 2.3 WS handler 改动
+
+`packages/server/src/api/agent/ws-client.ts:435-530`：
+
+```ts
+let result: RegisterClientResult;
+try {
+  result = await clientService.registerClient(
+    app.db,
+    { clientId: data.clientId, userId: session.userId, ... },
+    // Inject "is this canonical id currently held by a different live socket?"
+    // The connection manager already exposes `getSocket` / `isActiveClientConnection`;
+    // we wrap to give registerClient a yes/no without leaking the socket object.
+    (canonicalId) => {
+      const existing = connectionManager.getSocket(canonicalId);
+      return existing !== undefined && existing !== socket && existing.readyState === existing.OPEN;
+    },
+  );
+} catch (err) {
+  if (err instanceof ClientDedupConflictError) {
+    // Adversarial finding #3 — protect against silent connection-stealing.
+    // Different live CLI is already canonical; this caller does NOT take
+    // over its slot. CLI sees rejected + closes.
+    socket.send(JSON.stringify({
+      type: "client:register:rejected",
+      message: err.message,
+      code: err.code,
+    }));
+    socket.close(4403, "client dedup conflict");
+    return;
+  }
+  // existing ClientUserMismatchError / ClientOrgMismatchError handling
+  ...
+}
+
+// IMPORTANT: use canonical id for the local session, connection manager
+// registration, and the registered-response frame. A caller using stale yaml
+// gets corrected via the response and the next reconnect uses canonical.
+clientId = result.canonicalClientId;
+connectionManager.setClientConnection(result.canonicalClientId, socket);
+socket.send(JSON.stringify({ type: "client:registered", clientId: result.canonicalClientId }));
+
+// agent:pinned backfill: enumerate by canonical, not caller's id (adversarial
+// finding #3 sub-point — without this, the backfill would miss agents on
+// canonical that are not pinned to caller's input id).
+const pinned = await clientService.listActiveAgentsPinnedToClient(app.db, result.canonicalClientId);
+```
+
+CLI 端在 `ClientConnection.handleMessage` 已有的 `client:register:rejected` 分支需要识别新 code：
+
+```ts
+const err =
+  code === "CLIENT_USER_MISMATCH" ? new ClientUserMismatchError(message) :
+  code === "CLIENT_ORG_MISMATCH" ? new ClientOrgMismatchError(message) :
+  code === "CLIENT_DEDUP_CONFLICT" ? new ClientDedupConflictError(message) :
+  new Error(`client:register rejected: ${message}`);
+```
+
+新增 `ClientDedupConflictError` 类（在 client-connection.ts，mirror 现有 `ClientUserMismatchError` 模式），CLI bootstrap 看到该 error 后**不退出**（这是临时冲突，跟 stale auth 不同）；让 reconnect 退避后重试。如果对端 CLI 真的下线了，下次 register canonical slot 空闲，dedup 成功。
+
+### 2.4 CLI ClientConnection 改动
+
+`packages/client/src/client-connection.ts`:
+
+加新事件 `client:redirect`：
+
+```ts
+type ClientConnectionEvents = {
+  ...
+  /** Server soft-dedupped this register into a canonical clientId. The caller
+   *  should persist the new id to yaml, dispose this ClientConnection, and
+   *  spawn a fresh one with the canonical id. The current connection has
+   *  already closed; reconnection is suppressed. */
+  "client:redirect": [canonicalClientId: string];
+};
+```
+
+`handleMessage`:
+
+```ts
+if (type === "client:registered") {
+  const responseClientId = typeof msg.clientId === "string" ? msg.clientId : null;
+  if (responseClientId && responseClientId !== this.clientId) {
+    // Soft-dedup redirect. Stop the reconnect loop and surface for the caller.
+    this.wsLogger.info({ local: this.clientId, canonical: responseClientId }, "server dedup redirect");
+    this.closing = true;
+    this.emit("client:redirect", responseClientId);
+    this.ws?.close(1000, "client redirect");
+    return;
+  }
+  // existing path unchanged
+  this.registered = true;
+  ...
+}
+```
+
+### 2.5 CLI Bootstrap redirect handling
+
+**位置**：放在 `ClientRuntime` 自身。**关键修订（adversarial finding #2, #8, #17）**：原 plan 让 redirect 监听器直接 `process.exit(0)` —— 在事件回调里同步退出会绕开 `runtime.stop()` 优雅关闭路径，agent slot 和 git worktree 等清理不跑。修复：抽 `handleClientRedirect` 走 `runtime.stop()` 后再 exit；yaml 写失败时退出码 75 让 supervisor 走 backoff。
+
+```ts
+// in ClientRuntime constructor:
+this.connection.on("client:redirect", (canonicalId) => {
+  // Defer to a non-event-loop frame so the WS close handler finishes first.
+  // Without this, `process.exit` fires synchronously inside `handleMessage`
+  // and the close frame may not flush + heartbeat/auth-refresh timers
+  // (started elsewhere on this socket) won't be cleared by the close
+  // handler's natural unwind.
+  queueMicrotask(() => {
+    void this.handleClientRedirect(canonicalId);
+  });
+});
+
+protected async handleClientRedirect(canonicalId: string): Promise<void> {
+  // 1. Persist new id to yaml. Failure must be loud + retried by supervisor
+  //    backoff (exit 75 = TEMPFAIL) — silent failure would loop forever as
+  //    each restart re-reads the stale id, hits the same redirect, and
+  //    tries to write again (adversarial finding #8).
+  const yamlPath = join(defaultConfigDir(), "client.yaml");
+  try {
+    setConfigValue(yamlPath, "client.id", canonicalId);
+  } catch (err) {
+    print.check(false, "failed to persist canonical client id to yaml", err instanceof Error ? err.message : String(err));
+    print.status("", "Recovery: ensure the config directory is writable, then re-run the command.");
+    await this.stop().catch(() => {});
+    process.exit(75);
+  }
+
+  print.status("✓", `merged with existing computer record on this hub (id: ${canonicalId})`);
+  print.status("", "restarting to pick up the new identity...");
+
+  // 2. Graceful shutdown — run the same path SIGINT triggers in login.ts.
+  //    Without this, agent.slot.stop() never fires, git mirrors leak
+  //    worktree refs, and the WS close handler may not unbind agents
+  //    cleanly server-side.
+  await this.stop().catch((err) => {
+    print.status("⚠️", `runtime.stop() during redirect threw: ${err instanceof Error ? err.message : String(err)}`);
+  });
+
+  // 3. Exit cleanly. Service mode: supervisor restarts with new yaml.
+  //    Inline mode (login.ts:210 `await new Promise(() => {})`): the
+  //    process exits and the user re-runs login. Exit 0 over 75 — this
+  //    is a successful identity migration, not a fault.
+  process.exit(0);
+}
+```
+
+测试时子类化 `ClientRuntime` 覆盖 `handleClientRedirect` 来捕获 invocation 并验证 stop+exit 顺序。
+
+**`--override` 路径**（adversarial finding #10 — 部分接受）：
+- `login --override` 走 `claimClient` 后 register 用 yaml 里**已有**的 clientId，命中 §2.1 (A) 路径，dedup 查询不跑 → 不触发 redirect。✓
+- 但若 yaml 是新生成的（用户之前 `logout --purge` 过），`postClaim` 会先 404（row 不存在）。这是**已存在的 UX 限制**，PR-C 不解决。文档在 §6 known limitations 中记入。
+
+### 2.7 孤儿归档（user 2026-05-27 决策：30 天）
+
+#### Schema 改动
+
+`packages/server/src/db/schema/clients.ts` 加 `archived_at` 列：
+
+```ts
+export const clients = pgTable("clients", {
+  // ...existing columns...
+  /**
+   * Soft-delete timestamp. NULL = active row, surfaced in all read paths.
+   * Non-NULL = archived (abandoned orphan); excluded from read paths but
+   * still recoverable via admin SQL `UPDATE clients SET archived_at = NULL`.
+   * Set by the hourly `archiveAbandonedClients` sweep when a row is
+   * (disconnected AND last_seen > 30d AND zero pinned agents).
+   */
+  archivedAt: timestamp("archived_at", { withTimezone: true }),
+}, (table) => [
+  index("idx_clients_user").on(table.userId),
+  index("idx_clients_org").on(table.organizationId),
+  // New index supports the hourly sweep WHERE clause efficiently:
+  // (status, last_seen_at) covers the predicate scan; archived_at NULL is
+  // the bulk of the table, so filtering it via the index keeps the scan
+  // bounded as the table grows.
+  index("idx_clients_sweep").on(table.status, table.lastSeenAt).where(sql`archived_at IS NULL`),
+]);
+```
+
+Drizzle migration generated via `pnpm --filter @first-tree/server db:generate`. Migration is **additive** (ADD COLUMN NULLABLE + CREATE INDEX) — zero blast radius, PG can apply it online.
+
+#### 阈值常量
+
+`packages/server/src/services/client.ts`:
+
+```ts
+/**
+ * Orphan archival threshold. A `clients` row is auto-archived when ALL three
+ * hold:
+ *   1. `status = 'disconnected'`
+ *   2. `last_seen_at < NOW() - ORPHAN_ARCHIVAL_STALE_DAYS days`
+ *   3. zero non-deleted agents pinned to it
+ *
+ * 30 days chosen as a deliberate product decision (2026-05-27): long enough
+ * to survive a typical vacation / contractor cycle, short enough that
+ * abandoned `client.yaml` regenerations clear within a month. The threshold
+ * is decoupled from the auth refresh-token TTL — even if a row's auth
+ * credentials are still mintable, an unused machine for 30 days with no
+ * pinned work is treated as abandoned.
+ */
+export const ORPHAN_ARCHIVAL_STALE_DAYS = 30;
+```
+
+未来若需要可配置：把常量挪到 `app.config.runtime.clientArchivalStaleDays`，schema 在 `packages/shared/src/config/`。本 PR 先用 const，避免引入新配置字段。
+
+#### Sweep 函数
+
+`packages/server/src/services/client.ts`:
+
+```ts
+/**
+ * Sweep abandoned `clients` rows: disconnected, untouched for at least
+ * {@link ORPHAN_ARCHIVAL_STALE_DAYS} days, and carrying no non-deleted
+ * pinned agents. Sets `archived_at = NOW()` so read paths can filter
+ * them out without losing the data (admin SQL can resurrect by clearing
+ * the column).
+ *
+ * Returns the number of rows archived. Idempotent: re-archiving an
+ * already-archived row is a no-op via `archived_at IS NULL`.
+ *
+ * `agents` join uses a NOT EXISTS subquery (cheaper than COUNT GROUP BY
+ * for the "no rows" check the predicate cares about).
+ */
+export async function archiveAbandonedClients(db: Database, staleDays = ORPHAN_ARCHIVAL_STALE_DAYS): Promise<number> {
+  const result = await db.execute<{ id: string }>(sql`
+    UPDATE clients
+    SET archived_at = NOW()
+    WHERE status = 'disconnected'
+      AND archived_at IS NULL
+      AND last_seen_at < NOW() - make_interval(days => ${staleDays})
+      AND NOT EXISTS (
+        SELECT 1 FROM agents
+        WHERE agents.client_id = clients.id
+          AND agents.status != 'deleted'
+      )
+    RETURNING id
+  `);
+  return result.length;
+}
+```
+
+#### Scheduler 接入
+
+`packages/server/src/services/background-tasks.ts:55-75` 现有 `heartbeatTimer` 已经按 30s 跑 `cleanupStaleClients`。Archival 不需要 30s 这么频繁（孤儿状态变化以天为单位）。**单独加 hourly timer**：
+
+```ts
+let orphanArchiveTimer: ReturnType<typeof setInterval> | null = null;
+
+// ... inside start():
+
+// Orphan client archival sweep — runs hourly. Cheap (single indexed
+// UPDATE) so a tighter cadence is harmless, but the predicate is
+// 30-day-grained so hourly is plenty.
+orphanArchiveTimer = setInterval(async () => {
+  try {
+    const archived = await clientService.archiveAbandonedClients(app.db);
+    if (archived > 0) {
+      log.info({ archived, staleDays: clientService.ORPHAN_ARCHIVAL_STALE_DAYS }, "archived abandoned client rows");
+    }
+  } catch (err) {
+    log.error({ err }, "client orphan archival sweep failed");
+  }
+}, 60 * 60 * 1000);
+
+// ... inside stop():
+if (orphanArchiveTimer) {
+  clearInterval(orphanArchiveTimer);
+  orphanArchiveTimer = null;
+}
+```
+
+#### 读路径过滤
+
+**所有列出 clients 的查询必须加 `archived_at IS NULL`**：
+
+| 路径 | 当前 query | PR-C 改动 |
+|---|---|---|
+| `services/client.ts::listClients` | `select().from(clients).where(eq(userId,..))` | 加 `AND archived_at IS NULL` |
+| `services/client.ts::listClientsForOrgAdmin` | join + where(orgId) | 同上 |
+| `services/client.ts::getClient` | by id | 同上 — archived 行从 API 视角不存在（404） |
+| `services/client.ts::assertClientOwner` | by id + user check | 同上 |
+| `services/client.ts::cleanupStaleClients` | flip status | **不动**（cleanup 只标 disconnected，跟 archival 是两件事；archived 行天然不进 cleanup 因 status 已 disconnected） |
+| `api/me.ts::inferOnboardingStep` | `SELECT id FROM clients WHERE userId` | 加过滤（否则 archived 行让 onboarding 误以为有 client） |
+
+注意：`agent:bind` 路径 join `clients` 查 user 时也要过滤 archived — 否则一个 client 被 archive 后还能 bind 就是 bug。Verify in `ws-client.ts:539-557` agent.bind path。
+
+#### `registerClient` (A) 路径自动 unarchive
+
+用户带着原 yaml 在 31 天后回来 → `client:register` 用旧 id → 命中 (A) path → 同 id 行已被 archive。**Upsert 时 clear archived_at** 让用户无感复活：
+
+```ts
+// In (A) same-id path (§2.1)
+await tx.insert(clients).values({ ..., archivedAt: null })
+  .onConflictDoUpdate({
+    target: clients.id,
+    set: {
+      ...,
+      archivedAt: null,  // unarchive on reconnect
+    },
+  });
+```
+
+也要确认 dedup 路径 (D) 在 UPDATE canonical 时也带 `archivedAt: null`（如果 canonical 本身已被 archive 但仍是同 user/host/os 的最佳候选）。§2.1 (D) UPDATE 语句加这一字段。
+
+#### Unarchive 优先级 + pickCanonical
+
+`pickCanonical` 应该**偏好非 archived**：
+
+1. 非 archived 优先
+2. 同档：agentCount 降序
+3. 同档：lastSeen 降序
+4. 同档：id 升序
+
+```ts
+function pickCanonical(rows: Array<{id, status, lastSeenAt, agentCount, archivedAt}>): Row | null {
+  if (rows.length === 0) return null;
+  return [...rows].sort((a, b) => {
+    // Non-archived first (smaller archivedAt-ness wins)
+    const aArch = a.archivedAt !== null;
+    const bArch = b.archivedAt !== null;
+    if (aArch !== bArch) return aArch ? 1 : -1;
+    // Then agentCount desc
+    if (a.agentCount !== b.agentCount) return b.agentCount - a.agentCount;
+    // Then lastSeenAt desc
+    if (a.lastSeenAt > b.lastSeenAt) return -1;
+    if (a.lastSeenAt < b.lastSeenAt) return 1;
+    // Stable tie-break: id asc
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  })[0] ?? null;
+}
+```
+
+如果所有候选都是 archived（用户彻底放弃后回来），canonical 仍能选出来 → dedup UPDATE 同时 unarchive 该行。
+
+### 2.6 `logout --purge` 二次确认
+
+**关键修订（adversarial finding #7）**：交互式 prompt 在 non-TTY 环境（systemd unit、CI、`echo y |` pipe）会 hang。加 non-TTY guard：`--yes` 显式同意才允许 purge，否则提前 exit 1 with 明确错误。
+
+`apps/cli/src/commands/logout.ts`:
+
+```ts
+program
+  .command("logout")
+  .option("--purge", "Also remove client.yaml ...")
+  .option("--yes", "Skip the interactive confirmation when --purge is set (required in non-TTY env)")
+  .action(async (options) => {
+    ...
+    if (options.purge && !options.yes) {
+      if (!process.stdin.isTTY) {
+        // Non-TTY (cron, CI, systemd ExecStart) — interactive prompt would
+        // hang. Refuse loudly with the exact flag the operator needs.
+        print.line("\n  ✗ --purge requires interactive confirmation, but stdin is not a TTY.\n");
+        print.line("    Re-run with --yes to skip the prompt (only if you've confirmed the consequences).\n\n");
+        process.exit(1);
+      }
+      print.line("\n  ⚠️  --purge will permanently remove this computer's identity (client.yaml).\n");
+      print.line("     Next `first-tree login` will register a brand-new computer row on the Hub.\n");
+      print.line("     The existing row will become an orphan until the server's dedup merges it back\n");
+      print.line("     (only if the same user reconnects from the same hostname + OS).\n\n");
+      const choice = await select<"purge" | "cancel">({
+        message: "How would you like to continue?",
+        choices: [
+          { name: "Cancel — keep client.yaml", value: "cancel" },
+          { name: "Purge — I want to lose this computer's identity", value: "purge" },
+        ],
+      });
+      if (choice === "cancel") {
+        print.line("\n  Cancelled. client.yaml retained.\n");
+        return;
+      }
+    }
+    ...existing logic...
+  });
+```
+
+---
+
+## 3. Task 分解（TDD-style）
+
+### Task C1 · pickCanonical pure helper + tests
+
+**Files:**
+- Create: `packages/server/src/services/__tests__/pick-canonical.test.ts`
+- Modify: `packages/server/src/services/client.ts` (add `pickCanonical`)
+
+- [ ] **Step 1: Failing test** — table-driven cases:
+  - empty candidates → null
+  - single candidate → that candidate
+  - multiple, none has agents → most recent lastSeenAt wins
+  - multiple, some have agents → highest agentCount wins
+  - same agentCount + same lastSeenAt → oldest id (stable tie-break)
+- [ ] **Step 2:** implement `pickCanonical`
+- [ ] **Step 3:** test green
+- [ ] **Step 4: no commit** (per "single coherent PR commit" policy from PR-A)
+
+### Task C2 · Server `registerClient` dedup transaction + tests
+
+**Files:**
+- Modify: `packages/server/src/services/client.ts` (rewrite `registerClient`)
+- Modify: `packages/server/src/__tests__/client-register-claim.test.ts` (extend with dedup cases)
+
+- [ ] **Step 1: Failing test** — `registerClient` dedup matrix:
+  - new clientId + no canonical → INSERT new, returns `{canonicalClientId: input, redirected: false}`
+  - new clientId + canonical exists (status=disconnected) → UPDATE canonical to connected, returns `{canonicalClientId: canonical.id, redirected: true}`
+  - new clientId + canonical exists (already connected) → UPDATE canonical's instance_id + lastSeen, returns redirected. (Server WS-side `connectionManager.setClientConnection` already replaces old socket per existing behavior.)
+  - existing clientId (same id) → existing upsert path, returns `{canonicalClientId: input, redirected: false}`
+  - existing clientId + DIFFERENT userId → still throws `ClientUserMismatchError`
+  - hostname or os missing on register → no dedup, plain INSERT (defensive — pickCanonical without anchor would over-merge)
+  - **Concurrency test**: two concurrent registers from same (user, host, os) with different ids must serialize. Setup: use two `db.transaction` blocks in parallel with `Promise.all`, both calling `registerClient`. After both resolve, assert exactly ONE row exists for `(user, host, os)`. Without `FOR UPDATE` the test would observe two rows briefly; with it, one transaction blocks on the other's lock and observes the freshly-inserted canonical on its retry.
+- [ ] **Step 2:** rewrite `registerClient`
+- [ ] **Step 3:** test green
+
+### Task C3 · WS handler uses canonical id
+
+**Files:**
+- Modify: `packages/server/src/api/agent/ws-client.ts` (lines 435-530 approximately)
+- Add: `packages/server/src/__tests__/client-register-dedup-ws.test.ts` (integration test via inject)
+
+- [ ] **Step 1: Failing test** — WS `client:register` frame with dedup-triggering payload:
+  - Response is `{type: "client:registered", clientId: canonical}` (NOT the caller's input id)
+  - `connectionManager.getSocket(canonical)` returns the WS (NOT under input id)
+  - `agent:pinned` backfill enumerates by canonical (verify by setting up an agent pinned to canonical, then registering with new id — agent:pinned frames should arrive)
+- [ ] **Step 2:** update handler — all three sites:
+  - local `clientId = result.canonicalClientId`
+  - `connectionManager.setClientConnection(result.canonicalClientId, socket)`
+  - `socket.send({type: "client:registered", clientId: result.canonicalClientId})`
+  - `listActiveAgentsPinnedToClient(app.db, result.canonicalClientId)` (was `data.clientId`)
+- [ ] **Step 3:** test green
+
+### Task C4 · CLI ClientConnection emits redirect event
+
+**Files:**
+- Modify: `packages/client/src/client-connection.ts` (events type + handleMessage)
+- Add: `packages/client/src/__tests__/client-connection-redirect.test.ts`
+
+- [ ] **Step 1: Failing test** — mock WS server sends `client:registered {clientId: "Y"}` while connection's `clientId == "X"`:
+  - `client:redirect` event emitted with `"Y"`
+  - `connected` event NOT emitted
+  - `closing` is true; no reconnect attempts
+- [ ] **Step 2:** implement event + handleMessage branch
+- [ ] **Step 3:** test green
+
+### Task C5 · ClientRuntime / bootstrap redirect handling
+
+**Files:**
+- Modify: `apps/cli/src/core/client-runtime.ts` (add `client:redirect` listener)
+- Possibly: `apps/cli/src/commands/login.ts` if redirect needs handling during initial login (probably not — login uses fresh id, no canonical mismatch expected)
+- Add: `apps/cli/src/__tests__/client-runtime-redirect.test.ts`
+
+- [ ] **Step 1: Failing test** — simulate `client:redirect` event:
+  - yaml is rewritten with canonical id (verify via `getConfigValue`)
+  - `print.status` shows informative message
+  - `process.exit(0)` called (mock `process.exit` for testability)
+- [ ] **Step 2:** implement
+- [ ] **Step 3:** test green
+
+### Task C6 · `logout --purge` 2-step confirm
+
+**Files:**
+- Modify: `apps/cli/src/commands/logout.ts`
+- Add: `apps/cli/src/__tests__/logout-purge-confirm.test.ts`
+
+- [ ] **Step 1: Failing test** — invoke `logout --purge` programmatically with mocked inquirer prompt:
+  - prompt is shown
+  - "cancel" choice → yaml retained, "Cancelled" message
+  - "purge" choice → yaml removed
+  - `--yes` flag → prompt skipped, yaml removed directly
+- [ ] **Step 2:** implement
+- [ ] **Step 3:** test green
+
+### Task C7 · 孤儿归档（schema + sweep + read-path filter + unarchive）
+
+**Files:**
+- Modify: `packages/server/src/db/schema/clients.ts` — 加 `archivedAt` 列 + sweep 索引
+- Run: `pnpm --filter @first-tree/server db:generate` — drizzle 自动生成 SQL migration
+- Modify: `packages/server/src/services/client.ts`:
+  - 加 `ORPHAN_ARCHIVAL_STALE_DAYS = 30` 常量
+  - 加 `archiveAbandonedClients` 函数
+  - `listClients` / `listClientsForOrgAdmin` / `getClient` / `assertClientOwner` 加 `archived_at IS NULL`
+  - `pickCanonical` 偏好非 archived（同 §2.7）
+  - `registerClient` (A) + (D) 路径 set `archived_at = null` 复活旧行
+- Modify: `packages/server/src/services/background-tasks.ts` — 加 hourly `orphanArchiveTimer`
+- Modify: `packages/server/src/api/me.ts:554-572` `inferOnboardingStep` — `SELECT FROM clients WHERE userId AND archived_at IS NULL`
+- Modify: `packages/server/src/api/agent/ws-client.ts` agent:bind join (`agents → clients`) — 加 archived 过滤
+- Add: `packages/server/src/__tests__/client-archival.test.ts`
+
+- [ ] **Step 1: Failing tests** for the sweep matrix:
+  - row disconnected 31 天 + 0 agents + 非 archived → 被 archive
+  - row disconnected 29 天 + 0 agents → 不 archive（阈值边界）
+  - row disconnected 31 天 + 1 agent pinned → 不 archive（有 work）
+  - row connected 60 天 + 0 agents → 不 archive（在线就不算孤儿）
+  - row already archived → idempotent，不再次更新（`archived_at IS NULL` 守护）
+  - 多次跑 sweep 行为稳定
+- [ ] **Step 2: Failing tests** for read-path 过滤:
+  - `listClients` 不返回 archived 行
+  - `listClientsForOrgAdmin` admin 视图同样
+  - `GET /clients/:id` 对 archived 行返回 404（assertClientOwner 看不到 → NotFoundError）
+  - `agent:bind` 拒绝 bind 到 archived client 的 agent（WS-level test）
+  - `inferOnboardingStep` 对仅有 archived clients 的用户返回 "connect" 而非 "create_agent"
+- [ ] **Step 3: Failing tests** for unarchive on reconnect:
+  - 已 archived 的 client.id 重连 → (A) 路径 unarchive，行复活
+  - dedup 路径 (D) 命中 archived canonical → UPDATE 也 set archived_at=null
+- [ ] **Step 4:** implement migration + service + scheduler + read-path + unarchive
+- [ ] **Step 5:** test green
+- [ ] **Step 6:** verify migration applies cleanly on a clean DB (`pnpm --filter @first-tree/server db:migrate`)
+
+### Task C8 · End-to-end integration test
+
+**Files:**
+- Add: `packages/server/src/__tests__/client-dedup-e2e.test.ts`
+
+- [ ] Full dedup flow:
+  - User registers client A (hostname=H, os=O)
+  - User registers client B (same H, O, different clientId)
+  - B's WS gets `client:registered {clientId: A's id}` — verifies canonical preference
+  - DB has only A's row updated (status=connected, latest lastSeenAt)
+  - B's old id has no row in DB (was never inserted)
+- [ ] Archival + return flow:
+  - User registers A → A becomes disconnected → wait 31 days (manipulate `last_seen_at`) → sweep → A archived
+  - User reconnects with same A id → A row unarchived, status=connected
+  - `listClients` shows A again
+
+### Task C9 · Full check + lint + format
+
+- [ ] `pnpm test` all green
+- [ ] `pnpm typecheck` clean
+- [ ] `pnpm check` (biome) — no new lint errors in changed files
+
+### Task C9 · 2 rounds code review (per user directive)
+
+- [ ] Round 1 (correctness): fresh-context subagent, focus on dedup race conditions, redirect protocol back-compat, agent-pinned backfill consistency, FOR UPDATE lock scope
+- [ ] Round 2 (adversarial): fresh-context subagent, focus on dedup loop scenarios (canonical row's agent pinned to old id?), CLI redirect loop safety, SQL injection on hostname/os (zod max() caps cover it but verify)
+
+### Task C10 · Commit, push, PR, watch
+
+- [ ] Single coherent commit
+- [ ] Push branch, open PR with full body
+- [ ] Watch CI, address reviewer comments
+- [ ] Wait for user manual merge
+
+---
+
+## 4. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| Dedup 误合并真实多机（同 hostname） | 用户决策接受此限制（plan §8 已注明）。文档说明 |
+| Concurrent register race | `SELECT ... FOR UPDATE` 锁住候选集，事务串行化 |
+| 老 CLI 收到 redirect 后 ignore response.clientId | 服务端仍然 tracking canonical 行；老 CLI 每次连接都会被 dedup（浪费 1 个 round-trip），但不影响功能正确性 |
+| 新 CLI 的 process.exit(0) 行为在 inline 模式下让 user 困惑 | 退出前明确打印"restarting to pick up the new identity"；service 模式下完全自动 |
+| `agent:pinned` backfill 用 caller's clientId 而非 canonical | C3 显式改成 canonical（防止 backfill 漏 agent） |
+| Redirect loop（CLI 写 yaml → 重启 → 又被 redirect） | canonical id 由 server 决定且稳定；CLI 写完 yaml 后下次 register 用 canonical 直接命中 (A) 路径，不再 redirect |
+| 用户在 PR-C 之前已经有 orphan 行 | 本 PR 不主动清理，但下一次任一旧 client 重连都会触发 dedup 合并到当前 canonical。**长期看是 self-healing** |
+
+---
+
+## 5. 观测性
+
+在 `registerClient` 的 redirect 分支末尾 emit 一条结构化日志：
+
+```ts
+app.log.info({
+  event: "client.dedup_merged",
+  userId: data.userId,
+  hostname: data.hostname,
+  os: data.os,
+  callerId: data.clientId,
+  canonicalId: result.canonicalClientId,
+  candidateCount: candidates.length,
+}, "soft-dedup redirected register to canonical row");
+```
+
+→ 上线后第一天可以查日志验证：
+- dedup 频率（是否预期 / 是否有异常 spike）
+- candidateCount 分布（是否有 user 同 host 有 5+ orphan）
+- 哪些 hostname 最多 dedup（hostname 漂移可见）
+
+不引入 metric / counter（避免新依赖），靠日志查询即可。
+
+## 6. Design Reflection 日志
+
+### Round 1 · writing-plans self-review
+
+发现并 inline 修复：
+- §2.5 redirect listener 位置不清 → 钉在 `ClientRuntime`，抽 `handleClientRedirect` 让测试可 mock
+- §2.5 补：`--override` 不受 redirect 影响的论证
+- Task C2 测试矩阵补：canonical 已连接的场景 + concurrency test 具体写法（双 transaction Promise.all）
+- Task C3 显式列出全部 3 处需要换 canonical id 的位置 + agent:pinned backfill 必改
+
+### Round 2 · plan-eng-review 框架
+
+- 架构：app-layer dedup + FOR UPDATE 是 boring 选择，PG 部分 unique index 不可行（旧数据有重复，会建索引失败）
+- 性能：额外开销 = 1 个 SELECT FOR UPDATE on dedup path，可忽略
+- 观测：补 §5 结构化日志
+- 边界：canonical 已连接的场景已加测试
+
+### Round 3 · adversarial subagent (fresh-context challenge)
+
+20 finding，按严重度处理：
+
+**P0 / 必修**：
+- ✅ **#1 (conf 9)** — FOR UPDATE 在空结果集不锁任何行，并发 first-time register 仍然产生重复。修复：换成 `pg_advisory_xact_lock(hashtext(user|host|os))` 在 SELECT 前锁住 key（PG 事务级 advisory lock，空集仍有效）。§2.1 已重写
+
+**P1 / 必修**：
+- ✅ **#2 (conf 8)** — `process.exit(0)` 同步执行绕开 graceful shutdown。修复：`queueMicrotask` 推迟 + 走 `runtime.stop()` 后再 exit。§2.5 已重写
+- ✅ **#3, #19 (conf 8/7)** — 老 CLI 反复 redirect 会偷走 canonical 现有 socket。修复：`ClientDedupConflictError` 在 canonical 当前有活 socket 时抛出，CLI 看到 `CLIENT_DEDUP_CONFLICT` 错误码后等 reconnect backoff，不偷别人 slot。§2.1 + §2.3 已写
+- ✅ **#4 (conf 9)** — redirect 路径的 metadata UPDATE 必须复用现有 `||` jsonb merge SQL，否则 capabilities 被 wipe。§2.1 显式加了 `metadataMerge` 同款 SQL
+- ✅ **#5 (conf 7)** — GROUP BY + FOR UPDATE 在 PG 不合法。修复：两步查询，advisory lock 在外层覆盖。§2.1 + §2.2 已改
+- ✅ **#7 (conf 7)** — non-TTY 环境 `select` prompt 挂死。修复：`!process.stdin.isTTY && !--yes` 提前 exit 1。§2.6 已加 guard
+- ✅ **#8 (conf 8)** — yaml 写失败导致 supervisor 无限 redirect 循环。修复：try/catch + exit 75 让 supervisor backoff。§2.5 已加
+- ⏸ **#10 (conf 8)** — `--override` 后 yaml 被 purge 过的 UX 限制（postClaim 404）。**接受为已存在限制**，文档进 §7 known limitations，PR-C 不修
+
+**P2 / 接受或记入 known limitations**：
+- #6 pickCanonical 偏好"有 agents pinned"可能导致 stale row 复活 — 设计意图，文档
+- #9 同 id 并发 register 重启 race — pre-existing，未引入
+- #11 vitest 并发测试 fixture — 测试用例显式断言 "exactly one row" 即可揭示 #1 bug
+- #12 instanceId 跨 server-instance — 现有行为，dedup 后稍频繁但不破坏正确性
+- #13 PII (hostname/os) 在 log — 改成 `app.log.debug` 输出 hostname/os，summary 在 info（已调整 §5）
+- #14 close 时 timer 清理 — 验证 ClientConnection 的 close handler 已清 heartbeat/auth-refresh timer（已有逻辑，仅需测试覆盖）
+- #15 vanilla `logout`/login（不带 --purge）是 no-op for self-healing — 设计意图，因为 yaml 保留
+- #16 UUID v7 tie-break ≈ 创建时间 — 已知
+- #18 (A) vs (B) 之间的 TOCTOU — advisory lock 覆盖整个事务，含 (A) 的 SELECT
+- #20 partial unique index + 一次性数据迁移 — 接受为**未来更优方案**，PR-C 选 advisory lock 是因为 zero migration scope。文档
+
+**完成 Round 3 修订**。
+
+### 已应用修订汇总（plan v0.3）
+
+- §2.1 整段重写：advisory lock + 两步 candidate 查询 + canonical-slot-live guard + `ClientDedupConflictError`
+- §2.2 修订：两步 agent count（不能 JOIN aggregate with FOR UPDATE）
+- §2.3 修订：WS handler 注入 `isCanonicalSlotLive` + 翻译 `CLIENT_DEDUP_CONFLICT` 到 register-rejected
+- §2.5 重写：`queueMicrotask` 推迟 + `runtime.stop()` 走优雅关闭 + yaml 写失败 exit 75
+- §2.6 修订：non-TTY guard
+- §5 修订：hostname/os 落 debug 级，dedup event 落 info
+
+---
+
+## 7. Known Limitations (PR-C 不修)
+
+- **`login --override` 在 yaml purged 后 postClaim 会 404**（adversarial #10）。`postClaim` 需要 server-side 存在该 client.id；purge 后 yaml 是全新 id，server 没有匹配行。改进路径需重新设计 `--override` 语义（"找到我用户名下任意 hostname 匹配的行并 claim"），独立 PR
+- **真实多机同 hostname 会被合并成一行**（plan §4 风险表 + 用户决策接受）。短期变通：用户在系统设置改 hostname；长期：machine fingerprint (P2)
+- **老 CLI 永远 ignore response.clientId**（plan §4）：每次 reconnect 都触发一次 redirect 浪费 round-trip，但功能正确。等老 CLI 升级或下线
+- **现存 orphan 行不会被本 PR 自动清理**：只在被 dedup 触发时合并。完整清理需要 orphan archival（阈值待定）或用户 prune CLI（后续 PR）
+- **`logout`（不带 --purge）不触发 self-healing**：yaml 保留 → 下次 login 用同一 id → dedup 不跑（命中 (A) 路径）。这是设计：vanilla logout 是临时 sign-out，不该改 identity
+
+## 8. Plan 冻结
+
+Plan v0.3 完成所有 3 轮 reflection，进入实施阶段。


### PR DESCRIPTION
## Summary

Stops orphan `clients` rows from accumulating and cleans up existing ones. The bug reproduced in the dev DB before this change: two rows for the same `(user, hostname, os)` from successive `client.yaml` regenerations, both surfaced in Settings → Computers as if they were separate machines.

Background docs: `proposals/connect-computer-optimization.md` (gandy-assistant's product proposal) + `proposals/connect-computer-pr-c-plan.md` (this implementation plan with 3 rounds of design reflection).

### Server-side soft dedup (`services/client.ts`)

`registerClient` now has three branches:

- **(A) Same-id reconnect** — existing path, plus `archivedAt = NULL` to transparently unarchive a returning install. Refuses to claim an archived legacy (user_id NULL) row — security mitigation since `client.id` can leak via logs / shared FS and the existing claim path would transfer ownership silently.
- **(B) Dedup path** — new id + `(hostname, os)` anchor both present. Acquires `pg_advisory_xact_lock(hashtextextended(user|host|os, 0))` BEFORE the candidate SELECT (`FOR UPDATE` on an empty result set locks nothing — concurrent first-time registers would race past). 64-bit `hashtextextended` keyspace avoids the int4 collision floor. `pickCanonical` picks among matches: non-archived > agentCount > lastSeenAt > id. If the canonical slot is held by a different live socket, throws `ClientDedupConflictError` so the offending CLI backs off instead of silently stealing.
- **(C) Plain insert** — no anchor or no canonical match.

### Orphan archival sweep

`clients.archived_at TIMESTAMP NULL` (migration `0050`) set by `archiveAbandonedClients` when ALL hold:
- `status = 'disconnected'`
- `last_seen_at < NOW() - 30 days` (locked product decision 2026-05-27)
- zero non-deleted pinned agents
- not already archived (idempotency)

Hourly sweep wired into `background-tasks.ts::orphanArchiveTimer`. Rows stay in the table for audit + recovery; admin SQL can clear `archived_at`. Partial index `idx_clients_sweep WHERE archived_at IS NULL` keeps the sweep cheap. All read paths filter `archived_at IS NULL`: `listClients`, `listClientsForOrgAdmin`, `getClient`, `assertClientOwner`, `listMyPinnedAgents`, `inferOnboardingStep`.

### CLI redirect protocol (`packages/client` + `apps/cli`)

Server returns `canonicalClientId` in `client:registered` (the field already existed — its meaning is now load-bearing). New CLIs compare to their local id; on mismatch emit `client:redirect`, set `closing = true`, close cleanly. `ClientRuntime.handleClientRedirect` persists canonical id to `client.yaml` and exits via `runtime.stop()` (bounded by a 10s `Promise.race` so a wedged agent slot can't trap the CLI in stale identity) → supervisor restarts under the new identity. Yaml write failure exits 75 (TEMPFAIL) for backoff.

New `ClientDedupConflictError` (code `CLIENT_DEDUP_CONFLICT`) — treated as transient, NOT terminal, so reconnect loop continues. Once the conflicting live CLI disconnects, dedup succeeds.

Old CLIs that ignore `msg.clientId` keep using their local id locally; server-side tracking + `agent:bind` correctness is preserved because the WS handler's local `clientId` variable, connection-manager key, and `agent:pinned` backfill all consume `canonicalClientId`.

### `logout --purge` 2-step confirm (`apps/cli/src/commands/logout.ts`)

Interactive `select` prompt before the destructive yaml wipe; `--yes` skips it for scripted use; non-TTY environments without `--yes` exit 1 with a clear pointer instead of hanging on stdin.

## Migration

`0050_clients_archived_at.sql` is hand-written because `drizzle-kit generate` is blocked by a pre-existing snapshot collision in the repo (`0016` and `0018` snapshots both reference parent `0016`). Same convention recent migrations 0042-0049 followed: SQL + journal entry + LATEST sentinel, no snapshot. Migration is idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`).

## Review trail

Three rounds of design reflection on the plan:
- writing-plans self-review
- plan-eng-review framework
- adversarial subagent (fresh context) — 20 findings, 8 applied (P0: `FOR UPDATE` on empty result doesn't serialize → fixed via advisory lock; P1: `metadata` merge SQL must mirror existing single-id upsert to preserve capabilities; P1: `process.exit` inside event handler bypasses graceful shutdown)

Two rounds of code review on the diff:
- correctness (subagent A) — 16 findings, top: redirect `runtime.stop()` can hang indefinitely (fixed); migration not idempotent on manual partial-apply (fixed)
- adversarial (subagent B) — 22 findings, top: archived legacy row claim window via NULL user_id (P0, fixed); `hashtext` 32-bit collisions (fixed via `hashtextextended`); stale "race-safe within scope" comment (fixed)

All P0/P1s addressed; P2s either applied or recorded as known limitations in the plan doc.

## Sorting / read-path behavior changes

- `clients` read paths now filter `archived_at IS NULL` everywhere (member, admin team-view, agent-bind join, onboarding inference, owner assertion). Admin SQL recovery preserved via `UPDATE clients SET archived_at = NULL`.
- `assertClientOwner` 404s archived rows by design — user-driven cleanup paths (disconnect, retire, capabilities PATCH) all return 404 once a row is archived. Intentional: archived = sweep-soft-deleted = invisible from user perspective. Admin SQL can resurrect, or just `first-tree login` (the same-id `(A)` path auto-unarchives).
- `pickCanonical` priority: non-archived > agentCount > lastSeenAt > id (oldest UUID v7).

## Known limitations (NOT fixed in this PR)

- `setConfigValue` writes yaml without `fsync` — power loss between write and OS flush could truncate yaml. Existing behavior, not introduced by this PR; would need a write-rename-atomic helper across all callers.
- Multi-instance sweep runs hourly per instance — PG row locks serialize correctly (UPDATE is atomic), just log noise on N-instance deployments.
- `CREATE INDEX` is NOT `CONCURRENTLY` — drizzle's migrator runs migrations in transactions and PG forbids `CONCURRENTLY` inside a transaction. `clients` table is small (one row per user per machine), so the brief blocking is acceptable.
- `login --override` + previously-`logout --purge`'d yaml still 404s on `postClaim` (the yaml id no longer exists server-side). Pre-existing UX limitation; recovery is "generate a fresh connect token and let the server pick a new identity".
- Sweep doesn't take the dedup advisory lock — a register concurrent with the sweep may resurrect a row the sweep just archived (correct behavior: returning user, but not visible in logs).

## Test plan

- [x] `pnpm --filter @first-tree/server test` — 1251 tests green (1237 baseline + 14 new), 151 files
- [x] `pnpm typecheck` — all 13 packages clean
- [x] `pnpm check` (biome) — no new lint errors in changed files
- [x] Migration applies cleanly on a fresh test DB (verified — server tests run migrations on setup)

### Manual verification suggested before merge

- [ ] Start the dev stack; observe the existing dev DB orphan rows (`client_8cc8270d` + `client_379cfb47` for `GandydeMacBook-Pro.local`). `logout --purge --yes` + `login <token>` → dedup picks the agent-bearing canonical, new yaml id is replaced with canonical id, only one row surfaces in Settings → Computers.
- [ ] `logout --purge` without `--yes` from a TTY → prompt shows, "Cancel" leaves yaml, "Purge" wipes it.
- [ ] `logout --purge` from a non-TTY context (e.g., `bash -c 'logout --purge < /dev/null'`) → exits 1 with clear error.
- [ ] Force-archive a row via SQL: `UPDATE clients SET archived_at = NOW(), last_seen_at = NOW() - interval '31 days' WHERE id = '...'`. Refresh Settings → Computers — row no longer surfaces. `first-tree login <token>` with that yaml → row resurrects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)