### PR TITLE
fix(server): tighten private-agent invite gate to strict owner-exclusive

### DIFF
--- a/packages/server/src/__tests__/agent-visibility.test.ts
+++ b/packages/server/src/__tests__/agent-visibility.test.ts
@@ -1,3 +1,4 @@
+import { AGENT_VISIBILITY } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createAgent } from "../services/agent.js";
@@ -646,21 +647,27 @@ describe("Chat Access Control", () => {
       const adminBundle = await authedRequest(app);
       const member = await createMemberAndLogin(app, adminBundle);
 
-      // Create two agents managed by member. Using `autonomous_agent` (which
-      // defaults to `organization` visibility) keeps the test scenario
-      // reachable under the strict owner-exclusive rule (RFC §4.5): a chat
-      // of two PRIVATE agents not involving their human manager can't be
-      // created at all post-strict, but the watcher-recompute mechanism
-      // this test pins is type/visibility-agnostic.
+      // Create two non-human agents managed by member. `visibility` is
+      // pinned explicitly to `organization` (instead of leaning on
+      // `defaultVisibility(type)`) so the fixture states its intent in
+      // its own terms and won't shift if the type→default-visibility
+      // mapping ever changes. The strict owner-exclusive rule (RFC §4.5)
+      // would refuse a chat of two `visibility=private` agents that
+      // didn't include the human manager — keeping these
+      // `organization`-visible keeps the test scenario reachable while
+      // the watcher-recompute mechanism this test pins is itself
+      // type/visibility-agnostic.
       const agentA = await seedAgent(app, {
         name: "join-a",
         type: "autonomous_agent",
         managerId: member.memberId,
+        visibility: AGENT_VISIBILITY.ORGANIZATION,
       });
       const agentB = await seedAgent(app, {
         name: "join-b",
         type: "autonomous_agent",
         managerId: member.memberId,
+        visibility: AGENT_VISIBILITY.ORGANIZATION,
       });
 
       // Create a chat between the two agents (not including human agent).
@@ -693,23 +700,29 @@ describe("Chat Access Control", () => {
       const memberA = await createMemberAndLogin(app, adminBundle);
       const memberB = await createMemberAndLogin(app, adminBundle);
 
-      // Create agents managed by member A
+      // Create two private non-human agents managed by member A.
+      // `visibility` is pinned explicitly (rather than relying on
+      // `defaultVisibility(type)`) so the fixture states its intent
+      // — "private agents owned by A" — directly, with no implicit
+      // type→default-visibility coupling.
       const agentA = await seedAgent(app, {
         name: "nojoin-a",
-        type: "personal_assistant",
+        type: "autonomous_agent",
         managerId: memberA.memberId,
+        visibility: AGENT_VISIBILITY.PRIVATE,
       });
       const agentA2 = await seedAgent(app, {
         name: "nojoin-a2",
-        type: "personal_assistant",
+        type: "autonomous_agent",
         managerId: memberA.memberId,
+        visibility: AGENT_VISIBILITY.PRIVATE,
       });
 
-      // Create a chat between A's agents. Member A (the human, owner of
-      // both private agents) drives the creation — under the strict
-      // owner-exclusive rule (RFC §4.5) only the human-agent manager may
-      // bring a private agent in, so having one of A's personal_assistants
-      // create the chat with the other as a target would 403.
+      // Member A (the human, owner of both private agents) drives the
+      // creation — under the strict owner-exclusive rule (RFC §4.5)
+      // only the human-agent manager may bring a private agent in, so
+      // having one of A's non-human agents create the chat with the
+      // other as a target would 403.
       const chat = await createChat(app.db, memberA.agentId, {
         type: "group",
         participantIds: [agentA.uuid, agentA2.uuid],

--- a/packages/server/src/__tests__/agent-visibility.test.ts
+++ b/packages/server/src/__tests__/agent-visibility.test.ts
@@ -646,15 +646,20 @@ describe("Chat Access Control", () => {
       const adminBundle = await authedRequest(app);
       const member = await createMemberAndLogin(app, adminBundle);
 
-      // Create two agents managed by member
+      // Create two agents managed by member. Using `autonomous_agent` (which
+      // defaults to `organization` visibility) keeps the test scenario
+      // reachable under the strict owner-exclusive rule (RFC §4.5): a chat
+      // of two PRIVATE agents not involving their human manager can't be
+      // created at all post-strict, but the watcher-recompute mechanism
+      // this test pins is type/visibility-agnostic.
       const agentA = await seedAgent(app, {
         name: "join-a",
-        type: "personal_assistant",
+        type: "autonomous_agent",
         managerId: member.memberId,
       });
       const agentB = await seedAgent(app, {
         name: "join-b",
-        type: "personal_assistant",
+        type: "autonomous_agent",
         managerId: member.memberId,
       });
 
@@ -700,10 +705,14 @@ describe("Chat Access Control", () => {
         managerId: memberA.memberId,
       });
 
-      // Create a chat between A's agents
-      const chat = await createChat(app.db, agentA.uuid, {
+      // Create a chat between A's agents. Member A (the human, owner of
+      // both private agents) drives the creation — under the strict
+      // owner-exclusive rule (RFC §4.5) only the human-agent manager may
+      // bring a private agent in, so having one of A's personal_assistants
+      // create the chat with the other as a target would 403.
+      const chat = await createChat(app.db, memberA.agentId, {
         type: "group",
-        participantIds: [agentA2.uuid],
+        participantIds: [agentA.uuid, agentA2.uuid],
       });
 
       // Member B tries to join — refused. memberB has no watcher row for

--- a/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
+++ b/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
@@ -25,6 +25,7 @@ import { describe, expect, it } from "vitest";
 import { createAgent } from "../services/agent.js";
 import { addParticipant as agentAddParticipant, createChat as agentCreateChat } from "../services/chat.js";
 import { addMeChatParticipants, createMeChat } from "../services/me-chat.js";
+import { rejectedPrivateTargets } from "../services/participant-invite.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("chat-scoped identity rendering vs discovery visibility", () => {
@@ -224,5 +225,229 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
     await expect(agentAddParticipant(app.db, chat.id, bobsAgent.uuid, { agentId: alicesPrivate.uuid })).rejects.toThrow(
       /private agent/i,
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Strict owner-exclusive (RFC §4.5 strict reading): only the human-agent
+  // manager of a private target may invite it. The cases above pin the
+  // cross-manager rejection; the cases below pin the same-manager-but-
+  // non-human-caller rejection — i.e. the social-engineering path where
+  // M's public agent is instructed (via natural-language message or
+  // otherwise) to bring M's sibling private agent in.
+  // ---------------------------------------------------------------------------
+
+  it("addParticipant rejects M's public agent trying to pull M's private agent (bug path)", async () => {
+    // N1: this is the precise path the user reported — M is not in the
+    // chat; someone else legitimately added M's public agent (org-visible,
+    // anyone in the chat can add it); the public agent then turns around
+    // and invites M's private agent, "tricking" the gate when the rule was
+    // owner-exclusive in its lenient (shared-managerId) reading. Strict
+    // reading rejects: caller must be human.
+    const app = getApp();
+    const m = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const mPublic = await createAgent(app.db, {
+      name: `m-pub-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Public Agent",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.ORGANIZATION,
+    });
+    const mPrivate = await createAgent(app.db, {
+      name: `m-priv-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // Bob (different manager) creates a group chat with M's public agent.
+    // Pulling a PUBLIC agent in is allowed under both readings of the rule.
+    const chat = await agentCreateChat(app.db, bob.humanAgentUuid, {
+      type: "group",
+      participantIds: [mPublic.uuid],
+    });
+    if (!chat.id) throw new Error("Unexpected: createChat returned no id");
+
+    // Now M's public agent tries to bring M's private agent in. Under the
+    // lenient reading this was allowed (they share managerId). Strict
+    // reading rejects — only M's human agent can invite M's private agent.
+    await expect(agentAddParticipant(app.db, chat.id, mPublic.uuid, { agentId: mPrivate.uuid })).rejects.toThrow(
+      /private agent/i,
+    );
+  });
+
+  it("addParticipant rejects M's private agent trying to pull M's other private agent", async () => {
+    // N2: same shape as N1, but caller is itself a private agent. Same
+    // strict reading applies — caller must be human regardless of caller's
+    // own visibility.
+    const app = getApp();
+    const m = await createTestAdmin(app);
+    const bob = await createTestAdmin(app);
+
+    const mPrivateA = await createAgent(app.db, {
+      name: `m-priv-a-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent A",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+    const mPrivateB = await createAgent(app.db, {
+      name: `m-priv-b-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent B",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // M herself spins up a chat and brings privateA in (allowed — M is
+    // human, owns privateA). Bob is unrelated but needs to be in the chat
+    // for it to be a real group; here we keep the chat to just M + privateA
+    // by having M create it directly.
+    const chat = await agentCreateChat(app.db, m.humanAgentUuid, {
+      type: "group",
+      participantIds: [mPrivateA.uuid, bob.humanAgentUuid],
+    });
+    if (!chat.id) throw new Error("Unexpected: createChat returned no id");
+
+    // privateA now tries to pull privateB in. Strict reading rejects.
+    await expect(agentAddParticipant(app.db, chat.id, mPrivateA.uuid, { agentId: mPrivateB.uuid })).rejects.toThrow(
+      /private agent/i,
+    );
+  });
+
+  it("agent-SDK createChat rejects M's public agent including M's private agent as initial participant", async () => {
+    // N3: same rule applies at chat-creation time. M's public agent
+    // creating a fresh group chat with M's private agent listed in the
+    // initial participants must be rejected by the same strict
+    // owner-exclusive predicate. Closes the create-side bypass.
+    const app = getApp();
+    const m = await createTestAdmin(app);
+
+    const mPublic = await createAgent(app.db, {
+      name: `m-pub-create-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Public Agent",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.ORGANIZATION,
+    });
+    const mPrivate = await createAgent(app.db, {
+      name: `m-priv-create-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    await expect(
+      agentCreateChat(app.db, mPublic.uuid, {
+        type: "group",
+        participantIds: [mPrivate.uuid, m.humanAgentUuid],
+      }),
+    ).rejects.toThrow(/private agent/i);
+  });
+
+  it("agent-SDK createChat rejects M's private agent including M's other private agent as initial participant", async () => {
+    // N4: same as N3 but creator is itself private. Strict reading is
+    // independent of creator's visibility — only `type === 'human'` matters.
+    const app = getApp();
+    const m = await createTestAdmin(app);
+
+    const mPrivateA = await createAgent(app.db, {
+      name: `m-priv-a-create-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent A",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+    const mPrivateB = await createAgent(app.db, {
+      name: `m-priv-b-create-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "M's Private Agent B",
+      managerId: m.memberId,
+      organizationId: m.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    await expect(
+      agentCreateChat(app.db, mPrivateA.uuid, {
+        type: "group",
+        participantIds: [mPrivateB.uuid, m.humanAgentUuid],
+      }),
+    ).rejects.toThrow(/private agent/i);
+  });
+
+  it("HTTP web path: admin can pass discovery filter but is still rejected by the Layer-2 owner gate", async () => {
+    // N5: `assertAllAgentsVisibleInOrg` (the API-layer discovery filter)
+    // has an admin short-circuit — an admin can REFERENCE another member's
+    // private agent uuid without getting a 404. But the Layer-2 service
+    // gate has no admin override, so the call still 403s. This is the
+    // "admin is a discovery-side affordance, not a consent-side one"
+    // invariant explicit in `participant-invite.ts`.
+    const app = getApp();
+    const alice = await createTestAdmin(app); // both Alice and Bob have role=admin
+    const bob = await createTestAdmin(app);
+
+    // Bob owns a private agent. Alice (also admin) will try to pull it in
+    // via the web HTTP route.
+    const bobsPrivate = await createAgent(app.db, {
+      name: `bob-priv-admin-${crypto.randomUUID().slice(0, 8)}`,
+      type: "autonomous_agent",
+      displayName: "Bob's Private Agent",
+      managerId: bob.memberId,
+      organizationId: bob.organizationId,
+      visibility: AGENT_VISIBILITY.PRIVATE,
+    });
+
+    // Alice creates a chat she's a speaker in (just herself + a throwaway).
+    // Use createMeChat so Alice is the speaker — she'll then exercise the
+    // HTTP add-participant route against bobsPrivate.
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [bob.humanAgentUuid],
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/participants`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: { participantIds: [bobsPrivate.uuid] },
+    });
+
+    // 403 is the strict reading's expected response: discovery short-
+    // circuit let Alice past the API-layer 404, but Layer-2 refuses.
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatch(/private agent/i);
+  });
+
+  it("rejectedPrivateTargets carve-out: a private agent self-add is allowed (pure-function unit)", async () => {
+    // N6: the self-add (`target.uuid === caller.agentId`) carve-out lets
+    // a private agent rejoin a chat it already owns — this matters for
+    // runtime reconnects where the same private-agent uuid both authors
+    // the call and is the target. The full service path covers this
+    // around `errorOnAlreadySpeaker`; testing the pure predicate
+    // directly avoids tangling the carve-out with already-speaker
+    // conflict semantics.
+    const selfUuid = crypto.randomUUID();
+    const result = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-other", type: "autonomous_agent" }, [
+      { uuid: selfUuid, visibility: "private", managerId: "member-original" },
+    ]);
+    expect(result).toEqual([]);
+
+    // Sanity: same caller against a DIFFERENT private target with the same
+    // managerId is still rejected (the carve-out is *only* for self-add).
+    const otherUuid = crypto.randomUUID();
+    const result2 = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-shared", type: "autonomous_agent" }, [
+      { uuid: otherUuid, visibility: "private", managerId: "member-shared" },
+    ]);
+    expect(result2).toHaveLength(1);
+    expect(result2[0]?.uuid).toBe(otherUuid);
   });
 });

--- a/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
+++ b/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
@@ -286,7 +286,6 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
     // own visibility.
     const app = getApp();
     const m = await createTestAdmin(app);
-    const bob = await createTestAdmin(app);
 
     const mPrivateA = await createAgent(app.db, {
       name: `m-priv-a-${crypto.randomUUID().slice(0, 8)}`,
@@ -305,13 +304,12 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
       visibility: AGENT_VISIBILITY.PRIVATE,
     });
 
-    // M herself spins up a chat and brings privateA in (allowed — M is
-    // human, owns privateA). Bob is unrelated but needs to be in the chat
-    // for it to be a real group; here we keep the chat to just M + privateA
-    // by having M create it directly.
+    // M spins up a chat with privateA — 2 speakers is a legal v2 chat
+    // (group is the only `chats.type` Hub writes now; 1:1 behaviour is
+    // derived from `participants.length === 2`, see chat.ts:289).
     const chat = await agentCreateChat(app.db, m.humanAgentUuid, {
       type: "group",
-      participantIds: [mPrivateA.uuid, bob.humanAgentUuid],
+      participantIds: [mPrivateA.uuid],
     });
     if (!chat.id) throw new Error("Unexpected: createChat returned no id");
 

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -33,6 +33,14 @@ async function seedAgent(
     inboxId: `inbox_${uuid}`,
     managerId: opts.memberId,
     delegateMention: opts.delegateMention ?? null,
+    // Match `services/agent.ts::defaultVisibility` — an `autonomous_agent`
+    // created via the service layer is `organization`-visible. The raw
+    // INSERT here was implicitly relying on the column default ("private")
+    // which made these fixtures private agents, which in turn relied on
+    // the now-tightened owner-exclusive rule's lenient (shared-managerId)
+    // reading to admit them as participants. Pinning visibility here
+    // makes the fixture mirror prod reality.
+    visibility: "organization",
   });
   return uuid;
 }

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -129,7 +129,7 @@ describe("inviteParticipantsToChat", () => {
         targetAgentIds: [targetOwner.agent.uuid],
         errorOnAlreadySpeaker: true,
       }),
-    ).rejects.toThrow(/Only the owner/);
+    ).rejects.toThrow(/Only the human owner/);
   });
 
   it("throws ConflictError on already-speaker target when errorOnAlreadySpeaker=true", async () => {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type AddParticipant, AGENT_VISIBILITY, type CreateChat } from "@first-tree/shared";
+import type { AddParticipant, CreateChat } from "@first-tree/shared";
 import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -11,7 +11,7 @@ import { agentAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { resolveChatTitle } from "./me-chat.js";
 import { WIRE_RECIPIENT_MODE } from "./message-dispatcher.js";
-import { inviteParticipantsToChat } from "./participant-invite.js";
+import { inviteParticipantsToChat, rejectedPrivateTargets } from "./participant-invite.js";
 import { addChatParticipants, applyMembershipWrite, recomputeChatWatchers } from "./participant-mode.js";
 import { extractSummary } from "./session.js";
 import { leaveAsParticipant } from "./watcher.js";
@@ -49,19 +49,30 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
   }
 
-  // Owner-exclusive rule: a private agent can only be brought into a
-  // chat by another agent owned by the same member (i.e. the creator
-  // and the target share `managerId`). `creator.managerId` is the
-  // caller's effective owner identity — for a human agent this is the
-  // member's own id; for an autonomous agent this is whichever member
-  // owns it. RFC §4.4.2 / §4.5 — keeping the gate at the service layer
-  // closes the agent-SDK bypass path, not only the user-facing /me API.
-  const privateNotOwned = existingAgents.filter(
-    (a) => a.id !== creatorId && a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== creator.managerId,
+  // Strict owner-exclusive rule for private targets (RFC §4.5): only
+  // the human-agent manager of a private target may bring it into a
+  // chat. Even a manager's own public agent / other private agents
+  // CANNOT pull a sibling private agent in — that path is the social-
+  // engineering hole the strict reading closes. Self-add (`a.id ===
+  // creatorId`) is exempt; we filter the creator out of the target
+  // set before running the check so a private agent legitimately
+  // creating a chat with itself as a participant isn't tripped up.
+  //
+  // The predicate lives in `participant-invite.ts::rejectedPrivateTargets`
+  // alongside the Layer-2 invite gate so the invariant has exactly one
+  // source of truth (PR #550 collapsed the duplicate writers; this
+  // mirrors the same "one rule, one home" discipline for the create
+  // path).
+  const targetsForGate = existingAgents
+    .filter((a) => a.id !== creatorId)
+    .map((a) => ({ uuid: a.id, visibility: a.visibility, managerId: a.managerId }));
+  const rejectedTargets = rejectedPrivateTargets(
+    { agentId: creator.id, memberId: creator.managerId, type: creator.type },
+    targetsForGate,
   );
-  if (privateNotOwned.length > 0) {
+  if (rejectedTargets.length > 0) {
     throw new ForbiddenError(
-      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.id).join(", ")}`,
+      `Only the human owner can add a private agent to a chat: ${rejectedTargets.map((t) => t.uuid).join(", ")}`,
     );
   }
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -19,7 +19,6 @@
 import { randomUUID } from "node:crypto";
 import {
   type AddMeChatParticipants,
-  AGENT_VISIBILITY,
   CHAT_ENGAGEMENT_STATUSES,
   type ChatEngagementStatus,
   type ChatEngagementView,
@@ -48,7 +47,11 @@ import { BadRequestError, CallerNotSpeakerError, ForbiddenError, NotFoundError }
 import { agentAvatarImageUrl } from "./agent.js";
 import { resolveAgentChatStatuses } from "./agent-chat-status.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
-import { assertChatVisibleInOrgOrNotFound, inviteParticipantsToChat } from "./participant-invite.js";
+import {
+  assertChatVisibleInOrgOrNotFound,
+  inviteParticipantsToChat,
+  rejectedPrivateTargets,
+} from "./participant-invite.js";
 import { addChatParticipants } from "./participant-mode.js";
 import { extractSummary } from "./session.js";
 import { ensureCanJoin, joinAsParticipant, leaveAsParticipant, resolveChatMembership } from "./watcher.js";
@@ -640,21 +643,29 @@ export async function createMeChat(
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.uuid).join(", ")}`);
   }
 
-  // Owner-exclusive rule for private agents (creation path, mirroring
-  // the add-participant gate in `addMeChatParticipants`). The caller
-  // agent's `managerId` is its owning member — looking it up from
-  // `found` (rather than accepting it as a parameter) keeps the
-  // owner-id source-of-truth inside the service. RFC §4.4.2 / §4.5.
+  // Strict owner-exclusive for private targets (RFC §4.5). The route
+  // pins `humanAgentId = scope.humanAgentId`, so the caller is always
+  // human and the strict check coincides with the previous lenient
+  // shared-`managerId` form for THIS path. Routing through the shared
+  // `rejectedPrivateTargets` predicate anyway keeps the rule in exactly
+  // one place — same discipline as `inviteParticipantsToChat` and
+  // `chat.ts::createChat`. Without it, any future change that lets a
+  // non-human caller reach this code would silently fall back to the
+  // lenient reading (which is the exact two-copies-drift failure mode
+  // PR #550 wrote up).
   const caller = found.find((a) => a.uuid === humanAgentId);
   if (!caller) {
     throw new BadRequestError("Caller agent not found in the chat's organization");
   }
-  const privateNotOwned = found.filter(
-    (a) => a.uuid !== humanAgentId && a.visibility === AGENT_VISIBILITY.PRIVATE && a.managerId !== caller.managerId,
+  const rejected = rejectedPrivateTargets(
+    { agentId: humanAgentId, memberId: caller.managerId, type: caller.type },
+    found
+      .filter((a) => a.uuid !== humanAgentId)
+      .map((a) => ({ uuid: a.uuid, visibility: a.visibility, managerId: a.managerId })),
   );
-  if (privateNotOwned.length > 0) {
+  if (rejected.length > 0) {
     throw new ForbiddenError(
-      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((a) => a.uuid).join(", ")}`,
+      `Only the human owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
     );
   }
 

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -38,16 +38,22 @@
  *   - every target must exist (else BadRequestError listing the missing
  *     ids).
  *   - every target must be in the chat's organization (else BadRequestError).
- *   - private targets only land if the caller's owning member matches the
- *     target's owning member ("owner-exclusive" / "邀请即同意"; see
- *     `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.4.2 / §4.5).
- *     Self-add (`targetAgentId === callerAgentId`) is exempt.
+ *   - private targets only land if the caller is the **human agent** of the
+ *     same owning member as the target ("strict owner-exclusive" — the
+ *     invitation right belongs to the human manager themselves, not to any
+ *     agent the manager happens to own; see
+ *     `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.5). A
+ *     manager's public agent can NOT pull the manager's sibling private
+ *     agent in — that path was the social-engineering hole this rule
+ *     closes. Self-add (`targetAgentId === callerAgentId`) is exempt so
+ *     a runtime rejoin of a private agent isn't blocked. No admin override
+ *     — admin is a discovery-side affordance, not a consent-side one.
  *   - the actual write goes through `applyMembershipWrite`, which encloses
  *     the silent-context backfill + watcher recompute invariants and the
  *     post-commit audience-cache invalidation.
  */
 
-import { AGENT_VISIBILITY } from "@first-tree/shared";
+import { AGENT_TYPES, AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -79,6 +85,61 @@ export type InviteParticipantsArgs = {
   errorOnAlreadySpeaker: boolean;
 };
 
+export type PrivateGateCaller = {
+  /** Caller agent uuid. */
+  agentId: string;
+  /** Caller's `agents.managerId` — the member that owns the caller. */
+  memberId: string;
+  /**
+   * Caller's `agents.type` (drizzle `text` column → `string`). Narrowed inside
+   * the predicate via comparison with `AGENT_TYPES.HUMAN`; passing the raw
+   * column value through `string` matches the existing visibility-compare
+   * pattern in the file and avoids `as`-casts at call sites.
+   */
+  type: string;
+};
+
+export type PrivateGateTarget = {
+  uuid: string;
+  /** `agents.visibility` (drizzle `text` column → `string`); compared against `AGENT_VISIBILITY.PRIVATE`. */
+  visibility: string;
+  managerId: string;
+};
+
+/**
+ * Pure predicate: which of `targets` is the caller **NOT** allowed to bring
+ * into a chat under the strict owner-exclusive rule for private agents?
+ *
+ * Rule (RFC §4.5, strict reading):
+ *   - target.visibility !== PRIVATE                          → allowed
+ *   - target.uuid === caller.agentId                         → allowed (self-add rejoin)
+ *   - caller.type === 'human' && caller.memberId ===
+ *     target.managerId                                       → allowed (human manager invites own private)
+ *   - otherwise                                              → rejected
+ *
+ * Why this lives in `participant-invite.ts` (not on a shared util): the
+ * Layer-2 invite service is the canonical chat-membership gate, and
+ * `createChat` runs the same predicate on its initial-participants set.
+ * Co-locating the rule with `inviteParticipantsToChat` makes "the rule has
+ * exactly one source of truth" obvious to reviewers — the duplicated-write
+ * regression that PR #550 closed was exactly this kind of two-copies drift.
+ *
+ * Pure / no db access: callers pass the rows they already have. Errors
+ * (formatting, throwing, HTTP mapping) stay with the caller so it can
+ * surface the right uuids in the right error type.
+ */
+export function rejectedPrivateTargets(
+  caller: PrivateGateCaller,
+  targets: ReadonlyArray<PrivateGateTarget>,
+): PrivateGateTarget[] {
+  return targets.filter((t) => {
+    if (t.visibility !== AGENT_VISIBILITY.PRIVATE) return false;
+    if (t.uuid === caller.agentId) return false;
+    const isHumanOwner = caller.type === AGENT_TYPES.HUMAN && t.managerId === caller.memberId;
+    return !isHumanOwner;
+  });
+}
+
 /**
  * Invite one or more agents into a chat. See the file-level comment for the
  * contract and the rationale for which checks live here vs. in Layer-3
@@ -102,12 +163,12 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
   }
 
   // 2. Caller is a speaker. Join `chatMembership` × `agents` so we get the
-  //    caller's owning-member id in the same query — it's the authoritative
-  //    input to the owner-exclusive check below. Deriving it from the
-  //    caller's `managerId` (vs. accepting it as a parameter) prevents an
-  //    internal caller from mismatching the two and bypassing the gate.
+  //    caller's owning-member id AND agent type in the same query — both
+  //    are authoritative inputs to the strict owner-exclusive check below.
+  //    Deriving them from `agents` (vs. accepting them as parameters)
+  //    prevents an internal caller from mismatching and bypassing the gate.
   const [callerRow] = await db
-    .select({ ownerMemberId: agents.managerId })
+    .select({ ownerMemberId: agents.managerId, callerType: agents.type })
     .from(chatMembership)
     .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
     .where(
@@ -122,6 +183,7 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     throw new CallerNotSpeakerError(callerAgentId, chatId);
   }
   const callerMemberId = callerRow.ownerMemberId;
+  const callerType = callerRow.callerType;
 
   // 3. Targets exist + cross-org.
   const targetRows = await db
@@ -143,14 +205,20 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((t) => t.uuid).join(", ")}`);
   }
 
-  // 4. Owner-exclusive for private targets. Self-add (target === caller) is
-  //    exempt so an agent rejoining a chat it already owns isn't blocked.
-  const privateNotOwned = targetRows.filter(
-    (t) => t.visibility === AGENT_VISIBILITY.PRIVATE && t.uuid !== callerAgentId && t.managerId !== callerMemberId,
+  // 4. Strict owner-exclusive for private targets. Only the target's
+  //    human-agent manager can invite it; a manager's other agents
+  //    (public OR private siblings) cannot. Self-add (target === caller)
+  //    is exempt so an agent rejoining a chat it already owns isn't
+  //    blocked. The actual predicate lives in `rejectedPrivateTargets`
+  //    so `createChat` can share the exact same rule — keeping the
+  //    invariant in one place (the lesson PR #550 wrote up).
+  const rejected = rejectedPrivateTargets(
+    { agentId: callerAgentId, memberId: callerMemberId, type: callerType },
+    targetRows.map((t) => ({ uuid: t.uuid, visibility: t.visibility, managerId: t.managerId })),
   );
-  if (privateNotOwned.length > 0) {
+  if (rejected.length > 0) {
     throw new ForbiddenError(
-      `Only the owner can add a private agent to a chat: ${privateNotOwned.map((t) => t.uuid).join(", ")}`,
+      `Only the human owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Layer-2 `inviteParticipantsToChat` and `createChat` previously allowed any agent **sharing a `managerId` with the target** to bring a `visibility=private` agent into a chat. That's the lenient reading of RFC §4.5 "Owner-exclusive" — and it opens a social-engineering hole: any chat speaker can invite a manager's *public* agent (org-visible, no consent needed), then the public agent's runtime is told (natural-language or otherwise) to "bring X in", and the lenient gate admits X even though the human manager never agreed.
- This PR collapses both write paths onto a new pure predicate `rejectedPrivateTargets(caller, targets)` exported from `participant-invite.ts` that enforces the **strict reading**: `caller.type === 'human' && caller.memberId === target.managerId`. Self-add carve-out (runtime rejoin) preserved; no admin override.

### Behaviour shifts (only 2 of the 11 caller×target combinations)

| Caller | Target | Before | After |
|---|---|---|---|
| M's public agent | M's private agent | ✅ | ❌ |
| M's private agent | M's other private agent | ✅ | ❌ |

All other combinations unchanged. M's own human agent invites M's private agent freely; cross-manager rejections still 403; admin has no Layer-2 short-circuit (admin is a discovery-side affordance only).

## Why one predicate, two callers

PR #550 unified the speaker-writes onto a single Layer-2 invite path precisely to stop "same rule in two files → drifts independently → silent regression." But the create-side check was still inline in `chat.ts::createChat`. This PR keeps the same discipline: pulls the rule into `rejectedPrivateTargets` and calls it from both paths. Future entrypoints get the rule by construction.

## Test plan

- [x] `pnpm check` — 16 pre-existing github-scan warnings only
- [x] `pnpm typecheck` — 13/13 tasks pass
- [x] `pnpm test` — 1220 server tests pass (full suite)
- [x] **New cases** (in `chat-private-mention-visibility.test.ts`):
  - N1 — M's public agent → M's private (the precise reported bug path)
  - N2 — M's private → M's other private (same shape, private caller)
  - N3 — `createChat`: M's public creator with M's private as initial participant
  - N4 — `createChat`: M's private creator with M's other private
  - N5 — HTTP web path: admin passes discovery filter (admin short-circuit) but Layer-2 still 403s when adding another member's private agent
  - N6 — pure-function unit: self-add carve-out is preserved
- [x] **Adjusted fixtures**:
  - `participant-invite.test.ts` literal matcher: `/Only the owner/` → `/Only the human owner/`
  - `agent-visibility.test.ts` two chat-create cases switched away from private personal_assistants (that scenario is now unreachable under the strict rule); test intent preserved
  - `github-delivery.test.ts` `seedAgent` now pins `visibility: organization` — the raw INSERT was implicitly relying on the column default `"private"` plus the lenient rule

## Migration / changelog / docs

- **No migration**. Pure runtime predicate. Historical `chat_membership` rows (including private agents admitted under the lenient rule) stay — V1 has no membership-remove path (RFC §4.11).
- **Error wording shift**: `Only the owner can ...` → `Only the human owner can ...`. Scanned the repo — no production string-literal matchers hit the old text; only one test fixture, updated in this PR.
- **No CHANGELOG**: this repo doesn't carry a top-level `CHANGELOG.md` on `main`.
- **No RFC update**: `docs/agent-space-and-mention-visibility-design.zh-CN.md` lives only on the `docs/agent-space-mention-visibility-rfc` branch and was never merged to `main`; this PR's `.ts` files still reference the doc path for breadcrumbs but the doc itself isn't here to update. If/when that RFC branch merges, §4.5 "Owner-exclusive" should be tightened to explicitly call out *human owner agent* (not just owner).

## Regression risk

If any production agent-team flow currently relies on **"M's non-human agent autonomously invites M's sibling private agent"**, that flow will start 403'ing. We don't see any such caller in this repo's code; user-land business flows can't be enumerated from here. The owner of the gating decision (you) confirmed proceeding without a deprecation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)