### PR TITLE
refactor(onboarding): tighten copy, surface bailouts, and harden invitee defenses

### DIFF
--- a/packages/server/src/__tests__/github-app-installation-exists.test.ts
+++ b/packages/server/src/__tests__/github-app-installation-exists.test.ts
@@ -1,0 +1,102 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * `GET /orgs/:orgId/github-app-installation/exists` — member-readable
+ * boolean probe added so invitee onboarding can detect "admin set up the
+ * tree but never connected GitHub" without tripping the admin-gated
+ * details endpoint. Two failure modes the round-2 codex review flagged:
+ *
+ *   - 403 → "missing"   blocks every invitee of a healthy team
+ *   - 403 → "installed" makes the no-installation safeguard unreachable
+ *
+ * Both vanish once /exists is member-readable: members get a real
+ * boolean, no 403 in the way.
+ */
+describe("GET /orgs/:orgId/github-app-installation/exists", () => {
+  const getApp = useTestApp();
+
+  async function seedInstallation(app: ReturnType<typeof getApp>, orgId: string, installationId: number) {
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: `org-${installationId}`,
+        accountGithubId: installationId * 10,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
+    await bindInstallationToOrg(app.db, installationId, orgId);
+  }
+
+  it("returns { exists: true } when an installation is bound", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `e-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 900_001);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/exists`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ exists: true });
+  });
+
+  it("returns { exists: false } when no installation is bound (no 404 path; presence is the whole answer)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `e-admin-${crypto.randomUUID().slice(0, 8)}` });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/exists`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ exists: false });
+  });
+
+  it("is member-readable (does NOT require admin) — the whole point of this endpoint", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `e-admin-${crypto.randomUUID().slice(0, 8)}` });
+
+    // Demote the caller to member, then re-login so the JWT carries role:member.
+    const userId = (
+      await app.db.select({ id: users.id }).from(users).where(eq(users.username, admin.username)).limit(1)
+    )[0]?.id;
+    expect(userId).toBeDefined();
+    await app.db
+      .update(members)
+      .set({ role: "member" })
+      .where(eq(members.userId, userId ?? ""));
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username: admin.username, password: admin.password },
+    });
+    const fresh = loginRes.json<{ accessToken: string }>();
+
+    await seedInstallation(app, admin.organizationId, 900_002);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/exists`,
+      headers: { authorization: `Bearer ${fresh.accessToken}` },
+    });
+    // The admin-gated GET / would 403 here. /exists must 200.
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ exists: true });
+  });
+
+  // Non-member rejection is structurally enforced by the shared
+  // `requireOrgMembership` helper used at the top of /exists' handler. The
+  // helper has its own coverage in scope/* tests; setting up a truly
+  // disjoint org here would require building a second org from scratch,
+  // which isn't worth duplicating just to re-verify a one-liner.
+});

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -7,7 +7,7 @@ import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { authIdentities } from "../../db/schema/auth-identities.js";
 import { ForbiddenError, NotFoundError } from "../../errors.js";
-import { requireOrgAdmin } from "../../scope/require-org.js";
+import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
 import { getStoredGithubAccessToken } from "../../services/auth-identity.js";
 import {
   buildAppInstallUrl,
@@ -100,6 +100,26 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       updatedAt: row.updatedAt.toISOString(),
     };
     return out;
+  });
+
+  /**
+   * GET `/exists` — member-readable boolean "does this team have a GitHub
+   * App installation?". The full GET above is admin-only because it exposes
+   * installation-id / permissions / events that regular members shouldn't
+   * see; this endpoint redacts everything except the bare presence bit so
+   * the invitee onboarding path can authoritatively detect the
+   * "admin set up the tree but never connected code" failure mode (without
+   * which we either block every invitee of a working team — if 403 maps to
+   * `missing` — or never trip the warning at all — if 403 maps to
+   * `installed`).
+   *
+   * Returns `{ exists: boolean }`. No 404 path; presence is the whole
+   * answer.
+   */
+  app.get<{ Params: { orgId: string } }>("/exists", async (request) => {
+    const scope = await requireOrgMembership(request, app.db);
+    const row = await findInstallationByOrg(app.db, scope.organizationId);
+    return { exists: row !== null && row !== undefined };
   });
 
   // ── POST-ish helper: build the "Install on GitHub" URL ──────────────

--- a/packages/web/src/api/github-app.ts
+++ b/packages/web/src/api/github-app.ts
@@ -27,6 +27,21 @@ export async function getGithubAppInstallation(organizationId: string): Promise<
 }
 
 /**
+ * Member-readable "is the GitHub App installed for this team?" probe.
+ *
+ * The full installation endpoint above is admin-only because it exposes
+ * install-id / permissions / events. This redacted boolean view exists so
+ * non-admin onboarding paths (specifically invitee kickoff) can detect
+ * the "admin set up the tree but never connected code" failure mode
+ * without either (a) silently 403-ing every invitee out of the flow or
+ * (b) never tripping at all. Presence is the whole answer — no 404 path.
+ */
+export async function getGithubAppInstallationExists(organizationId: string): Promise<boolean> {
+  const r = await api.get<{ exists: boolean }>(`/orgs/${organizationId}/github-app-installation/exists`);
+  return r.exists;
+}
+
+/**
  * Fetch the GitHub App install URL for the active org. The server mints a
  * signed `state` JWT, sets the `oauth_state_nonce` cookie alongside it,
  * and returns `https://github.com/apps/<slug>/installations/new?state=…`

--- a/packages/web/src/pages/onboarding/__tests__/copy.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/copy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { resolvePathScoped, resolveStepLabel, STEP_COPY } from "../copy.js";
+
+describe("resolvePathScoped", () => {
+  it("returns the string as-is when the same copy applies to both paths", () => {
+    expect(resolvePathScoped("Connect computer", "admin")).toBe("Connect computer");
+    expect(resolvePathScoped("Connect computer", "invitee")).toBe("Connect computer");
+  });
+  it("picks the path-specific variant when an object is given", () => {
+    const v = { admin: "Start tree", invitee: "Start work" };
+    expect(resolvePathScoped(v, "admin")).toBe("Start tree");
+    expect(resolvePathScoped(v, "invitee")).toBe("Start work");
+  });
+});
+
+describe("resolveStepLabel", () => {
+  it("admin and invitee share a label for non-divergent steps", () => {
+    expect(resolveStepLabel("connect-computer", "admin")).toBe("Connect computer");
+    expect(resolveStepLabel("connect-computer", "invitee")).toBe("Connect computer");
+    expect(resolveStepLabel("create-agent", "admin")).toBe("Create agent");
+    expect(resolveStepLabel("create-agent", "invitee")).toBe("Create agent");
+  });
+  it("kickoff diverges: admin builds the tree, invitee just starts work", () => {
+    expect(resolveStepLabel("kickoff", "admin")).toBe("Start tree");
+    expect(resolveStepLabel("kickoff", "invitee")).toBe("Start work");
+  });
+  it("the admin's first step now uses the friendlier 'Welcome' rail label (form is still on the page)", () => {
+    expect(resolveStepLabel("team", "admin")).toBe("Welcome");
+    expect(resolveStepLabel("welcome", "invitee")).toBe("Welcome");
+  });
+});
+
+describe("STEP_COPY", () => {
+  it("no step has 'outcomes' (footer removed; merged into why)", () => {
+    for (const id of Object.keys(STEP_COPY) as Array<keyof typeof STEP_COPY>) {
+      // outcomes was removed from the StepCopy type; any leftover string array
+      // would indicate a stale entry that ships dead UI content.
+      expect((STEP_COPY[id] as unknown as Record<string, unknown>).outcomes).toBeUndefined();
+    }
+  });
+  it("kickoff's title/why stay empty (the step renders per-sub-state headings itself)", () => {
+    expect(STEP_COPY.kickoff.title).toBe("");
+    expect(STEP_COPY.kickoff.why).toBe("");
+  });
+});

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -128,14 +128,29 @@ describe("shouldEnterOnboarding", () => {
 
 describe("resolveInviteeKickoffState", () => {
   it("waits when the team has no knowledge link yet (admin not done)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "", teamRepoCount: 0 })).toBe("waiting");
-    expect(resolveInviteeKickoffState({ treeUrl: "", teamRepoCount: 3 })).toBe("waiting");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false, teamRepoCount: 0 })).toBe("waiting");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: true, teamRepoCount: 3 })).toBe("waiting");
   });
-  it("confirms from the team's projects when both link + projects exist", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", teamRepoCount: 2 })).toBe("confirm");
+  it("waiting wins over no-installation when the tree is also missing (fix the bigger blocker first)", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false, teamRepoCount: 3 })).toBe("waiting");
   });
-  it("lets the invitee pick when the team has a link but listed no projects", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", teamRepoCount: 0 })).toBe("picker");
+  it("stops at no-installation when the tree is set but the App was never installed (would 403 in picker)", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false, teamRepoCount: 0 })).toBe(
+      "no-installation",
+    );
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false, teamRepoCount: 3 })).toBe(
+      "no-installation",
+    );
+  });
+  it("confirms from the team's projects when link + install + projects all exist", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true, teamRepoCount: 2 })).toBe(
+      "confirm",
+    );
+  });
+  it("lets the invitee pick when the team has link + install but listed no projects", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true, teamRepoCount: 0 })).toBe(
+      "picker",
+    );
   });
 });
 

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -48,7 +48,7 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
   team: {
     label: "Welcome",
     title: "Name your team",
-    why: "This is the shared space where you, your teammates, and your AI agents work together. Rename it anytime.",
+    why: "The shared space where you, your teammates, and your AI agents work together. Rename it anytime.",
   },
   "connect-code": {
     label: "Connect code",
@@ -63,7 +63,7 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
   "create-agent": {
     label: "Create agent",
     title: "Create your agent",
-    why: "Name your agent and pick who can work with it. You'll be chatting in a moment, and you can add more anytime.",
+    why: "Name your agent and pick who can work with it. You'll be chatting in a moment.",
   },
   kickoff: {
     label: { admin: "Start tree", invitee: "Start work" },
@@ -102,7 +102,7 @@ export const COPY = {
     noRepos: "No projects found on your GitHub account yet.",
     reconnect: "Reconnect GitHub with project access",
     notConfigured:
-      "Code connection isn't set up on this server yet. You can continue now and connect a project later from Settings.",
+      "Code connection isn't set up here yet. You can continue now and connect a project later from Settings.",
     notAdmin: "Only a team admin can connect code. Ask an admin to finish this, or continue for now.",
     continueWithout: "Continue without connecting code",
     continueNoProject: "Continue without a project",
@@ -119,7 +119,7 @@ export const COPY = {
     /** Returned from the install dialog without a new installation. */
     postAttemptStuckTitle: "Looks like the install didn't complete.",
     postAttemptStuckBody:
-      "GitHub sent you back without adding First Tree. Try again, or get a link to send to your GitHub org owner.",
+      "GitHub sent you back without adding First Tree. Try again — GitHub will ask an org owner to approve if you're not one.",
     /** Skip-for-now warning. */
     skipWarningTitle: "Skip connecting code?",
     skipWarningBullets: [
@@ -178,7 +178,7 @@ export const COPY = {
     inviteePickerWhy: "Your team's set up — pick which of your own projects your agent should help with.",
     inviteePickerEmpty:
       "No projects found on your GitHub account yet. You can continue without one and add later from Settings.",
-    inviteePickerScopeMissing: "Couldn't see your projects — your GitHub access doesn't include project scope.",
+    inviteePickerScopeMissing: "Couldn't see your projects — your GitHub access is missing project read permission.",
     inviteePickerNetworkError: "Couldn't load your projects. Try again in a moment.",
     inviteeContinueNoProject: "Continue without a project",
     /** Shown atop confirm / picker so invitee knows where the work lands. */
@@ -199,9 +199,9 @@ export const COPY = {
     // the invitee here rather than letting them sail into the picker.
     noInstallTitle: "Almost there — your team's code isn't connected yet",
     noInstallBody:
-      "Your team's admin set up the Context Tree but hasn't connected code on GitHub yet. Your agent needs this to do real work.",
+      "Your team's admin set up the Context Tree but hasn't connected code on GitHub yet. Your agent needs that connection to do real work.",
     noInstallStatus: "Watching for the connection…",
-    noInstallShareIntro: "Send this link to your admin to remind them:",
+    noInstallShareIntro: "Send this link so your admin can connect your team's code:",
     confirmTitle: "Your team is ready",
     confirmBody: "Your team set up its projects and Context Tree. Pick what your agent should work on.",
     startAnyway: "Start chatting anyway",

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -104,10 +104,15 @@ export const COPY = {
     continueWithout: "Continue without connecting code",
     continueNoProject: "Continue without a project",
     pickHint: "Pick one or more projects for your agent — or continue without any for now.",
-    /** Non-owner / share-link affordance, surfaced right under the primary CTA. */
-    notOwnerToggle: "Not a GitHub organization owner?",
-    notOwnerIntro: "Send this link to an owner of your GitHub org:",
-    notOwnerAfter: "This page updates on its own when they finish.",
+    /**
+     * Non-owner hint shown under the primary CTA. We deliberately don't hand
+     * out a copy-the-install-link button — GitHub's install URL is bound to
+     * a per-browser `oauth_state_nonce` cookie, so a link opened in someone
+     * else's browser would fail the callback. GitHub already routes
+     * non-owner installs through an owner-approval flow, so the right
+     * advice is to click Install anyway and let GitHub handle the ask.
+     */
+    notOwnerHint: "Not a GitHub organization owner? Click Install anyway — GitHub will ask an owner to approve.",
     /** Returned from the install dialog without a new installation. */
     postAttemptStuckTitle: "Looks like the install didn't complete.",
     postAttemptStuckBody:

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -91,7 +91,10 @@ export const COPY = {
   hideSetup: "Hide setup",
   /** connect-code states */
   connectCode: {
-    intro: "Connect your projects so your agent can read the code. Every change comes back as a request you review.",
+    // `intro` was deleted (R1 from baixiaohang review): it duplicated
+    // `STEP_COPY['connect-code'].why` verbatim and had no remaining
+    // consumer after the connect-code step started reading from
+    // STEP_COPY directly. Keep the why as the single source of truth.
     cta: "Install First Tree on GitHub",
     waiting: "Waiting for GitHub…",
     connected: "Connected",

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -16,63 +16,66 @@
  * (no marketing word slips a banned term past review).
  */
 
-import type { StepId } from "./steps.js";
+import type { OnboardingPath, StepId } from "./steps.js";
+
+/**
+ * A string that can either apply to both paths, or differ per path.
+ * Use the object form when admin and invitee should see different copy on
+ * the same logical step (currently only `kickoff` needs this — admin builds
+ * a Context Tree, invitee just kicks off their own work).
+ */
+export type PathScopedString = string | { admin: string; invitee: string };
+
+export function resolvePathScoped(value: PathScopedString, path: OnboardingPath): string {
+  return typeof value === "string" ? value : value[path];
+}
+
+/** Convenience: pull a step's rail label for the given path. */
+export function resolveStepLabel(step: StepId, path: OnboardingPath): string {
+  return resolvePathScoped(STEP_COPY[step].label, path);
+}
 
 export type StepCopy = {
-  /** Short label shown in the left progress rail. */
-  label: string;
+  /** Short label shown in the left progress rail. May vary by path. */
+  label: PathScopedString;
   /** Heading at the top of the content column. */
   title: string;
   /** One plain-language sentence: why this step exists. */
   why: string;
-  /** What the user will have once this step is done (shown in the footer). */
-  outcomes: readonly string[];
 };
 
 export const STEP_COPY: Record<StepId, StepCopy> = {
   team: {
-    label: "Your team",
+    label: "Welcome",
     title: "Name your team",
-    why: "This is the shared space where you, your teammates, and your AI agents work together.",
-    outcomes: ["A team others can join", "You can rename it or invite people anytime"],
+    why: "This is the shared space where you, your teammates, and your AI agents work together. Rename it anytime.",
   },
   "connect-code": {
-    label: "Your projects",
-    title: "Connect your projects",
-    why: "Your agent is ready — now give it something to work on. Connect one or more projects and it can read the code, suggest changes, and open requests for you to review.",
-    outcomes: [
-      "Your agent can see the projects you pick",
-      "Nothing ships without you — every change comes back as a request you approve",
-    ],
+    label: "Connect code",
+    title: "Connect your code",
+    why: "Connect your projects so your agent can read the code. Every change comes back as a request you review.",
   },
   "connect-computer": {
-    label: "Your computer",
+    label: "Connect computer",
     title: "Connect a computer",
-    why: "Your agent runs on a real computer — yours or a shared one — so it can do real work, not just chat.",
-    outcomes: ["A computer linked to your team", "Somewhere for your agent to run"],
+    why: "Your agent needs a real computer — link one to your team so it has somewhere to run.",
   },
   "create-agent": {
-    label: "Your agent",
+    label: "Create agent",
     title: "Create your agent",
-    why: "Add an AI agent to your team — give it a name and choose who can work with it.",
-    outcomes: ["Your first agent, ready to talk", "You can add more agents later"],
+    why: "Name your agent and pick who can work with it. You'll be chatting in a moment, and you can add more anytime.",
   },
   kickoff: {
-    label: "Your Context Tree",
+    label: { admin: "Start tree", invitee: "Start work" },
     // title/why are rendered per-state by StepKickoff (new / existing / no
     // project / invitee sub-states); the shell skips them while empty.
     title: "",
     why: "",
-    outcomes: [
-      "Your agent opens its first changes for you to review",
-      "A shared Context Tree your team and its agents build on over time",
-    ],
   },
   welcome: {
     label: "Welcome",
     title: "Welcome to the team",
     why: "Your team is already set up. Let's get your own agent working in a couple of quick steps.",
-    outcomes: ["You're in the team", "Next: connect a computer and create your agent"],
   },
 };
 
@@ -82,15 +85,14 @@ export const COPY = {
   productName: "First Tree",
   continue: "Continue",
   back: "Back",
+  cancel: "Cancel",
   skipForNow: "Skip for now",
   finishLater: "I'll finish later",
   hideSetup: "Hide setup",
-  /** Generic reassurance shown wherever GitHub access is requested. */
-  reviewReassurance: "We never change your code without asking — every change comes back as a request you review.",
   /** connect-code states */
   connectCode: {
-    intro: "Your project's code lives on GitHub. Connect it so your agent can read it and help with it.",
-    cta: "Connect on GitHub",
+    intro: "Connect your projects so your agent can read the code. Every change comes back as a request you review.",
+    cta: "Install First Tree on GitHub",
     waiting: "Waiting for GitHub…",
     connected: "Connected",
     pickProject: "Which projects should your agent work on?",
@@ -99,16 +101,28 @@ export const COPY = {
     notConfigured:
       "Code connection isn't set up on this server yet. You can continue now and connect a project later from Settings.",
     notAdmin: "Only a team admin can connect code. Ask an admin to finish this, or continue for now.",
-    alreadyInstalledHint:
-      "Already added First Tree on GitHub? Connecting again just links it to this team — nothing is reinstalled.",
     continueWithout: "Continue without connecting code",
     continueNoProject: "Continue without a project",
     pickHint: "Pick one or more projects for your agent — or continue without any for now.",
+    /** Non-owner / share-link affordance, surfaced right under the primary CTA. */
+    notOwnerToggle: "Not a GitHub organization owner?",
+    notOwnerIntro: "Send this link to an owner of your GitHub org:",
+    notOwnerAfter: "This page updates on its own when they finish.",
+    /** Returned from the install dialog without a new installation. */
+    postAttemptStuckTitle: "Looks like the install didn't complete.",
+    postAttemptStuckBody:
+      "GitHub sent you back without adding First Tree. Try again, or get a link to send to your GitHub org owner.",
+    /** Skip-for-now warning. */
+    skipWarningTitle: "Skip connecting code?",
+    skipWarningBullets: [
+      "Your teammates' agents won't be able to read code (they'll hit errors)",
+      "Your first agent will start with just an intro chat",
+      "You can connect code later from Settings",
+    ],
+    skipAnyway: "Skip anyway",
   },
   /** connect-computer states */
   connectComputer: {
-    instruction:
-      "On the computer your agent will use, open Terminal (on a Mac) or PowerShell (on Windows), then paste this and press Enter:",
     waiting: "Waiting for your computer…",
     connected: "connected",
     noRuntime:
@@ -138,7 +152,7 @@ export const COPY = {
     // admin — new Context Tree (default when the team has none yet)
     newTitle: "Start building your Context Tree",
     newWhy:
-      "You're all set. Your agent builds your Context Tree with you in the chat, walking you through each change to approve.",
+      "You're all set. Your agent builds your team's Context Tree with you in the chat, walking you through each change to approve.",
     haveExisting: "I already have a Context Tree",
     // admin — existing Context Tree (auto-detected from team settings, or pasted)
     existingTitle: "Use your team's Context Tree",
@@ -152,8 +166,15 @@ export const COPY = {
     noProjectBody:
       "No project connected, so your agent will start with a quick intro. Connect a project later from Settings to give it real context.",
     // invitee — team's tree is ready, pick a project
-    inviteePickerTitle: "Your team's Context Tree is ready",
-    inviteePickerWhy: "Pick a project for your agent to work on.",
+    inviteePickerTitle: "Pick a project to work on",
+    inviteePickerWhy: "Your team's set up — pick which of your own projects your agent should help with.",
+    inviteePickerEmpty:
+      "No projects found on your GitHub account yet. You can continue without one and add later from Settings.",
+    inviteePickerScopeMissing: "Couldn't see your projects — your GitHub access doesn't include project scope.",
+    inviteePickerNetworkError: "Couldn't load your projects. Try again in a moment.",
+    inviteeContinueNoProject: "Continue without a project",
+    /** Shown atop confirm / picker so invitee knows where the work lands. */
+    treeLabel: "Context Tree",
     start: "Start",
     starting: "Starting your agent…",
     invalidUrl:
@@ -161,11 +182,21 @@ export const COPY = {
   },
   /** invitee states */
   invitee: {
-    waitingTitle: "Your team is still being set up",
+    waitingTitle: "Waiting for your team to set up",
     waitingBody:
-      "An admin hasn't finished setting up your team's projects and Context Tree yet. This page updates on its own once that's done — or you can start chatting in the meantime.",
+      "Your team's admin is still setting up projects and a Context Tree. This page updates on its own as soon as they're done.",
+    waitingStatus: "Watching for updates…",
+    // NEW: admin set up tree but never connected the GitHub App. Without
+    // an installation, every git op the agent runs will 403, so we hard-stop
+    // the invitee here rather than letting them sail into the picker.
+    noInstallTitle: "Almost there — your team's code isn't connected yet",
+    noInstallBody:
+      "Your team's admin set up the Context Tree but hasn't connected code on GitHub yet. Your agent needs this to do real work.",
+    noInstallStatus: "Watching for the connection…",
+    noInstallShareIntro: "Send this link to your admin to remind them:",
     confirmTitle: "Your team is ready",
-    confirmBody: "Your team already set up its projects and Context Tree. Pick what your agent should work on.",
+    confirmBody: "Your team set up its projects and Context Tree. Pick what your agent should work on.",
+    startAnyway: "Start chatting anyway",
   },
   /** failure recovery, shared */
   errors: {

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -3,34 +3,6 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import type { GithubRepo } from "../../api/github.js";
 
-/** Checklist of outcomes for the footer: "what you'll have after this". */
-export function OutcomeList({ items }: { items: readonly string[] }) {
-  return (
-    <ul className="flex flex-col" style={{ gap: "var(--sp-2_5)", margin: 0, padding: 0, listStyle: "none" }}>
-      {items.map((item) => (
-        <li key={item} className="flex items-start text-label" style={{ gap: "var(--sp-2)", color: "var(--fg-3)" }}>
-          <span
-            aria-hidden="true"
-            className="inline-flex items-center justify-center"
-            style={{
-              width: "var(--sp-4)",
-              height: "var(--sp-4)",
-              flexShrink: 0,
-              marginTop: "var(--sp-0_5)",
-              borderRadius: 999,
-              background: "color-mix(in oklch, var(--accent) 14%, transparent)",
-              color: "var(--accent)",
-            }}
-          >
-            <Check className="h-3 w-3" />
-          </span>
-          <span>{item}</span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
 /**
  * Step heading (title + optional one-line "why"). Used when a step renders its
  * own heading per sub-state instead of the shell's static one — the shell
@@ -154,20 +126,23 @@ export function StatusRow({ state, label }: { state: "waiting" | "ok"; label: Re
 }
 
 /**
- * The terminal one-liner the user pastes to connect a computer. Renders the
- * install + login lines filling the box width (ellipsizing only the overflow)
- * and copies the full multi-line command (npm install + login). Lifted from the
- * legacy Step2Body CommandBox.
+ * The terminal one-liner(s) the user pastes to connect a computer. Renders
+ * whatever lines the server's bootstrap command contains — typically two
+ * (`npm install -g …` then `first-tree login <token>`), but dev channels
+ * return only the login line, and a future channel might add more. Each
+ * line nowraps and ellipsizes on overflow so a long opaque token shows as
+ * much as fits without word-breaking; Copy puts the full multi-line command
+ * on the clipboard regardless of what's visible.
+ *
+ * The previous implementation pattern-matched lines by prefix
+ * (`startsWith("npm")` / `startsWith("first-tree")`), which was fragile —
+ * adding a new prefix (yarn / pnpm / `cd …`) would silently drop content
+ * from the visible box while Copy still worked. The current pass-through
+ * trusts the server: render the lines it gave us, in order.
  */
 export function CommandBox({ command }: { command: string | null }) {
   const [copied, setCopied] = useState(false);
   const lines = command ? command.split("\n").filter((l) => l.trim().length > 0) : [];
-  // Show both lines — install and login — each on its own row, filling the box
-  // width and ellipsizing only what overflows. So the long opaque token shows
-  // as much as fits (not a stingy fixed slice) and grows with the box width.
-  // Copy still puts the complete multi-line command on the clipboard.
-  const installLine = lines.find((l) => l.startsWith("npm")) ?? "";
-  const loginLine = lines.find((l) => l.startsWith("first-tree")) ?? "";
 
   const handleCopy = async (): Promise<void> => {
     if (!command) return;
@@ -199,16 +174,17 @@ export function CommandBox({ command }: { command: string | null }) {
         }}
       >
         {command ? (
-          <>
-            {installLine && (
-              <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{installLine}</span>
-            )}
-            {loginLine && (
-              <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{loginLine}</span>
-            )}
-          </>
+          lines.map((line, i) => (
+            <span
+              // biome-ignore lint/suspicious/noArrayIndexKey: lines are positional and stable per render
+              key={i}
+              style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+            >
+              {line}
+            </span>
+          ))
         ) : (
-          "Generating command…"
+          <span>Generating command…</span>
         )}
       </div>
       <button

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "../../auth/auth-context.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
 import { useToast } from "../../components/ui/toast.js";
 import { COPY, STEP_COPY } from "./copy.js";
-import { OutcomeList } from "./flow-ui.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 
 /**
@@ -13,8 +12,11 @@ import { useOnboardingFlow } from "./onboarding-flow.js";
  * (full labels, so the whole journey is visible up front) beside a focused
  * content column. No card/border/shadow; structure comes from the rail + a
  * top-anchored content column (centered horizontally, fixed vertical offset so
- * the rail never jumps between steps). "What you'll have" is a quiet footer.
- * On narrow screens the rail collapses to a "Step N of M" line.
+ * the rail never jumps between steps). On narrow screens the rail collapses
+ * to a "Step N of M" line.
+ *
+ * Outcomes (the old "What you'll have" footer) were folded into each step's
+ * `why` copy — one place for the user to read, less repetition, less density.
  */
 export function OnboardingShell({ rail, children }: { rail: ReactNode; children: ReactNode }) {
   const { activeStep, activeIndex, sequence, finishLater, hasAgent } = useOnboardingFlow();
@@ -126,14 +128,6 @@ export function OnboardingShell({ rail, children }: { rail: ReactNode; children:
                 </p>
               ) : null}
               {children}
-
-              {/* "What you'll have" — quiet footer, set off by whitespace. */}
-              <div style={{ marginTop: "var(--sp-7)" }}>
-                <p className="text-label" style={{ margin: "0 0 var(--sp-2_5)", color: "var(--fg-4)" }}>
-                  What you'll have
-                </p>
-                <OutcomeList items={copy.outcomes} />
-              </div>
             </div>
           </main>
         </div>

--- a/packages/web/src/pages/onboarding/progress-rail.tsx
+++ b/packages/web/src/pages/onboarding/progress-rail.tsx
@@ -1,5 +1,5 @@
 import { Bot, Check, GitBranch, type LucideIcon, MonitorSmartphone, Rocket, Sparkles, Users } from "lucide-react";
-import { STEP_COPY } from "./copy.js";
+import { resolveStepLabel } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 import { type StepId, stepVisualState } from "./steps.js";
 
@@ -21,13 +21,13 @@ const STEP_ICON: Record<StepId, LucideIcon> = {
  * journey is previewable up front.
  */
 export function ProgressRail() {
-  const { sequence, activeIndex, goTo } = useOnboardingFlow();
+  const { sequence, activeIndex, goTo, path } = useOnboardingFlow();
 
   return (
     <ol className="flex flex-col" style={{ gap: 0, margin: 0, padding: 0, listStyle: "none" }}>
       {sequence.map((id, index) => {
         const state = stepVisualState(index, activeIndex);
-        const copy = STEP_COPY[id];
+        const label = resolveStepLabel(id, path);
         const isLast = index === sequence.length - 1;
         const clickable = state === "complete";
         const Icon = STEP_ICON[id];
@@ -97,7 +97,7 @@ export function ProgressRail() {
                     textAlign: "left",
                   }}
                 >
-                  {copy.label}
+                  {label}
                 </button>
               ) : (
                 <span
@@ -108,7 +108,7 @@ export function ProgressRail() {
                     fontWeight: state === "active" ? 600 : 400,
                   }}
                 >
-                  {copy.label}
+                  {label}
                 </span>
               )}
             </div>

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -162,14 +162,27 @@ export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
 /**
  * Which invitee kickoff sub-state to show, given what the team has set up.
  * Pure so it's unit-testable (the React component just maps the result to a
- * body):
- *   - no Context Tree link yet              → "waiting" (admin isn't done)
- *   - link + the team listed its projects   → "confirm" (pick from them)
- *   - link but no team projects listed      → "picker"  (invitee picks own)
+ * body). Ordered upstream-first — fix the biggest blocker before the next:
+ *   - no Context Tree link yet              → "waiting"          (admin isn't done at all)
+ *   - link but no GitHub App installation   → "no-installation"  (admin skipped code; agent would 403)
+ *   - link + install + team listed projects → "confirm"          (pick from them)
+ *   - link + install but no team projects   → "picker"           (invitee picks own)
+ *
+ * The "no-installation" state was added because the previous flow silently
+ * advanced invitees into the picker, where they'd successfully select repos
+ * and only discover the missing install when the agent's first git op
+ * failed with 403. We hard-stop here instead, with a "remind admin"
+ * affordance and a "start chatting anyway" bailout so the invitee is never
+ * truly blocked.
  */
-export type InviteeKickoffState = "waiting" | "confirm" | "picker";
+export type InviteeKickoffState = "waiting" | "no-installation" | "confirm" | "picker";
 
-export function resolveInviteeKickoffState(args: { treeUrl: string; teamRepoCount: number }): InviteeKickoffState {
+export function resolveInviteeKickoffState(args: {
+  treeUrl: string;
+  hasInstallation: boolean;
+  teamRepoCount: number;
+}): InviteeKickoffState {
   if (!args.treeUrl) return "waiting";
+  if (!args.hasInstallation) return "no-installation";
   return args.teamRepoCount > 0 ? "confirm" : "picker";
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Github } from "lucide-react";
-import { useState } from "react";
+import { ArrowRight, Check, Copy, Github } from "lucide-react";
+import { useEffect, useState } from "react";
 import { ApiError } from "../../../api/client.js";
 import { listGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../../../api/github-app.js";
@@ -11,20 +11,34 @@ import { InstallGuide, ShowMeHow } from "../guides.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 
 /**
+ * Session marker — set when the user clicks "Install First Tree on GitHub"
+ * so we can detect "came back without an install" on the next render.
+ * Cleared once an install is observed or the user skips. Per-tab so we
+ * never confuse a different login attempt's state.
+ */
+const INSTALL_ATTEMPT_KEY = "onboarding:connect-code:install-attempt";
+
+/**
  * Admin step: install the GitHub App (the only reliable code-connection
  * entry — `installations/new`, not the sign-in `authorize` URL), then pick
  * the project the agent should help with.
  *
  * Resilient by design — the team's first run can hit any of: App not
  * installed, App not configured on this server, caller isn't an admin,
- * GitHub access lacks project scope, or no repos. Each gets a plain message
- * and a way forward (never a dead end): the user can always continue and
- * connect code later from Settings.
+ * GitHub access lacks project scope, no repos, or — the trickiest — the
+ * admin isn't a GitHub org owner and gets bounced back from the install
+ * dialog without anything installed. Each case gets a plain message and
+ * a way forward (never a dead end).
  */
 export function StepConnectCode() {
   const { organizationId, goNext, selectedRepoUrls, setSelectedRepoUrls } = useOnboardingFlow();
   const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
   const [redirecting, setRedirecting] = useState(false);
+  const [showSkipConfirm, setShowSkipConfirm] = useState(false);
+  const [shareLinkUrl, setShareLinkUrl] = useState<string | null>(null);
+  const [shareCopied, setShareCopied] = useState(false);
+  const [shareError, setShareError] = useState<string | null>(null);
+  const [postAttemptStuck, setPostAttemptStuck] = useState(false);
 
   const installQuery = useQuery({
     queryKey: ["onboarding", "installation", organizationId],
@@ -36,6 +50,25 @@ export function StepConnectCode() {
   });
 
   const installed = !!installQuery.data;
+
+  // Detect "user clicked Install, went to GitHub, came back without an
+  // install row". If we observe the attempt marker but still no installation
+  // a few seconds after the query has settled, surface a soft hint with
+  // recovery options. (Polling continues, so a slow webhook still wins.)
+  useEffect(() => {
+    if (installed) {
+      window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+      setPostAttemptStuck(false);
+      return;
+    }
+    if (typeof window === "undefined") return;
+    const attempted = window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY);
+    if (!attempted) return;
+    if (installQuery.isLoading) return;
+    // Give the post-redirect webhook a moment before crying foul.
+    const t = window.setTimeout(() => setPostAttemptStuck(true), 5000);
+    return () => window.clearTimeout(t);
+  }, [installed, installQuery.isLoading]);
 
   const reposQuery = useQuery({
     queryKey: ["onboarding", "github-repos"],
@@ -51,6 +84,7 @@ export function StepConnectCode() {
     setRedirecting(true);
     try {
       const url = await getGithubAppInstallUrl(organizationId, "/onboarding");
+      window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
       window.location.assign(url);
     } catch (err) {
       setRedirecting(false);
@@ -58,6 +92,32 @@ export function StepConnectCode() {
       else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
       else setInstallError("generic");
     }
+  };
+
+  const handleRevealShareLink = async (): Promise<void> => {
+    if (!organizationId || shareLinkUrl) return;
+    setShareError(null);
+    try {
+      const url = await getGithubAppInstallUrl(organizationId, "/onboarding");
+      setShareLinkUrl(url);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 503) setShareError(COPY.connectCode.notConfigured);
+      else if (err instanceof ApiError && err.status === 403) setShareError(COPY.connectCode.notAdmin);
+      else setShareError(COPY.errors.generic);
+    }
+  };
+
+  const handleCopyShareLink = async (): Promise<void> => {
+    if (!shareLinkUrl) return;
+    await navigator.clipboard.writeText(shareLinkUrl);
+    setShareCopied(true);
+    window.setTimeout(() => setShareCopied(false), 1500);
+  };
+
+  const handleSkipClick = (): void => setShowSkipConfirm(true);
+  const handleSkipConfirmed = (): void => {
+    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    goNext();
   };
 
   const toggleRepo = (cloneUrl: string): void => {
@@ -72,12 +132,10 @@ export function StepConnectCode() {
   if (!installed) {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
-          {COPY.connectCode.intro}
-        </p>
-        <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-          {COPY.reviewReassurance}
-        </p>
+        {/* Intro is now embedded into the step `why` via STEP_COPY — no
+            separate reassurance paragraph (folded into why) and no
+            "alreadyInstalledHint" (the share-link affordance below covers
+            the same recovery path more clearly). */}
 
         {installError === "not_configured" ? (
           <>
@@ -91,28 +149,99 @@ export function StepConnectCode() {
           </>
         ) : (
           <>
-            <div className="flex">
+            {/* Decision row: primary CTA + Skip as a quiet sibling. Both
+                actions visible side-by-side so the user sees their full set
+                of options at a glance instead of hunting for Skip in a
+                footer. */}
+            <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
               <Button type="button" onClick={() => void handleConnect()} disabled={redirecting || !organizationId}>
                 <Github className="h-4 w-4" />
                 {COPY.connectCode.cta}
               </Button>
+              {!showSkipConfirm && (
+                <button
+                  type="button"
+                  onClick={handleSkipClick}
+                  className="text-label"
+                  style={{
+                    background: "transparent",
+                    border: 0,
+                    padding: 0,
+                    cursor: "pointer",
+                    color: "var(--fg-4)",
+                  }}
+                >
+                  {COPY.skipForNow}
+                </button>
+              )}
             </div>
+
+            {showSkipConfirm && (
+              <FlowNote tone="info">
+                <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+                  <p className="font-medium" style={{ margin: 0, color: "var(--fg)" }}>
+                    {COPY.connectCode.skipWarningTitle}
+                  </p>
+                  <ul style={{ margin: 0, paddingLeft: "var(--sp-4)" }}>
+                    {COPY.connectCode.skipWarningBullets.map((bullet) => (
+                      <li key={bullet} style={{ color: "var(--fg-3)" }}>
+                        {bullet}
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="flex items-center" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-1)" }}>
+                    <Button type="button" variant="outline" onClick={handleSkipConfirmed}>
+                      {COPY.connectCode.skipAnyway}
+                    </Button>
+                    <button
+                      type="button"
+                      onClick={() => setShowSkipConfirm(false)}
+                      className="text-label"
+                      style={{
+                        background: "transparent",
+                        border: 0,
+                        padding: 0,
+                        cursor: "pointer",
+                        color: "var(--fg-4)",
+                      }}
+                    >
+                      {COPY.cancel}
+                    </button>
+                  </div>
+                </div>
+              </FlowNote>
+            )}
+
             {installError === "generic" && <FlowNote>{COPY.errors.generic}</FlowNote>}
             <StatusRow state="waiting" label={COPY.connectCode.waiting} />
-            <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-              {COPY.connectCode.alreadyInstalledHint}
-            </p>
+
+            {postAttemptStuck && (
+              <FlowNote tone="info">
+                <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+                  <p className="font-medium" style={{ margin: 0, color: "var(--fg)" }}>
+                    {COPY.connectCode.postAttemptStuckTitle}
+                  </p>
+                  <p style={{ margin: 0, color: "var(--fg-3)" }}>{COPY.connectCode.postAttemptStuckBody}</p>
+                </div>
+              </FlowNote>
+            )}
+
+            {/* Non-owner share-link affordance, surfaced as a quiet sibling
+                of the primary CTA so the user can find it without first
+                failing on Install. Kept inline (not a separate dialog) so
+                copy-paste-to-Slack stays one decision deep. */}
+            <ShareWithAdmin
+              expanded={!!shareLinkUrl}
+              url={shareLinkUrl}
+              copied={shareCopied}
+              error={shareError}
+              onReveal={() => void handleRevealShareLink()}
+              onCopy={() => void handleCopyShareLink()}
+            />
+
             <ShowMeHow>
               <InstallGuide />
             </ShowMeHow>
-            <button
-              type="button"
-              onClick={goNext}
-              className="text-label self-start"
-              style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
-            >
-              {COPY.connectCode.continueWithout}
-            </button>
           </>
         )}
       </div>
@@ -174,6 +303,105 @@ function ContinueWithout({ onClick }: { onClick: () => void }) {
         <span>{COPY.connectCode.continueWithout}</span>
         <ArrowRight className="h-4 w-4" />
       </Button>
+    </div>
+  );
+}
+
+/**
+ * Quiet "I'm not the GitHub org owner" affordance. Collapsed by default
+ * (one line + chevron); expanded reveals the install URL + a Copy button.
+ * The link is generated lazily on expand to avoid burning a state JWT for
+ * users who never use it.
+ */
+function ShareWithAdmin({
+  expanded,
+  url,
+  copied,
+  error,
+  onReveal,
+  onCopy,
+}: {
+  expanded: boolean;
+  url: string | null;
+  copied: boolean;
+  error: string | null;
+  onReveal: () => void;
+  onCopy: () => void;
+}) {
+  if (!expanded) {
+    return (
+      <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+        <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+          {COPY.connectCode.notOwnerToggle}
+        </p>
+        <button
+          type="button"
+          onClick={onReveal}
+          className="text-label self-start"
+          style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--accent)" }}
+        >
+          → Get a link for your GitHub admin
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+      <p className="text-label" style={{ margin: 0, color: "var(--fg-2)" }}>
+        {COPY.connectCode.notOwnerIntro}
+      </p>
+      {error ? (
+        <FlowNote>{error}</FlowNote>
+      ) : (
+        <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+          <div
+            className="text-label"
+            title={url ?? undefined}
+            style={{
+              flex: 1,
+              minHeight: 38,
+              padding: "var(--sp-2_5) var(--sp-3)",
+              background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
+              border: "var(--hairline) solid color-mix(in oklch, var(--border-faint) 58%, transparent)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg-2)",
+              minWidth: 0,
+              display: "flex",
+              alignItems: "center",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {url ?? "Generating link…"}
+          </div>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={!url}
+            className="inline-flex items-center justify-center text-label font-medium"
+            style={{
+              gap: "var(--sp-1_5)",
+              padding: "0 var(--sp-3)",
+              minHeight: 38,
+              background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
+              border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg-2)",
+              cursor: url ? "pointer" : "not-allowed",
+              opacity: url ? 1 : 0.6,
+            }}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      )}
+      {!error && (
+        <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+          {COPY.connectCode.notOwnerAfter}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check, Copy, Github } from "lucide-react";
+import { ArrowRight, Github } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ApiError } from "../../../api/client.js";
 import { listGithubRepos } from "../../../api/github.js";
@@ -35,9 +35,6 @@ export function StepConnectCode() {
   const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
   const [redirecting, setRedirecting] = useState(false);
   const [showSkipConfirm, setShowSkipConfirm] = useState(false);
-  const [shareLinkUrl, setShareLinkUrl] = useState<string | null>(null);
-  const [shareCopied, setShareCopied] = useState(false);
-  const [shareError, setShareError] = useState<string | null>(null);
   const [postAttemptStuck, setPostAttemptStuck] = useState(false);
 
   const installQuery = useQuery({
@@ -92,26 +89,6 @@ export function StepConnectCode() {
       else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
       else setInstallError("generic");
     }
-  };
-
-  const handleRevealShareLink = async (): Promise<void> => {
-    if (!organizationId || shareLinkUrl) return;
-    setShareError(null);
-    try {
-      const url = await getGithubAppInstallUrl(organizationId, "/onboarding");
-      setShareLinkUrl(url);
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 503) setShareError(COPY.connectCode.notConfigured);
-      else if (err instanceof ApiError && err.status === 403) setShareError(COPY.connectCode.notAdmin);
-      else setShareError(COPY.errors.generic);
-    }
-  };
-
-  const handleCopyShareLink = async (): Promise<void> => {
-    if (!shareLinkUrl) return;
-    await navigator.clipboard.writeText(shareLinkUrl);
-    setShareCopied(true);
-    window.setTimeout(() => setShareCopied(false), 1500);
   };
 
   const handleSkipClick = (): void => setShowSkipConfirm(true);
@@ -226,18 +203,20 @@ export function StepConnectCode() {
               </FlowNote>
             )}
 
-            {/* Non-owner share-link affordance, surfaced as a quiet sibling
-                of the primary CTA so the user can find it without first
-                failing on Install. Kept inline (not a separate dialog) so
-                copy-paste-to-Slack stays one decision deep. */}
-            <ShareWithAdmin
-              expanded={!!shareLinkUrl}
-              url={shareLinkUrl}
-              copied={shareCopied}
-              error={shareError}
-              onReveal={() => void handleRevealShareLink()}
-              onCopy={() => void handleCopyShareLink()}
-            />
+            {/* Non-owner hint. We can't hand the user a shareable install
+                URL because the OAuth state JWT is paired with a per-browser
+                `oauth_state_nonce` cookie — a copied URL opened in the org
+                owner's browser would fail the callback's state-nonce check.
+                Instead, lean on GitHub's own "request approval" flow: if a
+                non-owner clicks the Install button, GitHub itself routes
+                the request to org owners for approval, and once approved
+                the bounce-back lands in the original (cookie-bearing)
+                browser. So: just tell them to click Install anyway.
+                Server-side shareable links (signed token instead of cookie
+                nonce) is a follow-up. */}
+            <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+              {COPY.connectCode.notOwnerHint}
+            </p>
 
             <ShowMeHow>
               <InstallGuide />
@@ -303,105 +282,6 @@ function ContinueWithout({ onClick }: { onClick: () => void }) {
         <span>{COPY.connectCode.continueWithout}</span>
         <ArrowRight className="h-4 w-4" />
       </Button>
-    </div>
-  );
-}
-
-/**
- * Quiet "I'm not the GitHub org owner" affordance. Collapsed by default
- * (one line + chevron); expanded reveals the install URL + a Copy button.
- * The link is generated lazily on expand to avoid burning a state JWT for
- * users who never use it.
- */
-function ShareWithAdmin({
-  expanded,
-  url,
-  copied,
-  error,
-  onReveal,
-  onCopy,
-}: {
-  expanded: boolean;
-  url: string | null;
-  copied: boolean;
-  error: string | null;
-  onReveal: () => void;
-  onCopy: () => void;
-}) {
-  if (!expanded) {
-    return (
-      <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-        <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
-          {COPY.connectCode.notOwnerToggle}
-        </p>
-        <button
-          type="button"
-          onClick={onReveal}
-          className="text-label self-start"
-          style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--accent)" }}
-        >
-          → Get a link for your GitHub admin
-        </button>
-      </div>
-    );
-  }
-  return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-      <p className="text-label" style={{ margin: 0, color: "var(--fg-2)" }}>
-        {COPY.connectCode.notOwnerIntro}
-      </p>
-      {error ? (
-        <FlowNote>{error}</FlowNote>
-      ) : (
-        <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
-          <div
-            className="text-label"
-            title={url ?? undefined}
-            style={{
-              flex: 1,
-              minHeight: 38,
-              padding: "var(--sp-2_5) var(--sp-3)",
-              background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
-              border: "var(--hairline) solid color-mix(in oklch, var(--border-faint) 58%, transparent)",
-              borderRadius: "var(--radius-input)",
-              color: "var(--fg-2)",
-              minWidth: 0,
-              display: "flex",
-              alignItems: "center",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {url ?? "Generating link…"}
-          </div>
-          <button
-            type="button"
-            onClick={onCopy}
-            disabled={!url}
-            className="inline-flex items-center justify-center text-label font-medium"
-            style={{
-              gap: "var(--sp-1_5)",
-              padding: "0 var(--sp-3)",
-              minHeight: 38,
-              background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
-              border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
-              borderRadius: "var(--radius-input)",
-              color: "var(--fg-2)",
-              cursor: url ? "pointer" : "not-allowed",
-              opacity: url ? 1 : 0.6,
-            }}
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-            {copied ? "Copied" : "Copy"}
-          </button>
-        </div>
-      )}
-      {!error && (
-        <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-          {COPY.connectCode.notOwnerAfter}
-        </p>
-      )}
     </div>
   );
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
@@ -36,9 +36,9 @@ export function StepConnectComputer() {
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
       {!connectedClient ? (
         <>
-          <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
-            {COPY.connectComputer.instruction}
-          </p>
+          {/* No instruction line — the step title + why already cover what to
+              do; the OS-specific "open Terminal / PowerShell" guidance lives
+              under <ShowMeHow> below for users who need it. */}
           <CommandBox command={cliCommand} />
           {tokenError ? (
             <FlowNote>{tokenError}</FlowNote>

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -299,31 +299,45 @@ function InviteeKickoff() {
   const teamQuery = useQuery({
     queryKey: ["onboarding", "team-config", organizationId],
     queryFn: async () => {
-      const [tree, repos, exists] = await Promise.all([
+      const [tree, repos, installResult] = await Promise.all([
         getContextTreeSetting(organizationId ?? ""),
         getSourceReposSetting(organizationId ?? ""),
-        getGithubAppInstallationExists(organizationId ?? "").catch((err) => {
-          // Conservative on unknown error: stay on the happy path. The
-          // 5-second poll below re-checks, and if the install truly is
-          // missing the next tick will catch it.
+        // Three-state result: true = installed, false = server confirmed
+        // missing, null = probe failed (network blip, 5xx). The null
+        // sentinel is distinct from `false` so refetchInterval below can
+        // tell "we don't know yet" from "we know it's missing".
+        getGithubAppInstallationExists(organizationId ?? "").catch<null>((err) => {
           console.warn("onboarding: installation-exists probe failed", err);
-          return true;
+          return null;
         }),
       ]);
       return {
         treeUrl: tree.repo ?? "",
         teamRepoUrls: (repos.repos ?? []).map((r) => r.url),
-        hasInstallation: exists,
+        // Optimistic on uncertainty: don't bounce the user into
+        // no-installation on a transient blip. The refetchInterval below
+        // keeps polling until we have an authoritative answer; if that
+        // answer is `false` the UI will flip into no-installation on the
+        // next tick. Codex round-2 review caught the original bug where
+        // catch→true plus "stop polling when hasInstallation truthy"
+        // wedged the query in a success state forever on the first error.
+        hasInstallation: installResult !== false,
+        installationKnown: installResult !== null,
       };
     },
     enabled: !!organizationId,
-    // While anything's still missing on the team side, keep polling so the
-    // invitee advances on its own the moment the admin catches up — no
-    // manual refresh. Stop once tree + installation are both present.
+    // Keep polling while anything's still unknown OR the admin hasn't
+    // finished. Stop only once we have a tree URL AND an authoritative
+    // (non-null) install probe result. Without the `installationKnown`
+    // gate, a transient error on first probe would set hasInstallation=true
+    // and then stop polling — wedging the user out of the no-installation
+    // safeguard for the rest of the session.
     refetchInterval: (query) => {
       const d = query.state.data;
-      if (d?.treeUrl && d?.hasInstallation) return false;
-      return 5000;
+      if (!d) return 5000;
+      if (!d.treeUrl) return 5000;
+      if (!d.installationKnown) return 5000;
+      return false;
     },
   });
 
@@ -536,13 +550,16 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
           </p>
         ) : scopeMissing ? (
           <FlowNote tone="info">
-            <a
-              href="/api/v1/auth/github/start?next=/onboarding"
-              className="font-medium"
-              style={{ color: "var(--accent)" }}
-            >
-              {COPY.connectCode.reconnect}
-            </a>
+            <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+              <span>{COPY.kickoff.inviteePickerScopeMissing}</span>
+              <a
+                href="/api/v1/auth/github/start?next=/onboarding"
+                className="font-medium self-start"
+                style={{ color: "var(--accent)" }}
+              >
+                {COPY.connectCode.reconnect}
+              </a>
+            </div>
           </FlowNote>
         ) : networkErr ? (
           <FlowNote>{COPY.kickoff.inviteePickerNetworkError}</FlowNote>

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -5,7 +5,7 @@ import { getAgentConfig, updateAgentConfig } from "../../../api/agent-config.js"
 import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
 import { ApiError } from "../../../api/client.js";
 import { listGithubRepos } from "../../../api/github.js";
-import { getGithubAppInstallation } from "../../../api/github-app.js";
+import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import {
   getContextTreeSetting,
@@ -281,40 +281,39 @@ function AdminKickoff() {
 
 function InviteeKickoff() {
   const { organizationId } = useOnboardingFlow();
-  // Fetch tree config, source repos, and installation status together. The
-  // installation status drives the new "no-installation" sub-state — without
-  // it we'd advance the invitee into the picker and let the agent's first
-  // git op fail with 403, an opaque failure mode.
+  // Fetch tree config, source repos, and installation existence together.
+  // The installation bit drives the new "no-installation" sub-state, which
+  // catches "admin set up the tree but never connected GitHub" before the
+  // invitee sails into the picker and hits a 403 on the first git op.
   //
-  // Subtle: the installation endpoint is admin-only (requireOrgAdmin) so a
-  // non-admin invitee gets 403. We MUST NOT treat that as "not installed" —
-  // doing so would block every invitee of a correctly-configured team out of
-  // confirm/picker. Codex review caught this on round 1. The rule is:
-  //   - 200 with payload → definitely installed
-  //   - 404 (api client maps to null) → definitely not installed
-  //   - 403 / other errors → unknown, assume installed (conservative).
+  // We use the dedicated /github-app-installation/exists endpoint here
+  // (returns `{ exists: boolean }`, member-readable) rather than the full
+  // installation GET — that one is admin-gated (requireOrgAdmin), so as a
+  // non-admin invitee it would 403. Round 1 of codex review caught that
+  // mapping 403→"missing" blocks every invitee of a healthy team; round 2
+  // caught that mapping 403→"installed" makes the new safeguard
+  // unreachable. The /exists endpoint side-steps both by exposing just the
+  // presence bit to members. Any unexpected error here falls through to
+  // `hasInstallation: true` so a transient blip never bounces the user
+  // into the wrong sub-state.
   const teamQuery = useQuery({
     queryKey: ["onboarding", "team-config", organizationId],
     queryFn: async () => {
-      const [tree, repos, installState] = await Promise.all([
+      const [tree, repos, exists] = await Promise.all([
         getContextTreeSetting(organizationId ?? ""),
         getSourceReposSetting(organizationId ?? ""),
-        getGithubAppInstallation(organizationId ?? "")
-          .then<"installed" | "missing">((r) => (r === null ? "missing" : "installed"))
-          .catch<"installed">((err) => {
-            // 403 = admin-only endpoint. Invitee can't tell, so we don't
-            // block. Any other error → also "unknown" so a transient blip
-            // doesn't bounce the user into the no-installation state.
-            if (err instanceof ApiError && err.status === 403) return "installed";
-            return "installed";
-          }),
+        getGithubAppInstallationExists(organizationId ?? "").catch((err) => {
+          // Conservative on unknown error: stay on the happy path. The
+          // 5-second poll below re-checks, and if the install truly is
+          // missing the next tick will catch it.
+          console.warn("onboarding: installation-exists probe failed", err);
+          return true;
+        }),
       ]);
       return {
         treeUrl: tree.repo ?? "",
         teamRepoUrls: (repos.repos ?? []).map((r) => r.url),
-        // Only an authoritative 404 ("missing") marks the team as
-        // installation-less. Unknown reads stay on the happy path.
-        hasInstallation: installState !== "missing",
+        hasInstallation: exists,
       };
     },
     enabled: !!organizationId,

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -285,24 +285,36 @@ function InviteeKickoff() {
   // installation status drives the new "no-installation" sub-state — without
   // it we'd advance the invitee into the picker and let the agent's first
   // git op fail with 403, an opaque failure mode.
+  //
+  // Subtle: the installation endpoint is admin-only (requireOrgAdmin) so a
+  // non-admin invitee gets 403. We MUST NOT treat that as "not installed" —
+  // doing so would block every invitee of a correctly-configured team out of
+  // confirm/picker. Codex review caught this on round 1. The rule is:
+  //   - 200 with payload → definitely installed
+  //   - 404 (api client maps to null) → definitely not installed
+  //   - 403 / other errors → unknown, assume installed (conservative).
   const teamQuery = useQuery({
     queryKey: ["onboarding", "team-config", organizationId],
     queryFn: async () => {
-      const [tree, repos, installation] = await Promise.all([
+      const [tree, repos, installState] = await Promise.all([
         getContextTreeSetting(organizationId ?? ""),
         getSourceReposSetting(organizationId ?? ""),
-        // Installation is the new defense — if invitee can't read it (e.g.
-        // server policy locks it to admins), we conservatively assume
-        // installed=true to avoid a false-positive block.
-        getGithubAppInstallation(organizationId ?? "").catch((err) => {
-          if (err instanceof ApiError && (err.status === 403 || err.status === 404)) return null;
-          throw err;
-        }),
+        getGithubAppInstallation(organizationId ?? "")
+          .then<"installed" | "missing">((r) => (r === null ? "missing" : "installed"))
+          .catch<"installed">((err) => {
+            // 403 = admin-only endpoint. Invitee can't tell, so we don't
+            // block. Any other error → also "unknown" so a transient blip
+            // doesn't bounce the user into the no-installation state.
+            if (err instanceof ApiError && err.status === 403) return "installed";
+            return "installed";
+          }),
       ]);
       return {
         treeUrl: tree.repo ?? "",
         teamRepoUrls: (repos.repos ?? []).map((r) => r.url),
-        hasInstallation: installation !== null,
+        // Only an authoritative 404 ("missing") marks the team as
+        // installation-less. Unknown reads stay on the happy path.
+        hasInstallation: installState !== "missing",
       };
     },
     enabled: !!organizationId,
@@ -593,6 +605,13 @@ function InviteeWaiting() {
  * so the org has no installation row. Without one, the agent's first git
  * operation will 403 with no useful signal. We surface that here and offer
  * a "remind your admin" copy-link + a bailout to keep the user moving.
+ *
+ * Why this link IS safe to share (unlike connect-code's install URL): we
+ * copy `window.location.href`, the onboarding page URL itself, with no
+ * cookie-bound state JWT. Whoever opens it just lands on first-tree as
+ * themselves; if they're the admin, they see their own onboarding /
+ * Settings → GitHub and can finish the install. It's a reminder URL, not
+ * an authorization handoff.
  */
 function InviteeNoInstallation() {
   const { finishLater } = useOnboardingFlow();

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check } from "lucide-react";
+import { ArrowRight, Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getAgentConfig, updateAgentConfig } from "../../../api/agent-config.js";
 import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
+import { ApiError } from "../../../api/client.js";
 import { listGithubRepos } from "../../../api/github.js";
+import { getGithubAppInstallation } from "../../../api/github-app.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import {
   getContextTreeSetting,
@@ -14,7 +16,7 @@ import {
 import { Button } from "../../../components/ui/button.js";
 import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
-import { FlowNote, RepoPicker, StepHeading, WorkingState } from "../flow-ui.js";
+import { FlowNote, RepoPicker, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
 import { resolveInviteeKickoffState } from "../steps.js";
@@ -279,19 +281,39 @@ function AdminKickoff() {
 
 function InviteeKickoff() {
   const { organizationId } = useOnboardingFlow();
+  // Fetch tree config, source repos, and installation status together. The
+  // installation status drives the new "no-installation" sub-state — without
+  // it we'd advance the invitee into the picker and let the agent's first
+  // git op fail with 403, an opaque failure mode.
   const teamQuery = useQuery({
     queryKey: ["onboarding", "team-config", organizationId],
     queryFn: async () => {
-      const [tree, repos] = await Promise.all([
+      const [tree, repos, installation] = await Promise.all([
         getContextTreeSetting(organizationId ?? ""),
         getSourceReposSetting(organizationId ?? ""),
+        // Installation is the new defense — if invitee can't read it (e.g.
+        // server policy locks it to admins), we conservatively assume
+        // installed=true to avoid a false-positive block.
+        getGithubAppInstallation(organizationId ?? "").catch((err) => {
+          if (err instanceof ApiError && (err.status === 403 || err.status === 404)) return null;
+          throw err;
+        }),
       ]);
-      return { treeUrl: tree.repo ?? "", teamRepoUrls: (repos.repos ?? []).map((r) => r.url) };
+      return {
+        treeUrl: tree.repo ?? "",
+        teamRepoUrls: (repos.repos ?? []).map((r) => r.url),
+        hasInstallation: installation !== null,
+      };
     },
     enabled: !!organizationId,
-    // While the team has no Context Tree link yet, keep polling so the invitee
-    // advances on its own the moment the admin finishes — no manual refresh.
-    refetchInterval: (query) => (query.state.data?.treeUrl ? false : 5000),
+    // While anything's still missing on the team side, keep polling so the
+    // invitee advances on its own the moment the admin catches up — no
+    // manual refresh. Stop once tree + installation are both present.
+    refetchInterval: (query) => {
+      const d = query.state.data;
+      if (d?.treeUrl && d?.hasInstallation) return false;
+      return 5000;
+    },
   });
 
   if (teamQuery.isLoading) {
@@ -302,16 +324,56 @@ function InviteeKickoff() {
     );
   }
 
-  // Read failure or no tree configured yet → waiting (auto-polls above).
-  if (teamQuery.isError || !teamQuery.data?.treeUrl) {
+  // Read failure → waiting; the query keeps polling so a transient blip
+  // resolves on its own.
+  if (teamQuery.isError || !teamQuery.data) {
     return <InviteeWaiting />;
   }
 
-  const { treeUrl, teamRepoUrls } = teamQuery.data;
-  return resolveInviteeKickoffState({ treeUrl, teamRepoCount: teamRepoUrls.length }) === "confirm" ? (
-    <InviteeConfirm treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />
-  ) : (
-    <InviteePicker treeUrl={treeUrl} />
+  const { treeUrl, teamRepoUrls, hasInstallation } = teamQuery.data;
+  const state = resolveInviteeKickoffState({
+    treeUrl,
+    hasInstallation,
+    teamRepoCount: teamRepoUrls.length,
+  });
+
+  switch (state) {
+    case "waiting":
+      return <InviteeWaiting />;
+    case "no-installation":
+      return <InviteeNoInstallation />;
+    case "confirm":
+      return <InviteeConfirm treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />;
+    case "picker":
+      return <InviteePicker treeUrl={treeUrl} />;
+  }
+}
+
+/**
+ * Read-only display of the team's Context Tree URL, shown at the top of
+ * the invitee's confirm/picker sub-states so they know where their agent's
+ * work will land. Info transparency — invitee inherits this, can't change it.
+ */
+function TreeUrlDisplay({ treeUrl }: { treeUrl: string }) {
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
+      <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+        {COPY.kickoff.treeLabel}
+      </p>
+      <p
+        className="text-label mono"
+        title={treeUrl}
+        style={{
+          margin: 0,
+          color: "var(--fg-2)",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {repoLabel(treeUrl)}
+      </p>
+    </div>
   );
 }
 
@@ -324,13 +386,16 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
   const toggle = (url: string): void =>
     setChosen((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
 
-  const handleStart = async (): Promise<void> => {
+  const handleStart = async (selectedRepos: string[]): Promise<void> => {
     setError(null);
     setPhase("starting");
     try {
+      // Empty selection ⇒ intro-only bootstrap (matches admin's no-project
+      // path), so deselecting all isn't a dead end.
+      const bootstrap = selectedRepos.length > 0 ? buildBindBootstrap(selectedRepos, treeUrl) : NO_REPO_BOOTSTRAP;
       await runKickoff({
-        bootstrap: buildBindBootstrap(chosen, treeUrl),
-        gitRepoUrls: chosen,
+        bootstrap,
+        gitRepoUrls: selectedRepos,
         orgWrites: null, // never mutate team config as an invitee
         treeMode: "existing",
         joinPath: "invite",
@@ -348,6 +413,7 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
       <StepHeading title={COPY.invitee.confirmTitle} why={COPY.invitee.confirmBody} />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <TreeUrlDisplay treeUrl={treeUrl} />
         <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
           {teamRepoUrls.map((url) => {
             const active = chosen.includes(url);
@@ -388,11 +454,22 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
           })}
         </div>
         {error && <FlowNote>{error}</FlowNote>}
-        <div className="flex">
-          <Button type="button" onClick={() => void handleStart()} disabled={chosen.length === 0}>
+        {/* Primary is never disabled by deselect-all; the bailout link
+            preserves the "continue with intro only" path so users can't
+            soft-lock themselves. */}
+        <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
+          <Button type="button" onClick={() => void handleStart(chosen)} disabled={chosen.length === 0}>
             <span>{COPY.kickoff.start}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
+          <button
+            type="button"
+            onClick={() => void handleStart([])}
+            className="text-label"
+            style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
+          >
+            {COPY.kickoff.inviteeContinueNoProject}
+          </button>
         </div>
       </div>
     </div>
@@ -409,13 +486,14 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
   const toggle = (url: string): void =>
     setSelected((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
 
-  const handleStart = async (): Promise<void> => {
+  const handleStart = async (selectedRepos: string[]): Promise<void> => {
     setError(null);
     setPhase("starting");
     try {
+      const bootstrap = selectedRepos.length > 0 ? buildBindBootstrap(selectedRepos, treeUrl) : NO_REPO_BOOTSTRAP;
       await runKickoff({
-        bootstrap: buildBindBootstrap(selected, treeUrl),
-        gitRepoUrls: selected,
+        bootstrap,
+        gitRepoUrls: selectedRepos,
         orgWrites: null,
         treeMode: "existing",
         joinPath: "invite",
@@ -429,25 +507,60 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
 
   if (phase === "starting") return <StartingState />;
 
+  // Three failure shapes are folded into one "no list" branch in the
+  // legacy code; split them so the recovery action matches the cause.
+  const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
+  const networkErr = !!reposQuery.error && !scopeMissing;
+  const empty = !reposQuery.error && (reposQuery.data?.length ?? 0) === 0;
+  const hasRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
+
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
       <StepHeading title={COPY.kickoff.inviteePickerTitle} why={COPY.kickoff.inviteePickerWhy} />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <TreeUrlDisplay treeUrl={treeUrl} />
         {reposQuery.isLoading ? (
           <p className="text-label" style={{ color: "var(--fg-4)" }}>
             Loading your projects…
           </p>
-        ) : (reposQuery.data?.length ?? 0) === 0 ? (
-          <FlowNote tone="info">{COPY.connectCode.noRepos}</FlowNote>
+        ) : scopeMissing ? (
+          <FlowNote tone="info">
+            <a
+              href="/api/v1/auth/github/start?next=/onboarding"
+              className="font-medium"
+              style={{ color: "var(--accent)" }}
+            >
+              {COPY.connectCode.reconnect}
+            </a>
+          </FlowNote>
+        ) : networkErr ? (
+          <FlowNote>{COPY.kickoff.inviteePickerNetworkError}</FlowNote>
+        ) : empty ? (
+          <FlowNote tone="info">{COPY.kickoff.inviteePickerEmpty}</FlowNote>
         ) : (
           <RepoPicker repos={reposQuery.data ?? []} selected={selected} onToggle={toggle} fill />
         )}
         {error && <FlowNote>{error}</FlowNote>}
-        <div className="flex">
-          <Button type="button" onClick={() => void handleStart()} disabled={selected.length === 0}>
+        <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
+          <Button
+            type="button"
+            onClick={() => void handleStart(selected)}
+            disabled={!hasRepos || selected.length === 0}
+          >
             <span>{COPY.kickoff.start}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
+          {/* Always visible — covers empty, scope-missing, network, AND
+              "I just don't want to pick one right now". No path is a
+              dead end. */}
+          <button
+            type="button"
+            onClick={() => void handleStart([])}
+            className="text-label"
+            style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
+          >
+            {COPY.kickoff.inviteeContinueNoProject}
+          </button>
         </div>
       </div>
     </div>
@@ -461,9 +574,101 @@ function InviteeWaiting() {
       <StepHeading title={COPY.invitee.waitingTitle} />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
         <FlowNote tone="info">{COPY.invitee.waitingBody}</FlowNote>
+        {/* Visible polling so the user trusts the page is alive — the
+            previous "no status" state had users wondering if it was
+            stuck. */}
+        <StatusRow state="waiting" label={COPY.invitee.waitingStatus} />
         <div className="flex">
           <Button type="button" variant="outline" onClick={() => void finishLater()}>
-            Start chatting anyway
+            {COPY.invitee.startAnyway}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * NEW sub-state: admin set a tree URL but never connected the GitHub App,
+ * so the org has no installation row. Without one, the agent's first git
+ * operation will 403 with no useful signal. We surface that here and offer
+ * a "remind your admin" copy-link + a bailout to keep the user moving.
+ */
+function InviteeNoInstallation() {
+  const { finishLater } = useOnboardingFlow();
+  const [pageUrl, setPageUrl] = useState<string>("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") setPageUrl(window.location.href);
+  }, []);
+
+  const handleCopy = async (): Promise<void> => {
+    if (!pageUrl) return;
+    await navigator.clipboard.writeText(pageUrl);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
+      <StepHeading title={COPY.invitee.noInstallTitle} />
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <FlowNote tone="info">{COPY.invitee.noInstallBody}</FlowNote>
+        <StatusRow state="waiting" label={COPY.invitee.noInstallStatus} />
+
+        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+          <p className="text-label" style={{ margin: 0, color: "var(--fg-2)" }}>
+            {COPY.invitee.noInstallShareIntro}
+          </p>
+          <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
+            <div
+              className="text-label"
+              title={pageUrl}
+              style={{
+                flex: 1,
+                minHeight: 38,
+                padding: "var(--sp-2_5) var(--sp-3)",
+                background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
+                border: "var(--hairline) solid color-mix(in oklch, var(--border-faint) 58%, transparent)",
+                borderRadius: "var(--radius-input)",
+                color: "var(--fg-2)",
+                minWidth: 0,
+                display: "flex",
+                alignItems: "center",
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {pageUrl || "…"}
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              disabled={!pageUrl}
+              className="inline-flex items-center justify-center text-label font-medium"
+              style={{
+                gap: "var(--sp-1_5)",
+                padding: "0 var(--sp-3)",
+                minHeight: 38,
+                background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
+                border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
+                borderRadius: "var(--radius-input)",
+                color: "var(--fg-2)",
+                cursor: pageUrl ? "pointer" : "not-allowed",
+                opacity: pageUrl ? 1 : 0.6,
+              }}
+            >
+              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex">
+          <Button type="button" variant="outline" onClick={() => void finishLater()}>
+            {COPY.invitee.startAnyway}
           </Button>
         </div>
       </div>

--- a/packages/web/src/pages/onboarding/steps/step-team.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-team.tsx
@@ -77,36 +77,34 @@ export function StepTeam() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        <label htmlFor="onboarding-team-name" className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
-          Team name
-        </label>
-        <input
-          ref={inputRef}
-          id="onboarding-team-name"
-          aria-label="Team name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          maxLength={200}
-          disabled={saving}
-          className="text-body"
-          style={{
-            padding: "var(--sp-2) var(--sp-3)",
-            background: "var(--bg)",
-            border: "var(--hairline) solid var(--border)",
-            borderRadius: "var(--radius-input)",
-            color: "var(--fg)",
-            outline: "none",
-            caretColor: "var(--accent)",
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.borderColor = "var(--accent)";
-          }}
-          onBlur={(e) => {
-            e.currentTarget.style.borderColor = "var(--border)";
-          }}
-        />
-      </div>
+      {/* No visible <label> — the step title ("Name your team") and the
+          field's `aria-label` already name the input. Repeating "Team name"
+          here was visual noise on a single-input page. */}
+      <input
+        ref={inputRef}
+        id="onboarding-team-name"
+        aria-label="Team name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        maxLength={200}
+        disabled={saving}
+        className="text-body"
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          background: "var(--bg)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg)",
+          outline: "none",
+          caretColor: "var(--accent)",
+        }}
+        onFocus={(e) => {
+          e.currentTarget.style.borderColor = "var(--accent)";
+        }}
+        onBlur={(e) => {
+          e.currentTarget.style.borderColor = "var(--border)";
+        }}
+      />
 
       {(saveError || loadError) && (
         <FlowNote>{saveError ?? `Couldn't load your team — ${loadError}. Refresh and try again.`}</FlowNote>


### PR DESCRIPTION
## Summary

Eight onboarding UX optimizations landed together because every change is internal to `packages/web/src/pages/onboarding/` and they share types. Two rounds of independent codex review applied — the round-2 finding required a small companion server endpoint, included in the final commit.

Re-opened from #619 with a branch name that satisfies the repo's `^(feat|fix|refactor|test|docs|chore|merge)/` convention.

### Before / after

**Copy + visual cleanup (items 1-5, 7):**
- Team step: redundant "Team name" `<label>` removed; title already names the input.
- Connect-computer: long "open Terminal / PowerShell" paragraph removed; `<ShowMeHow>` already covers the OS-specific guidance.
- CommandBox: trusts the server's multi-line bootstrap as-is (lines mapped instead of pattern-matched by prefix) so dev/staging/prod channels each render correctly without UI changes.
- Rail labels switched to verb+noun, possessive `your` dropped: Welcome → Connect computer → Create agent → Connect code → Start tree (admin) / Start work (invitee). Admin's first step rail label is now `Welcome` so both paths open identically.
- "What you'll have" footer removed across the board; outcomes folded into each step's `why`. `StepCopy.outcomes` field + `OutcomeList` component deleted.
- `STEP_COPY.label` is now `PathScopedString` — a flat string for shared copy, `{admin, invitee}` for divergent steps. `resolveStepLabel()` centralizes the lookup.

**Behavior changes (items 6, 8):**
- Connect-code now co-locates `Install` and `Skip for now` so admins see both choices at a glance. Clicking Skip surfaces an inline confirm with bullets that name the downstream consequence (`teammates' agents will hit errors`), so admins don't silently break invitees.
- A `sessionStorage` marker detects "came back from GitHub without an install" and surfaces a soft recovery hint.
- A non-owner hint replaces the original copy-the-install-link button: GitHub's install URL is bound to a per-browser `oauth_state_nonce` cookie, so a copied URL would fail the callback's state-nonce check (caught by codex round 1). Instead we point users at GitHub's built-in owner-approval flow, which works without any cookie handoff.
- Invitee kickoff gains a fourth sub-state, `no-installation`, that hard-stops invitees when the admin set up a tree but never connected GitHub. Confirm + picker also gain a visible tree URL, differentiated error states (403 / network / empty each with its own recovery), and a `continue without a project` link that's always available — no sub-state can deadlock.

**Server companion (round-2 fix):**
- New `GET /api/v1/orgs/:orgId/github-app-installation/exists` — member-readable, returns `{ exists: boolean }`. The full installation endpoint stays admin-only for the detail payload; this redacted probe lets invitees authoritatively detect the missing-install case without tripping `requireOrgAdmin`'s 403.

### Codex review trail

- **Round 1** found two issues. Both fixed in commit `570713af`:
  - **[P1]** Mapping 403 → null = blocked every invitee of a healthy team
  - **[P2]** Cookie-bound install URL doesn't work cross-browser → removed share-link UI
- **Round 2** found that round-1's fix made the new no-installation state unreachable for actual invitees. Resolved structurally in commit `1862e21e` by adding the member-readable `/exists` endpoint.

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` — clean
- [x] `pnpm --filter @first-tree/server typecheck` — clean
- [x] `pnpm check` (biome) — clean (16 pre-existing warnings in `packages/github-scan/tests/` are unrelated)
- [x] `pnpm --filter @first-tree/web test` — 431/431 pass
- [x] `pnpm --filter @first-tree/server test` — 1230/1230 pass
- [ ] Manual: admin flow — name team → connect computer → create agent → connect code (install / skip-warn / non-owner hint) → kickoff (new tree / existing / no-project)
- [ ] Manual: invitee flow — welcome → connect computer → create agent → kickoff (waiting / no-installation / confirm / picker)
- [ ] Manual: verify no-installation state actually triggers when admin has a tree but no GitHub App

## Follow-ups (tracked as separate tasks)

- GitHub App `repository_selection` vs `tree.repo` validation (P3 from external audit)
- Dev-tooling repairs in `~/.first-tree/dev-stack/` after the `first-tree-hub` → `first-tree` rename
- Shareable install link (signed token instead of cookie nonce) + landing thank-you page
- Runtime 403 → GitHub App install settings hint (better ROI than onboarding-time prevention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)