### PR TITLE
fix(cli): include node bin in launchd path

### DIFF
--- a/apps/cli/src/__tests__/render-unit-channel.test.ts
+++ b/apps/cli/src/__tests__/render-unit-channel.test.ts
@@ -24,6 +24,24 @@ import { renderPlist, renderSystemdUnit } from "../core/service-install.js";
  */
 const FAKE_BIN_INVOCATION = { kind: "bin", program: "/usr/local/bin/first-tree-dev" } as const;
 
+function extractPlistPathValue(plist: string): string {
+  const match = /<key>PATH<\/key>\s*<string>([^<]+)<\/string>/.exec(plist);
+  if (!match?.[1]) {
+    throw new Error("Rendered plist does not contain a PATH environment value.");
+  }
+  return match[1];
+}
+
+function withExecPath(execPath: string, callback: () => void): void {
+  const original = process.execPath;
+  process.execPath = execPath;
+  try {
+    callback();
+  } finally {
+    process.execPath = original;
+  }
+}
+
 describe("renderSystemdUnit — channel identity baked into unit text", () => {
   const unit = renderSystemdUnit(FAKE_BIN_INVOCATION, {});
 
@@ -80,5 +98,28 @@ describe("renderPlist — channel identity baked into plist text", () => {
 
   it("embeds the CLI program path in ProgramArguments", () => {
     expect(plist).toContain("<string>/usr/local/bin/first-tree-dev</string>");
+  });
+
+  it("includes the current Node binary directory in PATH", () => {
+    const pathEntries = extractPlistPathValue(plist).split(":");
+    expect(pathEntries[0]).toBe(dirname(process.execPath));
+  });
+
+  it("keeps launchd fallback paths in PATH", () => {
+    const pathEntries = extractPlistPathValue(plist).split(":");
+    expect(pathEntries).toEqual(expect.arrayContaining(["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"]));
+  });
+
+  it("does not emit duplicate PATH entries", () => {
+    const pathEntries = extractPlistPathValue(plist).split(":");
+    expect(new Set(pathEntries).size).toBe(pathEntries.length);
+  });
+
+  it("does not duplicate launchd fallback paths that match the current Node binary directory", () => {
+    withExecPath("/usr/local/bin/node", () => {
+      const pathEntries = extractPlistPathValue(renderPlist(FAKE_BIN_INVOCATION, {})).split(":");
+      expect(pathEntries[0]).toBe("/usr/local/bin");
+      expect(pathEntries.filter((entry) => entry === "/usr/local/bin")).toHaveLength(1);
+    });
   });
 });

--- a/apps/cli/src/core/service-install.ts
+++ b/apps/cli/src/core/service-install.ts
@@ -81,6 +81,7 @@ const LAUNCHD_LABEL = channelConfig.launchdLabel;
 // reuse it for both.
 const SYSLOG_IDENT = channelConfig.launchdLabel;
 const SYSTEMD_BASE_PATH = ["/usr/local/bin", "/usr/bin", "/bin"];
+const LAUNCHD_BASE_PATH = ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"];
 
 // Function rather than const: see `channel-env.ts` history note. A
 // top-level `const = join(defaultHome(), ...)` would lock at module
@@ -90,9 +91,22 @@ function logDir(): string {
   return join(defaultHome(), "logs");
 }
 
+function servicePathEnv(basePaths: readonly string[]): string {
+  const seen = new Set<string>();
+  const paths = [dirname(process.execPath), ...basePaths].filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+  return paths.join(":");
+}
+
 function systemdPathEnv(): string {
-  const nodeBinDir = dirname(process.execPath);
-  return [nodeBinDir, ...SYSTEMD_BASE_PATH].filter((value, index, values) => values.indexOf(value) === index).join(":");
+  return servicePathEnv(SYSTEMD_BASE_PATH);
+}
+
+function launchdPathEnv(): string {
+  return servicePathEnv(LAUNCHD_BASE_PATH);
 }
 
 const PROXY_ENV_KEYS = [
@@ -237,6 +251,10 @@ export function renderPlist(invocation: ResolvedBinary, proxyEnv: Record<string,
   const proxyEnvXml = Object.entries(proxyEnv)
     .map(([k, v]) => `\n    <key>${escapeXml(k)}</key>\n    <string>${escapeXml(v)}</string>`)
     .join("");
+  // launchd does not inherit the operator's interactive shell PATH. Put the
+  // current Node directory first so npm-installed CLI shims and self-update
+  // run under the same Node toolchain that installed/refreshed the service.
+  const pathEnvXml = escapeXml(launchdPathEnv());
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
@@ -251,7 +269,7 @@ ${argsXml}
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+    <string>${pathEnvXml}</string>
     <key>FIRST_TREE_SERVICE_MODE</key>
     <string>1</string>${homeEnvXml}${proxyEnvXml}
   </dict>
@@ -448,8 +466,8 @@ export function renderSystemdUnit(
   // gets installed. Embedding the resolved home eliminates that drift.
   const homeEnv = `Environment=FIRST_TREE_HOME=${shellQuote(defaultHome())}\n`;
   // `systemd --user` does not inherit the operator's interactive shell PATH.
-  // Include this CLI's Node directory so npm/nvm-installed shebangs that use
-  // `#!/usr/bin/env node` keep working when supervised.
+  // Put this CLI's Node directory first so npm/nvm-installed shebangs and
+  // self-update use the same Node toolchain when supervised.
   const pathEnv = `Environment=PATH=${shellQuote(systemdPathEnv())}\n`;
 
   // Forward shell-side proxy env (see `collectProxyEnv` docblock for why).

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -21,13 +21,10 @@ export const PACKAGE_NAME = channelConfig.packageName;
 
 /**
  * Pick the `npm` binary to invoke for self-update. Background service units
- * hard-code a minimal PATH (/usr/local/bin, /opt/homebrew/bin, /usr/bin,
- * /bin) that misses nvm / asdf / Volta toolchain directories — the client
- * launches fine from an absolute path resolved at install time, but a plain
- * `spawn("npm")` then ENOENTs. Node and npm always ship side-by-side, so
- * `dirname(execPath)/npm` is the most reliable fallback across those
- * managers; if the sibling is missing (e.g. corporate custom layout) we
- * fall back to PATH lookup.
+ * prepend the current Node directory to PATH, but also prefer the sibling
+ * npm explicitly so self-update stays aligned with the Node toolchain that
+ * launched the daemon. If that sibling is missing (e.g. corporate custom
+ * layout), fall back to PATH lookup.
  */
 function resolveNpmCommand(): string {
   const binName = process.platform === "win32" ? "npm.cmd" : "npm";


### PR DESCRIPTION
## Summary

- Add shared service PATH rendering that prepends the current Node executable directory and removes duplicates.
- Render launchd plist PATH with the current Node bin plus macOS fallback paths, including `/opt/homebrew/bin`.
- Keep systemd PATH behavior equivalent and clarify the self-update npm resolution comment.
- Add launchd plist regression tests for Node bin precedence, fallback paths, and duplicate removal.

## Test Plan

- `pnpm --filter first-tree-dev test -- render-unit-channel`
- `pnpm --filter first-tree-dev test`
- `pnpm check && pnpm typecheck`

## Notes

- The requested `pnpm --filter first-tree test -- render-unit-channel` does not match this checkout because the CLI package is currently named `first-tree-dev`; I used the equivalent `first-tree-dev` filter.
- No Context Tree update expected: this is an implementation-level daemon/service fix.
