### PR TITLE
chore(server): auto-enable dev-callback in pnpm dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,15 @@ FIRST_TREE_HOST=0.0.0.0
 # │ Server — Dev-only (NEVER set in production)                              │
 # └───────────────────────────────────────────────────────────────────────────┘
 
+# Enable the GET /auth/github/dev-callback stub so the web login page's
+# "Dev: skip GitHub" button works (signs in as a stable `devuser` /
+# "Dev User" identity without a real GitHub OAuth client). The route is
+# also gated by `NODE_ENV !== "production"`, so this opt-in is harmless
+# in local dev. `pnpm --filter @first-tree/server dev` already sets this
+# inline — only set it here if you run the server some other way (custom
+# script, Docker dev image, etc.).
+# FIRST_TREE_DEV_CALLBACK_ENABLED=1
+
 # Personal access token injected into dev-callback so the Step 2/3 GitHub
 # repo picker can hit the real GitHub API in local development without
 # going through OAuth. Only honoured when the dev-callback route is reached

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "dev": "tsx watch --env-file=../../.env src/index.ts",
+    "dev": "FIRST_TREE_DEV_CALLBACK_ENABLED=1 tsx watch --env-file=../../.env src/index.ts",
     "build": "tsdown src/index.ts src/app.ts src/observability/index.ts --format esm --no-dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

The web login page renders a **"Dev: skip GitHub"** button on `localhost` that hits `GET /api/v1/auth/github/dev-callback` to sign in as the stable `devuser` / "Dev User" identity (`packages/web/src/pages/login.tsx:88-101`). The server route is gated by two checks (`packages/server/src/api/auth/github.ts:227-234`):

1. `NODE_ENV !== "production"`
2. `FIRST_TREE_DEV_CALLBACK_ENABLED` is explicitly `"1"` or `"true"` (P1-9 — defence-in-depth so misconfigured staging deploys can't accidentally expose the bypass).

Gate (2) was never listed in `.env.example`, so a fresh `cp .env.example .env` left it unset. The login button silently 404'd, and developers ended up creating ad-hoc users through the real GitHub OAuth flow or assuming "Dev User" was broken. This PR:

- **Inlines `FIRST_TREE_DEV_CALLBACK_ENABLED=1` in `packages/server`'s `dev` npm script.** Node's `--env-file` does *not* override variables already in `process.env`, so the inline shell-set value wins over anything the developer puts in `.env`. Only `pnpm --filter @first-tree/server dev` is affected — `tsdown` build → `node dist/...` (the Docker image / prod path) goes nowhere near this script, so the P1-9 guarantee on shipped artifacts is preserved.
- **Documents the variable in `.env.example`** for operators who boot the server some other way (custom script, Docker dev image, etc.).

No code change, no behavioral change in test/prod paths.

## Why not lift the gate in the route handler instead?

Considered. Rejected because `packages/server/src/__tests__/oauth-flow.test.ts:102-137` asserts the gate's exact behavior when the env var is unset / set to something other than `"1"|"true"`. Auto-enabling on `NODE_ENV !== "production"` would break those tests and dilute the codex P1-9 defence in code paths that *don't* go through the npm `dev` script.

## Test plan

Verified on `worktrees/first-tree-dev-callback-default`:

- [x] `pnpm install` + `pnpm --filter @first-tree/shared build` clean
- [x] `pnpm check` — 0 errors (16 pre-existing warnings in unrelated files)
- [x] `pnpm --filter @first-tree/server dev` boots cleanly: 28 tables migrated, server listening
- [x] Sanity A — `env -u FIRST_TREE_DEV_CALLBACK_ENABLED tsx --env-file=../../.env src/index.ts` (pre-change behavior): `GET /api/v1/auth/github/dev-callback?...` → **HTTP 404** ✅ (P1-9 gate still works)
- [x] Sanity B — `pnpm --filter @first-tree/server dev` (post-change behavior): same request → **HTTP 302** with Location fragment carrying valid `access` / `refresh` JWTs ✅
- [x] `SELECT * FROM users WHERE username='devuser'` confirms row + auto-created `devuser` organization in PG

🤖 Generated with [Claude Code](https://claude.com/claude-code)