### PR TITLE
fix(client): dev-channel build fingerprint for cliDrifted

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -956,6 +956,57 @@ describe("Bundled CLI version drift helpers", () => {
     writeFileSync(join(tmpBase, "cli-version-corrupt", "package.json"), "{not-json");
 
     expect(resolveBundledCliVersion(`file://${join(dir, "module.js")}`)).toMatch(/^\d+\.\d+\.\d+/u);
+  });
+
+  it("dev channel: appends a build fingerprint to the version", () => {
+    // Switch to the dev binding so the resolver appends the mtime
+    // suffix. Default moduleUrl points at this test bundle's own file,
+    // which exists, so statSync succeeds and the suffix is present.
+    setCliBinding({ binName: "first-tree-dev", packageName: null });
+    const version = resolveBundledCliVersion();
+    expect(version).toMatch(/\+build\.\d+$/u);
+  });
+
+  it("prod and staging channels: bare version, no fingerprint suffix", () => {
+    // CI bumps the package manifest's version on every release, so the
+    // fingerprint would be redundant noise in the `.agent/cli-version`
+    // pin. Assert both published channels explicitly.
+    setCliBinding({ binName: "first-tree", packageName: "first-tree" });
+    expect(resolveBundledCliVersion()).not.toMatch(/\+build\./u);
+
+    setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
+    expect(resolveBundledCliVersion()).not.toMatch(/\+build\./u);
+  });
+
+  it("dev channel: build fingerprint changes when the module file's mtime changes", () => {
+    setCliBinding({ binName: "first-tree-dev", packageName: null });
+    const dir = join(tmpBase, "cli-version-fingerprint");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "9.9.9" }));
+    const modulePath = join(dir, "module.js");
+    writeFileSync(modulePath, "// stub");
+    const moduleUrl = `file://${modulePath}`;
+
+    utimesSync(modulePath, new Date(1_700_000_000_000), new Date(1_700_000_000_000));
+    const first = resolveBundledCliVersion(moduleUrl);
+
+    utimesSync(modulePath, new Date(1_800_000_000_000), new Date(1_800_000_000_000));
+    const second = resolveBundledCliVersion(moduleUrl);
+
+    expect(first).toMatch(/^9\.9\.9\+build\.\d+$/u);
+    expect(second).toMatch(/^9\.9\.9\+build\.\d+$/u);
+    expect(first).not.toBe(second);
+  });
+
+  it("dev channel: falls back to bare version when the module file is missing (statSync throws)", () => {
+    setCliBinding({ binName: "first-tree-dev", packageName: null });
+    const dir = join(tmpBase, "cli-version-no-mtime");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: "0.0.1" }));
+    // Synthetic module URL — statSync throws and the resolver must
+    // degrade to the bare version (still drift-comparable, just not
+    // build-sensitive).
+    expect(resolveBundledCliVersion(`file://${join(dir, "ghost.js")}`)).toBe("0.0.1");
   });
 
   it("write/read roundtrip pins the CLI version for drift comparison", () => {

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -324,42 +324,58 @@ export function readCachedContextTreeHead(workspacePath: string): string | null 
 export const BUNDLED_CLI_VERSION_REL = join(".agent", "cli-version");
 
 /**
- * Walk up from the current module to find the closest `package.json` with
- * a `version` field.
+ * Resolve a stable identifier for the bundled CLI that the handler can
+ * compare against the cached `.agent/cli-version` to detect upgrades.
  *
- * - **Published / `dev-install.sh` bundle** (the path that actually matters
- *   for the drift trigger): `bootstrap.ts` is inlined into an `apps/cli/
- *   dist/<chunk>.mjs` chunk, so the walk goes `dist/<chunk>.mjs` → `dist/`
- *   → the CLI manifest. CI publish rewrites that manifest's `name`/`bin`
- *   to the channel before `pnpm build`, so the version we read is the
- *   consumer-facing CLI version (`first-tree` / `first-tree-staging` /
- *   `first-tree-dev`). This is what `first-tree upgrade` bumps.
- * - **Source-tree `tsx` / vitest runs**: there is no bundle; the walk
- *   from `packages/client/src/runtime/bootstrap.ts` hits the
- *   `@first-tree/client` manifest first. That package is `private`
- *   (no published release bumps it), so the pin doesn't track CLI
- *   versions in dev mode. Drift detection still works correctly because
- *   each invocation reads the same value; the dev-mode pin just won't
- *   tick when the operator runs a real `pnpm install -g first-tree@...`.
- *   Acceptable: dev iteration is the wrong place to validate CLI-upgrade
- *   refresh semantics anyway.
+ * Behaviour by channel:
+ *
+ *   - **prod / staging** — returns the bare `<pkgVersion>` from the
+ *     closest ancestor `package.json`. CI bumps that manifest's `version`
+ *     on every release, so version alone is the unique build identifier.
+ *   - **dev** — returns `<pkgVersion>+build.<mtime>`, where `<mtime>` is
+ *     the integer `mtimeMs` of the file backing `moduleUrl`. Dev iteration
+ *     never bumps `apps/cli/package.json` (CLAUDE.md forbids touching
+ *     `version` fields), so a bare version would be constant across every
+ *     `scripts/dev-install.sh` cycle and `cliDrifted` would never fire.
+ *     `pnpm build` rewrites `dist/cli/index.mjs` and updates its mtime,
+ *     so the appended suffix changes on every build → handler triggers
+ *     a full re-bootstrap and the agent home picks up the new
+ *     CLAUDE.md / tools.md / shipped skills payload.
+ *
+ * Channel is read from `getCliBinding().packageName`: `null` is the dev
+ * channel (dev binaries are not published — see
+ * `runtime/cli-binding.ts`), everything else is a published channel.
+ *
+ * If `getCliBinding()` has not been initialised yet (e.g. an early
+ * bootstrap call before `apps/cli` wired the binding), we fall through
+ * to the bare-version path so the caller still gets something
+ * drift-comparable.
+ *
+ * Walk source: the closest ancestor `package.json` with a non-empty
+ * `version`. For the **published bundle**, `bootstrap.ts` is inlined
+ * into `apps/cli/dist/<chunk>.mjs`, so the walk lands on the CLI
+ * manifest. For **source-tree `tsx` / vitest runs** it lands on the
+ * private `@first-tree/client` manifest — that version is constant in
+ * dev too, which is exactly why dev needs the mtime suffix.
  *
  * Imported from here (not from `apps/cli`) to keep the client → CLI
  * dependency direction one-way.
  *
- * Returns `null` if the walk exhausts every parent — we treat that as
- * "version unknown" and fall back to the sentinel-only path, never as
- * "drifted".
+ * Returns `null` only when the walk exhausts every parent without
+ * finding any `version` — drift detection then falls back to "unknown",
+ * never to "drifted".
  */
 export function resolveBundledCliVersion(moduleUrl: string = import.meta.url): string | null {
   let dir = dirname(fileURLToPath(moduleUrl));
+  let version: string | null = null;
   for (let i = 0; i < 10; i += 1) {
     const candidate = resolve(dir, "package.json");
     if (existsSync(candidate)) {
       try {
         const parsed = JSON.parse(readFileSync(candidate, "utf8")) as { version?: unknown };
         if (typeof parsed.version === "string" && parsed.version.length > 0) {
-          return parsed.version;
+          version = parsed.version;
+          break;
         }
       } catch {
         // Corrupt or unreadable — keep walking; finding *some* version is
@@ -370,7 +386,33 @@ export function resolveBundledCliVersion(moduleUrl: string = import.meta.url): s
     if (parent === dir) break;
     dir = parent;
   }
-  return null;
+  if (version === null) return null;
+
+  // Channel gate: only the dev channel needs the build fingerprint.
+  // packageName === null is the published-channel-absent marker (see
+  // CliBinding's docblock). Anywhere else (prod / staging / uninitialised)
+  // we keep the bare version — staging/prod have a release-bumped
+  // version that already changes per build, so a fingerprint would just
+  // be noise in the `.agent/cli-version` pin.
+  let isDevChannel = false;
+  try {
+    isDevChannel = getCliBinding().packageName === null;
+  } catch {
+    // Binding not initialised — treat as non-dev. Safer default: skip
+    // the suffix rather than emit a fingerprint into a sentinel that a
+    // later boot (with binding set) would reject as drifted.
+  }
+  if (!isDevChannel) return version;
+
+  // Wrapped in try/catch so a synthetic `moduleUrl` pointing at a
+  // non-existent path still produces a usable version string for callers
+  // (and tests) that hand in dummy URLs.
+  try {
+    const mtimeMs = Math.floor(statSync(fileURLToPath(moduleUrl)).mtimeMs);
+    return `${version}+build.${mtimeMs}`;
+  } catch {
+    return version;
+  }
 }
 
 /** Read the cached CLI version that last ran bootstrap, if any. */


### PR DESCRIPTION
## Summary

- `resolveBundledCliVersion()` now appends `+build.<bundle-mtime>` to the version **only on the dev channel** (`getCliBinding().packageName === null`).
- Fixes a silent stale-bootstrap bug on dev installs: rebuilding via `scripts/dev-install.sh` and restarting the daemon used to leave `~/.first-tree-dev/data/workspaces/<agent>/CLAUDE.md`, `tools.md`, and `.agents/skills/*` frozen at the first build's content, because `apps/cli/package.json#version` never moves between dev rebuilds (CLAUDE.md forbids touching `version` fields) and so the handler's `cliDrifted` gate never tripped.
- Prod / staging keep the bare version — CI bumps it per release, so the fingerprint suffix would just be noise in the `.agent/cli-version` pin.

## Why now

Dev runs `bootstrap.ts` is inlined into `apps/cli/dist/cli/index.mjs`. `pnpm build` rewrites that file (so its `mtime` changes), but the surrounding `package.json#version` is constant in dev iteration. Using the bundle file's `mtime` as a build fingerprint gives `cliDrifted` an automatic trigger that doesn't depend on operator discipline (manually clearing sentinels) or external state (Context Tree HEAD drift, which dev usually doesn't have since `contextTreePath` is `null` on local hub servers).

## Test plan

- [x] `pnpm --filter @first-tree/client test` — 910 passed (4 new cases: dev appends suffix, prod/staging do not, mtime change yields different fingerprint, statSync failure degrades to bare version)
- [x] `pnpm typecheck` — 13/13 successful
- [x] `pnpm exec biome check <changed files>` — clean
- [ ] Manual: on a dev install, run `./scripts/dev-install.sh && first-tree-dev daemon restart`, send any message to a `first-tree-dev` agent, then check `~/.first-tree-dev/data/workspaces/<agent>/.agent/cli-version` — should now look like `0.5.2+build.<mtime>` and the corresponding `CLAUDE.md` should reflect the latest `generateStableClaudeMd` output.

## Notes

- `binding not initialised` path defaults to non-dev (safer: avoids emitting a fingerprint into a sentinel that a later boot would reject as drifted).
- Cleanup of stale dev agent homes after this lands: their cached `cli-version` is bare (e.g. `0.5.2`), so the first session start under the new resolver will see `0.5.2+build.<mtime>` vs. `0.5.2` → `cliDrifted=true` → full re-bootstrap, exactly what we want.