### PR TITLE
chore: add root lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "check": "biome check .",
+    "lint": "biome lint .",
     "format": "biome check --write .",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary
- Add a root-level `lint` script backed by Biome.
- Leave existing `check`, package versions, lockfiles, CI config, and package-level scripts unchanged.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm typecheck`

Note: `pnpm lint` and `pnpm check` both complete successfully while reporting existing warning-level `noNonNullAssertion` findings under `packages/github-scan/tests`.