### PR TITLE
feat(agent): per-agent reasoning effort config (#626)

### DIFF
--- a/apps/cli/src/__tests__/agent-config-cli.test.ts
+++ b/apps/cli/src/__tests__/agent-config-cli.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { registerAgentConfigCommands } from "../commands/agent/config/index.js";
 
 describe("agent config CLI registration (Step 8)", () => {
-  it("registers all 7 subcommands under `config`", () => {
+  it("registers all 8 subcommands under `config`", () => {
     const root = new Command();
     const agent = root.command("agent");
     registerAgentConfigCommands(agent);
@@ -11,7 +11,16 @@ describe("agent config CLI registration (Step 8)", () => {
     const configCmd = agent.commands.find((c) => c.name() === "config");
     expect(configCmd).toBeDefined();
     const subs = configCmd?.commands.map((c) => c.name()).sort();
-    expect(subs).toEqual(["add-mcp", "add-repo", "append-prompt", "dry-run", "set-env", "set-model", "show"]);
+    expect(subs).toEqual([
+      "add-mcp",
+      "add-repo",
+      "append-prompt",
+      "dry-run",
+      "set-env",
+      "set-model",
+      "set-reasoning-effort",
+      "show",
+    ]);
   });
 
   it("set-env requires KEY=VALUE", () => {

--- a/apps/cli/src/commands/agent/config/_shared/fetchers.ts
+++ b/apps/cli/src/commands/agent/config/_shared/fetchers.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeConfig, AgentRuntimeConfigPayload } from "@first-tree/shared";
+import type { AgentRuntimeConfig, AgentRuntimeConfigPatch } from "@first-tree/shared";
 import { fail } from "../../../../cli/output.js";
 import { cliFetch } from "../../../../core/cli-fetch.js";
 import { type ResolvedAgent, resolveAgent } from "../../../_shared/resolve-agent.js";
@@ -54,7 +54,7 @@ export async function patchConfig(
   adminToken: string,
   agentId: string,
   expectedVersion: number,
-  patch: Partial<AgentRuntimeConfigPayload>,
+  patch: AgentRuntimeConfigPatch,
 ): Promise<AgentRuntimeConfig> {
   return adminFetch<AgentRuntimeConfig>(`${serverUrl}/api/v1/agents/${agentId}/config`, {
     method: "PATCH",
@@ -67,6 +67,7 @@ export function printConfig(cfg: AgentRuntimeConfig): void {
   process.stdout.write(`Agent: ${cfg.agentId}\n`);
   process.stdout.write(`Version: ${cfg.version} (updated ${cfg.updatedAt} by ${cfg.updatedBy})\n`);
   process.stdout.write(`\nModel:    ${cfg.payload.model || "(unset)"}\n`);
+  process.stdout.write(`Reasoning effort: ${cfg.payload.reasoningEffort || "(unset — inherits local effortLevel)"}\n`);
   process.stdout.write(`Prompt append: ${cfg.payload.prompt.append ? "(set)" : "(empty)"}\n`);
   if (cfg.payload.prompt.append) process.stdout.write(`  > ${cfg.payload.prompt.append.replace(/\n/g, "\n  > ")}\n`);
   process.stdout.write(`\nMCP servers (${cfg.payload.mcpServers.length}):\n`);

--- a/apps/cli/src/commands/agent/config/index.ts
+++ b/apps/cli/src/commands/agent/config/index.ts
@@ -5,6 +5,7 @@ import { registerAgentConfigAppendPromptCommand } from "./append-prompt.js";
 import { registerAgentConfigDryRunCommand } from "./dry-run.js";
 import { registerAgentConfigSetEnvCommand } from "./set-env.js";
 import { registerAgentConfigSetModelCommand } from "./set-model.js";
+import { registerAgentConfigSetReasoningEffortCommand } from "./set-reasoning-effort.js";
 import { registerAgentConfigShowCommand } from "./show.js";
 
 /**
@@ -16,6 +17,7 @@ export function registerAgentConfigCommands(parent: Command): void {
   const config = parent.command("config").description("Manage agent runtime configuration (Step 8)");
   registerAgentConfigShowCommand(config);
   registerAgentConfigSetModelCommand(config);
+  registerAgentConfigSetReasoningEffortCommand(config);
   registerAgentConfigAppendPromptCommand(config);
   registerAgentConfigAddMcpCommand(config);
   registerAgentConfigSetEnvCommand(config);

--- a/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
+++ b/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+import { success } from "../../../cli/output.js";
+import { ensureFreshAdminToken, resolveServerUrl } from "../../../core/bootstrap.js";
+import { getCurrent, patchConfig, resolveAgentRecord } from "./_shared/fetchers.js";
+
+export function registerAgentConfigSetReasoningEffortCommand(config: Command): void {
+  config
+    .command("set-reasoning-effort <agent> <level>")
+    .description(
+      'Set reasoning effort. claude-code: "" (inherit local) | low | medium | high | max. codex: low | medium | high | xhigh.',
+    )
+    .action(async (agentName: string, level: string) => {
+      const serverUrl = resolveServerUrl(process.env.FIRST_TREE_SERVER_URL);
+      const adminToken = await ensureFreshAdminToken();
+      const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
+      const current = await getCurrent(serverUrl, adminToken, uuid);
+      // The value set is provider-specific; the server validates `level`
+      // against the agent's runtime provider and rejects out-of-range values
+      // with a 400.
+      const updated = await patchConfig(serverUrl, adminToken, uuid, current.version, { reasoningEffort: level });
+      success({ agentId: updated.agentId, version: updated.version, reasoningEffort: updated.payload.reasoningEffort });
+    });
+}

--- a/packages/client/src/__tests__/agent-config-cache.test.ts
+++ b/packages/client/src/__tests__/agent-config-cache.test.ts
@@ -14,6 +14,7 @@ function makeConfig(version: number, urls: string[] = []): AgentRuntimeConfig {
       mcpServers: [],
       env: [],
       gitRepos: urls.map((url) => ({ url })),
+      reasoningEffort: "",
     },
     updatedAt: new Date().toISOString(),
     updatedBy: "test",

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -93,6 +93,7 @@ function makeSdk(options?: { agent?: RegisterResult; configError?: unknown }): F
           mcpServers: [],
           env: [],
           gitRepos: [],
+          reasoningEffort: "",
         },
         updatedAt: "2026-01-01T00:00:00.000Z",
         updatedBy: "user-1",

--- a/packages/client/src/__tests__/claude-code-config.test.ts
+++ b/packages/client/src/__tests__/claude-code-config.test.ts
@@ -10,6 +10,7 @@ describe("claude-code handler helpers (Step 6)", () => {
         model: "",
         env: [],
         gitRepos: [],
+        reasoningEffort: "",
         mcpServers: [{ name: "echo", transport: "stdio", command: "/bin/echo", args: ["-n", "hi"] }],
       });
       expect(out.echo).toEqual({ type: "stdio", command: "/bin/echo", args: ["-n", "hi"] });
@@ -22,6 +23,7 @@ describe("claude-code handler helpers (Step 6)", () => {
         model: "",
         env: [],
         gitRepos: [],
+        reasoningEffort: "",
         mcpServers: [
           { name: "remote", transport: "http", url: "https://x.example/y", headers: { Authorization: "Bearer t" } },
         ],
@@ -40,6 +42,7 @@ describe("claude-code handler helpers (Step 6)", () => {
         model: "",
         env: [],
         gitRepos: [],
+        reasoningEffort: "",
         mcpServers: [{ name: "sse-srv", transport: "sse", url: "https://x.example/sse" }],
       });
       expect(out["sse-srv"]).toEqual({ type: "sse", url: "https://x.example/sse", headers: undefined });
@@ -53,6 +56,7 @@ describe("claude-code handler helpers (Step 6)", () => {
           model: "",
           env: [],
           gitRepos: [],
+          reasoningEffort: "",
           mcpServers: [],
         }),
       ).toEqual({});

--- a/packages/client/src/__tests__/claude-query-options.test.ts
+++ b/packages/client/src/__tests__/claude-query-options.test.ts
@@ -1,0 +1,51 @@
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { buildClaudeQueryOptions } from "../handlers/claude-code.js";
+
+function claudePayload(
+  overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "claude-code" }>> = {},
+): AgentRuntimeConfigPayload {
+  return {
+    kind: "claude-code",
+    prompt: { append: "" },
+    model: "opus",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    reasoningEffort: "",
+    ...overrides,
+  };
+}
+
+describe("buildClaudeQueryOptions", () => {
+  it("returns an empty slice when there is no payload and no append", () => {
+    expect(buildClaudeQueryOptions(undefined, "")).toEqual({});
+  });
+
+  it("omits `effort` when reasoningEffort is '' (inherit the local effortLevel)", () => {
+    const opts = buildClaudeQueryOptions(claudePayload({ reasoningEffort: "" }), "");
+    expect("effort" in opts).toBe(false);
+  });
+
+  it("passes `effort` explicitly when a value is configured (overrides local)", () => {
+    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "low" }), "").effort).toBe("low");
+    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "max" }), "").effort).toBe("max");
+  });
+
+  it("maps model, systemPrompt append, and mcpServers from the payload", () => {
+    const opts = buildClaudeQueryOptions(
+      claudePayload({
+        model: "sonnet",
+        mcpServers: [{ name: "demo", transport: "stdio", command: "echo" }],
+      }),
+      "extra instructions",
+    );
+    expect(opts.model).toBe("sonnet");
+    expect(opts.systemPrompt).toEqual({ type: "preset", preset: "claude_code", append: "extra instructions" });
+    expect(opts.mcpServers).toEqual({ demo: { type: "stdio", command: "echo", args: undefined } });
+  });
+
+  it("omits model when empty (defers to SDK / local settings)", () => {
+    expect("model" in buildClaudeQueryOptions(claudePayload({ model: "" }), "")).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/codex-thread-options.test.ts
+++ b/packages/client/src/__tests__/codex-thread-options.test.ts
@@ -12,7 +12,9 @@ import { buildCodexThreadOptions } from "../handlers/codex.js";
  * regression here would silently break ChatGPT-auth users at first turn
  * (the symptom we hit before this fix: "turn completed with no message").
  */
-function basePayload(overrides: Partial<AgentRuntimeConfigPayload> = {}): AgentRuntimeConfigPayload {
+function basePayload(
+  overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "codex" }>> = {},
+): AgentRuntimeConfigPayload {
   return {
     kind: "codex",
     prompt: { append: "" },
@@ -20,6 +22,7 @@ function basePayload(overrides: Partial<AgentRuntimeConfigPayload> = {}): AgentR
     mcpServers: [],
     env: [],
     gitRepos: [],
+    reasoningEffort: "high",
     ...overrides,
   };
 }
@@ -41,9 +44,19 @@ describe("buildCodexThreadOptions", () => {
     expect(opts.skipGitRepoCheck).toBe(true);
     expect(opts.sandboxMode).toBe("workspace-write");
     expect(opts.approvalPolicy).toBe("never");
-    // Footgun F3: minimal reasoning is incompatible with default tools.
+    // Default reasoning effort for codex agents is "high" (footgun F3: minimal
+    // reasoning is incompatible with default tools and is excluded entirely).
     expect(opts.modelReasoningEffort).toBe("high");
     expect(opts.webSearchEnabled).toBe(false);
+  });
+
+  it("passes the operator-configured reasoning effort through to the SDK", () => {
+    expect(buildCodexThreadOptions(basePayload({ reasoningEffort: "medium" }), "/tmp/wsk").modelReasoningEffort).toBe(
+      "medium",
+    );
+    expect(buildCodexThreadOptions(basePayload({ reasoningEffort: "xhigh" }), "/tmp/wsk").modelReasoningEffort).toBe(
+      "xhigh",
+    );
   });
 
   it("derives additionalDirectories from gitRepos (with deriveRepoLocalPath fallback)", () => {

--- a/packages/client/src/__tests__/document-base-path.test.ts
+++ b/packages/client/src/__tests__/document-base-path.test.ts
@@ -11,7 +11,15 @@ import {
 } from "../runtime/session-manager.js";
 
 function payload(gitRepos: AgentRuntimeConfigPayload["gitRepos"]): AgentRuntimeConfigPayload {
-  return { kind: "claude-code", prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos };
+  return {
+    kind: "claude-code",
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos,
+    reasoningEffort: "",
+  };
 }
 
 const PER_CHAT = "/data/workspaces/agent/chat-123";

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -98,6 +98,7 @@ function runtimeConfig(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntim
       mcpServers: [],
       env: [],
       gitRepos: [],
+      reasoningEffort: "",
     },
     ...overrides,
   };
@@ -346,6 +347,7 @@ describe("SessionManager edge coverage", () => {
         mcpServers: [],
         env: [],
         gitRepos: [{ url: "https://github.com/acme/project.git", localPath: "src/project" }],
+        reasoningEffort: "",
       },
     });
     const cache = makeCache({
@@ -833,6 +835,7 @@ describe("SessionManager edge coverage", () => {
           mcpServers: [],
           env: [],
           gitRepos: [{ url: "https://github.com/acme/project.git", localPath: "project" }],
+          reasoningEffort: "",
         },
       }),
     });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -5,6 +5,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   CanUseTool,
+  EffortLevel,
   McpServerConfig,
   PermissionMode,
   PermissionResult,
@@ -506,6 +507,41 @@ export function mapMcpServers(payload: AgentRuntimeConfigPayload): Record<string
   return out;
 }
 
+/** Payload-derived slice of the Claude Code SDK query options. */
+export type ClaudeQueryConfigOptions = {
+  model?: string;
+  systemPrompt?: { type: "preset"; preset: "claude_code"; append: string };
+  mcpServers?: Record<string, McpServerConfig>;
+  effort?: EffortLevel;
+};
+
+/**
+ * Build the config-derived slice of the SDK query options (model, systemPrompt
+ * append, MCP servers, reasoning effort). Kept pure and exported so these
+ * mappings are unit-testable; the session-bound options (env, canUseTool,
+ * abortController, sessionId/resume) stay inline in `buildQuery`.
+ *
+ * Reasoning effort: the claude variant's `""` is an inherit sentinel — when
+ * set we omit the `effort` option so the SDK falls back to the operator's local
+ * `~/.claude/settings.json` effortLevel (preserving pre-feature behavior). A
+ * non-empty value is passed explicitly and overrides that local setting.
+ */
+export function buildClaudeQueryOptions(
+  payload: AgentRuntimeConfigPayload | undefined,
+  combinedAppend: string,
+): ClaudeQueryConfigOptions {
+  const options: ClaudeQueryConfigOptions = {};
+  if (payload?.model) options.model = payload.model;
+  if (combinedAppend.length > 0) {
+    options.systemPrompt = { type: "preset", preset: "claude_code", append: combinedAppend };
+  }
+  if (payload?.mcpServers.length) options.mcpServers = mapMcpServers(payload);
+  if (payload?.kind === "claude-code" && payload.reasoningEffort) {
+    options.effort = payload.reasoningEffort;
+  }
+  return options;
+}
+
 /**
  * Decide whether a model swap can use `query.setModel()` (in-flight, ~0ms)
  * vs needing a `resume` restart (~5–10s cold start).
@@ -837,11 +873,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // other tools auto-allow. See buildAskUserCanUseTool.
         canUseTool: buildAskUserCanUseTool(sessionCtx),
         ...(claudeCodeExecutable ? { pathToClaudeCodeExecutable: claudeCodeExecutable } : {}),
-        ...(payload?.model ? { model: payload.model } : {}),
-        ...(combinedAppend.length > 0
-          ? { systemPrompt: { type: "preset", preset: "claude_code", append: combinedAppend } }
-          : {}),
-        ...(payload?.mcpServers.length ? { mcpServers: mapMcpServers(payload) } : {}),
+        // model / systemPrompt / mcpServers / effort — the config-derived slice.
+        // `effort: ""` (inherit) is omitted so the SDK uses the local effortLevel.
+        ...buildClaudeQueryOptions(payload, combinedAppend),
       },
     });
   }

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -255,7 +255,11 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
     skipGitRepoCheck: true,
     sandboxMode: "workspace-write",
     approvalPolicy: "never",
-    modelReasoningEffort: "high",
+    // Operator-configured reasoning effort. Defaults to "high" (the value this
+    // previously hard-coded). The codex variant's enum (low|medium|high|xhigh)
+    // is a subset of the SDK's ModelReasoningEffort and deliberately omits
+    // "minimal", which is incompatible with the default tool set (footgun F3).
+    modelReasoningEffort: payload.kind === "codex" ? payload.reasoningEffort : "high",
     webSearchEnabled: false,
     additionalDirectories,
   };
@@ -1052,6 +1056,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
           mcpServers: [],
           env: [],
           gitRepos: [],
+          reasoningEffort: "high",
         };
       }
 
@@ -1099,6 +1104,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
           mcpServers: [],
           env: [],
           gitRepos: [],
+          reasoningEffort: "high",
         };
       }
 

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -87,6 +87,7 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
             mcpServers: [],
             env: [],
             gitRepos: [],
+            reasoningEffort: "",
           },
           updatedAt: "",
           updatedBy: "",

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -94,6 +94,39 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(payload.mcpServers).toEqual([{ name: "demo", transport: "stdio", command: "echo" }]);
   });
 
+  it("reasoning effort: defaults to '', persists a valid value, rejects a codex-only value with 400", async () => {
+    const app = getApp();
+    const req = await authedRequest(app);
+    const agent = await (await seedAgentFactory(app))({
+      name: `cfg-effort-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+    });
+
+    // A fresh claude-code agent defaults to "" (inherit the local effortLevel).
+    const before = await req("GET", `/api/v1/agents/${agent.uuid}/config`);
+    expect(before.json().payload.reasoningEffort).toBe("");
+
+    // A valid claude value is accepted and persisted.
+    const ok = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 1,
+      payload: { reasoningEffort: "max" },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(ok.json().payload.reasoningEffort).toBe("max");
+    await app.configService.flush(agent.uuid);
+
+    const after = await req("GET", `/api/v1/agents/${agent.uuid}/config`);
+    expect(after.json().payload.reasoningEffort).toBe("max");
+
+    // A codex-only value is rejected for a claude agent: the merged payload
+    // fails the tagged-union re-parse in commitWrite → ZodError → 400.
+    const bad = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 2,
+      payload: { reasoningEffort: "xhigh" },
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
   it("PATCH with stale expectedVersion returns 409", async () => {
     const app = getApp();
     const req = await authedRequest(app);

--- a/packages/server/src/services/config-service.ts
+++ b/packages/server/src/services/config-service.ts
@@ -1,6 +1,7 @@
 import {
   type AgentRuntimeConfig,
   type AgentRuntimeConfigDryRunResult,
+  type AgentRuntimeConfigPatch,
   type AgentRuntimeConfigPayload,
   agentRuntimeConfigPayloadSchema,
   ENV_REDACTED_PLACEHOLDER,
@@ -25,7 +26,7 @@ type PendingWrite = {
   awaiters: Array<{
     resolve: (cfg: AgentRuntimeConfig) => void;
     reject: (err: unknown) => void;
-    patch: Partial<AgentRuntimeConfigPayload>;
+    patch: AgentRuntimeConfigPatch;
     expectedVersion: number;
     updatedBy: string;
   }>;
@@ -37,7 +38,7 @@ export type ConfigService = {
   /** Get with sensitive env values decrypted — for runtime injection only. */
   getDecrypted(agentId: string): Promise<AgentRuntimeConfig>;
   update(agentId: string, patch: UpdateAgentRuntimeConfig, updatedBy: string): Promise<AgentRuntimeConfig>;
-  dryRun(agentId: string, patch: Partial<AgentRuntimeConfigPayload>): Promise<AgentRuntimeConfigDryRunResult>;
+  dryRun(agentId: string, patch: AgentRuntimeConfigPatch): Promise<AgentRuntimeConfigDryRunResult>;
   /** For tests: flush pending debounced writes immediately. */
   flush(agentId?: string): Promise<void>;
 };
@@ -109,10 +110,7 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
    *     when present in the patch; partial-list edits are an explicit non-goal
    *     for M1 (admins resend the full list — matches the Web form).
    */
-  function applyPatch(
-    current: AgentRuntimeConfigPayload,
-    patch: Partial<AgentRuntimeConfigPayload>,
-  ): AgentRuntimeConfigPayload {
+  function applyPatch(current: AgentRuntimeConfigPayload, patch: AgentRuntimeConfigPatch): AgentRuntimeConfigPayload {
     const next = {
       // `kind` is pinned to `agents.runtime_provider` and never patchable
       // from the config side; preserve the current value here and let
@@ -123,6 +121,9 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
       mcpServers: patch.mcpServers ?? current.mcpServers,
       env: patch.env ? mergeEnv(current.env, patch.env) : current.env,
       gitRepos: patch.gitRepos ?? current.gitRepos,
+      // `patch.reasoningEffort` is a loose string; provider-correct values are
+      // enforced when `commitWrite` re-parses `next` against the tagged union.
+      reasoningEffort: patch.reasoningEffort ?? current.reasoningEffort,
     } as AgentRuntimeConfigPayload;
     return next;
   }
@@ -170,7 +171,7 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
 
   async function commitWrite(
     agentId: string,
-    patch: Partial<AgentRuntimeConfigPayload>,
+    patch: AgentRuntimeConfigPatch,
     expectedVersion: number,
     updatedBy: string,
   ): Promise<AgentRuntimeConfig> {
@@ -247,7 +248,7 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
 
     // Re-build the aggregated patch from only the valid awaiters' patches,
     // so a rejected caller's edit never leaks into the committed payload.
-    const aggregated: Partial<AgentRuntimeConfigPayload> = {};
+    const aggregated: AgentRuntimeConfigPatch = {};
     for (const a of valid) Object.assign(aggregated, a.patch);
 
     try {
@@ -368,7 +369,7 @@ function computeDiff(
   b: AgentRuntimeConfigPayload,
 ): AgentRuntimeConfigDryRunResult["diff"] {
   const out: AgentRuntimeConfigDryRunResult["diff"] = [];
-  const fields = ["prompt", "model", "mcpServers", "env", "gitRepos"] as const;
+  const fields = ["prompt", "model", "mcpServers", "env", "gitRepos", "reasoningEffort"] as const;
   for (const f of fields) {
     const before = a[f];
     const after = b[f];

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -101,6 +101,65 @@ describe("agent runtime config — codex defaults", () => {
   });
 });
 
+describe("agent runtime config — reasoning effort", () => {
+  it("claude default is '' (inherit local effortLevel); codex default is 'high'", () => {
+    expect(DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD.reasoningEffort).toBe("");
+    expect(DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD.reasoningEffort).toBe("high");
+  });
+
+  it("schema backfills the per-provider default when reasoningEffort is absent", () => {
+    // Mirrors how legacy rows (written before this field existed) parse.
+    expect(agentRuntimeConfigPayloadSchema.parse({ kind: "claude-code" }).reasoningEffort).toBe("");
+    expect(agentRuntimeConfigPayloadSchema.parse({ kind: "codex" }).reasoningEffort).toBe("high");
+  });
+
+  it("a legacy row with neither kind nor reasoningEffort parses as claude-code with ''", () => {
+    const parsed = agentRuntimeConfigPayloadSchema.parse({ model: "opus" });
+    expect(parsed.kind).toBe("claude-code");
+    expect(parsed.reasoningEffort).toBe("");
+  });
+
+  it("claude accepts low/medium/high/max and the '' inherit sentinel", () => {
+    for (const v of ["", "low", "medium", "high", "max"]) {
+      expect(agentRuntimeConfigPayloadSchema.parse({ kind: "claude-code", reasoningEffort: v }).reasoningEffort).toBe(
+        v,
+      );
+    }
+  });
+
+  it("claude rejects codex-only values (xhigh) and unknown values", () => {
+    expect(agentRuntimeConfigPayloadSchema.safeParse({ kind: "claude-code", reasoningEffort: "xhigh" }).success).toBe(
+      false,
+    );
+    expect(agentRuntimeConfigPayloadSchema.safeParse({ kind: "claude-code", reasoningEffort: "banana" }).success).toBe(
+      false,
+    );
+  });
+
+  it("codex accepts low/medium/high/xhigh", () => {
+    for (const v of ["low", "medium", "high", "xhigh"]) {
+      expect(agentRuntimeConfigPayloadSchema.parse({ kind: "codex", reasoningEffort: v }).reasoningEffort).toBe(v);
+    }
+  });
+
+  it("codex rejects minimal (breaks tools), claude-only max, and the '' sentinel", () => {
+    for (const v of ["minimal", "max", ""]) {
+      expect(agentRuntimeConfigPayloadSchema.safeParse({ kind: "codex", reasoningEffort: v }).success).toBe(false);
+    }
+  });
+
+  it("patch shape accepts reasoningEffort as a loose string (validity enforced on merge)", () => {
+    expect(updateAgentRuntimeConfigSchema.parse({ expectedVersion: 1, payload: { reasoningEffort: "low" } })).toEqual({
+      expectedVersion: 1,
+      payload: { reasoningEffort: "low" },
+    });
+    // Omitted → absent from the parsed patch (merge leaves the field untouched).
+    expect(
+      updateAgentRuntimeConfigSchema.parse({ expectedVersion: 1, payload: { model: "sonnet" } }).payload,
+    ).not.toHaveProperty("reasoningEffort");
+  });
+});
+
 describe("agent runtime config — git repo localPath safety", () => {
   it("accepts safe relative local paths", () => {
     expect(gitRepoSchema.parse({ url: "https://github.com/acme/repo.git", localPath: "repos/repo-1" })).toEqual({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -91,6 +91,7 @@ export {
 export {
   type AgentRuntimeConfig,
   type AgentRuntimeConfigDryRunResult,
+  type AgentRuntimeConfigPatch,
   type AgentRuntimeConfigPayload,
   agentRuntimeConfigDryRunResultSchema,
   agentRuntimeConfigPayloadSchema,

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -144,9 +144,21 @@ export const agentRuntimeConfigPayloadShape = z.object({
  */
 const claudeRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
   kind: z.literal("claude-code"),
+  // Maps to claude-agent-sdk Options.effort (the `--effort` flag). The empty
+  // string is an "inherit" sentinel: when set, the handler omits the effort
+  // option so the SDK falls back to the operator's local
+  // `~/.claude/settings.json` effortLevel (the pre-feature behavior). A
+  // non-empty value is passed explicitly and overrides that local setting —
+  // verified against cli.js, which resolves `effort ?? settings.effortLevel`.
+  reasoningEffort: z.enum(["", "low", "medium", "high", "max"]).default(""),
 });
 const codexRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
   kind: z.literal("codex"),
+  // Maps to codex-sdk ThreadOptions.modelReasoningEffort. Default "high"
+  // preserves the value the handler previously hardcoded. "minimal" is
+  // intentionally excluded — it is incompatible with the default tool set and
+  // breaks tool calls (see the codex handler's footgun notes).
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).default("high"),
 });
 
 const taggedPayloadUnion = z.discriminatedUnion("kind", [
@@ -227,6 +239,7 @@ export const DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
   mcpServers: [],
   env: [],
   gitRepos: [],
+  reasoningEffort: "",
 };
 
 /**
@@ -242,6 +255,7 @@ export const DEFAULT_CODEX_RUNTIME_CONFIG_PAYLOAD: AgentRuntimeConfigPayload = {
   mcpServers: [],
   env: [],
   gitRepos: [],
+  reasoningEffort: "high",
 };
 
 /**
@@ -292,6 +306,12 @@ const agentRuntimeConfigPatchShape = z
     mcpServers: z.array(mcpServerSchema),
     env: z.array(envEntrySchema),
     gitRepos: z.array(gitRepoSchema),
+    // Loose `z.string()` here (like `model`), not a per-provider enum: the
+    // patch shape is flat and provider-agnostic, while the allowed values
+    // differ per provider. Validity is enforced when the merged payload is
+    // re-parsed against the tagged union in `commitWrite` — an out-of-range
+    // value (e.g. "max" for codex, "xhigh" for claude) is rejected there.
+    reasoningEffort: z.string(),
   })
   .partial();
 
@@ -306,6 +326,15 @@ export const updateAgentRuntimeConfigSchema = z.object({
   payload: agentRuntimeConfigPatchShape,
 });
 export type UpdateAgentRuntimeConfig = z.infer<typeof updateAgentRuntimeConfigSchema>;
+
+/**
+ * The patch half of an update — every payload field optional, and
+ * `reasoningEffort` typed as a loose `string` (not the per-provider enum). Use
+ * this for merge helpers instead of `Partial<AgentRuntimeConfigPayload>`: the
+ * latter is a partial of the tagged union, so its `reasoningEffort` narrows to
+ * each variant's enum and a flat patch string fails to assign.
+ */
+export type AgentRuntimeConfigPatch = UpdateAgentRuntimeConfig["payload"];
 
 export const dryRunAgentRuntimeConfigSchema = z.object({
   payload: agentRuntimeConfigPatchShape,

--- a/packages/web/src/api/agent-config.ts
+++ b/packages/web/src/api/agent-config.ts
@@ -1,7 +1,7 @@
 import type {
   AgentRuntimeConfig,
   AgentRuntimeConfigDryRunResult,
-  AgentRuntimeConfigPayload,
+  AgentRuntimeConfigPatch,
   UpdateAgentRuntimeConfig,
 } from "@first-tree/shared";
 import { api } from "./client.js";
@@ -19,7 +19,7 @@ export function updateAgentConfig(agentId: string, body: UpdateAgentRuntimeConfi
 }
 
 export type DryRunResult = AgentRuntimeConfigDryRunResult;
-export function dryRunAgentConfig(agentId: string, payload: Partial<AgentRuntimeConfigPayload>): Promise<DryRunResult> {
+export function dryRunAgentConfig(agentId: string, payload: AgentRuntimeConfigPatch): Promise<DryRunResult> {
   return api.post<DryRunResult>(`/agents/${agentId}/config/dry-run`, { payload });
 }
 

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -44,6 +44,7 @@ import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redire
 const SECTION_TO_TAB: Record<DraftSectionName, string> = {
   prompt: "prompt",
   model: "setup",
+  effort: "setup",
   mcp: "tools",
   env: "resources",
   git: "resources",

--- a/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.ts
@@ -11,6 +11,7 @@ const config: AgentRuntimeConfig = {
     kind: "claude-code",
     prompt: { append: "Be precise." },
     model: "sonnet",
+    reasoningEffort: "high",
     mcpServers: [{ name: "demo", transport: "stdio", command: "echo", args: ["ok"] }],
     env: [{ key: "FOO", value: "bar", sensitive: false }],
     gitRepos: [{ url: "https://github.com/acme/repo.git", localPath: "repo" }],
@@ -23,6 +24,7 @@ describe("createConfigDraft", () => {
 
     expect(draft.promptAppend).toBe("Be precise.");
     expect(draft.model).toBe("sonnet");
+    expect(draft.reasoningEffort).toBe("high");
     expect(draft.mcp).toEqual([
       {
         key: "mcp-1",

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -1,16 +1,15 @@
 import type { RuntimeProvider } from "@first-tree/shared";
-import { Check, ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo } from "react";
 import { Button } from "../../components/ui/button.js";
 import { ConfigRow } from "./flat-section.js";
+import { ChangedChip, OptionDropdown, type SelectOption } from "./option-dropdown.js";
 
 /**
  * Model — an inline dropdown with a "changed" hint and Revert. No inline save:
  * the page Save Bar handles submission.
  */
 
-export type ModelOption = { value: string; label: string; hint?: string };
+export type ModelOption = SelectOption;
 
 export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
   { value: "opus", label: "opus", hint: "most capable" },
@@ -87,157 +86,7 @@ export function ModelSection({
         ) : null
       }
     >
-      <ModelDropdown items={items} value={value} onChange={onChange} disabled={disabled} />
+      <OptionDropdown items={items} value={value} onChange={onChange} disabled={disabled} />
     </ConfigRow>
-  );
-}
-
-function ChangedChip() {
-  return (
-    <span
-      className="mono uppercase text-caption"
-      style={{
-        padding: "var(--hairline) var(--sp-1_5)",
-        borderRadius: "var(--radius-chip)",
-        background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
-        color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
-      }}
-    >
-      changed
-    </span>
-  );
-}
-
-/**
- * Custom listbox-style dropdown — built on top of a button + absolutely
- * positioned listbox so we can theme the popup (native `<select>` popups are
- * OS-controlled and unstylable). Anchors to the trigger via `top: 100%`,
- * dismisses on click-outside or Escape.
- */
-function ModelDropdown({
-  items,
-  value,
-  onChange,
-  disabled,
-}: {
-  items: ModelOption[];
-  value: string;
-  onChange: (v: string) => void;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [popupRect, setPopupRect] = useState<{ top: number; left: number; width: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const popupRef = useRef<HTMLDivElement | null>(null);
-  const selected = items.find((o) => o.value === value) ?? items[0];
-
-  const computePosition = useCallback(() => {
-    const t = triggerRef.current;
-    if (!t) return;
-    const r = t.getBoundingClientRect();
-    setPopupRect({ top: r.bottom + 4, left: r.left, width: r.width });
-  }, []);
-
-  useLayoutEffect(() => {
-    if (!open) return;
-    computePosition();
-  }, [open, computePosition]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (e: PointerEvent) => {
-      const target = e.target as Node;
-      if (triggerRef.current?.contains(target)) return;
-      if (popupRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    const onReflow = () => computePosition();
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKey);
-    window.addEventListener("scroll", onReflow, true);
-    window.addEventListener("resize", onReflow);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKey);
-      window.removeEventListener("scroll", onReflow, true);
-      window.removeEventListener("resize", onReflow);
-    };
-  }, [open, computePosition]);
-
-  return (
-    <div className="max-w-md">
-      <button
-        ref={triggerRef}
-        type="button"
-        disabled={disabled}
-        onClick={() => setOpen((v) => !v)}
-        className="mono flex h-9 w-full items-center justify-between rounded-[var(--radius-input)] border border-input bg-transparent pl-3 pr-2 py-1 text-body shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50 hover:border-ring transition-colors cursor-pointer"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-      >
-        <span className="truncate" style={{ color: selected?.value === "" ? "var(--fg-3)" : undefined }}>
-          {selected?.label ?? value}
-        </span>
-        <ChevronDown
-          className="ml-2 h-3.5 w-3.5 transition-transform"
-          style={{ color: "var(--fg-3)", transform: open ? "rotate(180deg)" : undefined }}
-        />
-      </button>
-      {open &&
-        popupRect &&
-        createPortal(
-          <div
-            ref={popupRef}
-            className="fixed z-50 overflow-hidden rounded-[var(--radius-input)] py-1"
-            style={{
-              top: popupRect.top,
-              left: popupRect.left,
-              width: popupRect.width,
-              background: "var(--bg-raised)",
-              border: "var(--hairline) solid var(--border)",
-              boxShadow: "var(--shadow-md)",
-              maxHeight: 280,
-              overflowY: "auto",
-            }}
-          >
-            {items.map((o) => {
-              const active = o.value === value;
-              return (
-                <button
-                  key={o.value || "__unset"}
-                  type="button"
-                  onClick={() => {
-                    onChange(o.value);
-                    setOpen(false);
-                  }}
-                  className="mono flex w-full items-center gap-2 cursor-pointer px-3 py-1.5 text-body text-left hover:bg-accent/40 transition-colors focus-visible:outline-none focus-visible:bg-accent/40"
-                  style={{
-                    background: active ? "var(--bg-hover)" : undefined,
-                    color: o.value === "" ? "var(--fg-3)" : undefined,
-                  }}
-                >
-                  <Check
-                    className="h-3.5 w-3.5 flex-shrink-0"
-                    style={{ visibility: active ? "visible" : "hidden", color: "var(--state-idle)" }}
-                  />
-                  <span className="flex-1 truncate">{o.label}</span>
-                  {o.hint && (
-                    <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-                      {o.hint}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>,
-          document.body,
-        )}
-    </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/option-dropdown.tsx
+++ b/packages/web/src/pages/agent-detail/option-dropdown.tsx
@@ -1,0 +1,161 @@
+import { Check, ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Shared building blocks for the inline config dropdowns (model, reasoning
+ * effort, ...): a themeable listbox-style dropdown plus the "changed" chip.
+ * Extracted so each config row doesn't re-implement the popup behavior.
+ */
+
+export type SelectOption = { value: string; label: string; hint?: string };
+
+export function ChangedChip() {
+  return (
+    <span
+      className="mono uppercase text-caption"
+      style={{
+        padding: "var(--hairline) var(--sp-1_5)",
+        borderRadius: "var(--radius-chip)",
+        background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+        color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
+      }}
+    >
+      changed
+    </span>
+  );
+}
+
+/**
+ * Custom listbox-style dropdown — built on top of a button + absolutely
+ * positioned listbox so we can theme the popup (native `<select>` popups are
+ * OS-controlled and unstylable). Anchors to the trigger via `top: 100%`,
+ * dismisses on click-outside or Escape.
+ */
+export function OptionDropdown({
+  items,
+  value,
+  onChange,
+  disabled,
+}: {
+  items: SelectOption[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [popupRect, setPopupRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+  const selected = items.find((o) => o.value === value) ?? items[0];
+
+  const computePosition = useCallback(() => {
+    const t = triggerRef.current;
+    if (!t) return;
+    const r = t.getBoundingClientRect();
+    setPopupRect({ top: r.bottom + 4, left: r.left, width: r.width });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+  }, [open, computePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (popupRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    const onReflow = () => computePosition();
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onReflow, true);
+    window.addEventListener("resize", onReflow);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onReflow, true);
+      window.removeEventListener("resize", onReflow);
+    };
+  }, [open, computePosition]);
+
+  return (
+    <div className="max-w-md">
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="mono flex h-9 w-full items-center justify-between rounded-[var(--radius-input)] border border-input bg-transparent pl-3 pr-2 py-1 text-body shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50 hover:border-ring transition-colors cursor-pointer"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="truncate" style={{ color: selected?.value === "" ? "var(--fg-3)" : undefined }}>
+          {selected?.label ?? value}
+        </span>
+        <ChevronDown
+          className="ml-2 h-3.5 w-3.5 transition-transform"
+          style={{ color: "var(--fg-3)", transform: open ? "rotate(180deg)" : undefined }}
+        />
+      </button>
+      {open &&
+        popupRect &&
+        createPortal(
+          <div
+            ref={popupRef}
+            className="fixed z-50 overflow-hidden rounded-[var(--radius-input)] py-1"
+            style={{
+              top: popupRect.top,
+              left: popupRect.left,
+              width: popupRect.width,
+              background: "var(--bg-raised)",
+              border: "var(--hairline) solid var(--border)",
+              boxShadow: "var(--shadow-md)",
+              maxHeight: 280,
+              overflowY: "auto",
+            }}
+          >
+            {items.map((o) => {
+              const active = o.value === value;
+              return (
+                <button
+                  key={o.value || "__unset"}
+                  type="button"
+                  onClick={() => {
+                    onChange(o.value);
+                    setOpen(false);
+                  }}
+                  className="mono flex w-full items-center gap-2 cursor-pointer px-3 py-1.5 text-body text-left hover:bg-accent/40 transition-colors focus-visible:outline-none focus-visible:bg-accent/40"
+                  style={{
+                    background: active ? "var(--bg-hover)" : undefined,
+                    color: o.value === "" ? "var(--fg-3)" : undefined,
+                  }}
+                >
+                  <Check
+                    className="h-3.5 w-3.5 flex-shrink-0"
+                    style={{ visibility: active ? "visible" : "hidden", color: "var(--state-idle)" }}
+                  />
+                  <span className="flex-1 truncate">{o.label}</span>
+                  {o.hint && (
+                    <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+                      {o.hint}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -1,0 +1,88 @@
+import type { RuntimeProvider } from "@first-tree/shared";
+import { useMemo } from "react";
+import { Button } from "../../components/ui/button.js";
+import { ConfigRow } from "./flat-section.js";
+import { ChangedChip, OptionDropdown, type SelectOption } from "./option-dropdown.js";
+
+/**
+ * Reasoning effort — an inline dropdown mirroring the Model row. Options and
+ * help copy are provider-specific (no abstraction over the providers):
+ *   - claude-code maps to the SDK `effort` (low/medium/high/max), plus an
+ *     "" inherit option that defers to the operator's local effortLevel.
+ *   - codex maps to `modelReasoningEffort` (low/medium/high/xhigh); "minimal"
+ *     is excluded because it breaks the default tool set.
+ */
+
+const CLAUDE_EFFORT_OPTIONS: SelectOption[] = [
+  { value: "", label: "(unset — inherits local)" },
+  { value: "low", label: "low", hint: "fastest" },
+  { value: "medium", label: "medium" },
+  { value: "high", label: "high", hint: "default" },
+  { value: "max", label: "max", hint: "Opus only" },
+];
+
+const CODEX_EFFORT_OPTIONS: SelectOption[] = [
+  { value: "low", label: "low", hint: "fastest" },
+  { value: "medium", label: "medium" },
+  { value: "high", label: "high", hint: "default" },
+  { value: "xhigh", label: "xhigh", hint: "most" },
+];
+
+const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
+  "claude-code": CLAUDE_EFFORT_OPTIONS,
+  codex: CODEX_EFFORT_OPTIONS,
+};
+
+const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
+  "claude-code": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
+  codex: "Applies to new sessions. Higher means more reasoning per turn.",
+};
+
+export type ReasoningEffortSectionProps = {
+  value: string;
+  baseline: string;
+  onChange: (v: string) => void;
+  onRevert: () => void;
+  disabled?: boolean;
+  /** Runtime this agent runs on — drives the option list and help copy. */
+  provider?: RuntimeProvider;
+};
+
+export function ReasoningEffortSection({
+  value,
+  baseline,
+  onChange,
+  onRevert,
+  disabled,
+  provider = "claude-code",
+}: ReasoningEffortSectionProps) {
+  const dirty = value !== baseline;
+  const presetOptions = EFFORT_OPTIONS_BY_PROVIDER[provider];
+
+  const items = useMemo<SelectOption[]>(() => {
+    // Surface an unrecognized stored value (e.g. after a provider rebind) so
+    // the dropdown still shows the current selection instead of silently
+    // snapping to the first option.
+    if (value !== "" && !presetOptions.some((o) => o.value === value)) {
+      return [...presetOptions, { value, label: value, hint: "custom" }];
+    }
+    return presetOptions;
+  }, [presetOptions, value]);
+
+  return (
+    <ConfigRow
+      label="Reasoning effort"
+      helpText={EFFORT_HELP_BY_PROVIDER[provider]}
+      meta={dirty ? <ChangedChip /> : null}
+      action={
+        dirty ? (
+          <Button size="xs" variant="ghost" onClick={onRevert} disabled={disabled}>
+            Revert
+          </Button>
+        ) : null
+      }
+    >
+      <OptionDropdown items={items} value={value} onChange={onChange} disabled={disabled} />
+    </ConfigRow>
+  );
+}

--- a/packages/web/src/pages/agent-detail/save-bar.tsx
+++ b/packages/web/src/pages/agent-detail/save-bar.tsx
@@ -30,6 +30,7 @@ export type SaveBarProps = {
 const SECTION_LABELS: Record<DraftSectionName, string> = {
   prompt: "Prompt",
   model: "Model",
+  effort: "Reasoning effort",
   mcp: "MCP",
   env: "Env",
   git: "Git",

--- a/packages/web/src/pages/agent-detail/setup-section.tsx
+++ b/packages/web/src/pages/agent-detail/setup-section.tsx
@@ -27,6 +27,8 @@ export type SetupSectionProps = {
   onRebind?: () => void;
   /** Slot for the Model dropdown — we reuse the existing ModelSection via composition. */
   modelSlot: ReactNode;
+  /** Slot for the Reasoning effort dropdown — same composition pattern as the model slot. */
+  effortSlot?: ReactNode;
 };
 
 const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> = {
@@ -55,6 +57,7 @@ export function SetupSection(props: SetupSectionProps) {
       />
       <RuntimeRow name={copy.name} caption={copy.caption} locked />
       {props.modelSlot}
+      {props.effortSlot}
     </Section>
   );
 }

--- a/packages/web/src/pages/agent-detail/setup-tab.tsx
+++ b/packages/web/src/pages/agent-detail/setup-tab.tsx
@@ -1,6 +1,7 @@
 import { Navigate } from "react-router";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ModelSection } from "./model-section.js";
+import { ReasoningEffortSection } from "./reasoning-effort-section.js";
 import { SetupSection } from "./setup-section.js";
 
 export function SetupTab() {
@@ -38,6 +39,16 @@ export function SetupTab() {
               baseline={ctx.config?.payload.model ?? ""}
               onChange={ctx.draft.setModel}
               onRevert={ctx.draft.revertModel}
+              disabled={ctx.agent.status !== "active"}
+              provider={ctx.setupRuntimeProvider}
+            />
+          }
+          effortSlot={
+            <ReasoningEffortSection
+              value={ctx.draft.draft.reasoningEffort}
+              baseline={ctx.config?.payload.reasoningEffort ?? ""}
+              onChange={ctx.draft.setReasoningEffort}
+              onRevert={ctx.draft.revertReasoningEffort}
               disabled={ctx.agent.status !== "active"}
               provider={ctx.setupRuntimeProvider}
             />

--- a/packages/web/src/pages/agent-detail/use-config-draft.ts
+++ b/packages/web/src/pages/agent-detail/use-config-draft.ts
@@ -1,6 +1,6 @@
 import {
   type AgentRuntimeConfig,
-  type AgentRuntimeConfigPayload,
+  type AgentRuntimeConfigPatch,
   ENV_REDACTED_PLACEHOLDER,
   type EnvEntry,
   type GitRepo,
@@ -30,12 +30,13 @@ export type DraftListItem<T> = {
 export type ConfigDraft = {
   promptAppend: string;
   model: string;
+  reasoningEffort: string;
   mcp: Array<DraftListItem<McpServer>>;
   env: Array<DraftListItem<EnvEntry>>;
   git: Array<DraftListItem<GitRepo>>;
 };
 
-export type DraftSectionName = "prompt" | "model" | "mcp" | "env" | "git";
+export type DraftSectionName = "prompt" | "model" | "effort" | "mcp" | "env" | "git";
 
 export type DraftSummary = {
   anyDirty: boolean;
@@ -114,6 +115,7 @@ export function createConfigDraft(cfg: AgentRuntimeConfig): ConfigDraft {
   return {
     promptAppend: cfg.payload.prompt.append,
     model: cfg.payload.model,
+    reasoningEffort: cfg.payload.reasoningEffort,
     mcp: toListItems(cfg.payload.mcpServers, "mcp"),
     env: toListItems(cfg.payload.env, "env"),
     git: toListItems(cfg.payload.gitRepos, "git"),
@@ -125,10 +127,13 @@ export type UseConfigDraftResult = {
   summary: DraftSummary;
   promptDirty: boolean;
   modelDirty: boolean;
+  reasoningEffortDirty: boolean;
   setPromptAppend: (v: string) => void;
   revertPrompt: () => void;
   setModel: (v: string) => void;
   revertModel: () => void;
+  setReasoningEffort: (v: string) => void;
+  revertReasoningEffort: () => void;
   addMcp: (value: McpServer) => void;
   updateMcp: (key: string, value: McpServer) => void;
   deleteMcp: (key: string) => void;
@@ -145,7 +150,7 @@ export type UseConfigDraftResult = {
   /** Replace the draft with a clean baseline from a known server config. */
   resetToConfig: (next: AgentRuntimeConfig) => void;
   /** PATCH body (payload only — expectedVersion is added by caller). */
-  buildPayloadPatch: () => Partial<AgentRuntimeConfigPayload>;
+  buildPayloadPatch: () => AgentRuntimeConfigPatch;
 };
 
 export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDraftResult {
@@ -165,12 +170,14 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
     }
   }, [cfg, draft]);
 
-  const current: ConfigDraft = draft ?? { promptAppend: "", model: "", mcp: [], env: [], git: [] };
+  const current: ConfigDraft = draft ?? { promptAppend: "", model: "", reasoningEffort: "", mcp: [], env: [], git: [] };
 
   const baselinePrompt = baseline?.payload.prompt.append ?? "";
   const baselineModel = baseline?.payload.model ?? "";
+  const baselineReasoningEffort = baseline?.payload.reasoningEffort ?? "";
   const promptDirty = current.promptAppend !== baselinePrompt;
   const modelDirty = current.model !== baselineModel;
+  const reasoningEffortDirty = current.reasoningEffort !== baselineReasoningEffort;
 
   const summary: DraftSummary = useMemo(() => {
     const dirty: DraftSectionName[] = [];
@@ -181,6 +188,7 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
     const gitN = listCount(current.git);
     if (promptDirty) dirty.push("prompt");
     if (modelDirty) dirty.push("model");
+    if (reasoningEffortDirty) dirty.push("effort");
     if (mcpN > 0) dirty.push("mcp");
     if (envN > 0) dirty.push("env");
     if (gitN > 0) dirty.push("git");
@@ -190,12 +198,13 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
       counts: {
         prompt: promptDirty ? 1 : 0,
         model: modelDirty ? 1 : 0,
+        effort: reasoningEffortDirty ? 1 : 0,
         mcp: mcpN,
         env: envN,
         git: gitN,
       },
     };
-  }, [current, promptDirty, modelDirty]);
+  }, [current, promptDirty, modelDirty, reasoningEffortDirty]);
 
   const mutate = useCallback((fn: (d: ConfigDraft) => ConfigDraft) => {
     setDraft((prev) => (prev ? fn(prev) : prev));
@@ -209,6 +218,12 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
 
   const setModel = useCallback((v: string) => mutate((d) => ({ ...d, model: v })), [mutate]);
   const revertModel = useCallback(() => mutate((d) => ({ ...d, model: baselineModel })), [mutate, baselineModel]);
+
+  const setReasoningEffort = useCallback((v: string) => mutate((d) => ({ ...d, reasoningEffort: v })), [mutate]);
+  const revertReasoningEffort = useCallback(
+    () => mutate((d) => ({ ...d, reasoningEffort: baselineReasoningEffort })),
+    [mutate, baselineReasoningEffort],
+  );
 
   const mcpOps = useMemo(() => makeListOps<McpServer>("mcp", mutate), [mutate]);
   const envOps = useMemo(() => makeListOps<EnvEntry>("env", mutate), [mutate]);
@@ -227,11 +242,12 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
     setDraft(createConfigDraft(next));
   }, []);
 
-  const buildPayloadPatch = useCallback((): Partial<AgentRuntimeConfigPayload> => {
+  const buildPayloadPatch = useCallback((): AgentRuntimeConfigPatch => {
     if (!draft || !baseline) return {};
-    const patch: Partial<AgentRuntimeConfigPayload> = {};
+    const patch: AgentRuntimeConfigPatch = {};
     if (promptDirty) patch.prompt = { append: draft.promptAppend };
     if (modelDirty) patch.model = draft.model;
+    if (reasoningEffortDirty) patch.reasoningEffort = draft.reasoningEffort;
     const mcpDirty = summary.counts.mcp > 0;
     const envDirty = summary.counts.env > 0;
     const gitDirty = summary.counts.git > 0;
@@ -249,17 +265,20 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
     }
     if (gitDirty) patch.gitRepos = draft.git.filter((i) => i.status !== "deleted").map((i) => i.value);
     return patch;
-  }, [draft, baseline, promptDirty, modelDirty, summary]);
+  }, [draft, baseline, promptDirty, modelDirty, reasoningEffortDirty, summary]);
 
   return {
     draft: current,
     summary,
     promptDirty,
     modelDirty,
+    reasoningEffortDirty,
     setPromptAppend,
     revertPrompt,
     setModel,
     revertModel,
+    setReasoningEffort,
+    revertReasoningEffort,
     addMcp: mcpOps.add,
     updateMcp: mcpOps.update,
     deleteMcp: mcpOps.remove,


### PR DESCRIPTION
Closes #626.

Adds a per-agent **reasoning effort** setting. Values are provider-native (no abstraction layer), mirroring the existing `model` field's plumbing — stored in `agent_configs.payload` (JSONB), so **no DB migration and no new API endpoint**.

- **claude-code** → SDK `effort` (`low|medium|high|max`). The `""` value is an inherit sentinel: the handler omits the option so the SDK uses the operator's local `~/.claude/settings.json` effortLevel (the pre-feature behavior). Default `""`.
- **codex** → `modelReasoningEffort` (`low|medium|high|xhigh`). Default `"high"` preserves the previously hard-coded value. `"minimal"` is intentionally excluded — it breaks the default tool set.

## A2 — foundation verified (static)
The whole feature rests on "an explicit `effort` overrides the local `effortLevel`". Verified against the installed SDK bundle:
- `sdk.mjs`: `options.effort` → CLI flag `--effort`.
- `cli.js`: `--effort <level>` ("current session") resolves as `effort !== undefined ? effort : effortValue`, where `effortValue` is seeded from the settings `effortLevel`. So an explicit effort **overrides** local; omitting it **inherits** local.

This is static code verification, not an end-to-end runtime run — runtime E2E is planned before merge (create one claude + one codex agent, set different efforts, confirm the strength actually takes effect).

## Implementation (5 layers, follows the `model` chain)
- **shared** (`agent-runtime-config.ts`): `reasoningEffort` on each tagged variant (claude enum incl. `""`; codex enum incl. `xhigh`); patch shape uses a loose `z.string()`; new exported `AgentRuntimeConfigPatch` type; per-provider defaults.
- **server** (`config-service.ts`): `applyPatch` + `computeDiff` thread the field; `applyPatch`/`commitWrite`/`dryRun` take `AgentRuntimeConfigPatch` instead of `Partial<AgentRuntimeConfigPayload>` (avoids enum-narrowing). Provider-correct values are enforced by the tagged-union re-parse in `commitWrite` → invalid combos (e.g. `xhigh` for claude) return **400** via the existing global ZodError handler.
- **client**: codex `buildCodexThreadOptions` reads the payload (default `high`); claude's query-options assembly is extracted into an exported pure `buildClaudeQueryOptions` (testability), omitting `effort` when `""`.
- **web**: extracted a reusable `OptionDropdown`; new provider-aware `ReasoningEffortSection` on the Setup tab; `use-config-draft` tracks the scalar.
- **cli**: `first-tree agent config set-reasoning-effort <agent> <level>`; `show` displays it.

## Verification
- `pnpm typecheck`: 13/13 ✅
- `pnpm check` (biome): 0 errors (pre-existing warnings only)
- New/extended tests green: shared schema (8 effort cases), server `admin-agent-config` (incl. `max` accepted / `xhigh`→400), client `codex-thread-options` + new `claude-query-options`, web `use-config-draft`.
- ⚠️ 3 pre-existing failures in client `doc-snapshots*` (filesystem realpath edge cases) — reproduced identically on a clean base via `git stash`, so unrelated to this change.

## Test plan
- [x] CI green (run 26567889610 — Test / Lint / Migrations all pass on 46f0dd8f)
- [x] Runtime E2E done (live dev hub, branch build) — see PR comment with objective handler→SDK logs
- [x] `agent config set-reasoning-effort` round-trips + Setup-tab save/revert verified (live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
