### PR TITLE
refactor(web): design-system token cleanup, guardrail, styleguide + docs

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -1,0 +1,198 @@
+# Design System Audit & Fix Log
+
+> Recorded 2026-05-28 from a source-grounded review of `src/index.css` + `src/components/ui/*`.
+> Companion to [DESIGN.md](DESIGN.md) (the spec) and `/preview/styleguide` (the visual reference).
+>
+> **This doc owns:** current implementation state, the gap vs DESIGN.md's adopted design
+> language, the phased migration plan, the audit/fix log, and known structural gaps.
+> DESIGN.md stays clean — the design system itself; everything time-bound or migration-related lives here.
+>
+> **Status legend:** `[ ]` open · `[~]` decision pending (needs owner) · `[x]` done.
+> P0 items are live visual bugs (not style opinions) — they reference CSS variables that
+> do not exist, so the property silently fails.
+
+---
+
+## Decisions (2026-05-28)
+
+Owner picked the optimization direction. These are now committed targets (implementation pending):
+
+1. **Two named vocabularies, deduped values.** `--ok` / `--warn` / `--danger` are a *severity* triad
+   (ok/warning/error, used in `context.tsx`), semantically distinct from agent-states even though the
+   colors coincide. Introduce a proper **feedback set `--success` / `--warning` / `--danger`**; each
+   (and the agent-`--state-*`) aliases to a single shared base hue, so there is **one value per color**.
+   The root problem was duplicate *values*, not duplicate *names*. The severity triad migrates onto the
+   feedback set; raw `--ok` is removed.
+2. **`--state-idle` → neutral.** Break the `--accent` == `--ok` == `--state-idle` collision: idle becomes a neutral/de-saturated tone, visually distinct from brand green and success — but still distinct from `--state-offline`. *(Value being chosen by eye in `/preview/styleguide`: candidates A `oklch(0.72 0.02 150)` / B `oklch(0.70 0.03 240)` / C `oklch(0.68 0.05 150)`.)*
+3. **Radius → semantic only; shadow stays 2-tier.** Standardize radius on `--radius-*`; migrate the 38
+   `rounded-md` (= 6px = `--radius-panel`, value-preserving) and `Dialog` `rounded-lg` (= 8px =
+   `--radius-dialog`, value-preserving); `Badge` → `--radius-chip` (match DenseBadge). Retire shadcn
+   `--radius-sm/md/lg/xl`. **Shadow:** keep the 2-tier `--shadow-sm/md` (no `--shadow-lg`); `Dialog`
+   moves from Tailwind `shadow-lg` to `--shadow-md`.
+4. **`--color-*` alias layer → delete.** `--fg` / `--bg-*` / `--border` are canonical. Remove the unadopted `--color-text-*`/`--color-surface-*`/`--color-border-*` layer (keep only the shadcn-compat aliases the primitives actually need, e.g. `--color-primary`, `--color-destructive`).
+
+---
+
+## Implemented (2026-05-28)
+
+Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`):
+
+- ✅ **P0** — all 7 ghost-token references fixed; the new guardrail then surfaced + fixed an 8th
+  (`var(--shadow-lg)` in `attentions-section.tsx`).
+- ✅ **P0.5** — undefined-token check added to `check-design-tokens.sh` (rule 7). Collects defined
+  tokens from `index.css` + inline `"--foo"` definitions, diffs against every literal `var(--x)`
+  (dynamic `var(--x-${…})` and `__tests__` excluded). Multi-line inline-style detection deferred.
+- ✅ **P1** — removed `--ok/--warn/--danger`; added `--success`/`--warning`/`--danger` aliased to
+  `--accent`/`--state-blocked`/`--state-error`; migrated all consumers (index.css + context.tsx).
+  `--state-idle` → `oklch(0.7 0.03 240)` (cool standby). Radius: 38 `rounded-md` + `rounded-lg/sm`
+  → semantic `rounded-[var(--radius-*)]`, `Badge` → chip, `Dialog` `shadow-lg` → `--shadow-md`,
+  removed `--radius-sm/md/lg/xl`.
+- ✅ **P2 (partial)** — deleted the unadopted `--color-text-*/surface-*/border-*` alias layer
+  (migrated `doc-preview-drawer.tsx`).
+- Styleguide updated: real tokens, new Feedback swatches, idle shows the new tone; the temporary
+  "Cleanup candidates" section was removed.
+
+**Still open:** focus-ring unification, `--text-live` adopt/drop, `--state-*-soft` companions,
+`color-scheme: dark` on `.dark`, info callout, `.context-live-*` palette, spacing rhythm, dead `--sp-*`.
+
+---
+
+## P0 — Ghost tokens (live bugs: referenced but undefined in index.css)
+
+Each of these resolves to an invalid/empty value at runtime. Fix = point at the real token.
+
+| # | File:line | Written | Effect | Fix |
+|---|-----------|---------|--------|-----|
+| [ ] 1 | `components/ui/toast.tsx:114` | `var(--surface-1)` | Toast background transparent | `--bg-raised` |
+| [ ] 2 | `pages/workspace/right-sidebar/attentions-section.tsx:89,167` | `var(--sp-0_25)` | Vertical padding collapses to 0 | `--sp-px` (1px) or `--sp-0_5` |
+| [ ] 3 | `pages/source-repos-settings-panel.tsx:161` | `var(--surface-2)` | Hover background no-op | `--bg-hover` |
+| [ ] 4 | `components/history-gap-banner.tsx:23` | `var(--fg-muted)` | Text color falls back to inherit | `--fg-3` |
+| [ ] 5 | `pages/workspace/conversations/new-chat-draft.tsx:451` | `var(--bg-base)` | Background transparent | `--bg` |
+| [ ] 6 | `pages/invite-accept.tsx:132` | `var(--destructive)` | Urgent color not applied | `--state-error` (or `text-destructive` util) |
+| [ ] 7 | `pages/agent-detail.tsx:692` | `fontSize: "var(--text-body-size)"` | Font size not applied **+** illegal inline `fontSize` | Use `text-body` class; drop inline `fontSize` |
+
+Also check: a stray `var(--shadow-lg)` reference exists (1×) but `--shadow-lg` is undefined
+(only `--shadow-sm` / `--shadow-md` exist). Locate and either define `--shadow-lg` or use `--shadow-md`.
+
+## P0.5 — Close the guardrail hole (highest leverage)
+
+The token linter (`scripts/check-design-tokens.sh`) is line-based, so it missed both classes
+of P0 bug. Two additions catch the entire P0 list automatically and stop recurrence:
+
+- [ ] **Undefined-token check:** collect every `var(--x)` in `src/`, diff against the tokens
+  defined in `index.css`; fail on any reference to an undefined token. (Would have caught all 7 above.)
+- [ ] **Multi-line style detection:** rules 1 (raw px) and 5 (inline font props) only match when
+  `style={{` and the property are on the same line. `agent-detail.tsx:692` evaded both by spanning
+  lines. Normalize whitespace before matching, or scan JSX style objects as blocks.
+
+## P1 — Redundancy & contradiction (DECISIONS NEEDED before fixing)
+
+- [ ] **Duplicate color vocab.** `--ok` / `--warn` / `--danger` have byte-identical values to
+  `--state-idle` / `--state-blocked` / `--state-error`. Two names per color = change-one-forget-other.
+  **DECIDED + DONE:** removed `--ok/--warn/--danger`; severity migrated to the feedback set
+  `--success` / `--warning` / `--danger` (aliased to `--accent` / `--state-blocked` / `--state-error`).
+- [ ] **Triple-identical green.** `--accent` == `--ok` == `--state-idle` == `oklch(0.72 0.17 150)`.
+  Brand/primary, "success", and "idle agent" are visually indistinguishable.
+  **DECIDED:** `--state-idle` becomes a neutral/de-saturated tone, distinct from `--accent` and from
+  `--state-offline`. New value TBD — propose options first.
+- [ ] **Two radius systems, both live.** Semantic `--radius-chip/input/panel/dialog` vs shadcn-legacy
+  `--radius-sm/md/lg/xl`. `rounded-md` (legacy) is used **38×**; the flagship `Dialog`
+  (`dialog.tsx:32`) uses `rounded-lg` + Tailwind `shadow-lg`, bypassing `--radius-dialog` /
+  `surface-overlay` / the `--shadow-*` scale. `Badge` uses `rounded-md` while `DenseBadge` uses
+  `--radius-chip`. **DECIDED:** standardize on the semantic four; migrate `rounded-md`/`rounded-lg`,
+  fix `Dialog`/`Badge`, retire `--radius-sm/md/lg/xl`.
+- [ ] **Dead token.** `--text-live` (32px tier) has zero `text-live` usages. Adopt it (it's meant for
+  the live-status hero) or delete it.
+- [~] **Inconsistent focus treatment.** Button `focus-visible:ring-1 ring-ring`; Badge
+  `focus:ring-2 ring-offset-2`; settings-save button `outline: --hairline-bold solid --accent-ring`.
+  **Decision:** define one focus recipe (token + utility) and apply everywhere.
+
+## P2 — Omissions
+
+- [ ] **No `--state-*-soft` companions.** Callouts have soft+strong pairs; state colors only have the
+  strong tone, so `lib/tones.ts` and `.context-change-breakdown` compute `color-mix(... 12-14%)` /
+  hardcode `oklch(.../0.12)` at the call site. Add `--state-idle-soft` … `--state-error-soft`.
+- [ ] **`.dark` missing `color-scheme: dark`** (only `.landing-marketing` sets it). Native form
+  controls / scrollbars don't get dark UA rendering in app dark mode.
+- [ ] **`--color-*` semantic alias layer is unadopted.** `--color-text-*` / `--color-surface-*` /
+  `--color-border-*` are each referenced once (only the styleguide). Real components use `--fg`,
+  `--bg-raised`, `--border` directly. **DECIDED:** delete the alias layer; `--fg`/`--bg-*`/`--border`
+  are canonical. Keep only the shadcn-compat aliases the primitives need (`--color-primary`,
+  `--color-destructive`, `--color-ring`, etc.).
+- [ ] **Marketing surface contrast gap.** `.landing-marketing` overrides `--bg`/`--fg`/`--border` but
+  not the callout soft/strong pairs or `--state-*` — a notice on the near-black marketing canvas
+  resolves to light-mode values. Define them in scope or guard against callouts there.
+- [ ] **No `info` (blue) callout pair** — only error/warn/success.
+
+## P3 — Discipline
+
+- [ ] **`.context-live-*` is off-palette.** ~40 lines in index.css hardcode blue hues 255–265
+  (e.g. `oklch(0.2 0.04 265)`) that exist in no token. Bring them into the token system.
+- [ ] **Spacing rhythm.** Half-steps (`--sp-1_25`=5px, `--sp-1_75`=7px) are used 12× / 23×, signalling
+  pixel-nudging off a 4/8 rhythm. Converge to 4/8; mark half-steps as explicit exceptions.
+- [ ] **Prune dead `--sp-*`.** Defined but unused in components: `--sp-2_75`, `--sp-3_25`, `--sp-3_75`,
+  `--sp-4_5`, `--sp-8_5`, `--sp-15`, `--sp-16`, `--sp-20`, `--sp-45`, `--sp-60`, `--sp-80`, `--sp-90`
+  (verify against index.css's own usage before removing).
+
+---
+
+## Structural gaps (longer-term, not blocking)
+
+- **No animation token registry** — durations/easings are per-keyframe literals in `index.css`.
+- **CLI (`apps/cli`) has no visual system** — plain commander + inquirer text; the design system covers the web surface only.
+
+---
+
+## Notes for whoever picks this up
+
+- P0 + P0.5 are safe to do anytime — pure bugfixes, no design judgment.
+- P1 / the `[~]` items need an owner decision; they're the agenda for the optimization discussion.
+- Verify after any change: `pnpm --filter @first-tree/web typecheck` (runs tsc + `lint:tokens`).
+
+---
+
+## Strategy A migration (design-language adoption — 2026-05-28)
+
+Adopted direction: **Strategy A** (see DESIGN.md → "Design language"). Migrate the app
+from green-primary to **neutral-primary + green-as-signature/semantic**, at Lark/Arco
+craft level. Reference mockup: `variant-F.html` (light + dark) in the design archive.
+This is a full visual pass — do it phased, not in one shot. The earlier P1–P3 leftovers
+fold into the phases below.
+
+**Decisions still needed before coding:**
+- [~] **Gray ramp temperature** — keep the current faint green tint in the neutrals
+  (hue 150, very low chroma — a quiet brand whisper) or de-tint to pure neutral?
+  *(Recommend: keep the faint tint — it's on-strategy "green as signature".)*
+- [~] **Exact `--primary` values** — neutral near-black (light) / near-white (dark) + hover.
+- [~] **Token naming** — split `--accent` → `--brand` (green: logo / Context-Tree) +
+  keep `--success`; introduce `--primary` (neutral). Keep `--accent` as a temporary
+  alias during migration, or rename in one pass?
+
+**Phase 0 — token role refactor (`index.css`):**
+- [ ] Add `--primary` / `--primary-hover` / `--primary-on` (neutral, auto-inverting `:root` / `.dark`).
+- [ ] Repoint primary actions from `--accent` → `--primary` (buttons, send, primary CTAs, selected state).
+- [ ] Rename `--accent` → `--brand` for logo / Context-Tree surfaces; keep `--success` for success.
+- [ ] Selected / active states → neutral fill (not green tint).
+- [ ] (already done in cleanup) confirm working=blue / blocked=amber / error=red / idle=neutral.
+
+**Phase 1 — primitives (`components/ui/`):**
+- [ ] `Button`: make the `default` variant neutral-primary; Arco radius/shadow.
+- [ ] Consistent thin line-icon set (lucide is fine; purge any emoji from product UI).
+- [ ] Restyle Badge / Card / Input / Tab / etc. to the neutral language.
+- [ ] Fold in leftover: **unify the focus-ring recipe** (Button/Badge/settings currently differ).
+
+**Phase 2 — component grammar (workspace):**
+- [ ] `ConversationList`: add a Search box; tabs-as-underline; rounded-square avatars; neutral selected row.
+- [ ] `ChatView`: neutral "you" bubble; neutral send button; blue working tag.
+- [ ] Right **Session sidebar**: agent card + Runtime/Model KV + Live-context tree nodes (green) + Needs-you.
+
+**Phase 3 — rollout + folded cleanup:**
+- [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
+- [ ] Add `--state-*-soft` tokens (so `tones.ts` stops computing `color-mix` at call sites).
+- [ ] `color-scheme: dark` on `.dark`; bring the off-palette `.context-live-*` blues into tokens.
+
+**Phase 4 — close-out:**
+- [ ] QA in light + dark.
+- [ ] Update `/preview/styleguide` to render the new language.
+- [ ] Rewrite DESIGN.md §3 (Color) / §8 (Iconography) / §10 (Theming) to describe the
+  now-implemented language; drop the "migration in progress" caveats.

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -1,0 +1,347 @@
+# First Tree — Web Design System
+
+> Source of truth for the React admin dashboard (`packages/web`).
+> Distilled from the live system: [`src/index.css`](src/index.css),
+> [`src/components/ui/`](src/components/ui), and
+> [`scripts/check-design-tokens.sh`](scripts/check-design-tokens.sh).
+>
+> **One rule above all:** components never hardcode color, size, spacing, or
+> typography. Everything references a token defined in `index.css`. This is not
+> a style guideline — it is enforced by a linter that fails the build (see
+> [Enforcement](#enforcement)).
+
+---
+
+## Design language
+
+> Implementation status, the gap vs the current build, and the step-by-step
+> migration plan live in **[DESIGN-AUDIT.md](DESIGN-AUDIT.md)**. This document
+> describes the design system itself.
+
+**Four pillars:**
+
+1. **Near-monochrome, content-first.** The UI is grays + near-black / near-white.
+   Color is rare and always *means* something — it never decorates.
+2. **Neutral primary.** Primary actions (buttons, send, primary CTAs, selected
+   state) use a **neutral** tone — near-black in light, near-white in dark
+   (auto-inverting). Not green, not blue. (Linear / Vercel restraint.)
+3. **Green = signature + success only.** The brand green lives on the logo, on
+   Context-Tree surfaces (node glyphs, "writing to tree"), and on `success`
+   semantics. It is **never** the generic button / link / selected color — that
+   collision (brand == success == idle) is exactly what this strategy retires.
+4. **Lark / Arco craft, not Lark color.** Borrow the *discipline* — a neutral
+   gray token ramp, hairline borders, soft low-opacity elevation, thin line
+   icons, search + underline tabs, rounded-square avatars, comfortable aligned
+   spacing, a right Session sidebar. Do **not** borrow Feishu's blue primary.
+
+**Semantic color map — the only places color appears:**
+
+| Meaning | Color |
+|---------|-------|
+| primary action / selected | neutral (near-black ↔ near-white) |
+| brand / Context-Tree | green (`--brand`) |
+| success / passing | green (`--success`) |
+| working / processing | blue |
+| blocked / waiting | amber |
+| error / attention | red |
+| idle / standby | neutral |
+| offline | dim neutral |
+
+Per-agent **avatars** keep their own identity hues (wayfinding, not brand).
+
+---
+
+## 1. Principles
+
+- **Single source of truth.** `index.css` is the only file allowed to define
+  raw values. Every other file in `src/` references tokens. `index.css` is the
+  one file exempt from the guardrail scan.
+- **Semantic over raw.** Components reference *intent* (`text-secondary`,
+  `surface-raised`, `state-error`) — not appearance (`gray-500`, `#fff`,
+  `red-600`). Re-theming happens in one place.
+- **Dense by default.** This is a control-room dashboard for agent teams, not a
+  marketing site. The type scale tops out at 16px for app chrome; large type is
+  reserved for the public landing surface.
+- **OkLCH everywhere.** All colors are authored in OkLCH for perceptual
+  uniformity — matched lightness/chroma reads with consistent visual weight
+  across hues, and light↔dark inversion stays balanced.
+- **Cross-platform stable.** Self-hosted fonts, fallback metric-matching, and
+  a CSS spacing ladder keep rendering identical on macOS / Windows / Linux and
+  offline.
+
+---
+
+## 2. Enforcement
+
+`pnpm --filter @first-tree/web lint:tokens` runs as part of `typecheck` and
+fails the build on the first violation. It bans, across all `*.ts` / `*.tsx`
+in `src/` (except `index.css`):
+
+| # | Banned | Use instead |
+|---|--------|-------------|
+| 1 | Raw `Npx` literals | `--sp-*`, `--hairline`, or Tailwind spacing utilities |
+| 2 | `#hex`, `rgb()`, `rgba()` | `--color-*` tokens / `oklch()` |
+| 3 | Tailwind palette classes (`text-gray-500`, `bg-red-50`, …) | semantic color tokens |
+| 4 | font-weights outside 400/500/600/700 | the four allowed weights |
+| 5 | Inline `fontSize`/`fontWeight`/`fontFamily`/`lineHeight`/`letterSpacing` | `text-*` tier + `font-*` class |
+| 6 | Tailwind default text sizes (`text-sm`, `text-xl`, …) | the 6-tier semantic scale |
+
+If you need a value the tokens don't cover, **add a token to `index.css`** —
+don't inline the literal.
+
+---
+
+## 3. Color
+
+Defined as raw values on `:root` (light) and `.dark` (dark), then exposed
+through semantic aliases in the Tailwind v4 `@theme` block. Components only
+ever touch the semantic layer.
+
+### Primary & brand
+| Token | Value | Role |
+|-------|-------|------|
+| `--primary` | neutral — near-black (light) / near-white (dark), auto-inverting | primary actions, send, primary CTAs, selected state |
+| `--brand` | green `oklch(0.72 0.17 150)` | logo, Context-Tree surfaces, brand moments — **never** a generic action / link / selected color |
+
+Color is sparse and meaningful: most of the UI is neutral, and the green only
+appears where it signals brand or success.
+
+The short `--fg*` / `--bg*` / `--border*` names below are canonical; write those.
+
+### Text (foreground)
+`--fg` (primary) → `--fg-2` (secondary) → `--fg-3` (tertiary) → `--fg-4`
+(disabled). Four steps, descending emphasis. `--fg-on-vivid` (near-white) is
+for text sitting on a saturated colored surface (badges, avatars) and does
+**not** invert in dark mode.
+
+### Surfaces (background)
+`--bg` (base) · `--bg-raised` · `--bg-sunken` · `--bg-hover` · `--bg-active`.
+
+### Borders
+`--border-faint` (subtle) · `--border` (default) · `--border-strong` (emphasis).
+
+### State / status (agent-centric)
+| Token | Hue | Meaning |
+|-------|-----|---------|
+| `--state-idle` | cool neutral `240` | idle / standby |
+| `--state-working` | cyan `195` | actively working |
+| `--state-blocked` | amber `75` | blocked |
+| `--state-error` | red `25` | error |
+| `--state-offline` | neutral | offline |
+| `--state-unread` | = error | notification/attention (kept separate identifier on purpose) |
+
+### Feedback / severity
+A named set, aliased to shared base hues (one value per color):
+`--success` (green, = brand hue) · `--warning` (amber) · `--danger` (red).
+
+### Inline callouts (notices)
+Each state ships a **soft** background + a **strong** text/border tone, so you
+never reach for `bg-red-50 / text-red-900`:
+`--color-error` / `--color-error-soft`, `--color-warn` / `--color-warn-soft`,
+`--color-success` / `--color-success-soft`.
+
+### Overlay
+`--color-overlay-scrim` — dialog/lightbox scrim (`oklch(0 0 0 / 0.55)`,
+uniform in both modes). Replaces hardcoded `rgba(0,0,0,…)`.
+
+### shadcn-compat aliases
+`--color-background/foreground/card/primary/secondary/muted/destructive/
+border/input/ring` are preserved so shadcn-shaped components keep working —
+prefer the short semantic names above in new code.
+
+---
+
+## 4. Typography
+
+Six dense tiers for app chrome (each bundles size + line-height +
+letter-spacing + weight), generating `.text-eyebrow … .text-title` utilities.
+Three marketing tiers for the public landing page only.
+
+| Tier | Size | Weight | Typical use |
+|------|------|--------|-------------|
+| `text-eyebrow` | 10px | 600 | all-caps kickers (0.1em tracking) |
+| `text-caption` | 10px | 500 | dense metadata |
+| `text-label` | 11px | 500 | form labels, chips |
+| `text-body` | 12px | 400 | body copy, buttons |
+| `text-subtitle` | 13px | 600 | row titles (**default body size**) |
+| `text-title` | 16px | 600 | section / page titles |
+| `text-live` | 32px | 600 | the "live" status hero number |
+| — marketing — | | | |
+| `text-lead` | 18px | 400 | landing lead copy |
+| `text-headline` | 24px | 600 | landing section headings |
+| `text-display` | `clamp(2.5rem, 6vw, 3.75rem)` | 600 | landing hero |
+
+**Only weights 400 / 500 / 600 / 700 exist.** Numerics use `tabular-nums`
+(`.tnum`); mono uses `--font-mono` with `ss01/ss02` features.
+
+---
+
+## 5. Spacing & radius
+
+**Spacing** — Tailwind utilities first; for compound inline `padding`/`gap`
+strings that can't be classes, use the `--sp-*` ladder (mirror of Tailwind:
+`--sp-N ≈ N × 0.25rem`, with 2/6/10/14px half-steps), range `--sp-0` →
+`--sp-240` (960px). Hairlines: `--hairline` (1px) / `--hairline-bold` (2px) —
+never write `"1px"`.
+
+**Radius** — semantic, ascending with surface importance:
+| Token | Value | Use |
+|-------|-------|-----|
+| `--radius-chip` | 3px | chips, pills, xs buttons |
+| `--radius-input` | 4px | inputs, default buttons |
+| `--radius-panel` | 6px | cards, panels |
+| `--radius-dialog` | 8px | dialogs, overlays |
+
+These four are the only radius tokens — reference them directly
+(`rounded-[var(--radius-panel)]`) or via the matching utilities.
+
+---
+
+## 6. Surfaces & elevation
+
+Three utility classes consolidate the background+border+radius+shadow combos
+(prefer these over hand-rolling):
+
+- `.surface-raised` — raised bg + 1px border + `--radius-panel` (cards/panels)
+- `.surface-sunken` — recessed bg (wells, inset areas)
+- `.surface-overlay` — raised bg + border + `--radius-dialog` + `--shadow-md`
+  (dialogs, popovers)
+
+Shadows are tokens: `--shadow-sm`, `--shadow-md` (deeper in dark mode).
+
+---
+
+## 7. Components
+
+~31 primitives in [`src/components/ui/`](src/components/ui), built on
+**Radix** (Dialog, Label, Slot, Popover) + **CVA** for variants +
+`cn()` (clsx + tailwind-merge) for class composition. No shadcn/MUI/Chakra —
+this is a bespoke system on Tailwind v4 + Radix.
+
+**Variant pattern** (every variant-bearing component follows this — see
+[`button.tsx`](src/components/ui/button.tsx),
+[`badge.tsx`](src/components/ui/badge.tsx)):
+
+```ts
+const buttonVariants = cva("…base classes…", {
+  variants: { variant: { default, destructive, outline, secondary, ghost, link },
+              size:    { default, sm, xs, lg, icon } },
+  defaultVariants: { variant: "default", size: "default" },
+});
+```
+
+`Button` sizes: `default` (h-9) · `sm` (h-8) · `xs` (h-7, chip radius) ·
+`lg` (h-10) · `icon` (9×9). `asChild` via Radix `Slot`.
+
+**Inventory** (representative):
+- **Actions / inputs:** Button, Input, Label, SegmentedControl, FilterPill,
+  Command (cmdk), RowActionsMenu
+- **Containers / layout:** Card, Panel, Section, Tile, SettingsField, PageHeader,
+  SectionHeader, FlatSectionHeader, TabBar
+- **Data:** Table, DenseTable, Breadcrumb, Markdown
+- **Status / presence:** Badge, DenseBadge, StateChip, StateDot, StatusGlyph,
+  PresenceChip, AgentStatusChip
+- **Overlay / feedback:** Dialog, Popover, Toast
+- **Theming:** ThemeToggle
+
+---
+
+## 8. Iconography
+
+`lucide-react` only — single icon set, no custom glyphs or icon fonts. Keeps
+stroke weight and sizing consistent everywhere.
+
+---
+
+## 9. Motion
+
+Keyframes live in `index.css` (not inline) so `prefers-reduced-motion` can
+override them — **every animation has a reduced-motion fallback**. Vocabulary:
+
+- **Status pulses** — opacity-led dot breathing (no concentric rings, so a
+  roster column stays pixel-aligned): `--working` 1.4s (faster, "alive"),
+  `--needs-you` 1.9s (calmer, "waiting for you").
+- **Arrival** — `.fade-in` (180ms rise), `toast-slide-in`, feed slide+flash on
+  fresh rows.
+- **Live/ambient** — halo breathe, ring pulse, typing-dot wave for "producing
+  output now".
+- **Standard easing** — `ease-out` for entrances; `cubic-bezier(0.2,0.8,0.2,1)`
+  for slides. Transitions ~120–180ms.
+
+---
+
+## 10. Theming
+
+Class-based: `.dark` on `<html>`, persisted to `localStorage`, falling back to
+`prefers-color-scheme`. Toggle in [`theme-toggle.tsx`](src/components/ui/theme-toggle.tsx).
+
+Three palettes share the **same variable names** (so every utility inherits
+automatically):
+1. **Light** (`:root`) — near-white green-tinted canvas, dark ink.
+2. **Dark** (`.dark`) — green-tinted near-black, light ink; deeper shadows;
+   higher-lightness callout text for contrast.
+3. **Marketing** (`.landing-marketing`) — pinned to the first-tree.ai brand:
+   near-black `#040404` canvas + cool-tinted light text, regardless of the
+   dashboard toggle. `color-scheme: dark`. Same green accent.
+
+---
+
+## 11. Fonts
+
+Self-hosted variable woff2 from `/public/fonts` (no Google Fonts network dep,
+no FOUT flash, works offline). Latin + Latin-Extended subsets; CJK falls
+through to system fonts.
+
+- **Sans:** Inter (400–700) → `Inter Fallback` (Arial, metric size-adjusted for
+  FOUT stability) → system stack (incl. PingFang SC / Microsoft YaHei for CJK).
+- **Mono:** JetBrains Mono (400–600) → ui-monospace stack.
+
+Body defaults: 13px / 1.45, `cv11 ss01 ss03` features, `tabular-nums`,
+antialiased, `font-synthesis: none`.
+
+---
+
+## 12. Avatars
+
+Per-agent identity color: 8 perceptually-balanced OkLCH hues
+(`--avatar-hue-0…7`, matched L/C) at the same visual weight. Same agent →
+same hue everywhere, via `pickAvatarHue(agentId)` /
+`resolveAvatarHue()` (manager-set token, else deterministic hash of agentId).
+White-ish initials (`--fg-on-vivid`) clear WCAG AA on every hue in both modes.
+**Add new hues in the `index.css` block, not at the call site.**
+
+---
+
+## 13. Accessibility
+
+- `--fg-on-vivid` initials and callout pairs are AA-checked in both themes.
+- Every animation respects `prefers-reduced-motion: reduce`.
+- Radix primitives provide focus management / ARIA for Dialog, Popover, Label.
+- Focus is visible: `focus-visible:ring-1 ring-ring` on interactive controls;
+  custom radio/checkbox cards surface a ring on `:focus-within` (the real input
+  is `sr-only`).
+- Scrollbars are styled thin/consistent cross-platform to avoid layout jump.
+
+---
+
+## 14. Extending the system
+
+1. **Need a new value?** Add a token to `index.css` — never inline a literal.
+   Put it in the right block (`@theme` for utility-generating tokens, `:root` /
+   `.dark` for raw mode-specific values).
+2. **Need a new component?** Build it in `src/components/ui/`, compose with
+   `cva` + `cn`, reference Radix for any interactive/overlay behavior, and only
+   use tokenized classes.
+3. **Re-run the guardrail:** `pnpm --filter @first-tree/web lint:tokens`.
+4. **Color authoring is OkLCH.** Keep lightness/chroma matched to neighbors so
+   visual weight stays even.
+
+---
+
+## Status & roadmap
+
+Current implementation status, the gap vs this design language, the phased
+migration plan, and known gaps all live in **[DESIGN-AUDIT.md](DESIGN-AUDIT.md)**.
+
+**Visual reference:** the living styleguide at `/preview/styleguide`
+(`src/pages/styleguide-preview.tsx`).

--- a/packages/web/scripts/check-design-tokens.sh
+++ b/packages/web/scripts/check-design-tokens.sh
@@ -76,6 +76,33 @@ if [ -n "$hits" ]; then
   report "Tailwind default text-size class found (use text-eyebrow/caption/label/body/subtitle/title):" "$hits"
 fi
 
+# 7. Undefined token references — every literal `var(--x)` must resolve to a
+#    token defined in index.css (the source of truth) or set inline in a
+#    component style object (e.g. `"--foo": value`). Catches ghost tokens like
+#    `var(--surface-1)` that silently fail at runtime. Dynamic refs such as
+#    `var(--state-${x})` are skipped: the closing-paren match never matches them.
+defined_file=$(mktemp)
+{
+  # tokens declared in index.css (:root / .dark / @theme / .landing-marketing)
+  grep -hoE -e '--[a-zA-Z0-9_-]+[[:space:]]*:' "$SRC/index.css" 2>/dev/null || true
+  # tokens set inline in components, e.g. style={{ "--foo": value }} or the
+  # computed-key form `["--foo" as string]: value` — match any quoted token
+  # literal in source so inline custom properties count as defined.
+  grep -rhoE --include="*.tsx" --include="*.ts" -e '"--[a-zA-Z0-9_-]+"' "$SRC" 2>/dev/null || true
+} | sed -E 's/"//g; s/[[:space:]]*:$//' | sort -u > "$defined_file"
+
+undef=""
+while IFS= read -r ref; do
+  [ -z "$ref" ] && continue
+  grep -qxF -e "$ref" "$defined_file" || undef="${undef}
+  ${ref}"
+done < <(grep -rhoE --include="*.tsx" --include="*.ts" --include="*.css" --exclude-dir=__tests__ \
+  -e 'var\(--[a-zA-Z0-9_-]+\)' "$SRC" 2>/dev/null | sed -E 's/^var\(//; s/\)$//' | sort -u)
+rm -f "$defined_file"
+if [ -n "$undef" ]; then
+  report "Reference to undefined CSS variable(s) — define in index.css or fix the name:" "$undef"
+fi
+
 if [ "$fail" -eq 0 ]; then
   echo "✓ design-token guardrails clean"
   exit 0

--- a/packages/web/scripts/check-design-tokens.sh
+++ b/packages/web/scripts/check-design-tokens.sh
@@ -103,6 +103,22 @@ if [ -n "$undef" ]; then
   report "Reference to undefined CSS variable(s) — define in index.css or fix the name:" "$undef"
 fi
 
+# 8. Tailwind default radius classes — radius is the semantic --radius-* four only.
+hits=$(grep -rnE '\brounded-(sm|md|lg|xl)\b' \
+  --include="*.tsx" \
+  "$SRC" || true)
+if [ -n "$hits" ]; then
+  report "Tailwind default radius class found (use rounded-[var(--radius-chip|input|panel|dialog)]):" "$hits"
+fi
+
+# 9. Tailwind shadow classes above the 2-tier scale — shadow is --shadow-sm/md only.
+hits=$(grep -rnE '\bshadow-(lg|xl|2xl)\b' \
+  --include="*.tsx" \
+  "$SRC" || true)
+if [ -n "$hits" ]; then
+  report "Tailwind shadow-(lg|xl|2xl) found (2-tier scale: use shadow-[var(--shadow-md)] or --shadow-sm):" "$hits"
+fi
+
 if [ "$fail" -eq 0 ]; then
   echo "✓ design-token guardrails clean"
   exit 0

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -49,6 +49,13 @@ const OnboardingPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/onboarding-preview.js").then((module) => ({ default: module.OnboardingPreviewPage })))
   : null;
 
+// Living design-system reference (companion to DESIGN.md). Unlike the previews
+// above this ships in prod too, so it can be opened on a deployed URL — it has
+// no auth-gated data, only tokens and `components/ui` primitives.
+const StyleguidePreviewPage = lazy(() =>
+  import("./pages/styleguide-preview.js").then((module) => ({ default: module.StyleguidePreviewPage })),
+);
+
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -92,6 +99,14 @@ export function App() {
                   }
                 />
               ) : null}
+              <Route
+                path="/preview/styleguide"
+                element={
+                  <Suspense fallback={null}>
+                    <StyleguidePreviewPage />
+                  </Suspense>
+                }
+              />
               {/* Auth-required pages. Onboarding is a standalone full-screen
                 /onboarding route (below); the workspace root redirects users
                 who haven't finished setup into it. */}

--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -286,7 +286,7 @@ export function AddParticipantDropdown({
           role="menu"
           aria-label="Add participant"
           tabIndex={-1}
-          className="absolute z-20 flex flex-col border shadow-lg outline-none"
+          className="absolute z-20 flex flex-col border shadow-[var(--shadow-md)] outline-none"
           style={{
             top: "calc(100% + var(--sp-1))",
             // Icon trigger sits at the panel's right edge → grow leftward;

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -351,7 +351,7 @@ export function DocPreviewDrawer() {
       aria-modal={isMobile}
       data-doc-preview-drawer=""
       className={cn(
-        "z-40 flex flex-col bg-surface-raised text-text-primary",
+        "z-40 flex flex-col bg-card text-foreground",
         "animate-in slide-in-from-right duration-200",
         isMobile
           ? "fixed inset-0 w-full border-l border-border"
@@ -384,7 +384,7 @@ export function DocPreviewDrawer() {
       >
         <div className="min-w-0 flex-1">
           <div className="truncate text-body font-medium">{title}</div>
-          {subtitle ? <div className="truncate text-caption text-text-tertiary">{subtitle}</div> : null}
+          {subtitle ? <div className="truncate text-caption text-fg-3">{subtitle}</div> : null}
         </div>
         <Button
           aria-label="Close document preview"
@@ -404,7 +404,7 @@ export function DocPreviewDrawer() {
         ) : (
           <>
             {previewQuery.isLoading ? (
-              <div className="flex h-full items-center justify-center text-body text-text-secondary">
+              <div className="flex h-full items-center justify-center text-body text-fg-2">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
                 Loading preview
               </div>

--- a/packages/web/src/components/history-gap-banner.tsx
+++ b/packages/web/src/components/history-gap-banner.tsx
@@ -20,7 +20,7 @@ export function HistoryGapBanner() {
       style={{
         margin: "var(--sp-2) 0",
         gap: "var(--sp-2)",
-        color: "var(--fg-muted)",
+        color: "var(--fg-3)",
       }}
     >
       {/* Hairlines are decorative — hide from screen readers. The caption

--- a/packages/web/src/components/last-step-modal.tsx
+++ b/packages/web/src/components/last-step-modal.tsx
@@ -116,7 +116,7 @@ export function LastStepModal({ agent, open, onClose, onBound }: Props) {
             Open a terminal on your computer and run this command. It installs the First Tree CLI, signs your computer
             in, and keeps it online in the background.
           </p>
-          <div className="flex items-start gap-2 rounded-md border border-border bg-muted p-3">
+          <div className="flex items-start gap-2 rounded-[var(--radius-panel)] border border-border bg-muted p-3">
             <code className="flex-1 text-caption font-mono break-all select-all">
               {command || "Generating command…"}
             </code>

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -451,7 +451,9 @@ export function MentionAutocompletePopover({
       ref={popoverRef}
       role="listbox"
       aria-label="Mention suggestions"
-      className={cn("absolute z-20 max-h-56 overflow-auto rounded-[var(--radius-panel)] border shadow-lg")}
+      className={cn(
+        "absolute z-20 max-h-56 overflow-auto rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]",
+      )}
       style={{
         bottom: "calc(100% + var(--sp-1))",
         left: 0,

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -451,7 +451,7 @@ export function MentionAutocompletePopover({
       ref={popoverRef}
       role="listbox"
       aria-label="Mention suggestions"
-      className={cn("absolute z-20 max-h-56 overflow-auto rounded-md border shadow-lg")}
+      className={cn("absolute z-20 max-h-56 overflow-auto rounded-[var(--radius-panel)] border shadow-lg")}
       style={{
         bottom: "calc(100% + var(--sp-1))",
         left: 0,

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -642,8 +642,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
               <label
                 className={
                   visibility === "organization"
-                    ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
-                    : "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
+                    ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3 cursor-pointer"
+                    : "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 cursor-pointer hover:bg-accent/30"
                 }
               >
                 <input
@@ -663,8 +663,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
               <label
                 className={
                   visibility === "private"
-                    ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
-                    : "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
+                    ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3 cursor-pointer"
+                    : "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 cursor-pointer hover:bg-accent/30"
                 }
               >
                 <input
@@ -733,8 +733,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                       key={client.id}
                       className={
                         picked
-                          ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
-                          : "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
+                          ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3 cursor-pointer"
+                          : "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 cursor-pointer hover:bg-accent/30"
                       }
                     >
                       <input
@@ -780,8 +780,8 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                           key={provider}
                           className={
                             active
-                              ? "inline-flex items-center gap-2 rounded-md border border-primary bg-primary/5 px-3 py-1.5 cursor-pointer"
-                              : "inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 cursor-pointer hover:bg-accent/30"
+                              ? "inline-flex items-center gap-2 rounded-[var(--radius-panel)] border border-primary bg-primary/5 px-3 py-1.5 cursor-pointer"
+                              : "inline-flex items-center gap-2 rounded-[var(--radius-panel)] border border-border px-3 py-1.5 cursor-pointer hover:bg-accent/30"
                           }
                         >
                           <input type="radio" name="runtime" checked={active} onChange={() => setRuntime(provider)} />
@@ -798,7 +798,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
           </div>
 
           {fieldErrors._root && (
-            <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-body text-destructive">
+            <div className="rounded-[var(--radius-panel)] border border-destructive/50 bg-destructive/5 px-3 py-2 text-body text-destructive">
               {fieldErrors._root}
             </div>
           )}
@@ -830,7 +830,7 @@ function ZeroComputerBlock({
   onCopy: () => void;
 }) {
   return (
-    <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2">
+    <div className="rounded-[var(--radius-panel)] border border-border bg-muted/30 p-3 space-y-2">
       <div className="text-body font-medium">No computer connected yet.</div>
       <div className="text-caption text-muted-foreground">
         Run this on the machine where this agent should live. We&apos;ll pick it up here automatically.
@@ -870,7 +870,7 @@ function ZeroComputerBlock({
 function SingleComputerCard({ client }: { client: HubClient | undefined }) {
   if (!client) return null;
   return (
-    <div className="rounded-md border border-primary bg-primary/5 p-3">
+    <div className="rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3">
       <div className="text-body font-medium truncate">{client.hostname ?? client.id}</div>
       <div className="text-caption text-muted-foreground">
         {client.os ?? "unknown OS"} · last seen {new Date(client.lastSeenAt).toLocaleString()}
@@ -889,7 +889,7 @@ function SingleComputerCard({ client }: { client: HubClient | undefined }) {
 function ComputerCardSkeleton({ label }: { label: string }) {
   return (
     <div
-      className="rounded-md border border-border bg-muted/20 p-3"
+      className="rounded-[var(--radius-panel)] border border-border bg-muted/20 p-3"
       role="status"
       aria-live="polite"
       aria-label={label}
@@ -913,7 +913,7 @@ function RuntimeChipsSkeleton() {
   return (
     <div className="flex flex-wrap gap-2" role="status" aria-live="polite" aria-label="Detecting installed runtimes">
       <span
-        className="inline-flex items-center rounded-md border border-border bg-muted/30 px-3 py-1.5 text-body"
+        className="inline-flex items-center rounded-[var(--radius-panel)] border border-border bg-muted/30 px-3 py-1.5 text-body"
         style={{ color: "var(--fg-4)" }}
       >
         Detecting installed runtimes…

--- a/packages/web/src/components/slash-command-autocomplete.tsx
+++ b/packages/web/src/components/slash-command-autocomplete.tsx
@@ -345,7 +345,9 @@ export function SlashCommandPopover({
       ref={popoverRef}
       role="listbox"
       aria-label="Slash command suggestions"
-      className={cn("absolute z-20 max-h-72 overflow-auto rounded-[var(--radius-panel)] border shadow-lg")}
+      className={cn(
+        "absolute z-20 max-h-72 overflow-auto rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]",
+      )}
       style={{
         bottom: "calc(100% + var(--sp-1))",
         left: 0,

--- a/packages/web/src/components/slash-command-autocomplete.tsx
+++ b/packages/web/src/components/slash-command-autocomplete.tsx
@@ -345,7 +345,7 @@ export function SlashCommandPopover({
       ref={popoverRef}
       role="listbox"
       aria-label="Slash command suggestions"
-      className={cn("absolute z-20 max-h-72 overflow-auto rounded-md border shadow-lg")}
+      className={cn("absolute z-20 max-h-72 overflow-auto rounded-[var(--radius-panel)] border shadow-lg")}
       style={{
         bottom: "calc(100% + var(--sp-1))",
         left: 0,

--- a/packages/web/src/components/team-setup-modal.tsx
+++ b/packages/web/src/components/team-setup-modal.tsx
@@ -90,7 +90,9 @@ function CreateForm({ onDone }: { onDone: () => void }) {
 
   return (
     <form className="space-y-3" onSubmit={submit}>
-      {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+      {error && (
+        <div className="rounded-[var(--radius-panel)] bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+      )}
       <Input
         id="team-display-name"
         aria-label="Team name"
@@ -144,7 +146,9 @@ function JoinForm({ onDone }: { onDone: () => void }) {
 
   return (
     <form className="space-y-3" onSubmit={submit}>
-      {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+      {error && (
+        <div className="rounded-[var(--radius-panel)] bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+      )}
       <Input
         id="join-token"
         aria-label="Invite token or full URL"

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes } from "react";
 import { cn } from "../../lib/utils.js";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-caption font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-[var(--radius-chip)] border px-2.5 py-0.5 text-caption font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -29,7 +29,7 @@ function CommandDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="overflow-hidden p-0 shadow-[var(--shadow-md)]">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -9,7 +9,7 @@ const Command = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof Comma
     <CommandPrimitive
       ref={ref}
       className={cn(
-        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        "flex h-full w-full flex-col overflow-hidden rounded-[var(--radius-panel)] bg-popover text-popover-foreground",
         className,
       )}
       {...props}
@@ -45,7 +45,7 @@ const CommandInput = forwardRef<HTMLInputElement, ComponentPropsWithoutRef<typeo
       <CommandPrimitive.Input
         ref={ref}
         className={cn(
-          "flex h-11 w-full rounded-md bg-transparent py-3 text-body outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-[var(--radius-panel)] bg-transparent py-3 text-body outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}
@@ -97,7 +97,7 @@ const CommandItem = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof C
     <CommandPrimitive.Item
       ref={ref}
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "relative flex cursor-default select-none items-center rounded-[var(--radius-input)] px-2 py-1.5 text-body outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
       {...props}

--- a/packages/web/src/components/ui/dense-badge.tsx
+++ b/packages/web/src/components/ui/dense-badge.tsx
@@ -14,7 +14,7 @@ type DenseBadgeProps = HTMLAttributes<HTMLSpanElement> & {
 
 // Mirrors the Badge atom in design-canvas/atoms.jsx:
 //   mono / var(--sp-2_5) / padding var(--hairline) var(--sp-1_75) / radius 3 / var(--hairline) border.
-// shadcn Badge is var(--sp-3) + rounded-md and reads as "chunky" in dense panels.
+// shadcn Badge is var(--sp-3) + a chunkier radius and reads as "chunky" in dense panels.
 // Typography is bound to the `text-caption` token from index.css; tones are
 // resolved via the shared tones map so chips stay in sync with state chips.
 // Casing is the caller's responsibility — pass sentence-case labels for

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -29,13 +29,13 @@ const DialogContent = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-[var(--shadow-md)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-[var(--radius-dialog)]",
           className,
         )}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-[var(--radius-input)] opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/packages/web/src/components/ui/row-actions-menu.tsx
+++ b/packages/web/src/components/ui/row-actions-menu.tsx
@@ -98,7 +98,7 @@ export function RowActionsMenu({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 rounded-md border bg-popover shadow-md"
+          className="absolute right-0 z-30 rounded-[var(--radius-panel)] border bg-popover shadow-md"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
           style={{

--- a/packages/web/src/components/ui/theme-toggle.tsx
+++ b/packages/web/src/components/ui/theme-toggle.tsx
@@ -24,7 +24,7 @@ export function ThemeToggle() {
       type="button"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
       aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-      className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-body text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      className="flex items-center gap-1.5 rounded-[var(--radius-panel)] px-2 py-1.5 text-body text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
       {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
     </button>

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -111,7 +111,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
         alignItems: "flex-start",
         gap: "var(--sp-2)",
         padding: "var(--sp-3) var(--sp-3_5)",
-        background: "var(--surface-1)",
+        background: "var(--bg-raised)",
         border: "var(--hairline) solid var(--border)",
         borderRadius: "var(--radius-input)",
         boxShadow: "var(--shadow-md)",

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -107,7 +107,7 @@ export function UserMenu() {
         {open && (
           <div
             role="menu"
-            className="absolute right-0 z-30 mt-2 rounded-md border bg-popover shadow-md"
+            className="absolute right-0 z-30 mt-2 rounded-[var(--radius-panel)] border bg-popover shadow-md"
             style={{ width: 280 }}
           >
             {/* User header */}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -147,21 +147,11 @@
   --font-sans: var(--font-sans-stack);
   --font-mono: var(--font-mono-stack);
 
-  /* ---- Semantic color aliases --------------------------------------------- */
-  /* Preferred in new code. Raw --fg / --bg remain for back-compat but new
-     components should reference semantic names for readability. */
-  --color-text-primary: var(--fg);
-  --color-text-secondary: var(--fg-2);
-  --color-text-tertiary: var(--fg-3);
-  --color-text-disabled: var(--fg-4);
-  --color-surface: var(--bg);
-  --color-surface-raised: var(--bg-raised);
-  --color-surface-sunken: var(--bg-sunken);
-  --color-surface-hover: var(--bg-hover);
-  --color-surface-active: var(--bg-active);
-  --color-border-subtle: var(--border-faint);
-  --color-border-default: var(--border);
-  --color-border-emphasis: var(--border-strong);
+  /* Canonical color tokens are the short --fg* / --bg* / --border* names (defined
+     on :root below, exposed to Tailwind via the --color-fg-* / --color-bg-* /
+     --color-border-* utility aliases further down). The old --color-text-* /
+     --color-surface-* / --color-border-subtle|default|emphasis "semantic" layer
+     was removed in the 2026-05-28 cleanup — it was unadopted (see DESIGN-AUDIT.md). */
 
   /* ---- shadcn-compatible aliases (preserved) ------------------------------ */
   --color-background: var(--bg);
@@ -215,12 +205,6 @@
 
   /* Overlay scrim for dialogs / lightboxes — replaces hardcoded rgba(0,0,0,...). */
   --color-overlay-scrim: var(--overlay-scrim);
-
-  /* shadcn radius aliases (legacy — prefer --radius-chip/input/panel/dialog) */
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
 }
 
 :root {
@@ -240,7 +224,10 @@
   --accent-bg: oklch(0.72 0.17 150 / 0.12);
   --accent-ring: oklch(0.72 0.17 150 / 0.3);
 
-  --state-idle: oklch(0.72 0.17 150);
+  /* idle = neutral cool "standby" tone. Deliberately NOT the brand/success
+     green (see --success) and distinct from --state-offline's dim gray, so an
+     idle agent reads as "present, at rest" rather than "healthy/success". */
+  --state-idle: oklch(0.7 0.03 240);
   --state-working: oklch(0.78 0.16 195);
   --state-blocked: oklch(0.82 0.18 75);
   --state-error: oklch(0.68 0.22 25);
@@ -251,9 +238,13 @@
      destructive-action warning" at the consumer site. */
   --state-unread: var(--state-error);
 
-  --ok: oklch(0.72 0.17 150);
-  --warn: oklch(0.82 0.18 75);
-  --danger: oklch(0.68 0.22 25);
+  /* Feedback / severity vocabulary (success / warning / error). Aliased to the
+     shared base hues so there is ONE value per color — distinct *names* from the
+     agent-state vocabulary (--state-*), same underlying tones. Replaces the old
+     --ok / --warn / --danger raw duplicates. */
+  --success: var(--accent);
+  --warning: var(--state-blocked);
+  --danger: var(--state-error);
 
   /* Near-white text for content rendered on top of a vivid colored
      surface (state-error badges, hashed-hue avatars, etc). Stable in
@@ -843,7 +834,7 @@
   place-items: center;
   border-radius: 50%;
   background: oklch(0.72 0.17 150 / 0.12);
-  color: var(--ok);
+  color: var(--success);
 }
 
 .context-network-summary-title {
@@ -875,7 +866,7 @@
   padding: var(--sp-0_5) var(--sp-2);
   border-radius: var(--radius-chip);
   background: oklch(0.72 0.17 150 / 0.12);
-  color: var(--ok);
+  color: var(--success);
   font-weight: 600;
 }
 
@@ -886,7 +877,7 @@
   width: var(--sp-3);
   height: var(--sp-3);
   border-radius: 50%;
-  background: var(--ok);
+  background: var(--success);
   box-shadow: 0 0 0 var(--sp-0_75) oklch(0.72 0.17 150 / 0.18);
 }
 
@@ -915,12 +906,12 @@
 
 .context-change-breakdown span[data-change-type="added"] {
   background: oklch(0.72 0.17 150 / 0.12);
-  color: var(--ok);
+  color: var(--success);
 }
 
 .context-change-breakdown span[data-change-type="edited"] {
   background: oklch(0.82 0.18 75 / 0.14);
-  color: var(--warn);
+  color: var(--warning);
 }
 
 .context-change-breakdown span[data-change-type="removed"] {
@@ -980,13 +971,13 @@
   width: var(--sp-1);
   height: var(--sp-1);
   border-radius: 50%;
-  background: var(--ok);
+  background: var(--success);
   animation: context-usage-feed-pulse 2.4s ease-in-out infinite;
   flex: 0 0 auto;
 }
 
 .context-usage-feed-live-label {
-  color: var(--ok);
+  color: var(--success);
   font-weight: 700;
   letter-spacing: 0.1em;
 }
@@ -998,10 +989,10 @@
 @keyframes context-usage-feed-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 color-mix(in oklch, var(--ok) 50%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--success) 50%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 var(--sp-1) color-mix(in oklch, var(--ok) 0%, transparent);
+    box-shadow: 0 0 0 var(--sp-1) color-mix(in oklch, var(--success) 0%, transparent);
   }
 }
 
@@ -1025,7 +1016,7 @@
   top: 0;
   bottom: 0;
   width: 0;
-  border-left: 1.5px dashed color-mix(in oklch, var(--ok) 25%, transparent);
+  border-left: 1.5px dashed color-mix(in oklch, var(--success) 25%, transparent);
 }
 
 .context-usage-feed-row {
@@ -1042,7 +1033,7 @@
   width: var(--sp-1);
   height: var(--sp-1);
   border-radius: 50%;
-  background: var(--ok);
+  background: var(--success);
   margin-left: 3px;
   position: relative;
   z-index: 1;
@@ -1166,7 +1157,7 @@
 
 @keyframes context-usage-feed-flash {
   0% {
-    background: color-mix(in oklch, var(--ok) 18%, transparent);
+    background: color-mix(in oklch, var(--success) 18%, transparent);
   }
   100% {
     background: transparent;
@@ -1176,11 +1167,11 @@
 @keyframes context-usage-feed-dot-pop {
   0% {
     transform: scale(0.3);
-    box-shadow: 0 0 0 0 color-mix(in oklch, var(--ok) 60%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--success) 60%, transparent);
   }
   60% {
     transform: scale(1.3);
-    box-shadow: 0 0 0 8px color-mix(in oklch, var(--ok) 0%, transparent);
+    box-shadow: 0 0 0 8px color-mix(in oklch, var(--success) 0%, transparent);
   }
   100% {
     transform: scale(1);

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -681,7 +681,7 @@ function TabsNav({
               aria-selected={active}
               onClick={() => navigate(`/agents/${agentUuid}/${t.path}`, { replace: true })}
               className={cn(
-                "bg-transparent border-0 cursor-pointer transition-colors",
+                "bg-transparent border-0 cursor-pointer transition-colors text-body",
                 "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                 !active && "hover:bg-accent",
               )}
@@ -690,7 +690,6 @@ function TabsNav({
                 borderBottom: `var(--hairline-bold) solid ${active ? "var(--accent)" : "transparent"}`,
                 color: active ? "var(--fg)" : "var(--fg-3)",
                 fontWeight: active ? 500 : 400,
-                fontSize: "var(--text-body-size)",
                 display: "inline-flex",
                 alignItems: "center",
                 gap: "var(--sp-1_5)",

--- a/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
@@ -146,10 +146,10 @@ export function ReBindDialog({ open, onOpenChange, agent }: Props) {
                     key={provider}
                     className={
                       checked
-                        ? "flex items-start gap-3 rounded-md border border-primary bg-primary/5 p-3 cursor-pointer"
+                        ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3 cursor-pointer"
                         : enabled
-                          ? "flex items-start gap-3 rounded-md border border-border p-3 cursor-pointer hover:bg-accent/30"
-                          : "flex items-start gap-3 rounded-md border border-border p-3 opacity-60"
+                          ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 cursor-pointer hover:bg-accent/30"
+                          : "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 opacity-60"
                     }
                   >
                     <input
@@ -172,7 +172,7 @@ export function ReBindDialog({ open, onOpenChange, agent }: Props) {
           </div>
 
           {(clientChanged || providerChanged) && (
-            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-caption space-y-1">
+            <div className="rounded-[var(--radius-panel)] border border-border bg-muted/30 px-3 py-2 text-caption space-y-1">
               <p>
                 <span className="font-medium">Heads up:</span> active sessions on the previous computer are suspended at
                 re-bind. Chat history is preserved.
@@ -197,7 +197,7 @@ export function ReBindDialog({ open, onOpenChange, agent }: Props) {
           )}
 
           {errorMessage && (
-            <div className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-body text-destructive">
+            <div className="rounded-[var(--radius-panel)] border border-destructive/50 bg-destructive/5 px-3 py-2 text-body text-destructive">
               {errorMessage}
             </div>
           )}

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -151,7 +151,7 @@ function ChangeMap({
                 key={`path:${group.id}`}
                 d={connectionPath(group)}
                 fill="none"
-                stroke={group.selected ? "var(--ok)" : "var(--border-strong)"}
+                stroke={group.selected ? "var(--success)" : "var(--border-strong)"}
                 strokeDasharray="5 8"
                 strokeLinecap="round"
                 strokeOpacity={group.selected ? 0.7 : 0.36}
@@ -441,7 +441,7 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
     <Panel>
       <PanelBody>
         <div className="flex items-start text-body" style={{ color: "var(--fg-2)", gap: "var(--sp-2)" }}>
-          <AlertTriangle size={18} style={{ color: "var(--warn)" }} />
+          <AlertTriangle size={18} style={{ color: "var(--warning)" }} />
           <div>
             <div className="font-semibold" style={{ color: "var(--fg)" }}>
               {title}
@@ -818,8 +818,8 @@ function summaryTitle(hiddenCount: number, changedHiddenCount: number): string {
 }
 
 function severityColor(severity: ContextTreeSnapshot["contextStatus"]["severity"]): string {
-  if (severity === "ok") return "var(--ok)";
-  if (severity === "warning") return "var(--warn)";
+  if (severity === "ok") return "var(--success)";
+  if (severity === "warning") return "var(--warning)";
   return "var(--danger)";
 }
 

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -222,7 +222,10 @@ export function InviteAcceptSkeleton() {
     <Card className="w-full max-w-sm">
       <CardHeader className="text-center">
         <div className="mx-auto h-5 w-2/3 rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
-        <div className="mx-auto mt-2 h-5 w-1/2 rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
+        <div
+          className="mx-auto mt-2 h-5 w-1/2 rounded-[var(--radius-panel)]"
+          style={{ background: "var(--bg-sunken)" }}
+        />
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="h-9 w-full rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -171,7 +171,7 @@ export function InviteAcceptCard({
       <CardContent className="space-y-4">
         {switchingTeam && (
           <div
-            className="flex items-start gap-2 rounded-md p-3 text-label"
+            className="flex items-start gap-2 rounded-[var(--radius-panel)] p-3 text-label"
             style={{ background: "var(--bg-sunken)", color: "var(--fg-2)" }}
           >
             <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -196,7 +196,7 @@ export function InviteAcceptCard({
         {expiresHint && (
           <p
             className="text-center text-label"
-            style={{ color: expiresHint.urgent ? "var(--destructive)" : "var(--fg-3)" }}
+            style={{ color: expiresHint.urgent ? "var(--state-error)" : "var(--fg-3)" }}
           >
             {expiresHint.text}
           </p>
@@ -221,12 +221,12 @@ export function InviteAcceptSkeleton() {
   return (
     <Card className="w-full max-w-sm">
       <CardHeader className="text-center">
-        <div className="mx-auto h-5 w-2/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
-        <div className="mx-auto mt-2 h-5 w-1/2 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        <div className="mx-auto h-5 w-2/3 rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
+        <div className="mx-auto mt-2 h-5 w-1/2 rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="h-9 w-full rounded-md" style={{ background: "var(--bg-sunken)" }} />
-        <div className="mx-auto h-3 w-1/3 rounded-md" style={{ background: "var(--bg-sunken)" }} />
+        <div className="h-9 w-full rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
+        <div className="mx-auto h-3 w-1/3 rounded-[var(--radius-panel)]" style={{ background: "var(--bg-sunken)" }} />
       </CardContent>
     </Card>
   );

--- a/packages/web/src/pages/invite-link-panel.tsx
+++ b/packages/web/src/pages/invite-link-panel.tsx
@@ -70,13 +70,15 @@ export function InviteLinkPanel() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        {error && <div className="rounded-md bg-destructive/10 p-2 text-label text-destructive">{error}</div>}
+        {error && (
+          <div className="rounded-[var(--radius-panel)] bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+        )}
         {invite ? (
           <>
             <div className="flex gap-2">
               <input
                 readOnly
-                className="flex-1 rounded-md border bg-muted px-2 py-1 text-label font-mono"
+                className="flex-1 rounded-[var(--radius-panel)] border bg-muted px-2 py-1 text-label font-mono"
                 value={invite.inviteUrl}
               />
               <Button

--- a/packages/web/src/pages/source-repos-settings-panel.tsx
+++ b/packages/web/src/pages/source-repos-settings-panel.tsx
@@ -158,7 +158,7 @@ function RepoRow({
             flexShrink: 0,
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.background = "var(--surface-2)";
+            e.currentTarget.style.background = "var(--bg-hover)";
             e.currentTarget.style.color = "var(--fg)";
           }}
           onMouseLeave={(e) => {

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -1,0 +1,737 @@
+import { type ReactNode, useEffect, useState } from "react";
+import { AgentStatusChip } from "../components/ui/agent-status-chip.js";
+import { Badge } from "../components/ui/badge.js";
+import { Breadcrumb, BreadcrumbCurrent, BreadcrumbLink, BreadcrumbSep } from "../components/ui/breadcrumb.js";
+import { Button } from "../components/ui/button.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
+import { DenseBadge } from "../components/ui/dense-badge.js";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../components/ui/dialog.js";
+import { FilterPill } from "../components/ui/filter-pill.js";
+import { Input } from "../components/ui/input.js";
+import { Label } from "../components/ui/label.js";
+import { Panel, PanelBody, PanelHeader, PanelTitle } from "../components/ui/panel.js";
+import { Popover } from "../components/ui/popover.js";
+import { PresenceChip } from "../components/ui/presence-chip.js";
+import { SectionHeader, UppercaseLabel } from "../components/ui/section-header.js";
+import { SegmentedControl } from "../components/ui/segmented-control.js";
+import { StateChip } from "../components/ui/state-chip.js";
+import { StateDot } from "../components/ui/state-dot.js";
+import { StatusGlyph } from "../components/ui/status-glyph.js";
+import { Tab, TabBadge, TabBar } from "../components/ui/tab-bar.js";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table.js";
+import { Tile } from "../components/ui/tile.js";
+import { useToast } from "../components/ui/toast.js";
+
+/**
+ * Human-facing visual reference for the web design system. Renders the real
+ * tokens (color / typography / spacing / radius / surfaces) and the real
+ * `components/ui` primitives in every variant, so a person can SEE the system
+ * instead of reading hex values out of `index.css`.
+ *
+ * Companion to `DESIGN.md` (the token/code spec for agents). This is the
+ * eyeball version.
+ *
+ * Follows the `/preview/*` convention: mounted outside `<Layout>` (no auth /
+ * no router context needed), self-contained, theme-togglable via the header
+ * control or `?theme=light|dark`. Unlike the other previews it is NOT gated by
+ * `import.meta.env.DEV` — it ships so it can be opened on a deployed URL.
+ */
+
+// ── token catalogs ─────────────────────────────────────────────────────────
+
+type SwatchDef = { name: string; token: string; note?: string };
+
+// Canonical names = the short tokens the codebase actually uses. The parallel
+// --color-text-* / --color-surface-* / --color-border-* alias layer is unadopted
+// (see DESIGN-AUDIT.md P2), so the styleguide shows the real names.
+const TEXT_COLORS: SwatchDef[] = [
+  { name: "--fg", token: "var(--fg)", note: "primary ink" },
+  { name: "--fg-2", token: "var(--fg-2)", note: "secondary" },
+  { name: "--fg-3", token: "var(--fg-3)", note: "tertiary / hints" },
+  { name: "--fg-4", token: "var(--fg-4)", note: "disabled" },
+  { name: "--fg-on-vivid", token: "var(--fg-on-vivid)", note: "on color (no invert)" },
+];
+
+const SURFACE_COLORS: SwatchDef[] = [
+  { name: "--bg", token: "var(--bg)", note: "page base" },
+  { name: "--bg-raised", token: "var(--bg-raised)", note: "cards / panels" },
+  { name: "--bg-sunken", token: "var(--bg-sunken)", note: "wells" },
+  { name: "--bg-hover", token: "var(--bg-hover)" },
+  { name: "--bg-active", token: "var(--bg-active)" },
+];
+
+const BORDER_COLORS: SwatchDef[] = [
+  { name: "--border-faint", token: "var(--border-faint)", note: "subtle" },
+  { name: "--border", token: "var(--border)", note: "default" },
+  { name: "--border-strong", token: "var(--border-strong)", note: "emphasis" },
+];
+
+const ACCENT_COLORS: SwatchDef[] = [
+  { name: "--accent", token: "var(--accent)", note: "brand green" },
+  { name: "--accent-dim", token: "var(--accent-dim)", note: "pressed" },
+  { name: "--accent-bg", token: "var(--accent-bg)", note: "tinted fill" },
+  { name: "--accent-ring", token: "var(--accent-ring)", note: "focus ring" },
+];
+
+const STATE_COLORS: SwatchDef[] = [
+  { name: "--state-idle", token: "var(--state-idle)", note: "neutral standby" },
+  { name: "--state-working", token: "var(--state-working)" },
+  { name: "--state-blocked", token: "var(--state-blocked)" },
+  { name: "--state-error", token: "var(--state-error)" },
+  { name: "--state-offline", token: "var(--state-offline)" },
+];
+
+// Feedback / severity vocabulary — distinct names, aliased to shared base hues.
+const FEEDBACK_COLORS: SwatchDef[] = [
+  { name: "--success", token: "var(--success)", note: "= accent green" },
+  { name: "--warning", token: "var(--warning)", note: "= blocked amber" },
+  { name: "--danger", token: "var(--danger)", note: "= error red" },
+];
+
+const CALLOUT_COLORS: SwatchDef[] = [
+  { name: "--color-error", token: "var(--color-error)", note: "text / border" },
+  { name: "--color-error-soft", token: "var(--color-error-soft)", note: "fill" },
+  { name: "--color-warn", token: "var(--color-warn)" },
+  { name: "--color-warn-soft", token: "var(--color-warn-soft)" },
+  { name: "--color-success", token: "var(--color-success)" },
+  { name: "--color-success-soft", token: "var(--color-success-soft)" },
+];
+
+const AVATAR_HUES: SwatchDef[] = Array.from({ length: 8 }, (_, i) => ({
+  name: `--avatar-hue-${i}`,
+  token: `var(--avatar-hue-${i})`,
+}));
+
+type TypeTier = { cls: string; name: string; meta: string; sample: string; uppercase?: boolean };
+
+// `meta` is "size / weight" in px-equivalent — no "px" suffix on purpose so the
+// design-token guardrail (which bans digit+px literals in src) stays clean.
+const APP_TIERS: TypeTier[] = [
+  { cls: "text-eyebrow", name: "text-eyebrow", meta: "10 / 600 / +0.1em", sample: "Section eyebrow", uppercase: true },
+  { cls: "text-caption", name: "text-caption", meta: "10 / 500", sample: "Dense caption metadata" },
+  { cls: "text-label", name: "text-label", meta: "11 / 500", sample: "Form label / chip" },
+  { cls: "text-body", name: "text-body", meta: "12 / 400", sample: "Body copy and button text." },
+  { cls: "text-subtitle", name: "text-subtitle", meta: "13 / 600 · default", sample: "Row title / subtitle" },
+  { cls: "text-title", name: "text-title", meta: "16 / 600", sample: "Section & page title" },
+  { cls: "text-live", name: "text-live", meta: "32 / 600", sample: "Live" },
+];
+
+const MARKETING_TIERS: TypeTier[] = [
+  { cls: "text-lead", name: "text-lead", meta: "18 / 400", sample: "Landing lead paragraph copy." },
+  { cls: "text-headline", name: "text-headline", meta: "24 / 600", sample: "Landing section headline" },
+  { cls: "text-display", name: "text-display", meta: "clamp 40–60 / 600", sample: "Hero display" },
+];
+
+// token name + the rem value (rem is guardrail-safe; px is not).
+const SPACING: Array<{ name: string; rem: string }> = [
+  { name: "--sp-0_5", rem: "0.125rem" },
+  { name: "--sp-1", rem: "0.25rem" },
+  { name: "--sp-1_5", rem: "0.375rem" },
+  { name: "--sp-2", rem: "0.5rem" },
+  { name: "--sp-3", rem: "0.75rem" },
+  { name: "--sp-4", rem: "1rem" },
+  { name: "--sp-6", rem: "1.5rem" },
+  { name: "--sp-8", rem: "2rem" },
+  { name: "--sp-12", rem: "3rem" },
+  { name: "--sp-16", rem: "4rem" },
+];
+
+const RADII: Array<{ name: string; token: string; value: string }> = [
+  { name: "--radius-chip", token: "var(--radius-chip)", value: "3" },
+  { name: "--radius-input", token: "var(--radius-input)", value: "4" },
+  { name: "--radius-panel", token: "var(--radius-panel)", value: "6" },
+  { name: "--radius-dialog", token: "var(--radius-dialog)", value: "8" },
+];
+
+// ── layout helpers ───────────────────────────────────────────────────────────
+
+function Section({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
+  return (
+    <section style={{ marginBottom: "var(--sp-12)" }}>
+      <div style={{ marginBottom: "var(--sp-4)" }}>
+        <h2 className="text-title" style={{ color: "var(--fg)" }}>
+          {title}
+        </h2>
+        {subtitle ? (
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Subhead({ children }: { children: ReactNode }) {
+  return (
+    <div className="mono uppercase text-eyebrow" style={{ color: "var(--fg-4)", marginBottom: "var(--sp-2)" }}>
+      {children}
+    </div>
+  );
+}
+
+function Row({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center" style={{ gap: "var(--sp-3)", marginBottom: "var(--sp-4)" }}>
+      {children}
+    </div>
+  );
+}
+
+function Swatch({ name, token, note }: SwatchDef) {
+  return (
+    <div>
+      <div
+        style={{
+          height: 52,
+          borderRadius: "var(--radius-input)",
+          border: "var(--hairline) solid var(--border)",
+          background: token,
+        }}
+      />
+      <div className="mono text-caption" style={{ color: "var(--fg-2)", marginTop: "var(--sp-1)" }}>
+        {name}
+      </div>
+      {note ? (
+        <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+          {note}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SwatchGrid({ items }: { items: SwatchDef[] }) {
+  return (
+    <div
+      className="grid"
+      style={{
+        gap: "var(--sp-3)",
+        gridTemplateColumns: "repeat(auto-fill, minmax(8.5rem, 1fr))",
+        marginBottom: "var(--sp-5)",
+      }}
+    >
+      {items.map((s) => (
+        <Swatch key={s.name} {...s} />
+      ))}
+    </div>
+  );
+}
+
+function TierRow({ tier }: { tier: TypeTier }) {
+  return (
+    <div
+      className="flex items-baseline"
+      style={{
+        gap: "var(--sp-4)",
+        padding: "var(--sp-3) 0",
+        borderBottom: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      <div className="mono text-caption shrink-0" style={{ color: "var(--fg-4)", width: "12rem" }}>
+        <div style={{ color: "var(--fg-2)" }}>{tier.name}</div>
+        <div>{tier.meta}</div>
+      </div>
+      <div className={`${tier.cls}${tier.uppercase ? " uppercase" : ""}`} style={{ color: "var(--fg)", minWidth: 0 }}>
+        {tier.sample}
+      </div>
+    </div>
+  );
+}
+
+// ── interactive demos (need local state) ─────────────────────────────────────
+
+function SegmentedDemo() {
+  const [value, setValue] = useState("list");
+  return (
+    <SegmentedControl
+      value={value}
+      onChange={setValue}
+      options={[
+        { value: "list", label: "List" },
+        { value: "grid", label: "Grid" },
+        { value: "tree", label: "Tree" },
+      ]}
+    />
+  );
+}
+
+function TabsDemo() {
+  const [tab, setTab] = useState("overview");
+  return (
+    <TabBar>
+      <Tab active={tab === "overview"} onClick={() => setTab("overview")}>
+        Overview
+      </Tab>
+      <Tab active={tab === "activity"} onClick={() => setTab("activity")}>
+        Activity <TabBadge>3</TabBadge>
+      </Tab>
+      <Tab active={tab === "settings"} onClick={() => setTab("settings")}>
+        Settings
+      </Tab>
+    </TabBar>
+  );
+}
+
+function ToastDemo() {
+  const { addToast } = useToast();
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() =>
+        addToast({
+          title: "Changes saved",
+          description: "Your agent profile was updated.",
+          action: { label: "Undo", onClick: () => undefined },
+        })
+      }
+    >
+      Show toast
+    </Button>
+  );
+}
+
+function PopoverDemo() {
+  return (
+    <Popover
+      trigger={({ toggle, open }) => (
+        <Button variant="outline" size="sm" onClick={toggle} aria-expanded={open}>
+          Open popover
+        </Button>
+      )}
+    >
+      {({ close }) => (
+        <div style={{ padding: "var(--sp-3)", width: 240 }}>
+          <p className="text-body" style={{ color: "var(--fg-2)" }}>
+            Anchored popover panel, portaled so an overflow-hidden ancestor can't clip it.
+          </p>
+          <Button variant="ghost" size="xs" onClick={close} style={{ marginTop: "var(--sp-2)" }}>
+            Close
+          </Button>
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+function ThemeControl() {
+  const [dark, setDark] = useState(
+    () => typeof document !== "undefined" && document.documentElement.classList.contains("dark"),
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const override = params.get("theme");
+    if (override === "light" || override === "dark") {
+      const wantDark = override === "dark";
+      document.documentElement.classList.toggle("dark", wantDark);
+      setDark(wantDark);
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = !document.documentElement.classList.contains("dark");
+    document.documentElement.classList.toggle("dark", next);
+    window.localStorage.setItem("theme", next ? "dark" : "light");
+    setDark(next);
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={toggle}>
+      {dark ? "Light mode" : "Dark mode"}
+    </Button>
+  );
+}
+
+// ── page ─────────────────────────────────────────────────────────────────────
+
+export function StyleguidePreviewPage() {
+  return (
+    <div style={{ background: "var(--bg)", minHeight: "100vh", padding: "var(--sp-8)" }}>
+      <div style={{ maxWidth: 1120, margin: "0 auto" }}>
+        <header
+          className="flex items-start justify-between"
+          style={{ gap: "var(--sp-4)", marginBottom: "var(--sp-10)" }}
+        >
+          <div>
+            <h1 className="text-title" style={{ color: "var(--fg)" }}>
+              First Tree · Design System
+            </h1>
+            <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)", maxWidth: "42rem" }}>
+              Live visual reference — rendered from the real tokens in <span className="mono">index.css</span> and the
+              real <span className="mono">components/ui</span> primitives. Companion to{" "}
+              <span className="mono">DESIGN.md</span>. Numbers shown without units are px-equivalent.
+            </p>
+          </div>
+          <div className="shrink-0">
+            <ThemeControl />
+          </div>
+        </header>
+
+        {/* ─── Color ─────────────────────────────────────────────────────── */}
+        <Section title="Color" subtitle="Semantic OkLCH tokens. Components reference intent, never raw hex.">
+          <Subhead>Text</Subhead>
+          <SwatchGrid items={TEXT_COLORS} />
+          <Subhead>Surface</Subhead>
+          <SwatchGrid items={SURFACE_COLORS} />
+          <Subhead>Border</Subhead>
+          <SwatchGrid items={BORDER_COLORS} />
+          <Subhead>Accent</Subhead>
+          <SwatchGrid items={ACCENT_COLORS} />
+          <Subhead>State (agent vocabulary)</Subhead>
+          <SwatchGrid items={STATE_COLORS} />
+          <Subhead>Feedback / severity</Subhead>
+          <SwatchGrid items={FEEDBACK_COLORS} />
+          <Subhead>Callout pairs (soft fill + strong text/border)</Subhead>
+          <SwatchGrid items={CALLOUT_COLORS} />
+          <Subhead>Avatar hues</Subhead>
+          <SwatchGrid items={AVATAR_HUES} />
+        </Section>
+
+        {/* ─── Typography ────────────────────────────────────────────────── */}
+        <Section
+          title="Typography"
+          subtitle="Six dense tiers for app chrome; three marketing tiers for the landing page. Weights 400/500/600/700 only."
+        >
+          <Subhead>App scale</Subhead>
+          <div style={{ marginBottom: "var(--sp-6)" }}>
+            {APP_TIERS.map((t) => (
+              <TierRow key={t.cls} tier={t} />
+            ))}
+          </div>
+          <Subhead>Marketing scale</Subhead>
+          <div>
+            {MARKETING_TIERS.map((t) => (
+              <TierRow key={t.cls} tier={t} />
+            ))}
+          </div>
+        </Section>
+
+        {/* ─── Spacing ───────────────────────────────────────────────────── */}
+        <Section title="Spacing" subtitle="The --sp-* ladder (mirror of Tailwind's spacing). Bar width = the token.">
+          <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+            {SPACING.map((s) => (
+              <div key={s.name} className="flex items-center" style={{ gap: "var(--sp-3)" }}>
+                <div className="mono text-caption shrink-0" style={{ color: "var(--fg-3)", width: "6rem" }}>
+                  {s.name}
+                </div>
+                <div style={{ height: 12, width: `var(${s.name})`, background: "var(--accent)", borderRadius: 2 }} />
+                <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+                  {s.rem}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* ─── Radius ────────────────────────────────────────────────────── */}
+        <Section title="Radius" subtitle="Semantic radii, ascending with surface importance.">
+          <Row>
+            {RADII.map((r) => (
+              <div key={r.name} style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    width: 72,
+                    height: 72,
+                    background: "var(--bg-raised)",
+                    border: "var(--hairline) solid var(--border-strong)",
+                    borderRadius: r.token,
+                  }}
+                />
+                <div className="mono text-caption" style={{ color: "var(--fg-2)", marginTop: "var(--sp-1)" }}>
+                  {r.name}
+                </div>
+                <div className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+                  {r.value}
+                </div>
+              </div>
+            ))}
+          </Row>
+        </Section>
+
+        {/* ─── Surfaces ──────────────────────────────────────────────────── */}
+        <Section
+          title="Surfaces & elevation"
+          subtitle="Consolidated background + border + radius (+ shadow) utilities."
+        >
+          <Row>
+            {["surface-raised", "surface-sunken", "surface-overlay"].map((cls) => (
+              <div
+                key={cls}
+                className={cls}
+                style={{ width: "14rem", height: 88, display: "grid", placeItems: "center" }}
+              >
+                <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+                  .{cls}
+                </span>
+              </div>
+            ))}
+          </Row>
+        </Section>
+
+        {/* ─── Buttons ───────────────────────────────────────────────────── */}
+        <Section title="Buttons" subtitle="6 variants × 5 sizes, via class-variance-authority.">
+          <Subhead>Variants</Subhead>
+          <Row>
+            <Button>Default</Button>
+            <Button variant="destructive">Destructive</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="link">Link</Button>
+            <Button disabled>Disabled</Button>
+          </Row>
+          <Subhead>Sizes</Subhead>
+          <Row>
+            <Button size="xs">Extra small</Button>
+            <Button size="sm">Small</Button>
+            <Button size="default">Default</Button>
+            <Button size="lg">Large</Button>
+          </Row>
+        </Section>
+
+        {/* ─── Badges & status ───────────────────────────────────────────── */}
+        <Section title="Badges & status" subtitle="Badge, DenseBadge, and the agent status vocabulary.">
+          <Subhead>Badge</Subhead>
+          <Row>
+            <Badge>Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+            <Badge variant="outline">Outline</Badge>
+          </Row>
+          <Subhead>DenseBadge</Subhead>
+          <Row>
+            <DenseBadge tone="neutral">Neutral</DenseBadge>
+            <DenseBadge tone="accent">Accent</DenseBadge>
+            <DenseBadge tone="warn">Warn</DenseBadge>
+            <DenseBadge tone="error">Error</DenseBadge>
+            <DenseBadge tone="outline">Outline</DenseBadge>
+          </Row>
+          <Subhead>StateChip (runtime vocabulary)</Subhead>
+          <Row>
+            <StateChip state="idle" />
+            <StateChip state="working" />
+            <StateChip state="blocked" />
+            <StateChip state="error" />
+            <StateChip state="offline" />
+          </Row>
+          <Subhead>AgentStatusChip (composite vocabulary)</Subhead>
+          <Row>
+            <AgentStatusChip main="ready" />
+            <AgentStatusChip main="working" />
+            <AgentStatusChip main="needs_you" />
+            <AgentStatusChip main="paused" />
+            <AgentStatusChip main="failed" />
+            <AgentStatusChip main="offline" />
+          </Row>
+          <Subhead>PresenceChip · StateDot · StatusGlyph</Subhead>
+          <Row>
+            <PresenceChip status="online" />
+            <PresenceChip status="offline" />
+            <span className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+              <StateDot state="idle" />
+              <StateDot state="working" />
+              <StateDot state="error" />
+            </span>
+            <span className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+              <StatusGlyph colorVar="var(--state-idle)" shape="dot" ariaLabel="dot" />
+              <StatusGlyph colorVar="var(--state-offline)" shape="hollow" ariaLabel="hollow" />
+              <StatusGlyph colorVar="var(--state-blocked)" shape="pause" ariaLabel="pause" />
+              <StatusGlyph colorVar="var(--state-working)" shape="dot" pulse="working" ariaLabel="working pulse" />
+              <StatusGlyph colorVar="var(--state-error)" shape="dot" pulse="needs-you" ariaLabel="needs-you pulse" />
+            </span>
+          </Row>
+          <Subhead>FilterPill</Subhead>
+          <Row>
+            <FilterPill active>All</FilterPill>
+            <FilterPill count={5}>Unread</FilterPill>
+            <FilterPill warn count={2}>
+              Failed
+            </FilterPill>
+          </Row>
+        </Section>
+
+        {/* ─── Form controls ─────────────────────────────────────────────── */}
+        <Section title="Form controls" subtitle="Input, Label, SegmentedControl.">
+          <div className="flex flex-col" style={{ gap: "var(--sp-2)", maxWidth: "22rem", marginBottom: "var(--sp-5)" }}>
+            <Label htmlFor="sg-name">Agent name</Label>
+            <Input id="sg-name" placeholder="e.g. kael" defaultValue="kael" />
+            <Input placeholder="Disabled" disabled />
+          </div>
+          <Subhead>SegmentedControl</Subhead>
+          <SegmentedDemo />
+        </Section>
+
+        {/* ─── Navigation ────────────────────────────────────────────────── */}
+        <Section title="Navigation" subtitle="Breadcrumb, TabBar, SectionHeader.">
+          <Subhead>Breadcrumb</Subhead>
+          <div style={{ marginBottom: "var(--sp-5)" }}>
+            <Breadcrumb>
+              <BreadcrumbLink onClick={() => undefined}>Team</BreadcrumbLink>
+              <BreadcrumbSep />
+              <BreadcrumbLink onClick={() => undefined}>kael</BreadcrumbLink>
+              <BreadcrumbSep />
+              <BreadcrumbCurrent>Profile</BreadcrumbCurrent>
+            </Breadcrumb>
+          </div>
+          <Subhead>TabBar</Subhead>
+          <div style={{ marginBottom: "var(--sp-5)" }}>
+            <TabsDemo />
+          </div>
+          <Subhead>SectionHeader</Subhead>
+          <SectionHeader right={<UppercaseLabel style={{ color: "var(--fg-4)" }}>3 items</UppercaseLabel>}>
+            Agents
+          </SectionHeader>
+        </Section>
+
+        {/* ─── Containers ────────────────────────────────────────────────── */}
+        <Section title="Containers" subtitle="Card, Panel, Tile.">
+          <Row>
+            <Card style={{ width: "20rem" }}>
+              <CardHeader>
+                <CardTitle>Card title</CardTitle>
+                <CardDescription>A shadcn-shaped card on the panel radius.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-body" style={{ color: "var(--fg-2)" }}>
+                  Card body content goes here.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Panel style={{ width: "20rem" }}>
+              <PanelHeader>
+                <PanelTitle>Panel title</PanelTitle>
+                <Badge variant="secondary">beta</Badge>
+              </PanelHeader>
+              <PanelBody>
+                <p className="text-body" style={{ color: "var(--fg-2)" }}>
+                  Panel body — the token-native container used across settings.
+                </p>
+              </PanelBody>
+            </Panel>
+          </Row>
+          <Subhead>Tile</Subhead>
+          <Row>
+            <Tile label="Agents" value="12" />
+            <Tile label="Online" value="8" accent="var(--accent-dim)" />
+            <Tile label="Failed" value="1" accent="var(--state-error)" />
+          </Row>
+        </Section>
+
+        {/* ─── Overlays & feedback ───────────────────────────────────────── */}
+        <Section title="Overlays & feedback" subtitle="Dialog, Popover, Toast.">
+          <Row>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button variant="outline" size="sm">
+                  Open dialog
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Delete agent?</DialogTitle>
+                  <DialogDescription>
+                    This removes the agent and its bindings. This action cannot be undone.
+                  </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                  <DialogClose asChild>
+                    <Button variant="ghost" size="sm">
+                      Cancel
+                    </Button>
+                  </DialogClose>
+                  <DialogClose asChild>
+                    <Button variant="destructive" size="sm">
+                      Delete
+                    </Button>
+                  </DialogClose>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+
+            <PopoverDemo />
+            <ToastDemo />
+          </Row>
+        </Section>
+
+        {/* ─── Data ──────────────────────────────────────────────────────── */}
+        <Section title="Data table" subtitle="The shared Table primitive.">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Agent</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Last active</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell>kael</TableCell>
+                <TableCell>
+                  <StateChip state="working" />
+                </TableCell>
+                <TableCell className="mono">now</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>design-critique</TableCell>
+                <TableCell>
+                  <StateChip state="idle" />
+                </TableCell>
+                <TableCell className="mono">2m</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>research</TableCell>
+                <TableCell>
+                  <StateChip state="offline" />
+                </TableCell>
+                <TableCell className="mono">1h</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Section>
+
+        {/* ─── Marketing surface ─────────────────────────────────────────── */}
+        <Section
+          title="Marketing surface"
+          subtitle="The .landing-marketing palette — pinned to the first-tree.ai brand regardless of the dashboard theme."
+        >
+          <div
+            className="landing-marketing"
+            style={{
+              padding: "var(--sp-6)",
+              borderRadius: "var(--radius-panel)",
+              background: "var(--bg)",
+              border: "var(--hairline) solid var(--border)",
+            }}
+          >
+            <div className="text-eyebrow uppercase" style={{ color: "var(--accent)", marginBottom: "var(--sp-1)" }}>
+              First Tree
+            </div>
+            <div className="text-headline" style={{ color: "var(--fg)" }}>
+              The unified CLI for agent teams
+            </div>
+            <p className="text-body" style={{ color: "var(--fg-2)", marginTop: "var(--sp-2)", maxWidth: "32rem" }}>
+              Same variable names as the dashboard, so every component utility inherits the brand palette inside this
+              scope. The green accent is shared across all three palettes.
+            </p>
+            <div style={{ marginTop: "var(--sp-4)" }}>
+              <Button size="sm">Get started</Button>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -890,7 +890,7 @@ function ParticipantChips({
           <div
             role="listbox"
             aria-label="Add participant"
-            className="absolute z-20 flex flex-col rounded-[var(--radius-panel)] border shadow-lg"
+            className="absolute z-20 flex flex-col rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]"
             style={{
               top: "calc(100% + var(--sp-1))",
               left: 0,

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -450,7 +450,7 @@ export function NewChatDraft({
   };
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden relative" style={{ background: "var(--bg-base)" }}>
+    <div className="flex-1 flex flex-col overflow-hidden relative" style={{ background: "var(--bg)" }}>
       {/* Narrow-viewport summon: parallels the hamburger in chat-view's
           header. Anchored absolutely so we don't disturb the existing
           centred composer layout. */}
@@ -890,7 +890,7 @@ function ParticipantChips({
           <div
             role="listbox"
             aria-label="Add participant"
-            className="absolute z-20 flex flex-col rounded-md border shadow-lg"
+            className="absolute z-20 flex flex-col rounded-[var(--radius-panel)] border shadow-lg"
             style={{
               top: "calc(100% + var(--sp-1))",
               left: 0,

--- a/packages/web/src/pages/workspace/right-sidebar/attentions-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/attentions-section.tsx
@@ -86,7 +86,7 @@ export function AttentionsSection({ chatId }: { chatId: string }) {
           <span
             className="mono"
             style={{
-              padding: "var(--sp-0_25) var(--sp-1)",
+              padding: "var(--sp-px) var(--sp-1)",
               borderRadius: "var(--radius-chip)",
               background: "var(--fg-error-strong)",
               color: "var(--fg-on-vivid)",
@@ -164,7 +164,7 @@ function AttentionRow({
         <span
           className="mono text-caption"
           style={{
-            padding: "var(--sp-0_25) var(--sp-1)",
+            padding: "var(--sp-px) var(--sp-1)",
             borderRadius: "var(--radius-chip)",
             background: isOpenAsk ? "var(--bg-error-soft)" : "var(--bg-sunken)",
             color: tagColor,
@@ -262,7 +262,7 @@ function AttentionPopover({
         background: "var(--bg-raised)",
         border: "var(--hairline) solid var(--border)",
         borderRadius: "var(--radius-panel)",
-        boxShadow: "var(--shadow-lg)",
+        boxShadow: "var(--shadow-md)",
         padding: "var(--sp-2_5) var(--sp-3) var(--sp-3)",
         zIndex: 1000,
       }}


### PR DESCRIPTION
## Summary

All changes are in `packages/web` — no backend / shared / CLI changes, and no business logic or component behavior touched (CSS tokens, value-preserving class renames, bugfixes, new tooling/docs/page).

- **fix** — repaired 8 styles that referenced undefined CSS variables and silently no-op'd at runtime (toast bg `--surface-1`, attentions padding `--sp-0_25` + shadow `--shadow-lg`, settings hover `--surface-2`, history-gap text `--fg-muted`, new-chat bg `--bg-base`, invite urgent color `--destructive`, agent-detail tab `--text-body-size`).
- **refactor** — consolidated design tokens: `--state-idle` → neutral cool `oklch(0.7 0.03 240)` (breaks the brand == success == idle green collision); deduped `--ok/--warn/--danger` into a `--success/--warning/--danger` feedback set (aliased to shared base hues); standardized radius on the semantic `--radius-*` four and migrated the 38 `rounded-md` / `rounded-lg` / `rounded-sm` classes (retired shadcn `--radius-sm/md/lg/xl`); removed the unadopted `--color-text-*/surface-*/border-*` alias layer.
- **chore** — the design-token guardrail now fails on references to undefined CSS variables (rule 7), catching ghost tokens in CI.
- **feat** — a living styleguide at `/preview/styleguide` renders the real tokens + `components/ui` primitives (lazy-loaded, ships).
- **docs** — `DESIGN.md` (clean spec incl. the adopted "Strategy A" design language: neutral primary, green reserved for brand + success) and `DESIGN-AUDIT.md` (current state, the gap, the phased migration plan, the audit/fix log, structural gaps).

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens` incl. the new undefined-token rule) — green
- [x] `biome check src` — green
- [x] Visual QA on `/preview/styleguide` (light + dark): components, `idle` = cool neutral, feedback colors, radius, primary stays green — no regressions
- [x] Toast P0 fix verified live (now renders with a solid raised background)
- [x] Invite page smoke — renders cleanly
- [ ] Auth-gated surfaces (right sidebar, new-chat draft, agent-detail tabs) — value-preserving token swaps, not yet verified in a logged-in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)