### PR TITLE
fix(client): dedup concurrent Context Tree syncs sharing one clone dir

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -6,10 +6,12 @@ import {
   bootstrapWorkspace,
   buildChatSystemPrompt,
   CONTEXT_TREE_HEAD_REL,
+  type ContextTreeBinding,
   type InstallFirstTreeIntegrationExec,
   installFirstTreeIntegration,
   readCachedContextTreeHead,
   readContextTreeHead,
+  withContextTreeSyncLock,
   writeContextTreeHead,
 } from "../runtime/bootstrap.js";
 import type { AgentIdentity } from "../runtime/handler.js";
@@ -54,6 +56,95 @@ describe("contextTreeCloneDir", () => {
     expect(main).not.toBe(otherOrg);
     expect(main).toContain("context-tree-repos");
     expect(main.split("/").at(-1)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe("withContextTreeSyncLock", () => {
+  it("dedups concurrent callers sharing the same key to a single fn invocation", async () => {
+    // Each clone dir corresponds to one (repo, branch) pair. When N agents
+    // share that pair (the common case — one Context Tree per org), all N
+    // must share one in-flight sync instead of queuing N sequential pulls.
+    let invocations = 0;
+    let resolveSync: ((value: ContextTreeBinding) => void) | undefined;
+    const fn = (): Promise<ContextTreeBinding | null> => {
+      invocations++;
+      return new Promise<ContextTreeBinding>((resolve) => {
+        resolveSync = resolve;
+      });
+    };
+
+    const key = "/tmp/clone-dir-A";
+    const p1 = withContextTreeSyncLock(key, fn);
+    const p2 = withContextTreeSyncLock(key, fn);
+    const p3 = withContextTreeSyncLock(key, fn);
+
+    expect(invocations).toBe(1);
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+
+    const binding: ContextTreeBinding = { path: key, repoUrl: "git@example/x", branch: "main" };
+    resolveSync?.(binding);
+    await expect(p1).resolves.toBe(binding);
+    await expect(p2).resolves.toBe(binding);
+    await expect(p3).resolves.toBe(binding);
+  });
+
+  it("isolates locks across distinct keys (different repos sync in parallel)", async () => {
+    let invocations = 0;
+    const fn = (): Promise<ContextTreeBinding | null> => {
+      invocations++;
+      return Promise.resolve(null);
+    };
+
+    await Promise.all([withContextTreeSyncLock("/tmp/clone-A", fn), withContextTreeSyncLock("/tmp/clone-B", fn)]);
+
+    expect(invocations).toBe(2);
+  });
+
+  it("clears the slot after settle so a later call triggers a fresh sync", async () => {
+    let invocations = 0;
+    const fn = (): Promise<ContextTreeBinding | null> => {
+      invocations++;
+      return Promise.resolve(null);
+    };
+
+    await withContextTreeSyncLock("/tmp/clone-C", fn);
+    await withContextTreeSyncLock("/tmp/clone-C", fn);
+
+    expect(invocations).toBe(2);
+  });
+
+  it("propagates rejection to all concurrent callers and clears the slot", async () => {
+    let invocations = 0;
+    let rejectSync: ((reason: Error) => void) | undefined;
+    const fn = (): Promise<ContextTreeBinding | null> => {
+      invocations++;
+      if (invocations === 1) {
+        return new Promise<ContextTreeBinding>((_, reject) => {
+          rejectSync = reject;
+        });
+      }
+      // Later retries succeed immediately so the test can observe that the
+      // slot was cleared without hanging on a second pending promise.
+      return Promise.resolve(null);
+    };
+
+    const key = "/tmp/clone-D";
+    const p1 = withContextTreeSyncLock(key, fn);
+    const p2 = withContextTreeSyncLock(key, fn);
+
+    expect(invocations).toBe(1);
+    expect(p1).toBe(p2);
+
+    rejectSync?.(new Error("git pull failed"));
+    await expect(p1).rejects.toThrow("git pull failed");
+    await expect(p2).rejects.toThrow("git pull failed");
+
+    // After the failed sync clears the slot, a new caller is allowed to
+    // retry — important so the next agent's bind isn't poisoned by an
+    // earlier transient network failure.
+    await expect(withContextTreeSyncLock(key, fn)).resolves.toBeNull();
+    expect(invocations).toBe(2);
   });
 });
 

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -52,18 +52,32 @@ function toSshGitUrl(httpsRepo: string): string | null {
   return rewrite.sshBase + httpsRepo.slice(rewrite.httpsBase.length);
 }
 
-function withContextTreeSyncLock(
+/**
+ * De-dup concurrent Context Tree syncs for the same clone dir: when an
+ * in-flight sync exists for `key`, share its settled result instead of
+ * queueing another `git pull` round-trip. Once the in-flight promise
+ * settles, the slot is cleared — subsequent calls trigger a fresh sync.
+ *
+ * The old implementation chained callers (`prev.then(fn)`), so N agents
+ * sharing one Context Tree (the common case) cost N×git-pull at startup
+ * — observed as ~7s per extra agent. With dedup, those N calls collapse
+ * to a single shared sync. Each Hub `agent:bind` still resyncs the tree
+ * once per process restart (the first caller's pull), which is the
+ * contract `syncAgentContextTree` advertises.
+ *
+ * Exported for direct unit-testing; not re-exported from `src/index.ts`.
+ */
+export function withContextTreeSyncLock(
   key: string,
   fn: () => Promise<ContextTreeBinding | null>,
 ): Promise<ContextTreeBinding | null> {
-  const next = (contextTreeSyncLocks.get(key) ?? Promise.resolve(null))
-    .catch(() => null)
-    .then(fn)
-    .finally(() => {
-      if (contextTreeSyncLocks.get(key) === next) {
-        contextTreeSyncLocks.delete(key);
-      }
-    });
+  const inFlight = contextTreeSyncLocks.get(key);
+  if (inFlight) return inFlight;
+  const next = fn().finally(() => {
+    if (contextTreeSyncLocks.get(key) === next) {
+      contextTreeSyncLocks.delete(key);
+    }
+  });
   contextTreeSyncLocks.set(key, next);
   return next;
 }


### PR DESCRIPTION
## Summary

- Client startup was serialising N `git pull` round-trips on the shared Context Tree sync lock, stretching boot to ~7s × N (recent staging log: 6 agents → ~40s, each agent spaced ~7s apart).
- `withContextTreeSyncLock` in `packages/client/src/runtime/bootstrap.ts` chained concurrent callers via `prev.then(fn)` instead of sharing the in-flight promise — so every agent's `syncAgentContextTree` queued its own `git pull` even though the resolved clone dir was identical.
- Rewrite the lock as in-flight de-dup: share the settled result while a sync is in flight; clear the slot on settle so the next caller triggers a fresh sync. `syncContextTreeRepo` is idempotent in `(repo, branch, cloneDir)`, so collapsing N concurrent callers to one shared sync is observationally equivalent to running it N times — minus the latency. Rejection now propagates to all in-flight callers and clears the slot, so a transient failure no longer fans out into N sequential retries.

**Expected impact:** 6 agents × ~7s per pull (~40s startup) → single shared pull (~10s).

## Files

- `packages/client/src/runtime/bootstrap.ts` — rewrite `withContextTreeSyncLock` (+ JSDoc explaining chain → dedup), export the helper at module scope (not added to `src/index.ts` barrel, so the public API is unchanged).
- `packages/client/src/__tests__/bootstrap.test.ts` — 4 new unit tests covering the dedup contract: concurrent same-key collapse, distinct-key isolation, post-settle slot clearing, rejection propagation + retry-after-clear.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/bootstrap.test.ts` — 32/32 pass (incl. 4 new)
- [x] `pnpm check` — client package zero warnings
- [x] `pnpm typecheck` — 13/13 pass
- [ ] Operator validation: install on a multi-agent client and confirm startup drops from ~7s × N to a single shared pull window
- [ ] Confirm logs still make sense — see "Follow-up" below

## Notes

**Out of scope for this PR (follow-up observation from reviewer):** after dedup, `syncContextTreeRepo`'s `log("Context Tree updated (pull)")` lines only land on the *first* caller's log channel. Later agents reuse the in-flight promise and so their per-slot logs show the binding "appearing from nowhere". Not a bug — the result is correct — but a future PR can add a `"reused another agent's in-flight pull"` log line in `resolveContextTreeBinding` on dedup-hit to keep every slot's log self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)