### PR TITLE
fix(client): warn agents the pre-checked-out source repo may be stale (#655)

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -807,6 +807,13 @@ describe("buildChatSystemPrompt", () => {
     expect(text).toContain(`\`${AGENT_HOME}/web\``);
     // For the second entry — only url should appear, ref/branch lines omitted.
     expect(text).not.toMatch(/url=git@github.com:example\/web\.git,\s*ref=/);
+    // The pre-checked-out source repo is on a never-advanced hub-session
+    // branch — the prompt must warn the agent NOT to reuse it for new
+    // work and instead branch a fresh worktree from a freshly-fetched
+    // origin ref (issue #655).
+    expect(text).toContain("refreshed during this chat");
+    expect(text).toContain("git fetch origin");
+    expect(text).toContain("origin/main");
   });
 
   it("appends the Current Chat Context block when chatContext is provided", () => {

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -804,9 +804,13 @@ export function buildChatSystemPrompt(options: BuildChatSystemPromptOptions): st
     lines.push("");
     lines.push(
       "The following repositories are pre-checked-out at the top level of your",
-      "working directory. Treat them as **read-only / browse-only baselines** —",
-      "they are shared with every chat of this agent, so do **not** modify them",
-      "in place or switch their branches:",
+      "working directory. They sit on a long-lived hub-session branch that is",
+      "**not** refreshed during this chat — the code may be many commits behind",
+      "`origin/main`. Use them only for read-only orientation (grep, file layout,",
+      "`git log`); for anything that must reflect current `main` (review, analysis,",
+      "code changes), do not reuse this checkout — create a fresh worktree off",
+      "`origin/<base>` (see below). Shared across every chat of this agent; do",
+      "not modify them in place or switch their branches.",
     );
     lines.push("");
     for (const repo of sourceRepos) {
@@ -829,21 +833,22 @@ export function buildChatSystemPrompt(options: BuildChatSystemPromptOptions): st
   worktreeBlock.push("## Creating Worktrees On Demand");
   worktreeBlock.push("");
   worktreeBlock.push(
-    "**No worktrees are pre-created.** When you need to modify code, branch off",
-    `into a new worktree under \`${agentHome}/worktrees/<task-name>/\` and work there:`,
+    "**No worktrees are pre-created.** Every new task starts by branching a",
+    `fresh worktree under \`${agentHome}/worktrees/<task-name>/\` off a freshly-`,
+    "fetched `origin/<base>` — do not reuse the pre-checked-out path above.",
   );
   worktreeBlock.push("");
   worktreeBlock.push(
     "```bash",
     `# from a source repo, e.g. ${sourceRepos[0]?.absolutePath ?? `${agentHome}/<source-repo>`}`,
-    `git worktree add ${agentHome}/worktrees/<task-name> -b <new-branch>`,
+    "git fetch origin",
+    `git worktree add ${agentHome}/worktrees/<task-name> -b <new-branch> origin/main`,
     "```",
   );
   worktreeBlock.push("");
   worktreeBlock.push(
-    "Replace `<task-name>` with something descriptive (e.g. `<repo>-<short-task-id>`)",
-    "and `<new-branch>` with a real branch name. When finished, the operator can",
-    "clean up worktrees with `git worktree remove`.",
+    "Replace `<task-name>`, `<new-branch>`, and `origin/main` to fit. When",
+    "finished, the operator cleans up with `git worktree remove`.",
   );
   sections.push(worktreeBlock.join("\n"));
 


### PR DESCRIPTION
## Summary

- Closes #655. The agent's per-chat system prompt now warns that the top-level pre-checked-out source repo is on a long-lived `hub-session` branch that is **not** refreshed during the chat — so for long-running chats the working tree can drift many commits behind `origin/main`.
- Tells the agent to use that checkout only for read-only orientation (grep, file layout, `git log`) and, for any task that must reflect current `main` (review, analysis, code change), to NOT reuse it but instead `git fetch origin` and branch a fresh worktree off `origin/<base>`.
- Pure prompt-template change in `buildChatSystemPrompt` (`packages/client/src/runtime/bootstrap.ts`). No runtime / git behavior is altered; nothing on the fetch / worktree-add path changes.

## Why this approach

Issue #655 surfaced an agent failure mode: in a long chat the worktree was 67 commits behind `main`, and the agent silently analyzed the stale code. Investigation confirmed `prepareSourceRepos` already `git fetch`-es the bare mirror on every `start`/`resume`, but the per-agent source-repo checkout is reused across chats by design (per-agent-home model) and never advanced — so refreshing the mirror doesn't help the agent. Rather than auto-rebasing the shared checkout (risky around concurrent / in-progress work) or injecting per-turn staleness telemetry, this change adopts the lighter route: tell the agent explicitly that the checkout is stale by design and that every new task starts with a fresh worktree off `origin/<base>`.

## Test plan

- [x] `pnpm --filter @first-tree/client exec vitest run src/__tests__/bootstrap.test.ts` — 54/54 pass; new assertions lock the wording (`refreshed during this chat`, `git fetch origin`, `origin/main`).
- [x] `pnpm --filter @first-tree/client typecheck` clean.
- [x] `pnpm check` (biome) clean (24 pre-existing warnings unchanged).
- [ ] Reviewer eyeballs the rendered prompt block (excerpt below).

### Rendered prompt excerpt (Source Repositories + Creating Worktrees On Demand)

```
## Source Repositories

The following repositories are pre-checked-out at the top level of your
working directory. They sit on a long-lived hub-session branch that is
**not** refreshed during this chat — the code may be many commits behind
`origin/main`. Use them only for read-only orientation (grep, file layout,
`git log`); for anything that must reflect current `main` (review, analysis,
code changes), do not reuse this checkout — create a fresh worktree off
`origin/<base>` (see below). Shared across every chat of this agent; do
not modify them in place or switch their branches.

- `<agent-home>/<repo>`  (url=..., ref=..., branch=...)

## Creating Worktrees On Demand

**No worktrees are pre-created.** Every new task starts by branching a
fresh worktree under `<agent-home>/worktrees/<task-name>/` off a freshly-
fetched `origin/<base>` — do not reuse the pre-checked-out path above.

```bash
# from a source repo, e.g. <agent-home>/<repo>
git fetch origin
git worktree add <agent-home>/worktrees/<task-name> -b <new-branch> origin/main
```

Replace `<task-name>`, `<new-branch>`, and `origin/main` to fit. When
finished, the operator cleans up with `git worktree remove`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)