### PR TITLE
release: bump apps/cli to v0.5.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Highlights

- Need-Human-Attention (NHA) primitive — server + web + CLI + skill (#602, #615, #616, #617)
- In-flight message recovery via agent:bind reset + deferred ack (#612)
- Card-based IA for Settings → Computers, with 4-state status pill and connect dialog (#594, #586, #603, #607)
- Per-agent slash-command catalog + composer popover (#588)
- Channel-aware CLI binding in agent prompts + server hints (multi-env) (#627)
- Translate codex/claude SDK auth errors into actionable chat hints (#618)
- Responsive workspace layout for mobile viewports + responsive Settings shell (#577, #596)

## Notable fixes

- Client resilience — error taxonomy, child process registry, auth paused, session/bind retry, stream sniff (#582)
- Retry SDK timeouts + tighten fetchAgentConfig budget (#631)
- Bundle skills/ in CLI tarball + auto-refresh on CLI drift (#605)
- Include node path in launchd / systemd units (#622, #625)
- Dedup concurrent Context Tree syncs sharing one clone dir (#606)
- Widen appendEvent seq retry budget + jitter to absorb concurrent bursts (#570)
- Stop ComposeStatusBar rendering the lead agent twice (#630)

Supersedes #634 (closed for branch-name convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)