### PR TITLE
refactor(computers): 9 UI fixes (per-row actions, runtime label, copy, layout)

### DIFF
--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -32,13 +32,15 @@ import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { formatDate, formatRelative } from "../lib/utils.js";
 import { ComputerCard } from "./clients/cards/computer-card.js";
 import {
-  PROVIDER_INSTALL_HINT,
   PROVIDER_LABEL,
   PROVIDER_ORDER,
-  PROVIDER_UNAUTH_HINT,
+  providerInstallHint,
+  providerUnauthHint,
 } from "./clients/cards/shared/providers.js";
 import { ComputerStatusPill } from "./clients/computer-status-pill.js";
+import { DemoNavigator, useDemoScenarioParam } from "./clients/demo-navigator.js";
 import { compareByPillPriority, deriveComputerStatus, summarizeComputers } from "./clients/derive-status.js";
+import { DEMO_AGENT_NAMES, DEMO_SELF_USER_ID, findDemoScenario } from "./clients/dev-fixtures.js";
 import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
 
 /**
@@ -61,14 +63,38 @@ import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
  */
 export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const queryClient = useQueryClient();
-  const agentName = useAgentNameMap();
+  const realAgentName = useAgentNameMap();
   const { role, user } = useAuth();
-  const isAdmin = role === "admin";
+  // DEV-only "?demo=<key>" param swaps the page's data sources for
+  // fixtures without touching the queries themselves. Lets a reviewer
+  // flip through every pill × sub-variant inside the real page chrome.
+  // Disabled (no-op) in production builds — Vite folds
+  // `import.meta.env.DEV` to false so the fixtures + DemoNavigator
+  // tree-shake out.
+  const [demoKey, setDemoKey] = useDemoScenarioParam();
+  const demoScenario = import.meta.env.DEV ? findDemoScenario(demoKey) : null;
+  const isAdmin = demoScenario ? demoScenario.key === "admin-grouped" : role === "admin";
+  const viewerUserId = demoScenario ? DEMO_SELF_USER_ID : user?.id;
+  // Demo agent names overlay the live map so fixture agent IDs render
+  // human-friendly labels in the bound-agents block.
+  const agentName = demoScenario
+    ? (uuid: string | null | undefined) => {
+        if (!uuid) return "unknown";
+        return DEMO_AGENT_NAMES[uuid] ?? realAgentName(uuid);
+      }
+    : realAgentName;
   // Personal scope: a user typically has 1-3 computers, so expand by default
   // and only let them collapse rows they actively want to hide. New clients
   // arriving via the 10s poll auto-expand too — we only treat the closed set
   // as "rows the user explicitly closed".
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set());
+  // Admin's Team computers section starts collapsed so it doesn't push the
+  // viewer's own machines below the fold. Visible count badge on the
+  // header still tells admins "you have N teammates" — they click to
+  // expand when they're in support mode. Reset rule: nothing forces it
+  // open automatically (in particular, polled changes to teamList shouldn't
+  // surprise-expand it).
+  const [teamExpanded, setTeamExpanded] = useState(false);
   const [confirmDisconnect, setConfirmDisconnect] = useState<HubClient | null>(null);
   const [confirmRetire, setConfirmRetire] = useState<HubClient | null>(null);
   const [retireError, setRetireError] = useState<string | null>(null);
@@ -134,9 +160,17 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // `grouped` decides whether to render the two-block admin layout (with the
   // Owner column). When the org-scoped listing fails we collapse back to
   // the single-block member-style view so the admin still sees their own
-  // computers instead of a broken page.
-  const grouped = isAdmin && !orgClientsQuery.isError;
-  const teamLoadError = isAdmin && orgClientsQuery.isError;
+  // computers instead of a broken page. Demo mode forces the split based
+  // on the scenario.
+  const grouped = demoScenario ? demoScenario.key === "admin-grouped" : isAdmin && !orgClientsQuery.isError;
+  const teamLoadError = !demoScenario && isAdmin && orgClientsQuery.isError;
+
+  // Demo-mode data overrides feed the same downstream useMemo / render
+  // tree. Production builds skip these (demoScenario stays null).
+  const orgClientsData = demoScenario ? demoScenario.clients : orgClientsQuery.data;
+  const meClientsData = demoScenario
+    ? demoScenario.clients.filter((c) => c.userId === DEMO_SELF_USER_ID)
+    : meClientsQuery.data;
 
   const { data: activity } = useQuery({
     queryKey: ["activity"],
@@ -168,15 +202,16 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   });
 
   const agentsByClient = useMemo(() => {
+    const source = demoScenario ? demoScenario.agents : (activity?.agents ?? []);
     const map = new Map<string, RuntimeAgent[]>();
-    for (const a of activity?.agents ?? []) {
+    for (const a of source) {
       if (!a.clientId) continue;
       const list = map.get(a.clientId) ?? [];
       list.push(a);
       map.set(a.clientId, list);
     }
     return map;
-  }, [activity?.agents]);
+  }, [activity?.agents, demoScenario]);
 
   const getClientAgents = (clientId: string): RuntimeAgent[] => agentsByClient.get(clientId) ?? [];
 
@@ -187,14 +222,14 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // to scan the full list. `userId === null` (legacy clients that pre-date
   // user binding) lands in the team block.
   const mineList = useMemo<HubClient[]>(() => {
-    if (!grouped || !orgClientsQuery.data || !user) return [];
-    return [...orgClientsQuery.data].filter((c) => c.userId === user.id).sort(compareByPillPriority);
-  }, [grouped, orgClientsQuery.data, user]);
+    if (!grouped || !orgClientsData || !viewerUserId) return [];
+    return [...orgClientsData].filter((c) => c.userId === viewerUserId).sort(compareByPillPriority);
+  }, [grouped, orgClientsData, viewerUserId]);
 
   const teamList = useMemo<HubClient[]>(() => {
-    if (!grouped || !orgClientsQuery.data || !user) return [];
-    return [...orgClientsQuery.data].filter((c) => c.userId !== user.id).sort(compareByPillPriority);
-  }, [grouped, orgClientsQuery.data, user]);
+    if (!grouped || !orgClientsData || !viewerUserId) return [];
+    return [...orgClientsData].filter((c) => c.userId !== viewerUserId).sort(compareByPillPriority);
+  }, [grouped, orgClientsData, viewerUserId]);
 
   /**
    * Member-mode list (non-admin): the `/me/clients` payload arrives in
@@ -203,9 +238,9 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
    * deliberate UX change vs. the prior table — see PR description.
    */
   const memberList = useMemo<HubClient[] | undefined>(() => {
-    if (grouped || !meClientsQuery.data) return meClientsQuery.data;
-    return [...meClientsQuery.data].sort(compareByPillPriority);
-  }, [grouped, meClientsQuery.data]);
+    if (grouped || !meClientsData) return meClientsData;
+    return [...meClientsData].sort(compareByPillPriority);
+  }, [grouped, meClientsData]);
 
   const membersById = useMemo<Map<string, string>>(() => {
     const map = new Map<string, string>();
@@ -215,15 +250,21 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
 
   const resolveOwner = (client: HubClient): { text: string; title?: string } => {
     if (client.userId === null) return { text: "—" };
-    if (client.userId === user?.id) {
+    if (client.userId === viewerUserId) {
       const display = membersById.get(client.userId);
       // "gandy · you" rather than "gandy (you)" — nested parens read stiff
       // in card headers; the middot is the same separator the rest of the
       // page uses for meta segments.
-      return { text: display ? `${display} · you` : "you" };
+      const name = display ?? (demoScenario ? "gandy" : null);
+      return { text: name ? `${name} · you` : "you" };
     }
     const display = membersById.get(client.userId);
     if (display) return { text: display };
+    if (demoScenario) {
+      // Fixtures don't have a real members map — fall back to a friendly
+      // display name so the team-table doesn't show "other-us" short-ids.
+      return { text: "Alice" };
+    }
     // Owner is bound to a userId we can't resolve right now — either the
     // members fetch is still in flight or the user was removed from the org
     // mid-session. Show the short-id with a tooltip carrying the full uuid
@@ -235,17 +276,20 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // grouped mode → the org-scoped list (covers both mineList + teamList);
   // member mode → the pill-sorted memberList. Driving the subtitle and the
   // empty-state branch off this list keeps the two display modes in sync.
-  const clients = grouped ? orgClientsQuery.data : memberList;
+  const clients = grouped ? orgClientsData : memberList;
 
   // "Are we still waiting on the primary listing?" — distinct from `!clients`
   // because once a query resolves with an empty array we want to drop out of
   // loading and show the empty state. Without this gate, admins see the empty
-  // CTA flash before the org-scoped query lands on first paint.
-  const clientsLoading = isAdmin
-    ? orgClientsQuery.isError
-      ? meClientsQuery.isLoading
-      : orgClientsQuery.isLoading
-    : meClientsQuery.isLoading;
+  // CTA flash before the org-scoped query lands on first paint. Demo mode
+  // short-circuits since fixtures are synchronous.
+  const clientsLoading = demoScenario
+    ? false
+    : isAdmin
+      ? orgClientsQuery.isError
+        ? meClientsQuery.isLoading
+        : orgClientsQuery.isLoading
+      : meClientsQuery.isLoading;
 
   // Subtitle is the pure-function output of `summarizeComputers` — single
   // headline for one row owned by the viewer ("Your computer is ready"),
@@ -253,7 +297,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // zero-suppressed pill-count breakdown for multi-row views. The `· N
   // agents bound` suffix restores the power-user signal the old subtitle
   // surfaced. See `clients/derive-status.ts` for the pure logic + tests.
-  const subtitle = useMemo(() => summarizeComputers(clients, user?.id), [clients, user?.id]);
+  const subtitle = useMemo(() => summarizeComputers(clients, viewerUserId), [clients, viewerUserId]);
 
   // Cards now host the per-row affordances (Generate new token, install
   // guide, ⋯ menu) inline, so the PageHeader's right slot no longer needs
@@ -268,13 +312,16 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // their own and only team rows are showing — they don't yet have one
   // to "add another" to. In that case fall back to the full-page empty
   // CTA inside the "Your computers" section instead of the bottom button.
-  const singleOwnCard = !grouped && (memberList?.length ?? 0) === 1 && memberList?.[0]?.userId === user?.id;
+  const singleOwnCard = !grouped && (memberList?.length ?? 0) === 1 && memberList?.[0]?.userId === viewerUserId;
   const viewerOwnCount = grouped ? mineList.length : (memberList?.length ?? 0);
   const showBottomAddButton = !singleOwnCard && viewerOwnCount >= 1;
 
   return (
     <div className={embedded ? "" : "-m-6"}>
       <PageHeader title="Computers" subtitle={subtitle} />
+      {demoScenario && (
+        <DemoNavigator activeKey={demoScenario.key} onSelect={(k) => setDemoKey(k)} onExit={() => setDemoKey(null)} />
+      )}
 
       <div style={{ padding: "var(--sp-3_5) var(--sp-5) var(--sp-7)" }}>
         <NewConnectionDialog
@@ -481,17 +528,41 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                     </CardStack>
                   )}
                 </Section>
-                <Section title="Team computers" count={teamList.length}>
+                <Section
+                  title="Team computers"
+                  count={teamList.length}
+                  action={
+                    teamList.length > 0 ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setTeamExpanded((e) => !e)}
+                        aria-expanded={teamExpanded}
+                      >
+                        {teamExpanded ? (
+                          <>
+                            <ChevronDown className="h-3 w-3" />
+                            Hide
+                          </>
+                        ) : (
+                          <>
+                            <ChevronRight className="h-3 w-3" />
+                            Show
+                          </>
+                        )}
+                      </Button>
+                    ) : undefined
+                  }
+                >
                   {teamList.length === 0 ? (
                     <EmptyCardsNote message="No other team computers." />
-                  ) : (
-                    // Team rows stay as table for PR-B — they're read-only,
-                    // their primary value is "at a glance, who needs help",
-                    // and the per-row inline action affordances cards offer
-                    // (Generate new token / install guide) aren't applicable
-                    // to teammates. The full team-card redesign with
-                    // "Copy suggestion → Alice" buttons is deferred to a
-                    // follow-up PR; see proposal §"Variant D".
+                  ) : teamExpanded ? (
+                    // Team rows stay as table for now — read-only audit
+                    // view. Per-row inline affordances (Generate new
+                    // token / install guide) don't apply to teammates;
+                    // the full team-card redesign with "Copy suggestion
+                    // → Alice" buttons is deferred to a follow-up PR
+                    // (proposal §"Variant D").
                     <TeamComputersTable
                       teamList={teamList}
                       collapsedIds={collapsedIds}
@@ -500,7 +571,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                       getClientAgents={getClientAgents}
                       resolveOwner={resolveOwner}
                     />
-                  )}
+                  ) : null}
                 </Section>
               </>
             ) : (
@@ -586,50 +657,57 @@ function TeamComputersTable({
   getClientAgents: (clientId: string) => RuntimeAgent[];
   resolveOwner: (client: HubClient) => { text: string; title?: string };
 }) {
+  // Wrapping div pulls the table left by the first cell's left padding
+  // so the chevron column lines up with the parent Section's title left
+  // edge. Without this the hostname column sits inside the section,
+  // breaking the page's vertical alignment rhythm. Audit-only table,
+  // no horizontal scroll concerns — safe to bleed past padding.
   return (
-    <DenseTable>
-      <DenseTableHeader>
-        <DenseTableRow>
-          <DenseTableHead style={{ width: "var(--sp-4)" }} />
-          <DenseTableHead>Hostname</DenseTableHead>
-          <DenseTableHead>Owner</DenseTableHead>
-          <DenseTableHead>OS</DenseTableHead>
-          <DenseTableHead>first-tree</DenseTableHead>
-          <DenseTableHead>Agents</DenseTableHead>
-          <DenseTableHead>Last seen</DenseTableHead>
-          <DenseTableHead>Status</DenseTableHead>
-        </DenseTableRow>
-      </DenseTableHeader>
-      <DenseTableBody>
-        {teamList.map((client) => {
-          const isExpanded = !collapsedIds.has(client.id);
-          const boundAgents = getClientAgents(client.id);
-          return (
-            <ClientRow
-              key={client.id}
-              client={client}
-              boundAgents={boundAgents}
-              isExpanded={isExpanded}
-              agentName={agentName}
-              onToggle={() =>
-                setCollapsedIds((prev) => {
-                  const next = new Set(prev);
-                  if (next.has(client.id)) next.delete(client.id);
-                  else next.add(client.id);
-                  return next;
-                })
-              }
-              onDisconnect={() => {}}
-              onRetire={() => {}}
-              onReconnect={() => {}}
-              showOwner
-              ownerLabel={resolveOwner(client)}
-              restricted
-            />
-          );
-        })}
-      </DenseTableBody>
-    </DenseTable>
+    <div style={{ marginLeft: "calc(-1 * var(--sp-3_5))", marginRight: "calc(-1 * var(--sp-3_5))" }}>
+      <DenseTable>
+        <DenseTableHeader>
+          <DenseTableRow>
+            <DenseTableHead style={{ width: "var(--sp-4)" }} />
+            <DenseTableHead>Hostname</DenseTableHead>
+            <DenseTableHead>Owner</DenseTableHead>
+            <DenseTableHead>OS</DenseTableHead>
+            <DenseTableHead>first-tree</DenseTableHead>
+            <DenseTableHead>Agents</DenseTableHead>
+            <DenseTableHead>Last seen</DenseTableHead>
+            <DenseTableHead>Status</DenseTableHead>
+          </DenseTableRow>
+        </DenseTableHeader>
+        <DenseTableBody>
+          {teamList.map((client) => {
+            const isExpanded = !collapsedIds.has(client.id);
+            const boundAgents = getClientAgents(client.id);
+            return (
+              <ClientRow
+                key={client.id}
+                client={client}
+                boundAgents={boundAgents}
+                isExpanded={isExpanded}
+                agentName={agentName}
+                onToggle={() =>
+                  setCollapsedIds((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(client.id)) next.delete(client.id);
+                    else next.add(client.id);
+                    return next;
+                  })
+                }
+                onDisconnect={() => {}}
+                onRetire={() => {}}
+                onReconnect={() => {}}
+                showOwner
+                ownerLabel={resolveOwner(client)}
+                restricted
+              />
+            );
+          })}
+        </DenseTableBody>
+      </DenseTable>
+    </div>
   );
 }
 
@@ -643,7 +721,7 @@ function TeamComputersTable({
  * — the card-based IA uses the same vocabulary, so duplicating strings
  * here would invite drift.
  */
-function CapabilityMatrix({ capabilities }: { capabilities: ClientCapabilities }) {
+function CapabilityMatrix({ capabilities, os }: { capabilities: ClientCapabilities; os: string | null }) {
   const empty = Object.keys(capabilities).length === 0;
   return (
     <>
@@ -655,7 +733,7 @@ function CapabilityMatrix({ capabilities }: { capabilities: ClientCapabilities }
       ) : (
         <div className="flex flex-col gap-1">
           {PROVIDER_ORDER.map((provider) => (
-            <ProviderRow key={provider} provider={provider} entry={capabilities[provider] ?? null} />
+            <ProviderRow key={provider} provider={provider} entry={capabilities[provider] ?? null} os={os} />
           ))}
         </div>
       )}
@@ -663,7 +741,15 @@ function CapabilityMatrix({ capabilities }: { capabilities: ClientCapabilities }
   );
 }
 
-function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: CapabilityEntry | null }) {
+function ProviderRow({
+  provider,
+  entry,
+  os,
+}: {
+  provider: RuntimeProvider;
+  entry: CapabilityEntry | null;
+  os: string | null;
+}) {
   const label = PROVIDER_LABEL[provider];
   if (!entry) {
     return (
@@ -672,7 +758,7 @@ function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: Ca
           {label}
         </span>
         <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          not reported · {PROVIDER_INSTALL_HINT[provider]}
+          not reported · {providerInstallHint(provider, os)}
         </span>
       </div>
     );
@@ -685,7 +771,8 @@ function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: Ca
             {label}
           </span>
           <span className="text-caption" style={{ color: "var(--state-idle)" }}>
-            ✓ {entry.sdkVersion ? `v${entry.sdkVersion} · ` : ""}authenticated ({entry.authMethod})
+            ✓ {entry.sdkVersion ? `v${entry.sdkVersion} · ` : ""}
+            {entry.authMethod ?? "authenticated"}
           </span>
         </div>
       );
@@ -697,7 +784,7 @@ function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: Ca
           </span>
           <span className="text-caption" style={{ color: "var(--state-blocked)" }}>
             ⚠ installed{entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated ·{" "}
-            {PROVIDER_UNAUTH_HINT[provider]}
+            {providerUnauthHint(provider, os)}
           </span>
         </div>
       );
@@ -708,7 +795,7 @@ function ProviderRow({ provider, entry }: { provider: RuntimeProvider; entry: Ca
             {label}
           </span>
           <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            ✗ not installed · {PROVIDER_INSTALL_HINT[provider]}
+            ✗ not installed · {providerInstallHint(provider, os)}
           </span>
         </div>
       );
@@ -862,7 +949,7 @@ function ClientRow({
         <tr style={{ background: "var(--bg-sunken)" }}>
           <DenseTableCell />
           <DenseTableCell colSpan={colSpan - 1} style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-3_5)" }}>
-            <CapabilityMatrix capabilities={client.capabilities} />
+            <CapabilityMatrix capabilities={client.capabilities} os={client.os} />
             {boundAgents.length > 0 && (
               <>
                 <UppercaseLabel style={{ display: "block", marginTop: "var(--sp-3)", marginBottom: 6 }}>

--- a/packages/web/src/pages/clients/cards/__tests__/view-models.test.ts
+++ b/packages/web/src/pages/clients/cards/__tests__/view-models.test.ts
@@ -115,6 +115,15 @@ describe("summarizeBoundAgents", () => {
     ]);
     expect(result.agents[0]).toMatchObject({ activeSessions: 2, totalSessions: 5 });
   });
+
+  it("preserves runtimeType so the bound-agents row can render `name · runtime`", () => {
+    const result = summarizeBoundAgents([
+      agent({ agentId: "a", runtimeType: "claude-code", runtimeState: "idle" }),
+      agent({ agentId: "b", runtimeType: "codex", runtimeState: null }),
+      agent({ agentId: "c", runtimeType: null, runtimeState: "idle" }),
+    ]);
+    expect(result.agents.map((a) => a.runtimeType)).toEqual(["claude-code", "codex", null]);
+  });
 });
 
 describe("diagnostic copy", () => {

--- a/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/auth-expired-card-body.tsx
@@ -2,6 +2,8 @@ import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { Button } from "../../../components/ui/button.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
 import { CardMetaFooter } from "./shared/card-meta-row.js";
+import { PROVIDER_ORDER } from "./shared/providers.js";
+import { DimmedGroup, StaleRuntimeLine } from "./shared/stale-runtimes.js";
 import { authExpiredDiagnostic, summarizeBoundAgents } from "./view-models.js";
 
 type AuthExpiredCardBodyProps = {
@@ -21,27 +23,44 @@ type AuthExpiredCardBodyProps = {
 /**
  * Variant B body — the most "we need to act" pill. Renders:
  *   - Diagnostic: "Hasn't checked in for N days. Token expired."
- *   - Single primary action: "Generate new token" button. Clicking it
- *     opens the NewConnectionDialog (parameterized for re-auth wording),
- *     where the actual command + copy flow lives. We intentionally do
- *     NOT show a placeholder command on the card — a user copy-pasting a
- *     placeholder token would just hit AUTH_ERROR on the CLI side.
- *   - Affected agents: compact summary line ("3 agents · all offline").
- *   - Dimmed meta row (heartbeat / first-tree / OS) under a divider.
+ *   - Primary action: inline "Generate new token" button
+ *   - Affected agents: expanded list with PresenceChips so the operator
+ *     can see exactly which agents are stuck (the "blast radius")
+ *   - Dimmed Runtimes block (last reported) — tells the operator what
+ *     will come back online once they re-auth. Runtime auth (e.g.
+ *     `claude login`) is independent of first-tree login, so this also
+ *     hints whether they'll need to re-auth a runtime separately.
+ *   - Dimmed meta footer (heartbeat / first-tree / OS)
  */
 export function AuthExpiredCardBody({ client, boundAgents, agentName, onGenerateNewToken }: AuthExpiredCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
+  const reportedProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p] != null);
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
       <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
         {authExpiredDiagnostic(client)}
       </p>
-      <div className="flex items-center" style={{ gap: "var(--sp-3)" }}>
+      <div>
         <Button size="sm" onClick={onGenerateNewToken}>
           Generate new token
         </Button>
-        {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
       </div>
+      {summary.total > 0 && (
+        <DimmedGroup label={summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}>
+          <BoundAgentsList summary={summary} agentName={agentName} headerless />
+        </DimmedGroup>
+      )}
+      {reportedProviders.length > 0 && (
+        <DimmedGroup label="Runtimes · last reported">
+          <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+            {reportedProviders.map((provider) => {
+              const entry = client.capabilities[provider];
+              if (entry == null) return null;
+              return <StaleRuntimeLine key={provider} provider={provider} entry={entry} />;
+            })}
+          </div>
+        </DimmedGroup>
+      )}
       <CardMetaFooter client={client} />
     </div>
   );

--- a/packages/web/src/pages/clients/cards/computer-card.tsx
+++ b/packages/web/src/pages/clients/cards/computer-card.tsx
@@ -19,11 +19,12 @@ export type ComputerCardProps = {
   onGenerateNewToken: () => void;
   /**
    * Opens the NewConnectionDialog UNSCOPED (fresh connect command).
-   * Used by the offline-card kebab "Reconnect" entry — an offline
-   * machine's credentials are still likely valid, so the operator just
-   * needs a working connect token to re-pair from the machine. Routing
-   * this through `onGenerateNewToken` would scope the arrival detector
-   * to this row and mislead with re-auth copy.
+   * The Offline card promotes this to an inline "Reconnect" button as
+   * its primary affordance — an offline machine's credentials are
+   * usually still alive, so the operator just needs a working connect
+   * token to re-pair. Routing this through `onGenerateNewToken` would
+   * scope the arrival detector to this row and mislead with re-auth
+   * copy.
    */
   onReconnect: () => void;
   /** Opens the disconnect-confirmation modal. */
@@ -51,10 +52,10 @@ export type ComputerCardProps = {
  * without an explicit card chrome.
  *
  * Header row: hostname + optional owner caption + pill + ⋯ menu.
- * The ⋯ menu carries the same actions the legacy table's RowActionsMenu
- * had — Disconnect / Retire (+ Reconnect when offline). Reconnect on
- * offline rows opens the dialog as a fresh connect (no targetClientId);
- * AuthExpired uses the inline "Generate new token" button instead.
+ * The ⋯ menu only carries the destructive low-frequency actions
+ * (Disconnect / Retire). State-specific *primary* actions live inline
+ * inside the body — Generate new token on AuthExpired, Reconnect on
+ * Offline — so they're discoverable without clicking a kebab.
  */
 export function ComputerCard({
   client,
@@ -67,7 +68,6 @@ export function ComputerCard({
   ownerLabel,
 }: ComputerCardProps) {
   const vm = computerCardViewModel(client);
-  const isOffline = client.status !== "connected";
 
   return (
     // `<article>` (instead of nested `<section>`) keeps the page outline
@@ -100,7 +100,6 @@ export function ComputerCard({
         <RowActionsMenu
           ariaLabel="Computer actions"
           actions={[
-            ...(isOffline ? [{ key: "reconnect", label: "Reconnect", onSelect: onReconnect }] : []),
             { key: "disconnect", label: "Disconnect", onSelect: onDisconnect },
             { key: "retire", label: "Retire", destructive: true, onSelect: onRetire },
           ]}
@@ -112,6 +111,7 @@ export function ComputerCard({
         boundAgents={boundAgents}
         agentName={agentName}
         onGenerateNewToken={onGenerateNewToken}
+        onReconnect={onReconnect}
       />
     </article>
   );
@@ -123,6 +123,7 @@ function CardBody(props: {
   boundAgents: RuntimeAgent[];
   agentName: (uuid: string | null | undefined) => string;
   onGenerateNewToken: () => void;
+  onReconnect: () => void;
 }) {
   switch (props.pill) {
     case "ready":
@@ -141,7 +142,14 @@ function CardBody(props: {
         <SetupIncompleteCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />
       );
     case "offline":
-      return <OfflineCardBody client={props.client} boundAgents={props.boundAgents} agentName={props.agentName} />;
+      return (
+        <OfflineCardBody
+          client={props.client}
+          boundAgents={props.boundAgents}
+          agentName={props.agentName}
+          onReconnect={props.onReconnect}
+        />
+      );
     default: {
       const exhaustive: never = props.pill;
       return exhaustive;

--- a/packages/web/src/pages/clients/cards/offline-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/offline-card-body.tsx
@@ -1,44 +1,73 @@
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
+import { Button } from "../../../components/ui/button.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
 import { CardMetaFooter } from "./shared/card-meta-row.js";
 import { InlineCommand } from "./shared/inline-command.js";
+import { PROVIDER_ORDER } from "./shared/providers.js";
+import { DimmedGroup, StaleRuntimeLine } from "./shared/stale-runtimes.js";
 import { offlineDiagnostic, summarizeBoundAgents } from "./view-models.js";
 
 type OfflineCardBodyProps = {
   client: HubClient;
   boundAgents: RuntimeAgent[];
   agentName: (uuid: string | null | undefined) => string;
+  /**
+   * Opens the NewConnectionDialog unscoped (fresh connect flow). The
+   * Reconnect button is promoted out of the kebab on Offline cards
+   * because it's the operator's primary affordance here — same role
+   * as "Generate new token" on AuthExpired.
+   */
+  onReconnect: () => void;
 };
 
 /**
  * Variant B-3 body — credentials are alive but the machine isn't
  * checking in. Renders:
  *   - Diagnostic: "Last seen X ago. Make sure the machine is awake..."
- *   - Wake-guide command: `first-tree daemon start` (a hint the
- *     operator can run on the machine itself once they're at the
- *     keyboard)
- *   - Compact agents summary (will be all-offline by definition)
- *   - Heartbeat meta row, dimmed (matches AuthExpired's visual weight —
- *     the meta is stale context, not the focus)
- *
- * Distinct from AuthExpired: no inline button-action because there's
- * nothing the operator can do from the web side to wake the machine.
- * The wake-guide command is informational + copy-pasteable.
+ *   - Primary action row: "Reconnect" button (re-pair from this hub)
+ *     + wake-guide hint with copy-pasteable `first-tree daemon start`
+ *     for when the operator is at the keyboard of the offline machine
+ *   - Expanded agents list with PresenceChips (operator wants to know
+ *     which specific agents are down, not just the count)
+ *   - Dimmed Runtimes block (last reported) so the operator knows
+ *     what comes back when the machine reconnects
+ *   - Dimmed meta footer
  */
-export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardBodyProps) {
+export function OfflineCardBody({ client, boundAgents, agentName, onReconnect }: OfflineCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
+  const reportedProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p] != null);
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
       <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
         {offlineDiagnostic(client)}
       </p>
+      <div>
+        <Button size="sm" onClick={onReconnect}>
+          Reconnect
+        </Button>
+      </div>
       <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
         <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
           If the daemon isn't running, on this computer:
         </p>
         <InlineCommand command="first-tree daemon start" ariaLabel="Daemon wake command" />
       </div>
-      {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
+      {summary.total > 0 && (
+        <DimmedGroup label={summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}>
+          <BoundAgentsList summary={summary} agentName={agentName} headerless />
+        </DimmedGroup>
+      )}
+      {reportedProviders.length > 0 && (
+        <DimmedGroup label="Runtimes · last reported">
+          <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+            {reportedProviders.map((provider) => {
+              const entry = client.capabilities[provider];
+              if (entry == null) return null;
+              return <StaleRuntimeLine key={provider} provider={provider} entry={entry} />;
+            })}
+          </div>
+        </DimmedGroup>
+      )}
       <CardMetaFooter client={client} />
     </div>
   );

--- a/packages/web/src/pages/clients/cards/ready-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/ready-card-body.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
 import { CardMetaRow } from "./shared/card-meta-row.js";
-import { PROVIDER_INSTALL_HINT, PROVIDER_LABEL, PROVIDER_ORDER, PROVIDER_UNAUTH_HINT } from "./shared/providers.js";
+import { PROVIDER_LABEL, PROVIDER_ORDER, providerInstallHint, providerUnauthHint } from "./shared/providers.js";
 import { summarizeBoundAgents } from "./view-models.js";
 
 type ReadyCardBodyProps = {
@@ -16,29 +16,40 @@ type ReadyCardBodyProps = {
  * Variant A body — the happy path. Three groups separated by hairlines
  * inside the per-computer block:
  *   1. Heartbeat / first-tree / OS — `<dl>` field grid via `CardMetaRow`
- *   2. Runtimes — per-provider state line
+ *   2. Runtimes — per-provider state line (filtered to reported runtimes)
  *   3. Bound agents — when ≥ 1
  *
  * Mockup §"Variant A" puts agents last. The Runtimes section is
- * informational (one runtime must be `ok` for the pill to be Ready) but
- * worth showing so the user sees at a glance whether they have both
- * runtimes or just one.
+ * informational (one runtime must be `ok` for the pill to be Ready)
+ * but worth showing so the user sees at a glance whether they have
+ * both runtimes or just one.
+ *
+ * Runtimes the SDK never reported (`entry === null`) are *not*
+ * rendered — they'd otherwise be a "not reported · Install …" advert
+ * for a runtime the user actively chose not to install. The fully-
+ * empty case is owned by the Setup-incomplete pill, which has its own
+ * install boxes.
  */
 export function ReadyCardBody({ client, boundAgents, agentName }: ReadyCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
+  const reportedProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p] != null);
   return (
     <div className="flex flex-col">
       <Group>
         <CardMetaRow client={client} />
       </Group>
-      <Group>
-        <GroupLabel>Runtimes</GroupLabel>
-        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-          {PROVIDER_ORDER.map((provider) => (
-            <RuntimeStateLine key={provider} provider={provider} entry={client.capabilities[provider] ?? null} />
-          ))}
-        </div>
-      </Group>
+      {reportedProviders.length > 0 && (
+        <Group>
+          <GroupLabel>Runtimes</GroupLabel>
+          <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+            {reportedProviders.map((provider) => {
+              const entry = client.capabilities[provider];
+              if (entry == null) return null;
+              return <RuntimeStateLine key={provider} provider={provider} entry={entry} os={client.os} />;
+            })}
+          </div>
+        </Group>
+      )}
       {summary.total > 0 && (
         <Group>
           <GroupLabel>{summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}</GroupLabel>
@@ -77,34 +88,52 @@ function GroupLabel({ children }: { children: ReactNode }) {
   );
 }
 
-function RuntimeStateLine({ provider, entry }: { provider: RuntimeProvider; entry: CapabilityEntry | null }) {
+/**
+ * Per-runtime state line. All states render with a leading status
+ * glyph and the provider label as the first segment, then peer
+ * mid-dot-separated segments for version / state-or-method. Action
+ * hints (login / install) come after a period as a separate sentence
+ * so they don't crowd the segment rhythm.
+ *
+ * `entry === null` (not-yet-reported) is filtered upstream — this
+ * function assumes a real capability snapshot.
+ */
+function RuntimeStateLine({
+  provider,
+  entry,
+  os,
+}: {
+  provider: RuntimeProvider;
+  entry: CapabilityEntry;
+  os: string | null;
+}) {
   const label = PROVIDER_LABEL[provider];
-  if (!entry) {
-    return (
-      <div className="text-body" style={{ color: "var(--fg-3)" }}>
-        <span style={{ color: "var(--fg-2)" }}>{label}</span> · not reported · {PROVIDER_INSTALL_HINT[provider]}
-      </div>
-    );
-  }
   switch (entry.state) {
-    case "ok":
+    case "ok": {
+      const segments = [label, entry.sdkVersion ? `v${entry.sdkVersion}` : null, entry.authMethod ?? null].filter(
+        Boolean,
+      ) as string[];
       return (
         <div className="text-body" style={{ color: "var(--fg-2)" }}>
-          <span style={{ color: "var(--state-idle)" }}>✓</span> {label}
-          {entry.sdkVersion ? ` · v${entry.sdkVersion}` : ""} · authenticated ({entry.authMethod})
+          <span style={{ color: "var(--state-idle)" }}>✓</span> {segments.join(" · ")}
         </div>
       );
-    case "unauthenticated":
+    }
+    case "unauthenticated": {
+      const segments = [label, entry.sdkVersion ? `v${entry.sdkVersion}` : null, "unauthenticated"].filter(
+        Boolean,
+      ) as string[];
       return (
         <div className="text-body" style={{ color: "var(--fg-2)" }}>
-          <span style={{ color: "var(--state-blocked)" }}>⚠</span> {label}
-          {entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}, not authenticated · {PROVIDER_UNAUTH_HINT[provider]}
+          <span style={{ color: "var(--state-blocked)" }}>⚠</span> {segments.join(" · ")}.{" "}
+          <span style={{ color: "var(--fg-3)" }}>{providerUnauthHint(provider, os)}</span>
         </div>
       );
+    }
     case "missing":
       return (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>
-          <span style={{ color: "var(--fg-4)" }}>✗</span> {label} · not installed · {PROVIDER_INSTALL_HINT[provider]}
+          <span style={{ color: "var(--fg-4)" }}>✗</span> {label} · not installed. {providerInstallHint(provider, os)}
         </div>
       );
     case "error":

--- a/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
@@ -53,7 +53,21 @@ export function SetupIncompleteCardBody({ client, boundAgents, agentName }: Setu
           />
         ))}
       </div>
-      {summary.total > 0 && <BoundAgentsList summary={summary} agentName={agentName} compact />}
+      {summary.total > 0 && (
+        <div
+          className="flex flex-col"
+          style={{
+            gap: "var(--sp-1_5)",
+            padding: "var(--sp-2_5) 0 0",
+            borderTop: "var(--hairline) solid var(--border-faint)",
+          }}
+        >
+          <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+            {summary.total === 1 ? "Agent · waiting on runtime" : `Agents · ${summary.total} · waiting on runtime`}
+          </div>
+          <BoundAgentsList summary={summary} agentName={agentName} headerless />
+        </div>
+      )}
       <CardMetaFooter client={client} dimmed={false} />
     </div>
   );

--- a/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
+++ b/packages/web/src/pages/clients/cards/shared/bound-agents-list.tsx
@@ -1,15 +1,11 @@
+import type { RuntimeProvider } from "@first-tree/shared";
 import { PresenceChip, runtimeStateToPresence } from "../../../../components/ui/presence-chip.js";
 import type { BoundAgentsSummary } from "../view-models.js";
+import { PROVIDER_LABEL } from "./providers.js";
 
 type BoundAgentsListProps = {
   summary: BoundAgentsSummary;
   agentName: (uuid: string | null | undefined) => string;
-  /**
-   * When true, render the agents list in a compact "N agent(s) — M online"
-   * form instead of a full per-agent list. Used by AuthExpired / Offline
-   * cards where the agents section is supporting context, not the focus.
-   */
-  compact?: boolean;
   /**
    * When true, skip the in-component "Agents · N" header — the parent
    * Group is already labeling the block. Without this the Ready card
@@ -19,37 +15,27 @@ type BoundAgentsListProps = {
 };
 
 /**
- * Renders the bound-agents block of a computer card body.
+ * Per-agent rows under a computer card body.
  *
- * Two display modes — both fed by the same `BoundAgentsSummary`:
- *   - **expanded** (Ready card): per-agent row with `PresenceChip`
- *   - **compact** (AuthExpired / Offline): single-line summary like
- *     "3 agents · all offline"
+ * Format: `<name> · <runtime-type>   <PresenceChip>` — the mid-dot
+ * separator matches the rest of the page's segment-meta rhythm
+ * (`gandy · you`, `Claude Code · v0.2.141 · oauth`). The runtime
+ * inline tells the operator which provider is carrying each agent so
+ * they can correlate an agent's idle/offline state with the
+ * runtime-level state above.
  *
  * Session counts (active / total) used to render here but were dropped
- * in the minimal-style pass — the per-computer card is a *status*
- * surface, not an agent detail view. Session info belongs on
- * `/agent/:id`, which the user reaches from the bound name.
+ * — the per-computer card is a *status* surface, not an agent detail
+ * view. Session info lives on `/agent/:id`.
+ *
+ * AuthExpired and Offline cards used to render a compact summary line
+ * here; that mode was retired so problem-state cards explicitly name
+ * the affected agents (operator's primary question on a broken
+ * machine is "which agents are down", not "how many").
  */
-export function BoundAgentsList({ summary, agentName, compact = false, headerless = false }: BoundAgentsListProps) {
+export function BoundAgentsList({ summary, agentName, headerless = false }: BoundAgentsListProps) {
   if (summary.total === 0) {
     return null;
-  }
-
-  if (compact) {
-    // Sentence: "{N} agent(s) · {state}". For total === 1 the "all" qualifier
-    // reads wrong, so collapse to bare "offline" / "online".
-    const noun = summary.total === 1 ? "agent" : "agents";
-    const allWord = summary.total === 1 ? "" : "all ";
-    let suffix: string;
-    if (summary.offline === summary.total) suffix = `${allWord}offline`;
-    else if (summary.online === summary.total) suffix = `${allWord}online`;
-    else suffix = `${summary.offline} offline`;
-    return (
-      <div className="text-caption" style={{ color: "var(--fg-3)" }}>
-        {summary.total} {noun} · {suffix}
-      </div>
-    );
   }
 
   return (
@@ -59,12 +45,39 @@ export function BoundAgentsList({ summary, agentName, compact = false, headerles
           {summary.total === 1 ? "Agent" : `Agents · ${summary.total}`}
         </div>
       )}
-      {summary.agents.map((a) => (
-        <div key={a.agentId} className="flex items-center text-body" style={{ gap: "var(--sp-2_5)" }}>
-          <span style={{ color: "var(--fg-2)" }}>{agentName(a.agentId)}</span>
-          <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
-        </div>
-      ))}
+      {summary.agents.map((a) => {
+        const runtimeLabel = formatRuntimeLabel(a.runtimeType);
+        return (
+          <div key={a.agentId} className="flex items-center text-body" style={{ gap: "var(--sp-3)" }}>
+            <span style={{ color: "var(--fg-2)" }}>
+              {agentName(a.agentId)}
+              {runtimeLabel && (
+                <>
+                  <span style={{ color: "var(--fg-4)", padding: "0 var(--sp-1)" }}>·</span>
+                  <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+                    {runtimeLabel}
+                  </span>
+                </>
+              )}
+            </span>
+            <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
+          </div>
+        );
+      })}
     </div>
   );
+}
+
+/**
+ * Map raw `runtimeType` (the wire-format string from `clients.agents`)
+ * to the human label used in PROVIDER_LABEL. Returns null when the
+ * provider isn't recognized so the row gracefully degrades to just
+ * `name + chip` rather than rendering "· null".
+ */
+function formatRuntimeLabel(runtimeType: string | null): string | null {
+  if (!runtimeType) return null;
+  if (runtimeType === "claude-code" || runtimeType === "codex") {
+    return PROVIDER_LABEL[runtimeType as RuntimeProvider];
+  }
+  return runtimeType;
 }

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -49,17 +49,49 @@ export function buildInstallCommand(provider: RuntimeProvider): string {
 }
 
 /**
- * Shortest hint string for "this runtime is installed but the user
- * isn't authed". Used by Ready card's compact capability matrix when
- * one provider is `unauthenticated`. Full re-auth lives in the
- * provider's docs.
+ * Friendly "this Mac / this Linux machine / this Windows PC" phrase
+ * derived from the client's reported OS. Lets recovery copy address
+ * the user's actual hardware instead of the generic "computer".
+ *
+ * Maps the kernel-side strings the SDK reports (`darwin`, `linux`,
+ * `win32`). Unknown / null falls back to "computer" — never breaks the
+ * sentence shape.
  */
-export const PROVIDER_UNAUTH_HINT: Record<RuntimeProvider, string> = {
-  "claude-code": "Run `claude login` (or set ANTHROPIC_API_KEY) on the computer.",
-  codex: "Run `codex login` (or set CODEX_API_KEY) on the computer.",
-};
+export function osDeviceName(os: string | null | undefined): string {
+  switch (os) {
+    case "darwin":
+      return "Mac";
+    case "linux":
+      return "Linux machine";
+    case "win32":
+    case "windows":
+      return "Windows PC";
+    default:
+      return "computer";
+  }
+}
 
-export const PROVIDER_INSTALL_HINT: Record<RuntimeProvider, string> = {
-  "claude-code": "Run `npm install -g @anthropic-ai/claude-code` on this computer.",
-  codex: "Install the OpenAI Codex CLI on this computer.",
-};
+/**
+ * Shortest hint for "this runtime is installed but the user isn't
+ * authed". Used by Ready card's runtime line when one provider is
+ * `unauthenticated`. The env-variable fallback (`ANTHROPIC_API_KEY` /
+ * `CODEX_API_KEY`) is intentionally dropped — most users discover the
+ * OAuth flow first, and the env var path is a footgun for newcomers
+ * who'd commit the key.
+ */
+export function providerUnauthHint(provider: RuntimeProvider, os: string | null | undefined): string {
+  return `Run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on this ${osDeviceName(os)}.`;
+}
+
+/**
+ * Hint for `state="missing"`. Distinct from `entry === null` ("not
+ * reported") — that case is suppressed in the Ready card entirely, so
+ * the hint only shows when the SDK explicitly probed and confirmed the
+ * runtime is not installed.
+ */
+export function providerInstallHint(provider: RuntimeProvider, os: string | null | undefined): string {
+  if (provider === "claude-code") {
+    return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${osDeviceName(os)}.`;
+  }
+  return `Install the OpenAI Codex CLI on this ${osDeviceName(os)}.`;
+}

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -36,15 +36,25 @@ export function RuntimeInstallBox({ provider, entry, hostname }: RuntimeInstallB
   // are a single visual unit the operator scans + copies). Wrapping
   // again would nest a box inside a box inside the page, which fights
   // the Settings tab's "flat hairline-only" vocabulary.
+  //
+  // Layout: `height: 100%` lets the box take the full grid-row height
+  // (CSS Grid stretches items by default), and the InlineCommand
+  // wrapper is pushed to the bottom via `margin-top: auto`. The result
+  // is that when two boxes sit side-by-side with headlines of
+  // different lengths, their Copy buttons baseline-align at the bottom
+  // — the operator's eye doesn't have to chase varying button
+  // positions.
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--sp-1_5)", height: "100%" }}>
       <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
         {label}
       </div>
       <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
         {renderHeadlineWithCode(headline)}
       </p>
-      <InlineCommand command={command} ariaLabel={`${label} setup command`} />
+      <div style={{ marginTop: "auto" }}>
+        <InlineCommand command={command} ariaLabel={`${label} setup command`} />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/pages/clients/cards/shared/stale-runtimes.tsx
+++ b/packages/web/src/pages/clients/cards/shared/stale-runtimes.tsx
@@ -1,0 +1,55 @@
+import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
+import type { ReactNode } from "react";
+import { PROVIDER_LABEL } from "./providers.js";
+
+/**
+ * Hairline-separated group with dimmed text. Used by AuthExpired and
+ * Offline to render "stale context" sections (runtimes / agents that
+ * were observed before the machine went silent). Visually quieter
+ * than the Ready card's Group so the primary action stays the focus.
+ */
+export function DimmedGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-1_5)",
+        padding: "var(--sp-2_5) 0 0",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+        opacity: 0.7,
+      }}
+    >
+      <div className="text-caption" style={{ color: "var(--fg-3)" }}>
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * "(last reported)" runtime line. No action affordance — the machine
+ * isn't checking in, so the operator can't directly act on the runtime
+ * state. Pure status snapshot from the last successful probe.
+ *
+ * Used by AuthExpired and Offline card bodies. Distinct from the Ready
+ * card's RuntimeStateLine which renders action hints inline; here we
+ * never tell the user what to do because they can't reach the machine
+ * to do it.
+ */
+export function StaleRuntimeLine({ provider, entry }: { provider: RuntimeProvider; entry: CapabilityEntry }) {
+  const label = PROVIDER_LABEL[provider];
+  const glyph =
+    entry.state === "ok" ? "✓" : entry.state === "unauthenticated" ? "⚠" : entry.state === "missing" ? "✗" : "!";
+  const segments: string[] = [label];
+  if (entry.sdkVersion) segments.push(`v${entry.sdkVersion}`);
+  if (entry.state === "ok" && entry.authMethod) segments.push(entry.authMethod);
+  else if (entry.state === "unauthenticated") segments.push("unauthenticated");
+  else if (entry.state === "missing") segments.push("not installed");
+  else if (entry.state === "error") segments.push(entry.error ?? "probe failed");
+  return (
+    <div className="text-body" style={{ color: "var(--fg-2)" }}>
+      <span style={{ color: "var(--fg-4)" }}>{glyph}</span> {segments.join(" · ")}
+    </div>
+  );
+}

--- a/packages/web/src/pages/clients/cards/view-models.ts
+++ b/packages/web/src/pages/clients/cards/view-models.ts
@@ -58,6 +58,14 @@ export type AgentLine = {
   agentId: string;
   /** Server-derived runtime state ("idle" / "working" / "blocked" / "error" / null = offline). */
   runtimeState: string | null;
+  /**
+   * Runtime provider this agent is pinned to (e.g. "claude-code" /
+   * "codex"). Surfaced inline in the bound-agents list so the operator
+   * can see which runtime is carrying which agent — useful when one
+   * runtime is unauth'd or missing on the machine and they need to
+   * trace blast-radius.
+   */
+  runtimeType: string | null;
   activeSessions: number | null;
   totalSessions: number | null;
 };
@@ -85,6 +93,7 @@ export function summarizeBoundAgents(agents: RuntimeAgent[]): BoundAgentsSummary
     return {
       agentId: a.agentId,
       runtimeState: a.runtimeState,
+      runtimeType: a.runtimeType,
       activeSessions: a.activeSessions,
       totalSessions: a.totalSessions,
     };

--- a/packages/web/src/pages/clients/demo-navigator.tsx
+++ b/packages/web/src/pages/clients/demo-navigator.tsx
@@ -204,17 +204,26 @@ export function DemoNavigator({
  * Reads `?demo=<key>` from the URL and keeps state in sync with browser
  * back/forward. Returns `null` when the param isn't set or doesn't
  * match a known scenario.
+ *
+ * Every branch is no-op in production: `import.meta.env.DEV` folds to
+ * `false`, the initializer returns null, the popstate listener bails,
+ * and the updater rejects writes — so the hook keeps a stable shape
+ * (React rules-of-hooks happy) while the demo code path stays inert.
+ * Combined with the gated `DEMO_SCENARIOS` array in `dev-fixtures.ts`,
+ * the entire feature drops out of the prod bundle.
  */
 export function useDemoScenarioParam(): [string | null, (key: string | null) => void] {
   const [key, setKey] = useState<string | null>(() => readDemoParam());
 
   useEffect(() => {
+    if (!import.meta.env.DEV) return;
     const sync = () => setKey(readDemoParam());
     window.addEventListener("popstate", sync);
     return () => window.removeEventListener("popstate", sync);
   }, []);
 
   const update = (nextKey: string | null) => {
+    if (!import.meta.env.DEV) return;
     const url = new URL(window.location.href);
     if (nextKey) {
       url.searchParams.set("demo", nextKey);
@@ -229,6 +238,7 @@ export function useDemoScenarioParam(): [string | null, (key: string | null) => 
 }
 
 function readDemoParam(): string | null {
+  if (!import.meta.env.DEV) return null;
   const params = new URLSearchParams(window.location.search);
   const raw = params.get("demo");
   if (!raw) return null;

--- a/packages/web/src/pages/clients/demo-navigator.tsx
+++ b/packages/web/src/pages/clients/demo-navigator.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState } from "react";
+import { DEMO_SCENARIOS, type DemoScenario, findDemoScenario } from "./dev-fixtures.js";
+
+/**
+ * Floating dev-only overlay rendered on `/settings/computers` when the
+ * URL carries `?demo=<key>`. Lets the reviewer walk every scenario
+ * inside the real page chrome (sidebar, PageHeader, ClientsPage layout)
+ * without seeding the DB.
+ *
+ * Lives bottom-right so it doesn't compete with the page's own header.
+ * Collapsible — the "What to check" list expands on click; the slim
+ * resting state stays out of the way so the reviewer can scrutinize
+ * the page itself.
+ *
+ * The component is mounted *only* when the page detects demo mode is
+ * active, so the prod page bundle never reaches this code path.
+ */
+export function DemoNavigator({
+  activeKey,
+  onSelect,
+  onExit,
+}: {
+  activeKey: string;
+  onSelect: (key: string) => void;
+  onExit: () => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const variant: DemoScenario | null = findDemoScenario(activeKey);
+  if (!variant) return null;
+
+  const idx = DEMO_SCENARIOS.findIndex((v) => v.key === activeKey);
+  const prev = idx > 0 ? DEMO_SCENARIOS[idx - 1] : null;
+  const next = idx < DEMO_SCENARIOS.length - 1 ? DEMO_SCENARIOS[idx + 1] : null;
+
+  return (
+    <aside
+      aria-label="Demo navigator"
+      style={{
+        position: "fixed",
+        right: "var(--sp-4)",
+        bottom: "var(--sp-4)",
+        width: 360,
+        maxHeight: "70vh",
+        overflowY: "auto",
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        boxShadow: "var(--shadow-md)",
+        zIndex: 60,
+      }}
+    >
+      <header
+        style={{
+          padding: "var(--sp-2_5) var(--sp-3)",
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--sp-2)",
+          borderBottom: "var(--hairline) solid var(--border-faint)",
+        }}
+      >
+        <span className="text-caption" style={{ color: "var(--state-idle)", whiteSpace: "nowrap" }}>
+          DEMO {idx + 1}/{DEMO_SCENARIOS.length}
+        </span>
+        <select
+          aria-label="Scenario"
+          value={variant.key}
+          onChange={(e) => onSelect(e.target.value)}
+          className="text-body"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            padding: "var(--sp-1) var(--sp-1_5)",
+            background: "var(--bg)",
+            color: "var(--fg)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            cursor: "pointer",
+          }}
+        >
+          {groupVariants(DEMO_SCENARIOS).map(([group, items]) => (
+            <optgroup key={group} label={group}>
+              {items.map((v) => (
+                <option key={v.key} value={v.key}>
+                  {v.title}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={onExit}
+          title="Exit demo mode"
+          className="text-caption"
+          style={{
+            padding: "var(--sp-1) var(--sp-2)",
+            background: "transparent",
+            color: "var(--fg-3)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            cursor: "pointer",
+          }}
+        >
+          Exit
+        </button>
+      </header>
+
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        style={{
+          width: "100%",
+          padding: "var(--sp-2) var(--sp-3)",
+          background: "transparent",
+          color: "var(--fg-2)",
+          border: "none",
+          textAlign: "left",
+          cursor: "pointer",
+        }}
+      >
+        <div className="text-caption" style={{ color: "var(--state-idle)", marginBottom: 2 }}>
+          {variant.group}
+        </div>
+        <div className="text-body font-semibold">{variant.title}</div>
+        <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: 4 }}>
+          {expanded ? "▾ Hide notes" : "▸ Show notes"}
+        </div>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: "0 var(--sp-3) var(--sp-3)" }}>
+          <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)", marginBottom: "var(--sp-2)" }}>
+            {variant.summary}
+          </p>
+          <div className="text-caption" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+            What to check
+          </div>
+          <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: "var(--sp-1)" }}>
+            {variant.whatToCheck.map((line, i) => (
+              <li
+                // biome-ignore lint/suspicious/noArrayIndexKey: static list per scenario.
+                key={i}
+                className="text-caption"
+                style={{ color: "var(--fg-2)", display: "flex", gap: "var(--sp-1_5)" }}
+              >
+                <span style={{ color: "var(--fg-4)", flexShrink: 0 }}>·</span>
+                <span>{line}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <footer
+        style={{
+          display: "flex",
+          gap: "var(--sp-2)",
+          padding: "var(--sp-2_5) var(--sp-3)",
+          borderTop: "var(--hairline) solid var(--border-faint)",
+        }}
+      >
+        <button
+          type="button"
+          disabled={!prev}
+          onClick={() => prev && onSelect(prev.key)}
+          className="text-caption"
+          style={{
+            flex: 1,
+            padding: "var(--sp-1_5) var(--sp-2)",
+            background: "transparent",
+            color: prev ? "var(--fg-2)" : "var(--fg-4)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            cursor: prev ? "pointer" : "default",
+            textAlign: "left",
+          }}
+        >
+          ← {prev?.title.slice(0, 28) ?? "—"}
+        </button>
+        <button
+          type="button"
+          disabled={!next}
+          onClick={() => next && onSelect(next.key)}
+          className="text-caption"
+          style={{
+            flex: 1,
+            padding: "var(--sp-1_5) var(--sp-2)",
+            background: "transparent",
+            color: next ? "var(--fg-2)" : "var(--fg-4)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            cursor: next ? "pointer" : "default",
+            textAlign: "right",
+          }}
+        >
+          {next?.title.slice(0, 28) ?? "—"} →
+        </button>
+      </footer>
+    </aside>
+  );
+}
+
+/**
+ * Reads `?demo=<key>` from the URL and keeps state in sync with browser
+ * back/forward. Returns `null` when the param isn't set or doesn't
+ * match a known scenario.
+ */
+export function useDemoScenarioParam(): [string | null, (key: string | null) => void] {
+  const [key, setKey] = useState<string | null>(() => readDemoParam());
+
+  useEffect(() => {
+    const sync = () => setKey(readDemoParam());
+    window.addEventListener("popstate", sync);
+    return () => window.removeEventListener("popstate", sync);
+  }, []);
+
+  const update = (nextKey: string | null) => {
+    const url = new URL(window.location.href);
+    if (nextKey) {
+      url.searchParams.set("demo", nextKey);
+    } else {
+      url.searchParams.delete("demo");
+    }
+    window.history.pushState({}, "", url);
+    setKey(nextKey);
+  };
+
+  return [key, update];
+}
+
+function readDemoParam(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get("demo");
+  if (!raw) return null;
+  return findDemoScenario(raw)?.key ?? null;
+}
+
+function groupVariants(variants: DemoScenario[]): Array<[string, DemoScenario[]]> {
+  const map = new Map<string, DemoScenario[]>();
+  for (const v of variants) {
+    const list = map.get(v.group) ?? [];
+    list.push(v);
+    map.set(v.group, list);
+  }
+  return [...map.entries()];
+}

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -1,0 +1,390 @@
+import type { CapabilityEntry } from "@first-tree/shared";
+import type { HubClient, RuntimeAgent } from "../../api/activity.js";
+
+/**
+ * DEV-only fixtures for the `?demo=<key>` query-param mode of
+ * `ClientsPage`. Lets a reviewer flip the live `/settings/computers`
+ * page through every pill × sub-variant without seeding the local DB
+ * or running multiple daemons.
+ *
+ * The page reads `?demo=<key>` from the URL when `import.meta.env.DEV`
+ * is true; if a scenario matches it overrides the react-query results
+ * and renders the same JSX with these fixtures. Production builds
+ * never check this param — but the module is tree-shake-friendly
+ * anyway (pure data + builders).
+ *
+ * Each scenario carries a `whatToCheck` checklist surfaced by the
+ * floating `<DemoNavigator>` overlay so the reviewer knows what's
+ * distinctive about the state without reading the source.
+ */
+
+const NOW = Date.now();
+
+function isoMinutesAgo(min: number): string {
+  return new Date(NOW - min * 60_000).toISOString();
+}
+
+function isoDaysAgo(days: number): string {
+  return new Date(NOW - days * 24 * 60 * 60_000).toISOString();
+}
+
+function cap(state: CapabilityEntry["state"], overrides: Partial<CapabilityEntry> = {}): CapabilityEntry {
+  return {
+    state,
+    available: state !== "missing",
+    authenticated: state === "ok",
+    authMethod: overrides.authMethod ?? "none",
+    detectedAt: overrides.detectedAt ?? isoMinutesAgo(1),
+    sdkVersion: overrides.sdkVersion,
+    error: overrides.error,
+  };
+}
+
+function client(overrides: Partial<HubClient>): HubClient {
+  return {
+    id: overrides.id ?? "fixture",
+    userId: overrides.userId ?? "self-uuid",
+    status: overrides.status ?? "connected",
+    authState: overrides.authState ?? "ok",
+    sdkVersion: overrides.sdkVersion ?? "0.5.3-staging.49.1",
+    hostname: overrides.hostname ?? "MacBook-Pro.local",
+    os: overrides.os ?? "darwin",
+    agentCount: overrides.agentCount ?? 0,
+    connectedAt: overrides.connectedAt ?? isoMinutesAgo(30),
+    lastSeenAt: overrides.lastSeenAt ?? isoMinutesAgo(0.2),
+    capabilities: overrides.capabilities ?? {},
+  };
+}
+
+function agent(overrides: Partial<RuntimeAgent>): RuntimeAgent {
+  // Default runtimeType picks claude-code for "*-dev" agents and codex
+  // for "*-asst" agents — gives the demo gallery visual variety when
+  // multiple agents are bound to the same fixture. Pin explicitly via
+  // `overrides.runtimeType` when a scenario needs a specific provider.
+  const id = overrides.agentId ?? "agent-uuid";
+  const defaultRuntime = id.endsWith("asst") ? "codex" : "claude-code";
+  return {
+    agentId: id,
+    clientId: overrides.clientId ?? "fixture",
+    runtimeType: overrides.runtimeType !== undefined ? overrides.runtimeType : defaultRuntime,
+    runtimeState: overrides.runtimeState ?? "idle",
+    activeSessions: overrides.activeSessions ?? 0,
+    totalSessions: overrides.totalSessions ?? 0,
+    runtimeUpdatedAt: overrides.runtimeUpdatedAt ?? isoMinutesAgo(1),
+    type: overrides.type ?? null,
+    managedByMe: overrides.managedByMe ?? true,
+  };
+}
+
+export const DEMO_SELF_USER_ID = "self-uuid";
+
+/**
+ * The set of clients + agents a particular `?demo=<key>` selects.
+ * Most scenarios use a single own-machine; "stack" and "admin-grouped"
+ * use multiple to exercise list-level UX.
+ */
+export type DemoScenario = {
+  key: string;
+  group: "Ready" | "Auth expired" | "Setup incomplete" | "Offline" | "Cross-cutting";
+  title: string;
+  summary: string;
+  whatToCheck: string[];
+  /** All clients in this scenario — first one is the "viewer's own" for non-admin paths. */
+  clients: HubClient[];
+  agents: RuntimeAgent[];
+};
+
+const READY_BOTH = client({
+  id: "demo-ready-both",
+  hostname: "GandydeMacBook-Pro.local",
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+    codex: cap("ok", { sdkVersion: "0.125.0", authMethod: "auth_json" }),
+  },
+});
+
+const READY_CC_ONLY = client({
+  id: "demo-ready-cc-only",
+  hostname: "Linux-box.lan",
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+  },
+});
+
+const READY_MIXED = client({
+  id: "demo-ready-mixed",
+  hostname: "MacBook-Pro.local",
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+    codex: cap("unauthenticated", { sdkVersion: "0.125.0" }),
+  },
+});
+
+const AUTH_EXPIRED = client({
+  id: "demo-auth-expired",
+  hostname: "Mac-mini.attic",
+  status: "disconnected",
+  authState: "expired",
+  lastSeenAt: isoDaysAgo(8),
+  sdkVersion: "0.5.1",
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
+  },
+});
+
+const SETUP_EMPTY = client({
+  id: "demo-setup-empty",
+  hostname: "fresh-linux-box.local",
+  os: "linux",
+});
+
+const SETUP_MIXED = client({
+  id: "demo-setup-mixed",
+  hostname: "MacBook-Pro.local",
+  capabilities: {
+    "claude-code": cap("unauthenticated", { sdkVersion: "0.2.141" }),
+  },
+});
+
+const SETUP_ERROR = client({
+  id: "demo-setup-error",
+  hostname: "MacBook-Pro.local",
+  capabilities: {
+    codex: cap("error", { error: "ENOENT: spawn /usr/local/bin/codex" }),
+  },
+});
+
+const OFFLINE_RECENT = client({
+  id: "demo-offline-recent",
+  hostname: "MacBook-Pro.local",
+  status: "disconnected",
+  lastSeenAt: isoMinutesAgo(120),
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+  },
+});
+
+const OFFLINE_STALE = client({
+  id: "demo-offline-stale",
+  hostname: "old-laptop.fritz.box",
+  status: "disconnected",
+  lastSeenAt: isoDaysAgo(4),
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
+  },
+});
+
+const TEAM_MACHINE = client({
+  id: "demo-team-machine",
+  userId: "other-user",
+  hostname: "alice-MBP.lan",
+  capabilities: {
+    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+  },
+});
+
+export const DEMO_AGENT_NAMES: Record<string, string> = {
+  "a-dev": "gandy-developer",
+  "a-asst": "gandy-assistant",
+  "a-rev": "code-reviewer",
+  "a-other": "alice-bot",
+};
+
+export const DEMO_SCENARIOS: DemoScenario[] = [
+  {
+    key: "ready-both",
+    group: "Ready",
+    title: "Ready · both runtimes ok · 2 agents",
+    summary:
+      "Happy path. Pill is Ready when status=connected, authState=ok, AND ≥1 capability=ok. Both runtimes ok is the most common shape.",
+    whatToCheck: [
+      "Green pill 'Ready' in the top-right",
+      "Hostname is the visual focus (font-semibold); owner label 'gandy · you' below (no nested parens)",
+      "Heartbeat / first-tree / OS as 2-col `<dl>` field grid",
+      "Runtimes block: ✓ Claude Code + ✓ Codex, lowercase label 'Runtimes'",
+      "Agent rows: name + presence chip only, no '3 / 7 sessions' counter",
+      "No background tint / shadow / radius — flat with hairlines",
+    ],
+    clients: [READY_BOTH],
+    agents: [
+      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+    ],
+  },
+  {
+    key: "ready-cc-only",
+    group: "Ready",
+    title: "Ready · only Claude Code · 0 agents",
+    summary: "Ready with one runtime ok + one missing. Bound-agents block hides entirely when total=0.",
+    whatToCheck: [
+      "Pill still Ready (one ok is enough)",
+      "Runtimes: ✓ Claude Code + ✗ Codex 'not installed' inline",
+      "Agents block NOT rendered — only 2 groups (meta + runtimes)",
+    ],
+    clients: [READY_CC_ONLY],
+    agents: [],
+  },
+  {
+    key: "ready-mixed",
+    group: "Ready",
+    title: "Ready · Codex unauthenticated",
+    summary: "One runtime ok, one installed-but-unauthed. Card stays Ready; the unauth runtime gets a yellow ⚠ hint.",
+    whatToCheck: [
+      "Pill stays Ready (Claude Code is ok)",
+      "Codex line shows ⚠ + 'installed v0.125.0, not authenticated' + login hint",
+      "Warning yellow on the unauth line, idle green on the ok line",
+    ],
+    clients: [READY_MIXED],
+    agents: [agent({ agentId: "a-dev", clientId: READY_MIXED.id, runtimeState: "running" })],
+  },
+  {
+    key: "auth-expired",
+    group: "Auth expired",
+    title: "Auth expired · 8 days · 3 agents",
+    summary:
+      "Token has expired (authState=expired). Pill is Auth expired regardless of capability. The card surfaces recovery action inline.",
+    whatToCheck: [
+      "Red pill 'Auth expired' in the top-right",
+      "Diagnostic: 'Hasn't checked in for 8 days. Your access token has expired.'",
+      "Primary 'Generate new token' button inline — NOT in the kebab",
+      "Right of the button: compact summary '3 agents · all offline'",
+      "Footer: dimmed meta block under hairline",
+    ],
+    clients: [AUTH_EXPIRED],
+    agents: [
+      agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+      agent({ agentId: "a-asst", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+      agent({ agentId: "a-rev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+    ],
+  },
+  {
+    key: "setup-empty",
+    group: "Setup incomplete",
+    title: "Setup incomplete · no runtime installed",
+    summary: "Machine connected + auth OK but no runtime is `ok`. Two install boxes shown — operator picks one.",
+    whatToCheck: [
+      "Yellow pill 'Setup incomplete'",
+      "Two install boxes side-by-side on wide cards, stacked 1-up on narrow",
+      "Each box: runtime name + headline with `command` as <code> + InlineCommand with Copy",
+      "Install box has NO outer raised background — only the inner pre block is wrapped",
+      "Footer meta NOT dimmed (machine is online)",
+    ],
+    clients: [SETUP_EMPTY],
+    agents: [],
+  },
+  {
+    key: "setup-mixed",
+    group: "Setup incomplete",
+    title: "Setup incomplete · one unauth, one missing",
+    summary:
+      "Mixed setup: Claude Code installed-not-logged-in, Codex not installed. Each install box adapts its command.",
+    whatToCheck: [
+      "Claude Code box: 'installed (v0.2.141) but not logged in' — command is ONLY `claude login` (no npm install)",
+      "Codex box: full install + login two-liner",
+      "Backticks in headlines render as <code> elements, not literal backticks",
+    ],
+    clients: [SETUP_MIXED],
+    agents: [],
+  },
+  {
+    key: "setup-error",
+    group: "Setup incomplete",
+    title: "Setup incomplete · probe error on Codex",
+    summary: "A runtime probe failed. Surface the error string + a reinstall command.",
+    whatToCheck: [
+      "Codex headline includes the error string ('ENOENT: spawn …')",
+      "Codex command is the reinstall (`npm install -g @openai/codex`), no login appended",
+      "Claude Code box still renders (its state is 'missing')",
+      "1 agent offline — compact summary reads '1 agent · offline' (singular, no 'all')",
+    ],
+    clients: [SETUP_ERROR],
+    agents: [agent({ agentId: "a-dev", clientId: SETUP_ERROR.id, runtimeState: "offline" })],
+  },
+  {
+    key: "offline-recent",
+    group: "Offline",
+    title: "Offline · 2 hours · 0 agents",
+    summary: "Disconnected but auth still alive. Wake-guide command + dimmed meta.",
+    whatToCheck: [
+      "Grey pill 'Offline'",
+      "Diagnostic: 'Last seen 2 hours ago. Make sure the machine is awake and connected.'",
+      "Hint + InlineCommand with `first-tree daemon start`",
+      "Copy button flips to 'Copied' briefly on click",
+      "Agents block hidden (total=0)",
+    ],
+    clients: [OFFLINE_RECENT],
+    agents: [],
+  },
+  {
+    key: "offline-stale",
+    group: "Offline",
+    title: "Offline · 4 days · 2 agents",
+    summary: "Stale but not expired. Compact agents summary uses 'all offline' for ≥2 agents.",
+    whatToCheck: [
+      "Diagnostic: 'Last seen 4 days ago. …'",
+      "Agents summary reads '2 agents · all offline' (NOT '2 agents · 2 offline')",
+    ],
+    clients: [OFFLINE_STALE],
+    agents: [
+      agent({ agentId: "a-dev", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+      agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+    ],
+  },
+  {
+    key: "stack",
+    group: "Cross-cutting",
+    title: "Stack of 3 own machines (member view)",
+    summary: "What a member with multiple machines sees. Hairline separators between cards.",
+    whatToCheck: [
+      "Top card has NO hairline above (first-child rule)",
+      "Subsequent cards each get a top hairline",
+      "Page subtitle reflects multi-machine summary",
+      "Bottom 'Add another computer' button visible",
+    ],
+    clients: [READY_BOTH, AUTH_EXPIRED, OFFLINE_STALE],
+    agents: [
+      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+      agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+    ],
+  },
+  {
+    key: "admin-grouped",
+    group: "Cross-cutting",
+    title: "Admin grouped: 2 own + 1 team machine",
+    summary:
+      "Admin view with 'Your computers' + 'Team computers'. Real Settings layout including the table for team rows.",
+    whatToCheck: [
+      "'Your computers · 2' section as Section heading with hairline below",
+      "'Team computers · 1' second Section",
+      "Team table uses the legacy dense-table chrome (deferred to Variant D)",
+      "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
+    ],
+    clients: [READY_BOTH, OFFLINE_RECENT, TEAM_MACHINE],
+    agents: [
+      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      agent({ agentId: "a-other", clientId: TEAM_MACHINE.id, runtimeState: "idle" }),
+    ],
+  },
+  {
+    key: "empty",
+    group: "Cross-cutting",
+    title: "Empty state · 0 computers",
+    summary: "Brand-new user with no machines connected. Centered CTA, no card stack.",
+    whatToCheck: [
+      "Page subtitle reads 0-machine summary",
+      "Centered 'No computers connected yet' message",
+      "Primary 'Connect your first computer' button (+ icon)",
+      "Bottom 'Add another' button NOT shown",
+    ],
+    clients: [],
+    agents: [],
+  },
+];
+
+export function findDemoScenario(key: string | null | undefined): DemoScenario | null {
+  if (!key) return null;
+  return DEMO_SCENARIOS.find((s) => s.key === key) ?? null;
+}

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -94,295 +94,327 @@ export type DemoScenario = {
   agents: RuntimeAgent[];
 };
 
-const READY_BOTH = client({
-  id: "demo-ready-both",
-  hostname: "GandydeMacBook-Pro.local",
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
-    codex: cap("ok", { sdkVersion: "0.125.0", authMethod: "auth_json" }),
-  },
-});
+/**
+ * Build the entire fixture set inside a function so prod bundles can
+ * tree-shake it. The module-level `DEMO_SCENARIOS` const below is gated
+ * on `import.meta.env.DEV`: in production builds, Vite folds it to
+ * `false`, the ternary picks the empty branch, and `buildDemoData` is
+ * never referenced → Rollup DCE drops the entire function body plus
+ * the `cap` / `client` / `agent` helpers and per-fixture consts inside.
+ *
+ * Without this gating the SCENARIOS array (and all its inline
+ * fixtures) showed up in the prod bundle even though the demo
+ * navigator was tree-shaken at the render layer — that's what
+ * yuezengwu flagged in PR-D2 review nit #1.
+ */
+function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string, string> } {
+  const READY_BOTH = client({
+    id: "demo-ready-both",
+    hostname: "GandydeMacBook-Pro.local",
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+      codex: cap("ok", { sdkVersion: "0.125.0", authMethod: "auth_json" }),
+    },
+  });
 
-const READY_CC_ONLY = client({
-  id: "demo-ready-cc-only",
-  hostname: "Linux-box.lan",
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
-  },
-});
+  const READY_CC_ONLY = client({
+    id: "demo-ready-cc-only",
+    hostname: "Linux-box.lan",
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+    },
+  });
 
-const READY_MIXED = client({
-  id: "demo-ready-mixed",
-  hostname: "MacBook-Pro.local",
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
-    codex: cap("unauthenticated", { sdkVersion: "0.125.0" }),
-  },
-});
+  const READY_MIXED = client({
+    id: "demo-ready-mixed",
+    hostname: "MacBook-Pro.local",
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+      codex: cap("unauthenticated", { sdkVersion: "0.125.0" }),
+    },
+  });
 
-const AUTH_EXPIRED = client({
-  id: "demo-auth-expired",
-  hostname: "Mac-mini.attic",
-  status: "disconnected",
-  authState: "expired",
-  lastSeenAt: isoDaysAgo(8),
-  sdkVersion: "0.5.1",
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
-  },
-});
+  const AUTH_EXPIRED = client({
+    id: "demo-auth-expired",
+    hostname: "Mac-mini.attic",
+    status: "disconnected",
+    authState: "expired",
+    lastSeenAt: isoDaysAgo(8),
+    sdkVersion: "0.5.1",
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
+    },
+  });
 
-const SETUP_EMPTY = client({
-  id: "demo-setup-empty",
-  hostname: "fresh-linux-box.local",
-  os: "linux",
-});
+  const SETUP_EMPTY = client({
+    id: "demo-setup-empty",
+    hostname: "fresh-linux-box.local",
+    os: "linux",
+  });
 
-const SETUP_MIXED = client({
-  id: "demo-setup-mixed",
-  hostname: "MacBook-Pro.local",
-  capabilities: {
-    "claude-code": cap("unauthenticated", { sdkVersion: "0.2.141" }),
-  },
-});
+  const SETUP_MIXED = client({
+    id: "demo-setup-mixed",
+    hostname: "MacBook-Pro.local",
+    capabilities: {
+      "claude-code": cap("unauthenticated", { sdkVersion: "0.2.141" }),
+    },
+  });
 
-const SETUP_ERROR = client({
-  id: "demo-setup-error",
-  hostname: "MacBook-Pro.local",
-  capabilities: {
-    codex: cap("error", { error: "ENOENT: spawn /usr/local/bin/codex" }),
-  },
-});
+  const SETUP_ERROR = client({
+    id: "demo-setup-error",
+    hostname: "MacBook-Pro.local",
+    capabilities: {
+      codex: cap("error", { error: "ENOENT: spawn /usr/local/bin/codex" }),
+    },
+  });
 
-const OFFLINE_RECENT = client({
-  id: "demo-offline-recent",
-  hostname: "MacBook-Pro.local",
-  status: "disconnected",
-  lastSeenAt: isoMinutesAgo(120),
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
-  },
-});
+  const OFFLINE_RECENT = client({
+    id: "demo-offline-recent",
+    hostname: "MacBook-Pro.local",
+    status: "disconnected",
+    lastSeenAt: isoMinutesAgo(120),
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+    },
+  });
 
-const OFFLINE_STALE = client({
-  id: "demo-offline-stale",
-  hostname: "old-laptop.fritz.box",
-  status: "disconnected",
-  lastSeenAt: isoDaysAgo(4),
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
-  },
-});
+  const OFFLINE_STALE = client({
+    id: "demo-offline-stale",
+    hostname: "old-laptop.fritz.box",
+    status: "disconnected",
+    lastSeenAt: isoDaysAgo(4),
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.130", authMethod: "oauth" }),
+    },
+  });
 
-const TEAM_MACHINE = client({
-  id: "demo-team-machine",
-  userId: "other-user",
-  hostname: "alice-MBP.lan",
-  capabilities: {
-    "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
-  },
-});
+  const TEAM_MACHINE = client({
+    id: "demo-team-machine",
+    userId: "other-user",
+    hostname: "alice-MBP.lan",
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141", authMethod: "oauth" }),
+    },
+  });
 
-export const DEMO_AGENT_NAMES: Record<string, string> = {
-  "a-dev": "gandy-developer",
-  "a-asst": "gandy-assistant",
-  "a-rev": "code-reviewer",
-  "a-other": "alice-bot",
-};
+  const agentNames: Record<string, string> = {
+    "a-dev": "gandy-developer",
+    "a-asst": "gandy-assistant",
+    "a-rev": "code-reviewer",
+    "a-other": "alice-bot",
+  };
 
-export const DEMO_SCENARIOS: DemoScenario[] = [
-  {
-    key: "ready-both",
-    group: "Ready",
-    title: "Ready · both runtimes ok · 2 agents",
-    summary:
-      "Happy path. Pill is Ready when status=connected, authState=ok, AND ≥1 capability=ok. Both runtimes ok is the most common shape.",
-    whatToCheck: [
-      "Green pill 'Ready' in the top-right",
-      "Hostname is the visual focus (font-semibold); owner label 'gandy · you' below (no nested parens)",
-      "Heartbeat / first-tree / OS as 2-col `<dl>` field grid",
-      "Runtimes block: ✓ Claude Code + ✓ Codex, lowercase label 'Runtimes'",
-      "Agent rows: name + presence chip only, no '3 / 7 sessions' counter",
-      "No background tint / shadow / radius — flat with hairlines",
-    ],
-    clients: [READY_BOTH],
-    agents: [
-      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
-      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
-    ],
-  },
-  {
-    key: "ready-cc-only",
-    group: "Ready",
-    title: "Ready · only Claude Code · 0 agents",
-    summary: "Ready with one runtime ok + one missing. Bound-agents block hides entirely when total=0.",
-    whatToCheck: [
-      "Pill still Ready (one ok is enough)",
-      "Runtimes: ✓ Claude Code + ✗ Codex 'not installed' inline",
-      "Agents block NOT rendered — only 2 groups (meta + runtimes)",
-    ],
-    clients: [READY_CC_ONLY],
-    agents: [],
-  },
-  {
-    key: "ready-mixed",
-    group: "Ready",
-    title: "Ready · Codex unauthenticated",
-    summary: "One runtime ok, one installed-but-unauthed. Card stays Ready; the unauth runtime gets a yellow ⚠ hint.",
-    whatToCheck: [
-      "Pill stays Ready (Claude Code is ok)",
-      "Codex line shows ⚠ + 'installed v0.125.0, not authenticated' + login hint",
-      "Warning yellow on the unauth line, idle green on the ok line",
-    ],
-    clients: [READY_MIXED],
-    agents: [agent({ agentId: "a-dev", clientId: READY_MIXED.id, runtimeState: "running" })],
-  },
-  {
-    key: "auth-expired",
-    group: "Auth expired",
-    title: "Auth expired · 8 days · 3 agents",
-    summary:
-      "Token has expired (authState=expired). Pill is Auth expired regardless of capability. The card surfaces recovery action inline.",
-    whatToCheck: [
-      "Red pill 'Auth expired' in the top-right",
-      "Diagnostic: 'Hasn't checked in for 8 days. Your access token has expired.'",
-      "Primary 'Generate new token' button inline — NOT in the kebab",
-      "Right of the button: compact summary '3 agents · all offline'",
-      "Footer: dimmed meta block under hairline",
-    ],
-    clients: [AUTH_EXPIRED],
-    agents: [
-      agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
-      agent({ agentId: "a-asst", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
-      agent({ agentId: "a-rev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
-    ],
-  },
-  {
-    key: "setup-empty",
-    group: "Setup incomplete",
-    title: "Setup incomplete · no runtime installed",
-    summary: "Machine connected + auth OK but no runtime is `ok`. Two install boxes shown — operator picks one.",
-    whatToCheck: [
-      "Yellow pill 'Setup incomplete'",
-      "Two install boxes side-by-side on wide cards, stacked 1-up on narrow",
-      "Each box: runtime name + headline with `command` as <code> + InlineCommand with Copy",
-      "Install box has NO outer raised background — only the inner pre block is wrapped",
-      "Footer meta NOT dimmed (machine is online)",
-    ],
-    clients: [SETUP_EMPTY],
-    agents: [],
-  },
-  {
-    key: "setup-mixed",
-    group: "Setup incomplete",
-    title: "Setup incomplete · one unauth, one missing",
-    summary:
-      "Mixed setup: Claude Code installed-not-logged-in, Codex not installed. Each install box adapts its command.",
-    whatToCheck: [
-      "Claude Code box: 'installed (v0.2.141) but not logged in' — command is ONLY `claude login` (no npm install)",
-      "Codex box: full install + login two-liner",
-      "Backticks in headlines render as <code> elements, not literal backticks",
-    ],
-    clients: [SETUP_MIXED],
-    agents: [],
-  },
-  {
-    key: "setup-error",
-    group: "Setup incomplete",
-    title: "Setup incomplete · probe error on Codex",
-    summary: "A runtime probe failed. Surface the error string + a reinstall command.",
-    whatToCheck: [
-      "Codex headline includes the error string ('ENOENT: spawn …')",
-      "Codex command is the reinstall (`npm install -g @openai/codex`), no login appended",
-      "Claude Code box still renders (its state is 'missing')",
-      "1 agent offline — compact summary reads '1 agent · offline' (singular, no 'all')",
-    ],
-    clients: [SETUP_ERROR],
-    agents: [agent({ agentId: "a-dev", clientId: SETUP_ERROR.id, runtimeState: "offline" })],
-  },
-  {
-    key: "offline-recent",
-    group: "Offline",
-    title: "Offline · 2 hours · 0 agents",
-    summary: "Disconnected but auth still alive. Wake-guide command + dimmed meta.",
-    whatToCheck: [
-      "Grey pill 'Offline'",
-      "Diagnostic: 'Last seen 2 hours ago. Make sure the machine is awake and connected.'",
-      "Hint + InlineCommand with `first-tree daemon start`",
-      "Copy button flips to 'Copied' briefly on click",
-      "Agents block hidden (total=0)",
-    ],
-    clients: [OFFLINE_RECENT],
-    agents: [],
-  },
-  {
-    key: "offline-stale",
-    group: "Offline",
-    title: "Offline · 4 days · 2 agents",
-    summary: "Stale but not expired. Compact agents summary uses 'all offline' for ≥2 agents.",
-    whatToCheck: [
-      "Diagnostic: 'Last seen 4 days ago. …'",
-      "Agents summary reads '2 agents · all offline' (NOT '2 agents · 2 offline')",
-    ],
-    clients: [OFFLINE_STALE],
-    agents: [
-      agent({ agentId: "a-dev", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
-      agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
-    ],
-  },
-  {
-    key: "stack",
-    group: "Cross-cutting",
-    title: "Stack of 3 own machines (member view)",
-    summary: "What a member with multiple machines sees. Hairline separators between cards.",
-    whatToCheck: [
-      "Top card has NO hairline above (first-child rule)",
-      "Subsequent cards each get a top hairline",
-      "Page subtitle reflects multi-machine summary",
-      "Bottom 'Add another computer' button visible",
-    ],
-    clients: [READY_BOTH, AUTH_EXPIRED, OFFLINE_STALE],
-    agents: [
-      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
-      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
-      agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
-      agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
-    ],
-  },
-  {
-    key: "admin-grouped",
-    group: "Cross-cutting",
-    title: "Admin grouped: 2 own + 1 team machine",
-    summary:
-      "Admin view with 'Your computers' + 'Team computers'. Real Settings layout including the table for team rows.",
-    whatToCheck: [
-      "'Your computers · 2' section as Section heading with hairline below",
-      "'Team computers · 1' second Section",
-      "Team table uses the legacy dense-table chrome (deferred to Variant D)",
-      "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
-    ],
-    clients: [READY_BOTH, OFFLINE_RECENT, TEAM_MACHINE],
-    agents: [
-      agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
-      agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
-      agent({ agentId: "a-other", clientId: TEAM_MACHINE.id, runtimeState: "idle" }),
-    ],
-  },
-  {
-    key: "empty",
-    group: "Cross-cutting",
-    title: "Empty state · 0 computers",
-    summary: "Brand-new user with no machines connected. Centered CTA, no card stack.",
-    whatToCheck: [
-      "Page subtitle reads 0-machine summary",
-      "Centered 'No computers connected yet' message",
-      "Primary 'Connect your first computer' button (+ icon)",
-      "Bottom 'Add another' button NOT shown",
-    ],
-    clients: [],
-    agents: [],
-  },
-];
+  const scenarios: DemoScenario[] = [
+    {
+      key: "ready-both",
+      group: "Ready",
+      title: "Ready · both runtimes ok · 2 agents",
+      summary:
+        "Happy path. Pill is Ready when status=connected, authState=ok, AND ≥1 capability=ok. Both runtimes ok is the most common shape.",
+      whatToCheck: [
+        "Green pill 'Ready' in the top-right",
+        "Hostname is the visual focus (font-semibold); owner label 'gandy · you' below (no nested parens)",
+        "Heartbeat / first-tree / OS as 2-col `<dl>` field grid",
+        "Runtimes block: ✓ Claude Code + ✓ Codex, lowercase label 'Runtimes'",
+        "Agent rows: name + presence chip only, no '3 / 7 sessions' counter",
+        "No background tint / shadow / radius — flat with hairlines",
+      ],
+      clients: [READY_BOTH],
+      agents: [
+        agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+        agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+      ],
+    },
+    {
+      key: "ready-cc-only",
+      group: "Ready",
+      title: "Ready · only Claude Code · 0 agents",
+      summary: "Ready with one runtime ok + one missing. Bound-agents block hides entirely when total=0.",
+      whatToCheck: [
+        "Pill still Ready (one ok is enough)",
+        "Runtimes: ✓ Claude Code + ✗ Codex 'not installed' inline",
+        "Agents block NOT rendered — only 2 groups (meta + runtimes)",
+      ],
+      clients: [READY_CC_ONLY],
+      agents: [],
+    },
+    {
+      key: "ready-mixed",
+      group: "Ready",
+      title: "Ready · Codex unauthenticated",
+      summary: "One runtime ok, one installed-but-unauthed. Card stays Ready; the unauth runtime gets a yellow ⚠ hint.",
+      whatToCheck: [
+        "Pill stays Ready (Claude Code is ok)",
+        "Codex line shows ⚠ + 'installed v0.125.0, not authenticated' + login hint",
+        "Warning yellow on the unauth line, idle green on the ok line",
+      ],
+      clients: [READY_MIXED],
+      agents: [agent({ agentId: "a-dev", clientId: READY_MIXED.id, runtimeState: "running" })],
+    },
+    {
+      key: "auth-expired",
+      group: "Auth expired",
+      title: "Auth expired · 8 days · 3 agents",
+      summary:
+        "Token has expired (authState=expired). Pill is Auth expired regardless of capability. The card surfaces recovery action inline.",
+      whatToCheck: [
+        "Red pill 'Auth expired' in the top-right",
+        "Diagnostic: 'Hasn't checked in for 8 days. Your access token has expired.'",
+        "Primary 'Generate new token' button inline — NOT in the kebab",
+        "Affected agents block (dimmed): 3 expanded rows with name + runtime + offline chip — operator can see which agents are stuck",
+        "Footer: dimmed meta block under hairline",
+      ],
+      clients: [AUTH_EXPIRED],
+      agents: [
+        agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+        agent({ agentId: "a-asst", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+        agent({ agentId: "a-rev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+      ],
+    },
+    {
+      key: "setup-empty",
+      group: "Setup incomplete",
+      title: "Setup incomplete · no runtime installed",
+      summary: "Machine connected + auth OK but no runtime is `ok`. Two install boxes shown — operator picks one.",
+      whatToCheck: [
+        "Yellow pill 'Setup incomplete'",
+        "Two install boxes side-by-side on wide cards, stacked 1-up on narrow",
+        "Each box: runtime name + headline with `command` as <code> + InlineCommand with Copy",
+        "Install box has NO outer raised background — only the inner pre block is wrapped",
+        "Footer meta NOT dimmed (machine is online)",
+      ],
+      clients: [SETUP_EMPTY],
+      agents: [],
+    },
+    {
+      key: "setup-mixed",
+      group: "Setup incomplete",
+      title: "Setup incomplete · one unauth, one missing",
+      summary:
+        "Mixed setup: Claude Code installed-not-logged-in, Codex not installed. Each install box adapts its command.",
+      whatToCheck: [
+        "Claude Code box: 'installed (v0.2.141) but not logged in' — command is ONLY `claude login` (no npm install)",
+        "Codex box: full install + login two-liner",
+        "Backticks in headlines render as <code> elements, not literal backticks",
+      ],
+      clients: [SETUP_MIXED],
+      agents: [],
+    },
+    {
+      key: "setup-error",
+      group: "Setup incomplete",
+      title: "Setup incomplete · probe error on Codex",
+      summary: "A runtime probe failed. Surface the error string + a reinstall command.",
+      whatToCheck: [
+        "Codex headline includes the error string ('ENOENT: spawn …')",
+        "Codex command is the reinstall (`npm install -g @openai/codex`), no login appended",
+        "Claude Code box still renders (its state is 'missing')",
+        "1 agent offline — Agents block shows the agent row with its runtime + offline chip (no 'all' qualifier for total=1)",
+      ],
+      clients: [SETUP_ERROR],
+      agents: [agent({ agentId: "a-dev", clientId: SETUP_ERROR.id, runtimeState: "offline" })],
+    },
+    {
+      key: "offline-recent",
+      group: "Offline",
+      title: "Offline · 2 hours · 0 agents",
+      summary: "Disconnected but auth still alive. Inline Reconnect + wake-guide command + dimmed Runtimes block.",
+      whatToCheck: [
+        "Grey pill 'Offline' in the top-right",
+        "Diagnostic: 'Last seen 2 hours ago. Make sure the machine is awake and connected.'",
+        "Inline 'Reconnect' button (was in kebab pre-PR-D2)",
+        "Hint + InlineCommand with `first-tree daemon start`; Copy button flips to 'Copied' briefly on click",
+        "Agents block hidden (total=0)",
+        "Dimmed Runtimes block under 'last reported' label",
+      ],
+      clients: [OFFLINE_RECENT],
+      agents: [],
+    },
+    {
+      key: "offline-stale",
+      group: "Offline",
+      title: "Offline · 4 days · 2 agents",
+      summary: "Stale but not expired. Agents block lists the affected agents so the operator knows what's stuck.",
+      whatToCheck: [
+        "Diagnostic: 'Last seen 4 days ago. …'",
+        "Reconnect button visible inline (promoted from kebab)",
+        "Agents block (dimmed) lists both agents with their runtime + offline chip",
+        "Runtimes block (dimmed, 'last reported') shows the last-known Claude Code state",
+      ],
+      clients: [OFFLINE_STALE],
+      agents: [
+        agent({ agentId: "a-dev", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+        agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+      ],
+    },
+    {
+      key: "stack",
+      group: "Cross-cutting",
+      title: "Stack of 3 own machines (member view)",
+      summary: "What a member with multiple machines sees. Hairline separators between cards.",
+      whatToCheck: [
+        "Top card has NO hairline above (first-child rule)",
+        "Subsequent cards each get a top hairline",
+        "Page subtitle reflects multi-machine summary",
+        "Bottom 'Add another computer' button visible",
+      ],
+      clients: [READY_BOTH, AUTH_EXPIRED, OFFLINE_STALE],
+      agents: [
+        agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+        agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+        agent({ agentId: "a-dev", clientId: AUTH_EXPIRED.id, runtimeState: "offline" }),
+        agent({ agentId: "a-asst", clientId: OFFLINE_STALE.id, runtimeState: "offline" }),
+      ],
+    },
+    {
+      key: "admin-grouped",
+      group: "Cross-cutting",
+      title: "Admin grouped: 2 own + 1 team machine",
+      summary:
+        "Admin view with 'Your computers' + 'Team computers'. Real Settings layout including the table for team rows.",
+      whatToCheck: [
+        "'Your computers · 2' section as Section heading with hairline below",
+        "'Team computers · 1' second Section",
+        "Team table uses the legacy dense-table chrome (deferred to Variant D)",
+        "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
+      ],
+      clients: [READY_BOTH, OFFLINE_RECENT, TEAM_MACHINE],
+      agents: [
+        agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
+        agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),
+        agent({ agentId: "a-other", clientId: TEAM_MACHINE.id, runtimeState: "idle" }),
+      ],
+    },
+    {
+      key: "empty",
+      group: "Cross-cutting",
+      title: "Empty state · 0 computers",
+      summary: "Brand-new user with no machines connected. Centered CTA, no card stack.",
+      whatToCheck: [
+        "Page subtitle reads 0-machine summary",
+        "Centered 'No computers connected yet' message",
+        "Primary 'Connect your first computer' button (+ icon)",
+        "Bottom 'Add another' button NOT shown",
+      ],
+      clients: [],
+      agents: [],
+    },
+  ];
+
+  return { scenarios, agentNames };
+}
+
+// The DEV gate here is what enables Rollup tree-shaking. In production
+// builds `import.meta.env.DEV` folds to `false`, so the ternary picks
+// the empty branch, `buildDemoData` becomes unreferenced, and the
+// entire function body (helper fns + per-fixture consts + the
+// 11-scenario array) drops out of the bundle.
+const __DEMO_DATA__: { scenarios: DemoScenario[]; agentNames: Record<string, string> } = import.meta.env.DEV
+  ? buildDemoData()
+  : { scenarios: [], agentNames: {} };
+
+export const DEMO_SCENARIOS: DemoScenario[] = __DEMO_DATA__.scenarios;
+export const DEMO_AGENT_NAMES: Record<string, string> = __DEMO_DATA__.agentNames;
 
 export function findDemoScenario(key: string | null | undefined): DemoScenario | null {
   if (!key) return null;


### PR DESCRIPTION
## Summary

Round of UI polish driven by gandy2025 design feedback. Stacked on top of PR-D1 (#598) — base set to `refactor/computers-minimal-style`. After PR-D1 merges this PR rebases onto main.

| # | Fix |
|---|---|
| 1 | **Offline → inline Reconnect button**, kebab keeps only Disconnect / Retire |
| 2 | **Agent rows show runtime type**: `gandy-developer · Claude Code   ● online` |
| 3 | **Ready card hides "not reported" runtimes** (no more "Install Codex" advert on machines that deliberately don't run it) |
| 4 | **Runtime line drops `(authMethod)` parens** → `Claude Code · v0.2.141 · oauth` |
| 5 | **Unauth hint drops env-var noise + becomes OS-aware**: `Run \`codex login\` on this Mac.` |
| 6 | **AuthExpired adds dimmed "Runtimes · last reported"** block — tells the operator what's at stake before they re-auth |
| 7 | **Setup-incomplete install boxes**: Copy buttons baseline-align via `margin-top: auto` |
| 8 | **Offline + AuthExpired agents** upgraded from compact summary to expanded list (the operator's question is *which* agents are down, not how many) |
| 9 | **Admin: Team computers section collapsed by default** with Show/Hide; team table left-aligns to Section title |

## Bonus: DEV-only `?demo=<key>` mode

Same PR also bundles a DEV-only demo navigator for `/settings/computers`. Open `/settings/computers?demo=auth-expired` (or any of 11 scenarios) in DEV to flip the live page through every pill × sub-variant with the real Settings chrome, without seeding the local DB. The navigator is a bottom-right floating overlay with a dropdown / prev / next / exit + a "What to check" checklist per scenario.

Production builds tree-shake the demo path entirely (Vite folds `import.meta.env.DEV` to false; `findDemoScenario` returns null; `<DemoNavigator>` never renders; the fixtures module is dead code).

## Files

| New |
|---|
| `cards/shared/stale-runtimes.tsx` — `DimmedGroup` + `StaleRuntimeLine` shared by AuthExpired + Offline |
| `clients/demo-navigator.tsx` — floating dev overlay + `useDemoScenarioParam` |
| `clients/dev-fixtures.ts` — 11 `HubClient` + `RuntimeAgent` scenarios |

| Modified |
|---|
| `clients/cards/{ready,auth-expired,offline,setup-incomplete}-card-body.tsx` |
| `clients/cards/computer-card.tsx` — kebab actions trimmed |
| `clients/cards/shared/{providers,runtime-install-box,bound-agents-list}.ts(x)` |
| `clients/cards/view-models.ts` — `runtimeType` added to `AgentLine` |
| `clients/cards/__tests__/view-models.test.ts` — +1 test |
| `clients.tsx` — demo mode wiring + Team section collapse + table left-align |

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (incl. design-token guardrails) — clean
- [x] `pnpm check` (biome) — clean, only pre-existing warnings in unrelated packages
- [x] `pnpm --filter @first-tree/web test` — 428 tests pass (+1 for runtimeType plumbing)
- [ ] Visual: flip through `?demo=` scenarios on `localhost:5174/settings/computers`
- [ ] Visual: Team computers collapsed by default for admin grouped view; click Show to expand
- [ ] Visual: Setup-incomplete two-runtime variant — Copy buttons baseline-align

🤖 Generated with [Claude Code](https://claude.com/claude-code)