### PR TITLE
docs: calibrate onboarding docs to the real web-guided flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ first-tree routes work to the right agent, gives it the same context your
 team has, and loops humans in only when the rules say so. Lives in your
 GitHub. Open source.
 
-## Install
+## Get started
+
+Sign in at <https://first-tree.ai> (or your own deployment) and the guided
+setup walks you through it end to end — name your team, connect a computer,
+create your first agent, and start your first chat. See the
+[Quickstart](docs/quickstart.md) for the full walkthrough.
+
+At the "connect a computer" step the setup hands you the command to install
+the CLI and link the machine:
 
 ```bash
 npm install -g first-tree
-first-tree --help
+first-tree login <connect-token>
 ```
 
 The binary lives at `first-tree`; a short alias `ft` is also installed.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -9,11 +9,17 @@
 first-tree 把工作分派给合适的 Agent，给它和团队同一份上下文，只在
 规则要求时把人类拉进流程。常驻在你的 GitHub 里。开源。
 
-## 安装
+## 开始使用
+
+打开 <https://first-tree.ai>（或你自己的部署）登录，引导式 setup 会带你从头
+走完整个流程——给团队命名、连接一台电脑、创建第一个 Agent、开始第一条对话。
+完整步骤见 [Quickstart](docs/quickstart.md)。
+
+走到"连接一台电脑"这步时，setup 会给你安装 CLI、把这台机器登入的命令：
 
 ```bash
 npm install -g first-tree
-first-tree --help
+first-tree login <connect-token>
 ```
 
 二进制名为 `first-tree`；同时安装短别名 `ft`。

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -3,6 +3,11 @@
 Bring a new member (human or agent) online — install the CLI, sign the
 machine in, create the agent, and start the runtime.
 
+> Most people onboard through the **web console**: sign in and follow the
+> guided setup (see the [Quickstart](quickstart.md)). This guide is the
+> **headless, CLI-driven** path — for automation, CI, unattended machines,
+> and self-hosted setups where clicking through a browser isn't an option.
+
 The single-shot `onboard` command was retired in Phase 1A. Onboarding is
 now a small sequence of explicit verbs: `login` to bind the machine,
 `agent create` to register the agent, optional `agent bind bot|user` for

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,102 +1,133 @@
 # Quickstart
 
-A walkthrough that takes a brand-new account from signup to a working
-chat with your first agent.
+A walkthrough that takes a brand-new account from signup to a working chat
+with your first agent.
 
-## 1. Open the web console
+Signing in for the first time drops you into a **full-screen guided setup**.
+It walks you through five steps — name your team, connect a computer, create
+your agent, connect your code, and start your first chat — with a progress
+rail on the left tracking where you are. You can leave and resume later. This
+page mirrors that flow.
 
-<https://first-tree.ai>
+> **Self-hosting?** Use your own deployment's URL wherever this guide says
+> <https://first-tree.ai>. The rest is identical — every connect token
+> carries its server URL in its `iss` claim, so the CLI follows the token
+> rather than a baked-in server name.
 
-Sign in with GitHub. A personal team is auto-created for you on first
-sign-in; you confirm or rename it in the first-run onboarding stepper.
+## Before you start
 
-> **Self-hosting?** Replace the URL above with your own deployment. The
-> rest of this guide is identical — every connect token carries its
-> server URL in its `iss` claim, so the CLI follows the token rather
-> than a baked-in server name.
+- A **GitHub account** to sign in with.
+- **Node.js ≥ 22.16** (24 recommended) on the computer your agent will run
+  on. Setup installs the CLI for you, but Node must already be present.
 
-## 2. Install the CLI
+## 1. Sign in and name your team
+
+Open <https://first-tree.ai> and sign in with GitHub. A personal team is
+created for you automatically; the first step, **Name your team**, lets you
+confirm or rename it (you can rename it anytime later). Press **Continue**.
+
+## 2. Connect a computer
+
+Your agent runs on a real machine, so the next step links one to your team.
+Copy the command the page shows and run it in a terminal on that machine:
 
 ```bash
-npm install -g first-tree@latest
-first-tree --version
-```
-
-The published binary is `first-tree`; `ft` is installed as a short
-alias.
-
-## 3. Connect this computer
-
-In the web console: **Computers → New Connection +**. Copy the
-generated command into your terminal:
-
-```bash
+npm install -g first-tree
 first-tree login <connect-token>
 ```
 
-`first-tree login`:
+This installs the CLI and signs the computer in. `first-tree login`:
 
-- Decodes the token's `iss` claim to derive the server URL. **No
-  `--server` flag needed**, and switching to a different server only
-  requires a new token, not a new command.
-- Persists the member JWT (access + refresh) at
-  `~/.first-tree/hub/config/credentials.json` (mode `0600`).
-- Writes `server.url` and a fresh `client.id` to
-  `~/.first-tree/hub/config/client.yaml`.
-- On macOS / Linux, installs and starts the background daemon as a
-  user-level service so the machine stays online across reboots. Pass
-  `--no-start` to skip the daemon launch.
+- Reads the server URL from the token's `iss` claim — **no `--server` flag
+  needed**, and switching servers only takes a new token.
+- Persists your member credentials and writes this machine's `client.id`.
+- On macOS / Linux, installs and starts a background daemon so the machine
+  stays online across reboots. (See the [Onboarding Guide](onboarding-guide.md)
+  for exactly what gets written and the `--no-start` flag.)
 
-Wait until the **Computers** page shows your machine with `status:
-connected` before continuing — agent binding will fail until then.
+The page watches for the machine, then confirms an AI engine — a **runtime**
+such as Claude Code — is installed and signed in on it. Once it shows your
+computer connected with a ready runtime, press **Continue**. If it reports
+that no engine is ready, install one (e.g. Claude Code) on that computer and
+sign in; it appears here automatically.
 
-## 4. Create your first agent
+## 3. Create your agent
 
-In the web console: **Agents → + New Agent**. Fill in:
+Give your agent a name (for example `Buddy`) and pick who can use it:
 
-- **Name** — e.g. `my-assistant`
-- **Type** — *Personal Assistant*
-- **Pin to client** — the machine you just connected
+- **Shared with team** — anyone on your team can talk to this agent.
+- **Just me** — only you can see and talk to it.
 
-Click **Create**. The dialog surfaces a copyable one-liner. Run it in
-the terminal on the same computer:
+There is no "type" to choose — every agent you create here is a standard
+agent, and the visibility choice is the only difference. Click **Create**.
 
-```bash
-first-tree agent add my-assistant --agent-id <uuid>
-```
+Setup then waits for the agent to come online on the computer you connected
+("Setting up your agent… usually about 10 seconds"). This **runtime-ready
+gate** is what guarantees your first message reaches a live agent. The daemon
+on your machine picks up the new agent automatically — there is no CLI
+command to run by hand. If it doesn't come online within ~30 seconds, check
+that the computer is awake and its runtime is signed in, then try again.
 
-Click **Done**. The daemon picks up the pin automatically via the
-server-pushed `agent:pinned` frame; no restart needed.
+## 4. Connect your code
 
-## 5. Chat with the agent
+Connect the projects your agent should work on: click **Install First Tree
+on GitHub**, approve the GitHub App, then pick one or more projects. Every
+change your agent makes comes back as a request you review.
 
-When the agent's status indicator turns green you can talk to it in the
-**Workspace** tab. The three-panel layout is:
+Not ready, or not a GitHub organization owner? You can **skip for now** and
+connect a project later from **Settings** — your first agent will simply
+start with an intro chat.
+
+## 5. Start your first chat
+
+The final step kicks off your first conversation. For a new team it is
+**Start building your Context Tree** — your agent builds your team's shared
+knowledge base with you in the chat, walking you through each change to
+approve. Press **Start** and you land in the **Workspace** with the chat
+open.
+
+The Workspace is a three-panel layout:
 
 - **Left rail** — the conversation list. New chats open inline; pick a
   target from the composer rather than a separate dialog.
-- **Center** — the selected conversation. Type a message and press
-  Enter to send. Markdown is rendered live; agent-generated document
-  references open inline in the right panel's preview mode.
+- **Center** — the selected conversation. Type a message and press Enter to
+  send. Markdown is rendered live; agent-generated document references open
+  inline in the right panel's preview mode.
 - **Right** — context for the selected chat: session state, agent text
-  output, connected computer, runtime, SDK version, recent
-  notifications, and management links.
+  output, connected computer, runtime, SDK version, recent notifications,
+  and management links.
+
+That's it — you're chatting with your first agent.
+
+## Invited to an existing team?
+
+If you joined through an invite rather than creating the team, setup is
+shorter: a brief welcome, **Connect a computer**, **Create your agent**, then
+**Start work** — picking which of your own projects your agent should help
+with. There is no team-naming or code-connection step; your team's admin has
+already set those up.
 
 ## Where to go next
 
-- [Onboarding Guide](onboarding-guide.md) — the same flow without the
-  web walkthrough, plus SDK and troubleshooting reference.
-- [CLI Reference](cli-reference.md) — every namespace, every command,
-  every env var.
-- [Observability](observability.md) — how to wire metrics and logs into
-  your stack.
+- [Onboarding Guide](onboarding-guide.md) — the same setup driven entirely
+  from the CLI (`login` → `agent create` → `daemon start`), plus the SDK and
+  troubleshooting reference.
+- [CLI Reference](cli-reference.md) — every namespace, every command, every
+  env var.
+- [Observability](observability.md) — how to wire metrics and logs into your
+  stack.
 
-## Common follow-ups
+## Adding more later
 
-| Need | Command |
+The guided setup covers your first run. Afterward, manage everything from the
+console:
+
+| Need | Where |
 |---|---|
+| Connect another computer | **Settings → Computers → + New Connection** |
+| Create another agent | **Team → New agent** (same name + visibility form) |
 | One-screen overview of your install | `first-tree status` |
 | Send a message to another agent | `first-tree chat send <agent> "..."` |
 | Stop the daemon and sign out | `first-tree logout` |
-| Take over a computer that is bound to another account | `first-tree login <token> --override` |
+| Take over a computer bound to another account | `first-tree login <token> --override` |
 | Update the CLI in place | `first-tree upgrade` |


### PR DESCRIPTION
## Summary

The onboarding docs had drifted from the actual product flow. New accounts onboard through a **full-screen web guided setup**, but the docs still described a CLI/manual-navigation flow and referenced UI that no longer exists. This calibrates all onboarding docs to what the code actually does (verified against `packages/web` first-run onboarding and `apps/cli`).

## Changes

- **`docs/quickstart.md`** — rewritten to follow the real 5-step guided setup (name your team → connect a computer → create your agent → connect your code → start your first chat), plus an "invited member" short path and an "adding more later" section. Removed two stale claims:
  - the nonexistent **"Personal Assistant" agent type** — agent creation is now just a name + visibility (*Shared with team* / *Just me*); `type` is fixed to `agent` in code.
  - the manual **`first-tree agent add --agent-id`** step — the daemon auto-pins the agent via the server-pushed `agent:pinned` frame; nothing to run by hand. Also documents the runtime-ready gate.
- **`README.md` / `README_zh-CN.md`** — the lead `## Install` section framed onboarding as CLI-first. Reframed to `## Get started`: the web console is the entry point, and the `npm install -g first-tree` + `first-tree login` snippet is shown as the connect-a-computer step the guided setup hands you. The CLI binary (`first-tree`) and alias (`ft`) remain documented.
- **`docs/onboarding-guide.md`** — added a callout clarifying it is the **headless, CLI-driven** path (automation, CI, unattended machines, self-hosting); most people onboard via the web console.

## Notes

- Docs-only change. `pnpm check` is Biome, which does not lint/format Markdown, and there is no separate Markdown linter, so there is nothing build-side to verify for this diff.
- All internal doc links verified to point at existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)