### PR TITLE
fix(web): split mention chip into composer .mention-text vs timeline .mention-chip

### DIFF
--- a/packages/web/src/components/mention-highlight-overlay.tsx
+++ b/packages/web/src/components/mention-highlight-overlay.tsx
@@ -15,6 +15,15 @@ import { type CSSProperties, type RefObject, useEffect, useRef } from "react";
  * behaviour. The host passes those via `mirrorStyle` (typically the
  * same style object used on the textarea, minus background/color).
  *
+ * Chip class contract — the `chipClassName` MUST NOT add horizontal
+ * padding, background-with-offset, border, margin, or any other
+ * box-width-affecting property. The textarea underneath positions
+ * its caret per character; any extra horizontal pixels on the chip
+ * shift glyphs out from under the caret and the user perceives
+ * "the cursor is in the wrong place." For the pill / capsule look,
+ * render the same `@<name>` through `rehype-mentions` after sending
+ * (see `.mention-chip`); the composer side uses `.mention-text`.
+ *
  * Long drafts that scroll inside the textarea are handled by an inner
  * `transform: translateY(-scrollTop)` — using a fixed-position inner
  * shifts the painted glyphs in lockstep with the textarea's own

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1395,19 +1395,36 @@ tr[data-interactive]:hover {
   }
 }
 
-/* Mention chip — used by the composer mirror overlay and the
- * rehype-mentions plugin so the same visual treatment shows up for
- * both the user's draft and rendered sent messages. The chip stays
- * inline (no block-level layout) and `white-space: nowrap` keeps the
- * `@<name>` from wrapping at a hyphen mid-handle. */
+/* Mention chip — pill style for rendered sent messages (rehype-mentions
+ * plugin). The composer mirror overlay uses `.mention-text` instead
+ * (see below) because any horizontal padding / background offset on
+ * the mirror chip pushes the visual glyphs out of sync with the
+ * textarea's caret position underneath. `white-space: nowrap` keeps
+ * `@<name>` from wrapping at a hyphen mid-handle. The hard-coded
+ * `999px` radius (instead of `--radius-chip`) gives the full capsule
+ * shape without touching the shared chip radius. */
 .mention-chip {
   display: inline;
   background: var(--accent);
   color: var(--fg-on-vivid);
-  padding: 0 5px;
-  border-radius: var(--radius-chip);
+  padding: 0 6px;
+  border-radius: 999px;
   font-weight: 500;
   white-space: nowrap;
+}
+
+/* Mention text — composer-side variant. MUST NOT introduce padding,
+ * background, border, margin, OR font-weight / font-size / letter-
+ * spacing changes, because the mirror overlay paints glyphs
+ * character-for-character on top of a transparent-text textarea;
+ * any per-glyph metric change shifts the painted text out from
+ * under the textarea's caret. Sans-serif fonts in particular widen
+ * by a few percent at weight 600 vs 400, which is small but enough
+ * to drift the trailing characters and re-introduce the caret-lag
+ * bug this class was created to fix. `color` is the only property
+ * that's metric-neutral, so it's the only differentiator we use. */
+.mention-text {
+  color: var(--accent);
 }
 
 /* Selection inside the mention composer: textarea text is rendered

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2761,7 +2761,7 @@ export function ChatView({
                         value={draft}
                         participants={mentionParticipants}
                         textareaRef={textareaRef}
-                        chipClassName="mention-chip"
+                        chipClassName="mention-text"
                         mirrorStyle={{
                           padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
                           fontSize: "var(--text-subtitle)",


### PR DESCRIPTION
## Summary

Splits the shared `.mention-chip` rule into two purpose-specific classes so the composer's mirror overlay can paint mentions without offsetting the caret, while the timeline chip keeps a strong pill look.

- **Composer**: `.mention-text` — only `color: var(--accent)`. Caret now sits exactly at the trailing character of the painted `@<name>` (was visually inside the chip because of `padding: 0 5px`).
- **Timeline**: `.mention-chip` upgraded to a full capsule (`padding: 0 6px`, `border-radius: 999px`). Hard-coded radius so other components using `--radius-chip` (settings cards, token row, etc.) are untouched.

## Why the composer class is so spartan

`MentionHighlightOverlay` paints chips on a mirror layer behind a transparent-text `<textarea>`. The textarea positions its caret per character, so any property that changes a glyph's box width — padding, border, background-with-offset, margin, `font-weight`, `font-size`, `letter-spacing` — drifts the painted glyphs out from under the caret and the user perceives "the cursor is in the wrong place." `color` is metric-neutral and is the only differentiator we use. The mistake of treating `font-weight` as safe is what produced the assistant's follow-up review during alignment; the contract is now documented in the class comment and overlay header.

## Behaviors preserved (vs PR #597)

- Mirror overlay architecture, `segmentMentions` chip ⇔ valid mention contract (color drops when user backspaces to an invalid token — this is the send-gate signal, intentional)
- Mention autocomplete + paste-safe `interactiveTriggerIndex`
- `rehype-mentions` timeline rendering + `data-mention-agent-id`
- `.mention-composer-textarea::selection` selection band
- `new-chat-draft.tsx` chip-row promotion (not touched; that surface does not use the overlay)

## Test plan

- [ ] Type `@gandy-developer hi` in chat composer → mention is green-colored bold-free text, caret sits at end after `hi`
- [ ] Backspace through the mention → color drops at each non-matching token state (`@gandy-develope`, etc.), restored when full name typed back
- [ ] Paste a block containing `@<name>` → no popover hijack, mention still colored
- [ ] Send the message → timeline renders the mention as a full capsule, padding 6px, fully rounded
- [ ] Other `--radius-chip` consumers (settings cards, token row in identities, badges) unchanged
- [ ] Dark mode: `--accent` text remains legible in composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)