### PR TITLE
feat: report per-turn token usage from agent handlers

### DIFF
--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -240,6 +240,21 @@ type ResultMessage = {
   total_cost_usd?: number;
   num_turns?: number;
   session_id?: string;
+  // Per-model token usage for this turn. Anthropic's Claude Agent SDK populates
+  // this on every ResultMessage (success and error subtypes). A single turn can
+  // span multiple models (e.g. fast-mode), so we emit one `token_usage` event
+  // per entry. Keys are model identifiers (e.g. "claude-opus-4-7"). Older SDK
+  // versions may omit the field entirely — treat absence as "no usage to emit"
+  // rather than an error.
+  modelUsage?: Record<
+    string,
+    {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadInputTokens?: number;
+      cacheCreationInputTokens?: number;
+    }
+  >;
 };
 
 function isResultMessage(message: unknown): message is ResultMessage {
@@ -278,6 +293,41 @@ function detectClaudeAuthFailure(message: unknown): { rawMessage: string } | nul
     return { rawMessage: m.error };
   }
   return null;
+}
+
+/**
+ * Emit one `token_usage` event per (model) entry in the result's `modelUsage`.
+ * The SDK lumps cache-creation tokens under their own field, but the wire
+ * schema folds them into `inputTokens` because they bill as input. Best-effort:
+ * a missing/empty `modelUsage` is silently skipped (older SDKs and some error
+ * subtypes don't populate it). Per-entry emit failures are swallowed so token
+ * accounting never blocks the turn close that follows.
+ */
+function emitTokenUsageFromResult(message: ResultMessage, sessionCtx: SessionContext): void {
+  const usage = message.modelUsage;
+  if (!usage) return;
+  for (const [model, m] of Object.entries(usage)) {
+    if (!m) continue;
+    const cacheCreation = m.cacheCreationInputTokens ?? 0;
+    const cachedRead = m.cacheReadInputTokens ?? 0;
+    const inputTokens = (m.inputTokens ?? 0) + cacheCreation;
+    const outputTokens = m.outputTokens ?? 0;
+    if (inputTokens === 0 && cachedRead === 0 && outputTokens === 0) continue;
+    try {
+      sessionCtx.emitEvent({
+        kind: "token_usage",
+        payload: {
+          provider: "claude-code",
+          model,
+          inputTokens,
+          cachedInputTokens: cachedRead,
+          outputTokens,
+        },
+      });
+    } catch (err) {
+      sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 }
 
 function extractToolResultText(content: unknown): string {
@@ -877,6 +927,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             }
 
             if (isResultMessage(message)) {
+              emitTokenUsageFromResult(message, sessionCtx);
               if (message.subtype === "success") {
                 retryCount = 0;
                 // Auto-bridge: forward result text back to the chat and close

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -293,6 +293,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
   let codex: Codex | null = null;
   let thread: Thread | null = null;
   let threadId: string | null = null;
+  // Best-effort label for the current Codex thread's model — recorded from the
+  // last `buildCodexThreadOptions` call so `token_usage` events can carry a
+  // model name. The SDK does not echo back the actual model used (the CLI may
+  // pick a default when `payload.model` is empty), so this is whatever the
+  // operator configured; absence is surfaced as the placeholder below.
+  let currentModel = "";
   let currentAbort: AbortController | null = null;
   let currentTurnPromise: Promise<void> | null = null;
   let ctx: SessionContext | null = null;
@@ -796,6 +802,29 @@ export const createCodexHandler: HandlerFactory = (config) => {
     }
 
     const succeeded = !turnFailed && !forwardFailed;
+    // Emit `token_usage` just before `turn_end` so the wire-order matches the
+    // claude-code handler (consumers can group all usage events for a turn
+    // between the previous and current `turn_end`). `usage` is null when the
+    // turn never reached `turn.completed` (abort / unrecoverable failure) —
+    // in that case the SDK has no totals to share and we skip the emit
+    // rather than ship zeros.
+    const usageForEvent = usageBox.value;
+    if (usageForEvent) {
+      try {
+        sessionCtx.emitEvent({
+          kind: "token_usage",
+          payload: {
+            provider: "codex",
+            model: currentModel || "codex-default",
+            inputTokens: usageForEvent.input_tokens,
+            cachedInputTokens: usageForEvent.cached_input_tokens,
+            outputTokens: usageForEvent.output_tokens,
+          },
+        });
+      } catch (err) {
+        sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
     sessionCtx.emitEvent({
       kind: "turn_end",
       payload: { status: succeeded ? "success" : "error" },
@@ -1038,6 +1067,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
       thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
+      currentModel = payload.model || "";
 
       const input = await toCodexInput(message, sessionCtx);
       await runTurn(input, sessionCtx, 1);
@@ -1088,6 +1118,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // re-pass them every time.
       thread = codex.resumeThread(sessionId, buildCodexThreadOptions(payload, cwd));
       threadId = sessionId;
+      currentModel = payload.model || "";
 
       if (message) {
         const input = await toCodexInput(message, sessionCtx);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -596,9 +596,11 @@ export {
   sessionEventRowSchema,
   sessionEventSchema,
   type ThinkingEventPayload,
+  type TokenUsageEventPayload,
   type ToolCallEventPayload,
   type TurnEndEventPayload,
   thinkingEventPayload,
+  tokenUsageEventPayload,
   toolCallEventPayload,
   turnEndEventPayload,
 } from "./schemas/session-event.js";

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -7,6 +7,7 @@ export const sessionEventKind = z.enum([
   "thinking",
   "turn_end",
   "context_tree_usage",
+  "token_usage",
 ]);
 export type SessionEventKind = z.infer<typeof sessionEventKind>;
 
@@ -77,6 +78,30 @@ export const contextTreeUsageEventPayload = z.object({
 });
 export type ContextTreeUsageEventPayload = z.infer<typeof contextTreeUsageEventPayload>;
 
+/**
+ * Token usage for one (provider, model) within a single turn. Emitted by the
+ * handler right before `turn_end`. A turn may produce multiple `token_usage`
+ * events when the underlying SDK runs more than one model in a single turn
+ * (e.g. Claude Agent SDK fast-mode). Codex always emits exactly one.
+ *
+ * Field semantics:
+ *   - `inputTokens`: prompt tokens NOT served from cache. For Anthropic this
+ *     includes cache-creation tokens (they bill as input). For OpenAI/Codex
+ *     this is `usage.input_tokens` straight from the SDK.
+ *   - `cachedInputTokens`: prompt tokens served from cache (Anthropic
+ *     `cache_read_input_tokens` / OpenAI `cached_input_tokens`).
+ *   - `outputTokens`: completion tokens (includes reasoning tokens for o-series
+ *     models — we deliberately do not split them out in this minimal schema).
+ */
+export const tokenUsageEventPayload = z.object({
+  provider: z.string(),
+  model: z.string(),
+  inputTokens: z.number().int().nonnegative(),
+  cachedInputTokens: z.number().int().nonnegative().default(0),
+  outputTokens: z.number().int().nonnegative(),
+});
+export type TokenUsageEventPayload = z.infer<typeof tokenUsageEventPayload>;
+
 export const sessionEventSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("tool_call"), payload: toolCallEventPayload }),
   z.object({ kind: z.literal("error"), payload: errorEventPayload }),
@@ -84,6 +109,7 @@ export const sessionEventSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("thinking"), payload: thinkingEventPayload }),
   z.object({ kind: z.literal("turn_end"), payload: turnEndEventPayload }),
   z.object({ kind: z.literal("context_tree_usage"), payload: contextTreeUsageEventPayload }),
+  z.object({ kind: z.literal("token_usage"), payload: tokenUsageEventPayload }),
 ]);
 export type SessionEvent = z.infer<typeof sessionEventSchema>;
 
@@ -101,6 +127,7 @@ export const sessionEventRowSchema = z.object({
     thinkingEventPayload,
     turnEndEventPayload,
     contextTreeUsageEventPayload,
+    tokenUsageEventPayload,
   ]),
   createdAt: z.string(),
 });


### PR DESCRIPTION
## Summary

Add a `token_usage` session event so every turn lands a typed row of model spend in `session_events`. Both built-in handlers (`claude-code` and `codex`) emit it right before `turn_end`.

Payload is intentionally minimal — `provider`, `model`, `inputTokens`, `cachedInputTokens`, `outputTokens`. No cost, no reasoning split, no cache-creation split. Server, DB schema, and WS protocol are unchanged (JSONB payload).

## Field mapping

| Wire field | claude-code | codex |
|---|---|---|
| `inputTokens` | `modelUsage[m].inputTokens + cacheCreationInputTokens` | `usage.input_tokens` |
| `cachedInputTokens` | `modelUsage[m].cacheReadInputTokens` | `usage.cached_input_tokens` |
| `outputTokens` | `modelUsage[m].outputTokens` | `usage.output_tokens` |
| `model` | per-`modelUsage` key (one event per model — Claude can use multiple in one turn) | operator-configured `payload.model`, falling back to `codex-default` when unset |

Event order per turn: `…tool_call / assistant_text / thinking… → token_usage × N → turn_end`.

## Test plan

- [x] `pnpm typecheck` ✓
- [x] `biome check` on the four touched files ✓
- [x] `pnpm --filter @first-tree/shared test` 270/270 ✓
- [x] `pnpm --filter @first-tree/client test` 638/641 ✓ (3 pre-existing skips)
- [x] **End-to-end against local server + PG** — created one claude-code agent and one codex agent, posted a real "@agent reply with OK" message to each, queried `session_events`:
  - claude-code: `{provider:"claude-code", model:"claude-opus-4-6", input:22595, cached:0, output:5}`
  - codex: `{provider:"codex", model:"codex-default", input:22392, cached:1536, output:24}`
  - Sequence in both cases: `assistant_text → token_usage → turn_end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)