### PR TITLE
feat(web): onboarding scenario preview at /preview/onboarding

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -45,6 +45,10 @@ const ChatRowAvatarPreviewPage = import.meta.env.DEV
     )
   : null;
 
+const OnboardingPreviewPage = import.meta.env.DEV
+  ? lazy(() => import("./pages/onboarding-preview.js").then((module) => ({ default: module.OnboardingPreviewPage })))
+  : null;
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -74,6 +78,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <ChatRowAvatarPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {OnboardingPreviewPage ? (
+                <Route
+                  path="/preview/onboarding"
+                  element={
+                    <Suspense fallback={null}>
+                      <OnboardingPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -20,6 +20,10 @@ import { markOnboardingResume } from "../utils/onboarding-flags.js";
  * The page is team-centric on purpose — invite links are shareable URLs that
  * may reach the recipient via channels we don't track, so identifying "who
  * invited you" can mislead. The team is the load-bearing identity.
+ *
+ * The page owns data + side effects; the three visual states (skeleton, error,
+ * and the join card) are extracted as exported presentational components so the
+ * DEV onboarding preview can render every state with fixtures.
  */
 export function InviteAcceptPage() {
   const { token } = useParams<{ token: string }>();
@@ -64,9 +68,24 @@ export function InviteAcceptPage() {
     })();
   }, [isAuthenticated]);
 
-  if (!token) return <ErrorScreen message="Bad invitation URL" />;
-  if (error) return <ErrorScreen message="This invitation is no longer valid" />;
-  if (!preview) return <SkeletonScreen />;
+  if (!token)
+    return (
+      <InviteAcceptShell>
+        <InviteAcceptError message="Bad invitation URL" />
+      </InviteAcceptShell>
+    );
+  if (error)
+    return (
+      <InviteAcceptShell>
+        <InviteAcceptError message="This invitation is no longer valid" />
+      </InviteAcceptShell>
+    );
+  if (!preview)
+    return (
+      <InviteAcceptShell>
+        <InviteAcceptSkeleton />
+      </InviteAcceptShell>
+    );
 
   const handleJoin = async () => {
     setBusy(true);
@@ -88,69 +107,23 @@ export function InviteAcceptPage() {
   };
 
   const continueOauthHref = `/api/v1/auth/github/start?next=${encodeURIComponent(`/invite/${token}`)}`;
-  const switchingTeam = isAuthenticated && currentTeamName && currentTeamName !== preview.organizationDisplayName;
-  const expiresHint = formatExpiresHint(preview.expiresAt);
 
   return (
-    <PageShell>
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <CardTitle className="text-title">
-            You're invited to join
-            <br />
-            {preview.organizationDisplayName}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {switchingTeam && (
-            <div
-              className="flex items-start gap-2 rounded-md p-3 text-label"
-              style={{ background: "var(--bg-sunken)", color: "var(--fg-2)" }}
-            >
-              <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>
-                You'll switch from <span className="font-medium">{currentTeamName}</span> to{" "}
-                <span className="font-medium">{preview.organizationDisplayName}</span>.
-              </span>
-            </div>
-          )}
-          {isAuthenticated ? (
-            <Button className="w-full" disabled={busy} onClick={handleJoin}>
-              {busy ? "Joining…" : `Join ${preview.organizationDisplayName}`}
-            </Button>
-          ) : (
-            <Button asChild className="w-full">
-              <a href={continueOauthHref}>
-                <Github className="h-4 w-4" />
-                Continue with GitHub to join
-              </a>
-            </Button>
-          )}
-          {expiresHint && (
-            <p
-              className="text-center text-label"
-              style={{ color: expiresHint.urgent ? "var(--destructive)" : "var(--fg-3)" }}
-            >
-              {expiresHint.text}
-            </p>
-          )}
-          <p className="text-center text-label text-muted-foreground">
-            By continuing you agree to our{" "}
-            <a href="/terms" className="underline underline-offset-2 transition-colors hover:text-foreground">
-              Terms
-            </a>{" "}
-            ·{" "}
-            <a href="/privacy" className="underline underline-offset-2 transition-colors hover:text-foreground">
-              Privacy
-            </a>
-          </p>
-        </CardContent>
-      </Card>
-    </PageShell>
+    <InviteAcceptShell>
+      <InviteAcceptCard
+        preview={preview}
+        isAuthenticated={isAuthenticated}
+        currentTeamName={currentTeamName}
+        busy={busy}
+        onJoin={handleJoin}
+        oauthHref={continueOauthHref}
+      />
+    </InviteAcceptShell>
   );
 }
 
-function PageShell({ children }: { children: React.ReactNode }) {
+/** Full-screen chrome for the invite page: a "back to home" header over the centered card. */
+export function InviteAcceptShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col bg-background">
       <header className="px-4 py-3">
@@ -167,46 +140,120 @@ function PageShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function SkeletonScreen() {
+/** The join card. Pure presentational — the page wires `onJoin` / auth state in. */
+export function InviteAcceptCard({
+  preview,
+  isAuthenticated,
+  currentTeamName,
+  busy,
+  onJoin,
+  oauthHref,
+}: {
+  preview: InvitationPreview;
+  isAuthenticated: boolean;
+  currentTeamName: string | null;
+  busy: boolean;
+  onJoin: () => void;
+  oauthHref: string;
+}) {
+  const switchingTeam = isAuthenticated && currentTeamName && currentTeamName !== preview.organizationDisplayName;
+  const expiresHint = formatExpiresHint(preview.expiresAt);
+
   return (
-    <PageShell>
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <div className="mx-auto h-5 w-2/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
-          <div className="mx-auto mt-2 h-5 w-1/2 rounded-md" style={{ background: "var(--bg-sunken)" }} />
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="h-9 w-full rounded-md" style={{ background: "var(--bg-sunken)" }} />
-          <div className="mx-auto h-3 w-1/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
-        </CardContent>
-      </Card>
-    </PageShell>
+    <Card className="w-full max-w-sm">
+      <CardHeader className="text-center">
+        <CardTitle className="text-title">
+          You're invited to join
+          <br />
+          {preview.organizationDisplayName}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {switchingTeam && (
+          <div
+            className="flex items-start gap-2 rounded-md p-3 text-label"
+            style={{ background: "var(--bg-sunken)", color: "var(--fg-2)" }}
+          >
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              You'll switch from <span className="font-medium">{currentTeamName}</span> to{" "}
+              <span className="font-medium">{preview.organizationDisplayName}</span>.
+            </span>
+          </div>
+        )}
+        {isAuthenticated ? (
+          <Button className="w-full" disabled={busy} onClick={onJoin}>
+            {busy ? "Joining…" : `Join ${preview.organizationDisplayName}`}
+          </Button>
+        ) : (
+          <Button asChild className="w-full">
+            <a href={oauthHref}>
+              <Github className="h-4 w-4" />
+              Continue with GitHub to join
+            </a>
+          </Button>
+        )}
+        {expiresHint && (
+          <p
+            className="text-center text-label"
+            style={{ color: expiresHint.urgent ? "var(--destructive)" : "var(--fg-3)" }}
+          >
+            {expiresHint.text}
+          </p>
+        )}
+        <p className="text-center text-label text-muted-foreground">
+          By continuing you agree to our{" "}
+          <a href="/terms" className="underline underline-offset-2 transition-colors hover:text-foreground">
+            Terms
+          </a>{" "}
+          ·{" "}
+          <a href="/privacy" className="underline underline-offset-2 transition-colors hover:text-foreground">
+            Privacy
+          </a>
+        </p>
+      </CardContent>
+    </Card>
   );
 }
 
-function ErrorScreen({ message }: { message: string }) {
+/** Loading shimmer shown while the invite preview is fetched. */
+export function InviteAcceptSkeleton() {
   return (
-    <PageShell>
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <div className="mb-2 flex justify-center text-fg-3">
-            <TriangleAlert className="h-6 w-6" />
-          </div>
-          <CardTitle className="text-title">{message}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-center text-body text-muted-foreground">
-            It may have expired or been revoked. Ask the team admin for a fresh link.
-          </p>
-          <Button asChild variant="outline" className="w-full">
-            <Link to="/">
-              <ArrowLeft className="h-3.5 w-3.5" />
-              Back to home
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
-    </PageShell>
+    <Card className="w-full max-w-sm">
+      <CardHeader className="text-center">
+        <div className="mx-auto h-5 w-2/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        <div className="mx-auto mt-2 h-5 w-1/2 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="h-9 w-full rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        <div className="mx-auto h-3 w-1/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Terminal "invitation invalid" card with a back-to-home action. */
+export function InviteAcceptError({ message }: { message: string }) {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader className="text-center">
+        <div className="mb-2 flex justify-center text-fg-3">
+          <TriangleAlert className="h-6 w-6" />
+        </div>
+        <CardTitle className="text-title">{message}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-center text-body text-muted-foreground">
+          It may have expired or been revoked. Ask the team admin for a fresh link.
+        </p>
+        <Button asChild variant="outline" className="w-full">
+          <Link to="/">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to home
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -216,7 +263,7 @@ function ErrorScreen({ message }: { message: string }) {
  * Marked `urgent` when under 24 hours so the UI can render it in the
  * destructive color.
  */
-function formatExpiresHint(expiresAt: string | null): { text: string; urgent: boolean } | null {
+export function formatExpiresHint(expiresAt: string | null): { text: string; urgent: boolean } | null {
   if (!expiresAt) return null;
   const target = new Date(expiresAt).getTime();
   if (!Number.isFinite(target)) return null;

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -1,0 +1,953 @@
+import type { AgentVisibility } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode, useMemo, useState } from "react";
+import type { HubClient } from "../api/activity.js";
+import type { GithubRepo } from "../api/github.js";
+import { InviteAcceptCard, InviteAcceptError, InviteAcceptShell, InviteAcceptSkeleton } from "./invite-accept.js";
+import { COPY } from "./onboarding/copy.js";
+import { WorkingState } from "./onboarding/flow-ui.js";
+import { OnboardingFlowContext, type OnboardingFlowValue, type TreeMode } from "./onboarding/onboarding-flow.js";
+import { OnboardingShell } from "./onboarding/onboarding-shell.js";
+import { ProgressRail } from "./onboarding/progress-rail.js";
+import { StepConnectCode } from "./onboarding/steps/step-connect-code.js";
+import { StepConnectComputer } from "./onboarding/steps/step-connect-computer.js";
+import { StepCreateAgent } from "./onboarding/steps/step-create-agent.js";
+import { StepKickoff } from "./onboarding/steps/step-kickoff.js";
+import { StepTeam } from "./onboarding/steps/step-team.js";
+import { StepWelcome } from "./onboarding/steps/step-welcome.js";
+import { getStepSequence, type OnboardingPath, type StepId } from "./onboarding/steps.js";
+import type { ComputerConnection } from "./onboarding/use-computer-connection.js";
+
+/**
+ * DEV-only gallery of every onboarding screen + state, mounted at
+ * `/preview/onboarding` (gated by `import.meta.env.DEV` in app.tsx). Renders
+ * the REAL step components / shell / rail / copy — nothing is reimplemented —
+ * so it stays pixel-faithful and tracks future flow changes automatically.
+ *
+ * How each scenario is driven:
+ *   - Wizard state (`agentPhase`, `computer`, `selectedRepoUrls`, tree mode…)
+ *     is injected through the real `OnboardingFlowContext`. Mutable fields are
+ *     backed by local state so inputs / checkboxes / radios stay interactive.
+ *   - The GitHub-backed steps fetch via React Query with inline `queryFn`s, so
+ *     we can't override them through query defaults. Instead each scenario
+ *     declares a tiny `net` profile and a scoped `window.fetch` shim returns
+ *     canned responses for the handful of read endpoints the steps call. A
+ *     fresh `QueryClient` per scenario keeps caches isolated.
+ *
+ * Two switcher axes (per the brief): role (Admin / Invitee) and, within a
+ * role, the scenario / screen.
+ */
+
+const ORG_ID = "org-acme";
+const TEAM_NAME = "Acme";
+const TREE_URL = "https://github.com/acme/context-tree";
+const DEFAULT_AGENT_NAME = "Gandy's assistant";
+const SAMPLE_CLI = "npm install -g first-tree\nfirst-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
+
+const NOW_ISO = new Date().toISOString();
+
+const HOST: HubClient = {
+  id: "client-7f3a91",
+  userId: "user-1",
+  status: "connected",
+  authState: "ok",
+  sdkVersion: "0.42.0",
+  hostname: "gandys-macbook",
+  os: "darwin",
+  agentCount: 0,
+  connectedAt: NOW_ISO,
+  lastSeenAt: NOW_ISO,
+  capabilities: {},
+};
+
+const REPO_WEB = "https://github.com/acme/web.git";
+const REPO_API = "https://github.com/acme/api.git";
+const REPO_INFRA = "https://github.com/acme/infra.git";
+
+const REPOS: GithubRepo[] = [
+  {
+    fullName: "acme/web",
+    cloneUrl: REPO_WEB,
+    htmlUrl: "https://github.com/acme/web",
+    private: false,
+    defaultBranch: "main",
+    pushedAt: NOW_ISO,
+  },
+  {
+    fullName: "acme/api",
+    cloneUrl: REPO_API,
+    htmlUrl: "https://github.com/acme/api",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: NOW_ISO,
+  },
+  {
+    fullName: "acme/infra",
+    cloneUrl: REPO_INFRA,
+    htmlUrl: "https://github.com/acme/infra",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: NOW_ISO,
+  },
+];
+
+const NOOP = (): void => {};
+const ASYNC_NOOP = async (): Promise<void> => {};
+
+// ── Computer-connection fixtures (drive the connect-computer + create-agent steps) ──
+const COMPUTER: Record<"waiting" | "tokenError" | "detecting" | "noRuntime" | "ready", ComputerConnection> = {
+  waiting: {
+    connectedClient: null,
+    capabilitiesLoaded: false,
+    okRuntimes: [],
+    selectedRuntime: null,
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+  },
+  tokenError: {
+    connectedClient: null,
+    capabilitiesLoaded: false,
+    okRuntimes: [],
+    selectedRuntime: null,
+    setSelectedRuntime: NOOP,
+    cliCommand: null,
+    tokenError: "Failed to generate connect command",
+  },
+  detecting: {
+    connectedClient: HOST,
+    capabilitiesLoaded: false,
+    okRuntimes: [],
+    selectedRuntime: null,
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+  },
+  noRuntime: {
+    connectedClient: HOST,
+    capabilitiesLoaded: true,
+    okRuntimes: [],
+    selectedRuntime: null,
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+  },
+  ready: {
+    connectedClient: HOST,
+    capabilitiesLoaded: true,
+    okRuntimes: ["claude-code"],
+    selectedRuntime: "claude-code",
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+  },
+};
+
+// ── Invite-page preview fixtures ──
+const PREVIEW = {
+  organizationId: "org-acme",
+  organizationName: "acme",
+  organizationDisplayName: "Acme Inc",
+  role: "member",
+  expiresAt: null as string | null,
+};
+const PREVIEW_DAYS = { ...PREVIEW, expiresAt: new Date(Date.now() + 3 * 24 * 3600_000).toISOString() };
+const PREVIEW_HOURS = { ...PREVIEW, expiresAt: new Date(Date.now() + 5 * 3600_000).toISOString() };
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario network profile + scoped fetch shim
+// ────────────────────────────────────────────────────────────────────────────
+
+type RepoOutcome = GithubRepo[] | "pending" | "scope" | "neterror";
+
+type NetProfile = {
+  /** GET /me/github/repos */
+  repos?: RepoOutcome;
+  /** GET /orgs/:id/github-app-installation — 200 vs 404 */
+  installed?: boolean;
+  /** GET /orgs/:id/github-app-installation/exists */
+  installExists?: boolean;
+  /** GET /orgs/:id/settings/context_tree → { repo } */
+  contextTree?: string | null | "pending";
+  /** GET /orgs/:id/settings/source_repos → { repos: [{ url }] } */
+  sourceRepos?: string[];
+};
+
+// The active scenario's net profile, read by the shim. Set during render of the
+// main panel (synchronous, before the keyed child subtree mounts and fetches).
+let activeNet: NetProfile = {};
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { status: 200, headers: JSON_HEADERS });
+}
+function statusResponse(code: number, body = ""): Response {
+  return new Response(body, { status: code, headers: JSON_HEADERS });
+}
+
+function reposResponse(outcome: RepoOutcome | undefined): Promise<Response> | Response {
+  if (outcome === "pending") return new Promise<Response>(() => {});
+  if (outcome === "scope") return statusResponse(403, JSON.stringify({ error: "missing project read permission" }));
+  if (outcome === "neterror") return Promise.reject(new TypeError("Failed to fetch"));
+  return jsonResponse({ repos: outcome ?? [] });
+}
+
+/** Map a request path (with `/api/v1` prefix) to a canned response, or null to fall through. */
+function handleNet(rawUrl: string): Promise<Response> | Response | null {
+  const idx = rawUrl.indexOf("/api/v1");
+  if (idx < 0) return null;
+  const p = rawUrl.slice(idx + "/api/v1".length).split("?")[0];
+
+  if (p === "/me/organizations") {
+    return jsonResponse([{ id: ORG_ID, name: "acme", displayName: TEAM_NAME, role: "admin" }]);
+  }
+  if (p === "/me/github/repos") return reposResponse(activeNet.repos);
+  if (p === `/orgs/${ORG_ID}/github-app-installation`) {
+    return activeNet.installed
+      ? jsonResponse({ installed: true })
+      : statusResponse(404, "No GitHub App installation is bound to this team");
+  }
+  if (p === `/orgs/${ORG_ID}/github-app-installation/exists`) {
+    return jsonResponse({ exists: !!activeNet.installExists });
+  }
+  if (p === `/orgs/${ORG_ID}/settings/context_tree`) {
+    if (activeNet.contextTree === "pending") return new Promise<Response>(() => {});
+    return jsonResponse({ repo: activeNet.contextTree ?? null });
+  }
+  if (p === `/orgs/${ORG_ID}/settings/source_repos`) {
+    return jsonResponse({ repos: (activeNet.sourceRepos ?? []).map((url) => ({ url })) });
+  }
+  return null;
+}
+
+// Patch window.fetch at module load (the module is only imported for this DEV
+// route, so this runs before any component renders). Installing here — rather
+// than in a useEffect — avoids an ordering trap: effects run child-first, so a
+// step's own fetch would fire before a parent effect could install the shim.
+// Interception is gated to the preview path, so navigating away (or the rest of
+// the app) is unaffected; the true original is stashed on window so HMR
+// re-imports re-wrap the real fetch instead of stacking.
+interface WindowWithOrigFetch extends Window {
+  __ftOrigFetch?: typeof fetch;
+}
+const previewWindow: WindowWithOrigFetch = window;
+previewWindow.__ftOrigFetch ??= window.fetch;
+const originalFetch = previewWindow.__ftOrigFetch;
+window.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  if (window.location.pathname.startsWith("/preview/onboarding")) {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const handled = handleNet(url);
+    if (handled !== null) return Promise.resolve(handled);
+  }
+  return originalFetch(input, init);
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Scenario catalog
+// ────────────────────────────────────────────────────────────────────────────
+
+type Role = OnboardingPath;
+
+type WizardSpec = {
+  step: StepId;
+  flow?: Partial<OnboardingFlowValue>;
+  net?: NetProfile;
+  /** Override the rendered body (used for transient working states). */
+  body?: ReactNode;
+};
+
+type Scenario = {
+  id: string;
+  label: string;
+  group: string;
+  role: Role;
+  wizard?: WizardSpec;
+  invite?: ReactNode;
+};
+
+const SCENARIOS: Scenario[] = [
+  // ── ADMIN ──────────────────────────────────────────────────────────────
+  { id: "admin-team", label: "Name your team", group: "1 · Team", role: "admin", wizard: { step: "team" } },
+
+  {
+    id: "admin-cc-waiting",
+    label: "Waiting for computer",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.waiting } },
+  },
+  {
+    id: "admin-cc-tokenerr",
+    label: "Connect-token error",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.tokenError } },
+  },
+  {
+    id: "admin-cc-detecting",
+    label: "Connected · detecting",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.detecting } },
+  },
+  {
+    id: "admin-cc-noruntime",
+    label: "Connected · no AI engine",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.noRuntime } },
+  },
+  {
+    id: "admin-cc-ready",
+    label: "Connected · ready",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.ready } },
+  },
+
+  {
+    id: "admin-ca-form",
+    label: "Form (idle)",
+    group: "3 · Create agent",
+    role: "admin",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "idle" } },
+  },
+  {
+    id: "admin-ca-creating",
+    label: "Creating…",
+    group: "3 · Create agent",
+    role: "admin",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "creating" } },
+  },
+  {
+    id: "admin-ca-timeout",
+    label: "Timeout",
+    group: "3 · Create agent",
+    role: "admin",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "timeout" } },
+  },
+  {
+    id: "admin-ca-error",
+    label: "Create error",
+    group: "3 · Create agent",
+    role: "admin",
+    wizard: {
+      step: "create-agent",
+      flow: { computer: COMPUTER.ready, agentPhase: "idle", agentError: "Couldn't create your agent" },
+    },
+  },
+
+  {
+    id: "admin-code-notinstalled",
+    label: "Not installed",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: false } },
+  },
+  {
+    id: "admin-code-loading",
+    label: "Loading projects",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: "pending" } },
+  },
+  {
+    id: "admin-code-norepos",
+    label: "No projects",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: [] } },
+  },
+  {
+    id: "admin-code-scope",
+    label: "Scope missing",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: "scope" } },
+  },
+  {
+    id: "admin-code-repos",
+    label: "Pick projects",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: REPOS } },
+  },
+
+  {
+    id: "admin-ko-noproject",
+    label: "No project",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: { step: "kickoff", flow: { selectedRepoUrls: [] } },
+  },
+  {
+    id: "admin-ko-new",
+    label: "New tree (default)",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: { step: "kickoff", flow: { selectedRepoUrls: [REPO_WEB], treeMode: "new" }, net: { contextTree: null } },
+  },
+  {
+    id: "admin-ko-existing",
+    label: "Existing (auto-detected)",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: { step: "kickoff", flow: { selectedRepoUrls: [REPO_WEB] }, net: { contextTree: TREE_URL } },
+  },
+  {
+    id: "admin-ko-invalid",
+    label: "Existing · invalid URL",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: {
+      step: "kickoff",
+      flow: { selectedRepoUrls: [REPO_WEB], treeMode: "existing", treeUrl: "ftp://not-a-link", treeAutoInitDone: true },
+      net: { contextTree: null },
+    },
+  },
+  {
+    id: "admin-ko-checking",
+    label: "Checking team setup",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: { step: "kickoff", flow: { selectedRepoUrls: [REPO_WEB] }, net: { contextTree: "pending" } },
+  },
+  {
+    id: "admin-ko-starting",
+    label: "Starting…",
+    group: "5 · Kickoff",
+    role: "admin",
+    wizard: {
+      step: "kickoff",
+      flow: { selectedRepoUrls: [REPO_WEB] },
+      body: <WorkingState label={COPY.kickoff.starting} />,
+    },
+  },
+
+  // ── INVITEE ────────────────────────────────────────────────────────────
+  {
+    id: "inv-link-loading",
+    label: "Loading",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: <InviteAcceptSkeleton />,
+  },
+  {
+    id: "inv-link-invalid",
+    label: "Invalid / expired",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: <InviteAcceptError message="This invitation is no longer valid" />,
+  },
+  {
+    id: "inv-link-signedout",
+    label: "Signed out",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: (
+      <InviteAcceptCard
+        preview={PREVIEW}
+        isAuthenticated={false}
+        currentTeamName={null}
+        busy={false}
+        onJoin={NOOP}
+        oauthHref="#"
+      />
+    ),
+  },
+  {
+    id: "inv-link-signedin",
+    label: "Signed in · join",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: (
+      <InviteAcceptCard
+        preview={PREVIEW}
+        isAuthenticated
+        currentTeamName={null}
+        busy={false}
+        onJoin={NOOP}
+        oauthHref="#"
+      />
+    ),
+  },
+  {
+    id: "inv-link-switch",
+    label: "Team switch warning",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: (
+      <InviteAcceptCard
+        preview={PREVIEW}
+        isAuthenticated
+        currentTeamName="Globex"
+        busy={false}
+        onJoin={NOOP}
+        oauthHref="#"
+      />
+    ),
+  },
+  {
+    id: "inv-link-exp-days",
+    label: "Expiry · days",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: (
+      <InviteAcceptCard
+        preview={PREVIEW_DAYS}
+        isAuthenticated={false}
+        currentTeamName={null}
+        busy={false}
+        onJoin={NOOP}
+        oauthHref="#"
+      />
+    ),
+  },
+  {
+    id: "inv-link-exp-hours",
+    label: "Expiry · hours (urgent)",
+    group: "0 · Invite link (pre-login)",
+    role: "invitee",
+    invite: (
+      <InviteAcceptCard
+        preview={PREVIEW_HOURS}
+        isAuthenticated={false}
+        currentTeamName={null}
+        busy={false}
+        onJoin={NOOP}
+        oauthHref="#"
+      />
+    ),
+  },
+
+  {
+    id: "inv-welcome",
+    label: "Welcome to the team",
+    group: "1 · Welcome",
+    role: "invitee",
+    wizard: { step: "welcome", flow: { teamDisplayName: "Acme Inc" } },
+  },
+
+  {
+    id: "inv-cc-waiting",
+    label: "Waiting for computer",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.waiting } },
+  },
+  {
+    id: "inv-cc-tokenerr",
+    label: "Connect-token error",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.tokenError } },
+  },
+  {
+    id: "inv-cc-detecting",
+    label: "Connected · detecting",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.detecting } },
+  },
+  {
+    id: "inv-cc-noruntime",
+    label: "Connected · no AI engine",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.noRuntime } },
+  },
+  {
+    id: "inv-cc-ready",
+    label: "Connected · ready",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.ready } },
+  },
+
+  {
+    id: "inv-ca-form",
+    label: "Form (idle)",
+    group: "3 · Create agent",
+    role: "invitee",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "idle" } },
+  },
+  {
+    id: "inv-ca-creating",
+    label: "Creating…",
+    group: "3 · Create agent",
+    role: "invitee",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "creating" } },
+  },
+  {
+    id: "inv-ca-timeout",
+    label: "Timeout",
+    group: "3 · Create agent",
+    role: "invitee",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.ready, agentPhase: "timeout" } },
+  },
+  {
+    id: "inv-ca-error",
+    label: "Create error",
+    group: "3 · Create agent",
+    role: "invitee",
+    wizard: {
+      step: "create-agent",
+      flow: { computer: COMPUTER.ready, agentPhase: "idle", agentError: "Couldn't create your agent" },
+    },
+  },
+
+  {
+    id: "inv-ko-waiting",
+    label: "Waiting for team",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { installExists: true } },
+  },
+  {
+    id: "inv-ko-noinstall",
+    label: "No code connection",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: false } },
+  },
+  {
+    id: "inv-ko-confirm",
+    label: "Confirm team projects",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [REPO_WEB, REPO_API] } },
+  },
+  {
+    id: "inv-ko-picker",
+    label: "Picker · pick own",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: REPOS } },
+  },
+  {
+    id: "inv-ko-picker-empty",
+    label: "Picker · no projects",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: [] } },
+  },
+  {
+    id: "inv-ko-picker-loading",
+    label: "Picker · loading",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "pending" } },
+  },
+  {
+    id: "inv-ko-picker-scope",
+    label: "Picker · scope missing",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "scope" } },
+  },
+  {
+    id: "inv-ko-picker-neterr",
+    label: "Picker · network error",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: {
+      step: "kickoff",
+      net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "neterror" },
+    },
+  },
+  {
+    id: "inv-ko-starting",
+    label: "Starting…",
+    group: "4 · Kickoff (start work)",
+    role: "invitee",
+    wizard: { step: "kickoff", body: <WorkingState label={COPY.kickoff.starting} /> },
+  },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Flow value + wizard renderer
+// ────────────────────────────────────────────────────────────────────────────
+
+function baseFlow(path: OnboardingPath): OnboardingFlowValue {
+  const sequence = getStepSequence(path);
+  return {
+    path,
+    sequence,
+    activeIndex: 0,
+    activeStep: sequence[0] as StepId,
+    goNext: NOOP,
+    goTo: NOOP,
+    organizationId: ORG_ID,
+    memberId: "mem-preview",
+    role: path === "admin" ? "admin" : "member",
+    username: "gandy",
+    teamDisplayName: TEAM_NAME,
+    orgHasOtherMembers: path === "invitee",
+    computer: COMPUTER.waiting,
+    agentDisplayName: DEFAULT_AGENT_NAME,
+    setAgentDisplayName: NOOP,
+    visibility: "organization",
+    setVisibility: NOOP,
+    agentPhase: "idle",
+    agentError: null,
+    createAgent: ASYNC_NOOP,
+    retryAgent: ASYNC_NOOP,
+    createdAgentUuid: null,
+    hasAgent: false,
+    selectedRepoUrls: [],
+    setSelectedRepoUrls: NOOP,
+    treeMode: "new",
+    setTreeMode: NOOP,
+    treeUrl: "",
+    setTreeUrl: NOOP,
+    treeAutoInitDone: false,
+    markTreeAutoInitDone: NOOP,
+    completeAndEnterChat: ASYNC_NOOP,
+    finishLater: ASYNC_NOOP,
+  };
+}
+
+function StepBody({ step }: { step: StepId }): ReactNode {
+  switch (step) {
+    case "team":
+      return <StepTeam />;
+    case "connect-code":
+      return <StepConnectCode />;
+    case "connect-computer":
+      return <StepConnectComputer />;
+    case "create-agent":
+      return <StepCreateAgent />;
+    case "kickoff":
+      return <StepKickoff />;
+    case "welcome":
+      return <StepWelcome />;
+    default:
+      return null;
+  }
+}
+
+/** Renders one wizard scenario at full fidelity. Remounted per scenario via key. */
+function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
+  const path: OnboardingPath = role;
+  const sequence = getStepSequence(path);
+  const activeIndex = Math.max(0, sequence.indexOf(spec.step));
+  const init = spec.flow ?? {};
+
+  const [agentDisplayName, setAgentDisplayName] = useState<string>(init.agentDisplayName ?? DEFAULT_AGENT_NAME);
+  const [visibility, setVisibility] = useState<AgentVisibility>(init.visibility ?? "organization");
+  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>(init.selectedRepoUrls ?? []);
+  const [treeMode, setTreeMode] = useState<TreeMode>(init.treeMode ?? "new");
+  const [treeUrl, setTreeUrl] = useState<string>(init.treeUrl ?? "");
+  const [treeAutoInitDone, setTreeAutoInitDone] = useState<boolean>(init.treeAutoInitDone ?? false);
+
+  const queryClient = useMemo(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } } }),
+    [],
+  );
+
+  const flow: OnboardingFlowValue = {
+    ...baseFlow(path),
+    ...init,
+    path,
+    sequence,
+    activeIndex,
+    activeStep: spec.step,
+    agentDisplayName,
+    setAgentDisplayName,
+    visibility,
+    setVisibility,
+    selectedRepoUrls,
+    setSelectedRepoUrls,
+    treeMode,
+    setTreeMode,
+    treeUrl,
+    setTreeUrl,
+    treeAutoInitDone,
+    markTreeAutoInitDone: () => setTreeAutoInitDone(true),
+  };
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <OnboardingFlowContext.Provider value={flow}>
+        <OnboardingShell rail={<ProgressRail />}>{spec.body ?? <StepBody step={spec.step} />}</OnboardingShell>
+      </OnboardingFlowContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Page (switcher + main panel)
+// ────────────────────────────────────────────────────────────────────────────
+
+export function OnboardingPreviewPage() {
+  const [role, setRole] = useState<Role>("admin");
+  const roleScenarios = useMemo(() => SCENARIOS.filter((s) => s.role === role), [role]);
+  const [scenarioId, setScenarioId] = useState<string>(roleScenarios[0]?.id ?? "");
+
+  const active = roleScenarios.find((s) => s.id === scenarioId) ?? roleScenarios[0];
+
+  const switchRole = (next: Role): void => {
+    setRole(next);
+    const first = SCENARIOS.find((s) => s.role === next);
+    if (first) setScenarioId(first.id);
+  };
+
+  // Set the net profile for the active wizard scenario BEFORE the keyed child
+  // subtree below mounts and fetches. Render is synchronous and parent-first,
+  // so the shim sees the right profile by the time the step components fetch.
+  activeNet = active?.wizard?.net ?? {};
+
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden", background: "var(--bg)" }}>
+      <aside
+        style={{
+          width: 288,
+          flexShrink: 0,
+          display: "flex",
+          flexDirection: "column",
+          borderRight: "var(--hairline) solid var(--border)",
+          background: "var(--bg-raised)",
+          overflowY: "auto",
+        }}
+      >
+        <div style={{ padding: "var(--sp-4) var(--sp-4) var(--sp-3)" }}>
+          <h1 className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
+            Onboarding · Preview
+          </h1>
+          <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-4)" }}>
+            DEV-only. Real components, mocked state.
+          </p>
+        </div>
+
+        {/* Axis 1 — role */}
+        <div style={{ padding: "0 var(--sp-4) var(--sp-3)" }}>
+          <div
+            className="flex"
+            style={{
+              gap: 2,
+              padding: 2,
+              borderRadius: "var(--radius-input)",
+              background: "var(--bg-sunken)",
+              border: "var(--hairline) solid var(--border-faint)",
+            }}
+          >
+            {(["admin", "invitee"] as const).map((r) => {
+              const on = role === r;
+              return (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => switchRole(r)}
+                  className="text-label font-medium"
+                  style={{
+                    flex: 1,
+                    padding: "var(--sp-1_5) var(--sp-2)",
+                    borderRadius: "var(--radius-chip)",
+                    border: 0,
+                    cursor: "pointer",
+                    textTransform: "capitalize",
+                    background: on ? "var(--bg-raised)" : "transparent",
+                    color: on ? "var(--fg)" : "var(--fg-3)",
+                    boxShadow: on ? "var(--shadow-sm)" : "none",
+                  }}
+                >
+                  {r}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Axis 2 — scenario list, grouped by step */}
+        <nav style={{ padding: "0 var(--sp-2) var(--sp-4)", flex: 1 }}>
+          {roleScenarios.map((s, i) => {
+            const newGroup = i === 0 || roleScenarios[i - 1]?.group !== s.group;
+            const on = active?.id === s.id;
+            return (
+              <div key={s.id}>
+                {newGroup && (
+                  <p
+                    className="text-caption mono"
+                    style={{
+                      margin: "var(--sp-3) var(--sp-2) var(--sp-1)",
+                      color: "var(--fg-4)",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {s.group}
+                  </p>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setScenarioId(s.id)}
+                  className="text-label w-full text-left"
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    padding: "var(--sp-1_5) var(--sp-2)",
+                    borderRadius: "var(--radius-input)",
+                    border: 0,
+                    cursor: "pointer",
+                    background: on ? "color-mix(in oklch, var(--accent) 12%, transparent)" : "transparent",
+                    color: on ? "var(--fg)" : "var(--fg-2)",
+                    fontWeight: on ? 600 : 400,
+                  }}
+                >
+                  {s.label}
+                </button>
+              </div>
+            );
+          })}
+        </nav>
+
+        <ThemeToggle />
+      </aside>
+
+      <main style={{ flex: 1, minWidth: 0, overflow: "hidden", position: "relative" }}>
+        {active?.wizard ? (
+          <WizardScenarioView key={active.id} spec={active.wizard} role={active.role} />
+        ) : active?.invite ? (
+          <div key={active.id} style={{ height: "100%", overflowY: "auto" }}>
+            <InviteAcceptShell>{active.invite}</InviteAcceptShell>
+          </div>
+        ) : null}
+      </main>
+    </div>
+  );
+}
+
+function ThemeToggle() {
+  return (
+    <div
+      style={{
+        padding: "var(--sp-3) var(--sp-4)",
+        borderTop: "var(--hairline) solid var(--border-faint)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      <span className="text-label mono" style={{ color: "var(--fg-4)" }}>
+        theme
+      </span>
+      <button
+        type="button"
+        className="text-caption mono"
+        onClick={() => {
+          const dark = document.documentElement.classList.toggle("dark");
+          window.localStorage.setItem("theme", dark ? "dark" : "light");
+        }}
+        style={{
+          padding: "var(--sp-1) var(--sp-2)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-input)",
+          background: "var(--bg-hover)",
+          color: "var(--fg-2)",
+          cursor: "pointer",
+        }}
+      >
+        toggle
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -62,7 +62,11 @@ export type OnboardingFlowValue = {
   finishLater: () => Promise<void>;
 };
 
-const OnboardingFlowContext = createContext<OnboardingFlowValue | null>(null);
+// Exported so the DEV-only onboarding preview page (pages/onboarding-preview.tsx)
+// can inject fixture flow values and render the real step components without the
+// live provider's API-backed hooks. Production code uses OnboardingFlowProvider /
+// useOnboardingFlow below and never touches the raw context.
+export const OnboardingFlowContext = createContext<OnboardingFlowValue | null>(null);
 
 // Remember the active step for the tab's lifetime so a full-page round-trip
 // (notably the GitHub App install redirect to github.com and back) returns


### PR DESCRIPTION
## Summary
- Adds a DEV-only page at **`/preview/onboarding`** (gated by `import.meta.env.DEV`, like the existing `/preview/*` pages) to iterate on the onboarding flow — a "living" test template for ongoing onboarding optimization.
- Two-axis switcher per the request: **role** (Admin / Invitee) × **scenario** (the screens/states within each role).
- Renders the **real** onboarding components (shell / rail / every `step-*` / `copy.ts`) — nothing is reimplemented, so it stays pixel/copy-faithful and auto-tracks future flow changes. Scenario state is injected via the real `OnboardingFlowContext`; the GitHub-backed steps are driven by a scoped, path-gated `fetch` shim with per-scenario canned responses (a fresh `QueryClient` per scenario keeps caches isolated).

### Scenarios covered (38)
- **Admin:** name team · connect computer (waiting / token-error / detecting / no-AI-engine / ready) · create agent (form / creating / timeout / error) · connect code (not-installed / loading / no-projects / scope-missing / pick-projects) · kickoff (no-project / new-tree / existing-auto-detected / invalid-URL / checking / starting)
- **Invitee:** pre-login invite page (loading / invalid / signed-out / signed-in / team-switch / expiry-days / expiry-hours-urgent) · welcome · connect computer (×5) · create agent (×4) · kickoff (waiting / no-code-connection / confirm / picker + loading/empty/scope/network / starting)

### Supporting changes
- Export `OnboardingFlowContext` from `onboarding-flow.tsx` (additive; no behavior change) so the preview can inject fixture flow values.
- Extract the invite-accept presentational pieces (`InviteAcceptCard` / `InviteAcceptShell` / `InviteAcceptSkeleton` / `InviteAcceptError`) as exports; `InviteAcceptPage` composes them (behavior unchanged).

### Extending it
Add one entry to the `SCENARIOS` array in `onboarding-preview.tsx`: set `role` / `group` / `step`, then drive state with `flow` (context), `net` (canned network), or `body` (a component for transient states).

## Test plan
- [x] `pnpm --filter @first-tree/web typecheck` (tsc + design-token guardrails) passes
- [x] `biome check` clean on changed files
- [x] Loaded `/preview/onboarding` in-browser: verified admin team, connect-code repo picker, invitee invite-card (team-switch), invitee picker scope-missing (full team-config → repos 403 chain), connect-computer ready, and dark mode — no console errors
- [ ] Reviewer: click through scenarios to sanity-check fidelity vs. the live flow

> Note: DEV-only — tree-shaken out of production builds (mounted behind `import.meta.env.DEV` in `app.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)