### PR TITLE
fix(client): replay user message on transient stream-error retry

### DIFF
--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for the `claude_socket_closed` transient retry path.
+ *
+ * Reported bug: a Claude SDK "wrapped" stream-API error (subtype=`success`
+ * payload whose `result` text is `"API Error: The socket connection was
+ * closed unexpectedly..."`) was correctly classified `transient/
+ * claude_socket_closed` and triggered the auto-resume branch — but the
+ * old `respawnQuery()` only rebuilt the SDK query and left the new
+ * `InputController` empty. With no user prompt in the iterable the SDK
+ * subprocess just hung idle (resume mode loads conversation history but
+ * still needs a fresh user message to drive the next turn), so the agent
+ * appeared to stall mid-conversation with no further log output and no
+ * recovery.
+ *
+ * Contract this test pins:
+ *   1. On the first transient stream-error, the handler enters the
+ *      retry path (logs `Attempting auto-resume`).
+ *   2. The rebuilt query receives the SAME user message that was pushed
+ *      against the failing query — verified by capturing every SDK
+ *      input message across all `query()` calls and asserting the
+ *      original prompt shows up at least twice (once per attempt).
+ *   3. After the second attempt also fails transient + retries exhaust,
+ *      the handler surfaces the error + acks (per PR #612 § "permanent
+ *      → ack").
+ */
+
+const ORIGINAL_PROMPT = "please reply";
+const FAKE_API_ERROR_TEXT =
+  "API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+
+// Capture every user prompt pushed into the SDK input controller across
+// retries. Each `query()` call enqueues its own slice; we concatenate
+// them in observation order so the test can assert the same prompt was
+// replayed on the second attempt.
+const observedInputMessages: Array<{ attempt: number; content: string }> = [];
+
+function makeWrappedStreamErrorQuery(
+  promptIterable: AsyncIterable<{ message: { content: unknown } }>,
+  attempt: number,
+) {
+  let yielded = false;
+  // Eagerly drain the input iterable in the background so the
+  // handler-side `inputController.push(...)` reaches us — without this,
+  // the test never sees what got pushed.
+  void (async () => {
+    for await (const sdkMsg of promptIterable) {
+      const content = sdkMsg.message?.content;
+      const flat = typeof content === "string" ? content : JSON.stringify(content);
+      observedInputMessages.push({ attempt, content: flat });
+    }
+  })();
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async (): Promise<IteratorResult<unknown>> => {
+          if (yielded) return { value: undefined, done: true };
+          yielded = true;
+          // Yield a "success" subtype with the wrapped API-error text —
+          // the handler's `detectStreamApiError` sniff will classify
+          // this as transient/claude_socket_closed and throw to drive
+          // the auto-resume path.
+          return {
+            value: {
+              type: "result",
+              subtype: "success",
+              result: FAKE_API_ERROR_TEXT,
+            },
+            done: false,
+          };
+        },
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  };
+}
+
+let attemptIdx = 0;
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  return {
+    query: (args: { prompt: AsyncIterable<{ message: { content: unknown } }> }) => {
+      attemptIdx += 1;
+      return makeWrappedStreamErrorQuery(args.prompt, attemptIdx);
+    },
+  };
+});
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019dd905-1234-7777-8888-bef95070f001";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-stream-retry-replay-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+describe("claude-code handler — transient stream-error retry replays user message", () => {
+  it("re-pushes the original prompt into the rebuilt InputController so the SDK isn't left idle", async () => {
+    attemptIdx = 0;
+    observedInputMessages.length = 0;
+
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const emitted: SessionEvent[] = [];
+    const logs: string[] = [];
+    const runtimeStates: string[] = [];
+    const markCompleted = vi.fn();
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-stream-retry",
+      log: (m) => logs.push(m),
+      touch: () => {},
+      setRuntimeState: (state) => runtimeStates.push(state),
+      emitEvent: (e) => emitted.push(e),
+      ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
+      markCompleted,
+    };
+
+    await handler.start(
+      {
+        id: "m1",
+        chatId: "chat-stream-retry",
+        senderId: "user-1",
+        format: "text",
+        content: ORIGINAL_PROMPT,
+        metadata: null,
+      },
+      ctx,
+    );
+    // suspend awaits `consumerDone` so the consumer loop runs through all
+    // retries and the eventual retry-exhausted ack before we assert.
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    // First retry must have been attempted — proves the catch path fired
+    // on the wrapped stream error.
+    expect(logs.some((l) => l.includes("Attempting auto-resume (retry 1/"))).toBe(true);
+
+    // The smoking gun: the rebuilt query (attempt 2) must have received
+    // a user message containing the original prompt. Pre-fix this was
+    // empty and the SDK subprocess hung idle.
+    const attempt2Inputs = observedInputMessages.filter((m) => m.attempt === 2);
+    expect(attempt2Inputs.length).toBeGreaterThan(0);
+    expect(attempt2Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+
+    // And the first attempt also saw the prompt (sanity check that the
+    // mock plumbing works at all).
+    const attempt1Inputs = observedInputMessages.filter((m) => m.attempt === 1);
+    expect(attempt1Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+
+    // After both retries fail transient (same wrapped API error every
+    // time), the handler must end in the retry-exhausted / permanent
+    // branch and ack — per PR #612 § "permanent → ack".
+    expect(markCompleted).toHaveBeenCalledTimes(1);
+
+    // A user-visible error must be surfaced on retry-exhaustion (so the
+    // chat timeline shows what happened), AND the turn must be closed
+    // with status:"error" so the frontend turn-grouping filter doesn't
+    // wait forever for the success boundary.
+    const errors = emitted.filter((e) => e.kind === "error");
+    expect(errors.some((e) => e.kind === "error" && e.payload.source === "sdk")).toBe(true);
+    const turnEnds = emitted.filter((e) => e.kind === "turn_end");
+    expect(turnEnds.length).toBeGreaterThan(0);
+    const lastTurnEnd = turnEnds[turnEnds.length - 1];
+    if (!lastTurnEnd || lastTurnEnd.kind !== "turn_end") throw new Error("expected turn_end event");
+    expect(lastTurnEnd.payload.status).toBe("error");
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -576,6 +576,34 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * — those are runtime-opaque (created by the agent, not by Hub).
    */
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+  /**
+   * The most recently pushed SDK user message, kept around as the replay
+   * payload for the transient stream-API retry path. Stashed at every
+   * `inputController.push` site (start / resume / inject) so a
+   * `claude_socket_closed` retry can re-push it into the rebuilt query —
+   * without this, `respawnQuery()` would leave the new `InputController`
+   * empty and the SDK subprocess would hang idle (resume mode loads
+   * conversation history but still needs a new user message to drive
+   * the next turn). We stash the already-converted SDK form (rather
+   * than the raw `SessionMessage`) so the retry path stays synchronous
+   * and timing-compatible with the existing consumer-loop catch block.
+   * Cleared once `ackTurnClose()` acks the entry — turn fully processed,
+   * no further replay needed.
+   *
+   * Invariant — single-consumer loop: this stash is safe ONLY because
+   * the catch → respawn → re-push sequence in `consumeOutput` is
+   * synchronous (no `await` between the sniff-throw catch entry and
+   * `respawnQuery`'s push). The interleaving inject() runs on its own
+   * `void maybeSwitchConfig().finally(...)` microtask and updates the
+   * stash via the same write site, so a properly-ordered consumer-loop
+   * iteration is the *only* reader and writer at any synchronous step.
+   * If future work ever introduces a second concurrent consumer (e.g.
+   * parallel turn execution, multi-`spawnQuery` fan-out), this stash
+   * must be redesigned per-consumer or the retry must own its own
+   * captured copy — otherwise an inject from chat N can overwrite a
+   * stash that chat M's retry is about to replay.
+   */
+  let stashedSdkMessage: SDKUserMessage | null = null;
 
   async function toSDKUserMessage(
     message: SessionMessage,
@@ -765,10 +793,50 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     };
   }
 
-  /** Rebuild query and input controller without starting a new consumer loop (used for retry within the existing loop). */
+  /**
+   * Single helper for "turn closed → ack the in-flight inbox entry AND
+   * drop the replay stash". The two operations are paired everywhere a
+   * turn finishes (success / sniff-permanent / forward-error / no-result /
+   * non-success subtype / MAX_RETRIES / respawn-fail) — folding them into
+   * one call keeps the invariant "stash lives only as long as the turn
+   * still might need a replay" enforced in one place. Use the raw
+   * `markCompleted(count)` directly for per-entry acks (e.g. inject's
+   * `toSDKUserMessage` catch) where the semantics is "ack this single
+   * inbox entry, NOT close the active turn".
+   */
+  function ackTurnClose(sessionCtx: SessionContext): void {
+    sessionCtx.markCompleted();
+    stashedSdkMessage = null;
+  }
+
+  /**
+   * Rebuild the SDK query in resume mode AND re-push the pending user
+   * message so the freshly built `InputController` is non-empty. The
+   * caller (the outer consumer loop's catch block) keeps owning the
+   * for-await, so we deliberately do NOT start a new consumer here —
+   * spawning one would create two parallel loops both consuming the
+   * same `currentQuery` reference and both racing their own
+   * `retryCount` counter (under persistent failure, that fans out into
+   * unbounded recursion). Configuration (`applied*`) is preserved
+   * across the retry — only the SDK query is recycled.
+   *
+   * Stays synchronous — the converted SDK payload is stashed at push
+   * time so the retry path doesn't need to re-run `toSDKUserMessage`
+   * (which is async and would shift the consumer-loop timing).
+   *
+   * `stashedSdkMessage` is `null` only in the corner case where the
+   * session was started via `handler.resume(undefined, ...)` (admin-
+   * triggered resume with no new user input) and the SDK happened to
+   * crash before processing anything. In that case we still rebuild
+   * the query, but without a replay message the SDK will be back to
+   * waiting on stdin — acceptable for the admin-resume edge case, and
+   * the next user message will drive it normally.
+   */
   function respawnQuery(sessionId: string, sessionCtx: SessionContext): void {
     buildQuery(sessionId, sessionCtx, sessionId);
-    // retry keeps the same config — applied* unchanged.
+    if (stashedSdkMessage) {
+      inputController?.push(stashedSdkMessage);
+    }
   }
 
   /**
@@ -907,12 +975,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     //   1. Within a single turn: per-turn reset on `result` boundary so the
     //      next turn within the SAME query (bg-agent multi-turn mode) starts
     //      fresh.
-    //   2. Across retries (outer while-loop reentry via the catch +
-    //      respawnQuery path): NOT reset. An auth failure won't self-heal,
-    //      so respawning typically hits the same error — without persistence
-    //      the user would see two identical hint lines in the timeline.
+    //   2. Across retries (outer catch path that hands off to
+    //      `handler.resume()`): NOT reset. An auth failure won't self-heal,
+    //      so the resumed session typically hits the same error — without
+    //      persistence the user would see two identical hint lines in the
+    //      timeline.
     // Hoisted out of the try block so the outer catch's reentry preserves it
-    // across the respawn boundary.
+    // across the resume boundary.
     let authHintEmitted = false;
     try {
       while (true) {
@@ -943,7 +1012,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             if (isResultMessage(message)) {
               emitTokenUsageFromResult(message, sessionCtx);
               if (message.subtype === "success") {
-                retryCount = 0;
                 // Auto-bridge: forward result text back to the chat and close
                 // the turn. We AWAIT sendMessage (rather than fire-and-forget)
                 // so the turn_end emit is guaranteed to hit the WebSocket
@@ -984,7 +1052,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     });
                     if (classification.kind === "transient" && retryCount < MAX_RETRIES) {
                       // Re-throw to drive the outer catch's auto-resume path
-                      // with the retry counter and respawnQuery wiring.
+                      // (retry counter + self-resume via handler.resume).
                       throw new StreamApiTransientError(sniff.message);
                     }
                     // Permanent (401/403) OR retries exhausted: surface to
@@ -1002,8 +1070,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     // Permanent stream API failure — ack so the server
                     // doesn't redeliver a message that would just produce
                     // the same error. Retry was exhausted upstream.
-                    sessionCtx.markCompleted();
+                    ackTurnClose(sessionCtx);
                   } else {
+                    // Genuine success — reset retry budget for the next turn.
+                    // Do NOT reset on the sniff-hit branches above: a wrapped
+                    // transient API error masquerades as `subtype: "success"`
+                    // and we MUST let `retryCount` accumulate so MAX_RETRIES
+                    // can fire and break us out of an unhealing transient
+                    // loop (rate limit / socket closed / etc.).
+                    retryCount = 0;
                     try {
                       // All enrichment (inReplyTo, mentions, participants
                       // lookup, transport) lives in ctx.forwardResult so every
@@ -1012,7 +1087,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       sessionCtx.log("Result forwarded to chat");
                       sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
                       // Turn closed cleanly — drain in-flight inbox entries.
-                      sessionCtx.markCompleted();
+                      ackTurnClose(sessionCtx);
                     } catch (err) {
                       const reason = err instanceof Error ? err.message : String(err);
                       sessionCtx.log(`Failed to forward result: ${reason}`);
@@ -1028,13 +1103,24 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       // Long-lived sdk.sendMessage failures are rare; if
                       // recovery is needed the user can retry by sending
                       // a new message.
-                      sessionCtx.markCompleted();
+                      //
+                      // Reset retryCount along with the forward-success
+                      // branch above: the SDK actually returned a clean
+                      // `result` here (the failure was in our own
+                      // sendMessage downstream), so the next turn should
+                      // not inherit the prior turn's transient-retry
+                      // counter when an unrelated future stream error
+                      // fires.
+                      retryCount = 0;
+                      ackTurnClose(sessionCtx);
                     }
                   }
                 } else {
                   // No result text to forward (edge case) — still close the turn.
+                  // Same reset rationale as the forward-success branch above.
+                  retryCount = 0;
                   sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
-                  sessionCtx.markCompleted();
+                  ackTurnClose(sessionCtx);
                 }
               } else {
                 const errors = message.errors ? message.errors.join("; ") : message.subtype;
@@ -1051,7 +1137,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                 // SDK reported a turn-level error (non-success subtype):
                 // redelivery would just hit the same error — ack.
-                sessionCtx.markCompleted();
+                ackTurnClose(sessionCtx);
               }
               sessionCtx.setRuntimeState("idle");
               // Reset the auth-hint flag only on a SUCCESSFUL result. This
@@ -1112,18 +1198,34 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // Deduplicator collapses every bind-reset replay so the entry
             // never re-dispatches and never gets acked. Per design §4
             // "permanent → ack".
-            sessionCtx.markCompleted();
+            ackTurnClose(sessionCtx);
             return;
           }
 
-          // Automatic retry — respawn query and continue loop. Flush any
-          // tool_use blocks that were in-flight when the session crashed so
-          // the admin event stream sees them as status:"pending" rather than
-          // getting paired against a replayed tool_use_id after resume.
+          // Automatic retry — rebuild the SDK query in resume mode AND re-push
+          // the pending user message into the freshly built InputController.
+          // The old `respawnQuery()` only did the rebuild; the new controller
+          // was empty so the SDK subprocess just hung idle waiting for a
+          // prompt that never came (it had the resumed conversation history
+          // but nothing to drive the next turn). Replaying `stashedSdkMessage`
+          // is the missing half — the SDK sees the same user message it was
+          // half-way through processing and re-runs the turn.
+          //
+          // We stay inside THIS consumer loop on purpose: spawning a fresh
+          // consumer (via `handler.resume` or `spawnQuery`) would create two
+          // parallel for-await loops over `currentQuery`, both stamping
+          // their own retryCount counter — under a persistent failure mode
+          // (e.g. SDK always throws) that fans out into unbounded recursion.
+          //
+          // Flush any tool_use blocks that were in-flight when the session
+          // crashed so the admin event stream sees them as status:"pending"
+          // rather than getting paired against a replayed tool_use_id
+          // after resume.
           toolCallProcessor.flush();
 
           retryCount++;
           sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${MAX_RETRIES})`);
+
           try {
             respawnQuery(claudeSessionId, sessionCtx);
           } catch (resumeErr) {
@@ -1149,7 +1251,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // Same reasoning as the MAX_RETRIES branch above — without this
             // ack the row would loop in `delivered` forever, deduped on every
             // bind-reset replay. Per design §4 "permanent → ack".
-            sessionCtx.markCompleted();
+            ackTurnClose(sessionCtx);
             return;
           }
         }
@@ -1494,8 +1596,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       sessionCtx.log(
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
       );
-      spawnQuery(claudeSessionId, sessionCtx, undefined, chatContext);
+      // Convert + stash BEFORE spawning the consumer loop. The consumer
+      // may race to first iteration before the post-spawn push lands —
+      // and if a wrapped stream-API error fires before we've stashed,
+      // the retry path's `respawnQuery` would have nothing to replay
+      // into the rebuilt InputController. See the
+      // `claude-code-stream-error-retry-replay.test.ts` regression.
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, claudeSessionId);
+      stashedSdkMessage = sdkMsg;
+      spawnQuery(claudeSessionId, sessionCtx, undefined, chatContext);
       inputController?.push(sdkMsg);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
@@ -1532,9 +1641,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // carries the v1.x bootstrap output (CLAUDE.md, AGENTS.md, .agent/,
         // <localPath>/ source repos), and the agent reads it via the SDK's
         // `settingSources: ["project"]` option.
-        spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+        // Same convert-stash-then-spawn ordering as `start()` so a stream
+        // error fired on the first turn of the resumed session can replay
+        // through `respawnQuery`.
+        let sdkMsg: SDKUserMessage | null = null;
         if (message) {
-          inputController?.push(await toSDKUserMessage(message, sessionCtx, sessionId));
+          sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
+          stashedSdkMessage = sdkMsg;
+        }
+        spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+        if (sdkMsg) {
+          inputController?.push(sdkMsg);
         }
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
         return sessionId;
@@ -1566,18 +1683,28 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             "Hub message history is preserved.",
         );
         claudeSessionId = freshSessionId;
-        spawnQuery(freshSessionId, sessionCtx, undefined, chatContext);
+        let freshSdkMsg: SDKUserMessage | null = null;
         if (message) {
-          inputController?.push(await toSDKUserMessage(message, sessionCtx, freshSessionId));
+          freshSdkMsg = await toSDKUserMessage(message, sessionCtx, freshSessionId);
+          stashedSdkMessage = freshSdkMsg;
+        }
+        spawnQuery(freshSessionId, sessionCtx, undefined, chatContext);
+        if (freshSdkMsg) {
+          inputController?.push(freshSdkMsg);
         }
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
         return freshSessionId;
       }
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
-      spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+      let resumeSdkMsg: SDKUserMessage | null = null;
       if (message) {
-        inputController?.push(await toSDKUserMessage(message, sessionCtx, sessionId));
+        resumeSdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
+        stashedSdkMessage = resumeSdkMsg;
+      }
+      spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+      if (resumeSdkMsg) {
+        inputController?.push(resumeSdkMsg);
       }
 
       sessionCtx.log(`Session resumed (${sessionId})`);
@@ -1602,6 +1729,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         .finally(async () => {
           try {
             const sdkMsg = await toSDKUserMessage(message, sessionCtx, sid);
+            stashedSdkMessage = sdkMsg;
             inputController?.push(sdkMsg);
           } catch (err) {
             sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
@@ -1635,6 +1763,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       }
 
       abortController = null;
+      // The session is no longer active — any pending replay message would
+      // be moot. Resume goes through `handler.resume(message, sessionId)`
+      // which re-stashes from its own argument.
+      stashedSdkMessage = null;
     },
 
     async shutdown() {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -602,6 +602,21 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * must be redesigned per-consumer or the retry must own its own
    * captured copy — otherwise an inject from chat N can overwrite a
    * stash that chat M's retry is about to replay.
+   *
+   * Tolerated same-chat race — inject mid-retry: an inject()'s
+   * `toSDKUserMessage` await can interleave with a consumer-triggered
+   * transient retry. Sequence: consumer sniff-hit → respawn replays
+   * the PRIOR stash into the new query → inject's await resolves →
+   * inject overwrites stash and pushes the new prompt. The rebuilt
+   * query then sees `[replayed_prior_prompt, injected_new_prompt]`
+   * as two consecutive user messages. The replayed prompt is already
+   * in the resumed conversation history, so the model perceives a
+   * one-message duplicate before processing the inject — recoverable,
+   * not a correctness break. Avoiding this would require either
+   * draining inject through a queue gated on the consumer's catch
+   * state or making the retry path async — both have larger blast
+   * radius than the duplicate-message symptom. Documented per PR #648
+   * reviewer observation #1.
    */
   let stashedSdkMessage: SDKUserMessage | null = null;
 


### PR DESCRIPTION
## Summary

Fix the `claude_socket_closed` auto-resume path so it actually recovers instead of hanging the session.

When the Claude SDK packages an API error as a `subtype: "success"` result whose text starts with `"API Error: The socket connection was closed unexpectedly..."`, the handler classifies it `transient / claude_socket_closed` and throws into the consumer-loop's catch + auto-resume path. Two latent bugs combined to leave that path stuck:

1. **`respawnQuery()` only rebuilt the SDK query** — the freshly-built `InputController` was empty. The SDK subprocess loaded the resumed conversation history but had no new user message to drive the next turn, so it sat idle and the runtime state stayed `working` forever. Operators saw `Attempting auto-resume (retry 1/2)` in the log and then complete silence (no retry 2/2, no recovery).
2. **`retryCount = 0` was reset at the top of the `subtype === "success"` branch, BEFORE the stream-API-error sniff.** Each wrapped error re-entered the success branch, reset the counter, sniffed positive, threw transient — looping forever between catch and respawn. `MAX_RETRIES` could never fire.

Together these manifested as a chat that went silent mid-turn after a brief Anthropic API blip, with no indication that anything could un-stick it short of a daemon restart.

## What the fix does

- **Stash + replay**: introduce `stashedSdkMessage: SDKUserMessage | null`, written at every `inputController.push` site (start / resume legacy / resume fresh / resume normal / inject) and re-pushed from `respawnQuery()`. Stashing the already-converted SDK form keeps the retry path synchronous and timing-compatible with the existing consumer-loop catch block (a `SessionMessage`-typed stash would require async `toSDKUserMessage` on the retry path, which changed timing enough to break sibling tests).
- **Pre-spawn stash ordering**: reorder `start()` / `resume()` to `toSDKUserMessage` → stash → `spawnQuery` → push so the stash is populated before the consumer loop's first iteration. Without this, an SDK that yields its first result before `start()` finishes its await would already throw transient before the stash exists.
- **`retryCount` reset moved**: from the top of the success branch into the sniff-miss leaves (forward success / forward error / no-result). The wrapped-error sniff-hit branches no longer reset, so `MAX_RETRIES` actually fires. `forward-error` resets too — semantically the SDK returned a clean result, only the downstream `sendMessage` failed, so the next turn shouldn't inherit this turn's transient counter.
- **`ackTurnClose(sessionCtx)` helper**: folds the `markCompleted() + stashedSdkMessage = null` pair into one call at all seven turn-close points (sniff-permanent / forward-success / forward-error / no-result / non-success-subtype / MAX_RETRIES / respawn-fail). `inject`'s `markCompleted(1)` stays separate — per-entry ack semantics, not turn-close.
- **Single-consumer-loop invariant documented**: the stash safety relies on the `catch → respawn → push` sequence being synchronous (no `await` between sniff-throw and the re-push) and `inject`'s microtask never interleaving inside the catch. Spelled this out on the stash declaration so future concurrent-turn / multi-consumer refactors don't quietly break the replay property.

## Why not route through `handler.resume()` (PR #612 bind-reset path)

Considered, rejected. `handler.resume()` calls `spawnQuery()`, which fires off `consumerDone = consumeOutput(...)` as a fresh consumer loop. The current consumer is still in its catch block `await`ing — under a persistent failure mode (e.g. the SDK always throws), each retry recursively spawns another consumer, each with its own `retryCount = 0`, and the recursion never terminates. This crashed vitest during development.

PR #612's bind-reset path is safe because it's externally triggered (WS reconnect after the old client process died), so there is no live consumer to race. In-process retry is internally triggered with the old consumer still on the stack — it must stay inside that consumer to avoid the recursion.

## Test plan

- [x] New regression test `packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts` — mocks the SDK to return the wrapped API error on every attempt, captures every push into every retried `InputController`, asserts the rebuilt query (attempt 2) actually receives the original prompt and the handler eventually reaches retry-exhausted ack with `turn_end: error`. Pre-fix the test hangs in the infinite-retry loop; post-fix it completes in milliseconds.
- [x] `pnpm --filter @first-tree/client test` — 909 / 909 pass (including the new regression + the pre-existing retry-exhausted / auto-resume-failed coverage that this PR's reorderings could plausibly have broken).
- [x] `pnpm typecheck` — all 13 packages green.
- [x] `pnpm check` — 0 errors (24 pre-existing warnings unchanged, same baseline as PR #612).
- [ ] Manual staging verification: trigger a wrapped stream-API error during an active turn and confirm the agent resumes and forwards a real result, instead of going silent at `Attempting auto-resume (retry 1/2)`. (Operator follow-up; depends on Anthropic-side hiccup reproducibility.)

## Review

- @reviewer (one-shot review + revision pass) — first pass surfaced two non-blocking improvements (R1 `ackTurnClose` helper, R4 `retryCount = 0` in forward-error catch) and one architecture-comment ask (R5 single-consumer-loop invariant); all three landed before second review and were approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)