### PR TITLE
feat(computers): card-based IA for Settings → Computers

### DIFF
--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -255,12 +255,18 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // guide, ⋯ menu) inline, so the PageHeader's right slot no longer needs
   // a "+ Connect" button. The connect entry point lives at the bottom of
   // the page as a low-emphasis "Add another computer" outline button when
-  // appropriate (see `addAnotherSpot` below). Single-device + viewer-owned
-  // hides the button entirely per mockup §"已敲定" 第 5 条 — a user with
-  // exactly one working computer doesn't usually want a second one, and
-  // they can still reach the entry via the empty-state CTA after retire.
+  // appropriate. Single-device + viewer-owned hides it entirely per
+  // mockup §"已敲定" 第 5 条 — a user with exactly one working computer
+  // doesn't usually want a second one, and they can still reach the entry
+  // via the empty-state CTA after retire.
+  //
+  // "Add another" copy reads wrong when the viewer (admin) has 0 of
+  // their own and only team rows are showing — they don't yet have one
+  // to "add another" to. In that case fall back to the full-page empty
+  // CTA inside the "Your computers" section instead of the bottom button.
   const singleOwnCard = !grouped && (memberList?.length ?? 0) === 1 && memberList?.[0]?.userId === user?.id;
-  const showBottomAddButton = !singleOwnCard && (clients?.length ?? 0) >= 1;
+  const viewerOwnCount = grouped ? mineList.length : (memberList?.length ?? 0);
+  const showBottomAddButton = !singleOwnCard && viewerOwnCount >= 1;
 
   return (
     <div className={embedded ? "" : "-m-6"}>
@@ -436,7 +442,20 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
               <>
                 <CardSection title="Your computers" count={mineList.length}>
                   {mineList.length === 0 ? (
-                    <EmptyCardsNote message="No computers of your own." />
+                    // Admin with no own computers + N team rows — the "Add
+                    // another computer" bottom button would read wrong here
+                    // ("another" implies a first), so keep the connect CTA
+                    // inside the empty section instead.
+                    <div
+                      className="flex flex-col items-start py-6"
+                      style={{ color: "var(--fg-3)", gap: "var(--sp-3)" }}
+                    >
+                      <span className="text-body">No computers of your own.</span>
+                      <Button size="sm" onClick={openNewConnection}>
+                        <Plus className="h-3 w-3" />
+                        Connect your first computer
+                      </Button>
+                    </div>
                   ) : (
                     <CardGrid>
                       {mineList.map((client) => (

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -1,9 +1,4 @@
-import {
-  type CapabilityEntry,
-  type ClientCapabilities,
-  RUNTIME_PROVIDERS,
-  type RuntimeProvider,
-} from "@first-tree/shared";
+import type { CapabilityEntry, ClientCapabilities, RuntimeProvider } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -34,6 +29,13 @@ import { RowActionsMenu } from "../components/ui/row-actions-menu.js";
 import { UppercaseLabel } from "../components/ui/section-header.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { formatDate, formatRelative } from "../lib/utils.js";
+import { ComputerCard } from "./clients/cards/computer-card.js";
+import {
+  PROVIDER_INSTALL_HINT,
+  PROVIDER_LABEL,
+  PROVIDER_ORDER,
+  PROVIDER_UNAUTH_HINT,
+} from "./clients/cards/shared/providers.js";
 import { ComputerStatusPill } from "./clients/computer-status-pill.js";
 import { compareByPillPriority, deriveComputerStatus, summarizeComputers } from "./clients/derive-status.js";
 import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
@@ -70,6 +72,34 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const [confirmRetire, setConfirmRetire] = useState<HubClient | null>(null);
   const [retireError, setRetireError] = useState<string | null>(null);
   const [newConnectionOpen, setNewConnectionOpen] = useState(false);
+  /**
+   * Re-auth target — when set, the next NewConnectionDialog opening is
+   * scoped to *this specific client.id* so the arrival detector only
+   * succeeds when that machine reconnects. Without this, a parallel
+   * AuthExpired re-auth on another card could consume the wrong event.
+   * Cleared when the dialog closes.
+   */
+  const [reAuthClientId, setReAuthClientId] = useState<string | null>(null);
+  /** Hostname captured when the re-auth was kicked off — drives dialog copy. */
+  const [reAuthHostname, setReAuthHostname] = useState<string | null>(null);
+
+  const openNewConnection = (): void => {
+    setReAuthClientId(null);
+    setReAuthHostname(null);
+    setNewConnectionOpen(true);
+  };
+  const openReAuth = (client: HubClient): void => {
+    setReAuthClientId(client.id);
+    setReAuthHostname(client.hostname);
+    setNewConnectionOpen(true);
+  };
+  const handleDialogClose = (next: boolean): void => {
+    setNewConnectionOpen(next);
+    if (!next) {
+      setReAuthClientId(null);
+      setReAuthHostname(null);
+    }
+  };
 
   const orgClientsQuery = useQuery({
     queryKey: ["clients", "org"],
@@ -203,6 +233,16 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // empty-state branch off this list keeps the two display modes in sync.
   const clients = grouped ? orgClientsQuery.data : memberList;
 
+  // "Are we still waiting on the primary listing?" — distinct from `!clients`
+  // because once a query resolves with an empty array we want to drop out of
+  // loading and show the empty state. Without this gate, admins see the empty
+  // CTA flash before the org-scoped query lands on first paint.
+  const clientsLoading = isAdmin
+    ? orgClientsQuery.isError
+      ? meClientsQuery.isLoading
+      : orgClientsQuery.isLoading
+    : meClientsQuery.isLoading;
+
   // Subtitle is the pure-function output of `summarizeComputers` — single
   // headline for one row owned by the viewer ("Your computer is ready"),
   // neutral phrasing when admin is looking at a teammate's lone row, and a
@@ -211,23 +251,33 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // surfaced. See `clients/derive-status.ts` for the pure logic + tests.
   const subtitle = useMemo(() => summarizeComputers(clients, user?.id), [clients, user?.id]);
 
+  // Cards now host the per-row affordances (Generate new token, install
+  // guide, ⋯ menu) inline, so the PageHeader's right slot no longer needs
+  // a "+ Connect" button. The connect entry point lives at the bottom of
+  // the page as a low-emphasis "Add another computer" outline button when
+  // appropriate (see `addAnotherSpot` below). Single-device + viewer-owned
+  // hides the button entirely per mockup §"已敲定" 第 5 条 — a user with
+  // exactly one working computer doesn't usually want a second one, and
+  // they can still reach the entry via the empty-state CTA after retire.
+  const singleOwnCard = !grouped && (memberList?.length ?? 0) === 1 && memberList?.[0]?.userId === user?.id;
+  const showBottomAddButton = !singleOwnCard && (clients?.length ?? 0) >= 1;
+
   return (
     <div className={embedded ? "" : "-m-6"}>
-      <PageHeader
-        title="Computers"
-        subtitle={subtitle}
-        right={
-          <div className="flex items-center gap-1.5">
-            <Button size="xs" onClick={() => setNewConnectionOpen(true)}>
-              <Plus className="h-3 w-3" />
-              Connect computer
-            </Button>
-          </div>
-        }
-      />
+      <PageHeader title="Computers" subtitle={subtitle} />
 
       <div style={{ padding: "var(--sp-3_5) var(--sp-5) var(--sp-7)" }}>
-        <NewConnectionDialog open={newConnectionOpen} onOpenChange={setNewConnectionOpen} />
+        <NewConnectionDialog
+          open={newConnectionOpen}
+          onOpenChange={handleDialogClose}
+          targetClientId={reAuthClientId ?? undefined}
+          titleOverride={reAuthClientId ? "Re-authenticate computer" : undefined}
+          descriptionOverride={
+            reAuthClientId
+              ? `Run this command on ${reAuthHostname ?? "the computer"} to refresh its access token.`
+              : undefined
+          }
+        />
 
         {confirmRetire && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay-scrim">
@@ -355,138 +405,109 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
           </div>
         )}
 
-        {!clients || clients.length === 0 ? (
+        {clientsLoading ? (
+          // Hold the page chrome quiet while the primary listing is still
+          // in flight. Without this, admins briefly see the "No computers
+          // connected yet" empty state on first paint because
+          // `orgClientsQuery.data` is `undefined` for one render before the
+          // 10s-poll query resolves — a confusing flash on a settings page
+          // they're typically returning to, not visiting fresh.
+          <div className="py-10 text-body" style={{ color: "var(--fg-4)", textAlign: "center" }}>
+            Loading computers…
+          </div>
+        ) : !clients || clients.length === 0 ? (
           <div>
             {teamLoadError && <TeamLoadErrorBanner />}
-            <div className="text-center py-10 text-body" style={{ color: "var(--fg-3)" }}>
-              No computers connected. Use the button above to generate a connect command.
+            <div
+              className="flex flex-col items-center text-center py-10 text-body"
+              style={{ color: "var(--fg-3)", gap: "var(--sp-3)" }}
+            >
+              <span>No computers connected yet.</span>
+              <Button size="sm" onClick={openNewConnection}>
+                <Plus className="h-3 w-3" />
+                Connect your first computer
+              </Button>
             </div>
           </div>
         ) : (
-          <div>
+          <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
             {teamLoadError && <TeamLoadErrorBanner />}
-            <DenseTable>
-              <DenseTableHeader>
-                <DenseTableRow>
-                  <DenseTableHead style={{ width: 16 }} />
-                  <DenseTableHead>Hostname</DenseTableHead>
-                  {grouped && <DenseTableHead>Owner</DenseTableHead>}
-                  <DenseTableHead>OS</DenseTableHead>
-                  <DenseTableHead>first-tree</DenseTableHead>
-                  <DenseTableHead>Agents</DenseTableHead>
-                  <DenseTableHead>Last seen</DenseTableHead>
-                  <DenseTableHead>Status</DenseTableHead>
-                  <DenseTableHead aria-hidden />
-                </DenseTableRow>
-              </DenseTableHeader>
-              <DenseTableBody>
-                {grouped ? (
-                  <>
-                    <GroupHeaderRow title="Your computers" count={mineList.length} colSpan={ADMIN_COLSPAN} />
-                    {mineList.length === 0 ? (
-                      <EmptyGroupRow colSpan={ADMIN_COLSPAN} message="No computers of your own." />
-                    ) : (
-                      mineList.map((client) => {
-                        const isExpanded = !collapsedIds.has(client.id);
-                        const boundAgents = getClientAgents(client.id);
-                        return (
-                          <ClientRow
-                            key={client.id}
-                            client={client}
-                            boundAgents={boundAgents}
-                            isExpanded={isExpanded}
-                            agentName={agentName}
-                            onToggle={() =>
-                              setCollapsedIds((prev) => {
-                                const next = new Set(prev);
-                                if (next.has(client.id)) next.delete(client.id);
-                                else next.add(client.id);
-                                return next;
-                              })
-                            }
-                            onDisconnect={() => setConfirmDisconnect(client)}
-                            onRetire={() => {
-                              setRetireError(null);
-                              setConfirmRetire(client);
-                            }}
-                            onReconnect={() => setNewConnectionOpen(true)}
-                            showOwner
-                            ownerLabel={resolveOwner(client)}
-                          />
-                        );
-                      })
-                    )}
-                    <GroupHeaderRow title="Team computers" count={teamList.length} colSpan={ADMIN_COLSPAN} />
-                    {teamList.length === 0 ? (
-                      <EmptyGroupRow colSpan={ADMIN_COLSPAN} message="No other team computers." />
-                    ) : (
-                      teamList.map((client) => {
-                        const isExpanded = !collapsedIds.has(client.id);
-                        const boundAgents = getClientAgents(client.id);
-                        return (
-                          <ClientRow
-                            key={client.id}
-                            client={client}
-                            boundAgents={boundAgents}
-                            isExpanded={isExpanded}
-                            agentName={agentName}
-                            onToggle={() =>
-                              setCollapsedIds((prev) => {
-                                const next = new Set(prev);
-                                if (next.has(client.id)) next.delete(client.id);
-                                else next.add(client.id);
-                                return next;
-                              })
-                            }
-                            // Team rows are read-only for admins — see ClientRow:restricted
-                            // for the full story. Server enforces this too:
-                            // `DELETE /clients/:id` 403s on non-owners, and
-                            // `GET /clients/:id` (used by the expanded row's
-                            // capability matrix) does the same. We don't even
-                            // wire the open/close callbacks, since the row is
-                            // not interactive.
-                            onDisconnect={() => {}}
-                            onRetire={() => {}}
-                            onReconnect={() => {}}
-                            showOwner
-                            ownerLabel={resolveOwner(client)}
-                            restricted
-                          />
-                        );
-                      })
-                    )}
-                  </>
-                ) : (
-                  clients.map((client) => {
-                    const isExpanded = !collapsedIds.has(client.id);
-                    const boundAgents = getClientAgents(client.id);
-                    return (
-                      <ClientRow
-                        key={client.id}
-                        client={client}
-                        boundAgents={boundAgents}
-                        isExpanded={isExpanded}
-                        agentName={agentName}
-                        onToggle={() =>
-                          setCollapsedIds((prev) => {
-                            const next = new Set(prev);
-                            if (next.has(client.id)) next.delete(client.id);
-                            else next.add(client.id);
-                            return next;
-                          })
-                        }
-                        onDisconnect={() => setConfirmDisconnect(client)}
-                        onRetire={() => {
-                          setRetireError(null);
-                          setConfirmRetire(client);
-                        }}
-                        onReconnect={() => setNewConnectionOpen(true)}
-                      />
-                    );
-                  })
-                )}
-              </DenseTableBody>
-            </DenseTable>
+            {grouped ? (
+              <>
+                <CardSection title="Your computers" count={mineList.length}>
+                  {mineList.length === 0 ? (
+                    <EmptyCardsNote message="No computers of your own." />
+                  ) : (
+                    <CardGrid>
+                      {mineList.map((client) => (
+                        <ComputerCard
+                          key={client.id}
+                          client={client}
+                          boundAgents={getClientAgents(client.id)}
+                          agentName={agentName}
+                          onGenerateNewToken={() => openReAuth(client)}
+                          onReconnect={openNewConnection}
+                          onDisconnect={() => setConfirmDisconnect(client)}
+                          onRetire={() => {
+                            setRetireError(null);
+                            setConfirmRetire(client);
+                          }}
+                          ownerLabel={resolveOwner(client)}
+                        />
+                      ))}
+                    </CardGrid>
+                  )}
+                </CardSection>
+                <CardSection title="Team computers" count={teamList.length}>
+                  {teamList.length === 0 ? (
+                    <EmptyCardsNote message="No other team computers." />
+                  ) : (
+                    // Team rows stay as table for PR-B — they're read-only,
+                    // their primary value is "at a glance, who needs help",
+                    // and the per-row inline action affordances cards offer
+                    // (Generate new token / install guide) aren't applicable
+                    // to teammates. The full team-card redesign with
+                    // "Copy suggestion → Alice" buttons is deferred to a
+                    // follow-up PR; see proposal §"Variant D".
+                    <TeamComputersTable
+                      teamList={teamList}
+                      collapsedIds={collapsedIds}
+                      setCollapsedIds={setCollapsedIds}
+                      agentName={agentName}
+                      getClientAgents={getClientAgents}
+                      resolveOwner={resolveOwner}
+                    />
+                  )}
+                </CardSection>
+              </>
+            ) : (
+              <CardGrid>
+                {(memberList ?? []).map((client) => (
+                  <ComputerCard
+                    key={client.id}
+                    client={client}
+                    boundAgents={getClientAgents(client.id)}
+                    agentName={agentName}
+                    onGenerateNewToken={() => openReAuth(client)}
+                    onReconnect={openNewConnection}
+                    onDisconnect={() => setConfirmDisconnect(client)}
+                    onRetire={() => {
+                      setRetireError(null);
+                      setConfirmRetire(client);
+                    }}
+                  />
+                ))}
+              </CardGrid>
+            )}
+
+            {showBottomAddButton && (
+              <div className="flex justify-center" style={{ paddingTop: "var(--sp-2)" }}>
+                <Button variant="outline" size="sm" onClick={openNewConnection}>
+                  <Plus className="h-3 w-3" />
+                  Add another computer
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -494,28 +515,134 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   );
 }
 
-const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
-  "claude-code": "Claude Code",
-  codex: "Codex",
-};
+/**
+ * Responsive card grid. `auto-fit` with `minmax(min(100%, 35rem), 1fr)`
+ * yields 2-up on viewports wider than ~1120 logical units and 1-up
+ * below. The 35rem minimum keeps the AuthExpired card's
+ * `first-tree login <jwt>` command from wrapping into ugly multi-line
+ * fragments inside narrow cards.
+ */
+function CardGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--sp-4)",
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 35rem), 1fr))",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
 
-const PROVIDER_ORDER: RuntimeProvider[] = [RUNTIME_PROVIDERS.CLAUDE_CODE, RUNTIME_PROVIDERS.CODEX];
+function CardSection({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+      <header className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
+        {/*
+          `text-subtitle` + `font-semibold` is the same visual weight used by
+          PageHeader's section headings — bumping above `text-body` makes the
+          "Your computers" / "Team computers" hierarchy survive when both
+          sections are present (admin view) and the page is otherwise wall-
+          to-wall cards.
+        */}
+        <h2 className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
+          {title}
+        </h2>
+        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+          · {count}
+        </span>
+      </header>
+      {children}
+    </section>
+  );
+}
 
-const PROVIDER_INSTALL_HINT: Record<RuntimeProvider, string> = {
-  "claude-code": "Run `npm install -g @anthropic-ai/claude-code` on this computer.",
-  codex: "Install the OpenAI Codex CLI on this computer.",
-};
+function EmptyCardsNote({ message }: { message: string }) {
+  return (
+    <div className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) var(--sp-1)" }}>
+      {message}
+    </div>
+  );
+}
 
-const PROVIDER_UNAUTH_HINT: Record<RuntimeProvider, string> = {
-  "claude-code": "Run `claude login` (or set ANTHROPIC_API_KEY) on the computer.",
-  codex: "Run `codex login` (or set CODEX_API_KEY) on the computer.",
-};
+/**
+ * Team computers table — preserved from pre-PR-B as the admin's
+ * read-only audit view. Wraps the existing `ClientRow` component with
+ * the table chrome that used to live inline in `ClientsPage`.
+ */
+function TeamComputersTable({
+  teamList,
+  collapsedIds,
+  setCollapsedIds,
+  agentName,
+  getClientAgents,
+  resolveOwner,
+}: {
+  teamList: HubClient[];
+  collapsedIds: Set<string>;
+  setCollapsedIds: (updater: (prev: Set<string>) => Set<string>) => void;
+  agentName: (uuid: string | null | undefined) => string;
+  getClientAgents: (clientId: string) => RuntimeAgent[];
+  resolveOwner: (client: HubClient) => { text: string; title?: string };
+}) {
+  return (
+    <DenseTable>
+      <DenseTableHeader>
+        <DenseTableRow>
+          <DenseTableHead style={{ width: "var(--sp-4)" }} />
+          <DenseTableHead>Hostname</DenseTableHead>
+          <DenseTableHead>Owner</DenseTableHead>
+          <DenseTableHead>OS</DenseTableHead>
+          <DenseTableHead>first-tree</DenseTableHead>
+          <DenseTableHead>Agents</DenseTableHead>
+          <DenseTableHead>Last seen</DenseTableHead>
+          <DenseTableHead>Status</DenseTableHead>
+        </DenseTableRow>
+      </DenseTableHeader>
+      <DenseTableBody>
+        {teamList.map((client) => {
+          const isExpanded = !collapsedIds.has(client.id);
+          const boundAgents = getClientAgents(client.id);
+          return (
+            <ClientRow
+              key={client.id}
+              client={client}
+              boundAgents={boundAgents}
+              isExpanded={isExpanded}
+              agentName={agentName}
+              onToggle={() =>
+                setCollapsedIds((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(client.id)) next.delete(client.id);
+                  else next.add(client.id);
+                  return next;
+                })
+              }
+              onDisconnect={() => {}}
+              onRetire={() => {}}
+              onReconnect={() => {}}
+              showOwner
+              ownerLabel={resolveOwner(client)}
+              restricted
+            />
+          );
+        })}
+      </DenseTableBody>
+    </DenseTable>
+  );
+}
 
 /**
  * Runtime-provider capability matrix shown inside the expanded row of the
  * Computers table. The snapshot is pre-loaded with the list response now
  * (single-source via `/me/clients` / `/orgs/:orgId/clients`), so the
  * matrix renders synchronously — no extra round-trip when a row opens.
+ *
+ * Constants for label / order / hints live in `cards/shared/providers.ts`
+ * — the card-based IA uses the same vocabulary, so duplicating strings
+ * here would invite drift.
  */
 function CapabilityMatrix({ capabilities }: { capabilities: ClientCapabilities }) {
   const empty = Object.keys(capabilities).length === 0;
@@ -621,40 +748,6 @@ function TeamLoadErrorBanner() {
     >
       Failed to load team computers. Showing only your computers.
     </div>
-  );
-}
-
-function GroupHeaderRow({ title, count, colSpan }: { title: string; count: number; colSpan: number }) {
-  return (
-    <DenseTableRow>
-      <td colSpan={colSpan} style={{ padding: "var(--sp-6) var(--sp-3_5) var(--sp-2) 0" }}>
-        <span className="inline-flex items-baseline" style={{ gap: "var(--sp-2)" }}>
-          <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
-            {title}
-          </span>
-          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            · {count}
-          </span>
-        </span>
-      </td>
-    </DenseTableRow>
-  );
-}
-
-function EmptyGroupRow({ colSpan, message }: { colSpan: number; message: string }) {
-  return (
-    <DenseTableRow>
-      <td
-        colSpan={colSpan}
-        className="text-body"
-        style={{
-          padding: "var(--sp-3) var(--sp-3_5)",
-          color: "var(--fg-4)",
-        }}
-      >
-        {message}
-      </td>
-    </DenseTableRow>
   );
 }
 

--- a/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
+++ b/packages/web/src/pages/clients/__tests__/new-connection-dialog.test.ts
@@ -106,4 +106,26 @@ describe("selectArrivedClient", () => {
     const b = client({ id: "b", connectedAt: new Date(OPENED_AT + 2_000).toISOString() });
     expect(selectArrivedClient([a, b], OPENED_AT, ME)?.id).toBe("a");
   });
+
+  it("with targetClientId set, only the matching row counts (re-auth from a specific card)", () => {
+    // Re-auth flow: card A (clientId 'wanted') was AuthExpired, user clicked
+    // Generate new token. Meanwhile card B's CLI ('unwanted') also reconnects.
+    // Without targetClientId, B would consume A's mint event — wrong card
+    // would flip to success. The constraint prevents that.
+    const wanted = client({ id: "wanted", connectedAt: new Date(OPENED_AT + 3_000).toISOString() });
+    const unwanted = client({ id: "unwanted", connectedAt: new Date(OPENED_AT + 1_000).toISOString() });
+    expect(selectArrivedClient([unwanted, wanted], OPENED_AT, ME, "wanted")?.id).toBe("wanted");
+    expect(selectArrivedClient([unwanted], OPENED_AT, ME, "wanted")).toBeNull();
+  });
+
+  it("with targetClientId set, still respects the userId filter", () => {
+    // Defense-in-depth: a same-id-different-user collision shouldn't unlock
+    // the success branch. The userId check stays primary.
+    const theirs = client({
+      id: "wanted",
+      userId: OTHER,
+      connectedAt: new Date(OPENED_AT + 3_000).toISOString(),
+    });
+    expect(selectArrivedClient([theirs], OPENED_AT, ME, "wanted")).toBeNull();
+  });
 });

--- a/packages/web/src/pages/clients/cards/__tests__/view-models.test.ts
+++ b/packages/web/src/pages/clients/cards/__tests__/view-models.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubClient, RuntimeAgent } from "../../../../api/activity.js";
+import {
+  authExpiredDiagnostic,
+  cardHostnameLabel,
+  computerCardViewModel,
+  formatOfflineDuration,
+  offlineDiagnostic,
+  SETUP_INCOMPLETE_DIAGNOSTIC,
+  summarizeBoundAgents,
+} from "../view-models.js";
+
+/**
+ * Pure view-model tests for the card layer. Mirrors PR-A's testing
+ * convention (`presence-chip.test.ts`, `derive-status.test.ts`) — assert
+ * against pure functions rather than render output. The actual body
+ * components are thin renderers consuming these plans, so visual
+ * regressions are caught by manual QA + the dev stack walkthrough.
+ */
+
+const T0 = new Date("2026-05-01T12:00:00Z");
+
+function client(overrides: Partial<HubClient>): HubClient {
+  return {
+    id: "client_abc12345",
+    userId: "u-1",
+    status: "connected",
+    authState: "ok",
+    sdkVersion: "0.5.2",
+    hostname: "MacBook-Pro.local",
+    os: "darwin",
+    agentCount: 0,
+    connectedAt: T0.toISOString(),
+    lastSeenAt: T0.toISOString(),
+    capabilities: {},
+    ...overrides,
+  };
+}
+
+function agent(overrides: Partial<RuntimeAgent>): RuntimeAgent {
+  return {
+    agentId: "agent-1",
+    clientId: "client_abc12345",
+    runtimeType: "claude-code",
+    runtimeState: null,
+    activeSessions: null,
+    totalSessions: null,
+    runtimeUpdatedAt: null,
+    type: "autonomous_agent",
+    managedByMe: true,
+    ...overrides,
+  };
+}
+
+describe("formatOfflineDuration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for null / undefined / invalid input", () => {
+    expect(formatOfflineDuration(null)).toBeNull();
+    expect(formatOfflineDuration(undefined)).toBeNull();
+    expect(formatOfflineDuration("not-a-date")).toBeNull();
+  });
+
+  it("returns null for timestamps in the future (clock skew)", () => {
+    expect(formatOfflineDuration("2026-05-01T12:00:05Z")).toBeNull();
+  });
+
+  it("formats seconds for offsets under a minute", () => {
+    expect(formatOfflineDuration("2026-05-01T11:59:45Z")).toBe("15 seconds");
+    // Singular form for 1 second.
+    expect(formatOfflineDuration("2026-05-01T11:59:59Z")).toBe("1 second");
+  });
+
+  it("formats minutes for offsets under an hour", () => {
+    expect(formatOfflineDuration("2026-05-01T11:55:00Z")).toBe("5 minutes");
+    expect(formatOfflineDuration("2026-05-01T11:59:00Z")).toBe("1 minute");
+  });
+
+  it("formats hours for offsets under a day", () => {
+    expect(formatOfflineDuration("2026-05-01T10:00:00Z")).toBe("2 hours");
+  });
+
+  it("formats days for offsets of a day or more", () => {
+    expect(formatOfflineDuration("2026-04-23T12:00:00Z")).toBe("8 days");
+    expect(formatOfflineDuration("2026-04-30T12:00:00Z")).toBe("1 day");
+  });
+});
+
+describe("summarizeBoundAgents", () => {
+  it("returns zero counts for an empty list", () => {
+    expect(summarizeBoundAgents([])).toEqual({ total: 0, online: 0, offline: 0, agents: [] });
+  });
+
+  it("classifies agents by runtimeState null vs non-null", () => {
+    const result = summarizeBoundAgents([
+      agent({ agentId: "a", runtimeState: "idle" }),
+      agent({ agentId: "b", runtimeState: "working" }),
+      agent({ agentId: "c", runtimeState: null }),
+    ]);
+    expect(result.total).toBe(3);
+    expect(result.online).toBe(2);
+    expect(result.offline).toBe(1);
+    expect(result.agents.map((a) => a.agentId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves activeSessions and totalSessions on each line", () => {
+    const result = summarizeBoundAgents([
+      agent({ agentId: "busy", runtimeState: "working", activeSessions: 2, totalSessions: 5 }),
+    ]);
+    expect(result.agents[0]).toMatchObject({ activeSessions: 2, totalSessions: 5 });
+  });
+});
+
+describe("diagnostic copy", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("authExpiredDiagnostic includes the offline duration when available", () => {
+    expect(authExpiredDiagnostic({ lastSeenAt: "2026-04-23T12:00:00Z" })).toBe(
+      "This computer hasn't checked in for 8 days. Your access token has expired.",
+    );
+  });
+
+  it("authExpiredDiagnostic falls back to a generic line when duration is unknown", () => {
+    // Server invariant: lastSeenAt is non-null, but if it ever weren't, the
+    // fallback must still read sensibly.
+    expect(authExpiredDiagnostic({ lastSeenAt: "" })).toBe(
+      "Your access token has expired. Run the command below on this computer to re-authenticate.",
+    );
+  });
+
+  it("offlineDiagnostic mentions last-seen duration + wake guidance", () => {
+    expect(offlineDiagnostic({ lastSeenAt: "2026-05-01T10:00:00Z" })).toBe(
+      "Last seen 2 hours ago. Make sure the machine is awake and connected.",
+    );
+  });
+
+  it("SETUP_INCOMPLETE_DIAGNOSTIC is a stable copy string", () => {
+    expect(SETUP_INCOMPLETE_DIAGNOSTIC).toContain("no runtime is ready");
+  });
+});
+
+describe("cardHostnameLabel", () => {
+  it("returns hostname when set", () => {
+    expect(cardHostnameLabel(client({ hostname: "MacBook-Pro.local" }))).toBe("MacBook-Pro.local");
+  });
+
+  it("falls back to short id (first 8 chars) when hostname is null", () => {
+    expect(cardHostnameLabel(client({ id: "client_deadbeef", hostname: null }))).toBe("client_d");
+  });
+});
+
+describe("computerCardViewModel", () => {
+  it("returns ready pill + aria label for a healthy client", () => {
+    const ready = client({
+      hostname: "MacBook-Pro.local",
+      capabilities: {
+        "claude-code": {
+          state: "ok",
+          available: true,
+          authenticated: true,
+          sdkVersion: "0.8.1",
+          authMethod: "oauth",
+          detectedAt: T0.toISOString(),
+        },
+      },
+    });
+    const vm = computerCardViewModel(ready);
+    expect(vm).toEqual({
+      pill: "ready",
+      label: "MacBook-Pro.local",
+      ariaLabel: "Computer: MacBook-Pro.local — Ready",
+    });
+  });
+
+  it("returns auth_expired pill + aria label when authState is expired", () => {
+    const c = client({ hostname: "old.local", status: "disconnected", authState: "expired" });
+    const vm = computerCardViewModel(c);
+    expect(vm.pill).toBe("auth_expired");
+    expect(vm.ariaLabel).toBe("Computer: old.local — Auth expired");
+  });
+
+  it("returns setup_incomplete pill when connected but no runtime is ok", () => {
+    const c = client({
+      hostname: "fresh.local",
+      capabilities: {
+        "claude-code": {
+          state: "missing",
+          available: false,
+          authenticated: false,
+          sdkVersion: null,
+          authMethod: "none",
+          detectedAt: T0.toISOString(),
+        },
+      },
+    });
+    const vm = computerCardViewModel(c);
+    expect(vm.pill).toBe("setup_incomplete");
+    expect(vm.ariaLabel).toBe("Computer: fresh.local — Setup incomplete");
+  });
+
+  it("returns offline pill when disconnected but auth ok", () => {
+    const c = client({ hostname: "away.local", status: "disconnected", authState: "ok" });
+    const vm = computerCardViewModel(c);
+    expect(vm.pill).toBe("offline");
+    expect(vm.ariaLabel).toBe("Computer: away.local — Offline");
+  });
+});

--- a/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
@@ -1,0 +1,61 @@
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { Button } from "../../../components/ui/button.js";
+import { BoundAgentsList } from "./shared/bound-agents-list.js";
+import { CardMetaRow } from "./shared/card-meta-row.js";
+import { authExpiredDiagnostic, summarizeBoundAgents } from "./view-models.js";
+
+type AuthExpiredCardBodyProps = {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+  /**
+   * Click handler for the "Generate new token" button. The page wires
+   * this to `setReAuthClientId(client.id) + setNewConnectionOpen(true)`
+   * so the dialog opens scoped to this specific machine (`targetClientId`
+   * prop on the dialog). Without that scoping, a parallel re-auth on
+   * another card could consume the wrong arrival event.
+   */
+  onGenerateNewToken: () => void;
+};
+
+/**
+ * Variant B body — the most "we need to act" pill. Renders:
+ *   - Diagnostic: "Hasn't checked in for N days. Token expired."
+ *   - Single primary action: "Generate new token" button. Clicking it
+ *     opens the NewConnectionDialog (parameterized for re-auth wording),
+ *     where the actual command + copy flow lives. We intentionally do
+ *     NOT show a placeholder command on the card — a user copy-pasting a
+ *     placeholder token would just hit AUTH_ERROR on the CLI side.
+ *   - Affected agents: compact summary line ("3 agents · all offline").
+ *   - Dimmed meta row (heartbeat / first-tree / OS) under a divider.
+ */
+export function AuthExpiredCardBody({ client, boundAgents, agentName, onGenerateNewToken }: AuthExpiredCardBodyProps) {
+  const summary = summarizeBoundAgents(boundAgents);
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+        {authExpiredDiagnostic(client)}
+      </p>
+      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+        <Button size="sm" onClick={onGenerateNewToken}>
+          Generate new token
+        </Button>
+        {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
+      </div>
+      <Divider />
+      <CardMetaRow client={client} dimmed />
+    </div>
+  );
+}
+
+function Divider() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        borderTop: "var(--hairline) solid var(--border-faint)",
+        margin: 0,
+      }}
+    />
+  );
+}

--- a/packages/web/src/pages/clients/cards/computer-card.tsx
+++ b/packages/web/src/pages/clients/cards/computer-card.tsx
@@ -1,0 +1,150 @@
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { RowActionsMenu } from "../../../components/ui/row-actions-menu.js";
+import { ComputerStatusPill } from "../computer-status-pill.js";
+import { AuthExpiredCardBody } from "./auth-expired-card-body.js";
+import { OfflineCardBody } from "./offline-card-body.js";
+import { ReadyCardBody } from "./ready-card-body.js";
+import { SetupIncompleteCardBody } from "./setup-incomplete-card-body.js";
+import { computerCardViewModel } from "./view-models.js";
+
+export type ComputerCardProps = {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+  /**
+   * Opens the NewConnectionDialog scoped to this client.id (re-auth path
+   * — used by AuthExpired card's primary action). The dialog's arrival
+   * detector matches only this row; copy + title indicate re-auth.
+   */
+  onGenerateNewToken: () => void;
+  /**
+   * Opens the NewConnectionDialog UNSCOPED (fresh connect command).
+   * Used by the offline-card kebab "Reconnect" entry — an offline
+   * machine's credentials are still likely valid, so the operator just
+   * needs a working connect token to re-pair from the machine. Routing
+   * this through `onGenerateNewToken` would scope the arrival detector
+   * to this row and mislead with re-auth copy.
+   */
+  onReconnect: () => void;
+  /** Opens the disconnect-confirmation modal. */
+  onDisconnect: () => void;
+  /** Opens the retire-confirmation modal. */
+  onRetire: () => void;
+  /**
+   * Optional owner label rendered in the header below the hostname.
+   * Used by admin "Your computers" cards to display the viewer's name
+   * (matches the pre-PR-B Owner column).
+   */
+  ownerLabel?: { text: string; title?: string };
+};
+
+/**
+ * Top-level card shell. Routes by `deriveComputerStatus(client).pill`
+ * to one of four body components — each mockup variant (A/B/B-2/B-3)
+ * gets its own body so the per-pill content is encapsulated.
+ *
+ * Card chrome (shared across pills):
+ *   - role="region" + aria-label for screen-reader semantic equivalence
+ *     to the table's row/column structure pre-PR-B
+ *   - Header row: hostname (+ optional owner) + pill chip + ⋯ menu
+ *   - Body slot driven by pill
+ *
+ * The ⋯ menu carries the same actions the table's RowActionsMenu had —
+ * Disconnect / Retire (+ Reconnect when offline). Reconnect on offline
+ * cards opens the dialog as a fresh connect (no targetClientId), since
+ * "the user wants to fire up a new install path" is the offline-mode
+ * mental model. AuthExpired uses the Generate-new-token button instead
+ * (it threads `targetClientId` through).
+ */
+export function ComputerCard({
+  client,
+  boundAgents,
+  agentName,
+  onGenerateNewToken,
+  onReconnect,
+  onDisconnect,
+  onRetire,
+  ownerLabel,
+}: ComputerCardProps) {
+  const vm = computerCardViewModel(client);
+  const isOffline = client.status !== "connected";
+
+  return (
+    // `<section>` already conveys region semantics; biome flags an
+    // explicit `role="region"` as redundant. `aria-label` on a labeled
+    // section is the documented pattern for naming the region.
+    <section
+      aria-label={vm.ariaLabel}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-3_5)",
+        padding: "var(--sp-4) var(--sp-5)",
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        boxShadow: "var(--shadow-sm)",
+      }}
+    >
+      <header className="flex items-start" style={{ gap: "var(--sp-3)" }}>
+        <div className="flex flex-col" style={{ flex: 1, minWidth: 0, gap: "var(--sp-1)" }}>
+          <h3 className="text-subtitle" style={{ margin: 0, overflowWrap: "anywhere" }}>
+            {vm.label}
+          </h3>
+          {ownerLabel && (
+            <span className="text-caption" style={{ color: "var(--fg-3)" }} title={ownerLabel.title}>
+              {ownerLabel.text}
+            </span>
+          )}
+        </div>
+        <ComputerStatusPill pill={vm.pill} />
+        <RowActionsMenu
+          ariaLabel="Computer actions"
+          actions={[
+            ...(isOffline ? [{ key: "reconnect", label: "Reconnect", onSelect: onReconnect }] : []),
+            { key: "disconnect", label: "Disconnect", onSelect: onDisconnect },
+            { key: "retire", label: "Retire", destructive: true, onSelect: onRetire },
+          ]}
+        />
+      </header>
+      <CardBody
+        client={client}
+        boundAgents={boundAgents}
+        agentName={agentName}
+        onGenerateNewToken={onGenerateNewToken}
+      />
+    </section>
+  );
+}
+
+function CardBody(props: {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+  onGenerateNewToken: () => void;
+}) {
+  const vm = computerCardViewModel(props.client);
+  switch (vm.pill) {
+    case "ready":
+      return <ReadyCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />;
+    case "auth_expired":
+      return (
+        <AuthExpiredCardBody
+          client={props.client}
+          boundAgents={props.boundAgents}
+          agentName={props.agentName}
+          onGenerateNewToken={props.onGenerateNewToken}
+        />
+      );
+    case "setup_incomplete":
+      return (
+        <SetupIncompleteCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />
+      );
+    case "offline":
+      return <OfflineCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />;
+    default: {
+      const exhaustive: never = vm.pill;
+      return exhaustive;
+    }
+  }
+}

--- a/packages/web/src/pages/clients/cards/computer-card.tsx
+++ b/packages/web/src/pages/clients/cards/computer-card.tsx
@@ -5,7 +5,7 @@ import { AuthExpiredCardBody } from "./auth-expired-card-body.js";
 import { OfflineCardBody } from "./offline-card-body.js";
 import { ReadyCardBody } from "./ready-card-body.js";
 import { SetupIncompleteCardBody } from "./setup-incomplete-card-body.js";
-import { computerCardViewModel } from "./view-models.js";
+import { type ComputerCardViewModel, computerCardViewModel } from "./view-models.js";
 
 export type ComputerCardProps = {
   client: HubClient;
@@ -108,6 +108,7 @@ export function ComputerCard({
         />
       </header>
       <CardBody
+        pill={vm.pill}
         client={client}
         boundAgents={boundAgents}
         agentName={agentName}
@@ -118,13 +119,13 @@ export function ComputerCard({
 }
 
 function CardBody(props: {
+  pill: ComputerCardViewModel["pill"];
   client: HubClient;
   boundAgents: RuntimeAgent[];
   agentName: (uuid: string | null | undefined) => string;
   onGenerateNewToken: () => void;
 }) {
-  const vm = computerCardViewModel(props.client);
-  switch (vm.pill) {
+  switch (props.pill) {
     case "ready":
       return <ReadyCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />;
     case "auth_expired":
@@ -143,7 +144,7 @@ function CardBody(props: {
     case "offline":
       return <OfflineCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />;
     default: {
-      const exhaustive: never = vm.pill;
+      const exhaustive: never = props.pill;
       return exhaustive;
     }
   }

--- a/packages/web/src/pages/clients/cards/offline-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/offline-card-body.tsx
@@ -1,0 +1,45 @@
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { BoundAgentsList } from "./shared/bound-agents-list.js";
+import { CardMetaRow } from "./shared/card-meta-row.js";
+import { InlineCommand } from "./shared/inline-command.js";
+import { offlineDiagnostic, summarizeBoundAgents } from "./view-models.js";
+
+type OfflineCardBodyProps = {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+};
+
+/**
+ * Variant B-3 body — credentials are alive but the machine isn't
+ * checking in. Renders:
+ *   - Diagnostic: "Last seen X ago. Make sure the machine is awake..."
+ *   - Wake-guide command: `first-tree daemon start` (a hint the
+ *     operator can run on the machine itself once they're at the
+ *     keyboard)
+ *   - Compact agents summary (will be all-offline by definition)
+ *   - Heartbeat meta row, dimmed (matches AuthExpired's visual weight —
+ *     the meta is stale context, not the focus)
+ *
+ * Distinct from AuthExpired: no inline button-action because there's
+ * nothing the operator can do from the web side to wake the machine.
+ * The wake-guide command is informational + copy-pasteable.
+ */
+export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardBodyProps) {
+  const summary = summarizeBoundAgents(boundAgents);
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+        {offlineDiagnostic(client)}
+      </p>
+      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+        <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+          If the daemon isn't running, on this computer:
+        </p>
+        <InlineCommand command="first-tree daemon start" ariaLabel="Daemon wake command" />
+      </div>
+      {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
+      <CardMetaRow client={client} dimmed />
+    </div>
+  );
+}

--- a/packages/web/src/pages/clients/cards/ready-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/ready-card-body.tsx
@@ -1,0 +1,118 @@
+import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { UppercaseLabel } from "../../../components/ui/section-header.js";
+import { BoundAgentsList } from "./shared/bound-agents-list.js";
+import { CardMetaRow } from "./shared/card-meta-row.js";
+import { PROVIDER_INSTALL_HINT, PROVIDER_LABEL, PROVIDER_ORDER, PROVIDER_UNAUTH_HINT } from "./shared/providers.js";
+import { summarizeBoundAgents } from "./view-models.js";
+
+type ReadyCardBodyProps = {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+};
+
+/**
+ * Variant A body — the happy path. Renders:
+ *   - Heartbeat / first-tree / OS meta row
+ *   - Runtimes section: per-provider state line (✓ / ⚠ / ⊘)
+ *   - Bound agents: full list with PresenceChips
+ *
+ * Mockup §"Variant A" puts the agents section last. The Runtimes
+ * matrix on a Ready card is informational (one runtime is `ok` by
+ * definition — that's why the pill is Ready) but worth showing so the
+ * user can see at a glance whether they're running both Claude Code
+ * and Codex, or only one.
+ */
+export function ReadyCardBody({ client, boundAgents, agentName }: ReadyCardBodyProps) {
+  const summary = summarizeBoundAgents(boundAgents);
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <CardMetaRow client={client} />
+      <RuntimesSection capabilities={client.capabilities} />
+      <BoundAgentsList summary={summary} agentName={agentName} />
+    </div>
+  );
+}
+
+/**
+ * Compact Runtimes section for Ready cards. Same vocabulary as the
+ * pre-PR-B `ProviderRow` (under the table's expanded row) but rendered
+ * unconditionally inline. Reused so the visual hint colors stay
+ * consistent across the page.
+ */
+function RuntimesSection({ capabilities }: { capabilities: HubClient["capabilities"] }) {
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+      <UppercaseLabel style={{ display: "block", marginBottom: 4 }}>Runtimes</UppercaseLabel>
+      <div className="flex flex-col gap-1">
+        {PROVIDER_ORDER.map((provider) => (
+          <RuntimeStateLine key={provider} provider={provider} entry={capabilities[provider] ?? null} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RuntimeStateLine({ provider, entry }: { provider: RuntimeProvider; entry: CapabilityEntry | null }) {
+  const label = PROVIDER_LABEL[provider];
+  if (!entry) {
+    return (
+      <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
+        <span className="font-medium" style={{ minWidth: 140 }}>
+          {label}
+        </span>
+        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+          not reported · {PROVIDER_INSTALL_HINT[provider]}
+        </span>
+      </div>
+    );
+  }
+  switch (entry.state) {
+    case "ok":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="font-medium" style={{ minWidth: 140 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-idle)" }}>
+            ✓ {entry.sdkVersion ? `v${entry.sdkVersion} · ` : ""}authenticated ({entry.authMethod})
+          </span>
+        </div>
+      );
+    case "unauthenticated":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="font-medium" style={{ minWidth: 140 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-blocked)" }}>
+            ⚠ installed{entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated ·{" "}
+            {PROVIDER_UNAUTH_HINT[provider]}
+          </span>
+        </div>
+      );
+    case "missing":
+      return (
+        <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
+          <span className="font-medium" style={{ minWidth: 140 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+            ✗ not installed · {PROVIDER_INSTALL_HINT[provider]}
+          </span>
+        </div>
+      );
+    case "error":
+      return (
+        <div className="flex items-center gap-2.5 text-body">
+          <span className="font-medium" style={{ minWidth: 140 }}>
+            {label}
+          </span>
+          <span className="text-caption" style={{ color: "var(--state-error)" }}>
+            error · {entry.error ?? "probe failed"}
+          </span>
+        </div>
+      );
+  }
+}

--- a/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
@@ -1,0 +1,60 @@
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { BoundAgentsList } from "./shared/bound-agents-list.js";
+import { CardMetaRow } from "./shared/card-meta-row.js";
+import { PROVIDER_ORDER } from "./shared/providers.js";
+import { RuntimeInstallBox } from "./shared/runtime-install-box.js";
+import { cardHostnameLabel, SETUP_INCOMPLETE_DIAGNOSTIC, summarizeBoundAgents } from "./view-models.js";
+
+type SetupIncompleteCardBodyProps = {
+  client: HubClient;
+  boundAgents: RuntimeAgent[];
+  agentName: (uuid: string | null | undefined) => string;
+};
+
+/**
+ * Variant B-2 body — connected machine with no runtime ready. Renders:
+ *   - Diagnostic line + "install one of the following" framing
+ *   - Per-provider install boxes (RuntimeInstallBox × N), side-by-side
+ *     on wide cards, stacked on narrow ones
+ *   - Compact agents summary if any are pinned (they'll be offline)
+ *   - Heartbeat meta row at the bottom (NOT dimmed — the machine is
+ *     online; meta is supporting but not stale)
+ *
+ * The boxes filter to non-`ok` runtimes only. If a runtime is `ok` here
+ * the pill should not be `setup_incomplete` (by `deriveComputerStatus`
+ * definition), so the filter is defensive against drift in the pill
+ * rules.
+ */
+export function SetupIncompleteCardBody({ client, boundAgents, agentName }: SetupIncompleteCardBodyProps) {
+  const hostname = cardHostnameLabel(client);
+  const summary = summarizeBoundAgents(boundAgents);
+  const installableProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p]?.state !== "ok");
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+        {SETUP_INCOMPLETE_DIAGNOSTIC}
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gap: "var(--sp-3)",
+          // Side-by-side install boxes when the card is wide enough,
+          // stacked 1-up below the breakpoint (17.5rem ≈ 280 baseline
+          // for the install-command pre block).
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 17.5rem), 1fr))",
+        }}
+      >
+        {installableProviders.map((provider) => (
+          <RuntimeInstallBox
+            key={provider}
+            provider={provider}
+            entry={client.capabilities[provider] ?? null}
+            hostname={hostname}
+          />
+        ))}
+      </div>
+      {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
+      <CardMetaRow client={client} />
+    </div>
+  );
+}

--- a/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
+++ b/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
@@ -1,0 +1,68 @@
+import { PresenceChip, runtimeStateToPresence } from "../../../../components/ui/presence-chip.js";
+import { UppercaseLabel } from "../../../../components/ui/section-header.js";
+import type { BoundAgentsSummary } from "../view-models.js";
+
+type BoundAgentsListProps = {
+  summary: BoundAgentsSummary;
+  agentName: (uuid: string | null | undefined) => string;
+  /**
+   * When true, render the agents list in a compact "N agent(s) — M online"
+   * form instead of a full per-agent list. Used by AuthExpired / Offline
+   * cards where the agents section is supporting context, not the focus.
+   */
+  compact?: boolean;
+};
+
+/**
+ * Renders the bound-agents section of a computer card.
+ *
+ * Two display modes — both driven by the same `BoundAgentsSummary` from
+ * `view-models.ts`:
+ *
+ *   - **expanded** (Ready card): full list, one row per agent, with
+ *     `PresenceChip` + active/total session counts.
+ *   - **compact** (AuthExpired / Offline): single-line summary like
+ *     "3 agents · all offline".
+ */
+export function BoundAgentsList({ summary, agentName, compact = false }: BoundAgentsListProps) {
+  if (summary.total === 0) {
+    return null;
+  }
+
+  if (compact) {
+    // Sentence: "{N} agent(s) · {state}". For total === 1 the "all" qualifier
+    // reads wrong, so collapse to bare "offline" / "online".
+    const noun = summary.total === 1 ? "agent" : "agents";
+    const allWord = summary.total === 1 ? "" : "all ";
+    let suffix: string;
+    if (summary.offline === summary.total) suffix = `${allWord}offline`;
+    else if (summary.online === summary.total) suffix = `${allWord}online`;
+    else suffix = `${summary.offline} offline`;
+    return (
+      <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+        {summary.total} {noun} · {suffix}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>Agents · {summary.total}</UppercaseLabel>
+      <div className="flex flex-col gap-1">
+        {summary.agents.map((a) => (
+          <div key={a.agentId} className="flex items-center gap-2.5 text-body">
+            <span className="font-medium" style={{ minWidth: 140 }}>
+              {agentName(a.agentId)}
+            </span>
+            <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
+            {a.activeSessions !== null && (
+              <span className="mono tnum text-caption" style={{ color: "var(--fg-3)" }}>
+                {a.activeSessions} / {a.totalSessions ?? 0} sessions
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
+++ b/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import type { HubClient } from "../../../../api/activity.js";
+import { formatDate, formatRelative } from "../../../../lib/utils.js";
+
+type CardMetaRowProps = {
+  client: HubClient;
+  /**
+   * When true, render the heartbeat / first-tree / OS labels with reduced
+   * opacity. Used by AuthExpired and Offline cards where the diagnostic
+   * + action is the primary message and the meta fields are supporting
+   * context (mockup §"Variant B" / §"B-3" show "last reported" prefix
+   * on the same fields).
+   */
+  dimmed?: boolean;
+  /** Trailing extra content (e.g. agents count). */
+  trailing?: ReactNode;
+};
+
+/**
+ * "Heartbeat / first-tree / OS / Agents" 4-field meta row shown at the
+ * bottom (or under a divider) of every card. Same data points as the
+ * old table's columns, just rearranged for the card form factor.
+ *
+ * The labels follow the column-header copy locked in PR-A:
+ *   - "Heartbeat" (was "Last seen") — uses `formatRelative` so the
+ *     value reads "12 sec ago" / "8 days ago"
+ *   - "first-tree" — hub CLI version (NOT a per-provider runtime
+ *     version)
+ *   - "OS" — `client.os` raw value
+ *
+ * Cards are wider than table cells, so the rendering uses a flex row
+ * with right-aligned values; on narrow viewports the row wraps cleanly
+ * without truncation because each field is bounded.
+ */
+export function CardMetaRow({ client, dimmed = false, trailing }: CardMetaRowProps) {
+  const opacity = dimmed ? 0.6 : 1;
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-1_5)",
+        fontSize: "var(--text-caption-size)",
+        color: "var(--fg-3)",
+        opacity,
+      }}
+    >
+      <MetaLine label="Heartbeat" value={formatRelative(client.lastSeenAt)} title={formatDate(client.lastSeenAt)} />
+      <MetaLine label="first-tree" value={client.sdkVersion ?? "—"} mono />
+      <MetaLine label="OS" value={client.os ?? "—"} />
+      {trailing}
+    </div>
+  );
+}
+
+function MetaLine({
+  label,
+  value,
+  title,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  title?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline" style={{ gap: "var(--sp-3)" }}>
+      <span className="text-caption" style={{ minWidth: 96, color: "var(--fg-4)" }}>
+        {label}
+      </span>
+      <span className={mono ? "mono text-caption" : "text-caption"} title={title}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/pages/clients/cards/shared/inline-command.tsx
+++ b/packages/web/src/pages/clients/cards/shared/inline-command.tsx
@@ -37,14 +37,27 @@ type InlineCommandProps = {
  */
 export function InlineCommand({ command, caption, ariaLabel = "Command" }: InlineCommandProps) {
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const reactId = useId();
   const preId = `${reactId}-cmd`;
   const captionId = `${reactId}-cap`;
 
   const handleCopy = async (): Promise<void> => {
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopyError(false);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // `navigator.clipboard.writeText` rejects in non-secure contexts
+      // and when the user denies the clipboard permission. Silent failure
+      // would leave the operator wondering why nothing landed, so flip
+      // the button to a transient "Copy failed" state. The command text
+      // is still visible above for manual select-copy.
+      setCopied(false);
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), COPY_FEEDBACK_MS);
+    }
   };
 
   return (
@@ -80,7 +93,7 @@ export function InlineCommand({ command, caption, ariaLabel = "Command" }: Inlin
           style={{ alignSelf: "flex-start" }}
         >
           {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          {copied ? "Copied" : "Copy"}
+          {copyError ? "Copy failed" : copied ? "Copied" : "Copy"}
         </Button>
         {caption && (
           <span className="text-label" style={{ color: "var(--fg-4)" }}>

--- a/packages/web/src/pages/clients/cards/shared/inline-command.tsx
+++ b/packages/web/src/pages/clients/cards/shared/inline-command.tsx
@@ -1,0 +1,93 @@
+import { Check, Copy } from "lucide-react";
+import { useId, useState } from "react";
+import { Button } from "../../../../components/ui/button.js";
+
+const COPY_FEEDBACK_MS = 1_500;
+
+type InlineCommandProps = {
+  command: string;
+  /** Optional caption shown below the command block. */
+  caption?: string;
+  /**
+   * Accessible label for the figure. Defaults to "Command". Pass a
+   * more specific label (e.g. "Install Claude Code") when several
+   * InlineCommand blocks live side-by-side and the visible runtime
+   * label is the only thing distinguishing them — screen-reader users
+   * navigating by landmarks need that distinction in the name.
+   */
+  ariaLabel?: string;
+};
+
+/**
+ * Mini command-with-copy block for use inside computer cards. Distinct
+ * from `ConnectCommandPanel` (which owns the dialog's full phase
+ * machine: waiting / success / error / stuck panel). This is the
+ * stripped-down variant for inline use — no phase, no expiry chip, no
+ * stuck panel. Visual vocabulary stays aligned with the panel so a user
+ * scanning from card to dialog sees the same code block style.
+ *
+ * Used by:
+ *   - Setup-incomplete card → install + login command per runtime
+ *   - Offline card → wake guide command (`first-tree daemon start`)
+ *
+ * A11y: wrapped in `<figure>` with a `<figcaption>` (visually hidden) so
+ * the command block has an accessible name. The Copy button references
+ * the `<pre>` via `aria-describedby` so the announced action includes
+ * the command text for screen readers.
+ */
+export function InlineCommand({ command, caption, ariaLabel = "Command" }: InlineCommandProps) {
+  const [copied, setCopied] = useState(false);
+  const reactId = useId();
+  const preId = `${reactId}-cmd`;
+  const captionId = `${reactId}-cap`;
+
+  const handleCopy = async (): Promise<void> => {
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  };
+
+  return (
+    <figure className="flex flex-col" style={{ margin: 0, gap: "var(--sp-2)" }} aria-labelledby={captionId}>
+      <figcaption id={captionId} className="sr-only">
+        {ariaLabel}
+      </figcaption>
+      <pre
+        id={preId}
+        className="mono text-label"
+        style={{
+          margin: 0,
+          padding: "var(--sp-2_5) var(--sp-3)",
+          background: "var(--bg-sunken)",
+          border: "var(--hairline) solid var(--border-faint)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg-2)",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-all",
+          overflowWrap: "anywhere",
+          minWidth: 0,
+        }}
+      >
+        {command}
+      </pre>
+      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleCopy}
+          aria-describedby={preId}
+          style={{ alignSelf: "flex-start" }}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+        {caption && (
+          <span className="text-label" style={{ color: "var(--fg-4)" }}>
+            {caption}
+          </span>
+        )}
+      </div>
+    </figure>
+  );
+}

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -1,0 +1,65 @@
+import { RUNTIME_PROVIDERS, type RuntimeProvider } from "@first-tree/shared";
+
+/**
+ * Shared provider constants for runtime-related UI. Previously lived
+ * locally in `clients.tsx`; extracted so the card-based IA can reuse
+ * the same labels + setup commands without duplicating strings.
+ *
+ * Display order for runtime sections — Claude Code first because it
+ * is the more common entry point, Codex second. Mirrors mockup §"Variant
+ * B-2" ordering.
+ */
+export const PROVIDER_ORDER: RuntimeProvider[] = [RUNTIME_PROVIDERS.CLAUDE_CODE, RUNTIME_PROVIDERS.CODEX];
+
+export const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+/**
+ * `npm install -g` package spec per runtime. The CLI canonical install
+ * command lives here so the Setup-incomplete card body can render the
+ * full install + login two-step without each card duplicating strings.
+ */
+export const PROVIDER_NPM_PACKAGE: Record<RuntimeProvider, string> = {
+  "claude-code": "@anthropic-ai/claude-code",
+  codex: "@openai/codex",
+};
+
+/**
+ * Per-runtime login command shown after install. Codex prints
+ * `codex login`; Claude Code prints `claude login`. Both accept
+ * `--api-key` flavored alternatives the user discovers on the install
+ * step's stdout — the card surfaces the OAuth form by default since
+ * it's the documented happy path.
+ */
+export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
+  "claude-code": "claude login",
+  codex: "codex login",
+};
+
+/**
+ * One-liner install + login command for an empty Setup-incomplete card.
+ * Joined with `\n` so the CommandPanel-style pre block renders both
+ * lines. The Setup-incomplete card body wraps this in a per-provider
+ * box with a copy button per box.
+ */
+export function buildInstallCommand(provider: RuntimeProvider): string {
+  return `npm install -g ${PROVIDER_NPM_PACKAGE[provider]}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
+}
+
+/**
+ * Shortest hint string for "this runtime is installed but the user
+ * isn't authed". Used by Ready card's compact capability matrix when
+ * one provider is `unauthenticated`. Full re-auth lives in the
+ * provider's docs.
+ */
+export const PROVIDER_UNAUTH_HINT: Record<RuntimeProvider, string> = {
+  "claude-code": "Run `claude login` (or set ANTHROPIC_API_KEY) on the computer.",
+  codex: "Run `codex login` (or set CODEX_API_KEY) on the computer.",
+};
+
+export const PROVIDER_INSTALL_HINT: Record<RuntimeProvider, string> = {
+  "claude-code": "Run `npm install -g @anthropic-ai/claude-code` on this computer.",
+  codex: "Install the OpenAI Codex CLI on this computer.",
+};

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -1,0 +1,111 @@
+import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
+import type { ReactNode } from "react";
+import { InlineCommand } from "./inline-command.js";
+import { buildInstallCommand, PROVIDER_LABEL, PROVIDER_LOGIN_COMMAND, PROVIDER_NPM_PACKAGE } from "./providers.js";
+
+type RuntimeInstallBoxProps = {
+  provider: RuntimeProvider;
+  /**
+   * Current capability state for this provider, or null if the client
+   * has never reported any. Drives the command + headline:
+   *   - null / missing → "install + login" two-liner
+   *   - unauthenticated → "login only" one-liner
+   *   - error → "reinstall — last probe error: ..." + install command
+   *   - ok → no install box rendered (caller suppresses)
+   */
+  entry: CapabilityEntry | null;
+  /** Computer hostname for the diagnostic copy. */
+  hostname: string;
+};
+
+/**
+ * One install-box per runtime on a Setup-incomplete card.
+ *
+ * Mockup §"Variant B-2" shows two boxes side-by-side (Claude Code +
+ * Codex). The box's job is to give the operator one copy-pasteable
+ * command and the smallest possible operator-side narration. Distinct
+ * from the `ProviderRow` chips in the Ready card's CapabilityMatrix —
+ * that's a state-only summary line; this is an actionable surface.
+ */
+export function RuntimeInstallBox({ provider, entry, hostname }: RuntimeInstallBoxProps) {
+  const label = PROVIDER_LABEL[provider];
+  const { headline, command } = installBoxView(entry, provider, hostname);
+
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-3)",
+        borderRadius: "var(--radius-input)",
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+        <span className="text-body font-medium">{label}</span>
+      </div>
+      <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+        {renderHeadlineWithCode(headline)}
+      </p>
+      <InlineCommand command={command} ariaLabel={`${label} setup command`} />
+    </div>
+  );
+}
+
+/**
+ * Render a headline string with `inline-code` segments wrapped in `<code>`.
+ * The view-model emits literal backticks (e.g. "Run `claude login` on
+ * host") for the diagnostic copy; without this helper the user sees raw
+ * backticks rendered as text.
+ */
+function renderHeadlineWithCode(text: string): ReactNode {
+  const parts = text.split(/`([^`]+)`/);
+  return parts.map((part, idx) =>
+    idx % 2 === 1 ? (
+      // biome-ignore lint/suspicious/noArrayIndexKey: text is static; index identifies the segment.
+      <code key={idx} className="mono text-label" style={{ color: "var(--fg-2)" }}>
+        {part}
+      </code>
+    ) : (
+      // biome-ignore lint/suspicious/noArrayIndexKey: text is static; index identifies the segment.
+      <span key={idx}>{part}</span>
+    ),
+  );
+}
+
+/**
+ * Pure helper — returns `{headline, command}` for a given capability
+ * entry. Extracted for testability so the install-box's per-state
+ * branching is unit-tested without DOM.
+ */
+export function installBoxView(
+  entry: CapabilityEntry | null,
+  provider: RuntimeProvider,
+  hostname: string,
+): { headline: string; command: string } {
+  if (!entry || entry.state === "missing") {
+    return {
+      headline: `Install ${PROVIDER_LABEL[provider]} and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`,
+      command: buildInstallCommand(provider),
+    };
+  }
+  if (entry.state === "unauthenticated") {
+    return {
+      headline: `${PROVIDER_LABEL[provider]} is installed${entry.sdkVersion ? ` (v${entry.sdkVersion})` : ""} but not logged in. Run on ${hostname}:`,
+      command: PROVIDER_LOGIN_COMMAND[provider],
+    };
+  }
+  if (entry.state === "error") {
+    return {
+      headline: `${PROVIDER_LABEL[provider]} probe failed: ${entry.error ?? "unknown error"}. Reinstall on ${hostname}:`,
+      command: `npm install -g ${PROVIDER_NPM_PACKAGE[provider]}`,
+    };
+  }
+  // `ok` should not reach here — the Setup-incomplete card filters such
+  // entries out. Provide a defensive fallback that's still actionable.
+  return {
+    headline: `${PROVIDER_LABEL[provider]} is configured. To reinstall, run on ${hostname}:`,
+    command: buildInstallCommand(provider),
+  };
+}

--- a/packages/web/src/pages/clients/cards/view-models.ts
+++ b/packages/web/src/pages/clients/cards/view-models.ts
@@ -150,10 +150,11 @@ const PILL_ARIA: Record<ReturnType<typeof deriveComputerStatus>["pill"], string>
 };
 
 /**
- * Top-level view-model for `ComputerCard`. Computed once per client at
- * the page parent (`useMemo`) so the N² re-derivation tax flagged by
- * the adversarial review on PR-A's `compareByPillPriority` doesn't
- * recur here.
+ * Top-level view-model for `ComputerCard`. Pure + cheap — wraps
+ * `deriveComputerStatus` plus the hostname/label/aria fallout. Called
+ * once per card render inside `ComputerCard`; the resulting `pill` is
+ * threaded down to `CardBody` so we don't re-derive for the body
+ * routing.
  */
 export function computerCardViewModel(client: HubClient): ComputerCardViewModel {
   const status = deriveComputerStatus(client);

--- a/packages/web/src/pages/clients/cards/view-models.ts
+++ b/packages/web/src/pages/clients/cards/view-models.ts
@@ -1,0 +1,166 @@
+import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { deriveComputerStatus } from "../derive-status.js";
+
+/**
+ * Pure view-model layer for the computer cards.
+ *
+ * Why this exists: the team's test convention is "test the pure
+ * view-model, not the rendered DOM" — `presence-chip.test.ts` and
+ * `computer-status-pill.test.tsx` both pin a `PILL_VIEW`-style record
+ * rather than driving an `@testing-library/react` render. This file
+ * mirrors that: each card body has a `viewBody*()` function that
+ * returns a render-plan object the body component consumes. Tests
+ * assert against the plan; the body component is a thin renderer.
+ *
+ * The render plans intentionally avoid `ReactNode` and stay as
+ * primitives + structured records so they serialize cleanly for snapshot
+ * comparisons and stay decoupled from React.
+ */
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/**
+ * Human-readable "N units ago" for the diagnostic copy on AuthExpired /
+ * Offline cards. Distinct from `formatRelative` (lib/utils.ts) — that one
+ * is a thin `Intl.RelativeTimeFormat` wrapper that returns "yesterday" /
+ * "in 3 seconds" / etc. The card diagnostic wants a stable
+ * "8 days" / "2 hours" / "15 minutes" string we can splice into a
+ * sentence like "Last seen X ago" or "Offline for X" — locale-fixed,
+ * past-only.
+ *
+ * Returns null when the timestamp is invalid or in the future.
+ */
+export function formatOfflineDuration(lastSeenIso: string | null | undefined): string | null {
+  if (!lastSeenIso) return null;
+  const ms = new Date(lastSeenIso).getTime();
+  if (Number.isNaN(ms)) return null;
+  const elapsed = Date.now() - ms;
+  if (elapsed < 0) return null;
+  if (elapsed < MS_PER_MINUTE) {
+    const seconds = Math.max(1, Math.round(elapsed / 1000));
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  if (elapsed < MS_PER_HOUR) {
+    const minutes = Math.round(elapsed / MS_PER_MINUTE);
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (elapsed < MS_PER_DAY) {
+    const hours = Math.round(elapsed / MS_PER_HOUR);
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(elapsed / MS_PER_DAY);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+export type AgentLine = {
+  agentId: string;
+  /** Server-derived runtime state ("idle" / "working" / "blocked" / "error" / null = offline). */
+  runtimeState: string | null;
+  activeSessions: number | null;
+  totalSessions: number | null;
+};
+
+export type BoundAgentsSummary = {
+  total: number;
+  online: number;
+  offline: number;
+  agents: AgentLine[];
+};
+
+/**
+ * Reduce a `RuntimeAgent[]` to the data each card body needs to render
+ * its agents section. The card-side renderer can resolve agent display
+ * names from `agentName(uuid)` — the view-model stays id-only so it can
+ * be tested without injecting a name resolver.
+ */
+export function summarizeBoundAgents(agents: RuntimeAgent[]): BoundAgentsSummary {
+  let online = 0;
+  let offline = 0;
+  const lines: AgentLine[] = agents.map((a) => {
+    const isOnline = a.runtimeState !== null && a.runtimeState !== undefined;
+    if (isOnline) online += 1;
+    else offline += 1;
+    return {
+      agentId: a.agentId,
+      runtimeState: a.runtimeState,
+      activeSessions: a.activeSessions,
+      totalSessions: a.totalSessions,
+    };
+  });
+  return { total: agents.length, online, offline, agents: lines };
+}
+
+/**
+ * Diagnostic line shown at the top of the AuthExpired card.
+ *
+ * Without lastSeenAt: minimal fallback.
+ * With lastSeenAt: "This computer hasn't checked in for X. Your access
+ * token has expired." — mirrors mockup §"Variant B".
+ */
+export function authExpiredDiagnostic(client: Pick<HubClient, "lastSeenAt">): string {
+  const duration = formatOfflineDuration(client.lastSeenAt);
+  if (!duration) return "Your access token has expired. Run the command below on this computer to re-authenticate.";
+  return `This computer hasn't checked in for ${duration}. Your access token has expired.`;
+}
+
+/**
+ * Diagnostic line for Offline card. Distinguishes "moments ago"
+ * (probably about to reconnect) from "hours/days ago" (machine actually
+ * away).
+ */
+export function offlineDiagnostic(client: Pick<HubClient, "lastSeenAt">): string {
+  const duration = formatOfflineDuration(client.lastSeenAt);
+  if (!duration) return "This computer is offline. Make sure the machine is awake and connected.";
+  return `Last seen ${duration} ago. Make sure the machine is awake and connected.`;
+}
+
+/**
+ * Diagnostic line for SetupIncomplete card. Static — the empty
+ * capability state doesn't carry a time signal.
+ */
+export const SETUP_INCOMPLETE_DIAGNOSTIC =
+  "This computer is online, but no runtime is ready. Install one of the following on this computer to start running agents:";
+
+/**
+ * Per-card hostname fallback. The mockup shows the hostname prominently;
+ * pre-PR-A code used `hostname ?? id.slice(0, 8)`. Keep that fallback so
+ * a client that registers without a hostname (rare — only happens via a
+ * misconfigured SDK build) still has a label.
+ */
+export function cardHostnameLabel(client: Pick<HubClient, "hostname" | "id">): string {
+  return client.hostname ?? client.id.slice(0, 8);
+}
+
+export type ComputerCardViewModel = {
+  /** Pill name. Drives which body component renders + the aria-label. */
+  pill: ReturnType<typeof deriveComputerStatus>["pill"];
+  /** Hostname or short-id fallback. */
+  label: string;
+  /** Per-pill ARIA suffix: "Computer: {label} — {pill text}". */
+  ariaLabel: string;
+};
+
+const PILL_ARIA: Record<ReturnType<typeof deriveComputerStatus>["pill"], string> = {
+  ready: "Ready",
+  auth_expired: "Auth expired",
+  setup_incomplete: "Setup incomplete",
+  offline: "Offline",
+};
+
+/**
+ * Top-level view-model for `ComputerCard`. Computed once per client at
+ * the page parent (`useMemo`) so the N² re-derivation tax flagged by
+ * the adversarial review on PR-A's `compareByPillPriority` doesn't
+ * recur here.
+ */
+export function computerCardViewModel(client: HubClient): ComputerCardViewModel {
+  const status = deriveComputerStatus(client);
+  const label = cardHostnameLabel(client);
+  return {
+    pill: status.pill,
+    label,
+    ariaLabel: `Computer: ${label} — ${PILL_ARIA[status.pill]}`,
+  };
+}

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -21,14 +21,26 @@ import { runVisibilityAwareInterval } from "../../lib/visibility-interval.js";
  * both first-time insert and `ON CONFLICT DO UPDATE` reconnect — so this
  * works for brand-new machines AND re-pairs of previously-known machines.
  *
+ * When `targetClientId` is set (re-auth path from an AuthExpired card), the
+ * detector only matches that specific row — prevents a card-A reauth from
+ * accidentally consuming a card-B connect event when both happen to land in
+ * the same poll cycle.
+ *
  * @param openedAt epoch-ms; the modal-open timestamp (already adjusted for
  *   any clock-skew fudge by the caller).
+ * @param targetClientId optional — when set, only the matching row counts.
  */
-export function selectArrivedClient(clients: HubClient[], openedAt: number, userId: string): HubClient | null {
+export function selectArrivedClient(
+  clients: HubClient[],
+  openedAt: number,
+  userId: string,
+  targetClientId?: string,
+): HubClient | null {
   if (!userId) return null;
   return (
     clients.find((c) => {
       if (c.status !== "connected" || c.userId !== userId || !c.connectedAt) return false;
+      if (targetClientId && c.id !== targetClientId) return false;
       return new Date(c.connectedAt).getTime() >= openedAt;
     }) ?? null
   );
@@ -68,7 +80,38 @@ const TOKEN_EXPIRY_BUFFER_MS = 2_000;
  *
  * Cancel / backdrop close: drops the unused token (server expires it on TTL).
  */
-export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (next: boolean) => void }) {
+/**
+ * `NewConnectionDialog` props.
+ *
+ * Default UX is "pair a brand-new computer with this Hub". The optional
+ * overrides re-purpose the dialog for the re-auth flow triggered from an
+ * AuthExpired computer card — same mint + polling machinery, different
+ * wording + a `targetClientId` constraint on the success-arrival detector
+ * so card-A's reauth doesn't accidentally consume card-B's arrival event.
+ */
+export type NewConnectionDialogProps = {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  /**
+   * Re-auth path only: only the specified clientId counts as arrival.
+   * Without this, any newly-connected client owned by the user would
+   * succeed — wrong when the user has 2+ AuthExpired cards open and the
+   * other one happens to reconnect first.
+   */
+  targetClientId?: string;
+  /** Override dialog title for non-default flows (e.g. re-auth). */
+  titleOverride?: string;
+  /** Override dialog description. */
+  descriptionOverride?: string;
+};
+
+export function NewConnectionDialog({
+  open,
+  onOpenChange,
+  targetClientId,
+  titleOverride,
+  descriptionOverride,
+}: NewConnectionDialogProps) {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const [phase, setPhase] = useState<ConnectPhase>("loading");
@@ -111,6 +154,16 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
   // 1. On open: mint a token. On close: reset all transient state. The
   //    mint cycle bump in mintToken ensures any in-flight resolve from a
   //    previous open() can't bleed into the new lifecycle.
+  //
+  //    `targetClientId` is in the dep array even though the effect body
+  //    doesn't read it directly: when the user clicks "Generate new
+  //    token" on a *different* AuthExpired card while the dialog is
+  //    already open, the prop changes (parent rewires the dialog target)
+  //    and we want a fresh mint. Without this dep the arrival detector
+  //    would silently wait on the old client.id while the visible dialog
+  //    header (and the user's mental model) point at a new one.
+  //    See PR-B review #1.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: targetClientId is intentionally in deps; see block comment above.
   useEffect(() => {
     if (!open) {
       mintCycleRef.current += 1;
@@ -123,7 +176,7 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
       return;
     }
     void mintToken();
-  }, [open, mintToken]);
+  }, [open, mintToken, targetClientId]);
 
   // 2. While waiting: poll for a client whose handshake landed AFTER the modal
   //    opened. Timestamp comparison (not id-set diff) is what lets us catch a
@@ -136,7 +189,7 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
     const tick = async () => {
       try {
         const fresh = await queryClient.fetchQuery({ queryKey: ["clients"], queryFn: listClients });
-        const arrived = selectArrivedClient(fresh, openedAtRef.current, user.id);
+        const arrived = selectArrivedClient(fresh, openedAtRef.current, user.id, targetClientId);
         if (arrived) {
           setArrivedHostname(arrived.hostname ?? null);
           setPhase("success");
@@ -146,7 +199,7 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
       }
     };
     return runVisibilityAwareInterval(tick, POLL_MS);
-  }, [open, phase, queryClient, user]);
+  }, [open, phase, queryClient, user, targetClientId]);
 
   // 2b. Token expiry: server returns `expiresIn` (seconds). When that
   //     elapses, flip to error so the user sees the dead-token state
@@ -202,10 +255,10 @@ export function NewConnectionDialog({ open, onOpenChange }: { open: boolean; onO
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Connect computer</DialogTitle>
+          <DialogTitle>{titleOverride ?? "Connect computer"}</DialogTitle>
           <DialogDescription>
-            Run this command on the machine you want to pair with this Hub. If first-tree isn't installed yet, the
-            command includes the install step.
+            {descriptionOverride ??
+              "Run this command on the machine you want to pair with this Hub. If first-tree isn't installed yet, the command includes the install step."}
           </DialogDescription>
         </DialogHeader>
 


### PR DESCRIPTION
## Summary

- Replace the dense Computers table with a per-status card layout. Each `ComputerCard` routes by `deriveComputerStatus(client).pill` to one of four bodies (Ready / Auth expired / Setup incomplete / Offline), so the action the operator needs is inline (Generate new token, install + login command per runtime, daemon wake guide).
- `NewConnectionDialog` accepts `targetClientId` + title/description overrides. AuthExpired cards open the dialog scoped to their own client.id so two concurrent re-auths can't consume the wrong arrival event.
- Admin "Team computers" still uses a read-only table — the rows offer no actionable affordance from the admin's side, and density-on-glance is the point.

## Background

- Builds on PR-A (#586) which shipped the 4-state pill + dialog hardening.
- Runs in parallel with PR-C (#591). Zero file conflicts.

## Layout

- **Member mode**: single `CardGrid` of all the user's own machines, sorted by pill priority (`auth_expired → setup_incomplete → offline → ready`).
- **Admin mode**: two sections — "Your computers" (cards) + "Team computers" (table).
- Responsive: `auto-fit minmax(min(100%, 35rem), 1fr)` — 2-up wide, 1-up below ~1120px.
- Bottom-of-page outline button "Add another computer" replaces the header-right `+ Connect` (cards host the inline affordances).
- A11y: each card is a `<section aria-label>`; inline command blocks live in a `<figure>` with a screen-reader figcaption + `aria-describedby` from the Copy button.

## Notes for reviewers

- View-model logic lives in `cards/view-models.ts` (pure functions, 19 vitest cases) — pill routing + diagnostic copy + bound-agents summary are testable without DOM. Same convention the rest of `@first-tree/web` uses.
- Shared provider constants moved from `clients.tsx` to `cards/shared/providers.ts`. The legacy `CapabilityMatrix` (used inside the team table's expanded row) imports them from there now.
- `selectArrivedClient` gets a fourth optional param `targetClientId`. Two new unit tests pin the constraint contract (a parallel reconnect of card B doesn't satisfy card A's mint).
- Offline-card "Reconnect" kebab opens an UNSCOPED dialog (`onReconnect`), distinct from AuthExpired's scoped re-auth (`onGenerateNewToken`) — an offline machine's creds are likely still valid; the operator just needs a fresh connect command from the keyboard.

## Test plan

- [x] `pnpm typecheck` (full repo)
- [x] `pnpm check` (biome — only pre-existing warnings remain in unrelated packages)
- [x] `pnpm --filter @first-tree/web test` — 427 tests pass, 19 new for view-models, 2 new for `selectArrivedClient(targetClientId)`
- [ ] Manual smoke: open `/settings/computers` as member with mixed-state computers; verify each pill renders its body and that AuthExpired's "Generate new token" opens a scoped dialog
- [ ] Manual smoke: as admin with both own + team rows, verify two sections + that Team table still shows the expanded capability matrix
- [ ] Manual smoke: kebab Reconnect on an offline card opens the unscoped dialog with default "Connect computer" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)