### PR TITLE
feat(chat): agent-driven chat topic + github topic auto-sync

### DIFF
--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -86,7 +86,7 @@ describe("CLI command registration", () => {
       "workspace",
     ]);
     expect(subcommands(root, "attention")).toEqual(["cancel", "list", "raise", "respond", "show"]);
-    expect(subcommands(root, "chat")).toEqual(["history", "invite", "list", "open", "send"]);
+    expect(subcommands(root, "chat")).toEqual(["history", "invite", "list", "open", "send", "set-topic"]);
     expect(subcommands(root, "daemon")).toEqual([
       "doctor",
       "home-info",

--- a/apps/cli/src/commands/chat/index.ts
+++ b/apps/cli/src/commands/chat/index.ts
@@ -4,12 +4,16 @@ import { registerChatInviteCommand } from "./invite.js";
 import { registerChatListCommand } from "./list.js";
 import { registerChatOpenCommand } from "./open.js";
 import { registerChatSendCommand } from "./send.js";
+import { registerChatSetTopicCommand } from "./set-topic.js";
 
 export function registerChatCommands(program: Command): void {
-  const chat = program.command("chat").description("Chats and messaging — list, history, send, open");
+  const chat = program
+    .command("chat")
+    .description("Chats and messaging — send, invite, list, history, set-topic, open");
   registerChatSendCommand(chat);
   registerChatInviteCommand(chat);
   registerChatListCommand(chat);
   registerChatHistoryCommand(chat);
+  registerChatSetTopicCommand(chat);
   registerChatOpenCommand(chat);
 }

--- a/apps/cli/src/commands/chat/set-topic.ts
+++ b/apps/cli/src/commands/chat/set-topic.ts
@@ -1,0 +1,66 @@
+import type { Command } from "commander";
+import { fail, success } from "../../cli/output.js";
+import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+
+type Options = {
+  chat?: string;
+  clear?: boolean;
+  agent?: string;
+};
+
+function describe(): string {
+  return (
+    "Set or clear the topic (display label) of a chat. The topic is what the " +
+    "workspace chat list shows for this chat. By default acts on the caller's " +
+    "current chat (FIRST_TREE_CHAT_ID); use --chat <id> to target another."
+  );
+}
+
+async function run(topicArg: string | undefined, options: Options): Promise<void> {
+  const chatId = options.chat ?? process.env.FIRST_TREE_CHAT_ID;
+  if (!chatId) {
+    fail(
+      "NO_CHAT_CONTEXT",
+      "`chat set-topic` needs a chat to target. Either run it from an agent session that exports FIRST_TREE_CHAT_ID, or pass --chat <id>.",
+      2,
+    );
+  }
+
+  let topic: string | null;
+  if (options.clear) {
+    if (topicArg !== undefined) {
+      fail("CONFLICTING_ARGS", "Pass either --clear or a topic value, not both.", 2);
+    }
+    topic = null;
+  } else {
+    if (topicArg === undefined) {
+      fail("MISSING_TOPIC", "Provide a topic value, or use --clear to unset.", 2);
+    }
+    const trimmed = topicArg.trim();
+    if (trimmed.length === 0) {
+      fail("EMPTY_TOPIC", "Topic cannot be empty. Use --clear to unset.", 2);
+    }
+    topic = trimmed;
+  }
+
+  try {
+    const sdk = createSdk(options.agent);
+    const updated = await sdk.updateChat(chatId, { topic });
+    success(updated);
+  } catch (error) {
+    handleSdkError(error);
+  }
+}
+
+export function registerChatSetTopicCommand(chat: Command): void {
+  chat
+    .command("set-topic [topic]")
+    .alias("rename")
+    .description(describe())
+    .option("--chat <chatId>", "Target chat id (default: FIRST_TREE_CHAT_ID)")
+    .option("--clear", "Clear the topic (sets it to null, falls back to auto-derived title)")
+    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .action(async (topicArg: string | undefined, options: Options) => {
+      await run(topicArg, options);
+    });
+}

--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -221,7 +221,7 @@ describe("renderChatContextSection", () => {
     expect(renderChatContextSection(undefined)).toBeNull();
   });
 
-  it("renders Current Chat Context with chatId/title/participants — Topic line elided when title === topic", () => {
+  it("renders Topic line with the raw value when topic is set (Title line de-duped against topic)", () => {
     const md = renderChatContextSection({
       chatId: "chat-1",
       title: "ship v1",
@@ -235,18 +235,20 @@ describe("renderChatContextSection", () => {
     if (!md) return;
     expect(md).toContain("## Current Chat Context");
     expect(md).toContain("Chat ID: chat-1");
-    expect(md).toContain("Title: ship v1");
-    // De-dup: when topic equals title, only the Title line is emitted.
-    expect(md).not.toContain("Topic: ship v1");
+    expect(md).toContain("Topic: ship v1");
+    // Title is de-duped when it equals topic — the agent already knows the
+    // label from the Topic line.
+    expect(md).not.toMatch(/Title \(auto-derived\):/);
     expect(md).toContain("@alice (Alice, type=human)");
     expect(md).toContain("@bob-bot (Bob Bot, type=agent)");
     expect(md).not.toContain("Your owner:");
   });
 
-  it("emits server-resolved Title even when topic is null (fallback case)", () => {
+  it("emits Topic: (unset) sentinel + auto-derived Title when topic is null", () => {
     // Most real chats are created without an explicit topic — server's
-    // `title` falls back to first-message preview / participant join. This
-    // pins that the rendered section always has a Title line.
+    // `title` falls back to first-message preview / participant join. The
+    // section now always renders a Topic line so the agent can see whether
+    // it should set one this turn.
     const md = renderChatContextSection({
       chatId: "chat-1",
       title: "alice, bob-bot",
@@ -258,32 +260,27 @@ describe("renderChatContextSection", () => {
     });
     expect(md).not.toBeNull();
     if (!md) return;
-    expect(md).toContain("Title: alice, bob-bot");
-    expect(md).not.toMatch(/Topic:/);
+    expect(md).toContain("Topic: (unset");
+    expect(md).toContain("Title (auto-derived): alice, bob-bot");
   });
 
-  it("emits BOTH Title and Topic when the creator set a custom topic distinct from the fallback title", () => {
+  it("renders Topic + auto-derived Title when topic is set but distinct from title", () => {
+    // Currently impossible via server logic (title falls back to topic when
+    // topic is non-null), but the render path must still be sound if the
+    // two ever diverge — e.g. a stale cache or a future server change.
     const md = renderChatContextSection({
-      chatId: "chat-1",
-      title: "ship v1",
-      topic: "ship v1",
-      participants: [],
-    });
-    // Equal → only Title (covered above). Now exercise the distinct case:
-    const md2 = renderChatContextSection({
       chatId: "chat-1",
       title: "alice, bob-bot",
       topic: "Q2 launch coordination",
       participants: [{ name: "alice", displayName: "Alice", type: "human" }],
     });
     expect(md).not.toBeNull();
-    expect(md2).not.toBeNull();
-    if (!md2) return;
-    expect(md2).toContain("Title: alice, bob-bot");
-    expect(md2).toContain("Topic: Q2 launch coordination");
+    if (!md) return;
+    expect(md).toContain("Topic: Q2 launch coordination");
+    expect(md).toContain("Title (auto-derived): alice, bob-bot");
   });
 
-  it("includes 'Your owner' line only when selfOwner is set", () => {
+  it("includes 'Your owner' line only when selfOwner is set; Topic sentinel still emitted when unset", () => {
     const md = renderChatContextSection({
       chatId: "chat-1",
       title: "alice + Me PA",
@@ -294,8 +291,7 @@ describe("renderChatContextSection", () => {
     expect(md).not.toBeNull();
     if (!md) return;
     expect(md).toContain("Your owner: Owner Human (@owner)");
-    // Topic missing → line elided
-    expect(md).not.toMatch(/Topic:/);
+    expect(md).toContain("Topic: (unset");
   });
 
   it("does NOT leak internal id / access_mode / role / mode fields", () => {

--- a/packages/client/src/__tests__/claude-code-bootstrap.test.ts
+++ b/packages/client/src/__tests__/claude-code-bootstrap.test.ts
@@ -309,7 +309,9 @@ describe("CLAUDE.md generation", () => {
     });
     expect(md).toContain("## Current Chat Context");
     expect(md).toContain("Chat ID: chat-cc");
-    expect(md).toContain("Title: ship v1");
+    // Topic is the canonical label line; Title (auto-derived) is suppressed
+    // when it equals topic. See chat-context-section.ts.
+    expect(md).toContain("Topic: ship v1");
     expect(md).toContain("@alice (Alice, type=human)");
     expect(md).toContain("@bob-bot (Bob Bot, type=agent)");
     expect(md).not.toContain("Your owner:");

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -1055,5 +1055,39 @@ this command.
 Use \`${bin} attention raise --requires-response\` before any irreversible or externally-visible action that needs the human's go-ahead (ask), use \`${bin} attention raise\` without the flag right after such an action completes while the human is not watching (notify), and use plain \`chat send\` for everything else — full trigger lists, body templates, and waiting behaviour live in the attention skill (\`.claude/skills/attention/SKILL.md\` or \`.agents/skills/attention/SKILL.md\`).
 
 **\`AskUserQuestion\` is NOT available in this Hub — it is denied on call.** If you ever invoke \`AskUserQuestion\` (or any built-in "ask the user" tool) and it is denied, you MUST re-issue the request as a request-type NHA via \`${bin} attention raise --requires-response\`. Do NOT fall back to asking the question as plain final-text or a \`chat send\`: a request-NHA is the only mechanism that targets a specific human, carries a response expectation, and resumes your turn when they reply. Convert each choice you would have offered into the NHA body (and \`metadata.options\` / \`metadata.questions\` when the human should click rather than type).
+
+## Naming this Chat (Topic)
+
+The workspace chat list uses each chat's \`topic\` as its label. A good topic
+is a short (≤ 30 chars) phrase that tells a teammate at a glance what this
+chat is about — e.g. "调研 chat rename 方案" or "本周 ship 计划".
+
+The current value is shown in the "Current Chat Context" block above as
+either an explicit \`Topic: <value>\` or the sentinel \`Topic: (unset ...)\`.
+
+**Two hard rules:**
+
+1. **Topic is unset → set one before ending this turn.**
+   When the context block shows \`Topic: (unset ...)\`, run:
+
+       ${bin} chat set-topic "<short phrase>"
+
+   The fallback label the workspace would otherwise show ("first 50 chars
+   of the first message" / "alice, bob-bot") is rarely distinctive across
+   many chats — naming the chat is a cheap win.
+
+2. **Topic is set but no longer matches what this chat is about → update it.**
+   Use judgment: don't churn the topic for minor digressions. Only run
+   \`${bin} chat set-topic "<new phrase>"\` when a teammate scanning the
+   workspace list would be misled by the current value.
+
+**Exception: GitHub-sourced topics — leave them alone.**
+
+Topics that look like \`PR repo#307: title\`, \`Issue repo#42\`, \`PR Review
+repo#X: ...\`, \`Discussion repo#X\`, or \`Commit repo@sha\` were auto-set
+by Hub when the chat was minted from a GitHub event, and Hub keeps them in
+sync with the upstream PR/issue title. Overriding them with your own label
+loses the repo / entity-id anchor that makes the chat list useful. **Do
+not run \`set-topic\` on a chat whose topic already has that shape.**
 `;
 }

--- a/packages/client/src/runtime/chat-context-section.ts
+++ b/packages/client/src/runtime/chat-context-section.ts
@@ -16,15 +16,22 @@ export function renderChatContextSection(chatContext: ChatContext | undefined): 
   lines.push("## Current Chat Context");
   lines.push("");
   lines.push(`- Chat ID: ${chatContext.chatId}`);
-  // Title is server-resolved and always non-empty (falls back to first-message
-  // preview / participant join). Topic is the raw column — render it as a
-  // separate line only when explicitly set, so the LLM can tell "creator
-  // chose this label" from "Hub auto-derived a label".
-  if (chatContext.title && chatContext.title.trim().length > 0) {
-    lines.push(`- Title: ${chatContext.title}`);
-  }
-  if (chatContext.topic && chatContext.topic.trim().length > 0 && chatContext.topic !== chatContext.title) {
+  // Topic is the raw `chats.topic` column. We render it on every turn —
+  // either the explicit value or a sentinel — so the agent can decide
+  // whether to set/refresh it without round-tripping through the API. See
+  // the "Naming this Chat (Topic)" section in tools.md for the two hard
+  // rules the agent is expected to follow when it sees `(unset)` here.
+  if (chatContext.topic && chatContext.topic.trim().length > 0) {
     lines.push(`- Topic: ${chatContext.topic}`);
+  } else {
+    lines.push(`- Topic: (unset — see "Naming this Chat" in tools.md)`);
+  }
+  // Title is the server-resolved display label (falls back to first-message
+  // preview / participant join when topic is null). Only render when it
+  // differs from topic — when topic is set, title == topic and the second
+  // line would be redundant.
+  if (chatContext.title && chatContext.title.trim().length > 0 && chatContext.title !== chatContext.topic) {
+    lines.push(`- Title (auto-derived): ${chatContext.title}`);
   }
   if (chatContext.selfOwner) {
     lines.push(`- Your owner: ${chatContext.selfOwner.displayName} (@${chatContext.selfOwner.name})`);

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -324,6 +324,22 @@ export class FirstTreeHubSDK {
   }
 
   /**
+   * Update chat metadata. Currently the only mutable field is `topic` — the
+   * human-readable label rendered by `resolveChatTitle` and shown in the
+   * workspace chat list. Pass `topic: null` to clear it (the title then
+   * falls back to first-message preview / participant names).
+   *
+   * Auth: caller must be a speaker in the chat (server-side
+   * `assertParticipant` gate).
+   */
+  async updateChat(chatId: string, body: { topic: string | null }): Promise<Chat> {
+    return this.requestJson<Chat>(`/api/v1/agent/chats/${chatId}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
    * Add a participant to a chat by uuid or by name. Names resolve within the
    * chat's organization. Idempotent: re-adding an existing speaker returns
    * the chat's current participant list (the server treats it as a conflict

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -113,4 +113,63 @@ describe("Agent Chats API", () => {
     const res = await a3.request("GET", `/api/v1/agent/chats/${chatId}/participants`);
     expect(res.statusCode).toBe(403);
   });
+
+  describe("PATCH /chats/:id (set topic)", () => {
+    it("updates topic and persists; null clears", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `topic-a1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `topic-a2-${uid}` });
+
+      const createRes = await a1.request("POST", "/api/v1/agent/chats", {
+        type: "group",
+        participantIds: [a2.uuid],
+      });
+      const chatId = createRes.json().id;
+
+      const setRes = await a1.request("PATCH", `/api/v1/agent/chats/${chatId}`, { topic: "ship plan" });
+      expect(setRes.statusCode).toBe(200);
+      expect(setRes.json().topic).toBe("ship plan");
+
+      const detailRes = await a1.request("GET", `/api/v1/agent/chats/${chatId}`);
+      expect(detailRes.json().topic).toBe("ship plan");
+
+      const clearRes = await a1.request("PATCH", `/api/v1/agent/chats/${chatId}`, { topic: null });
+      expect(clearRes.statusCode).toBe(200);
+      expect(clearRes.json().topic).toBeNull();
+    });
+
+    it("rejects non-participants with 403", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `topic-deny-a1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `topic-deny-a2-${uid}` });
+      const a3 = await createTestAgent(app, { name: `topic-deny-a3-${uid}` });
+
+      const createRes = await a1.request("POST", "/api/v1/agent/chats", {
+        type: "group",
+        participantIds: [a2.uuid],
+      });
+      const chatId = createRes.json().id;
+
+      const res = await a3.request("PATCH", `/api/v1/agent/chats/${chatId}`, { topic: "intrusion" });
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("rejects malformed body (topic missing)", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const a1 = await createTestAgent(app, { name: `topic-bad-a1-${uid}` });
+      const { agent: a2 } = await createTestAgent(app, { name: `topic-bad-a2-${uid}` });
+
+      const createRes = await a1.request("POST", "/api/v1/agent/chats", {
+        type: "group",
+        participantIds: [a2.uuid],
+      });
+      const chatId = createRes.json().id;
+
+      const res = await a1.request("PATCH", `/api/v1/agent/chats/${chatId}`, {});
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -51,17 +51,20 @@ function makeEvent(opts: {
   entityKey: string;
   involves?: NormalizedEvent["involves"];
   body?: string;
+  rawEventType?: string;
+  rawAction?: string;
+  title?: string;
 }): NormalizedEvent {
   return {
     source: { kind: "github-app-installation", installationId: 1, organizationId: opts.orgId },
     deliveryId: "delivery-1",
-    rawEventType: "pull_request",
-    rawAction: "opened",
+    rawEventType: opts.rawEventType ?? "pull_request",
+    rawAction: opts.rawAction ?? "opened",
     entity: {
       type: opts.entityType,
       repo: "owner/repo",
       key: opts.entityKey,
-      title: "Refactor inbox",
+      title: opts.title ?? "Refactor inbox",
       url: `https://github.com/owner/repo/pull/1`,
     },
     actor: { githubLogin: "alice", isBot: false },
@@ -129,6 +132,225 @@ describe("deliverNormalizedEvent", () => {
     const content = sent[0]?.content as { type: string; reason: string };
     expect(content.type).toBe("github_event");
     expect(content.reason).toBe("subscribed");
+  });
+
+  it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+
+    // Seed an existing github-bound chat with a stale topic (e.g. PR title
+    // was different when the chat was minted).
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "direct",
+      topic: "PR repo#200: Old title from creation",
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#200",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#200",
+    });
+    await deliverNormalizedEvent(app, event, [target]);
+
+    const [row] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    expect(row?.topic).toBe("PR repo#200: Refactor inbox");
+  });
+
+  it("preserves the original prefix on a review-flow event (no PR → PR Review drift)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+
+    // Chat was minted from `pull_request.opened` → head is the plain "PR"
+    // prefix. A later review event must update the title but keep "PR" — it
+    // must NOT promote the head to "PR Review".
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "direct",
+      topic: "PR repo#200: Old title",
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#200",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#200",
+      rawEventType: "pull_request_review",
+      rawAction: "submitted",
+      title: "Renamed title",
+    });
+    await deliverNormalizedEvent(app, event, [target]);
+
+    const [row] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    expect(row?.topic).toBe("PR repo#200: Renamed title");
+  });
+
+  it("does NOT overwrite the owning topic when a linked (fixes_link) entity's event arrives", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+
+    // Chat was minted for issue#42 (its direct anchor + topic). A PR#99 that
+    // `Fixes #42` later got a `fixes_link` mapping row pointing at the same
+    // chat. An event for PR#99 must NOT hijack the chat's issue topic.
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "direct",
+      topic: "Issue repo#42: Login bug",
+    });
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "issue",
+        entityKey: "owner/repo#42",
+        chatId,
+        boundVia: "direct",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#99",
+        chatId,
+        boundVia: "fixes_link",
+      },
+    ]);
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#99",
+      title: "Fix the login bug",
+    });
+    await deliverNormalizedEvent(app, event, [target]);
+
+    const [row] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    expect(row?.topic).toBe("Issue repo#42: Login bug");
+  });
+
+  it("does NOT touch chats.topic for chats without a github entity mapping (manual / agent-set topic is preserved)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+
+    // A chat that the agent renamed to a custom label — no mapping row.
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "direct",
+      topic: "agent-chosen label",
+    });
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#999",
+    });
+    await deliverNormalizedEvent(app, event, [target]);
+
+    const [row] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    expect(row?.topic).toBe("agent-chosen label");
   });
 
   it("creates a fresh chat + mapping for a `new` target, card.reason matches involveReason, mentionedUser populated", async () => {

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -1,5 +1,7 @@
-import { addParticipantSchema, createChatSchema, paginationQuerySchema } from "@first-tree/shared";
+import { addParticipantSchema, createChatSchema, paginationQuerySchema, updateChatSchema } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import { chats } from "../../db/schema/chats.js";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
 import { agentAvatarImageUrl } from "../../services/agent.js";
@@ -76,6 +78,24 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       avatarColorToken: r.avatarColorToken ?? null,
       avatarImageUrl: agentAvatarImageUrl(r.agentId, r.avatarImageUpdatedAt ?? null),
     }));
+  });
+
+  // Update chat metadata (currently: `topic` only). Mirrors the user-scope
+  // PATCH /api/v1/chats/:chatId so agent-token callers (e.g. `chat set-topic`
+  // from inside an agent session) can rename a chat they participate in.
+  // Auth: must be a speaker in the chat — same gate as message send.
+  app.patch<{ Params: { chatId: string } }>("/:chatId", { config: { otelRecordBody: true } }, async (request) => {
+    const identity = requireAgent(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
+    const body = updateChatSchema.parse(request.body);
+    const nextTopic = body.topic && body.topic.length > 0 ? body.topic : null;
+    const [updated] = await app.db
+      .update(chats)
+      .set({ topic: nextTopic, updatedAt: new Date() })
+      .where(eq(chats.id, request.params.chatId))
+      .returning();
+    if (!updated) throw new Error("Unexpected: chat missing after update");
+    return serializeChat(updated);
   });
 
   // Participant management

--- a/packages/server/src/api/webhooks/github-entity.ts
+++ b/packages/server/src/api/webhooks/github-entity.ts
@@ -176,7 +176,17 @@ function entityTitlePrefix(entity: GithubEntity, eventType: string, action: stri
   if (eventType === "pull_request" && action === "review_requested") return "PR Review";
   if (eventType === "pull_request_review") return "PR Review";
   if (eventType === "pull_request_review_comment") return "PR Review";
-  switch (entity.type) {
+  return baseTypePrefix(entity.type);
+}
+
+/**
+ * Prefix derived purely from the entity type, with no review-flow
+ * special-casing. Used both as the fallback inside `entityTitlePrefix` and to
+ * enumerate the legal title heads when refreshing a topic (see
+ * `refreshEntityTitle`).
+ */
+function baseTypePrefix(type: GithubEntity["type"]): string {
+  switch (type) {
     case "issue":
       return "Issue";
     case "pull_request":
@@ -216,4 +226,37 @@ export function formatEntityTitle(entity: GithubEntity, eventType: string, actio
     return `${head}: ${entity.title}`;
   }
   return head;
+}
+
+/**
+ * Recompute a github chat topic when the upstream entity title changes, while
+ * *preserving* the original prefix + anchor head. The prefix ("PR" vs
+ * "PR Review", "Issue", …) is decided once at chat creation from the
+ * first-touch event and must NOT drift when a later event with a different
+ * `(eventType, action)` arrives — so we reuse the head already baked into the
+ * stored topic rather than re-deriving it from this event.
+ *
+ * Returns the new topic, or `null` when `storedTopic` is not a recognised
+ * github-format title for `entity` (e.g. an agent renamed the chat off-spec,
+ * or the payload carries no title). The caller leaves such topics untouched.
+ *
+ *   refreshEntityTitle("PR Review repo#307: old", { type: "pull_request", key: "o/repo#307", title: "new" })
+ *     → "PR Review repo#307: new"
+ *   refreshEntityTitle("my custom name", <pr>) → null
+ */
+export function refreshEntityTitle(storedTopic: string, entity: GithubEntity): string | null {
+  if (!entity.title || entity.title.length === 0) return null;
+  const shortKey = shortEntityKey(entity.key);
+  // For a PR the original head could be either the plain "PR" prefix or the
+  // review-flow "PR Review" prefix; every other type has a single legal head.
+  const heads =
+    entity.type === "pull_request"
+      ? [`PR Review ${shortKey}`, `PR ${shortKey}`]
+      : [`${baseTypePrefix(entity.type)} ${shortKey}`];
+  // Longest first so "PR Review repo#7" is matched before "PR repo#7".
+  const head = heads
+    .sort((a, b) => b.length - a.length)
+    .find((h) => storedTopic === h || storedTopic.startsWith(`${h}: `));
+  if (!head) return null;
+  return `${head}: ${entity.title}`;
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { createLogger } from "../observability/index.js";
 import type { AudienceTarget } from "./github-audience.js";
-import { resolveTargetChat } from "./github-entity-chat.js";
+import { refreshGithubChatTopic, resolveTargetChat } from "./github-entity-chat.js";
 import { sendMessage } from "./message.js";
 import { notifyRecipients } from "./notifier.js";
 
@@ -68,6 +68,22 @@ export async function deliverNormalizedEvent(
         continue;
       }
       if (resolved.created) stats.newChats += 1;
+
+      // Existing github-sourced chats: refresh the topic so PR / issue
+      // title edits on GitHub propagate into the workspace chat list. The
+      // helper only touches a chat whose own `direct` anchor entity matches
+      // this event (never a linked fixes_link entity), preserves the original
+      // prefix, and no-ops when the payload carries no title — keeping the
+      // refresh scoped to chats Hub originally minted from this entity.
+      if (!resolved.created) {
+        const entity: GithubEntity = {
+          type: event.entity.type,
+          key: event.entity.key,
+          title: event.entity.title,
+          url: event.entity.url,
+        };
+        await refreshGithubChatTopic(app.db, resolved.chatId, entity);
+      }
 
       const card = buildCard(event, target);
       const mentionedUser = card.mentionedUser ?? undefined;

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -2,7 +2,7 @@ import type { ToolCallEventPayload } from "@first-tree/shared";
 import { chatMetadataSchema } from "@first-tree/shared";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
-import { formatEntityTitle } from "../api/webhooks/github-entity.js";
+import { formatEntityTitle, refreshEntityTitle } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -403,6 +403,71 @@ async function resolveBindingPair(
     humanAgentId: representative.agentId,
     delegateAgentId: reporterAgentId,
   };
+}
+
+/**
+ * Refresh a GitHub-sourced chat's `topic` to match the current entity title.
+ *
+ * The chat's topic was first written at creation time by `createEntityChat`
+ * using `formatEntityTitle(entity, eventType, action)`. If the upstream PR /
+ * issue title later changes on GitHub, that webhook arrives with the new
+ * `entity.title` — we swap the title portion in and leave the prefix/anchor
+ * head intact.
+ *
+ * Scope rules (all three matter — see PR #657 review):
+ *   - **Owning anchor only.** A chat can carry several mapping rows: the
+ *     `direct` first-touch row the chat was minted for, plus `fixes_link` /
+ *     `human_fallback` siblings that point *related* entities at the same
+ *     chat. We refresh only when the incoming event is for the chat's own
+ *     `direct` anchor entity; an event for a linked entity must never
+ *     overwrite the topic with a different entity's title. (A chat with no
+ *     `direct` row — e.g. one an agent created a PR inside of, bound via
+ *     `agent_created` — is not github-minted and is left alone.)
+ *   - **Prefix preserved.** `refreshEntityTitle` reuses the prefix already
+ *     baked into the stored topic, so a later `review_requested` /
+ *     `*_review_comment` event can't drift a `PR …` head into `PR Review …`
+ *     (or vice-versa). It also returns null — leaving the topic untouched —
+ *     when the stored topic isn't a recognised github head (agent rename) or
+ *     the payload carries no title (would downgrade to a bare \`PR repo#307\`).
+ *   - No-op when the recomputed topic equals the stored topic.
+ *
+ * Failures are swallowed: the caller is the github delivery loop, and a
+ * topic-refresh hiccup must not block message delivery.
+ */
+export async function refreshGithubChatTopic(db: Database, chatId: string, entity: GithubEntity): Promise<void> {
+  if (!entity.title || entity.title.length === 0) return;
+
+  try {
+    const [anchor] = await db
+      .select({
+        entityType: githubEntityChatMappings.entityType,
+        entityKey: githubEntityChatMappings.entityKey,
+      })
+      .from(githubEntityChatMappings)
+      .where(and(eq(githubEntityChatMappings.chatId, chatId), eq(githubEntityChatMappings.boundVia, "direct")))
+      .limit(1);
+    if (!anchor) return;
+    if (anchor.entityType !== entity.type || anchor.entityKey !== entity.key) return;
+
+    const [row] = await db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    if (!row || !row.topic) return;
+
+    const nextTopic = refreshEntityTitle(row.topic, entity);
+    if (!nextTopic || nextTopic === row.topic) return;
+
+    await db.update(chats).set({ topic: nextTopic, updatedAt: new Date() }).where(eq(chats.id, chatId));
+    log.info({ chatId, entityType: entity.type, entityKey: entity.key, nextTopic }, "refreshed github chat topic");
+  } catch (err) {
+    log.warn(
+      {
+        chatId,
+        entityType: entity.type,
+        entityKey: entity.key,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      },
+      "failed to refresh github chat topic — continuing",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Today the workspace chat list uses `chats.topic` if set, otherwise falls back to first-message preview / participant join. GitHub-sourced chats already write a `PR repo#N: title` topic at creation, so they read well. Non-github chats fall through to the (often non-distinctive) preview / participant fallback.

This PR lets agents own `topic` for chats they participate in, and keeps github chats in sync with the upstream entity when the PR/issue title changes.

## Changes

### Server
- New `PATCH /api/v1/agent/chats/:chatId` (agent scope), mirroring the user-scope PATCH. Reuses `updateChatSchema`. Gated by `assertParticipant` (speaker only).
- `refreshGithubChatTopic` runs on every delivered event for an existing github-bound chat — propagates upstream title edits into `chats.topic`. Scoped by the presence of a `github_entity_chat_mappings` row so agent-renamed chats are never overwritten; no-ops when the event lacks an entity title (would downgrade a good `PR repo#N: title` to a bare `PR repo#N`).

### Client / SDK
- `FirstTreeHubSDK.updateChat(chatId, { topic })`.
- `renderChatContextSection` now emits `Topic:` on every turn — either the value or the sentinel `(unset — see "Naming this Chat" in tools.md)`. **Fix:** the previous `topic !== title` guard suppressed the `Topic:` line in every realistic state (title falls back to topic, so when topic was set the two were equal). The `Title (auto-derived):` line is rendered only when title diverges from topic.
- `generateToolsDoc()` gains `## Naming this Chat (Topic)`: two hard rules (set if unset, refresh on drift) plus an explicit carve-out telling agents not to touch `PR repo#X: title` / `Issue repo#X` / `PR Review repo#X` / `Discussion repo#X` / `Commit repo@sha` shapes.

### CLI
- New `first-tree chat set-topic [topic]` (alias `rename`). Defaults to `FIRST_TREE_CHAT_ID`; `--clear` to null-out; `--chat <id>` to target another.

### Schema
- No DB / Drizzle changes. The `topic` column already exists.

## Test plan
- [x] Server: agent PATCH route (set/clear, non-participant 403, malformed body 400). `packages/server/src/__tests__/agent-chats.test.ts`.
- [x] Server: github topic refresh — updates stale topic when entity title changes; leaves non-github chats untouched. `packages/server/src/__tests__/github-delivery.test.ts`.
- [x] Client: chat-context-section renders Topic line in all three states (set / unset / divergent). `packages/client/src/__tests__/chat-context.test.ts`.
- [x] Client: claude-code bootstrap snapshot updated for the Topic-first rendering.
- [x] CLI: `chat set-topic --help` shows the new subcommand and `rename` alias.
- [x] LLM behaviour (manual): Claude Opus 4.7 invoked `set-topic` once when `(unset)` was rendered, did not churn for an already-set custom topic, and did not touch a github-format topic.
- [x] `pnpm check && pnpm typecheck` clean.