### PR TITLE
refactor(computers): align card chrome with Settings minimal style

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1275,6 +1275,16 @@
   outline-offset: var(--sp-0_5);
 }
 
+/*
+ * Settings → Computers card stack. Adjacent ComputerCards get a hairline
+ * separator on the top edge (skipping the first child so the first
+ * card sits flush against the parent Section's own bottom border).
+ * Keeps each ComputerCard's JSX free of "am I first?" branching.
+ */
+.computer-card-stack > * + * {
+  border-top: var(--hairline) solid var(--border-faint);
+}
+
 .onboarding-runtime-option {
   border-radius: var(--radius-input);
   outline: var(--hairline) solid transparent;

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -26,6 +26,7 @@ import {
 import { PageHeader } from "../components/ui/page-header.js";
 import { PresenceChip, runtimeStateToPresence } from "../components/ui/presence-chip.js";
 import { RowActionsMenu } from "../components/ui/row-actions-menu.js";
+import { Section } from "../components/ui/section.js";
 import { UppercaseLabel } from "../components/ui/section-header.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { formatDate, formatRelative } from "../lib/utils.js";
@@ -216,7 +217,10 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
     if (client.userId === null) return { text: "—" };
     if (client.userId === user?.id) {
       const display = membersById.get(client.userId);
-      return { text: display ? `${display} (you)` : "you" };
+      // "gandy · you" rather than "gandy (you)" — nested parens read stiff
+      // in card headers; the middot is the same separator the rest of the
+      // page uses for meta segments.
+      return { text: display ? `${display} · you` : "you" };
     }
     const display = membersById.get(client.userId);
     if (display) return { text: display };
@@ -440,15 +444,15 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
             {teamLoadError && <TeamLoadErrorBanner />}
             {grouped ? (
               <>
-                <CardSection title="Your computers" count={mineList.length}>
+                <Section title="Your computers" count={mineList.length}>
                   {mineList.length === 0 ? (
                     // Admin with no own computers + N team rows — the "Add
                     // another computer" bottom button would read wrong here
                     // ("another" implies a first), so keep the connect CTA
                     // inside the empty section instead.
                     <div
-                      className="flex flex-col items-start py-6"
-                      style={{ color: "var(--fg-3)", gap: "var(--sp-3)" }}
+                      className="flex flex-col items-start"
+                      style={{ color: "var(--fg-3)", gap: "var(--sp-3)", padding: "var(--sp-4) 0" }}
                     >
                       <span className="text-body">No computers of your own.</span>
                       <Button size="sm" onClick={openNewConnection}>
@@ -457,7 +461,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                       </Button>
                     </div>
                   ) : (
-                    <CardGrid>
+                    <CardStack>
                       {mineList.map((client) => (
                         <ComputerCard
                           key={client.id}
@@ -474,10 +478,10 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                           ownerLabel={resolveOwner(client)}
                         />
                       ))}
-                    </CardGrid>
+                    </CardStack>
                   )}
-                </CardSection>
-                <CardSection title="Team computers" count={teamList.length}>
+                </Section>
+                <Section title="Team computers" count={teamList.length}>
                   {teamList.length === 0 ? (
                     <EmptyCardsNote message="No other team computers." />
                   ) : (
@@ -497,10 +501,10 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                       resolveOwner={resolveOwner}
                     />
                   )}
-                </CardSection>
+                </Section>
               </>
             ) : (
-              <CardGrid>
+              <CardStack>
                 {(memberList ?? []).map((client) => (
                   <ComputerCard
                     key={client.id}
@@ -516,7 +520,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                     }}
                   />
                 ))}
-              </CardGrid>
+              </CardStack>
             )}
 
             {showBottomAddButton && (
@@ -535,52 +539,28 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
 }
 
 /**
- * Responsive card grid. `auto-fit` with `minmax(min(100%, 35rem), 1fr)`
- * yields 2-up on viewports wider than ~1120 logical units and 1-up
- * below. The 35rem minimum keeps the AuthExpired card's
- * `first-tree login <jwt>` command from wrapping into ugly multi-line
- * fragments inside narrow cards.
+ * Vertical stack of computer cards with hairline separators. Each card
+ * renders as a flat `<article>` (no own chrome) inside the parent
+ * `<Section>`; this wrapper paints a hairline between adjacent computers
+ * so the eye still sees "here ends one machine, here begins the next"
+ * without nesting boxes.
+ *
+ * The hairline is injected via a sibling-selector class — defining it
+ * once at the page level keeps every ComputerCard pure of "I might be
+ * first or not" awareness.
+ *
+ * Previous PR-B used a `repeat(auto-fit, minmax(35rem, 1fr))` 2-up grid
+ * — that fights the Settings tab's single-column hairline-separated
+ * vocabulary (see /settings/github, /settings/messaging), so it was
+ * collapsed to a stack here.
  */
-function CardGrid({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        display: "grid",
-        gap: "var(--sp-4)",
-        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 35rem), 1fr))",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function CardSection({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
-  return (
-    <section className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
-      <header className="flex items-baseline" style={{ gap: "var(--sp-2)" }}>
-        {/*
-          `text-subtitle` + `font-semibold` is the same visual weight used by
-          PageHeader's section headings — bumping above `text-body` makes the
-          "Your computers" / "Team computers" hierarchy survive when both
-          sections are present (admin view) and the page is otherwise wall-
-          to-wall cards.
-        */}
-        <h2 className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
-          {title}
-        </h2>
-        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          · {count}
-        </span>
-      </header>
-      {children}
-    </section>
-  );
+function CardStack({ children }: { children: React.ReactNode }) {
+  return <div className="computer-card-stack">{children}</div>;
 }
 
 function EmptyCardsNote({ message }: { message: string }) {
   return (
-    <div className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) var(--sp-1)" }}>
+    <div className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0" }}>
       {message}
     </div>
   );

--- a/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
@@ -32,30 +32,24 @@ type AuthExpiredCardBodyProps = {
 export function AuthExpiredCardBody({ client, boundAgents, agentName, onGenerateNewToken }: AuthExpiredCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
         {authExpiredDiagnostic(client)}
       </p>
-      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+      <div className="flex items-center" style={{ gap: "var(--sp-3)" }}>
         <Button size="sm" onClick={onGenerateNewToken}>
           Generate new token
         </Button>
         {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
       </div>
-      <Divider />
-      <CardMetaRow client={client} dimmed />
+      <div
+        style={{
+          borderTop: "var(--hairline) solid var(--border-faint)",
+          paddingTop: "var(--sp-2_5)",
+        }}
+      >
+        <CardMetaRow client={client} dimmed />
+      </div>
     </div>
-  );
-}
-
-function Divider() {
-  return (
-    <div
-      aria-hidden
-      style={{
-        borderTop: "var(--hairline) solid var(--border-faint)",
-        margin: 0,
-      }}
-    />
   );
 }

--- a/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
@@ -1,7 +1,7 @@
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { Button } from "../../../components/ui/button.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
-import { CardMetaRow } from "./shared/card-meta-row.js";
+import { CardMetaFooter } from "./shared/card-meta-row.js";
 import { authExpiredDiagnostic, summarizeBoundAgents } from "./view-models.js";
 
 type AuthExpiredCardBodyProps = {
@@ -42,14 +42,7 @@ export function AuthExpiredCardBody({ client, boundAgents, agentName, onGenerate
         </Button>
         {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
       </div>
-      <div
-        style={{
-          borderTop: "var(--hairline) solid var(--border-faint)",
-          paddingTop: "var(--sp-2_5)",
-        }}
-      >
-        <CardMetaRow client={client} dimmed />
-      </div>
+      <CardMetaFooter client={client} />
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/computer-card.tsx
+++ b/packages/web/src/pages/clients/cards/computer-card.tsx
@@ -39,22 +39,22 @@ export type ComputerCardProps = {
 };
 
 /**
- * Top-level card shell. Routes by `deriveComputerStatus(client).pill`
- * to one of four body components — each mockup variant (A/B/B-2/B-3)
- * gets its own body so the per-pill content is encapsulated.
+ * Per-computer detail block. Renders as a flat region inside its parent
+ * `<Section>` ("Your computers" / "Team computers") — no raised
+ * background, no shadow, no border. The visual vocabulary matches the
+ * rest of Settings (Section → fields → hairline separators) so this tab
+ * sits next to /settings/github and /settings/messaging without looking
+ * like an outlier.
  *
- * Card chrome (shared across pills):
- *   - role="region" + aria-label for screen-reader semantic equivalence
- *     to the table's row/column structure pre-PR-B
- *   - Header row: hostname (+ optional owner) + pill chip + ⋯ menu
- *   - Body slot driven by pill
+ * Multiple machines stack vertically; the parent `CardStack` paints a
+ * hairline between adjacent entries so the eye still sees the boundary
+ * without an explicit card chrome.
  *
- * The ⋯ menu carries the same actions the table's RowActionsMenu had —
- * Disconnect / Retire (+ Reconnect when offline). Reconnect on offline
- * cards opens the dialog as a fresh connect (no targetClientId), since
- * "the user wants to fire up a new install path" is the offline-mode
- * mental model. AuthExpired uses the Generate-new-token button instead
- * (it threads `targetClientId` through).
+ * Header row: hostname + optional owner caption + pill + ⋯ menu.
+ * The ⋯ menu carries the same actions the legacy table's RowActionsMenu
+ * had — Disconnect / Retire (+ Reconnect when offline). Reconnect on
+ * offline rows opens the dialog as a fresh connect (no targetClientId);
+ * AuthExpired uses the inline "Generate new token" button instead.
  */
 export function ComputerCard({
   client,
@@ -70,25 +70,24 @@ export function ComputerCard({
   const isOffline = client.status !== "connected";
 
   return (
-    // `<section>` already conveys region semantics; biome flags an
-    // explicit `role="region"` as redundant. `aria-label` on a labeled
-    // section is the documented pattern for naming the region.
-    <section
+    // `<article>` (instead of nested `<section>`) keeps the page outline
+    // flat: the parent `<Section>` is the named region, each computer is
+    // an article inside it. `aria-label` names it for screen readers.
+    <article
       aria-label={vm.ariaLabel}
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: "var(--sp-3_5)",
-        padding: "var(--sp-4) var(--sp-5)",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        boxShadow: "var(--shadow-sm)",
+        gap: "var(--sp-3)",
+        // Padding only on the inline axis — vertical spacing comes from
+        // the parent stack's hairline separators so adjacent rows don't
+        // collide but also don't waste extra padding on themselves.
+        padding: "var(--sp-3_5) 0",
       }}
     >
       <header className="flex items-start" style={{ gap: "var(--sp-3)" }}>
-        <div className="flex flex-col" style={{ flex: 1, minWidth: 0, gap: "var(--sp-1)" }}>
-          <h3 className="text-subtitle" style={{ margin: 0, overflowWrap: "anywhere" }}>
+        <div className="flex flex-col" style={{ flex: 1, minWidth: 0, gap: "var(--sp-0_5)" }}>
+          <h3 className="text-body font-semibold" style={{ margin: 0, overflowWrap: "anywhere", color: "var(--fg)" }}>
             {vm.label}
           </h3>
           {ownerLabel && (
@@ -114,7 +113,7 @@ export function ComputerCard({
         agentName={agentName}
         onGenerateNewToken={onGenerateNewToken}
       />
-    </section>
+    </article>
   );
 }
 

--- a/packages/web/src/pages/clients/cards/offline-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/offline-card-body.tsx
@@ -1,6 +1,6 @@
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
-import { CardMetaRow } from "./shared/card-meta-row.js";
+import { CardMetaFooter } from "./shared/card-meta-row.js";
 import { InlineCommand } from "./shared/inline-command.js";
 import { offlineDiagnostic, summarizeBoundAgents } from "./view-models.js";
 
@@ -39,14 +39,7 @@ export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardB
         <InlineCommand command="first-tree daemon start" ariaLabel="Daemon wake command" />
       </div>
       {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
-      <div
-        style={{
-          borderTop: "var(--hairline) solid var(--border-faint)",
-          paddingTop: "var(--sp-2_5)",
-        }}
-      >
-        <CardMetaRow client={client} dimmed />
-      </div>
+      <CardMetaFooter client={client} />
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/offline-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/offline-card-body.tsx
@@ -28,18 +28,25 @@ type OfflineCardBodyProps = {
 export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
         {offlineDiagnostic(client)}
       </p>
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+      <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+        <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
           If the daemon isn't running, on this computer:
         </p>
         <InlineCommand command="first-tree daemon start" ariaLabel="Daemon wake command" />
       </div>
       {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
-      <CardMetaRow client={client} dimmed />
+      <div
+        style={{
+          borderTop: "var(--hairline) solid var(--border-faint)",
+          paddingTop: "var(--sp-2_5)",
+        }}
+      >
+        <CardMetaRow client={client} dimmed />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/ready-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/ready-card-body.tsx
@@ -1,6 +1,6 @@
 import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
+import type { ReactNode } from "react";
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
-import { UppercaseLabel } from "../../../components/ui/section-header.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
 import { CardMetaRow } from "./shared/card-meta-row.js";
 import { PROVIDER_INSTALL_HINT, PROVIDER_LABEL, PROVIDER_ORDER, PROVIDER_UNAUTH_HINT } from "./shared/providers.js";
@@ -13,43 +13,66 @@ type ReadyCardBodyProps = {
 };
 
 /**
- * Variant A body — the happy path. Renders:
- *   - Heartbeat / first-tree / OS meta row
- *   - Runtimes section: per-provider state line (✓ / ⚠ / ⊘)
- *   - Bound agents: full list with PresenceChips
+ * Variant A body — the happy path. Three groups separated by hairlines
+ * inside the per-computer block:
+ *   1. Heartbeat / first-tree / OS — `<dl>` field grid via `CardMetaRow`
+ *   2. Runtimes — per-provider state line
+ *   3. Bound agents — when ≥ 1
  *
- * Mockup §"Variant A" puts the agents section last. The Runtimes
- * matrix on a Ready card is informational (one runtime is `ok` by
- * definition — that's why the pill is Ready) but worth showing so the
- * user can see at a glance whether they're running both Claude Code
- * and Codex, or only one.
+ * Mockup §"Variant A" puts agents last. The Runtimes section is
+ * informational (one runtime must be `ok` for the pill to be Ready) but
+ * worth showing so the user sees at a glance whether they have both
+ * runtimes or just one.
  */
 export function ReadyCardBody({ client, boundAgents, agentName }: ReadyCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <CardMetaRow client={client} />
-      <RuntimesSection capabilities={client.capabilities} />
-      <BoundAgentsList summary={summary} agentName={agentName} />
+    <div className="flex flex-col">
+      <Group>
+        <CardMetaRow client={client} />
+      </Group>
+      <Group>
+        <GroupLabel>Runtimes</GroupLabel>
+        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+          {PROVIDER_ORDER.map((provider) => (
+            <RuntimeStateLine key={provider} provider={provider} entry={client.capabilities[provider] ?? null} />
+          ))}
+        </div>
+      </Group>
+      {summary.total > 0 && (
+        <Group>
+          <GroupLabel>{summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}</GroupLabel>
+          <BoundAgentsList summary={summary} agentName={agentName} headerless />
+        </Group>
+      )}
     </div>
   );
 }
 
 /**
- * Compact Runtimes section for Ready cards. Same vocabulary as the
- * pre-PR-B `ProviderRow` (under the table's expanded row) but rendered
- * unconditionally inline. Reused so the visual hint colors stay
- * consistent across the page.
+ * Group inside a card body: stacks vertically with a hairline separator
+ * on top. Keeps meta/runtimes/agents visually separated without nesting
+ * boxes — same vocabulary `<Section>` uses for its top border.
  */
-function RuntimesSection({ capabilities }: { capabilities: HubClient["capabilities"] }) {
+function Group({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-      <UppercaseLabel style={{ display: "block", marginBottom: 4 }}>Runtimes</UppercaseLabel>
-      <div className="flex flex-col gap-1">
-        {PROVIDER_ORDER.map((provider) => (
-          <RuntimeStateLine key={provider} provider={provider} entry={capabilities[provider] ?? null} />
-        ))}
-      </div>
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-1_5)",
+        padding: "var(--sp-2_5) 0",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function GroupLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+      {children}
     </div>
   );
 }
@@ -58,60 +81,36 @@ function RuntimeStateLine({ provider, entry }: { provider: RuntimeProvider; entr
   const label = PROVIDER_LABEL[provider];
   if (!entry) {
     return (
-      <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
-        <span className="font-medium" style={{ minWidth: 140 }}>
-          {label}
-        </span>
-        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          not reported · {PROVIDER_INSTALL_HINT[provider]}
-        </span>
+      <div className="text-body" style={{ color: "var(--fg-3)" }}>
+        <span style={{ color: "var(--fg-2)" }}>{label}</span> · not reported · {PROVIDER_INSTALL_HINT[provider]}
       </div>
     );
   }
   switch (entry.state) {
     case "ok":
       return (
-        <div className="flex items-center gap-2.5 text-body">
-          <span className="font-medium" style={{ minWidth: 140 }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--state-idle)" }}>
-            ✓ {entry.sdkVersion ? `v${entry.sdkVersion} · ` : ""}authenticated ({entry.authMethod})
-          </span>
+        <div className="text-body" style={{ color: "var(--fg-2)" }}>
+          <span style={{ color: "var(--state-idle)" }}>✓</span> {label}
+          {entry.sdkVersion ? ` · v${entry.sdkVersion}` : ""} · authenticated ({entry.authMethod})
         </div>
       );
     case "unauthenticated":
       return (
-        <div className="flex items-center gap-2.5 text-body">
-          <span className="font-medium" style={{ minWidth: 140 }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--state-blocked)" }}>
-            ⚠ installed{entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated ·{" "}
-            {PROVIDER_UNAUTH_HINT[provider]}
-          </span>
+        <div className="text-body" style={{ color: "var(--fg-2)" }}>
+          <span style={{ color: "var(--state-blocked)" }}>⚠</span> {label}
+          {entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated · {PROVIDER_UNAUTH_HINT[provider]}
         </div>
       );
     case "missing":
       return (
-        <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
-          <span className="font-medium" style={{ minWidth: 140 }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            ✗ not installed · {PROVIDER_INSTALL_HINT[provider]}
-          </span>
+        <div className="text-body" style={{ color: "var(--fg-3)" }}>
+          <span style={{ color: "var(--fg-4)" }}>✗</span> {label} · not installed · {PROVIDER_INSTALL_HINT[provider]}
         </div>
       );
     case "error":
       return (
-        <div className="flex items-center gap-2.5 text-body">
-          <span className="font-medium" style={{ minWidth: 140 }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--state-error)" }}>
-            error · {entry.error ?? "probe failed"}
-          </span>
+        <div className="text-body" style={{ color: "var(--fg-2)" }}>
+          <span style={{ color: "var(--state-error)" }}>!</span> {label} · {entry.error ?? "probe failed"}
         </div>
       );
   }

--- a/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
@@ -1,6 +1,6 @@
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
-import { CardMetaRow } from "./shared/card-meta-row.js";
+import { CardMetaFooter } from "./shared/card-meta-row.js";
 import { PROVIDER_ORDER } from "./shared/providers.js";
 import { RuntimeInstallBox } from "./shared/runtime-install-box.js";
 import { cardHostnameLabel, SETUP_INCOMPLETE_DIAGNOSTIC, summarizeBoundAgents } from "./view-models.js";
@@ -54,14 +54,7 @@ export function SetupIncompleteCardBody({ client, boundAgents, agentName }: Setu
         ))}
       </div>
       {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
-      <div
-        style={{
-          borderTop: "var(--hairline) solid var(--border-faint)",
-          paddingTop: "var(--sp-2_5)",
-        }}
-      >
-        <CardMetaRow client={client} />
-      </div>
+      <CardMetaFooter client={client} dimmed={false} />
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
@@ -30,8 +30,8 @@ export function SetupIncompleteCardBody({ client, boundAgents, agentName }: Setu
   const summary = summarizeBoundAgents(boundAgents);
   const installableProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p]?.state !== "ok");
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <p className="text-body" style={{ margin: 0, color: "var(--fg)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
         {SETUP_INCOMPLETE_DIAGNOSTIC}
       </p>
       <div
@@ -54,7 +54,14 @@ export function SetupIncompleteCardBody({ client, boundAgents, agentName }: Setu
         ))}
       </div>
       {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
-      <CardMetaRow client={client} />
+      <div
+        style={{
+          borderTop: "var(--hairline) solid var(--border-faint)",
+          paddingTop: "var(--sp-2_5)",
+        }}
+      >
+        <CardMetaRow client={client} />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
+++ b/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
@@ -1,5 +1,4 @@
 import { PresenceChip, runtimeStateToPresence } from "../../../../components/ui/presence-chip.js";
-import { UppercaseLabel } from "../../../../components/ui/section-header.js";
 import type { BoundAgentsSummary } from "../view-models.js";
 
 type BoundAgentsListProps = {
@@ -11,20 +10,28 @@ type BoundAgentsListProps = {
    * cards where the agents section is supporting context, not the focus.
    */
   compact?: boolean;
+  /**
+   * When true, skip the in-component "Agents · N" header — the parent
+   * Group is already labeling the block. Without this the Ready card
+   * would render two labels (one in the group, one here).
+   */
+  headerless?: boolean;
 };
 
 /**
- * Renders the bound-agents section of a computer card.
+ * Renders the bound-agents block of a computer card body.
  *
- * Two display modes — both driven by the same `BoundAgentsSummary` from
- * `view-models.ts`:
- *
- *   - **expanded** (Ready card): full list, one row per agent, with
- *     `PresenceChip` + active/total session counts.
+ * Two display modes — both fed by the same `BoundAgentsSummary`:
+ *   - **expanded** (Ready card): per-agent row with `PresenceChip`
  *   - **compact** (AuthExpired / Offline): single-line summary like
- *     "3 agents · all offline".
+ *     "3 agents · all offline"
+ *
+ * Session counts (active / total) used to render here but were dropped
+ * in the minimal-style pass — the per-computer card is a *status*
+ * surface, not an agent detail view. Session info belongs on
+ * `/agent/:id`, which the user reaches from the bound name.
  */
-export function BoundAgentsList({ summary, agentName, compact = false }: BoundAgentsListProps) {
+export function BoundAgentsList({ summary, agentName, compact = false, headerless = false }: BoundAgentsListProps) {
   if (summary.total === 0) {
     return null;
   }
@@ -46,23 +53,18 @@ export function BoundAgentsList({ summary, agentName, compact = false }: BoundAg
   }
 
   return (
-    <>
-      <UppercaseLabel style={{ display: "block", marginBottom: 6 }}>Agents · {summary.total}</UppercaseLabel>
-      <div className="flex flex-col gap-1">
-        {summary.agents.map((a) => (
-          <div key={a.agentId} className="flex items-center gap-2.5 text-body">
-            <span className="font-medium" style={{ minWidth: 140 }}>
-              {agentName(a.agentId)}
-            </span>
-            <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
-            {a.activeSessions !== null && (
-              <span className="mono tnum text-caption" style={{ color: "var(--fg-3)" }}>
-                {a.activeSessions} / {a.totalSessions ?? 0} sessions
-              </span>
-            )}
-          </div>
-        ))}
-      </div>
-    </>
+    <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+      {!headerless && (
+        <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+          {summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}
+        </div>
+      )}
+      {summary.agents.map((a) => (
+        <div key={a.agentId} className="flex items-center text-body" style={{ gap: "var(--sp-2_5)" }}>
+          <span style={{ color: "var(--fg-2)" }}>{agentName(a.agentId)}</span>
+          <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
+        </div>
+      ))}
+    </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
+++ b/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
@@ -74,3 +74,24 @@ function MetaEntry({
     </>
   );
 }
+
+/**
+ * `CardMetaRow` with the hairline-separated bottom-of-card framing used
+ * by AuthExpired / Offline / SetupIncomplete bodies. The diagnostic +
+ * action lives above; this footer slot renders the meta block under a
+ * `border-top` hairline so the eye registers it as supporting context,
+ * not the focus. Extracted to dedupe the 3-way repeat of the same
+ * wrapper pattern (yuezengwu review nit #3 on PR-D1).
+ */
+export function CardMetaFooter({ client, dimmed = true }: { client: HubClient; dimmed?: boolean }) {
+  return (
+    <div
+      style={{
+        borderTop: "var(--hairline) solid var(--border-faint)",
+        paddingTop: "var(--sp-2_5)",
+      }}
+    >
+      <CardMetaRow client={client} dimmed={dimmed} />
+    </div>
+  );
+}

--- a/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
+++ b/packages/web/src/pages/clients/cards/shared/card-meta-row.tsx
@@ -17,42 +17,38 @@ type CardMetaRowProps = {
 };
 
 /**
- * "Heartbeat / first-tree / OS / Agents" 4-field meta row shown at the
- * bottom (or under a divider) of every card. Same data points as the
- * old table's columns, just rearranged for the card form factor.
+ * "Heartbeat / first-tree / OS" meta block. Rendered as a `<dl>` so the
+ * label/value pairing is semantically explicit, with a 2-column grid for
+ * visual alignment. This matches the Settings tab's field-value rhythm
+ * used in /settings/github and /settings/messaging.
  *
- * The labels follow the column-header copy locked in PR-A:
- *   - "Heartbeat" (was "Last seen") — uses `formatRelative` so the
- *     value reads "12 sec ago" / "8 days ago"
- *   - "first-tree" — hub CLI version (NOT a per-provider runtime
- *     version)
+ * Labels follow the copy locked in PR-A:
+ *   - "Heartbeat" — `formatRelative(lastSeenAt)`, e.g. "12 sec ago"
+ *   - "first-tree" — hub CLI version (NOT a per-provider runtime version)
  *   - "OS" — `client.os` raw value
- *
- * Cards are wider than table cells, so the rendering uses a flex row
- * with right-aligned values; on narrow viewports the row wraps cleanly
- * without truncation because each field is bounded.
  */
 export function CardMetaRow({ client, dimmed = false, trailing }: CardMetaRowProps) {
-  const opacity = dimmed ? 0.6 : 1;
+  const opacity = dimmed ? 0.65 : 1;
   return (
-    <div
-      className="flex flex-col"
+    <dl
       style={{
-        gap: "var(--sp-1_5)",
-        fontSize: "var(--text-caption-size)",
-        color: "var(--fg-3)",
+        margin: 0,
+        display: "grid",
+        gridTemplateColumns: "max-content 1fr",
+        columnGap: "var(--sp-4)",
+        rowGap: "var(--sp-1)",
         opacity,
       }}
     >
-      <MetaLine label="Heartbeat" value={formatRelative(client.lastSeenAt)} title={formatDate(client.lastSeenAt)} />
-      <MetaLine label="first-tree" value={client.sdkVersion ?? "—"} mono />
-      <MetaLine label="OS" value={client.os ?? "—"} />
+      <MetaEntry label="Heartbeat" value={formatRelative(client.lastSeenAt)} title={formatDate(client.lastSeenAt)} />
+      <MetaEntry label="first-tree" value={client.sdkVersion ?? "—"} mono />
+      <MetaEntry label="OS" value={client.os ?? "—"} />
       {trailing}
-    </div>
+    </dl>
   );
 }
 
-function MetaLine({
+function MetaEntry({
   label,
   value,
   title,
@@ -64,13 +60,17 @@ function MetaLine({
   mono?: boolean;
 }) {
   return (
-    <div className="flex items-baseline" style={{ gap: "var(--sp-3)" }}>
-      <span className="text-caption" style={{ minWidth: 96, color: "var(--fg-4)" }}>
+    <>
+      <dt className="text-caption" style={{ color: "var(--fg-3)" }}>
         {label}
-      </span>
-      <span className={mono ? "mono text-caption" : "text-caption"} title={title}>
+      </dt>
+      <dd
+        className={mono ? "mono text-caption" : "text-caption"}
+        style={{ margin: 0, color: "var(--fg-2)" }}
+        title={title}
+      >
         {value}
-      </span>
-    </div>
+      </dd>
+    </>
   );
 }

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -31,21 +31,17 @@ export function RuntimeInstallBox({ provider, entry, hostname }: RuntimeInstallB
   const label = PROVIDER_LABEL[provider];
   const { headline, command } = installBoxView(entry, provider, hostname);
 
+  // No outer raised-bg / border / radius — the inner `InlineCommand`'s
+  // sunken pre-block is the only chrome that earns its weight (commands
+  // are a single visual unit the operator scans + copies). Wrapping
+  // again would nest a box inside a box inside the page, which fights
+  // the Settings tab's "flat hairline-only" vocabulary.
   return (
-    <div
-      className="flex flex-col"
-      style={{
-        gap: "var(--sp-2)",
-        padding: "var(--sp-3)",
-        borderRadius: "var(--radius-input)",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border-faint)",
-      }}
-    >
-      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-        <span className="text-body font-medium">{label}</span>
+    <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+      <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+        {label}
       </div>
-      <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+      <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
         {renderHeadlineWithCode(headline)}
       </p>
       <InlineCommand command={command} ariaLabel={`${label} setup command`} />


### PR DESCRIPTION
## Summary

Drops PR-B's raised-bg + shadow + border + radius "real card" chrome and routes Computers cards through the same `<Section>` vocabulary used by `/settings/github`, `/settings/messaging`, and `/settings/onboarding`. Computers tab no longer looks like an outlier when toggling between Settings sub-tabs.

> **Stacked on top of #594 (PR-B)** — base set to `feat/connect-computer-cards`. After PR-B merges, this PR will rebase onto main with no expected conflicts (the diff is purely additive on top of PR-B's card structure).

## Changes

| Surface | Before (PR-B) | After |
|---|---|---|
| Card shell | `<section>` with `bg-raised` + `border` + `radius-panel` + `shadow-sm` | flat `<article>` inside parent `<Section>`, hairline separators between |
| "Your computers" / "Team computers" header | bespoke `CardSection` h2 | shared `<Section>` component |
| Layout | 2-up `auto-fit` grid | single-column stack |
| Heartbeat / first-tree / OS | 3 label-value rows | `<dl>` 2-col grid |
| Section labels | UPPERCASE small caps | sentence-case `text-caption` |
| Agent row | `name · ● Online · 3 / 7 sessions` | `name ● Online` |
| RuntimeInstallBox | nested raised-bg wrapper around InlineCommand | flat label + headline + InlineCommand |
| Owner label | `gandy (you)` | `gandy · you` |

## Visual reference

Static HTML preview in [/tmp/computer-card-preview/index.html](file:///tmp/computer-card-preview/index.html) — three-column side-by-side (Section minimal / card-but-flat / current). This PR ships column A.

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (incl. design-token guardrails)
- [x] `pnpm check` (biome — only pre-existing unrelated warnings)
- [x] `pnpm --filter @first-tree/web test` — 427 tests pass
- [x] `pnpm --filter @first-tree/web build` — production bundle succeeds
- [ ] Manual smoke: switch between `/settings/computers` ↔ `/settings/github` ↔ `/settings/integrations` — verify visual rhythm is the same; no more "real card" outlier on Computers
- [ ] Manual smoke: admin with both own + team rows — "Your computers" cards stack vertically with hairlines; "Team computers" table still legible
- [ ] Manual smoke: Setup-incomplete card — install boxes no longer nest visually inside another box

🤖 Generated with [Claude Code](https://claude.com/claude-code)