### PR TITLE
fix: stop ComposeStatusBar rendering the lead agent twice

### DIFF
--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -206,7 +206,10 @@ export function ComposeStatusBar({
           className="flex flex-col"
           style={{ gap: "var(--sp-1)", maxHeight: EXPANDED_MAX_HEIGHT, overflowY: "auto" }}
         >
-          {attention.map((s) => (
+          {/* `others`, NOT `attention`: the lead already has its own always-on
+              row above, so mapping the full set here would render the lead a
+              second time (the duplicate-row bug). */}
+          {others.map((s) => (
             <RailRow key={s.agentId} status={s} nameOf={nameFor(agents)} mounted={mounted} />
           ))}
         </div>


### PR DESCRIPTION
## Summary

The chat compose status rail (`ComposeStatusBar`) showed the same agent twice — duplicate `gandy-developer · Working` rows — whenever the rail was **expanded**.

Root cause is a pure frontend render bug, **not** data duplication:
- The rail always renders a dedicated **lead** row above the composer.
- The expanded tray then renders `attention.map(...)` — the *full* active set, which still includes the lead.
- So when expanded, the lead agent is rendered twice.

Fix: the expanded tray maps `others` (`attention` minus the lead) instead of `attention`. Lead + others then covers every active agent exactly once.

### Why it's not a data-layer bug
- `chat_membership` has a composite primary key on `(chatId, agentId)` — duplicate membership rows are structurally impossible.
- `getChatAgentStatuses` / `resolveAgentChatStatuses` `Set`-dedup by `agentId`, and the admin-WS `upsertAgentStatus` replaces-by-id. The status array reaching the UI is already unique.

So the suggested "clean duplicate rows + make join idempotent" and "frontend agentId dedup fallback" are not needed: there are no duplicate rows to clean, and the array is already unique (the dup was one element rendered in two places, which array-dedup can't catch).

## Test plan

- [x] `tsc --noEmit` + design-token lint pass
- [x] `compose-status-bar.test.ts` — 9/9 pass (`pickLead` / `selectAttention` untouched)
- [x] biome check clean
- [x] Isolated harness repro: rendered the real component with two working agents.
  - **Before** (`attention.map`): expanded shows `gandy-developer` ×2 + `gandy-assistant`, `+1` — matches the bug report.
  - **After** (`others.map`): expanded shows `gandy-developer` + `gandy-assistant`, each once.
- [ ] Manual check in a live multi-agent chat: expand the rail, confirm no duplicate row; collapse, confirm single lead + `+N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)