### PR TITLE
chore(deps): bump @openai/codex-sdk to ^0.134.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
     "@inquirer/prompts": "^8.3.0",
     "@larksuiteoapi/node-sdk": "^1.59.0",
-    "@openai/codex-sdk": "^0.125.0",
+    "@openai/codex-sdk": "^0.134.0",
     "commander": "^13.1.0",
     "gray-matter": "^4.0.3",
     "jose": "^6.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-    "@openai/codex-sdk": "^0.125.0",
+    "@openai/codex-sdk": "^0.134.0",
     "pino": "^9.5.0",
     "semver": "^7.6.3",
     "ws": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.59.0
         version: 1.59.0
       '@openai/codex-sdk':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.134.0
+        version: 0.134.0
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -94,8 +94,8 @@ importers:
         specifier: ^0.2.84
         version: 0.2.84(zod@4.3.6)
       '@openai/codex-sdk':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.134.0
+        version: 0.134.0
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -1377,47 +1377,47 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@openai/codex-sdk@0.125.0':
-    resolution: {integrity: sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg==}
+  '@openai/codex-sdk@0.134.0':
+    resolution: {integrity: sha512-fQIIj6RYiVZ7sr8XyEsc2t0zsLvRd+gCx9qUksCDgwc8MzVHhLN7eUjAM5l3tro6PcikBha1+40Tu5OVrF32lg==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.125.0':
-    resolution: {integrity: sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==}
+  '@openai/codex@0.134.0':
+    resolution: {integrity: sha512-N0vmdTXl/rglZjgd3PaMe9oRrqjO6zZ//uAvUhCDRnJNAUT3LrpYvCK3y9B/ev7QcChfXR43IGUh3ssqWRvMmA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.125.0-darwin-arm64':
-    resolution: {integrity: sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ==}
+  '@openai/codex@0.134.0-darwin-arm64':
+    resolution: {integrity: sha512-pOxwQjb1HHtY6KG66+g/rX7uP4yBvchfCrQw22ddYy64s7fJqnD6UV/Ur60j6MWXt71jcaWLEkV1pJthQy9CFQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.125.0-darwin-x64':
-    resolution: {integrity: sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg==}
+  '@openai/codex@0.134.0-darwin-x64':
+    resolution: {integrity: sha512-XjRtq8PB9dtpxQ5QU6TrzR/z8EVlLLk55oonsyRp3VkMOsKjJWXvLxAnmzUm1MuVZqz90Ua7CJbr+8BG+ZUWpA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.125.0-linux-arm64':
-    resolution: {integrity: sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA==}
+  '@openai/codex@0.134.0-linux-arm64':
+    resolution: {integrity: sha512-fqI8iClQGvrANFx/dJwZK8KNQlqlQKo7A/UB5G7IaeTAAJ+y/CG2R33Bbd9GboH/8ormY39ureNk27eqt++51g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.125.0-linux-x64':
-    resolution: {integrity: sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ==}
+  '@openai/codex@0.134.0-linux-x64':
+    resolution: {integrity: sha512-d/o1AVAniQU2oSEq7ZV0hVwzmk6Dj2IWeNPLnX/KXyv1DfIMJbY+qEg/xhfRmuVW4VPhrhQLBITwrkAYviy1MA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.125.0-win32-arm64':
-    resolution: {integrity: sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ==}
+  '@openai/codex@0.134.0-win32-arm64':
+    resolution: {integrity: sha512-8OdRmbCcyLLMF3Bg6945PW6INZ7bZVygYo2lusnC0Q2KZ3MRYrMnXRJ6mfvkDc8kPpFE+djMFnQ70gt/jBLVCA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.125.0-win32-x64':
-    resolution: {integrity: sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==}
+  '@openai/codex@0.134.0-win32-x64':
+    resolution: {integrity: sha512-hW1omBcN1jKeVUVnTqWlpc42nF2qAwCEN6l1IFeKFJegYoZ39YrE7pdh56gAmaZTyT5Eexx7cgNpaEK3JElxvA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -5905,35 +5905,35 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@openai/codex-sdk@0.125.0':
+  '@openai/codex-sdk@0.134.0':
     dependencies:
-      '@openai/codex': 0.125.0
+      '@openai/codex': 0.134.0
 
-  '@openai/codex@0.125.0':
+  '@openai/codex@0.134.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.125.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.125.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.125.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.125.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.125.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.125.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.134.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.134.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.134.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.134.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.134.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.134.0-win32-x64'
 
-  '@openai/codex@0.125.0-darwin-arm64':
+  '@openai/codex@0.134.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.125.0-darwin-x64':
+  '@openai/codex@0.134.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.125.0-linux-arm64':
+  '@openai/codex@0.134.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.125.0-linux-x64':
+  '@openai/codex@0.134.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.125.0-win32-arm64':
+  '@openai/codex@0.134.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.125.0-win32-x64':
+  '@openai/codex@0.134.0-win32-x64':
     optional: true
 
   '@opentelemetry/api-logs@0.215.0':


### PR DESCRIPTION
## Summary

- Bumps `@openai/codex-sdk` from `^0.125.0` → `^0.134.0` at both pinning sites (`packages/client/package.json`, `apps/cli/package.json`)
- Zero handler-code changes — 0.125 → 0.134 has exactly one type-level change (`McpToolCallItem.result._meta?: unknown`, additive) that our handler doesn't touch
- Follow-up to #600 (turn-level retry + race detection + usage metrics); that PR's review surfaced 9 minor versions / ~7 weeks of upstream fixes were stuck behind the caret-on-0.x semver behaviour

## Why now

`^0.x.y` in npm is treated as `~0.x.y` (only patch updates), so `pnpm install` never picked up 0.126 → 0.134 even though they were stable releases. PR #600's review explicitly called out the resulting "9 minor versions behind" gap as the highest-impact follow-up to that PR.

## Diff scope (audited)

| File | Change |
|---|---|
| `packages/client/package.json` | `^0.125.0` → `^0.134.0` |
| `apps/cli/package.json` | `^0.125.0` → `^0.134.0` |
| `pnpm-lock.yaml` | Only `@openai/codex-sdk` and its 6 platform binary packages (`codex-{darwin,linux,win32}-{arm64,x64}`) moved version. No transitive dep upgrades — confirmed via grep of `+/-` lines in the lockfile diff. |

## Breaking-change diff (`dist/index.d.ts` 0.125 vs 0.134)

```diff
 type McpToolCallItem = {
   ...
   result?: {
       content: ContentBlock[];
+      _meta?: unknown;
       structured_content: unknown;
   };
   ...
 };
```

One additive optional field. Every other exported type (`Codex`, `Thread`, `ThreadOptions`, `ThreadEvent` union members, `Usage`, `Input`, `CodexOptions`, `ApprovalMode`, `SandboxMode`, `ModelReasoningEffort`, `WebSearchMode`) is byte-identical. Our handler reads `item.result.structured_content ?? item.result.content` and never touches `_meta`, so this is a no-op.

## Test plan

- [x] `pnpm typecheck` — 13/13 packages pass
- [x] `pnpm check` — exit 0 (16 pre-existing biome warnings in `packages/github-scan/tests`, unrelated)
- [x] `pnpm --filter @first-tree/client test` — 632 passed, 3 skipped
- [ ] (post-merge) smoke-test a codex-runtime agent end-to-end on a non-prod client — `_meta` field shape is the only realistic regression vector and won't surface in unit tests

## Out of scope (filed as follow-up)

This pin will get stuck again at `^0.134.x` for the same caret-on-0.x reason. The structural fix is a Renovate / Dependabot config that proposes minor bumps for `@openai/codex-sdk` on a two-weekly cadence — better as its own discussion / config PR than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)