### PR TITLE
test(client): lock down detectClaudeAuthFailure shape contract with SDK union

### DIFF
--- a/packages/client/src/__tests__/claude-auth-failure-detector.test.ts
+++ b/packages/client/src/__tests__/claude-auth-failure-detector.test.ts
@@ -1,0 +1,175 @@
+import type {
+  SDKAPIRetryMessage,
+  SDKAssistantMessage,
+  SDKAssistantMessageError,
+  SDKAuthStatusMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it } from "vitest";
+import { isClaudeAuthError } from "../handlers/auth-error-hint.js";
+import { detectClaudeAuthFailure } from "../handlers/claude-code.js";
+
+/**
+ * Architectural-fragility guard for the Claude-side auth-failure detector.
+ *
+ * `detectClaudeAuthFailure` infers its message-shape contract from the SDK's
+ * `.d.ts` types, NOT from a documented runtime contract. An SDK internal
+ * restructure (collapsing message types, renaming `subtype`, moving the
+ * terminal auth signal to `result`) would silently break detection: the
+ * runtime regresses to dumping the opaque raw SDK error, which is exactly
+ * the failure mode PR #618 set out to fix.
+ *
+ * Two layers of protection here:
+ *
+ *   1. **Compile-time exhaustiveness over `SDKAssistantMessageError`** — the
+ *      `KNOWN_CODES` table is typed `Record<SDKAssistantMessageError, ...>`,
+ *      so if Anthropic adds a new union member (e.g. `tos_violation`), the
+ *      typecheck fails until someone explicitly triages it. That's the
+ *      forcing function: a new error code can't slip past unclassified.
+ *
+ *   2. **Runtime fixtures typed against the SDK message interfaces** — every
+ *      positive / negative case is built from `SDKAssistantMessage`,
+ *      `SDKAuthStatusMessage`, `SDKAPIRetryMessage` so a rename / field-drop
+ *      in the SDK breaks compilation rather than silently producing junk.
+ */
+
+const FIXTURE_UUID = "00000000-0000-7000-8000-000000000000" as const;
+const FIXTURE_SESSION_ID = "session-fixture";
+
+function makeAssistantMessage(error: SDKAssistantMessageError | undefined): SDKAssistantMessage {
+  const base = {
+    type: "assistant",
+    // `BetaMessage` is opaque to this test — the detector never reads its
+    // contents. Casting through `unknown` keeps the test focused on the
+    // fields the detector actually inspects (`type`, `error`).
+    message: {} as SDKAssistantMessage["message"],
+    parent_tool_use_id: null,
+    uuid: FIXTURE_UUID,
+    session_id: FIXTURE_SESSION_ID,
+  } satisfies Omit<SDKAssistantMessage, "error">;
+  return error === undefined ? base : { ...base, error };
+}
+
+function makeAuthStatusMessage(error: string | undefined): SDKAuthStatusMessage {
+  const base = {
+    type: "auth_status",
+    isAuthenticating: error === undefined,
+    output: [],
+    uuid: FIXTURE_UUID,
+    session_id: FIXTURE_SESSION_ID,
+  } satisfies Omit<SDKAuthStatusMessage, "error">;
+  return error === undefined ? base : { ...base, error };
+}
+
+function makeApiRetryMessage(error: SDKAssistantMessageError): SDKAPIRetryMessage {
+  return {
+    type: "system",
+    subtype: "api_retry",
+    attempt: 1,
+    max_retries: 3,
+    retry_delay_ms: 500,
+    error_status: 401,
+    error,
+    uuid: FIXTURE_UUID,
+    session_id: FIXTURE_SESSION_ID,
+  };
+}
+
+describe("SDKAssistantMessageError union — exhaustive classification", () => {
+  it("classifies every union member; adding a new SDK code breaks compile", () => {
+    // The Record type forces compile-time exhaustiveness. If Anthropic ships
+    // a new code (e.g. `tos_violation`), this object becomes incomplete and
+    // the typecheck fails — that's the intended forcing function. When the
+    // typecheck fails, someone must consciously decide whether the new code
+    // is an auth signal or not, and add it here AND update isClaudeAuthError.
+    const KNOWN_CODES: Record<SDKAssistantMessageError, boolean> = {
+      authentication_failed: true,
+      billing_error: false,
+      rate_limit: false,
+      invalid_request: false,
+      server_error: false,
+      unknown: false,
+      max_output_tokens: false,
+    };
+    for (const [code, expectedIsAuth] of Object.entries(KNOWN_CODES)) {
+      expect(isClaudeAuthError(code), `code=${code}`).toBe(expectedIsAuth);
+    }
+  });
+});
+
+describe("detectClaudeAuthFailure — positive cases", () => {
+  it("triggers on assistant.error === 'authentication_failed'", () => {
+    const msg = makeAssistantMessage("authentication_failed");
+    expect(detectClaudeAuthFailure(msg)).toEqual({ rawMessage: "authentication_failed" });
+  });
+
+  it("triggers on auth_status with a non-empty error string and quotes it verbatim", () => {
+    const msg = makeAuthStatusMessage("OAuth refresh failed: invalid_grant");
+    expect(detectClaudeAuthFailure(msg)).toEqual({ rawMessage: "OAuth refresh failed: invalid_grant" });
+  });
+});
+
+describe("detectClaudeAuthFailure — negative cases (drift counter-examples)", () => {
+  it("does NOT trigger on assistant.error for other typed codes", () => {
+    // Hand-listed instead of derived from the Record above because the test's
+    // value is in being explicit: each non-auth code is intentional. If a new
+    // code lands, the exhaustiveness test forces a triage; this loop just
+    // proves the current classification is wired through detect→isAuthError.
+    const nonAuthCodes: readonly SDKAssistantMessageError[] = [
+      "billing_error",
+      "rate_limit",
+      "invalid_request",
+      "server_error",
+      "unknown",
+      "max_output_tokens",
+    ];
+    for (const code of nonAuthCodes) {
+      const msg = makeAssistantMessage(code);
+      expect(detectClaudeAuthFailure(msg), `code=${code}`).toBeNull();
+    }
+  });
+
+  it("does NOT trigger on assistant message without an error field", () => {
+    const msg = makeAssistantMessage(undefined);
+    expect(detectClaudeAuthFailure(msg)).toBeNull();
+  });
+
+  it("does NOT trigger on auth_status with empty or missing error", () => {
+    expect(detectClaudeAuthFailure(makeAuthStatusMessage(undefined))).toBeNull();
+    expect(detectClaudeAuthFailure(makeAuthStatusMessage(""))).toBeNull();
+  });
+
+  it("does NOT trigger on api_retry — deliberately dropped to avoid pre-attempt false alarms", () => {
+    // api_retry fires BEFORE the SDK's next retry attempt; if the retry then
+    // succeeds, an emitted hint would have been wrong. The detector waits
+    // for the authoritative post-failure signals (`assistant.error` /
+    // `auth_status.error`) — see the function docblock for the rationale.
+    const msg = makeApiRetryMessage("authentication_failed");
+    expect(detectClaudeAuthFailure(msg)).toBeNull();
+  });
+});
+
+describe("detectClaudeAuthFailure — malformed input tolerance", () => {
+  it("returns null for null / undefined / non-object / primitive input", () => {
+    expect(detectClaudeAuthFailure(null)).toBeNull();
+    expect(detectClaudeAuthFailure(undefined)).toBeNull();
+    expect(detectClaudeAuthFailure("not an object")).toBeNull();
+    expect(detectClaudeAuthFailure(42)).toBeNull();
+    expect(detectClaudeAuthFailure(true)).toBeNull();
+    expect(detectClaudeAuthFailure([])).toBeNull();
+  });
+
+  it("returns null for objects with unknown / missing type discriminator", () => {
+    expect(detectClaudeAuthFailure({})).toBeNull();
+    expect(detectClaudeAuthFailure({ type: undefined })).toBeNull();
+    expect(detectClaudeAuthFailure({ type: "user", error: "authentication_failed" })).toBeNull();
+    expect(detectClaudeAuthFailure({ type: "tool_result", error: "authentication_failed" })).toBeNull();
+  });
+
+  it("returns null for auth_status whose error field is not a string", () => {
+    // The SDK types `error?: string`, but the message arrives over a JSON
+    // boundary — a future SDK could ship a richer object. We require string
+    // before quoting it into a chat-timeline message.
+    expect(detectClaudeAuthFailure({ type: "auth_status", error: 401 })).toBeNull();
+    expect(detectClaudeAuthFailure({ type: "auth_status", error: { code: "invalid_grant" } })).toBeNull();
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -267,7 +267,7 @@ function isResultMessage(message: unknown): message is ResultMessage {
  * `assistant.error` or `result.subtype === "error"` is the authoritative
  * post-failure signal — let those drive the chat-timeline message.
  */
-function detectClaudeAuthFailure(message: unknown): { rawMessage: string } | null {
+export function detectClaudeAuthFailure(message: unknown): { rawMessage: string } | null {
   if (!message || typeof message !== "object") return null;
   const m = message as Record<string, unknown>;
   if (m.type === "assistant" && isClaudeAuthError(m.error as string | undefined)) {


### PR DESCRIPTION
## Context

Follow-up to #618. @baixiaohang flagged a strongly-recommended architectural-fragility guard during that PR's review:

> Detection 依赖的是从 `sdk.d.ts` 反推的 message shape 假设，不是 SDK 文档化契约。任何 SDK 内部 message 重构（合并 type、新增 type、重命名 subtype、把终态搬到 `result` 路径）都会让 detection 静默漏检。

I committed to the follow-up in the #618 thread. Here it is.

## Change

Add a single test file (`packages/client/src/__tests__/claude-auth-failure-detector.test.ts`) that pins down `detectClaudeAuthFailure`'s contract with the Claude SDK in two layers:

**1. Compile-time exhaustiveness over `SDKAssistantMessageError`**

```ts
const KNOWN_CODES: Record<SDKAssistantMessageError, boolean> = {
  authentication_failed: true,
  billing_error: false,
  rate_limit: false,
  invalid_request: false,
  server_error: false,
  unknown: false,
  max_output_tokens: false,
};
```

The `Record` constraint forces compile-time exhaustiveness. When Anthropic adds a new union member (e.g. `tos_violation`), the typecheck fails until someone explicitly classifies whether it's an auth signal. New SDK codes can't slip past unclassified.

**2. Runtime fixtures typed against the SDK message interfaces**

Every positive / negative case is built via small factory helpers (`makeAssistantMessage`, `makeAuthStatusMessage`, `makeApiRetryMessage`) returning the typed SDK interfaces (`SDKAssistantMessage`, `SDKAuthStatusMessage`, `SDKAPIRetryMessage`). A SDK rename / field-drop breaks compilation rather than silently producing garbage fixtures that bypass the detector.

## What's covered

10 tests, in 4 describes:

- **Exhaustive classification**: every `SDKAssistantMessageError` member is mapped to is-auth / not-auth.
- **Positive cases**: `assistant.error: "authentication_failed"` + `auth_status.error: "..."` both trigger and carry the right raw message.
- **Negative cases** (drift counter-examples): all 6 non-auth typed codes, assistant without `error`, `auth_status` with empty / missing error, and `api_retry` with `authentication_failed` (we deliberately dropped that path — fires before SDK retry verdict).
- **Malformed input**: null / undefined / primitive / array / unknown type discriminator / non-string `error` field on `auth_status`.

## Side change

`detectClaudeAuthFailure` is now exported from `claude-code.ts` (was module-local). The function still has no other internal consumers; the export is purely so the test can hit it without mocking the full `consumeOutput` loop.

## Test plan

- [x] `pnpm --filter @first-tree/client test src/__tests__/claude-auth-failure-detector.test.ts` — 10 / 10 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm check` — no new biome warnings on touched files (24 pre-existing warnings on `inbox-bind-recovery.test.ts` etc., unrelated)

## Pre-existing failures noted

`doc-snapshots.test.ts` and `doc-snapshots.fs-mocks.test.ts` have failing tests on `main` independent of this PR (filesystem-realpath edge cases sensitive to test cwd). Confirmed by running the same tests on a clean main checkout without my changes. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)