### PR TITLE
feat(web): responsive Settings shell + Team table for narrow viewports

### DIFF
--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
+import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
 
 /**
@@ -20,6 +21,11 @@ import { cn } from "../lib/utils.js";
  * (sidebar 200 + main 960 = 1160 total).
  * Layout opts out of the default 960 wrapper via `isSettings` so this whole
  * shell can centre itself at ~1180.
+ *
+ * Narrow viewport (<48rem): the sidebar would steal half the screen,
+ * so it collapses into a horizontally-scrollable pill bar above the
+ * `<Outlet/>`. Same NavLink semantics (active state via `isActive`), same
+ * route targets — only the chrome shape changes.
  *
  * Sub-routes:
  *   Computers     — user-scoped: machines connected to Hub (most-frequent
@@ -47,6 +53,7 @@ const ITEMS: Item[] = [
 
 export function SettingsLayout() {
   const { role, onboardingCompletedAt, meLoaded } = useAuth();
+  const viewport = useWorkspaceViewport();
   // Wait for `/me` to resolve before rendering the nav — otherwise a fresh
   // direct hit on /settings/github would briefly paint the member-view nav
   // (no GitHub) before `role` flips to "admin".
@@ -64,6 +71,38 @@ export function SettingsLayout() {
     if (it.to === "/settings/onboarding" && hasCompletedOnboarding) return false;
     return true;
   });
+
+  if (viewport === "narrow") {
+    return (
+      <div className="flex flex-col" style={{ minHeight: "100%" }}>
+        <nav
+          aria-label="Settings"
+          // Pill row is non-sticky on purpose: settings is a low-frequency
+          // switch scenario (users come here to do one thing, not to bounce
+          // between sub-pages). Letting the row scroll away with the content
+          // gives the sub-page itself the full vertical space below the
+          // Layout's already-permanent top nav. Horizontal scroll inside
+          // keeps the row one line even when all 5 items wouldn't fit on
+          // the narrowest phone.
+          className="flex shrink-0"
+          style={{
+            gap: "var(--sp-1)",
+            padding: "var(--sp-2) var(--sp-3)",
+            borderBottom: "var(--hairline) solid var(--border)",
+            background: "var(--bg)",
+            overflowX: "auto",
+          }}
+        >
+          {visible.map((item) => (
+            <PillLink key={item.to} to={item.to} label={item.label} />
+          ))}
+        </nav>
+        <div className="flex-1 min-w-0">
+          <Outlet />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex" style={{ maxWidth: 1160, minHeight: "100%" }}>
@@ -109,6 +148,33 @@ function SidebarLink({ to, label }: { to: string; label: string }) {
           className="block"
           style={{
             padding: "var(--sp-2) var(--sp-3)",
+            borderRadius: "var(--radius-input)",
+            color: isActive ? "var(--fg)" : "var(--fg-3)",
+            background: isActive ? "var(--bg-hover)" : "transparent",
+            fontWeight: isActive ? 500 : 400,
+          }}
+        >
+          {label}
+        </span>
+      )}
+    </NavLink>
+  );
+}
+
+function PillLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      className={cn(
+        "shrink-0 text-body transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      )}
+    >
+      {({ isActive }) => (
+        <span
+          className="inline-block whitespace-nowrap"
+          style={{
+            padding: "var(--sp-1_5) var(--sp-3)",
             borderRadius: "var(--radius-input)",
             color: isActive ? "var(--fg)" : "var(--fg-3)",
             background: isActive ? "var(--bg-hover)" : "transparent",

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -492,7 +492,14 @@ function HumanDelegateInline({ row }: { row: HumanRow }) {
         row.onEditDelegate();
       }}
       className="text-caption hover:underline"
-      style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-3)", textAlign: "left" }}
+      style={{
+        background: "transparent",
+        border: 0,
+        padding: 0,
+        cursor: "pointer",
+        color: "var(--fg-3)",
+        textAlign: "left",
+      }}
       title="Change delegate"
     >
       Delegate: <span style={{ color: "var(--fg-2)" }}>{label}</span>
@@ -614,11 +621,7 @@ function AgentRowView({
             handle={agent.name ? `@${agent.name}` : null}
             visibility={showVisibilityChip ? agent.visibility : null}
             extra={
-              <span
-                className="block text-caption truncate"
-                style={{ color: "var(--fg-4)" }}
-                title={meta}
-              >
+              <span className="block text-caption truncate" style={{ color: "var(--fg-4)" }} title={meta}>
                 {meta}
               </span>
             }

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -1,6 +1,6 @@
 import type { Agent } from "@first-tree/shared";
 import { Bot, Lock, type LucideIcon, User, Users } from "lucide-react";
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, type ReactNode, useState } from "react";
 import { AgentChip } from "../../components/agent-chip.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import {
@@ -13,6 +13,7 @@ import {
 } from "../../components/ui/dense-table.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../../components/ui/row-actions-menu.js";
+import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { formatDay } from "../../lib/utils.js";
 
 export type { RowAction };
@@ -86,7 +87,16 @@ type Props = {
   getAgentActions: (row: AgentRow) => RowAction[];
 };
 
-const COLUMNS = [
+type ColumnKey = "name" | "delegate" | "manager" | "runtime" | "status" | "created" | "actions";
+
+type Column = {
+  key: ColumnKey;
+  label: string;
+  /** Omit to let the column flex (used by the narrow-mode Name column). */
+  width?: number;
+};
+
+const COLUMNS_WIDE: Column[] = [
   // Column widths sum to ~870 so the table renders without horizontal
   // compression inside the shared 960 page canvas (960 − 48 layout padding
   // − 40 page padding ≈ 872 content width). Every populated cell already
@@ -113,7 +123,20 @@ const COLUMNS = [
   { key: "status", label: "Status", width: 88 },
   { key: "created", label: "Created", width: 88 },
   { key: "actions", label: "", width: 44 },
-] as const;
+];
+
+// Narrow-viewport layout: only Name + Status + actions render as columns.
+// The Manager / Runtime / Created / Delegate signals fold into the Name
+// cell's secondary line so the table fits one screen without horizontal
+// scrolling. Status keeps its own column because PresenceChip is the most
+// scanned signal in the agent roster and the chip's pill width is hostile
+// to wrap inside the Name cell. Total width budget: ~88 (Status) + 44
+// (actions) + Name (flex) ≈ fits the narrowest phone with room to spare.
+const COLUMNS_NARROW: Column[] = [
+  { key: "name", label: "Name" },
+  { key: "status", label: "Status", width: 72 },
+  { key: "actions", label: "", width: 36 },
+];
 
 function sectionCellStyle(isLast: boolean, style?: CSSProperties): CSSProperties | undefined {
   if (!isLast) return style;
@@ -121,17 +144,27 @@ function sectionCellStyle(isLast: boolean, style?: CSSProperties): CSSProperties
 }
 
 export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions, getAgentActions }: Props) {
+  const viewport = useWorkspaceViewport();
+  const isNarrow = viewport === "narrow";
+  const columns = isNarrow ? COLUMNS_NARROW : COLUMNS_WIDE;
   return (
-    <DenseTable className="table-fixed">
+    // Narrow drops `table-fixed`: with only Name + Status + Actions we let
+    // the Name column flex to fill the remaining width (Status/Actions are
+    // fixed via td-level `width`). Wide keeps `table-fixed` so the 7-column
+    // canvas balances by the declared widths as before.
+    <DenseTable className={isNarrow ? undefined : "table-fixed"}>
       <DenseTableHeader>
         <DenseTableRow>
-          {COLUMNS.map((col) => (
+          {columns.map((col) => (
             <DenseTableHead
               key={col.key}
               // The first column (Name) also shifts to `sp-6` left padding
               // so the column header sits in the same vertical alignment
               // line as the section title text and the row name text.
-              style={{ width: col.width, ...(col.key === "name" ? { paddingLeft: "var(--sp-6)" } : null) }}
+              style={{
+                width: col.width,
+                ...(col.key === "name" ? { paddingLeft: "var(--sp-6)" } : null),
+              }}
               aria-hidden={col.key === "actions"}
             >
               {col.label}
@@ -143,6 +176,8 @@ export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions
         <GroupBody
           key={group.key}
           group={group}
+          columns={columns}
+          isNarrow={isNarrow}
           clientHostMap={clientHostMap}
           onAgentClick={onAgentClick}
           getHumanActions={getHumanActions}
@@ -155,12 +190,16 @@ export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions
 
 function GroupBody({
   group,
+  columns,
+  isNarrow,
   clientHostMap,
   onAgentClick,
   getHumanActions,
   getAgentActions,
 }: {
   group: TeamGroup;
+  columns: Column[];
+  isNarrow: boolean;
   clientHostMap: Map<string, string>;
   onAgentClick: (uuid: string) => void;
   getHumanActions: (row: HumanRow) => RowAction[];
@@ -170,11 +209,11 @@ function GroupBody({
 
   return (
     <DenseTableBody>
-      <GroupHeaderRow group={group} open={open} onToggle={() => setOpen((v) => !v)} />
+      <GroupHeaderRow group={group} columnCount={columns.length} open={open} onToggle={() => setOpen((v) => !v)} />
       {open && group.rows.length === 0 && group.emptyMessage && (
         <DenseTableRow>
           <DenseTableCell
-            colSpan={COLUMNS.length}
+            colSpan={columns.length}
             style={{
               color: "var(--fg-4)",
               textAlign: "left",
@@ -190,7 +229,13 @@ function GroupBody({
         group.rows.map((row, index) => {
           const isLast = index === group.rows.length - 1;
           return row.kind === "human" ? (
-            <HumanRowView key={`h:${row.id}`} row={row} actions={getHumanActions(row)} isLast={isLast} />
+            <HumanRowView
+              key={`h:${row.id}`}
+              row={row}
+              actions={getHumanActions(row)}
+              isLast={isLast}
+              isNarrow={isNarrow}
+            />
           ) : (
             <AgentRowView
               key={`a:${row.agent.uuid}`}
@@ -199,6 +244,7 @@ function GroupBody({
               actions={getAgentActions(row)}
               onClick={() => onAgentClick(row.agent.uuid)}
               isLast={isLast}
+              isNarrow={isNarrow}
             />
           );
         })}
@@ -230,7 +276,17 @@ function sectionIcon(key: string): LucideIcon | null {
   }
 }
 
-function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boolean; onToggle: () => void }) {
+function GroupHeaderRow({
+  group,
+  columnCount,
+  open,
+  onToggle,
+}: {
+  group: TeamGroup;
+  columnCount: number;
+  open: boolean;
+  onToggle: () => void;
+}) {
   const Icon = sectionIcon(group.key);
   // Alignment contract (must hold across all 4 sections):
   //   - Section icon at cell X=0 ("hangs out" as section marker).
@@ -288,7 +344,7 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
   return (
     <DenseTableRow>
       <td
-        colSpan={COLUMNS.length}
+        colSpan={columnCount}
         style={{
           // Section header sits at the table's left edge (padding-left: 0);
           // its icon (sp-4 wide) + gap (sp-2) puts the section TITLE TEXT
@@ -330,7 +386,44 @@ function GroupHeaderRow({ group, open, onToggle }: { group: TeamGroup; open: boo
   );
 }
 
-function HumanRowView({ row, actions, isLast }: { row: HumanRow; actions: RowAction[]; isLast: boolean }) {
+function HumanRowView({
+  row,
+  actions,
+  isLast,
+  isNarrow,
+}: {
+  row: HumanRow;
+  actions: RowAction[];
+  isLast: boolean;
+  isNarrow: boolean;
+}) {
+  if (isNarrow) {
+    // Narrow Name cell folds the delegate signal into a secondary line —
+    // either the resolved delegate identity or the inline "Set delegate →"
+    // CTA (still only clickable when the viewer is self or admin). Status
+    // column stays empty for humans (they have no PresenceChip), matching
+    // the desktop "—" placement so the chip alignment in agent rows below
+    // doesn't shift.
+    return (
+      <DenseTableRow>
+        <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
+          <NameCell
+            displayName={row.displayName}
+            handle={`@${row.username}`}
+            selfTag={row.isSelf}
+            extra={<HumanDelegateInline row={row} />}
+          />
+        </DenseTableCell>
+        <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
+          —
+        </DenseTableCell>
+        <DenseTableCell style={sectionCellStyle(isLast, { padding: 0, textAlign: "right" })}>
+          <RowActionsMenu actions={actions} ariaLabel={`Actions for ${row.displayName}`} />
+        </DenseTableCell>
+      </DenseTableRow>
+    );
+  }
+
   return (
     <DenseTableRow>
       <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
@@ -355,6 +448,55 @@ function HumanRowView({ row, actions, isLast }: { row: HumanRow; actions: RowAct
         <RowActionsMenu actions={actions} ariaLabel={`Actions for ${row.displayName}`} />
       </DenseTableCell>
     </DenseTableRow>
+  );
+}
+
+/**
+ * Narrow-mode delegate slot inside the Name cell's secondary line. The
+ * verbose chip+tooltip treatment from the desktop Delegate column would
+ * dwarf the single-line caption row at this density, so we render plain
+ * text with a discrete "→ change" affordance trailing it. Same edit
+ * permissions as the desktop cell (self or admin) — non-editable viewers
+ * just see the resolved name.
+ */
+function HumanDelegateInline({ row }: { row: HumanRow }) {
+  if (!row.delegate) {
+    if (!row.canEditDelegate) return null;
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          row.onEditDelegate();
+        }}
+        className="text-caption hover:underline"
+        style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--accent-dim)" }}
+      >
+        Set delegate →
+      </button>
+    );
+  }
+  const label = row.delegate.name ? `@${row.delegate.name}` : row.delegate.displayName;
+  if (!row.canEditDelegate) {
+    return (
+      <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+        Delegate: {label}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        row.onEditDelegate();
+      }}
+      className="text-caption hover:underline"
+      style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-3)", textAlign: "left" }}
+      title="Change delegate"
+    >
+      Delegate: <span style={{ color: "var(--fg-2)" }}>{label}</span>
+    </button>
   );
 }
 
@@ -440,14 +582,60 @@ function AgentRowView({
   actions,
   onClick,
   isLast,
+  isNarrow,
 }: {
   row: AgentRow;
   clientHost: string | null;
   actions: RowAction[];
   onClick: () => void;
   isLast: boolean;
+  isNarrow: boolean;
 }) {
   const { agent, managerLabel, isOwnedBySelf, showVisibilityChip } = row;
+
+  if (isNarrow) {
+    // Narrow Name cell folds Manager · Runs-on · Created into a single
+    // dot-separated caption line so the row still answers "who built it /
+    // where does it run / how old is it" without a 7-column scroll. Order
+    // chosen by scan priority: manager (governance), then runtime+host
+    // (operational), then created (least urgent).
+    const meta = buildAgentMeta({
+      managerLabel,
+      isOwnedBySelf,
+      runtime: agent.runtimeProvider,
+      clientHost,
+      createdAt: agent.createdAt,
+    });
+    return (
+      <DenseTableRow interactive onClick={onClick}>
+        <DenseTableCell style={sectionCellStyle(isLast, { paddingLeft: "var(--sp-6)" })}>
+          <NameCell
+            displayName={agent.displayName}
+            handle={agent.name ? `@${agent.name}` : null}
+            visibility={showVisibilityChip ? agent.visibility : null}
+            extra={
+              <span
+                className="block text-caption truncate"
+                style={{ color: "var(--fg-4)" }}
+                title={meta}
+              >
+                {meta}
+              </span>
+            }
+          />
+        </DenseTableCell>
+        <DenseTableCell style={sectionCellStyle(isLast)}>
+          <PresenceChip status={runtimeStateToPresence(agent.runtimeState)} />
+        </DenseTableCell>
+        <DenseTableCell
+          style={sectionCellStyle(isLast, { padding: 0, textAlign: "right" })}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <RowActionsMenu actions={actions} ariaLabel={`Actions for ${agent.displayName}`} />
+        </DenseTableCell>
+      </DenseTableRow>
+    );
+  }
 
   return (
     <DenseTableRow interactive onClick={onClick}>
@@ -505,11 +693,28 @@ function AgentRowView({
   );
 }
 
+function buildAgentMeta(args: {
+  managerLabel: string | null;
+  isOwnedBySelf: boolean;
+  runtime: string;
+  clientHost: string | null;
+  createdAt: string;
+}): string {
+  const parts: string[] = [];
+  if (args.managerLabel) {
+    parts.push(args.isOwnedBySelf ? `${args.managerLabel} (you)` : args.managerLabel);
+  }
+  parts.push(args.clientHost ? `${args.runtime} @ ${args.clientHost}` : args.runtime);
+  parts.push(formatDay(args.createdAt));
+  return parts.join(" · ");
+}
+
 function NameCell({
   displayName,
   handle,
   selfTag,
   visibility,
+  extra,
 }: {
   displayName: string;
   handle: string | null;
@@ -521,6 +726,13 @@ function NameCell({
    * the section title already encodes the visibility.
    */
   visibility?: Agent["visibility"] | null;
+  /**
+   * Extra caption line rendered below the handle (or below the display
+   * name if no handle). Used in narrow-viewport mode to fold the columns
+   * that got cut (Manager / Runs on / Created / Delegate) into a single
+   * secondary line so the row stays one screen wide.
+   */
+  extra?: ReactNode;
 }) {
   return (
     <div className="min-w-0">
@@ -540,6 +752,7 @@ function NameCell({
           {handle}
         </div>
       )}
+      {extra && <div className="min-w-0">{extra}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase-2 of the mobile dashboard rewire — picks up where #577 left off. PR #577 covered the workspace surface (chat list / chat view / right rail / top bar); this PR lands the two remaining high-traffic admin pages so the dashboard is usable end-to-end on a phone.

### Behavior by breakpoint

| Surface                 | xl/md (≥48rem)                          | narrow (<48rem)                                                                           |
| ----------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------- |
| Settings sub-nav        | 200px sidebar + 1160 canvas (unchanged) | horizontal pill row above `<Outlet/>`, non-sticky, x-scrolls if items overflow            |
| Team roster table       | 7 columns (Name · Delegate · Manager · Runs on · Status · Created · ⋯) | 3 columns: Name + Status + ⋯. Manager / Runs on / Created collapse into a `·`-joined caption under the handle |
| Humans row              | Delegate column has chip + edit         | Delegate folds into Name caption; "Set delegate →" inline CTA preserved for self/admin     |

### Why a *non-sticky* pill row for Settings

Settings is a low-frequency switch scenario (users come here to do one thing, not bounce between sub-pages). The Layout top nav is already permanent; pinning a second nav row would steal another ~36px from a phone screen that already lost the brand cluster. Letting the pill row scroll away gives the sub-page its full vertical space — and tapping the global "Settings" tab again returns to the top anyway.

### Why keep Status as its own column at narrow

PresenceChip is the single most-scanned signal in the roster ("is this agent live?"). The pill's width is hostile to wrapping inside a caption line, and scanning down a fixed column of chips is much faster than scanning a free-text caption. Manager / Runs-on / Created are reference data — fine to fold; Status isn't.

### Files

- `packages/web/src/pages/settings.tsx` — `useWorkspaceViewport()` gate; new `PillLink` for narrow; existing sidebar branch untouched
- `packages/web/src/pages/team/team-table.tsx` — `COLUMNS_WIDE` / `COLUMNS_NARROW` split; `HumanRowView` / `AgentRowView` get an `isNarrow` branch; `NameCell` gains optional `extra` slot for the caption fold-in; new `HumanDelegateInline` for the narrow Set-delegate CTA

No data structure / schema / migration / API change. No new hooks. No new dependencies. `pnpm --filter @first-tree/web typecheck` clean (incl. design-token lint); `pnpm --filter @first-tree/web test` 406/406 pass.

### Self-review (P2 follow-ups intentionally not in this PR)

- No RTL render test for the narrow path yet — `team-groups.test.ts` only covers `buildGroups` pure logic. Adding one needs a `useWorkspaceViewport` mock; happy to file an issue or follow-up if you want it tracked.
- `useWorkspaceViewport` is no longer "workspace-only"; rename to `useResponsiveViewport` is a worthwhile but cross-cutting follow-up.

## Test plan

- [ ] Desktop (xl ≥80rem): Settings shows sidebar + 1160 canvas; Team table shows all 7 columns — unchanged from `main`
- [ ] md (48–80rem): same as xl for these surfaces
- [ ] narrow (<48rem) Settings: pill row visible at top of `/settings/*`, scrolls horizontally when items don't fit, scrolls away with content (not sticky)
- [ ] narrow (<48rem) Team: only Name + Status + ⋯ visible; Agent rows show `manager (you) · runtime @ host · 5/12` caption; Human rows show `Delegate: @x` (or `Set delegate →` for self/admin) caption
- [ ] narrow Team: clicking an Agent row still navigates to `/agents/<id>`; "Set delegate →" inside a Human row's caption opens the delegate dialog and does NOT propagate to row click
- [ ] narrow Team: collapsible "Other members' private agents" section (admin-only) toggles correctly with chevron
- [ ] Breakpoint flip (resize across 48rem boundary): UI hot-reflows cleanly; section-collapsed state preserved across flips
- [ ] `pnpm --filter @first-tree/web typecheck` and `pnpm --filter @first-tree/web test` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)