### PR TITLE
refactor(needs-attention): narrow mention rule to explicit @<me> (Phase 1)

### DIFF
--- a/docs/development/needs-attention-scoping.20260526.md
+++ b/docs/development/needs-attention-scoping.20260526.md
@@ -1,348 +1,102 @@
-# Needs-Attention Scoping — Technical Design (2026-05-26)
+# Needs-Attention Scoping — Technical Design (2026-05-27 rewrite — Phase 1)
 
-> Status: **draft — pending review by gandy-s-assistant + gandy2025**
+> Status: **Phase 1 — narrow the mention rule to explicit `@<me>`. Independent of NHA.**
 > Author: gandy-developer
-> Scope: chat-granularity attention predicate (no item-level, no inbox, no dismiss/snooze, no schema migration).
+> Supersedes: the original four-rule (R1 mine-failed / R2 mine-pending / R3 speaker-fallback / R4 unread-mention) variant from the 2026-05-26 draft.
 
-## 1. Problem & Locked Rules (recap)
+## 1. Two products, one easily-confused name
 
-The Agent Hub Web me-chat list pins a chat into the "Needs attention" bucket when *any* speaker agent is `failed` or *any* agent has a pending `AskUserQuestion`. There is no "is this related to me?" filter — so a watcher (or even a speaker peer) sees attention pins for other people's broken / waiting agents.
+The chat-list left-rail **"Needs attention"** bucket and the NHA chat-bottom **AttentionCard** primitive are two distinct products that happen to share the word "attention":
 
-Discussion with the user has locked the new predicate:
+| Surface | Granularity | Owns the data | Drives |
+|---|---|---|---|
+| **Left-rail "Needs attention"** (this doc) | **Chat-granularity** — pins entire chats to the top of the list | Chat-level signals: `failedAgentIds`, `messages.metadata.mentions`, `unread_mention_count` | Triage: which chats do I need to look at right now |
+| **Chat-bottom AttentionCard** (NHA) | **Per-record** — one Attention row → one card | `attentions` table (NHA M1) | Structured agent → human Q&A within a chat |
+
+The two are conceptually independent. They may eventually compose (a future R3 can escalate an open NHA Attention into the chat-list bucket), but Phase 1 of this design keeps them strictly separated so the chat-list bucket does not depend on NHA's still-iterating infrastructure.
+
+## 2. Phase 1 predicate
+
+A chat enters the "Needs attention" bucket when **either**:
 
 ```
 chat ∈ Needs Attention ⇔ any of:
-  R1. agent ∈ chat has main = failed       AND  agent.manager = caller_member
-  R2. agent ∈ chat has pending question    AND  agent.manager = caller_member
-  R3. agent ∈ chat has pending question    AND  caller is a human SPEAKER in chat
-  R4. unread_mention_count(chat, caller) > 0
+  R1. agent ∈ chat has main = 'failed'  AND  agent.manager = caller
+  R2. unreadMentionCount > 0  AND  ∃ message ∈ chat
+        with created_at > caller.last_read_at  AND  caller_human_id ∈ message.metadata.mentions
 ```
 
-Boundaries already locked: A (manager wins over watcher/speaker membership for R1+R2), B (R3 fires even for someone else's agent), C (R3 fires for every speaker when there are multiple humans — accepted as noise vs precision tradeoff). No UI toggle.
+Sort ladder inside the bucket: `failed > mention`.
 
-## 2. Current State — Verified
+The `needs_you` middle tier in `ATTENTION_PRIORITY` is intentionally retained as a forward-compatibility slot for Phase 2's R3 (open Attention targeting me). It currently has no predicate branch.
 
-| Concern                                | File                                                                              | Notes                                                                  |
-|----------------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| Backend per-chat status producer       | `packages/server/src/services/agent-chat-status.ts:314-455`                       | `resolveAgentChatStatuses` — viewpoint-agnostic; should stay that way. |
-| Backend per-row projection (caller-scoped) | `packages/server/src/services/me-chat.ts:442-478`                            | `failedAgentIds` is speaker-filtered; `pendingQuestionAgentIds` is NOT. Neither is manager-filtered. |
-| Route handler (knows caller identity)  | `packages/server/src/api/orgs/chats.ts:94`                                        | Already has `scope.memberId` and `scope.humanAgentId`. Passes only the latter.        |
-| Frontend attention predicate           | `packages/web/src/pages/workspace/conversations/group-rows.ts:189-225`            | `splitAttentionRows` consumes `failedAgentIds.length`, `pendingQuestionAgentIds.length`. |
-| Wire schema                            | `packages/shared/src/schemas/me-chat.ts:188-287`                                  | Two zod arrays with `.default([])` for version skew.                   |
-| Agent → manager link                   | `packages/server/src/db/schema/agents.ts:47` (`managerId text NOT NULL`)          | Indexed: `idx_agents_manager`. `managerId` = `members.id` (not `users.id`). |
-| Caller speaker / watcher per chat      | `chat_membership.access_mode` — already selected as `r.access_mode` in the main JOIN | No extra join needed.                                                  |
-| Mention count                          | `chat_user_state.unread_mention_count` — already selected as `r.unread_mention_count` | No extra join needed.                                                  |
-| `pending_questions` schema             | `packages/server/src/db/schema/pending-questions.ts`                              | No addressee field — out of scope for this fix.                        |
+## 3. What changed vs. main (PR #579)
 
-## 3. Design Decisions
+PR #579 (`d8f8bbd1 refactor(me-chat): scope "Needs attention" to caller-relevant chats`, on main today) landed a four-rule predicate. After PR #578 (`aafb2e6d refactor: remove chat-internal ask-user surface (NHA M0 prep)`) removed every production writer to `pending_questions`, two of those four rules (R2 mine-pending, R3 speaker-fallback) became dead code in production — the field always reads empty. The fourth rule (R4 `unreadMentionCount > 0`) over-fired because it rode on the v1 1-on-1 implicit DM auto-mention (`services/message.ts:282 dmAutoProjection`), pinning every DM reply.
 
-### 3.1 Where does the manager filter live?
+Phase 1 collapses to two rules:
 
-`resolveAgentChatStatuses` returns full per-chat status arrays and is shared with `GET /chats/:id/agent-status` (panel view, where every speaker should show regardless of manager). **Keep it viewpoint-agnostic.** The manager filter belongs to the *caller-scoped projection* — i.e. inside `me-chat.ts:listMeChats`.
+| Old | Phase 1 |
+|---|---|
+| R1 mine-failed (manager-narrowed) | **R1** unchanged. |
+| R2 mine-pending (via `pending_questions`) | **Dropped.** Dead source post-#578. |
+| R3 speaker-fallback (any open question + I'm speaker) | **Dropped.** Same dead source. |
+| R4 `unreadMentionCount > 0` (any mention) | **R2** — narrowed to **explicit `@<me>`** via a new `chatHasExplicitMentionToMe` boolean. Closes the user's reported 1v1-DM-plain-final-message false positive. |
 
-### 3.2 Field semantics — narrow the existing fields, add ONE small new field
+`pendingQuestionAgentIds` and `chatHasOpenQuestion` remain on the wire (deprecated, server emits empty/false naturally because their backing data is dormant); the front-end stops consuming them. A follow-up PR drops the fields entirely.
 
-**Narrow** `failedAgentIds` and `pendingQuestionAgentIds` semantics: they become **"agents I manage in this chat that …"**.
-
-**Add** `chatHasOpenQuestion: boolean` — pure raw "ANY agent in this chat has a pending question". Drives R3 alone.
-
-Why narrow vs add a parallel "mine" field?
-
-- The badges on the chat row (`failed` red dot, `needsYou` orange dot — see `chat-row-avatar-preview.tsx:275-276`) **should** also narrow to "mine". Today a watcher sees a red dot for someone else's broken agent — exactly the same badcase pattern. Narrowing the field repairs the badge for free.
-- A parallel `myFailedAgentIds` would double the wire footprint, and we'd have to also decide what `failedAgentIds` is supposed to communicate after the fix. Cleaner to repurpose.
-- `chatHasOpenQuestion` is a single bit, only consulted by R3. The cost is negligible.
-
-Rejected alternatives:
-
-- **Single computed `needsAttention` boolean from server.** Tempting (one bit replaces all the logic), but the front-end still needs the failed-vs-needs-you priority for sort ordering inside the bucket, AND the row badges need to know individually. So the front-end loses fidelity. Skip.
-- **Pass `memberId` to `resolveAgentChatStatuses` and have it filter.** Couples viewpoint to the shared producer; would force `GET /chats/:id/agent-status` to acquire a viewpoint param too. Skip.
-
-### 3.3 Caller-is-speaker check (R3 needs it)
-
-Already available **for free** in the existing per-row data: `r.access_mode` is selected from `cm.access_mode` where `cm.agent_id = humanAgentId`. So:
+## 4. New wire field
 
 ```ts
-const callerIsHumanSpeaker = r.access_mode === "speaker";
+// packages/shared/src/schemas/me-chat.ts
+chatHasExplicitMentionToMe: z.boolean().default(false),
 ```
 
-(Humans never have `access_mode` other than speaker / watcher; no other check needed.)
+True iff there exists a message in the chat with `created_at > caller.last_read_at` AND `metadata.mentions` containing the caller's human-agent UUID.
 
-### 3.4 Mention (R4) — where does the predicate live?
+Derived at query time via a correlated `EXISTS` on `messages`. No schema migration. Uses the existing `idx_messages_chat_time` for the chat+window scan.
 
-`unreadMentionCount` is already on `MeChatRow`. The cleanest place to add R4 is the **frontend** `splitAttentionRows` (same place as R1/R2/R3 consumption), not a new server field. Front-end already reads `r.unreadMentionCount` for the unread bold styling.
+`.default(false)` for version skew; the front-end uses strict `=== true` (the web client doesn't run rows through `meChatRowSchema.parse`, so `.default(false)` only applies server-side).
 
-### 3.5 Attention bucket sort priority (3-tier now)
+## 5. v1 red-dot contract — preserved
 
-Today: `failed` > `needs_you`, delegated to shared `compareMainStatus`.
+`dmAutoProjection` is unchanged. `unread_mention_count` still bumps on every DM and still drives the red dot + bold row title. Only the bucket predicate decouples from the raw counter; the new `chatHasExplicitMentionToMe` is an additional signal on top, not a replacement.
 
-After: `failed` > `needs_you` > `mention`. `compareMainStatus` is keyed on agent main-status enum (failed/needs_you/working/…); `mention` is a chat-level signal that doesn't fit that ladder. Add a local `ATTENTION_PRIORITY` const in `group-rows.ts` rather than overload the shared comparator.
+`direct-chat-auto-mention.test.ts` continues to pass unchanged.
 
-Sort rule: a chat that triggers multiple reasons sorts under its highest-priority reason. A chat that is both failed AND has a mention sorts as failed.
+## 6. User scenarios verified
 
-## 4. Field Changes
+| Scenario | Result |
+|---|---|
+| 1v1, agent → me plain "ack" final message (the original pain point) | counter bumps (red dot stays), `chatHasExplicitMentionToMe=false` → **NOT** in attention |
+| 1v1, agent → me with explicit `@<me>` in the message | counter bumps, `chatHasExplicitMentionToMe=true` → **IN** attention (mention tier) |
+| Group, my managed agent fails in this chat | `failedAgentIds=[mine]` → **IN** attention (failed tier) |
+| Group, peer agent fails in this chat | `failedAgentIds=[]` (manager-narrowed) → **NOT** in attention |
+| Group, any agent `@<me>` in unread | `chatHasExplicitMentionToMe=true` → **IN** attention (mention tier) |
+| Group, any agent `@<peer>` (not me) | `chatHasExplicitMentionToMe=false` → **NOT** in attention |
+| Mark-read | `last_read_at` advances past mentioning message → `chatHasExplicitMentionToMe=false` |
 
-### 4.1 `MeChatRow` (`packages/shared/src/schemas/me-chat.ts`)
+## 7. Phase 2 — open question targeting me, via NHA
 
-```ts
-// SEMANTIC NARROW — no schema shape change.
-failedAgentIds: z.array(z.string()).default([]),
-  // Was: every failed non-human SPEAKER in this chat.
-  // Now: every failed non-human SPEAKER in this chat that the CALLER manages
-  //      (agents.manager_id = caller.member_id).
+When the NHA `attentions` infrastructure stabilises (per @yuezengwu's review note on the closed Phase 0 PR), this design will be extended with:
 
-pendingQuestionAgentIds: z.array(z.string()).default([]),
-  // Was: every non-human agent in this chat with a PENDING AskUserQuestion
-  //      (NOT speaker-filtered — preserved).
-  // Now: every non-human agent in this chat with a PENDING AskUserQuestion
-  //      that the CALLER manages.
-
-// NEW FIELD.
-chatHasOpenQuestion: z.boolean().default(false),
-  // True iff ANY non-human agent in this chat has a PENDING question
-  // (raw, unfiltered). Drives R3 (caller-is-speaker fallback) on the front-end.
-  // .default(false) for version skew: old server → new web reads `false`,
-  // which keeps the conservative R1/R2/R4 behaviour while the deploy progresses.
+```
+  R3. ∃ attention ∈ chat with state = 'open' AND target_human_id = caller
 ```
 
-`busyAgentIds` is **not** narrowed — `busy` is a live-activity indicator, not an attention signal, and a watcher seeing "someone is working" is correct, not noise.
+— served by a new `chatHasOpenAttentionForMe` boolean derived from an `EXISTS` on `attentions`. Rationale: when an agent raises a structured NHA Attention targeting me but does **not** also send a chat message with `@<me>` (the message is optional in NHA's design), the chat needs to bubble up to the left-rail bucket — the chat-bottom AttentionCard alone is not a global enough surface to ensure discovery. This is the **escalation contract** between the two products.
 
-### 4.2 No schema migration
+Phase 2 will land as a separate, smaller PR once NHA is on main. It will reuse the `needs_you` ladder tier already reserved in `ATTENTION_PRIORITY`.
 
-`agents.manager_id` exists and is indexed. `chat_membership.access_mode` exists. `chat_user_state.unread_mention_count` exists. No DB changes.
+## 8. Roll-out
 
-## 5. Backend Implementation Plan
+- **No DB migration.**
+- **Deploy order**: server first (emits new field), then web (consumes it).
+- **Skew direction**: under-pin, never over-pin. New web + old server → `chatHasExplicitMentionToMe` undefined → strict `=== true` returns false → mention rule degrades to off, R1 keeps firing.
+- **Rollback**: pure code revert. No data corruption risk.
 
-### 5.1 Route — `packages/server/src/api/orgs/chats.ts:94`
+## 9. Followups
 
-```diff
-- return listMeChats(app.db, scope.humanAgentId, scope.organizationId, query);
-+ return listMeChats(app.db, scope.humanAgentId, scope.memberId, scope.organizationId, query);
-```
-
-The "Class B → mine-scope" route already builds `scope` via `requireOrgMembership`, which produces both `humanAgentId` and `memberId`.
-
-### 5.2 Service signature
-
-```ts
-export async function listMeChats(
-  db: Database,
-  humanAgentId: string,
-  callerMemberId: string,     // NEW
-  organizationId: string,
-  query: ListMeChatsQuery,
-): Promise<ListMeChatsResponse> { ... }
-```
-
-(Existing tests pass `humanAgentId` and `organizationId` only — they'll need a `callerMemberId` arg too. Helpers already track `admin.memberId`, so the diff is trivial.)
-
-### 5.3 Within `listMeChats` — the projection loop
-
-After the existing participant lookup, but before the per-chat projection (`for (const [chatId, statuses] of statusByChat)`):
-
-```ts
-// Set of agent UUIDs the caller manages — used to narrow failed/pending
-// projections to "mine". One indexed read (`idx_agents_manager`); the
-// chat-list is necessarily org-scoped so we add organization_id for
-// belt-and-braces. Caller's own human agent has manager_id = caller's
-// own member_id (Phase 2 of agent-naming refactor), so the set is
-// self-inclusive — harmless because human agents never produce
-// pending questions or failed sessions.
-const managedRows = await db
-  .select({ uuid: agents.uuid })
-  .from(agents)
-  .where(and(eq(agents.managerId, callerMemberId), eq(agents.organizationId, organizationId)));
-const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
-```
-
-Inside the existing projection loop, refine the field builders:
-
-```ts
-const failed: string[] = [];
-const pending: string[] = [];
-const busy: string[] = [];
-let chatHasOpenQuestion = false;
-for (const s of statuses) {
-  const isSpeaker = speakers?.has(s.agentId) ?? false;
-  const isMine = managedAgentIds.has(s.agentId);
-  // live-dot / busy — unchanged semantics
-  if (isSpeaker && s.activity) { /* ... */ }
-  if (isSpeaker && s.working) busy.push(s.agentId);
-  // failed — speaker-filtered AND narrowed to mine (R1).
-  if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
-  // pending — NOT speaker-filtered (matches existing behaviour for a
-  // pending agent that has since left). NARROWED to mine (R2).
-  if (s.needsYou && isMine) pending.push(s.agentId);
-  // chatHasOpenQuestion — raw bit feeding R3 on the front-end. Computed
-  // over the same union (non-human speakers + non-human pending) that
-  // resolveAgentChatStatuses returns, so a pending agent that has left
-  // still flips this true (parity with the current `pending` field).
-  if (s.needsYou) chatHasOpenQuestion = true;
-}
-```
-
-Wire the new boolean into the row:
-
-```ts
-return {
-  ...,
-  pendingQuestionAgentIds: pendingByChat.get(r.chat_id) ?? [],
-  failedAgentIds: failedByChat.get(r.chat_id) ?? [],
-  busyAgentIds: busyByChat.get(r.chat_id) ?? [],
-  chatHasOpenQuestion: hasOpenQuestionByChat.get(r.chat_id) ?? false,
-};
-```
-
-(One new `Map<string, boolean>` alongside the three existing maps.)
-
-### 5.4 SQL impact
-
-| Query                              | Before        | After       | Notes                                       |
-|------------------------------------|---------------|-------------|---------------------------------------------|
-| main `chats` JOIN                  | unchanged     | unchanged   | No new joins / filters.                     |
-| `participantRows` lookup           | unchanged     | unchanged   |                                             |
-| `resolveAgentChatStatuses` reads   | unchanged     | unchanged   | Viewpoint-agnostic by design.               |
-| **NEW** `managedAgentIds` lookup   | n/a           | 1 indexed scan on `idx_agents_manager`. Bounded by caller's managed-agent count (typically <50). One round-trip. |
-
-Negligible. The managed-agents set is a per-request constant; it's cheaper than the participants lookup that already happens.
-
-## 6. Frontend Implementation Plan
-
-`packages/web/src/pages/workspace/conversations/group-rows.ts:189-225`:
-
-```ts
-const ATTENTION_PRIORITY = ["failed", "needs_you", "mention"] as const;
-type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
-
-function rowAttentionReason(r: MeChatRow): AttentionReason | null {
-  // R1 — mine failed in chat.
-  if (r.failedAgentIds.length > 0) return "failed";
-  // R2 — mine pending in chat.   OR
-  // R3 — any pending in chat, AND I'm a speaker.
-  if (
-    r.pendingQuestionAgentIds.length > 0 ||
-    (r.chatHasOpenQuestion && r.membershipKind === "participant")
-  ) {
-    return "needs_you";
-  }
-  // R4 — unread @-mention.
-  if (r.unreadMentionCount > 0) return "mention";
-  return null;
-}
-
-export function rowIsFailed(r: MeChatRow): boolean {
-  return rowAttentionReason(r) === "failed";
-}
-export function rowNeedsYou(r: MeChatRow): boolean {
-  return rowAttentionReason(r) === "needs_you";
-}
-// (Optional, only if any caller needs it — current consumers don't.)
-// export function rowIsMention(r: MeChatRow): boolean { ... }
-
-export function splitAttentionRows(rows: ReadonlyArray<MeChatRow>): {
-  attention: MeChatRow[];
-  rest: MeChatRow[];
-} {
-  const attention: MeChatRow[] = [];
-  const rest: MeChatRow[] = [];
-  for (const r of rows) {
-    if (rowAttentionReason(r) !== null) attention.push(r);
-    else rest.push(r);
-  }
-  attention.sort((a, b) => {
-    const ra = rowAttentionReason(a);
-    const rb = rowAttentionReason(b);
-    // Both are non-null inside this bucket; non-null assert via index.
-    return ATTENTION_PRIORITY.indexOf(ra!) - ATTENTION_PRIORITY.indexOf(rb!);
-  });
-  return { attention, rest };
-}
-```
-
-Side effects on existing consumers:
-
-- `chat-row-avatar-preview.tsx:275-276` (`needsYou={row.pendingQuestionAgentIds.length > 0}` / `failed={row.failedAgentIds.length > 0}`) — these badges **narrow** to "mine". This is **intentional and desired** (manager-noise reduction also for the indicator dots, not just the bucket). Confirmed by the design discussion — a watcher seeing a red `!` on someone else's broken agent is the same badcase pattern.
-- `conversations/index.tsx:633-634` — same.
-
-**Bucket vs. badge — important asymmetry:** R3 (peer's agent asking in a chat where I'm a speaker) ENTERS the bucket but does NOT light the `rowNeedsYou` badge. The badge stays specific to R2 ("an agent I manage is waiting on me"). Rationale: `pendingQuestionAgentIds` is now server-narrowed to caller-managed; lighting the orange `?` for a row where the caller manages nothing would contradict the field's wire semantics. The bucket position alone signals R3-only rows; the row's last-message preview surfaces the actual question. The exported `rowAttentionReason(r)` returns the bucket tier (so any future consumer can branch on it without re-deriving) while `rowNeedsYou` stays a badge predicate.
-
-`compareMainStatus` is **not** touched (it's the shared agent-status ladder; mention isn't an agent status).
-
-## 7. Test Matrix
-
-### 7.1 Frontend unit — `packages/web/src/pages/workspace/__tests__/group-rows.test.ts`
-
-Append a new `describe("splitAttentionRows — predicate")` block. Each case is a single fixture row with the boolean fields set; assert `rowAttentionReason` / bucket membership / ordering.
-
-| # | Setup                                                                                          | Expected                                |
-|---|------------------------------------------------------------------------------------------------|-----------------------------------------|
-| 1 | `failedAgentIds: ["mine"]`                                                                     | attention; reason=failed                |
-| 2 | `pendingQuestionAgentIds: ["mine"]`                                                            | attention; reason=needs_you             |
-| 3 | `chatHasOpenQuestion: true, membershipKind: "participant"`, mine empty                         | attention; reason=needs_you (R3 path)   |
-| 4 | `chatHasOpenQuestion: true, membershipKind: "watching"`, mine empty                            | NOT attention (watcher → R3 not fired)  |
-| 5 | `unreadMentionCount: 3`, all else empty                                                        | attention; reason=mention               |
-| 6 | All empty / zero                                                                               | NOT attention                           |
-| 7 | `failedAgentIds:["x"]` + `unreadMentionCount: 1`                                               | attention; reason=failed (priority wins)|
-| 8 | `pendingQuestionAgentIds:["x"]` + `chatHasOpenQuestion: true, membershipKind: participant`     | attention; reason=needs_you (R2 wins over R3, but both produce needs_you; just don't double-count) |
-| 9 | Three rows: f, n, m; assert ordered `[f, n, m]` after `splitAttentionRows`                     | sort order honors `ATTENTION_PRIORITY`  |
-| 10| `chatHasOpenQuestion: false`, `membershipKind: "participant"`, `pendingQuestionAgentIds: []`   | NOT attention (no question anywhere)    |
-| 11| Stable sort within tier: two `failed` rows in input order → preserved in output                | failed-tier order preserved             |
-
-Boundary mapping (from the discussion):
-- Boundary A: case 1 with `membershipKind: "watching"` and `failedAgentIds: ["mine"]` → still attention (manager wins over watcher).
-- Boundary B: case 3 (1:1 chat shape) and case 4 (watcher) — covered above.
-- Boundary C: a single row with `chatHasOpenQuestion: true, membershipKind: "participant"` is enough; the "multiple speakers" replication is a fan-out of the same single-row rule.
-
-### 7.2 Backend integration — new file `packages/server/src/__tests__/me-chat-attention.test.ts`
-
-Patterns adapted from `me-chat-activity.test.ts` (uses `createTestAdmin` / `createTestAgent`). `createTestAgent` creates an admin behind the scenes and sets `managerId = that admin's memberId` — meaning we can simulate "someone else's agent" by calling `createTestAgent(app, ...)` instead of `createTestAgent(app, { ... })` from the current admin's perspective.
-
-Test cases:
-
-| # | Scenario                                                                                                  | Expected projection           |
-|---|-----------------------------------------------------------------------------------------------------------|-------------------------------|
-| B1 | Caller manages agent A; A is in a chat with caller, A `errored` via session.                              | `failedAgentIds == ["A"]`     |
-| B2 | Someone else manages agent X; caller is **speaker** in the chat with X; X `errored`.                      | `failedAgentIds == []`        |
-| B3 | Someone else manages agent X; caller is **watcher**; X `errored`.                                         | `failedAgentIds == []`        |
-| B4 | Caller manages A; caller is **watcher** of the chat; A `errored`.                                         | `failedAgentIds == ["A"]` (boundary A) |
-| B5 | Caller manages A; A has pending question; caller is speaker.                                              | `pendingQuestionAgentIds == ["A"]`, `chatHasOpenQuestion == true` |
-| B6 | Someone else manages X; X has pending question; caller is **speaker**.                                    | `pendingQuestionAgentIds == []`, `chatHasOpenQuestion == true` (R3 raw bit) |
-| B7 | Someone else manages X; X has pending question; caller is **watcher**.                                    | `pendingQuestionAgentIds == []`, `chatHasOpenQuestion == true` (frontend filters R3) |
-| B8 | No agents failed / no pending; caller has a chat with non-zero `unread_mention_count`.                    | All three new fields empty/false (mention is frontend-only). |
-| B9 | Multi-chat list: B1 + B2 + B5 + B6 returned in one `listMeChats` call.                                    | Each row independent — no cross-contamination. |
-| B10| Caller is in chat with their own human agent only (no others).                                            | All fields empty/false (no false positive from self). |
-
-### 7.3 Existing regressions to keep green
-
-- `me-chat-activity.test.ts` — `liveActivity` is unaffected (busyAgentIds / live dot unchanged).
-- `me-chat-source-tags.test.ts` — source counts unaffected.
-- `cross-org-chat-pollution.test.ts` — org scoping unaffected.
-- `direct-chat-auto-mention.test.ts` — mention logic unaffected.
-- `me-chat-service.test.ts` — basic CRUD unaffected; signature change requires passing the new `callerMemberId` arg (small diff).
-
-### 7.4 Static / lint
-
-`pnpm check && pnpm typecheck` from the repo root. The narrowed semantics are documented in the zod schema comments — no signature changes user-visible on the wire.
-
-## 8. Rollout / Version Skew
-
-- `chatHasOpenQuestion` defaults to `false` in the zod schema → old server + new web reads `false` → R3 silently degrades to "off". R1, R2, R4 still fire correctly. Acceptable transient (the only case it affects is "I'm in chat with someone else's agent that asked a question").
-- Field semantic narrow on `failedAgentIds` / `pendingQuestionAgentIds` is the BADCASE fix itself — new web + old server would still over-pin (because the old server still returns un-narrowed sets), which is the same buggy behaviour we have today. Acceptable since the web rolls before the server in this codebase.
-- No DB migration → instant rollback safe.
-
-## 9. Out of Scope (explicitly)
-
-- `pending_questions.addressee_user_id` — would refine R3 from "any speaker" to "the actual addressee". Deferred (would require schema migration + SDK contract change). The current R3 noise (multi-speaker group chats) is accepted per boundary C.
-- Per-user `dismiss` / `snooze` state. Item-level inbox view. Cross-surface unification (GitHub, Adapter). Per the Aha conversation, these are M2-M5; this PR is M1.
-- "Show all" UI toggle (declined by user).
-- Treating mention as a distinct on-row badge (today it already drives the unread bold styling — bucket inclusion is enough).
-
-## 10. Questions for Reviewer
-
-1. **Field semantic narrow vs adding `myFailedAgentIds` / `myPendingQuestionAgentIds`** — design picks narrow (rationale §3.2). If reviewer prefers parallel "mine" fields (keeping the existing fields raw for some panel UI we don't yet have), say so before implementation.
-2. **Mention as 3rd attention tier** — design adds `mention` to `ATTENTION_PRIORITY`. If you'd rather mention NOT sort *inside* the attention bucket (e.g. mention rows stay in their normal recency / source bucket but get a different visual cue), say so — that's a smaller frontend-only change but a different product feel.
-3. **`busyAgentIds`** — design keeps it un-narrowed (a watcher seeing "someone is working" is informational, not attention). Confirm.
-4. **Doc location** — placed under `docs/development/` to fit existing repo layout. If a `proposals/` directory is preferred (matches in-repo code-comment references like `proposals/chat-data-model-restructure.20260512.md` — those resolve in a sibling first-tree-context repo, not here), I'll move it.
-
----
-
-On approval I'll convert this into a step-by-step implementation plan (`docs/superpowers/plans/2026-05-26-needs-attention-scoping.md`) following the `writing-plans` skill format, then execute.
+1. Drop the deprecated `pendingQuestionAgentIds` / `chatHasOpenQuestion` wire fields after one release.
+2. Phase 2: add `chatHasOpenAttentionForMe` once NHA `attentions` lands on main.
+3. Possibly extend R2 to cover "human watcher explicitly `@`-mentioned" — currently the watcher's `unread_mention_count` doesn't bump under `applyAfterFanOut`'s speaker branch, so a `@<human-watcher>` in a group doesn't pin. Tracked separately.

--- a/packages/server/src/__tests__/me-chat-attention.test.ts
+++ b/packages/server/src/__tests__/me-chat-attention.test.ts
@@ -1,42 +1,36 @@
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { createMeChat, listMeChats } from "../services/me-chat.js";
+import { createMeChat, listMeChats, markMeChatRead } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
- * Chat-granularity "Needs attention" scoping — server projection.
+ * Chat-granularity "Needs attention" scoping — Phase 1 (two-rule predicate).
  *
- * The chat-list pinning rule has four parts; the server is responsible for
- * R1 (mine-failed), R2 (mine-pending), and the raw R3 bit
- * (`chatHasOpenQuestion`). R4 (unread mention) and the R3 speaker check both
- * live on the front-end — see `packages/web/.../group-rows.ts`.
+ * R1. agent ∈ chat has main = 'failed'  AND  agent.manager = caller_member
+ * R2. unreadMentionCount > 0  AND  ∃ message in unread window with
+ *     caller_human_id ∈ message.metadata.mentions
  *
- * Matrix:
- *   B1  mine failed, caller is speaker          → failedAgentIds = [mine]
- *   B2  theirs failed, caller is speaker        → failedAgentIds = []
- *   B3  theirs failed, caller is watcher        → failedAgentIds = []
- *   B4  mine failed, caller is watcher          → failedAgentIds = [mine]   (boundary A)
- *   B5  mine pending question                    → pending = [mine], chatHasOpenQuestion = true
- *   B6  theirs pending, caller is speaker        → pending = [], chatHasOpenQuestion = true
- *   B7  theirs pending, caller is watcher        → pending = [], chatHasOpenQuestion = true
- *   B8  nothing pending / failed                → all new fields empty/false
- *   B9  multi-chat list mixing B1 + B2          → projections per-row independent
- *   B10 chat with only my own human + a peer     → no false positives on quiet
+ * The legacy R2 (mine-pending) and R3 (speaker-fallback chatHasOpenQuestion)
+ * served by `pending_questions` were dropped in Phase 1 — the table has had
+ * no production writer since PR #578 (NHA M0 prep), so the rules never fired
+ * anyway. The legacy R4 (`unreadMentionCount > 0` unfiltered) is narrowed to
+ * the new explicit-mention bool — closes the 1v1-DM-plain-final-message
+ * false positive.
  *
- * See docs/development/needs-attention-scoping.20260526.md.
+ * The wire keeps `pendingQuestionAgentIds: []` and `chatHasOpenQuestion: false`
+ * for backward compat (front-end no longer reads them). Follow-up PR drops.
+ *
+ * This file pins the SERVER projection for R1 (unchanged from PR #579) plus
+ * the new `chatHasExplicitMentionToMe` boolean.
  */
-describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () => {
+describe("listMeChats: Phase 1 needs-attention scoping", () => {
   const getApp = useTestApp();
 
-  // Make an agent reachable by mirroring its `agents.client_id` into
-  // `agent_presence`. `deriveMainStatus` returns "offline" when
-  // `reachable=false`, gating ALL other states — so without a presence row,
-  // `markErrored` alone would promote main to "offline" instead of "failed"
-  // and the projection would emit `[]` even for mine-failed (false-pass).
-  //
-  // Reuses the client the agent is already pinned to (seeded by
-  // `createTestAgent`) instead of allocating a parallel client row — keeps
-  // the FK chain consistent with how the real runtime binds presence.
+  // Make an agent reachable by mirroring `agents.client_id` into `agent_presence`.
+  // `deriveMainStatus` returns "offline" when `reachable=false`, gating ALL
+  // other states — so without a presence row, `markErrored` alone would
+  // promote main to "offline" instead of "failed".
   async function makeReachable(agentId: string): Promise<void> {
     const app = getApp();
     const [row] = await app.db.execute<{ client_id: string | null }>(sql`
@@ -55,10 +49,9 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     `);
   }
 
-  // Mark an `(agent,chat)` pair as failed by writing an `agent_chat_sessions`
-  // row with `state='errored'`. `computeErrored` in `agent-chat-status.ts`
-  // promotes this into `errored=true`, and `deriveMainStatus` promotes that
-  // (gated on `reachable`) into `main === "failed"`. Pair with `makeReachable`.
+  // Mark an `(agent, chat)` pair as failed via `agent_chat_sessions.state='errored'`
+  // + `runtime_state='error'`. Pair with `makeReachable` so the composite
+  // promotes to `main = 'failed'`.
   async function markErrored(agentId: string, chatId: string): Promise<void> {
     const app = getApp();
     await app.db.execute(sql`
@@ -72,29 +65,16 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     await makeReachable(agentId);
   }
 
-  // Seed a pending AskUserQuestion row for the given agent in the chat.
-  async function markPending(agentId: string, chatId: string): Promise<void> {
-    const app = getApp();
-    await app.db.execute(sql`
-      INSERT INTO pending_questions (id, agent_id, chat_id, message_id, status, created_at)
-      VALUES (${crypto.randomUUID()}, ${agentId}, ${chatId}, ${crypto.randomUUID()}, 'pending', NOW())
-    `);
-  }
-
-  // `createTestAgent` always creates an internal admin and binds the agent's
-  // managerId to that admin's memberId. Re-anchor to a chosen memberId via a
-  // direct UPDATE — `agents.manager_id` is plain text with no FK / trigger,
-  // and re-targeting it is exactly what a future "transfer manager" admin
+  // `createTestAgent` binds the agent's `managerId` to the seeding admin's
+  // memberId. Re-anchor by direct UPDATE — `agents.manager_id` is plain text
+  // with no FK/trigger, exactly what a future "transfer manager" admin
   // action would do.
   async function setManager(agentId: string, memberId: string): Promise<void> {
     const app = getApp();
     await app.db.execute(sql`UPDATE agents SET manager_id = ${memberId} WHERE uuid = ${agentId}`);
   }
 
-  // Add the caller's human agent as a *watcher* of a chat that someone else
-  // created. The chat membership table has no FK / trigger; an INSERT with
-  // `access_mode='watcher'` is sufficient to flip the row's
-  // `membershipKind` to "watching" in the listMeChats projection.
+  // Add the caller's human agent as a *watcher* of a chat someone else created.
   async function addAsWatcher(chatId: string, humanAgentUuid: string): Promise<void> {
     const app = getApp();
     await app.db.execute(sql`
@@ -114,10 +94,14 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     return rows.find((r) => r.chatId === chatId) ?? null;
   }
 
-  it("B1: my failed agent, caller is speaker → failedAgentIds = [mine]", async () => {
+  // ---------------------------------------------------------------------------
+  // R1 — my failed agent (manager-narrowed). Same as PR #579 B1-B4.
+  // ---------------------------------------------------------------------------
+
+  it("R1.a: my failed agent, caller is speaker → failedAgentIds = [mine]", async () => {
     const app = getApp();
     const me = await createTestAdmin(app);
-    const mine = await createTestAgent(app, { name: `b1-${crypto.randomUUID().slice(0, 6)}` });
+    const mine = await createTestAgent(app, { name: `r1a-${crypto.randomUUID().slice(0, 6)}` });
     await setManager(mine.agent.uuid, me.memberId);
     const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
       participantIds: [mine.agent.uuid],
@@ -127,13 +111,12 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
   });
 
-  it("B2: peer's failed agent, caller is speaker → failedAgentIds = []", async () => {
+  it("R1.b: peer's failed agent, caller is speaker → failedAgentIds = [] (manager-narrowed)", async () => {
     const app = getApp();
     const me = await createTestAdmin(app);
     const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    const theirs = await createTestAgent(app, { name: `b2-${crypto.randomUUID().slice(0, 6)}` });
+    const theirs = await createTestAgent(app, { name: `r1b-${crypto.randomUUID().slice(0, 6)}` });
     await setManager(theirs.agent.uuid, them.memberId);
-    // `me` creates the chat so `me` is the speaker.
     const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
       participantIds: [theirs.agent.uuid],
     });
@@ -142,29 +125,12 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     expect(row?.failedAgentIds).toEqual([]);
   });
 
-  it("B3: peer's failed agent, caller is watcher → failedAgentIds = []", async () => {
+  it("R1.c: my failed agent, caller is watcher → failedAgentIds = [mine] (boundary A)", async () => {
     const app = getApp();
     const me = await createTestAdmin(app);
     const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    const theirs = await createTestAgent(app, { name: `b3-${crypto.randomUUID().slice(0, 6)}` });
-    await setManager(theirs.agent.uuid, them.memberId);
-    // `them` creates the chat; `me` watches.
-    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
-      participantIds: [theirs.agent.uuid],
-    });
-    await addAsWatcher(chatId, me.humanAgentUuid);
-    await markErrored(theirs.agent.uuid, chatId);
-    const row = await rowFor(chatId, me);
-    expect(row?.failedAgentIds).toEqual([]);
-  });
-
-  it("B4: my failed agent, caller is watcher → failedAgentIds = [mine] (boundary A)", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    const mine = await createTestAgent(app, { name: `b4-${crypto.randomUUID().slice(0, 6)}` });
+    const mine = await createTestAgent(app, { name: `r1c-${crypto.randomUUID().slice(0, 6)}` });
     await setManager(mine.agent.uuid, me.memberId);
-    // `them` creates the chat; `me` watches.
     const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
       participantIds: [mine.agent.uuid],
     });
@@ -174,103 +140,122 @@ describe("listMeChats: needs-attention scoping (R1-R3 backend projection)", () =
     expect(row?.failedAgentIds).toEqual([mine.agent.uuid]);
   });
 
-  it("B5: my pending question → pending = [mine] AND chatHasOpenQuestion = true", async () => {
+  // ---------------------------------------------------------------------------
+  // R2 — explicit @me in unread window
+  // ---------------------------------------------------------------------------
+
+  it("R2.a (痛点 t7): 1v1 agent → human plain final message → chatHasExplicitMentionToMe = false", async () => {
+    // The v1 1-on-1 auto-mention still bumps `unread_mention_count` (red
+    // dot stays correct), but `metadata.mentions` is empty, so
+    // `chatHasExplicitMentionToMe` is false → the chat does NOT pin into
+    // Needs attention. This is the original user-reported false positive.
     const app = getApp();
     const me = await createTestAdmin(app);
-    const mine = await createTestAgent(app, { name: `b5-${crypto.randomUUID().slice(0, 6)}` });
+    const peer = await createTestAgent(app, { name: `r2a-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "ack",
+    });
+    const row = await rowFor(chatId, me);
+    // v1 red-dot contract preserved.
+    expect(row?.unreadMentionCount).toBeGreaterThanOrEqual(1);
+    // R2 not fired — chat must not pin.
+    expect(row?.chatHasExplicitMentionToMe).toBe(false);
+  });
+
+  it("R2.b: 1v1 agent → human with explicit @<me> → chatHasExplicitMentionToMe = true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `r2b-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "fyi look at this",
+      metadata: { mentions: [me.humanAgentUuid] },
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.chatHasExplicitMentionToMe).toBe(true);
+  });
+
+  it("R2.c: group, explicit @<me> by any agent → chatHasExplicitMentionToMe = true", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peerA = await createTestAgent(app, { name: `r2c-a-${crypto.randomUUID().slice(0, 6)}` });
+    const peerB = await createTestAgent(app, { name: `r2c-b-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peerA.agent.uuid, peerB.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "hey check this",
+      metadata: { mentions: [me.humanAgentUuid] },
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.chatHasExplicitMentionToMe).toBe(true);
+  });
+
+  it("R2.d: group, explicit @ <someone else> (not me) → chatHasExplicitMentionToMe = false", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peerA = await createTestAgent(app, { name: `r2d-a-${crypto.randomUUID().slice(0, 6)}` });
+    const peerB = await createTestAgent(app, { name: `r2d-b-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peerA.agent.uuid, peerB.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "hey B",
+      metadata: { mentions: [peerB.agent.uuid] },
+    });
+    const row = await rowFor(chatId, me);
+    expect(row?.chatHasExplicitMentionToMe).toBe(false);
+  });
+
+  it("R2.e: mark-read advances last_read_at → chatHasExplicitMentionToMe flips back to false", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `r2e-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "look",
+      metadata: { mentions: [me.humanAgentUuid] },
+    });
+    const before = await rowFor(chatId, me);
+    expect(before?.chatHasExplicitMentionToMe).toBe(true);
+    await markMeChatRead(app.db, chatId, me.humanAgentUuid);
+    const after = await rowFor(chatId, me);
+    expect(after?.chatHasExplicitMentionToMe).toBe(false);
+    expect(after?.unreadMentionCount).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Deprecation guards — wire fields kept emitting empty / false
+  // ---------------------------------------------------------------------------
+
+  it("deprecation: pendingQuestionAgentIds emits [] (dormant source post-#578)", async () => {
+    const app = getApp();
+    const me = await createTestAdmin(app);
+    const mine = await createTestAgent(app, { name: `dep-${crypto.randomUUID().slice(0, 6)}` });
     await setManager(mine.agent.uuid, me.memberId);
     const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
       participantIds: [mine.agent.uuid],
     });
-    await markPending(mine.agent.uuid, chatId);
     const row = await rowFor(chatId, me);
-    expect(row?.pendingQuestionAgentIds).toEqual([mine.agent.uuid]);
-    expect(row?.chatHasOpenQuestion).toBe(true);
-  });
-
-  it("B6: peer's pending question, caller is speaker → pending = [] AND chatHasOpenQuestion = true", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    const theirs = await createTestAgent(app, { name: `b6-${crypto.randomUUID().slice(0, 6)}` });
-    await setManager(theirs.agent.uuid, them.memberId);
-    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
-      participantIds: [theirs.agent.uuid],
-    });
-    await markPending(theirs.agent.uuid, chatId);
-    const row = await rowFor(chatId, me);
-    expect(row?.pendingQuestionAgentIds).toEqual([]);
-    expect(row?.chatHasOpenQuestion).toBe(true);
-  });
-
-  it("B7: peer's pending question, caller is watcher → pending = [] AND chatHasOpenQuestion = true", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    const theirs = await createTestAgent(app, { name: `b7-${crypto.randomUUID().slice(0, 6)}` });
-    await setManager(theirs.agent.uuid, them.memberId);
-    const { chatId } = await createMeChat(app.db, them.humanAgentUuid, them.organizationId, {
-      participantIds: [theirs.agent.uuid],
-    });
-    await addAsWatcher(chatId, me.humanAgentUuid);
-    await markPending(theirs.agent.uuid, chatId);
-    const row = await rowFor(chatId, me);
-    expect(row?.pendingQuestionAgentIds).toEqual([]);
-    expect(row?.chatHasOpenQuestion).toBe(true);
-  });
-
-  it("B8: nothing failed / no pending → all attention fields empty / false", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const peer = await createTestAgent(app, { name: `b8-${crypto.randomUUID().slice(0, 6)}` });
-    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
-      participantIds: [peer.agent.uuid],
-    });
-    const row = await rowFor(chatId, me);
-    expect(row?.failedAgentIds).toEqual([]);
-    expect(row?.pendingQuestionAgentIds).toEqual([]);
-    expect(row?.chatHasOpenQuestion).toBe(false);
-  });
-
-  it("B9: multi-chat list — mine-failed + peer-failed are projected independently per row", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const them = await createTestAdmin(app, { username: `peer-${crypto.randomUUID().slice(0, 8)}` });
-    // Chat A — my failed agent.
-    const mineFailed = await createTestAgent(app, { name: `b9-mf-${crypto.randomUUID().slice(0, 6)}` });
-    await setManager(mineFailed.agent.uuid, me.memberId);
-    const { chatId: chatA } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
-      participantIds: [mineFailed.agent.uuid],
-    });
-    await markErrored(mineFailed.agent.uuid, chatA);
-    // Chat B — their failed agent (me as speaker).
-    const theirsFailed = await createTestAgent(app, { name: `b9-tf-${crypto.randomUUID().slice(0, 6)}` });
-    await setManager(theirsFailed.agent.uuid, them.memberId);
-    const { chatId: chatB } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
-      participantIds: [theirsFailed.agent.uuid],
-    });
-    await markErrored(theirsFailed.agent.uuid, chatB);
-
-    const { rows } = await listMeChats(app.db, me.humanAgentUuid, me.memberId, me.organizationId, {
-      limit: 50,
-      filter: "all",
-      engagement: "all",
-    });
-    const rowA = rows.find((r) => r.chatId === chatA);
-    const rowB = rows.find((r) => r.chatId === chatB);
-    expect(rowA?.failedAgentIds).toEqual([mineFailed.agent.uuid]);
-    expect(rowB?.failedAgentIds).toEqual([]);
-  });
-
-  it("B10: chat with only a quiet peer agent → no false positives", async () => {
-    const app = getApp();
-    const me = await createTestAdmin(app);
-    const peer = await createTestAgent(app, { name: `b10-${crypto.randomUUID().slice(0, 6)}` });
-    const { chatId } = await createMeChat(app.db, me.humanAgentUuid, me.organizationId, {
-      participantIds: [peer.agent.uuid],
-    });
-    const row = await rowFor(chatId, me);
-    expect(row?.failedAgentIds).toEqual([]);
+    // pending_questions has no production writer; the field still ships
+    // on the wire but always reads empty.
     expect(row?.pendingQuestionAgentIds).toEqual([]);
     expect(row?.chatHasOpenQuestion).toBe(false);
   });

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -325,6 +325,15 @@ export async function listMeChats(
   // postgres-js returns timestamptz as ISO strings when bound through
   // a raw sql template; coerce below so the response uses ISO
   // strings consistently.
+  //
+  // The `chat_has_explicit_mention_to_me` correlated subquery scans the
+  // caller's unread window (`m.created_at > last_read_at`) for any message
+  // whose `metadata.mentions` JSONB array contains the caller's
+  // human-agent uuid. Distinguishes explicit `@<me>` from the v1 1-on-1
+  // implicit DM auto-mention (services/message.ts:282 `dmAutoProjection`),
+  // which bumps `unread_mention_count` for the red dot but never writes
+  // the recipient into `metadata.mentions`. Uses the existing
+  // `idx_messages_chat_time` for the chat+window scan.
   const rawRows = (await db.execute(sql`
     SELECT
       c.id                  AS chat_id,
@@ -339,7 +348,13 @@ export async function listMeChats(
       COALESCE(cus.unread_mention_count, 0) AS unread_mention_count,
       COALESCE(cus.engagement_status, ${ACTIVE}) AS engagement_status,
       ${chatSourceSqlExpression} AS source,
-      c.metadata->>'entityType' AS entity_type
+      c.metadata->>'entityType' AS entity_type,
+      EXISTS (
+        SELECT 1 FROM messages m
+         WHERE m.chat_id = c.id
+           AND m.created_at > COALESCE(cus.last_read_at, '-infinity'::timestamptz)
+           AND m.metadata -> 'mentions' @> jsonb_build_array(${humanAgentId}::text)
+      ) AS chat_has_explicit_mention_to_me
       FROM chats c
       JOIN chat_membership cm
         ON cm.chat_id = c.id AND cm.agent_id = ${humanAgentId}
@@ -373,6 +388,7 @@ export async function listMeChats(
     engagement_status: ChatEngagementStatus;
     source: ChatSource;
     entity_type: string | null;
+    chat_has_explicit_mention_to_me: boolean;
   }>;
 
   const toDate = (v: Date | string | null): Date | null => {
@@ -576,6 +592,7 @@ export async function listMeChats(
       failedAgentIds: failedByChat.get(r.chat_id) ?? [],
       busyAgentIds: busyByChat.get(r.chat_id) ?? [],
       chatHasOpenQuestion: hasOpenQuestionByChat.get(r.chat_id) ?? false,
+      chatHasExplicitMentionToMe: r.chat_has_explicit_mention_to_me,
     };
   });
 

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -303,6 +303,33 @@ export const meChatRowSchema = z.object({
    * See docs/development/needs-attention-scoping.20260526.md §4 / §5.
    */
   chatHasOpenQuestion: z.boolean().default(false),
+  /**
+   * True iff there exists at least one unread message in this chat whose
+   * `messages.metadata.mentions` array explicitly contains the caller's
+   * human-agent UUID. Drives the chat-list "Needs attention" mention rule on
+   * the front-end after the explicit-mention narrowing (Phase 1 of the
+   * three-rule simplification).
+   *
+   * Distinguishes explicit `@<me>` from the v1 1-on-1 implicit DM
+   * auto-mention (`services/message.ts:282 dmAutoProjection`): the latter
+   * still bumps `unreadMentionCount` for the red dot but never writes the
+   * recipient into `metadata.mentions`, so a 1-on-1 agent → human plain
+   * final message correctly leaves `chatHasExplicitMentionToMe = false` and
+   * stops pinning the chat into Needs attention.
+   *
+   * Unread window = `(cus.last_read_at, NOW()]`; NULL `last_read_at` means
+   * "never read", treated as "every message counts".
+   *
+   * Derived at query time via a correlated `EXISTS` on `messages`. No schema
+   * migration. `.default(false)` for version skew: an older server build
+   * that predates this field would otherwise produce `undefined`, which —
+   * combined with the strict `=== true` check in the front-end predicate
+   * (`group-rows.ts`) — silently disables the explicit-mention rule on the
+   * new web during a web-ahead-of-server rollout. R1 (failed) keeps firing.
+   *
+   * See docs/development/needs-attention-scoping.20260526.md.
+   */
+  chatHasExplicitMentionToMe: z.boolean().default(false),
 });
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -40,6 +40,7 @@ function row(overrides: Partial<MeChatRow>): MeChatRow {
     failedAgentIds: overrides.failedAgentIds ?? [],
     busyAgentIds: overrides.busyAgentIds ?? [],
     chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? false,
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
   };
 }
 

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -35,6 +35,7 @@ function row(overrides: Partial<MeChatRow> & { id: string; lastMessageAt: string
     failedAgentIds: overrides.failedAgentIds ?? [],
     busyAgentIds: overrides.busyAgentIds ?? [],
     chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? false,
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
   };
 }
 
@@ -184,63 +185,11 @@ describe("groupRows — type", () => {
   });
 });
 
-describe("splitAttentionRows — pinned failed + needs-you partition", () => {
-  it("separates failed and needs-you rows from the rest, preserving order", () => {
-    const rows = [
-      row({ id: "a", lastMessageAt: offsetIso(-1) }),
-      row({ id: "b", lastMessageAt: offsetIso(-2), pendingQuestionAgentIds: ["agent-1"] }),
-      row({ id: "c", lastMessageAt: offsetIso(-3) }),
-      row({ id: "d", lastMessageAt: offsetIso(-4), failedAgentIds: ["agent-2"] }),
-    ];
-    const { attention, rest } = splitAttentionRows(rows);
-    // failed (d) ranks above needs-you (b); rest keeps source order.
-    expect(attention.map((r) => r.chatId)).toEqual(["d", "b"]);
-    expect(rest.map((r) => r.chatId)).toEqual(["a", "c"]);
-  });
-
-  it("failed ranks above needs-you within the attention bucket", () => {
-    const rows = [
-      row({ id: "n", lastMessageAt: offsetIso(-1), pendingQuestionAgentIds: ["a1"] }),
-      row({ id: "f", lastMessageAt: offsetIso(-2), failedAgentIds: ["a2"] }),
-    ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["f", "n"]);
-  });
-
-  it("a chat that is both failed AND needs-you appears once, in the failed tier", () => {
-    const rows = [
-      row({ id: "both", lastMessageAt: offsetIso(-1), failedAgentIds: ["a1"], pendingQuestionAgentIds: ["a2"] }),
-      row({ id: "n", lastMessageAt: offsetIso(-2), pendingQuestionAgentIds: ["a3"] }),
-    ];
-    const { attention, rest } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["both", "n"]);
-    expect(rest).toEqual([]);
-  });
-
-  it("all-quiet → empty attention", () => {
-    const { attention, rest } = splitAttentionRows([row({ id: "x", lastMessageAt: null })]);
-    expect(attention).toEqual([]);
-    expect(rest.map((r) => r.chatId)).toEqual(["x"]);
-  });
-
-  it("orders the attention bucket by ATTENTION_PRIORITY (failed > needs_you), stable within tier", () => {
-    // Interleaved failed / needs-you; the bucket order must put every failed
-    // row before every needs-you row, preserving source order inside each tier.
-    const rows = [
-      row({ id: "n1", lastMessageAt: offsetIso(-1), pendingQuestionAgentIds: ["a"] }),
-      row({ id: "f1", lastMessageAt: offsetIso(-2), failedAgentIds: ["b"] }),
-      row({ id: "n2", lastMessageAt: offsetIso(-3), pendingQuestionAgentIds: ["c"] }),
-      row({ id: "f2", lastMessageAt: offsetIso(-4), failedAgentIds: ["d"] }),
-    ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["f1", "f2", "n1", "n2"]);
-  });
-});
-
-// Chat-granularity scoping predicate — R1 (mine-failed), R2 (mine-pending),
-// R3 (chatHasOpenQuestion AND caller is a HUMAN speaker), R4 (unread mention).
-// See docs/development/needs-attention-scoping.20260526.md.
-describe("splitAttentionRows — predicate (R1–R4)", () => {
+// Phase 1 chat-granularity predicate.
+// R1 (mine-failed via failedAgentIds), R2 (explicit @<me> in unread window via
+// chatHasExplicitMentionToMe + unreadMentionCount > 0). See
+// docs/development/needs-attention-scoping.20260526.md.
+describe("splitAttentionRows — Phase 1 predicate", () => {
   it("R1: mine-failed → attention bucket, failed tier", () => {
     const rows = [row({ id: "r1", lastMessageAt: null, failedAgentIds: ["mine"] })];
     const { attention } = splitAttentionRows(rows);
@@ -248,50 +197,36 @@ describe("splitAttentionRows — predicate (R1–R4)", () => {
     expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
   });
 
-  it("R2: mine-pending → attention bucket, needs_you tier", () => {
-    const rows = [row({ id: "r2", lastMessageAt: null, pendingQuestionAgentIds: ["mine"] })];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["r2"]);
-    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
-  });
-
-  it("R3: chatHasOpenQuestion + caller is speaker → attention bucket, needs_you tier (but badge stays narrow)", () => {
+  it("R2: unread + explicit @<me> → attention bucket, mention tier", () => {
     const rows = [
       row({
-        id: "r3",
+        id: "r2",
         lastMessageAt: null,
-        chatHasOpenQuestion: true,
-        membershipKind: "participant",
+        unreadMentionCount: 1,
+        chatHasExplicitMentionToMe: true,
       }),
     ];
     const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["r3"]);
-    // Bucket placement: needs_you tier (so it sorts between failed and mention).
-    expect(attention[0] && rowAttentionReason(attention[0])).toBe("needs_you");
-    // Row badge: stays specific to caller-managed (R2 only). R3 enters the
-    // bucket but does NOT light the orange ? indicator — `pendingQuestionAgentIds`
-    // is server-narrowed to "mine", and this peer-question row has [].
-    expect(attention[0] && rowNeedsYou(attention[0])).toBe(false);
+    expect(attention.map((r) => r.chatId)).toEqual(["r2"]);
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("mention");
   });
 
-  it("R3 watcher: chatHasOpenQuestion + caller is watcher → NOT attention", () => {
+  it("R2 disabled by 1-on-1 implicit auto-mention: unreadMentionCount > 0 but flag false → NOT attention", () => {
+    // The original痛点 (t7): in a 1v1, agent → human plain "ack" bumps the
+    // v1 red-dot counter but `metadata.mentions` is empty, so the server
+    // emits `chatHasExplicitMentionToMe: false`. The front-end must NOT
+    // pin this row even though unreadMentionCount > 0.
     const rows = [
       row({
-        id: "r3w",
+        id: "r2-implicit",
         lastMessageAt: null,
-        chatHasOpenQuestion: true,
-        membershipKind: "watching",
+        unreadMentionCount: 1,
+        chatHasExplicitMentionToMe: false,
       }),
     ];
     const { attention, rest } = splitAttentionRows(rows);
     expect(attention).toEqual([]);
-    expect(rest.map((r) => r.chatId)).toEqual(["r3w"]);
-  });
-
-  it("R4: unread @-mention → attention bucket (no failed/pending)", () => {
-    const rows = [row({ id: "r4", lastMessageAt: null, unreadMentionCount: 3 })];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["r4"]);
+    expect(rest.map((r) => r.chatId)).toEqual(["r2-implicit"]);
   });
 
   it("quiet row → NOT attention", () => {
@@ -301,61 +236,45 @@ describe("splitAttentionRows — predicate (R1–R4)", () => {
     expect(rest.map((r) => r.chatId)).toEqual(["quiet"]);
   });
 
-  it("priority: failed beats mention", () => {
+  it("priority: failed > mention across two tiers", () => {
+    const rows = [
+      row({ id: "m", lastMessageAt: null, unreadMentionCount: 1, chatHasExplicitMentionToMe: true }),
+      row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f", "m"]);
+  });
+
+  it("priority: failed beats mention on the same row", () => {
     const rows = [
       row({
         id: "fm",
         lastMessageAt: null,
         failedAgentIds: ["a"],
         unreadMentionCount: 1,
+        chatHasExplicitMentionToMe: true,
       }),
     ];
     const { attention } = splitAttentionRows(rows);
-    expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("failed");
   });
 
-  it("priority: needs_you beats mention (R2 + mention)", () => {
+  it("rowNeedsYou stays dark — no R3 in Phase 1", () => {
+    // Phase 1 reserves the `needs_you` tier in ATTENTION_PRIORITY for a
+    // future open-Attention-targeting-me rule (R3, NHA-backed). No
+    // predicate branch emits it yet, and rowNeedsYou returns false for
+    // every input.
     const rows = [
-      row({
-        id: "pm",
-        lastMessageAt: null,
-        pendingQuestionAgentIds: ["a"],
-        unreadMentionCount: 1,
-      }),
+      row({ id: "f", lastMessageAt: null, failedAgentIds: ["a"] }),
+      row({ id: "m", lastMessageAt: null, unreadMentionCount: 1, chatHasExplicitMentionToMe: true }),
+      row({ id: "q", lastMessageAt: null }),
     ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention[0] && rowIsFailed(attention[0])).toBe(false);
-    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
+    for (const r of rows) {
+      expect(rowNeedsYou(r)).toBe(false);
+    }
   });
 
-  it("sort: failed > needs_you > mention across all three tiers", () => {
-    const rows = [
-      row({ id: "m", lastMessageAt: null, unreadMentionCount: 1 }),
-      row({ id: "n", lastMessageAt: null, pendingQuestionAgentIds: ["x"] }),
-      row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
-    ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["f", "n", "m"]);
-  });
-
-  it("R2 + R3 simultaneously → single needs_you tier row (no double-count), badge fires for R2", () => {
-    const rows = [
-      row({
-        id: "r23",
-        lastMessageAt: null,
-        pendingQuestionAgentIds: ["mine"],
-        chatHasOpenQuestion: true,
-        membershipKind: "participant",
-      }),
-    ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention).toHaveLength(1);
-    expect(attention[0] && rowAttentionReason(attention[0])).toBe("needs_you");
-    // Badge DOES fire here because mine-pending (R2) is true on this row.
-    expect(attention[0] && rowNeedsYou(attention[0])).toBe(true);
-  });
-
-  it("stable sort within failed tier preserves input order", () => {
+  it("stable sort within tier preserves input order", () => {
     const rows = [
       row({ id: "f1", lastMessageAt: null, failedAgentIds: ["a"] }),
       row({ id: "f2", lastMessageAt: null, failedAgentIds: ["b"] }),
@@ -364,7 +283,7 @@ describe("splitAttentionRows — predicate (R1–R4)", () => {
     expect(attention.map((r) => r.chatId)).toEqual(["f1", "f2"]);
   });
 
-  it("boundary A: my failed agent, caller is watcher → still attention (manager wins over membership)", () => {
+  it("boundary A: my failed agent, caller is watcher → still attention", () => {
     // Server already narrows `failedAgentIds` to mine regardless of membership.
     // The front-end predicate stays membership-agnostic for R1, so the row
     // pins even when membershipKind is "watching" — boundary A locked.
@@ -379,5 +298,32 @@ describe("splitAttentionRows — predicate (R1–R4)", () => {
     const { attention } = splitAttentionRows(rows);
     expect(attention.map((r) => r.chatId)).toEqual(["rA"]);
     expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
+  });
+});
+
+// Version-skew safety: the web client casts the server response as-is and
+// does NOT run rows through `meChatRowSchema.parse`, so the zod
+// `.default(false)` only applies server-side. The predicate must therefore
+// check the new boolean with strict `=== true` so an `undefined` value from
+// an old server returns "off" for that rule instead of trusting a `&&`
+// coercion of an unknown shape.
+describe("splitAttentionRows — version skew (old server, new web)", () => {
+  it("missing chatHasExplicitMentionToMe (undefined) → R2 disabled", () => {
+    const stale = {
+      ...row({ id: "stale", lastMessageAt: null, unreadMentionCount: 1 }),
+    };
+    delete (stale as { chatHasExplicitMentionToMe?: boolean }).chatHasExplicitMentionToMe;
+    const { attention, rest } = splitAttentionRows([stale]);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["stale"]);
+  });
+
+  it("missing field still lets R1 (failedAgentIds) fire", () => {
+    const stale = {
+      ...row({ id: "stale-r1", lastMessageAt: null, failedAgentIds: ["mine"] }),
+    };
+    delete (stale as { chatHasExplicitMentionToMe?: boolean }).chatHasExplicitMentionToMe;
+    const { attention } = splitAttentionRows([stale]);
+    expect(attention.map((r) => r.chatId)).toEqual(["stale-r1"]);
   });
 });

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -182,27 +182,42 @@ function groupByType(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket>
 }
 
 // ---------------------------------------------------------------------------
-// attention pinning (failed + needs-you + mention)
+// attention pinning (failed + mention)
 // ---------------------------------------------------------------------------
 //
 // Chat-granularity predicate — see docs/development/needs-attention-scoping.20260526.md.
 // A chat enters the "Needs attention" bucket when ANY of:
-//   R1. `failedAgentIds.length > 0`
-//       (server-narrowed to agents the caller manages — see services/me-chat.ts)
-//   R2. `pendingQuestionAgentIds.length > 0`
-//       (same narrowing)
-//   R3. `chatHasOpenQuestion && membershipKind === "participant"`
-//       (anyone has a pending question AND the caller is a HUMAN speaker in the
-//        chat — covers "someone else's agent is asking in a chat I'm in")
-//   R4. `unreadMentionCount > 0`
-//       (someone @-mentioned the caller)
 //
-// Sort priority inside the bucket: `failed > needs_you > mention`.
+//   R1. `failedAgentIds.length > 0`
+//       — A non-human agent I MANAGE is `failed` in this chat. Server
+//         narrows `failedAgentIds` to `agents.manager_id = caller` so a
+//         peer's broken agent never pins my row.
+//
+//   R2. `unreadMentionCount > 0 && chatHasExplicitMentionToMe === true`
+//       — I have unread, and at least one unread message explicitly
+//         `@<me>`-mentions me (server checks `messages.metadata.mentions`
+//         in the unread window). Distinguishes explicit `@<me>` from the
+//         v1 1-on-1 implicit DM auto-mention (`services/message.ts:282
+//         dmAutoProjection`), which still bumps `unreadMentionCount` for
+//         the red dot but never writes the recipient into
+//         `metadata.mentions` — so an agent's plain `"ack"` to me in a DM
+//         correctly stays out of attention.
+//
+// Sort priority: `failed > mention`. The intermediate `needs_you` tier is
+// reserved in `ATTENTION_PRIORITY` for a future "open Attention targeting
+// me" rule (R3) that will be sourced from the NHA `attentions` table after
+// that subsystem stabilises; not yet exposed as a predicate branch.
 //
 // This ladder is INTENTIONALLY separate from the shared agent-status
 // `compareMainStatus` (`failed`, `needs_you`, `working`, ...). `mention` is a
 // chat-level signal, not an agent main status — overloading the shared
 // comparator would couple two ladders that should evolve independently.
+//
+// `=== true` checks (not truthy) on booleans: the web client does NOT run
+// rows through `meChatRowSchema.parse`, so the Zod `.default(false)` only
+// applies server-side; an older server returning `undefined` would
+// silently degrade the rule to "off" under strict equality (safer
+// direction).
 
 const ATTENTION_PRIORITY = ["failed", "needs_you", "mention"] as const;
 type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
@@ -211,25 +226,12 @@ type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
  * Highest-priority attention reason for this row, or `null` when the row is
  * NOT in the attention bucket. Order matters: a row that satisfies multiple
  * rules sorts under its highest tier (e.g. failed + mention → failed).
- *
- * Exported because external surfaces sometimes need the tier (e.g. for
- * a per-row visual treatment), but the row-level indicator helpers
- * (`rowIsFailed` / `rowNeedsYou`) are deliberately NOT just thin wrappers
- * over this — they project the narrower "mine" semantics so the badges
- * stay specific to caller-managed agents even when R3 fires.
  */
 export function rowAttentionReason(r: MeChatRow): AttentionReason | null {
   if (r.failedAgentIds.length > 0) return "failed";
-  // `chatHasOpenQuestion === true` (not just truthy) because the web client
-  // does NOT run the row through `meChatRowSchema.parse` — it casts the
-  // response as-is. So the Zod `.default(false)` only applies server-side;
-  // an old server skewed with new web returns `undefined` here, and `&&` on
-  // an unknown shape should not silently coerce. Explicit boolean check
-  // keeps the R3 fallback off until the server actually emits the bit.
-  if (r.pendingQuestionAgentIds.length > 0 || (r.chatHasOpenQuestion === true && r.membershipKind === "participant")) {
-    return "needs_you";
+  if (r.unreadMentionCount > 0 && r.chatHasExplicitMentionToMe === true) {
+    return "mention";
   }
-  if (r.unreadMentionCount > 0) return "mention";
   return null;
 }
 
@@ -243,16 +245,13 @@ export function rowIsFailed(r: MeChatRow): boolean {
 }
 
 /**
- * The row's "needs-you" indicator (orange `?` / left border). Lights ONLY
- * for caller-managed agents with a pending question (R2). The R3 fallback
- * (someone else's agent asking in a chat where I'm a speaker) DOES enter
- * the attention bucket but does NOT light this badge — the indicator stays
- * specific to "an agent I manage is waiting on me", matching the field's
- * narrowed wire semantics. The bucket position alone signals R3-only rows;
- * the row's last-message preview surfaces the actual question.
+ * The row's "needs-you" indicator (orange `?` / left border). No rule in
+ * the current predicate emits this tier — it stays dark until the NHA-backed
+ * R3 lands (open Attention targeting me). Kept as a function for forward
+ * compatibility with `ATTENTION_PRIORITY`'s middle tier.
  */
-export function rowNeedsYou(r: MeChatRow): boolean {
-  return r.pendingQuestionAgentIds.length > 0;
+export function rowNeedsYou(_r: MeChatRow): boolean {
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of the chat-list "Needs attention" cleanup. Closes the false positive where a 1v1 plain agent reply pins the chat into the bucket (the original user report). Replaces the over-broad `unreadMentionCount > 0` rule with an explicit-mention check, drops the post-#578 dead rules, and **does not touch NHA `attentions`** so the still-iterating subsystem stays out of this PR's footprint.

Phase 2 (separate follow-up) will add an escalation rule once NHA stabilises on main — when an agent raises a structured Attention targeting me without a chat message, the chat should bubble up to the left-rail bucket. That's tracked but not in scope here.

## Phase 1 predicate (two rules)

```
chat ∈ Needs Attention ⇔ any of:
  R1. agent ∈ chat has main = 'failed'  AND  agent.manager = caller
  R2. unreadMentionCount > 0  AND  ∃ unread message with
      caller_human_id ∈ message.metadata.mentions
```

Sort ladder: `failed > mention`. The `needs_you` middle tier is reserved in `ATTENTION_PRIORITY` for Phase 2's R3.

## Two products, one easily-confused name

The chat-list left-rail "Needs attention" bucket pins chats based on chat-granular signals. The NHA chat-bottom AttentionCard renders per-record structured asks. They share the word but not the data store. This PR treats them as independent (Phase 1).

## Why each old rule changed

| Old (PR #579) | Phase 1 |
|---|---|
| R1 mine-failed (manager-narrowed) | Unchanged |
| R2 mine-pending (`pending_questions`) | **Dropped** — table has no production writer since PR #578 |
| R3 speaker-fallback (`chatHasOpenQuestion` AND I'm speaker) | **Dropped** — same dead source |
| R4 `unreadMentionCount > 0` (unfiltered) | **Narrowed** to explicit `@<me>` via new `chatHasExplicitMentionToMe` bool |

The v1 1-on-1 implicit DM auto-mention (`services/message.ts:282 dmAutoProjection`) still bumps the counter for the red dot but never writes the recipient into `metadata.mentions`, so a plain `"ack"` in a DM no longer pins.

## v1 red-dot — preserved

`dmAutoProjection` unchanged. `unread_mention_count` still bumps on every DM and still drives the red dot + bold row title. `direct-chat-auto-mention.test.ts` passes without changes.

## Wire compat

- New field `chatHasExplicitMentionToMe: z.boolean().default(false)`.
- Legacy `pendingQuestionAgentIds` / `chatHasOpenQuestion` stay on the wire (deprecated; server emits empty/false naturally since their backing data is dormant). Follow-up PR drops them.
- Front-end uses strict `=== true` (web client doesn't run rows through `meChatRowSchema.parse`, so `.default(false)` only applies server-side; old-server `undefined` silently degrades the mention rule to off).

## NHA-respecting scope

Per @yuezengwu's review on PR #593, NHA `attentions` table / `services/attention.ts` / related wire schemas are untouched in this PR.

## Test plan

- [x] `pnpm typecheck` — 13/13 tasks green
- [x] `pnpm check` — clean (16 pre-existing github-scan warnings unrelated)
- [x] `pnpm test` — 1219 server / 383 web / 239 cli tests pass
- [x] 9 server tests pin scenarios:
  - 1v1 plain final → NOT in attention (the **原痛点** from the user report)
  - 1v1 explicit `@<me>` → in
  - group explicit `@<me>` → in
  - group `@<other>` → not in
  - mark-read clears the mention bool
  - R1 manager-narrow × {speaker, watcher, peer}
  - deprecation guard: legacy fields emit `[]` / `false`
- [x] 13 web tests cover the two-rule predicate
- [x] 2 version-skew tests: missing `chatHasExplicitMentionToMe` → R2 disabled, R1 still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)