### PR TITLE
feat(web): token-usage Team column, Agent profile Usage tab, chat pill

### DIFF
--- a/packages/web/src/api/sessions.ts
+++ b/packages/web/src/api/sessions.ts
@@ -61,7 +61,8 @@ export type SessionEventKind =
   | "assistant_text"
   | "thinking"
   | "turn_end"
-  | "context_tree_usage";
+  | "context_tree_usage"
+  | "token_usage";
 
 export type SessionEventRow = {
   id: string;

--- a/packages/web/src/api/usage.ts
+++ b/packages/web/src/api/usage.ts
@@ -1,0 +1,42 @@
+import type { UsageAgentSummary, UsageByAgentResponse, UsageTurnsResponse } from "@first-tree/shared";
+import { api, withOrg } from "./client.js";
+
+/**
+ * Token-usage aggregation API. Backed by the endpoints introduced in the
+ * backend PR (`packages/server/src/services/usage.ts`). All windows are
+ * computed server-side; the client passes `from/to` as ISO strings.
+ */
+
+export type UsageWindow = "7d" | "30d";
+
+export function windowToDays(w: UsageWindow): number {
+  return w === "7d" ? 7 : 30;
+}
+
+function windowQuery(w: UsageWindow): string {
+  const to = new Date();
+  const from = new Date(to.getTime() - windowToDays(w) * 24 * 60 * 60 * 1000);
+  return `?from=${encodeURIComponent(from.toISOString())}&to=${encodeURIComponent(to.toISOString())}`;
+}
+
+/** Per-agent aggregate, used by the Team page Usage column. */
+export function getOrgUsageByAgent(window: UsageWindow): Promise<UsageByAgentResponse> {
+  return api.get<UsageByAgentResponse>(withOrg(`/usage/by-agent${windowQuery(window)}`));
+}
+
+/** Single-agent summary: window totals + trailing-90d activity grid. */
+export function getAgentUsageSummary(agentId: string, window: UsageWindow): Promise<UsageAgentSummary> {
+  return api.get<UsageAgentSummary>(`/agents/${encodeURIComponent(agentId)}/usage/summary${windowQuery(window)}`);
+}
+
+/** Paginated per-turn list. `cursor` is opaque (base64url ISO timestamp). */
+export function getAgentUsageTurns(
+  agentId: string,
+  args: { window: UsageWindow; cursor?: string | null; limit?: number },
+): Promise<UsageTurnsResponse> {
+  const wq = windowQuery(args.window).slice(1); // strip leading "?"
+  const parts = [wq];
+  if (args.cursor) parts.push(`cursor=${encodeURIComponent(args.cursor)}`);
+  if (args.limit) parts.push(`limit=${args.limit}`);
+  return api.get<UsageTurnsResponse>(`/agents/${encodeURIComponent(agentId)}/usage/turns?${parts.join("&")}`);
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -11,6 +11,7 @@ import { PromptTab } from "./pages/agent-detail/prompt-tab.js";
 import { ResourcesTab } from "./pages/agent-detail/resources-tab.js";
 import { SetupTab } from "./pages/agent-detail/setup-tab.js";
 import { ToolsTab } from "./pages/agent-detail/tools-tab.js";
+import { UsageTab } from "./pages/agent-detail/usage-tab.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { ContextPage } from "./pages/context.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
@@ -127,6 +128,7 @@ export function App() {
                   <Route path="agents/:uuid" element={<AgentDetailPage />}>
                     <Route index element={<Navigate to="profile" replace />} />
                     <Route path="profile" element={<ProfileTab />} />
+                    <Route path="usage" element={<UsageTab />} />
                     <Route path="setup" element={<SetupTab />} />
                     <Route path="prompt" element={<PromptTab />} />
                     <Route path="tools" element={<ToolsTab />} />

--- a/packages/web/src/components/chat/token-usage-pill.tsx
+++ b/packages/web/src/components/chat/token-usage-pill.tsx
@@ -14,10 +14,11 @@ import { formatCompactCount } from "../../lib/utils.js";
  * for spend are already looking; everyone else mostly scrolls past it.
  */
 export function TokenUsagePill({ event }: { event: SessionEventRow }): React.ReactElement | null {
-  // Payload shape comes from `tokenUsageEventPayload` (shared schema). We
-  // narrow defensively — older clients pre-PR-637 won't emit this event at
-  // all, but if a payload arrives with surprise shape we degrade silently
-  // rather than crash the timeline.
+  // Payload shape comes from `tokenUsageEventPayload` (shared schema). The
+  // pill is an audit primitive — "this turn cost N tokens" — so we fail
+  // closed: any missing-or-wrong-type field hides the pill entirely rather
+  // than rendering a placeholder zero. Silent zeros would read as "this
+  // turn was free", polluting the audit trail (review nit R2).
   if (typeof event.payload !== "object" || event.payload === null) return null;
   const p = event.payload as {
     inputTokens?: unknown;
@@ -26,13 +27,24 @@ export function TokenUsagePill({ event }: { event: SessionEventRow }): React.Rea
     provider?: unknown;
     model?: unknown;
   };
-  const input = typeof p.inputTokens === "number" ? p.inputTokens : 0;
-  const cached = typeof p.cachedInputTokens === "number" ? p.cachedInputTokens : 0;
-  const output = typeof p.outputTokens === "number" ? p.outputTokens : 0;
+  if (
+    typeof p.inputTokens !== "number" ||
+    typeof p.cachedInputTokens !== "number" ||
+    typeof p.outputTokens !== "number"
+  ) {
+    return null;
+  }
+  const input = p.inputTokens;
+  const cached = p.cachedInputTokens;
+  const output = p.outputTokens;
   const provider = typeof p.provider === "string" ? p.provider : "";
   const model = typeof p.model === "string" ? p.model : "";
 
   const total = input + cached + output;
+  // A turn that genuinely reported zero tokens across all three buckets is
+  // not a real turn we want to flag — drop the pill rather than render a
+  // misleading "0 tokens" badge.
+  if (total === 0) return null;
   const title = [
     `${provider}${model ? `/${model}` : ""}`,
     `Input ${input.toLocaleString()}`,

--- a/packages/web/src/components/chat/token-usage-pill.tsx
+++ b/packages/web/src/components/chat/token-usage-pill.tsx
@@ -1,0 +1,63 @@
+import type { SessionEventRow } from "../../api/sessions.js";
+import { formatCompactCount } from "../../lib/utils.js";
+
+/**
+ * Per-turn token-usage pill rendered inline in the chat timeline.
+ *
+ * Sociocurrency + audit principle (see token-usage design doc v4): every
+ * agent reply gets a small, always-on cost stamp. Hovering shows the full
+ * breakdown so disputes ("why was that turn so expensive?") have an
+ * immediate evidence pointer without leaving the chat.
+ *
+ * The pill is intentionally subdued — caption-sized, low-contrast — so
+ * it never competes with the assistant message body. Operators looking
+ * for spend are already looking; everyone else mostly scrolls past it.
+ */
+export function TokenUsagePill({ event }: { event: SessionEventRow }): React.ReactElement | null {
+  // Payload shape comes from `tokenUsageEventPayload` (shared schema). We
+  // narrow defensively — older clients pre-PR-637 won't emit this event at
+  // all, but if a payload arrives with surprise shape we degrade silently
+  // rather than crash the timeline.
+  if (typeof event.payload !== "object" || event.payload === null) return null;
+  const p = event.payload as {
+    inputTokens?: unknown;
+    cachedInputTokens?: unknown;
+    outputTokens?: unknown;
+    provider?: unknown;
+    model?: unknown;
+  };
+  const input = typeof p.inputTokens === "number" ? p.inputTokens : 0;
+  const cached = typeof p.cachedInputTokens === "number" ? p.cachedInputTokens : 0;
+  const output = typeof p.outputTokens === "number" ? p.outputTokens : 0;
+  const provider = typeof p.provider === "string" ? p.provider : "";
+  const model = typeof p.model === "string" ? p.model : "";
+
+  const total = input + cached + output;
+  const title = [
+    `${provider}${model ? `/${model}` : ""}`,
+    `Input ${input.toLocaleString()}`,
+    `Cached ${cached.toLocaleString()}`,
+    `Output ${output.toLocaleString()}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="flex justify-end" style={{ padding: "var(--sp-0_5) var(--sp-5)" }}>
+      <span
+        className="text-caption mono inline-flex items-center"
+        style={{
+          gap: "var(--sp-1)",
+          padding: "var(--sp-0_5) var(--sp-2)",
+          color: "var(--fg-4)",
+          background: "var(--bg-sunken)",
+          borderRadius: "var(--hairline)",
+        }}
+        title={title}
+      >
+        <span>{formatCompactCount(total)}</span>
+        <span style={{ color: "var(--fg-4)" }}>tokens</span>
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -59,6 +59,23 @@ const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("en", { numeric: "auto" }
  *
  * @param iso ISO 8601 timestamp (server returns `lastSeenAt.toISOString()`).
  */
+/**
+ * Compact integer formatter used by the Team-page Usage column and the
+ * Agent-profile KPI block. Renders values as `1.24M / 845K / 12K / 800`.
+ * `Intl.NumberFormat("en", { notation: "compact" })` would say `1.2M` —
+ * we want one decimal in the millions/thousands tier so a 1.04M agent
+ * does not collapse to `1M` (operationally that hides a 4% delta).
+ *
+ * Returns `"—"` for null/undefined/NaN so callers don't have to branch.
+ */
+export function formatCompactCount(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(2).replace(/\.?0+$/, "")}M`;
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(2).replace(/\.?0+$/, "")}K`;
+  return value.toLocaleString("en");
+}
+
 export function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "—";
   const t = new Date(iso).getTime();

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -52,8 +52,14 @@ const SECTION_TO_TAB: Record<DraftSectionName, string> = {
 
 type TabDef = { key: string; label: string; path: string };
 
-function buildTabs(canEditConfig: boolean): TabDef[] {
+function buildTabs(canEditConfig: boolean, isHuman: boolean): TabDef[] {
   const tabs: TabDef[] = [{ key: "profile", label: "Profile", path: "profile" }];
+  // Usage tab is visible to any org member for any non-human agent — token
+  // usage is the team's social currency, deliberately public within the org.
+  // Human-type agents have no token usage to show.
+  if (!isHuman) {
+    tabs.push({ key: "usage", label: "Usage", path: "usage" });
+  }
   if (canEditConfig) {
     tabs.push(
       { key: "setup", label: "Setup", path: "setup" },
@@ -62,9 +68,6 @@ function buildTabs(canEditConfig: boolean): TabDef[] {
       { key: "resources", label: "Resources", path: "resources" },
     );
   }
-  // Human agents have no runtime to configure. Danger zone (suspend / delete)
-  // lives on the Profile tab, so they don't need a Setup tab entry either —
-  // it would render blank without any rows to show.
   return tabs;
 }
 
@@ -288,7 +291,7 @@ export function AgentDetailPage() {
     return set;
   }, [draft.summary.dirtySections]);
 
-  const tabs = useMemo(() => buildTabs(canEditConfig), [canEditConfig]);
+  const tabs = useMemo(() => buildTabs(canEditConfig, isHumanLocal), [canEditConfig, isHumanLocal]);
   const currentTabKey = useMemo(() => {
     const segments = location.pathname.split("/");
     const last = segments[segments.length - 1] ?? "";

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -15,10 +15,25 @@ const ACTIVITY_GRID_DAYS = 90;
  *   1. KPI strip      — window totals (driven by 7d/30d selector)
  *   2. Activity grid  — fixed 90d daily density (always-on, ignores selector)
  *   3. Recent turns   — paginated per-turn detail with deep-link back to chat
+ *
+ * Summary query is lifted here so the KPI block + activity grid share one
+ * `/usage/summary` round-trip (review nit R4). Backend always
+ * returns the trailing-90d `daily` series regardless of `from`, so the same
+ * response feeds both surfaces.
  */
 export function UsageTab(): ReactElement {
   const ctx = useAgentDetailContext();
   const [window, setWindow] = useState<UsageWindow>("30d");
+
+  // Shared summary query — `totals` honours `window`, `daily` is always
+  // trailing-90d. Both KPI and Activity grid read from the same data.
+  const summaryQuery = useQuery({
+    queryKey: ["usage-summary", ctx.agent.uuid, window],
+    queryFn: () => getAgentUsageSummary(ctx.agent.uuid, window),
+    enabled: !ctx.isHuman,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
 
   if (ctx.isHuman) {
     return (
@@ -33,44 +48,53 @@ export function UsageTab(): ReactElement {
 
   return (
     <>
-      <SummaryBlock agentId={ctx.agent.uuid} window={window} onWindowChange={setWindow} />
-      <ActivityGridBlock agentId={ctx.agent.uuid} />
+      <SummaryBlock
+        window={window}
+        onWindowChange={setWindow}
+        data={summaryQuery.data}
+        isLoading={summaryQuery.isLoading}
+        isError={summaryQuery.isError}
+      />
+      <ActivityGridBlock data={summaryQuery.data} isLoading={summaryQuery.isLoading} isError={summaryQuery.isError} />
       <RecentTurnsBlock agentId={ctx.agent.uuid} window={window} />
     </>
   );
 }
 
 function SummaryBlock({
-  agentId,
   window,
   onWindowChange,
+  data,
+  isLoading,
+  isError,
 }: {
-  agentId: string;
   window: UsageWindow;
   onWindowChange: (next: UsageWindow) => void;
+  data: UsageAgentSummary | undefined;
+  isLoading: boolean;
+  isError: boolean;
 }): ReactElement {
-  const summaryQuery = useQuery({
-    queryKey: ["usage-summary", agentId, window],
-    queryFn: () => getAgentUsageSummary(agentId, window),
-    refetchInterval: 60_000,
-    staleTime: 30_000,
-  });
-  const totals = summaryQuery.data?.totals;
+  const totals = data?.totals;
   const totalTokens = totals ? totals.inputTokens + totals.cachedInputTokens + totals.outputTokens : null;
-
   return (
     <Section title="Token Usage" action={<WindowPicker window={window} onChange={onWindowChange} />}>
-      <div className="grid" style={{ gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "var(--sp-4)" }}>
-        <Kpi label={`Tokens (${window})`} value={formatCompactCount(totalTokens)} loading={summaryQuery.isLoading} />
-        <Kpi label="Turns" value={formatCompactCount(totals?.turns ?? null)} loading={summaryQuery.isLoading} />
-        <Kpi label="Chats" value={formatCompactCount(totals?.chats ?? null)} loading={summaryQuery.isLoading} />
-        <Kpi label="Last active" value={formatRelative(totals?.lastUsageAt ?? null)} loading={summaryQuery.isLoading} />
-      </div>
-      {totals?.inputTokens !== undefined && totalTokens !== null && totalTokens > 0 && (
-        <p className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-3)" }}>
-          Input {formatCompactCount(totals.inputTokens)} · Cached {formatCompactCount(totals.cachedInputTokens)} ·
-          Output {formatCompactCount(totals.outputTokens)}
-        </p>
+      {isError ? (
+        <ErrorRow message="Failed to load usage summary." />
+      ) : (
+        <>
+          <div className="grid" style={{ gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "var(--sp-4)" }}>
+            <Kpi label={`Tokens (${window})`} value={formatCompactCount(totalTokens)} loading={isLoading} />
+            <Kpi label="Turns" value={formatCompactCount(totals?.turns ?? null)} loading={isLoading} />
+            <Kpi label="Chats" value={formatCompactCount(totals?.chats ?? null)} loading={isLoading} />
+            <Kpi label="Last active" value={formatRelative(totals?.lastUsageAt ?? null)} loading={isLoading} />
+          </div>
+          {totals && totalTokens !== null && totalTokens > 0 && (
+            <p className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-3)" }}>
+              Input {formatCompactCount(totals.inputTokens)} · Cached {formatCompactCount(totals.cachedInputTokens)} ·
+              Output {formatCompactCount(totals.outputTokens)}
+            </p>
+          )}
+        </>
       )}
     </Section>
   );
@@ -124,20 +148,18 @@ function WindowPicker({
   );
 }
 
-function ActivityGridBlock({ agentId }: { agentId: string }): ReactElement {
-  // Fixed-90d query that does not change with the KPI window picker —
-  // the grid is the "long-horizon density" view; if it followed the
-  // selector to 7d, 83 of 90 cells would always be grey and the grid
-  // would stop conveying anything.
-  const summaryQuery = useQuery({
-    queryKey: ["usage-summary", agentId, "30d"],
-    queryFn: () => getAgentUsageSummary(agentId, "30d"),
-    refetchInterval: 60_000,
-    staleTime: 30_000,
-  });
+function ActivityGridBlock({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: UsageAgentSummary | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}): ReactElement {
   return (
     <Section title="Activity (last 90 days)">
-      <ActivityGrid summary={summaryQuery.data} loading={summaryQuery.isLoading} />
+      {isError ? <ErrorRow message="Failed to load activity." /> : <ActivityGrid summary={data} loading={isLoading} />}
     </Section>
   );
 }
@@ -172,7 +194,6 @@ function ActivityGrid({
     days.push({ date: iso, tokens: byDate.get(iso) ?? 0 });
   }
   const max = Math.max(1, ...days.map((d) => d.tokens));
-  // Five buckets (0..4). 0 reserved for zero; 1..4 split log-scaled max.
   function bucket(t: number): 0 | 1 | 2 | 3 | 4 {
     if (t <= 0) return 0;
     const r = Math.log10(1 + t) / Math.log10(1 + max);
@@ -183,19 +204,16 @@ function ActivityGrid({
   }
   const colors: Record<0 | 1 | 2 | 3 | 4, string> = {
     0: "var(--bg-sunken)",
-    1: "var(--accent-bg)",
-    2: "color-mix(in oklch, var(--accent) 35%, var(--bg-sunken))",
-    3: "color-mix(in oklch, var(--accent) 65%, var(--bg-sunken))",
-    4: "var(--accent)",
+    1: "var(--brand-bg)",
+    2: "color-mix(in oklch, var(--brand) 35%, var(--bg-sunken))",
+    3: "color-mix(in oklch, var(--brand) 65%, var(--bg-sunken))",
+    4: "var(--brand)",
   };
   return (
     <div>
       <div
         className="grid"
-        style={{
-          gridTemplateColumns: `repeat(${ACTIVITY_GRID_DAYS}, minmax(0, 1fr))`,
-          gap: "var(--hairline)",
-        }}
+        style={{ gridTemplateColumns: `repeat(${ACTIVITY_GRID_DAYS}, minmax(0, 1fr))`, gap: "var(--hairline)" }}
       >
         {days.map((d) => {
           const b = bucket(d.tokens);
@@ -213,9 +231,6 @@ function ActivityGrid({
           );
         })}
       </div>
-      <p className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-2)" }}>
-        Darker = more input tokens that day · Data since 2026-05-28
-      </p>
     </div>
   );
 }
@@ -239,12 +254,7 @@ function RecentTurnsBlock({ agentId, window }: { agentId: string; window: UsageW
             type="button"
             onClick={() => void turnsQuery.fetchNextPage()}
             className="text-caption font-semibold"
-            style={{
-              background: "transparent",
-              border: 0,
-              cursor: "pointer",
-              color: "var(--accent)",
-            }}
+            style={{ background: "transparent", border: 0, cursor: "pointer", color: "var(--primary)" }}
             disabled={turnsQuery.isFetchingNextPage}
           >
             {turnsQuery.isFetchingNextPage ? "Loading…" : "Load more"}
@@ -252,7 +262,9 @@ function RecentTurnsBlock({ agentId, window }: { agentId: string; window: UsageW
         ) : null
       }
     >
-      {turnsQuery.isLoading ? (
+      {turnsQuery.isError ? (
+        <ErrorRow message="Failed to load recent turns." />
+      ) : turnsQuery.isLoading ? (
         <p className="text-caption" style={{ color: "var(--fg-4)" }}>
           Loading…
         </p>
@@ -295,7 +307,7 @@ function TurnsTable({ rows }: { rows: UsageTurnRow[] }): ReactElement {
                     background: "transparent",
                     border: 0,
                     cursor: "pointer",
-                    color: "var(--accent)",
+                    color: "var(--primary)",
                     padding: 0,
                   }}
                 >
@@ -321,5 +333,18 @@ function TurnsTable({ rows }: { rows: UsageTurnRow[] }): ReactElement {
         ))}
       </tbody>
     </table>
+  );
+}
+
+/**
+ * Inline error placeholder for failed usage queries. Made distinct from
+ * the empty-state copy so an actual outage (network / 401 / 5xx) doesn't
+ * read as "no data" — review nit R3 flagged this as an audit-blocker.
+ */
+function ErrorRow({ message }: { message: string }): ReactElement {
+  return (
+    <p className="text-caption" style={{ color: "var(--state-error)" }}>
+      {message}
+    </p>
   );
 }

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -1,0 +1,325 @@
+import type { UsageAgentSummary, UsageTurnRow } from "@first-tree/shared";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { type ReactElement, useState } from "react";
+import { useNavigate } from "react-router";
+import { getAgentUsageSummary, getAgentUsageTurns, type UsageWindow, windowToDays } from "../../api/usage.js";
+import { Section } from "../../components/ui/section.js";
+import { formatCompactCount, formatRelative } from "../../lib/utils.js";
+import { useAgentDetailContext } from "./layout-context.js";
+
+const ACTIVITY_GRID_DAYS = 90;
+
+/**
+ * Agent profile Usage tab — the deep view onto one agent's token usage.
+ * Three blocks:
+ *   1. KPI strip      — window totals (driven by 7d/30d selector)
+ *   2. Activity grid  — fixed 90d daily density (always-on, ignores selector)
+ *   3. Recent turns   — paginated per-turn detail with deep-link back to chat
+ */
+export function UsageTab(): ReactElement {
+  const ctx = useAgentDetailContext();
+  const [window, setWindow] = useState<UsageWindow>("30d");
+
+  if (ctx.isHuman) {
+    return (
+      <Section title="Token Usage">
+        <p className="text-body" style={{ color: "var(--fg-3)" }}>
+          Token usage is only tracked for agent-type accounts. This profile represents a human member and does not run
+          model turns.
+        </p>
+      </Section>
+    );
+  }
+
+  return (
+    <>
+      <SummaryBlock agentId={ctx.agent.uuid} window={window} onWindowChange={setWindow} />
+      <ActivityGridBlock agentId={ctx.agent.uuid} />
+      <RecentTurnsBlock agentId={ctx.agent.uuid} window={window} />
+    </>
+  );
+}
+
+function SummaryBlock({
+  agentId,
+  window,
+  onWindowChange,
+}: {
+  agentId: string;
+  window: UsageWindow;
+  onWindowChange: (next: UsageWindow) => void;
+}): ReactElement {
+  const summaryQuery = useQuery({
+    queryKey: ["usage-summary", agentId, window],
+    queryFn: () => getAgentUsageSummary(agentId, window),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+  const totals = summaryQuery.data?.totals;
+  const totalTokens = totals ? totals.inputTokens + totals.cachedInputTokens + totals.outputTokens : null;
+
+  return (
+    <Section title="Token Usage" action={<WindowPicker window={window} onChange={onWindowChange} />}>
+      <div className="grid" style={{ gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "var(--sp-4)" }}>
+        <Kpi label={`Tokens (${window})`} value={formatCompactCount(totalTokens)} loading={summaryQuery.isLoading} />
+        <Kpi label="Turns" value={formatCompactCount(totals?.turns ?? null)} loading={summaryQuery.isLoading} />
+        <Kpi label="Chats" value={formatCompactCount(totals?.chats ?? null)} loading={summaryQuery.isLoading} />
+        <Kpi label="Last active" value={formatRelative(totals?.lastUsageAt ?? null)} loading={summaryQuery.isLoading} />
+      </div>
+      {totals?.inputTokens !== undefined && totalTokens !== null && totalTokens > 0 && (
+        <p className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-3)" }}>
+          Input {formatCompactCount(totals.inputTokens)} · Cached {formatCompactCount(totals.cachedInputTokens)} ·
+          Output {formatCompactCount(totals.outputTokens)}
+        </p>
+      )}
+    </Section>
+  );
+}
+
+function Kpi({ label, value, loading }: { label: string; value: string; loading: boolean }): ReactElement {
+  return (
+    <div>
+      <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+        {label}
+      </div>
+      <div className="text-h3 mono" style={{ color: "var(--fg-2)", marginTop: "var(--sp-1)" }}>
+        {loading ? "…" : value}
+      </div>
+    </div>
+  );
+}
+
+function WindowPicker({
+  window,
+  onChange,
+}: {
+  window: UsageWindow;
+  onChange: (next: UsageWindow) => void;
+}): ReactElement {
+  const base = "px-2 py-0_5 text-caption font-semibold";
+  const baseStyle = { background: "transparent", border: 0, cursor: "pointer", color: "var(--fg-3)" };
+  const activeStyle = { ...baseStyle, color: "var(--fg-2)", background: "var(--bg-hover)" };
+  return (
+    <span
+      className="inline-flex items-center"
+      style={{ gap: "var(--hairline)", border: "var(--hairline) solid var(--border)", padding: "var(--hairline)" }}
+    >
+      <button
+        type="button"
+        className={base}
+        onClick={() => onChange("7d")}
+        style={window === "7d" ? activeStyle : baseStyle}
+      >
+        7d
+      </button>
+      <button
+        type="button"
+        className={base}
+        onClick={() => onChange("30d")}
+        style={window === "30d" ? activeStyle : baseStyle}
+      >
+        30d
+      </button>
+    </span>
+  );
+}
+
+function ActivityGridBlock({ agentId }: { agentId: string }): ReactElement {
+  // Fixed-90d query that does not change with the KPI window picker —
+  // the grid is the "long-horizon density" view; if it followed the
+  // selector to 7d, 83 of 90 cells would always be grey and the grid
+  // would stop conveying anything.
+  const summaryQuery = useQuery({
+    queryKey: ["usage-summary", agentId, "30d"],
+    queryFn: () => getAgentUsageSummary(agentId, "30d"),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+  return (
+    <Section title="Activity (last 90 days)">
+      <ActivityGrid summary={summaryQuery.data} loading={summaryQuery.isLoading} />
+    </Section>
+  );
+}
+
+/**
+ * 90-day daily-density grid. Buckets daily input-token totals into 5 levels;
+ * cells with no events render as the lowest level (effectively empty). The
+ * server returns only days with activity, so we backfill the missing days
+ * on the client to keep the grid's geometry stable regardless of activity.
+ */
+function ActivityGrid({
+  summary,
+  loading,
+}: {
+  summary: UsageAgentSummary | undefined;
+  loading: boolean;
+}): ReactElement {
+  if (loading) {
+    return (
+      <p className="text-caption" style={{ color: "var(--fg-4)" }}>
+        Loading…
+      </p>
+    );
+  }
+  const byDate = new Map<string, number>();
+  for (const d of summary?.daily ?? []) byDate.set(d.date, d.inputTokens);
+  const today = new Date();
+  const days: { date: string; tokens: number }[] = [];
+  for (let i = ACTIVITY_GRID_DAYS - 1; i >= 0; i--) {
+    const dt = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
+    const iso = dt.toISOString().slice(0, 10);
+    days.push({ date: iso, tokens: byDate.get(iso) ?? 0 });
+  }
+  const max = Math.max(1, ...days.map((d) => d.tokens));
+  // Five buckets (0..4). 0 reserved for zero; 1..4 split log-scaled max.
+  function bucket(t: number): 0 | 1 | 2 | 3 | 4 {
+    if (t <= 0) return 0;
+    const r = Math.log10(1 + t) / Math.log10(1 + max);
+    if (r < 0.25) return 1;
+    if (r < 0.5) return 2;
+    if (r < 0.75) return 3;
+    return 4;
+  }
+  const colors: Record<0 | 1 | 2 | 3 | 4, string> = {
+    0: "var(--bg-sunken)",
+    1: "var(--accent-bg)",
+    2: "color-mix(in oklch, var(--accent) 35%, var(--bg-sunken))",
+    3: "color-mix(in oklch, var(--accent) 65%, var(--bg-sunken))",
+    4: "var(--accent)",
+  };
+  return (
+    <div>
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: `repeat(${ACTIVITY_GRID_DAYS}, minmax(0, 1fr))`,
+          gap: "var(--hairline)",
+        }}
+      >
+        {days.map((d) => {
+          const b = bucket(d.tokens);
+          return (
+            <span
+              key={d.date}
+              title={`${d.date} · ${formatCompactCount(d.tokens)} input tokens`}
+              style={{
+                background: colors[b],
+                height: "var(--sp-3)",
+                borderRadius: "var(--hairline)",
+                display: "block",
+              }}
+            />
+          );
+        })}
+      </div>
+      <p className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-2)" }}>
+        Darker = more input tokens that day · Data since 2026-05-28
+      </p>
+    </div>
+  );
+}
+
+function RecentTurnsBlock({ agentId, window }: { agentId: string; window: UsageWindow }): ReactElement {
+  const turnsQuery = useInfiniteQuery({
+    queryKey: ["usage-turns", agentId, window],
+    queryFn: ({ pageParam }) => getAgentUsageTurns(agentId, { window, cursor: pageParam ?? null, limit: 50 }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) => last.nextCursor,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+  const rows = turnsQuery.data?.pages.flatMap((p) => p.rows) ?? [];
+  return (
+    <Section
+      title={`Recent turns (${window})`}
+      action={
+        turnsQuery.hasNextPage ? (
+          <button
+            type="button"
+            onClick={() => void turnsQuery.fetchNextPage()}
+            className="text-caption font-semibold"
+            style={{
+              background: "transparent",
+              border: 0,
+              cursor: "pointer",
+              color: "var(--accent)",
+            }}
+            disabled={turnsQuery.isFetchingNextPage}
+          >
+            {turnsQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+          </button>
+        ) : null
+      }
+    >
+      {turnsQuery.isLoading ? (
+        <p className="text-caption" style={{ color: "var(--fg-4)" }}>
+          Loading…
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="text-caption" style={{ color: "var(--fg-4)" }}>
+          No turns in the last {windowToDays(window)} days.
+        </p>
+      ) : (
+        <TurnsTable rows={rows} />
+      )}
+    </Section>
+  );
+}
+
+function TurnsTable({ rows }: { rows: UsageTurnRow[] }): ReactElement {
+  const navigate = useNavigate();
+  return (
+    <table className="w-full text-caption" style={{ borderCollapse: "collapse" }}>
+      <thead>
+        <tr className="font-semibold" style={{ color: "var(--fg-4)" }}>
+          <th style={{ textAlign: "left", padding: "var(--sp-2)" }}>When</th>
+          <th style={{ textAlign: "left", padding: "var(--sp-2)" }}>Chat</th>
+          <th style={{ textAlign: "right", padding: "var(--sp-2)" }}>Input</th>
+          <th style={{ textAlign: "right", padding: "var(--sp-2)" }}>Cached</th>
+          <th style={{ textAlign: "right", padding: "var(--sp-2)" }}>Output</th>
+          <th style={{ textAlign: "left", padding: "var(--sp-2)" }}>Model</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={`${r.chatId}:${r.seq}`} style={{ borderTop: "var(--hairline) solid var(--border-faint)" }}>
+            <td style={{ padding: "var(--sp-2)", color: "var(--fg-3)" }}>{formatRelative(r.createdAt)}</td>
+            <td style={{ padding: "var(--sp-2)" }}>
+              {r.chatTitle ? (
+                <button
+                  type="button"
+                  onClick={() => navigate(`/?chat=${encodeURIComponent(r.chatId)}`)}
+                  className="font-medium"
+                  style={{
+                    background: "transparent",
+                    border: 0,
+                    cursor: "pointer",
+                    color: "var(--accent)",
+                    padding: 0,
+                  }}
+                >
+                  {r.chatTitle}
+                </button>
+              ) : (
+                <span style={{ color: "var(--fg-4)" }}>private chat</span>
+              )}
+            </td>
+            <td className="mono" style={{ padding: "var(--sp-2)", textAlign: "right" }}>
+              {formatCompactCount(r.inputTokens)}
+            </td>
+            <td className="mono" style={{ padding: "var(--sp-2)", textAlign: "right", color: "var(--fg-3)" }}>
+              {formatCompactCount(r.cachedInputTokens)}
+            </td>
+            <td className="mono" style={{ padding: "var(--sp-2)", textAlign: "right" }}>
+              {formatCompactCount(r.outputTokens)}
+            </td>
+            <td className="mono" style={{ padding: "var(--sp-2)", color: "var(--fg-3)" }}>
+              {r.provider}/{r.model}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -14,6 +14,7 @@ import {
   updateAgent,
 } from "../../api/agents.js";
 import { deleteMember, listMembers, updateMember } from "../../api/members.js";
+import { getOrgUsageByAgent, type UsageWindow } from "../../api/usage.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { NewAgentDialog } from "../../components/new-agent-dialog.js";
 import { Button } from "../../components/ui/button.js";
@@ -106,11 +107,38 @@ export function TeamPage() {
   const [delegateTarget, setDelegateTarget] = useState<DelegateTarget | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
+  // 7d / 30d window for the Usage column. Default 30d — matches the
+  // settled-on default in the design doc; the column header exposes a
+  // segmented control so 7d switching costs one click.
+  const [usageWindow, setUsageWindow] = useState<UsageWindow>("30d");
 
   const membersQuery = useQuery({
     queryKey: ["members"],
     queryFn: listMembers,
   });
+
+  /**
+   * Org-wide per-agent usage for the current `usageWindow`. One request
+   * powers the entire Team table's Usage column; the table looks up by
+   * `agent.uuid`. Agents missing from the response are rendered as "—"
+   * (zero usage) by `UsageCell`.
+   */
+  const usageQuery = useQuery({
+    queryKey: ["usage", "by-agent", usageWindow],
+    queryFn: () => getOrgUsageByAgent(usageWindow),
+    // Token usage is monotone-rising during the window; a tight refetch
+    // would burn API calls for a number that moves rarely on the human
+    // timescale of "looking at the Team page". 60s is the same cadence
+    // ledger-style sociocurrency surfaces typically refresh at.
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+  const usageByAgentId = useMemo(() => {
+    if (!usageQuery.data) return null;
+    const m = new Map<string, (typeof usageQuery.data.rows)[number]>();
+    for (const r of usageQuery.data.rows) m.set(r.agentId, r);
+    return m;
+  }, [usageQuery.data]);
 
   // Admins read the superset; members read the visibility-filtered view.
   // Both produce the same `Agent[]` shape so downstream code branches only
@@ -373,6 +401,10 @@ export function TeamPage() {
             onAgentClick={(uuid) => navigate(`/agents/${encodeURIComponent(uuid)}`)}
             getHumanActions={getHumanActions}
             getAgentActions={getAgentActions}
+            usageByAgentId={usageByAgentId}
+            usageWindow={usageWindow}
+            onUsageWindowChange={setUsageWindow}
+            usageLoading={usageQuery.isLoading}
           />
         )}
       </div>

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -1,6 +1,7 @@
-import type { Agent } from "@first-tree/shared";
+import type { Agent, UsageByAgentRow } from "@first-tree/shared";
 import { Bot, Lock, type LucideIcon, User, Users } from "lucide-react";
 import { type CSSProperties, type ReactNode, useState } from "react";
+import type { UsageWindow } from "../../api/usage.js";
 import { AgentChip } from "../../components/agent-chip.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import {
@@ -14,7 +15,7 @@ import {
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../../components/ui/row-actions-menu.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
-import { formatDay } from "../../lib/utils.js";
+import { formatCompactCount, formatDay } from "../../lib/utils.js";
 
 export type { RowAction };
 
@@ -85,9 +86,22 @@ type Props = {
   onAgentClick: (uuid: string) => void;
   getHumanActions: (row: HumanRow) => RowAction[];
   getAgentActions: (row: AgentRow) => RowAction[];
+  /**
+   * Aggregate token-usage rows keyed by `agent.uuid` for the current
+   * `usageWindow`. Map missing entries render as "—" — same visual
+   * affordance as a zero-usage row. Pass `null` to hide the Usage column
+   * entirely (used while the query is still loading).
+   */
+  usageByAgentId: Map<string, UsageByAgentRow> | null;
+  /** Currently-selected aggregation window. Drives the column header label and the segmented control's active state. */
+  usageWindow: UsageWindow;
+  /** Fired when the user clicks 7d / 30d in the column header's segmented control. */
+  onUsageWindowChange: (next: UsageWindow) => void;
+  /** True while the usage query is in flight — keeps the column visible with skeleton cells. */
+  usageLoading: boolean;
 };
 
-type ColumnKey = "name" | "delegate" | "manager" | "runtime" | "status" | "created" | "actions";
+type ColumnKey = "name" | "delegate" | "manager" | "runtime" | "status" | "usage" | "created" | "actions";
 
 type Column = {
   key: ColumnKey;
@@ -119,9 +133,14 @@ const COLUMNS_WIDE: Column[] = [
   // tooltip — 170 fits the typical `claude-code @ alice-macbook` form on
   // one line and longer FQDNs ellipsize cleanly. Status (live operational
   // state) is the orthogonal axis and stays in its own column.
-  { key: "runtime", label: "Runs on", width: 170 },
-  { key: "status", label: "Status", width: 88 },
-  { key: "created", label: "Created", width: 88 },
+  { key: "runtime", label: "Runs on", width: 150 },
+  { key: "status", label: "Status", width: 80 },
+  // Usage column header doubles as the 7d/30d window picker — see
+  // UsageColumnHeader. Width chosen to fit "1.24M · 142t" without ellipsis
+  // at the dominant content density. Sits after Status (the next visually
+  // dominant signal) so the eye reaches "how online?" before "how busy?".
+  { key: "usage", label: "Usage", width: 120 },
+  { key: "created", label: "Created", width: 80 },
   { key: "actions", label: "", width: 44 },
 ];
 
@@ -143,15 +162,25 @@ function sectionCellStyle(isLast: boolean, style?: CSSProperties): CSSProperties
   return { ...style, borderBottom: 0 };
 }
 
-export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions, getAgentActions }: Props) {
+export function TeamTable({
+  groups,
+  clientHostMap,
+  onAgentClick,
+  getHumanActions,
+  getAgentActions,
+  usageByAgentId,
+  usageWindow,
+  onUsageWindowChange,
+  usageLoading,
+}: Props) {
   const viewport = useWorkspaceViewport();
   const isNarrow = viewport === "narrow";
   const columns = isNarrow ? COLUMNS_NARROW : COLUMNS_WIDE;
   return (
     // Narrow drops `table-fixed`: with only Name + Status + Actions we let
     // the Name column flex to fill the remaining width (Status/Actions are
-    // fixed via td-level `width`). Wide keeps `table-fixed` so the 7-column
-    // canvas balances by the declared widths as before.
+    // fixed via td-level `width`). Wide keeps `table-fixed` so the 8-column
+    // canvas (post-Usage column) balances by the declared widths as before.
     <DenseTable className={isNarrow ? undefined : "table-fixed"}>
       <DenseTableHeader>
         <DenseTableRow>
@@ -167,7 +196,11 @@ export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions
               }}
               aria-hidden={col.key === "actions"}
             >
-              {col.label}
+              {col.key === "usage" ? (
+                <UsageColumnHeader window={usageWindow} onChange={onUsageWindowChange} />
+              ) : (
+                col.label
+              )}
             </DenseTableHead>
           ))}
         </DenseTableRow>
@@ -182,9 +215,60 @@ export function TeamTable({ groups, clientHostMap, onAgentClick, getHumanActions
           onAgentClick={onAgentClick}
           getHumanActions={getHumanActions}
           getAgentActions={getAgentActions}
+          usageByAgentId={usageByAgentId}
+          usageLoading={usageLoading}
         />
       ))}
     </DenseTable>
+  );
+}
+
+/**
+ * Column-header cell that doubles as the 7d/30d window picker. The header
+ * row is the only place the table exposes a control, so keeping the
+ * "Usage" label and the chooser in one cell keeps the chrome quiet.
+ */
+function UsageColumnHeader({ window, onChange }: { window: UsageWindow; onChange: (next: UsageWindow) => void }) {
+  const baseBtn: CSSProperties = {
+    background: "transparent",
+    border: 0,
+    padding: "0 var(--sp-1_5)",
+    cursor: "pointer",
+    color: "var(--fg-3)",
+    fontWeight: 600,
+  };
+  const active: CSSProperties = { ...baseBtn, color: "var(--fg-2)", background: "var(--bg-hover)" };
+  return (
+    <span className="inline-flex items-center" style={{ gap: "var(--sp-1_5)" }}>
+      <span>Usage</span>
+      <span
+        className="inline-flex items-center text-caption"
+        style={{ gap: "var(--hairline)", border: "var(--hairline) solid var(--border)", padding: "var(--hairline)" }}
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onChange("7d");
+          }}
+          style={window === "7d" ? active : baseBtn}
+          aria-pressed={window === "7d"}
+        >
+          7d
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onChange("30d");
+          }}
+          style={window === "30d" ? active : baseBtn}
+          aria-pressed={window === "30d"}
+        >
+          30d
+        </button>
+      </span>
+    </span>
   );
 }
 
@@ -196,6 +280,8 @@ function GroupBody({
   onAgentClick,
   getHumanActions,
   getAgentActions,
+  usageByAgentId,
+  usageLoading,
 }: {
   group: TeamGroup;
   columns: Column[];
@@ -204,6 +290,8 @@ function GroupBody({
   onAgentClick: (uuid: string) => void;
   getHumanActions: (row: HumanRow) => RowAction[];
   getAgentActions: (row: AgentRow) => RowAction[];
+  usageByAgentId: Map<string, UsageByAgentRow> | null;
+  usageLoading: boolean;
 }) {
   const [open, setOpen] = useState(!group.collapsible);
 
@@ -245,6 +333,8 @@ function GroupBody({
               onClick={() => onAgentClick(row.agent.uuid)}
               isLast={isLast}
               isNarrow={isNarrow}
+              usage={usageByAgentId ? (usageByAgentId.get(row.agent.uuid) ?? null) : null}
+              usageLoading={usageLoading}
             />
           );
         })}
@@ -441,6 +531,10 @@ function HumanRowView({
       <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         —
       </DenseTableCell>
+      {/* Usage column — humans don't run turns; render the half-blank em-dash for visual structure (same pattern as Manager/Runs-on for human rows). */}
+      <DenseTableCell className="text-label" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
+        —
+      </DenseTableCell>
       <DenseTableCell className="mono text-caption" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         {formatDay(row.createdAt)}
       </DenseTableCell>
@@ -590,6 +684,8 @@ function AgentRowView({
   onClick,
   isLast,
   isNarrow,
+  usage,
+  usageLoading,
 }: {
   row: AgentRow;
   clientHost: string | null;
@@ -597,6 +693,10 @@ function AgentRowView({
   onClick: () => void;
   isLast: boolean;
   isNarrow: boolean;
+  /** `null` when the org-wide usage map has no entry for this agent (idle in window). */
+  usage: UsageByAgentRow | null;
+  /** Drives the loading skeleton in the Usage cell while the org query is in flight. */
+  usageLoading: boolean;
 }) {
   const { agent, managerLabel, isOwnedBySelf, showVisibilityChip } = row;
 
@@ -683,6 +783,9 @@ function AgentRowView({
       <DenseTableCell style={sectionCellStyle(isLast)}>
         <PresenceChip status={runtimeStateToPresence(agent.runtimeState)} />
       </DenseTableCell>
+      <DenseTableCell style={sectionCellStyle(isLast)}>
+        <UsageCell usage={usage} loading={usageLoading} />
+      </DenseTableCell>
       <DenseTableCell className="mono text-caption" style={sectionCellStyle(isLast, { color: "var(--fg-4)" })}>
         {formatDay(agent.createdAt)}
       </DenseTableCell>
@@ -693,6 +796,41 @@ function AgentRowView({
         <RowActionsMenu actions={actions} ariaLabel={`Actions for ${agent.displayName}`} />
       </DenseTableCell>
     </DenseTableRow>
+  );
+}
+
+/**
+ * Render the Usage cell for one agent. Shows "1.24M · 142t" when the agent
+ * has activity in the window, "—" when idle (zero usage), and a skeleton
+ * dash while the org-wide query is still loading. Total tokens here =
+ * input + cached + output so the number reads as the agent's whole
+ * footprint, matching how the agent-profile KPI counts.
+ */
+function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading: boolean }) {
+  if (loading && !usage) {
+    return (
+      <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+        …
+      </span>
+    );
+  }
+  if (!usage || usage.turns === 0) {
+    return (
+      <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+        —
+      </span>
+    );
+  }
+  const totalTokens = usage.inputTokens + usage.cachedInputTokens + usage.outputTokens;
+  return (
+    <span
+      className="text-caption mono"
+      style={{ color: "var(--fg-2)" }}
+      title={`Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · ${usage.turns} turns`}
+    >
+      {formatCompactCount(totalTokens)}
+      <span style={{ color: "var(--fg-4)" }}>{` · ${formatCompactCount(usage.turns)}t`}</span>
+    </span>
   );
 }
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -72,6 +72,7 @@ import {
   isGithubEventCardContent,
   isTrustedGithubDispatcherMessage,
 } from "../../../components/chat/github-event-card.js";
+import { TokenUsagePill } from "../../../components/chat/token-usage-pill.js";
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
 import { HistoryGapBanner } from "../../../components/history-gap-banner.js";
 import {
@@ -2535,6 +2536,13 @@ export function ChatView({
                       switch (ev.kind) {
                         case "error":
                           node = <ErrorRow key={item.key} event={ev} agentNameFn={chatScopedAgentName} />;
+                          break;
+                        case "token_usage":
+                          // Inline per-turn audit pill — see token-usage
+                          // design doc (sociocurrency + audit). Kept by
+                          // `filterEventsForTimeline` across turn_end so
+                          // historical turns retain their cost stamp.
+                          node = <TokenUsagePill key={item.key} event={ev} />;
                           break;
                         default:
                           // assistant_text / tool_call / thinking are folded into

--- a/packages/web/src/utils/session-timeline.ts
+++ b/packages/web/src/utils/session-timeline.ts
@@ -31,6 +31,10 @@ export function filterEventsForTimeline(events: SessionEventRow[]): SessionEvent
     if (e.kind === "turn_end") return false;
     if (e.kind === "context_tree_usage") return false;
     if (e.kind === "error") return true;
+    // `token_usage` is the per-turn audit pill — keep across turns so a
+    // completed turn's pill stays visible in the timeline (always-on
+    // audit). All other transient kinds are dropped once their turn ends.
+    if (e.kind === "token_usage") return true;
     return e.seq > lastTurnEndSeq;
   });
 


### PR DESCRIPTION
## Summary

Frontend half of the token-usage epic. Stacked on top of #660 (backend API + partial index). Surfaces the three new endpoints across three call sites per the design doc (sociocurrency + audit positioning).

> **Base:** `feat/usage-aggregation-api` — review **after** #660 lands; PR will auto-rebase to `main` on merge.

## Three surfaces

| Where | What |
|---|---|
| **Team table** | New `Usage` column with `[7d \| 30d]` segmented control in the header. One `/orgs/:orgId/usage/by-agent` query feeds every row by `agent.uuid`. Human rows + idle agents render em-dash. |
| **Agent profile `Usage` tab** | KPI strip (Tokens / Turns / Chats / Last active) + fixed-90d activity grid + paginated `Recent turns` with deep-link back to chat. Chat names are participant-gated. |
| **Chat timeline** | Per-turn `TokenUsagePill` rendered inline. `filterEventsForTimeline` keeps `token_usage` across `turn_end` (always-on audit, parallel to `error`). |

## Access model

- **Aggregate numbers** — visible to any org member (`requireOrgMembership` / `requireAgentAccess(visible)`).
- **Chat names** in turn details — gated by the caller's `humanAgentId` participation in the chat. Backend masks `chatTitle: null` for non-participants; UI renders "private chat".

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` ✓ (incl. design-token guardrails)
- [x] `pnpm --filter @first-tree/web test` — 418/418 ✓
- [x] `biome check packages/web/src` ✓
- [ ] **Manual full-stack** — reviewer runs `pnpm --filter @first-tree/server dev` + dev daemon + posts messages, opens `/team` and `/agents/:uuid/usage` to visually verify (automated UI verify deferred to reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)