### PR TITLE
fix(server): relax private-agent invite gate back to shared-owner reading

### DIFF
--- a/packages/server/src/__tests__/agent-visibility.test.ts
+++ b/packages/server/src/__tests__/agent-visibility.test.ts
@@ -674,15 +674,12 @@ describe("Chat Access Control", () => {
       const member = await createMemberAndLogin(app, adminBundle);
 
       // Create two non-human agents managed by member. `visibility` is
-      // pinned explicitly to `organization` (instead of leaning on
+      // pinned explicitly to `organization` (rather than leaning on
       // `defaultVisibility(type)`) so the fixture states its intent in
       // its own terms and won't shift if the type→default-visibility
-      // mapping ever changes. The strict owner-exclusive rule (RFC §4.5)
-      // would refuse a chat of two `visibility=private` agents that
-      // didn't include the human manager — keeping these
-      // `organization`-visible keeps the test scenario reachable while
-      // the watcher-recompute mechanism this test pins is itself
-      // type/visibility-agnostic.
+      // mapping changes. The watcher-recompute mechanism this test
+      // pins is itself type/visibility-agnostic — the pin is for
+      // fixture clarity, not behaviour.
       const agentA = await seedAgent(app, {
         name: "join-a",
         type: "agent",
@@ -745,10 +742,10 @@ describe("Chat Access Control", () => {
       });
 
       // Member A (the human, owner of both private agents) drives the
-      // creation — under the strict owner-exclusive rule (RFC §4.5)
-      // only the human-agent manager may bring a private agent in, so
-      // having one of A's non-human agents create the chat with the
-      // other as a target would 403.
+      // creation. Under the shared-owner reading of RFC §4.5 either A
+      // herself OR any of A's non-human agents could open this chat
+      // with the others as targets; using the human keeps the fixture's
+      // intent (a chat A supervises but isn't yet a speaker in) tidy.
       const chat = await createChat(app.db, memberA.agentId, {
         type: "group",
         participantIds: [agentA.uuid, agentA2.uuid],

--- a/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
+++ b/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
@@ -21,7 +21,9 @@
  */
 
 import { AGENT_VISIBILITY, type ChatDetail } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { createAgent } from "../services/agent.js";
 import { addParticipant as agentAddParticipant, createChat as agentCreateChat } from "../services/chat.js";
 import { addMeChatParticipants, createMeChat } from "../services/me-chat.js";
@@ -228,21 +230,26 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Strict owner-exclusive (RFC §4.5 strict reading): only the human-agent
-  // manager of a private target may invite it. The cases above pin the
-  // cross-manager rejection; the cases below pin the same-manager-but-
-  // non-human-caller rejection — i.e. the social-engineering path where
-  // M's public agent is instructed (via natural-language message or
-  // otherwise) to bring M's sibling private agent in.
+  // Owner-exclusive (RFC §4.5, shared-owner reading): any agent owned by the
+  // target's manager may invite a private target; the manager and the
+  // manager's agents act under one consent boundary. PR #601 implemented
+  // the strict reading (caller MUST be `type=human`), which a follow-up
+  // product decision (PR #604) reversed: an owner's agent acting on the
+  // owner's behalf is intentional delegation, not a social-engineering
+  // hole. The cases below pin BOTH (a) the cross-manager rejection (the
+  // permission still does block "Bob pulls owner M's private agent")
+  // AND (b) the same-manager admission (M's public agent / private
+  // sibling can pull M's other private agent).
   // ---------------------------------------------------------------------------
 
-  it("addParticipant rejects M's public agent trying to pull M's private agent (bug path)", async () => {
-    // N1: this is the precise path the user reported — M is not in the
-    // chat; someone else legitimately added M's public agent (org-visible,
-    // anyone in the chat can add it); the public agent then turns around
-    // and invites M's private agent, "tricking" the gate when the rule was
-    // owner-exclusive in its lenient (shared-managerId) reading. Strict
-    // reading rejects: caller must be human.
+  it("addParticipant allows M's public agent to pull M's private agent (owner-team delegation)", async () => {
+    // N1: shared-owner reading admits this path. Bob (a different manager)
+    // legitimately pulls M's public agent into a chat; M's public agent
+    // then invites M's private agent. Both M-owned agents share `managerId
+    // = M`, so the predicate treats the public agent as acting on M's
+    // behalf and admits the private target. Bob himself still cannot invite
+    // M's private agent directly — see the "rejects a non-owner" case
+    // above for the cross-manager rejection that this PR keeps in place.
     const app = getApp();
     const m = await createTestAdmin(app);
     const bob = await createTestAdmin(app);
@@ -265,25 +272,33 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
     });
 
     // Bob (different manager) creates a group chat with M's public agent.
-    // Pulling a PUBLIC agent in is allowed under both readings of the rule.
     const chat = await agentCreateChat(app.db, bob.humanAgentUuid, {
       type: "group",
       participantIds: [mPublic.uuid],
     });
     if (!chat.id) throw new Error("Unexpected: createChat returned no id");
 
-    // Now M's public agent tries to bring M's private agent in. Under the
-    // lenient reading this was allowed (they share managerId). Strict
-    // reading rejects — only M's human agent can invite M's private agent.
-    await expect(agentAddParticipant(app.db, chat.id, mPublic.uuid, { agentId: mPrivate.uuid })).rejects.toThrow(
-      /private agent/i,
-    );
+    // M's public agent pulls M's private agent in — shared `managerId`,
+    // shared-owner reading admits.
+    await expect(agentAddParticipant(app.db, chat.id, mPublic.uuid, { agentId: mPrivate.uuid })).resolves.not.toThrow();
+
+    // Verify the private agent is now a speaker in the chat.
+    const speakers = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, chat.id),
+          eq(chatMembership.agentId, mPrivate.uuid),
+          eq(chatMembership.accessMode, "speaker"),
+        ),
+      );
+    expect(speakers).toHaveLength(1);
   });
 
-  it("addParticipant rejects M's private agent trying to pull M's other private agent", async () => {
-    // N2: same shape as N1, but caller is itself a private agent. Same
-    // strict reading applies — caller must be human regardless of caller's
-    // own visibility.
+  it("addParticipant allows M's private agent to pull M's other private agent (shared-owner)", async () => {
+    // N2: same shape as N1, but the caller is itself a private agent.
+    // Shared-owner reading is type-agnostic — only `managerId` matches.
     const app = getApp();
     const m = await createTestAdmin(app);
 
@@ -306,24 +321,39 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
 
     // M spins up a chat with privateA — 2 speakers is a legal v2 chat
     // (group is the only `chats.type` Hub writes now; 1:1 behaviour is
-    // derived from `participants.length === 2`, see chat.ts:289).
+    // derived from `participants.length === 2`, see chat.ts).
     const chat = await agentCreateChat(app.db, m.humanAgentUuid, {
       type: "group",
       participantIds: [mPrivateA.uuid],
     });
     if (!chat.id) throw new Error("Unexpected: createChat returned no id");
 
-    // privateA now tries to pull privateB in. Strict reading rejects.
-    await expect(agentAddParticipant(app.db, chat.id, mPrivateA.uuid, { agentId: mPrivateB.uuid })).rejects.toThrow(
-      /private agent/i,
-    );
+    // privateA pulls privateB in — shared `managerId`, admitted.
+    await expect(
+      agentAddParticipant(app.db, chat.id, mPrivateA.uuid, { agentId: mPrivateB.uuid }),
+    ).resolves.not.toThrow();
+
+    const speakers = await app.db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, chat.id),
+          eq(chatMembership.agentId, mPrivateB.uuid),
+          eq(chatMembership.accessMode, "speaker"),
+        ),
+      );
+    expect(speakers).toHaveLength(1);
   });
 
-  it("agent-SDK createChat rejects M's public agent including M's private agent as initial participant", async () => {
-    // N3: same rule applies at chat-creation time. M's public agent
-    // creating a fresh group chat with M's private agent listed in the
-    // initial participants must be rejected by the same strict
-    // owner-exclusive predicate. Closes the create-side bypass.
+  it("agent-SDK createChat admits M's public agent + M's private agent as initial participants", async () => {
+    // N3: shared-owner reading applies at chat-creation time too. M's
+    // public agent creating a fresh group chat with M's private agent
+    // listed in the initial participants is admitted — same `managerId`.
+    // The cross-manager rejection at create-time is covered by the
+    // pre-existing "agent-SDK createChat rejects a private target
+    // owned by a different member" case above; this case pins the
+    // same-owner admission.
     const app = getApp();
     const m = await createTestAdmin(app);
 
@@ -349,12 +379,12 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
         type: "group",
         participantIds: [mPrivate.uuid, m.humanAgentUuid],
       }),
-    ).rejects.toThrow(/private agent/i);
+    ).resolves.not.toThrow();
   });
 
-  it("agent-SDK createChat rejects M's private agent including M's other private agent as initial participant", async () => {
-    // N4: same as N3 but creator is itself private. Strict reading is
-    // independent of creator's visibility — only `type === 'human'` matters.
+  it("agent-SDK createChat admits M's private agent + M's other private agent as initial participants", async () => {
+    // N4: same as N3 but the creator is itself a private agent. Shared-
+    // owner reading is type-agnostic — only `managerId` matters.
     const app = getApp();
     const m = await createTestAdmin(app);
 
@@ -380,7 +410,7 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
         type: "group",
         participantIds: [mPrivateB.uuid, m.humanAgentUuid],
       }),
-    ).rejects.toThrow(/private agent/i);
+    ).resolves.not.toThrow();
   });
 
   it("HTTP web path: admin can pass discovery filter but is still rejected by the Layer-2 owner gate", async () => {
@@ -419,33 +449,46 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
       payload: { participantIds: [bobsPrivate.uuid] },
     });
 
-    // 403 is the strict reading's expected response: discovery short-
-    // circuit let Alice past the API-layer 404, but Layer-2 refuses.
+    // Discovery short-circuit lets admin Alice past the API-layer 404,
+    // but Layer-2 still refuses cross-manager admission of a private
+    // target — shared-owner reading is still owner-exclusive across
+    // managers.
     expect(res.statusCode).toBe(403);
     expect(res.body).toMatch(/private agent/i);
   });
 
-  it("rejectedPrivateTargets carve-out: a private agent self-add is allowed (pure-function unit)", async () => {
-    // N6: the self-add (`target.uuid === caller.agentId`) carve-out lets
-    // a private agent rejoin a chat it already owns — this matters for
-    // runtime reconnects where the same private-agent uuid both authors
-    // the call and is the target. The full service path covers this
-    // around `errorOnAlreadySpeaker`; testing the pure predicate
-    // directly avoids tangling the carve-out with already-speaker
-    // conflict semantics.
+  it("rejectedPrivateTargets carve-outs: self-add + same-owner admit; cross-owner rejects (pure-function unit)", async () => {
+    // N6: pure-function exercise of the three shared-owner predicate
+    // outcomes — self-add carve-out, same-owner admission, cross-owner
+    // rejection. Testing the predicate directly avoids tangling these
+    // outcomes with the service layer's already-speaker / chat-exists
+    // / caller-is-speaker preconditions.
+
+    // (a) Self-add carve-out: caller invites itself. `managerId` mismatch
+    //     is irrelevant — the carve-out short-circuits first. Matters
+    //     for runtime reconnect of a private agent.
     const selfUuid = crypto.randomUUID();
-    const result = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-other", type: "agent" }, [
+    const selfAdd = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-other" }, [
       { uuid: selfUuid, visibility: "private", managerId: "member-original" },
     ]);
-    expect(result).toEqual([]);
+    expect(selfAdd).toEqual([]);
 
-    // Sanity: same caller against a DIFFERENT private target with the same
-    // managerId is still rejected (the carve-out is *only* for self-add).
-    const otherUuid = crypto.randomUUID();
-    const result2 = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-shared", type: "agent" }, [
-      { uuid: otherUuid, visibility: "private", managerId: "member-shared" },
+    // (b) Same-owner admission: caller and a DIFFERENT private target
+    //     share `managerId`. Shared-owner reading admits — owner's
+    //     agents act under owner's authority.
+    const siblingUuid = crypto.randomUUID();
+    const sameOwner = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-shared" }, [
+      { uuid: siblingUuid, visibility: "private", managerId: "member-shared" },
     ]);
-    expect(result2).toHaveLength(1);
-    expect(result2[0]?.uuid).toBe(otherUuid);
+    expect(sameOwner).toEqual([]);
+
+    // (c) Cross-owner rejection: caller and target are owned by
+    //    different members. The owner-exclusive boundary still holds.
+    const strangerUuid = crypto.randomUUID();
+    const crossOwner = rejectedPrivateTargets({ agentId: selfUuid, memberId: "member-mine" }, [
+      { uuid: strangerUuid, visibility: "private", managerId: "member-theirs" },
+    ]);
+    expect(crossOwner).toHaveLength(1);
+    expect(crossOwner[0]?.uuid).toBe(strangerUuid);
   });
 });

--- a/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
+++ b/packages/server/src/__tests__/chat-private-mention-visibility.test.ts
@@ -234,7 +234,7 @@ describe("chat-scoped identity rendering vs discovery visibility", () => {
   // target's manager may invite a private target; the manager and the
   // manager's agents act under one consent boundary. PR #601 implemented
   // the strict reading (caller MUST be `type=human`), which a follow-up
-  // product decision (PR #604) reversed: an owner's agent acting on the
+  // product decision (PR #608) reversed: an owner's agent acting on the
   // owner's behalf is intentional delegation, not a social-engineering
   // hole. The cases below pin BOTH (a) the cross-manager rejection (the
   // permission still does block "Bob pulls owner M's private agent")

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -129,7 +129,7 @@ describe("inviteParticipantsToChat", () => {
         targetAgentIds: [targetOwner.agent.uuid],
         errorOnAlreadySpeaker: true,
       }),
-    ).rejects.toThrow(/Only the human owner/);
+    ).rejects.toThrow(/Only the owner/);
   });
 
   it("throws ConflictError on already-speaker target when errorOnAlreadySpeaker=true", async () => {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -59,7 +59,7 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
   //
   // The predicate lives in `participant-invite.ts::rejectedPrivateTargets`
   // alongside the Layer-2 invite gate so the invariant has exactly one
-  // source of truth — see that file's comment for the PR #601 → PR #604
+  // source of truth — see that file's comment for the PR #601 → PR #608
   // strict-vs-shared history.
   const targetsForGate = existingAgents
     .filter((a) => a.id !== creatorId)

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -49,30 +49,25 @@ export async function createChat(db: Database, creatorId: string, data: CreateCh
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
   }
 
-  // Strict owner-exclusive rule for private targets (RFC §4.5): only
-  // the human-agent manager of a private target may bring it into a
-  // chat. Even a manager's own public agent / other private agents
-  // CANNOT pull a sibling private agent in — that path is the social-
-  // engineering hole the strict reading closes. Self-add (`a.id ===
-  // creatorId`) is exempt; we filter the creator out of the target
-  // set before running the check so a private agent legitimately
-  // creating a chat with itself as a participant isn't tripped up.
+  // Owner-exclusive rule for private targets (RFC §4.5, shared-owner
+  // reading): a private agent can only be brought into a chat by another
+  // agent owned by the same member (i.e. the creator and the target
+  // share `managerId`). Self-add (`a.id === creatorId`) is exempt; we
+  // filter the creator out of the target set before running the check
+  // so a private agent legitimately creating a chat with itself as a
+  // participant isn't tripped up.
   //
   // The predicate lives in `participant-invite.ts::rejectedPrivateTargets`
   // alongside the Layer-2 invite gate so the invariant has exactly one
-  // source of truth (PR #550 collapsed the duplicate writers; this
-  // mirrors the same "one rule, one home" discipline for the create
-  // path).
+  // source of truth — see that file's comment for the PR #601 → PR #604
+  // strict-vs-shared history.
   const targetsForGate = existingAgents
     .filter((a) => a.id !== creatorId)
     .map((a) => ({ uuid: a.id, visibility: a.visibility, managerId: a.managerId }));
-  const rejectedTargets = rejectedPrivateTargets(
-    { agentId: creator.id, memberId: creator.managerId, type: creator.type },
-    targetsForGate,
-  );
+  const rejectedTargets = rejectedPrivateTargets({ agentId: creator.id, memberId: creator.managerId }, targetsForGate);
   if (rejectedTargets.length > 0) {
     throw new ForbiddenError(
-      `Only the human owner can add a private agent to a chat: ${rejectedTargets.map((t) => t.uuid).join(", ")}`,
+      `Only the owner can add a private agent to a chat: ${rejectedTargets.map((t) => t.uuid).join(", ")}`,
     );
   }
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -660,29 +660,27 @@ export async function createMeChat(
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.uuid).join(", ")}`);
   }
 
-  // Strict owner-exclusive for private targets (RFC §4.5). The route
-  // pins `humanAgentId = scope.humanAgentId`, so the caller is always
-  // human and the strict check coincides with the previous lenient
-  // shared-`managerId` form for THIS path. Routing through the shared
-  // `rejectedPrivateTargets` predicate anyway keeps the rule in exactly
-  // one place — same discipline as `inviteParticipantsToChat` and
-  // `chat.ts::createChat`. Without it, any future change that lets a
-  // non-human caller reach this code would silently fall back to the
-  // lenient reading (which is the exact two-copies-drift failure mode
-  // PR #550 wrote up).
+  // Owner-exclusive for private targets (RFC §4.5, shared-owner reading).
+  // The route pins `humanAgentId = scope.humanAgentId`, so the caller's
+  // owning member is the route caller's own member; the predicate refuses
+  // any private target whose `managerId` doesn't match. Routing through
+  // the shared `rejectedPrivateTargets` keeps the rule in exactly one
+  // place — same discipline as `inviteParticipantsToChat` and
+  // `chat.ts::createChat`. See that predicate's comment for the strict-
+  // vs-shared history (PR #601 / #604).
   const caller = found.find((a) => a.uuid === humanAgentId);
   if (!caller) {
     throw new BadRequestError("Caller agent not found in the chat's organization");
   }
   const rejected = rejectedPrivateTargets(
-    { agentId: humanAgentId, memberId: caller.managerId, type: caller.type },
+    { agentId: humanAgentId, memberId: caller.managerId },
     found
       .filter((a) => a.uuid !== humanAgentId)
       .map((a) => ({ uuid: a.uuid, visibility: a.visibility, managerId: a.managerId })),
   );
   if (rejected.length > 0) {
     throw new ForbiddenError(
-      `Only the human owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
+      `Only the owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
     );
   }
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -667,7 +667,7 @@ export async function createMeChat(
   // the shared `rejectedPrivateTargets` keeps the rule in exactly one
   // place — same discipline as `inviteParticipantsToChat` and
   // `chat.ts::createChat`. See that predicate's comment for the strict-
-  // vs-shared history (PR #601 / #604).
+  // vs-shared history (PR #601 / #608).
   const caller = found.find((a) => a.uuid === humanAgentId);
   if (!caller) {
     throw new BadRequestError("Caller agent not found in the chat's organization");

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -38,22 +38,29 @@
  *   - every target must exist (else BadRequestError listing the missing
  *     ids).
  *   - every target must be in the chat's organization (else BadRequestError).
- *   - private targets only land if the caller is the **human agent** of the
- *     same owning member as the target ("strict owner-exclusive" — the
- *     invitation right belongs to the human manager themselves, not to any
- *     agent the manager happens to own; see
- *     `docs/agent-space-and-mention-visibility-design.zh-CN.md` §4.5). A
- *     manager's public agent can NOT pull the manager's sibling private
- *     agent in — that path was the social-engineering hole this rule
- *     closes. Self-add (`targetAgentId === callerAgentId`) is exempt so
- *     a runtime rejoin of a private agent isn't blocked. No admin override
- *     — admin is a discovery-side affordance, not a consent-side one.
+ *   - private targets only land if the caller's owning member matches the
+ *     target's owning member ("owner-exclusive" — a manager's whole agent
+ *     team acts under the manager's authority; the manager and every agent
+ *     they own can invite any of the manager's private agents into a chat
+ *     they themselves are already a speaker of; see RFC §4.5). Cross-
+ *     manager invites of a private target are refused. Self-add
+ *     (`targetAgentId === callerAgentId`) is exempt so a runtime rejoin
+ *     of a private agent isn't blocked. No admin override — admin is a
+ *     discovery-side affordance, not a consent-side one (an admin from
+ *     a different owning member still cannot invite someone else's
+ *     private agent).
+ *
+ *     Earlier (PR #601) this gate required the caller to be a `type=human`
+ *     agent of the owning member; PR #604 relaxed back to the shared-
+ *     managerId reading after a product decision that "owner's agent
+ *     acts on owner's behalf" — see that PR for the deliberation
+ *     transcript.
  *   - the actual write goes through `applyMembershipWrite`, which encloses
  *     the silent-context backfill + watcher recompute invariants and the
  *     post-commit audience-cache invalidation.
  */
 
-import { AGENT_TYPES, AGENT_VISIBILITY } from "@first-tree/shared";
+import { AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -90,13 +97,6 @@ export type PrivateGateCaller = {
   agentId: string;
   /** Caller's `agents.managerId` — the member that owns the caller. */
   memberId: string;
-  /**
-   * Caller's `agents.type` (drizzle `text` column → `string`). Narrowed inside
-   * the predicate via comparison with `AGENT_TYPES.HUMAN`; passing the raw
-   * column value through `string` matches the existing visibility-compare
-   * pattern in the file and avoids `as`-casts at call sites.
-   */
-  type: string;
 };
 
 export type PrivateGateTarget = {
@@ -108,21 +108,37 @@ export type PrivateGateTarget = {
 
 /**
  * Pure predicate: which of `targets` is the caller **NOT** allowed to bring
- * into a chat under the strict owner-exclusive rule for private agents?
+ * into a chat under the owner-exclusive rule for private agents?
  *
- * Rule (RFC §4.5, strict reading):
- *   - target.visibility !== PRIVATE                          → allowed
- *   - target.uuid === caller.agentId                         → allowed (self-add rejoin)
- *   - caller.type === 'human' && caller.memberId ===
- *     target.managerId                                       → allowed (human manager invites own private)
- *   - otherwise                                              → rejected
+ * Rule (RFC §4.5, shared-owner reading):
+ *   - target.visibility !== PRIVATE       → allowed (no gate on public agents)
+ *   - target.uuid === caller.agentId      → allowed (self-add rejoin)
+ *   - caller.memberId === target.managerId → allowed (owner OR any agent the
+ *                                            owner owns; the manager's whole
+ *                                            agent team acts under the
+ *                                            manager's authority)
+ *   - otherwise                            → rejected (cross-manager pull
+ *                                            of a private target)
+ *
+ * History (don't strip — it's load-bearing for future review):
+ *   - PR #601 implemented this as the **strict** reading
+ *     (`caller.type === 'human' && caller.memberId === target.managerId`)
+ *     to close a social-engineering path: Bob pulls owner M's PUBLIC agent
+ *     X_pub into a chat, then X_pub turns around and pulls M's PRIVATE
+ *     agent X_priv. The lenient reading admits X_priv there.
+ *   - PR #604 reverted to this lenient reading after the product owner
+ *     decided that "owner's agent acts on owner's behalf" — i.e. X_pub
+ *     pulling X_priv is intentional delegation, not a social-engineering
+ *     hole. Cross-manager admission of a private agent remains refused;
+ *     same-manager admission via any owned agent is now intended.
  *
  * Why this lives in `participant-invite.ts` (not on a shared util): the
  * Layer-2 invite service is the canonical chat-membership gate, and
- * `createChat` runs the same predicate on its initial-participants set.
- * Co-locating the rule with `inviteParticipantsToChat` makes "the rule has
- * exactly one source of truth" obvious to reviewers — the duplicated-write
- * regression that PR #550 closed was exactly this kind of two-copies drift.
+ * `createChat` / `createMeChat` run the same predicate on their initial-
+ * participants set. Co-locating the rule with `inviteParticipantsToChat`
+ * makes "the rule has exactly one source of truth" obvious to reviewers —
+ * the duplicated-write regression that PR #550 closed was exactly this
+ * kind of two-copies drift.
  *
  * Pure / no db access: callers pass the rows they already have. Errors
  * (formatting, throwing, HTTP mapping) stay with the caller so it can
@@ -135,8 +151,7 @@ export function rejectedPrivateTargets(
   return targets.filter((t) => {
     if (t.visibility !== AGENT_VISIBILITY.PRIVATE) return false;
     if (t.uuid === caller.agentId) return false;
-    const isHumanOwner = caller.type === AGENT_TYPES.HUMAN && t.managerId === caller.memberId;
-    return !isHumanOwner;
+    return t.managerId !== caller.memberId;
   });
 }
 
@@ -163,12 +178,12 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
   }
 
   // 2. Caller is a speaker. Join `chatMembership` × `agents` so we get the
-  //    caller's owning-member id AND agent type in the same query — both
-  //    are authoritative inputs to the strict owner-exclusive check below.
-  //    Deriving them from `agents` (vs. accepting them as parameters)
-  //    prevents an internal caller from mismatching and bypassing the gate.
+  //    caller's owning-member id in the same query — the authoritative
+  //    input to the owner-exclusive check below. Deriving it from
+  //    `agents.managerId` (vs. accepting it as a parameter) prevents an
+  //    internal caller from mismatching and bypassing the gate.
   const [callerRow] = await db
-    .select({ ownerMemberId: agents.managerId, callerType: agents.type })
+    .select({ ownerMemberId: agents.managerId })
     .from(chatMembership)
     .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
     .where(
@@ -183,7 +198,6 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     throw new CallerNotSpeakerError(callerAgentId, chatId);
   }
   const callerMemberId = callerRow.ownerMemberId;
-  const callerType = callerRow.callerType;
 
   // 3. Targets exist + cross-org.
   const targetRows = await db
@@ -205,20 +219,22 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
     throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((t) => t.uuid).join(", ")}`);
   }
 
-  // 4. Strict owner-exclusive for private targets. Only the target's
-  //    human-agent manager can invite it; a manager's other agents
-  //    (public OR private siblings) cannot. Self-add (target === caller)
-  //    is exempt so an agent rejoining a chat it already owns isn't
-  //    blocked. The actual predicate lives in `rejectedPrivateTargets`
-  //    so `createChat` can share the exact same rule — keeping the
-  //    invariant in one place (the lesson PR #550 wrote up).
+  // 4. Owner-exclusive for private targets. The caller's owning member
+  //    must match the target's owning member — i.e. the manager and any
+  //    agent the manager owns share invitation rights for the manager's
+  //    private agents. Cross-manager admission of a private target is
+  //    refused. Self-add (target === caller) is exempt so an agent
+  //    rejoining a chat it already owns isn't blocked. The actual
+  //    predicate lives in `rejectedPrivateTargets` so `createChat` /
+  //    `createMeChat` share the exact same rule — keeping the invariant
+  //    in one place (the lesson PR #550 wrote up).
   const rejected = rejectedPrivateTargets(
-    { agentId: callerAgentId, memberId: callerMemberId, type: callerType },
+    { agentId: callerAgentId, memberId: callerMemberId },
     targetRows.map((t) => ({ uuid: t.uuid, visibility: t.visibility, managerId: t.managerId })),
   );
   if (rejected.length > 0) {
     throw new ForbiddenError(
-      `Only the human owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
+      `Only the owner can add a private agent to a chat: ${rejected.map((t) => t.uuid).join(", ")}`,
     );
   }
 

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -51,7 +51,7 @@
  *     private agent).
  *
  *     Earlier (PR #601) this gate required the caller to be a `type=human`
- *     agent of the owning member; PR #604 relaxed back to the shared-
+ *     agent of the owning member; PR #608 relaxed back to the shared-
  *     managerId reading after a product decision that "owner's agent
  *     acts on owner's behalf" — see that PR for the deliberation
  *     transcript.
@@ -126,7 +126,7 @@ export type PrivateGateTarget = {
  *     to close a social-engineering path: Bob pulls owner M's PUBLIC agent
  *     X_pub into a chat, then X_pub turns around and pulls M's PRIVATE
  *     agent X_priv. The lenient reading admits X_priv there.
- *   - PR #604 reverted to this lenient reading after the product owner
+ *   - PR #608 reverted to this lenient reading after the product owner
  *     decided that "owner's agent acts on owner's behalf" — i.e. X_pub
  *     pulling X_priv is intentional delegation, not a social-engineering
  *     hole. Cross-manager admission of a private agent remains refused;


### PR DESCRIPTION
## Summary

PR #601 implemented the **strict** owner-exclusive rule (only `type=human` of the same owning member can invite a private agent). The product decision behind it has been **reversed**: an owner's agent acting on the owner's behalf is **intentional delegation**, not a social-engineering hole.

The owner-exclusive boundary still holds across managers — cross-manager admission of a private target remains 403. Inside one owning member's agent team, public siblings, private siblings, and the human owner now share invitation rights.

### The new predicate

`rejectedPrivateTargets(caller, targets)` rejects a target iff all three hold:

1. `target.visibility === PRIVATE`
2. `target.uuid !== caller.agentId` (self-add carve-out preserved for runtime rejoin)
3. `target.managerId !== caller.memberId` (cross-manager refusal)

The `caller.type === 'human'` clause from PR #601 is dropped, as is the `agents.type` column from the caller-row query and the `type` field on `PrivateGateCaller`. Error wording reverts from `Only the human owner ...` to `Only the owner ...` across the three writer sites.

### Behaviour shifts vs PR #601 (only 2 of 11 caller×target combos)

| Caller | Target | #601 | This PR |
|---|---|---|---|
| M's public agent | M's private agent | ❌ | ✅ |
| M's private agent | M's other private agent | ❌ | ✅ |

All other combinations unchanged.

### What PR #601's structural wins keep

The `rejectedPrivateTargets` pure predicate, the three writer paths (`inviteParticipantsToChat` / `chat.ts::createChat` / `me-chat.ts::createMeChat`) all routing through it, and the fixture cleanup that pinned `visibility` explicitly — all survive. This PR flips the predicate inside the function, keeping the "one rule, one home" discipline intact.

### Why the reversal

The strict reading made a manager's whole non-human team inert for chat-membership management — the manager had to be at the keyboard for every private-sibling invite. In practice manager-delegate-to-agent flows want the opposite. The cross-manager boundary (the part actually carrying the privacy guarantee) is unchanged.

## Test plan

- [x] `pnpm check` — exit 0 (16 pre-existing github-scan warnings)
- [x] `pnpm typecheck` — 13/13 tasks pass
- [x] `pnpm --filter @first-tree/server test` — **1220 server tests pass**
- [x] `chat-private-mention-visibility.test.ts`:
  - N1, N2, N3, N4 **flipped** from `rejects` → `resolves`, with post-write speaker-membership check on add-participant cases
  - N5 preserved (admin cross-manager still 403)
  - N6 expanded into 3-case pure-function exercise: self-add, same-owner, cross-owner
- [x] `participant-invite.test.ts` matcher reverted to `/Only the owner/`
- [x] `agent-visibility.test.ts` two comments updated; fixtures still pin `visibility` explicitly

## Migration / docs

- **No migration.** Runtime predicate change only.
- **No new chat-membership rows** materialise from this; the rule only governs future invites. Existing membership rows from the strict era stay (a no-op set anyway because the strict era was hours long).
- **RFC §4.5 "Owner-exclusive"** semantics should read as shared-owner-team to stay in sync. The RFC lives only on the unmerged `docs/agent-space-mention-visibility-rfc` branch; not touched here.

## Reviewer note

@yuezengwu @baixiaohang — the strict-reading direction you both LGTM'd on #601 is being reversed by product decision (`gandy2025`: "我的 agent 应该可以拉我的 agent 入群，但不允许其他人拉我的 private agent 进群"). The cross-manager protection you'd care about is intact; only the within-team delegation is loosened. Re-review appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)