### PR TITLE
refactor(web): flatten primitives + unify focus ring (Strategy A Phase 1)

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -186,13 +186,26 @@ fold into the phases below.
 - [x] Updated `/preview/styleguide` swatches (split into Primary / Brand groups); verified light + dark.
 - [x] (already done in cleanup) working=blue / blocked=amber / error=red / idle=neutral.
 
-**Phase 1 — primitives (`components/ui/`):**
-- [ ] `Button`: make the `default` variant neutral-primary; Arco radius/shadow.
-- [ ] Consistent thin line-icon set (lucide is fine; purge any emoji from product UI).
-- [ ] Restyle Badge / Card / Input / Tab / etc. to the neutral language.
-- [ ] Fold in leftover: **unify the focus-ring recipe** (Button/Badge/settings currently differ).
-  *(Phase 0 already unified the ring **color** → neutral `--ring` / `--color-ring`; the
-  recipe — `ring-1` vs `ring-2 ring-offset` vs `outline` — still varies per primitive.)*
+**Phase 1 — primitives (`components/ui/`) — DONE 2026-05-28 (PR ____):**
+- [x] `Button`: default variant neutral-primary (via Phase 0 tokens); flat (removed the
+  Tailwind-default `shadow`) for the crisp Arco look; default hover wired to `--primary-hover`.
+- [x] Flatten / tokenize primitive shadows to the flat reference: `badge` + `input` flat;
+  `card` → `shadow-[var(--shadow-sm)]`; `row-actions-menu` → `shadow-[var(--shadow-md)]`.
+- [x] **Unify the focus-ring recipe** → one accessible form
+  (`focus-visible:ring-2 ring-ring ring-offset-2` + a surface-matched `ring-offset` color)
+  across Button / Badge / Input / Dialog-close / Toast / settings-field (theme-toggle
+  already conformed). Fixes the invisible-ring-on-`--primary`-fill bug; `ring-offset` color
+  matches each control's real surface (`--bg-sunken` for settings-field, `--bg-raised` for toast).
+- [ ] **Follow-ups (deferred):**
+  - Line-icon set / purge the ✓ ⚠ ✗ ⚙ glyphs in favor of lucide — layout-affecting, spread
+    across pages; needs a by-eye pass.
+  - Extend the focus ring to the remaining interactive primitives (`tab-bar`,
+    `segmented-control`, `command`, `popover` triggers, `filter-pill`) — they paint no ring
+    today, so no visible mismatch, but it's an a11y coverage gap.
+  - Button/Badge base `ring-offset-background` uses the page surface; on a raised card/menu
+    a sub-perceptible 2px seam can appear on keyboard focus (a primitive can't know its
+    parent surface). Masked by the filled fill; acceptable until a per-surface convention exists.
+  - Component-grammar restyle (Tabs, ConversationList, ChatView, etc.) is Phase 2.
 
 **Phase 2 — component grammar (workspace):**
 - [ ] `ConversationList`: add a Search box; tabs-as-underline; rounded-square avatars; neutral selected row.

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -3,11 +3,11 @@ import type { HTMLAttributes } from "react";
 import { cn } from "../../lib/utils.js";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-[var(--radius-chip)] border px-2.5 py-0.5 text-caption font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-[var(--radius-chip)] border px-2.5 py-0.5 text-caption font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground shadow",
+        default: "border-transparent bg-primary text-primary-foreground",
         secondary: "border-transparent bg-secondary text-secondary-foreground",
         destructive: "border-transparent bg-destructive/10 text-destructive",
         outline: "text-foreground",

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -4,14 +4,14 @@ import { type ButtonHTMLAttributes, forwardRef } from "react";
 import { cn } from "../../lib/utils.js";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-input)] text-body font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-input)] text-body font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary-hover",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -4,7 +4,10 @@ import { cn } from "../../lib/utils.js";
 const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("rounded-[var(--radius-panel)] border bg-card text-card-foreground shadow-sm", className)}
+    className={cn(
+      "rounded-[var(--radius-panel)] border bg-card text-card-foreground shadow-[var(--shadow-sm)]",
+      className,
+    )}
     {...props}
   />
 ));

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-[var(--radius-input)] opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-[var(--radius-input)] opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-1 text-body shadow-sm transition-colors file:border-0 file:bg-transparent file:text-body file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-1 text-body transition-colors file:border-0 file:bg-transparent file:text-body file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/packages/web/src/components/ui/row-actions-menu.tsx
+++ b/packages/web/src/components/ui/row-actions-menu.tsx
@@ -98,7 +98,7 @@ export function RowActionsMenu({
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-30 rounded-[var(--radius-panel)] border bg-popover shadow-md"
+          className="absolute right-0 z-30 rounded-[var(--radius-panel)] border bg-popover shadow-[var(--shadow-md)]"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
           style={{

--- a/packages/web/src/components/ui/settings-field.tsx
+++ b/packages/web/src/components/ui/settings-field.tsx
@@ -49,7 +49,7 @@ export function SettingsField({
   pattern?: string;
 }) {
   const inputId = useId();
-  const inputClass = `flex-1 min-w-0 outline-none text-body focus-visible:ring-1 focus-visible:ring-ring ${mono ? "mono" : ""}`;
+  const inputClass = `flex-1 min-w-0 outline-none text-body focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-sunken)] ${mono ? "mono" : ""}`;
   const inputStyle: React.CSSProperties = {
     padding: "var(--sp-1_5) var(--sp-2_5)",
     background: "var(--bg-sunken)",

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -134,7 +134,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
               toast.action?.onClick();
               onDismiss();
             }}
-            className="text-label font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="text-label font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-raised)]"
             style={{
               alignSelf: "flex-start",
               marginTop: "var(--sp-1)",
@@ -153,7 +153,7 @@ function ToastItem({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }
         type="button"
         onClick={onDismiss}
         aria-label="Dismiss"
-        className="hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-raised)]"
         style={{
           padding: "var(--sp-1)",
           background: "transparent",


### PR DESCRIPTION
## Summary

Phase 1 of the **Strategy A** migration — UI-primitive craft (`components/ui/`). Stacked on Phase 0 (#662); this PR's base is the Phase 0 branch, so the diff shows only Phase 1.

- **Flatten primitive shadows** to the flat/crisp Lark-Arco reference (variant-F): remove the Tailwind-default soft `shadow` from filled `Button` variants, the default `Badge`, and `Input`; tokenize `Card` → `shadow-[var(--shadow-sm)]` and the row-actions menu → `shadow-[var(--shadow-md)]` (off Tailwind defaults, onto our 2-tier scale).
- **Wire the default Button hover** to `--primary-hover` (was `bg-primary/90`).
- **Unify the focus-ring recipe** → one accessible form `focus-visible:ring-2 ring-ring ring-offset-2` across Button / Badge / Input / Dialog-close / Toast / settings-field (theme-toggle already conformed). The `ring-offset` color is matched to each control's real surface — `--bg-sunken` for the sunken settings field, `--bg-raised` for the toast — so there's no halo seam. **Fixes the invisible focus ring on `--primary`-filled buttons** (old `ring-1` with no offset put the ring color on top of the same-color fill).

## Review & test
- **3 independent code-review rounds** (fixes between each): caught two `ring-offset` surface-mismatch seams (settings-field on `--bg-sunken`, toast on `--bg-raised`) and confirmed `bg-primary-hover` generates, the `focus`→`focus-visible` swap is regression-free, and the `--primary-hover` hover direction is correct. Final verdict: merge-ready.
- `pnpm --filter @first-tree/web typecheck` (tsc + token guardrail) and Biome both clean.
- **Browser E2E** (light + dark, no console errors) on `/preview/styleguide`: all button variants render flat/crisp, badges flat, inputs flat; computed styles confirm `boxShadow: none`, neutral `--primary` fills, and the `focus-visible` + arbitrary `ring-offset` rules generate.

## Deferred (tracked in DESIGN-AUDIT)
- Extend the focus ring to the remaining interactive primitives (`tab-bar`, `segmented-control`, `command`, `popover` triggers, `filter-pill`) — they paint no ring today, so no visible mismatch, but it's an a11y coverage gap.
- The line-icon set / purge of `✓ ⚠ ✗ ⚙` glyphs (layout-affecting, needs a by-eye pass).
- Button/Badge base `ring-offset-background` is the page surface; a sub-perceptible 2px seam can appear when a button on a raised card gets keyboard focus (a primitive can't know its parent surface; masked by the filled fill).
- Component-grammar restyle (Tabs, ConversationList, ChatView) is Phase 2.

## Test plan
- [ ] Confirm the flat button/badge/input craft reads right in both themes.
- [ ] Tab through a dialog / form to confirm the focus ring is now clearly visible (incl. on the primary button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)