### PR TITLE
feat(web): redesign jump-to palette with chat/agent/NHA search

### DIFF
--- a/packages/web/src/api/attention.ts
+++ b/packages/web/src/api/attention.ts
@@ -48,3 +48,25 @@ export async function listAttentionsInChat(chatId: string): Promise<Attention[]>
   const qs = new URLSearchParams({ chat: chatId, state: "all" });
   return api.get<Attention[]>(`/attention?${qs.toString()}`);
 }
+
+/** React-Query key for the cross-chat "Attentions waiting on me" list. */
+export const myAttentionsQueryKey = ["attentions", "me"] as const;
+
+/**
+ * `GET /attention?state=open&limit=200` — every open Attention visible to
+ * the caller across all of their chats. The server's user-JWT route in
+ * `api/attention.ts` already scopes by the caller's human agent
+ * identities, so no `target` / `chat` filter is needed for the "needs my
+ * reply" set.
+ *
+ * `limit=200` is the server-enforced max (`listAttentionsQuerySchema`);
+ * the default of 50 would silently truncate the jump-to candidate list
+ * for multi-chat users.
+ *
+ * Used by the topbar Jump-to palette to surface waiting NHAs alongside
+ * chats and agents.
+ */
+export async function listMyAttentions(): Promise<Attention[]> {
+  const qs = new URLSearchParams({ state: "open", limit: "200" });
+  return api.get<Attention[]>(`/attention?${qs.toString()}`);
+}

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -36,7 +36,7 @@ export function Layout() {
   }, []);
 
   const location = useLocation();
-  const isWorkspace = location.pathname === "/" || location.search.includes("a=");
+  const isWorkspace = location.pathname === "/";
   // Settings owns its own two-column (sidebar + main) layout and centres a
   // ~1160 wrapper instead of the default 960 canvas — let it manage its
   // own width.

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
@@ -18,6 +18,22 @@ const navTabs = [
 
 export function Layout() {
   const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // ⌘K / Ctrl+K to open the Jump-to palette from anywhere. Listens at
+  // window-level so the shortcut survives inside textareas / editable
+  // surfaces; that mirrors how Linear / GitHub / Slack treat their global
+  // command palette and matches the existing "Jump to…" affordance, which
+  // is the only top-bar control reachable without a click.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setPaletteOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   const location = useLocation();
   const isWorkspace = location.pathname === "/" || location.search.includes("a=");
@@ -142,7 +158,20 @@ export function Layout() {
               }}
             >
               <Search className="h-4 w-4" />
-              <span>Jump to…</span>
+              <span className="flex-1 text-left">Jump to…</span>
+              <span
+                aria-hidden
+                className="text-caption font-mono"
+                style={{
+                  padding: "var(--sp-0_5) var(--sp-1_5)",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--sp-1)",
+                  color: "var(--fg-3)",
+                  background: "var(--bg-raised)",
+                }}
+              >
+                ⌘K
+              </span>
             </button>
             <span
               style={{

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -492,9 +492,9 @@ export function AgentDetailPage() {
             <Button
               variant="ghost"
               size="xs"
-              onClick={() => navigate(`/?a=${agent.uuid}`)}
-              title="Open chat"
-              aria-label="Open chat"
+              onClick={() => navigate(`/agents/${encodeURIComponent(agent.uuid)}/profile`)}
+              title="Open profile"
+              aria-label="Open profile"
               style={{ paddingLeft: "var(--sp-1_5)", paddingRight: "var(--sp-1_5)" }}
             >
               <MessageSquare className="h-4 w-4" />

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { Bot, LayoutDashboard, MessageSquare } from "lucide-react";
+import { AlertCircle, Bot, LayoutDashboard, MessageSquare } from "lucide-react";
 import { useNavigate } from "react-router";
-import { getActivityOverview } from "../../../api/activity.js";
-import { listAgentSessions, type SessionListItem } from "../../../api/sessions.js";
+import { listMyAttentions, myAttentionsQueryKey } from "../../../api/attention.js";
+import { listMeChats } from "../../../api/me-chats.js";
 import {
   CommandDialog,
   CommandEmpty,
@@ -13,6 +13,7 @@ import {
   CommandSeparator,
 } from "../../../components/ui/command.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
+import { useOrgAgents } from "../../../lib/use-org-agents.js";
 
 const STATIC_ROUTES = [
   { path: "/", label: "Workspace" },
@@ -21,38 +22,53 @@ const STATIC_ROUTES = [
   { path: "/settings", label: "Settings" },
 ];
 
+/**
+ * Topbar "Jump to…" palette.
+ *
+ * Data sources are all pure-frontend reuses of existing per-resource
+ * endpoints — no aggregating backend route:
+ *   - Chats: `/me/chats` (default engagement, server-paged). Replaces the
+ *     prior per-agent `/agents/:uuid/sessions` fan-out, which issued one
+ *     request per managed agent.
+ *   - Agents: `useOrgAgents` (`/agents?limit=100`), the same cache used by
+ *     the participant picker and identity maps.
+ *   - NHA: `GET /attention?state=open` (no chat filter), which the
+ *     user-JWT route already scopes to the caller's human agent identities.
+ *
+ * Filtering is handled by `cmdk` — each item's `value` is a space-joined
+ * string of every searchable token, and cmdk fuzzy-matches against it.
+ */
 export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const navigate = useNavigate();
   const agentName = useAgentNameMap();
 
-  const { data: activity } = useQuery({
-    queryKey: ["activity"],
-    queryFn: getActivityOverview,
+  const { data: orgAgents } = useOrgAgents();
+  const agents = orgAgents?.items ?? [];
+
+  const { data: chatsResp } = useQuery({
+    // Prefix-aligned with conversations-page invalidations
+    // (`["me", "chats"]` is the family every chat mutation invalidates —
+    // new-chat-draft, row-engagement-menu, etc.) so creating / archiving
+    // a chat refreshes the palette without waiting on staleTime.
+    // `"palette"` keeps this fetch's cache distinct from the multi-filter
+    // entries the conversations rail writes.
+    //
+    // `engagement: "all"` lets jump-to reach archived chats too — finding
+    // an old conversation is a common reason to open the palette.
+    queryKey: ["me", "chats", "palette"],
+    queryFn: () => listMeChats({ limit: 100, engagement: "all" }),
     enabled: open,
     staleTime: 30_000,
   });
+  const chats = chatsResp?.rows ?? [];
 
-  const agents = activity?.agents ?? [];
-
-  const sessionQueries = useQuery({
-    queryKey: ["palette-sessions", agents.map((a) => a.agentId).join(",")],
-    queryFn: async () => {
-      const results: Array<{ agentId: string; session: SessionListItem }> = [];
-      for (const a of agents) {
-        try {
-          const list = await listAgentSessions(a.agentId);
-          for (const s of list) results.push({ agentId: a.agentId, session: s });
-        } catch {
-          // per-agent failure is fine — skip
-        }
-      }
-      return results;
-    },
-    enabled: open && agents.length > 0,
+  const { data: attentions } = useQuery({
+    queryKey: myAttentionsQueryKey,
+    queryFn: listMyAttentions,
+    enabled: open,
     staleTime: 30_000,
   });
-
-  const sessions = sessionQueries.data ?? [];
+  const nhas = attentions ?? [];
 
   const go = (url: string) => {
     onOpenChange(false);
@@ -61,46 +77,69 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandInput placeholder="Jump to agent, chat, or page…" />
+      <CommandInput placeholder="Jump to chat, agent, or NHA…" />
       <CommandList>
         <CommandEmpty>No results</CommandEmpty>
 
-        {agents.length > 0 && (
-          <CommandGroup heading="Agents">
-            {agents.map((a) => {
-              const name = agentName(a.agentId);
+        {chats.length > 0 && (
+          <CommandGroup heading="Chats">
+            {chats.map((c) => {
+              // Participant names give cmdk extra search tokens — typing a
+              // teammate's name surfaces the 1:1 chats and group chats that
+              // include them, even when the chat's own title doesn't.
+              const participantNames = c.participants.map((p) => p.displayName).join(" ");
               return (
                 <CommandItem
-                  key={a.agentId}
-                  value={`agent ${name} ${a.agentId}`}
-                  onSelect={() => go(`/?a=${a.agentId}`)}
+                  key={c.chatId}
+                  value={`chat ${c.title} ${c.topic ?? ""} ${participantNames} ${c.chatId}`}
+                  onSelect={() => go(`/?c=${encodeURIComponent(c.chatId)}`)}
                 >
-                  <Bot className="mr-2 h-4 w-4 shrink-0 opacity-70" />
-                  <span className="flex-1 truncate">{name}</span>
-                  <span className="text-caption text-muted-foreground font-mono ml-2">{a.agentId.slice(0, 8)}</span>
+                  <MessageSquare className="mr-2 h-4 w-4 shrink-0 opacity-70" />
+                  <span className="flex-1 truncate">{c.title || "(untitled)"}</span>
+                  {c.topic ? (
+                    <span className="text-caption text-muted-foreground ml-2 truncate max-w-[40%]">{c.topic}</span>
+                  ) : null}
+                  <span className="text-caption text-muted-foreground font-mono ml-2">{c.chatId.slice(0, 8)}</span>
                 </CommandItem>
               );
             })}
           </CommandGroup>
         )}
 
-        {sessions.length > 0 && (
+        {agents.length > 0 && (
           <>
             <CommandSeparator />
-            <CommandGroup heading="Chats">
-              {sessions.map(({ agentId, session }) => {
-                const name = agentName(agentId);
+            <CommandGroup heading="Agents">
+              {agents.map((a) => (
+                <CommandItem
+                  key={a.uuid}
+                  value={`agent ${a.displayName} ${a.name ?? ""} ${a.uuid}`}
+                  onSelect={() => go(`/agents/${encodeURIComponent(a.uuid)}/profile`)}
+                >
+                  <Bot className="mr-2 h-4 w-4 shrink-0 opacity-70" />
+                  <span className="flex-1 truncate">{a.displayName}</span>
+                  {a.name ? <span className="text-caption text-muted-foreground ml-2">@{a.name}</span> : null}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {nhas.length > 0 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Needs your reply">
+              {nhas.map((n) => {
+                const from = agentName(n.originAgentId);
                 return (
                   <CommandItem
-                    key={`${agentId}-${session.chatId}`}
-                    value={`chat ${name} ${session.chatId}`}
-                    onSelect={() => go(`/?a=${agentId}&c=${session.chatId}`)}
+                    key={n.id}
+                    value={`nha attention ${n.subject} ${n.body} ${from} ${n.id}`}
+                    onSelect={() => go(`/?c=${encodeURIComponent(n.originChatId)}`)}
                   >
-                    <MessageSquare className="mr-2 h-4 w-4 shrink-0 opacity-70" />
-                    <span className="flex-1 truncate">{name}</span>
-                    <span className="text-caption text-muted-foreground font-mono ml-2">
-                      {session.chatId.slice(0, 8)}
-                    </span>
+                    <AlertCircle className="mr-2 h-4 w-4 shrink-0 text-warn" />
+                    <span className="flex-1 truncate">{n.subject}</span>
+                    <span className="text-caption text-muted-foreground ml-2 truncate max-w-[35%]">from {from}</span>
                   </CommandItem>
                 );
               })}


### PR DESCRIPTION
Reopens #643 after branch rename `yzw/jump-to-redesign` → `feat/jump-to-palette` (CI's branch-name convention check rejected the old name; GitHub's branch-rename API closed the PR instead of migrating the head ref). Same two commits, same review history — see #643 for the original review thread.

## Summary

Expands the topbar Jump-to palette from `agents + chats + pages` to **chats + agents + NHA + pages**, with a ⌘K shortcut and corrected jump targets.

Frontend-only refactor — no backend changes, no schema changes.

### Data sources

| Group | Before | After |
| --- | --- | --- |
| Chats | per-agent fan-out `/agents/:uuid/sessions` (N+1) | single `/me/chats?engagement=all&limit=100` |
| Agents | `/activity` overview (separate cache) | shared `useOrgAgents` (`/agents?limit=100`) |
| NHA | — | `/attention?state=open&limit=200` (reuses existing user-JWT route, caller-scoped server-side) |
| Pages | static | unchanged |

### Jump targets

- Chat → `/?c=<chatId>` (selects the chat)
- Agent → `/agents/:uuid/profile`
- NHA → `/?c=<originChatId>` (lands in the chat that owns the NHA)

### Other

- Window-level **⌘K / Ctrl+K** shortcut. Topbar button gains a `⌘K` kbd hint.
- Palette `queryKey` aligned with `["me", "chats"]` family so existing chat mutations refresh palette results immediately.
- Follow-on cleanup (commit `44f650e`) addresses sibling `?a=` callers flagged in #643 review:
  - `agent-detail.tsx` Open-chat button now navigates to `/agents/:uuid/profile` (label updated to "Open profile")
  - `layout.tsx` removes the dead `search.includes("a=")` branch from `isWorkspace`

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) passes
- [x] `pnpm --filter @first-tree/web build` (Vite production) passes
- [x] Biome clean on changed files
- [x] `pnpm --filter @first-tree/web dev` boots; modified modules are served and transform-clean
- [ ] **Manual UI smoke** (reviewer):
  - [ ] ⌘K opens palette from any page; ⌘K again closes
  - [ ] Typing matches chats by title, topic, participants, or chat id prefix
  - [ ] Typing matches agents by display name, @handle, or uuid prefix
  - [ ] Open NHAs appear under "Needs your reply", searchable by subject / body / originator
  - [ ] Selecting each row navigates to the documented target
  - [ ] Archived chats are reachable from the palette
  - [ ] No console errors on open / type / select

## Out of scope (deferred follow-up)

- NHA `limit=200` server-cap truncation hint (#643 review note #3)
- Pinyin first-letter matching for Chinese agent names
- Prefix filters (`@`, `#`, `!`)
- Recents group (localStorage)
- NHA scroll-to-card after jump
- Cross-platform `⌘K` vs `Ctrl K` hint string

🤖 Generated with [Claude Code](https://claude.com/claude-code)