### PR TITLE
fix(nha): wake asking agent on attention respond via @mention prefix

### DIFF
--- a/packages/server/src/__tests__/attention.test.ts
+++ b/packages/server/src/__tests__/attention.test.ts
@@ -207,7 +207,14 @@ describe("attention service — invariants", () => {
 
     const closed = await respondAttention(app.db, human, created.id, { text: "deploy — diff looks clean" });
     expect(closed.state).toBe("closed");
+    // The canonical answer on the attention row is the raw response text
+    // — the `@<origin>` echo prefix is a chat-rendering concern, not part
+    // of the stored answer.
     expect(closed.response).toBe("deploy — diff looks clean");
+
+    const [botRow] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, bot));
+    expect(botRow?.name).toBeTruthy();
+    const botName = botRow?.name ?? "";
 
     const postEcho = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
     expect(postEcho.length).toBe(1);
@@ -215,12 +222,22 @@ describe("attention service — invariants", () => {
     expect(echo).toBeDefined();
     if (!echo) return;
     expect(echo.senderId).toBe(human);
-    expect(echo.content).toBe("deploy — diff looks clean");
+    // Echo content is prefixed with `@<originAgent>` so readers of the
+    // chat thread see who the reply is directed at, and so sendMessage's
+    // `@<name>` extraction wakes the asking agent.
+    expect(echo.content).toBe(`@${botName} deploy — diff looks clean`);
     expect(echo.format).toBe("text");
     // The echo carries the linkage back to the originating attention so
     // exports / search / rendering can opt in to a "this was an answer"
     // visual without inferring from heuristics.
-    expect((echo.metadata as Record<string, unknown>).attentionResponseFor).toBe(created.id);
+    const echoMetadata = echo.metadata as Record<string, unknown>;
+    expect(echoMetadata.attentionResponseFor).toBe(created.id);
+    // The `@<originAgent>` prefix must resolve to the asker's uuid via
+    // content extraction — this is the wake-up routing that lets the
+    // asking agent resume after the human responds.
+    const mentions = echoMetadata.mentions;
+    expect(Array.isArray(mentions)).toBe(true);
+    expect(mentions as string[]).toContain(bot);
   });
 
   it("cancel by non-origin → ForbiddenError", async () => {

--- a/packages/server/src/services/attention.ts
+++ b/packages/server/src/services/attention.ts
@@ -275,6 +275,20 @@ export async function respondAttention(
   // other speakers (co-targets, auditors) see the decision inline. This
   // is a side effect of `respond`; failure to write the message is
   // swallowed (the canonical answer is on `attentions.response`).
+  //
+  // Routing: prefix the echo content with `@<originAgent>` and let
+  // sendMessage's standard `@<name>` extraction wake them. The asking
+  // agent is already a speaker of origin_chat_id (raise invariant), so
+  // the mention always resolves. Visible-in-thread is the goal — readers
+  // of the chat history see the reply is directed at the asker, not just
+  // a free-floating message.
+  const [originAgentRow] = await db
+    .select({ name: agents.name })
+    .from(agents)
+    .where(eq(agents.uuid, row.originAgentId))
+    .limit(1);
+  const mentionPrefix = originAgentRow?.name ? `@${originAgentRow.name} ` : "";
+  const echoContent = `${mentionPrefix}${responseText}`;
   try {
     await sendMessage(
       db,
@@ -282,7 +296,7 @@ export async function respondAttention(
       callerHumanId,
       {
         format: "text",
-        content: responseText,
+        content: echoContent,
         // Tag the message so consumers can attribute it to the NHA flow
         // (web rendering may opt to chip-decorate "answer to <subject>",
         // exports / search may filter on it). The bag also carries the
@@ -290,11 +304,10 @@ export async function respondAttention(
         metadata: { attentionResponseFor: attentionId },
         source: "api",
       },
-      // No mention extraction: the response text often contains plain
-      // `@<name>` tokens that aren't routing intent (e.g. quoting the
-      // ask), and the ask itself already names the audience. Keep this
-      // path quiet — receiverNames is empty, content extraction off.
-      { extractMentionsFromContent: false },
+      // Content extraction ON so the `@<originAgent>` prefix above resolves
+      // and wakes the asker. Any narrative `@peer` the human quoted in the
+      // reply may also resolve — acceptable: the human typed it, and the
+      // standard chat-send path treats typed `@peer` the same way.
     );
   } catch (err) {
     log.warn(


### PR DESCRIPTION
## Summary

When a human responded to an NHA via UI, the accompanying chat-echo message landed silently — UI showed "✓ sent" but the asking agent was never woken because `respondAttention` called `sendMessage` with `extractMentionsFromContent: false` and no explicit mention routing.

This change prefixes the echo content with `@<originAgent>` and re-enables standard `@<name>` extraction. The asker is already a speaker of `origin_chat_id` (raise invariant), so the mention always resolves and the agent resumes after the answer. Chat readers also now see the reply is directed at the asker rather than a free-floating message.

## Changes

- `packages/server/src/services/attention.ts` — look up `agents.name` for `originAgentId`, prefix echo content with `@<name> `, remove `extractMentionsFromContent: false` so prefix resolves
- `packages/server/src/__tests__/attention.test.ts` — assert echo content carries the `@<originAgent>` prefix and that `metadata.mentions` contains the asker's uuid (confirms wake-up routing)

## Self-review notes

- Agent name regex `^[a-z0-9][a-z0-9_-]{0,63}$` is fully compatible with shared `MENTION_REGEX` — every valid agent name resolves
- Null `name` is handled (empty prefix → no wake, but echo + attention close still succeed)
- `closed.response` stays as the raw text — the prefix is a chat-rendering concern, not part of the canonical answer
- Echo write is still best-effort; failure does not unwind the close

## Test plan

- [x] `pnpm --filter @first-tree/server test attention` — 1227 pass
- [x] `pnpm typecheck` — 13 tasks pass
- [x] `pnpm exec biome check` on modified files — clean
- [ ] Manual: in UI, raise an NHA with `requiresResponse: true`, respond via UI, verify the asking agent wakes and receives the answer