### PR TITLE
feat: add dev skip onboarding login shortcut

### DIFF
--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -200,6 +200,43 @@ describe("GitHub OAuth onboarding flow", () => {
     expect(body.defaultOrganizationId).toBe(body.memberships[0]?.organizationId);
     expect(body.onboarding.step).toBe("connect");
   });
+
+  it("dev-callback can simulate an onboarded returning user for local testing", async () => {
+    const app = getApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=920&login=skip-onboarding&skipOnboarding=1",
+    });
+
+    expect(res.statusCode, res.body).toBe(302);
+    const location = res.headers.location ?? "";
+    expect(location).toContain("/auth/github/complete#");
+    const fragment = location.split("#")[1] ?? "";
+    const params = new URLSearchParams(fragment);
+    expect(params.get("joinPath")).toBe("returning");
+    const access = params.get("access");
+    expect(access).toBeTruthy();
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${access}` },
+    });
+
+    expect(me.statusCode).toBe(200);
+    const body = me.json<{ onboarding: { step: string; completedAt: string | null } }>();
+    expect(body.onboarding.step).toBe("completed");
+    expect(body.onboarding.completedAt).toEqual(expect.any(String));
+
+    const step = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/onboarding-step",
+      headers: { authorization: `Bearer ${access}` },
+    });
+
+    expect(step.statusCode).toBe(200);
+    expect(step.json<{ step: string }>().step).toBe("completed");
+  });
 });
 
 describe("OAuth callback rejects malformed state", () => {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -1,16 +1,24 @@
 import {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  AGENT_VISIBILITY,
   githubCallbackQuerySchema,
   githubDevCallbackQuerySchema,
   githubStartQuerySchema,
   safeRedirectPath,
 } from "@first-tree/shared";
+import { and, eq, isNull } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { agents } from "../../db/schema/agents.js";
+import { users } from "../../db/schema/users.js";
+import { createAgent } from "../../services/agent.js";
 import { signTokensForUser } from "../../services/auth.js";
 import {
   findOrCreateUserFromGithub,
   type GithubProfile,
   type GithubTokenBundle,
 } from "../../services/auth-identity.js";
+import { registerClient } from "../../services/client.js";
 import { encryptValue } from "../../services/crypto.js";
 import {
   buildAppAuthorizeUrl,
@@ -307,8 +315,89 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
 
     // Dev bypass never carries a `targetOrganizationId` — the install
     // stub binds to whatever team the dev session resolves into.
-    return completeOauthFlow(app, request, reply, profile, next, tokens, devInstallationId, null);
+    return completeOauthFlow(app, request, reply, profile, next, tokens, devInstallationId, null, {
+      simulateOnboarded: params.skipOnboarding === "1",
+    });
   });
+}
+
+type CompleteOauthFlowOptions = {
+  simulateOnboarded?: boolean;
+};
+
+function devAgentNameForProfile(profile: GithubProfile): string {
+  const seed =
+    profile.githubId
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 47) || "user";
+  return `local-test-agent-${seed}`;
+}
+
+async function seedDevOnboardedWorkspace(
+  app: FastifyInstance,
+  data: { userId: string; organizationId: string; profile: GithubProfile },
+): Promise<void> {
+  const membership = await findActiveMembership(app.db, data.userId, data.organizationId);
+  if (!membership) {
+    throw new Error("Cannot seed onboarded dev workspace without an active membership");
+  }
+
+  const clientId = `dev-onboarded-${data.profile.githubId}`;
+  await registerClient(app.db, {
+    clientId,
+    userId: data.userId,
+    organizationId: data.organizationId,
+    instanceId: "dev-callback",
+    hostname: "dev.local",
+    os: "dev",
+    sdkVersion: "dev",
+  });
+
+  const agentName = devAgentNameForProfile(data.profile);
+  const [existingAgent] = await app.db
+    .select({ uuid: agents.uuid, status: agents.status, type: agents.type })
+    .from(agents)
+    .where(and(eq(agents.organizationId, data.organizationId), eq(agents.name, agentName)))
+    .limit(1);
+
+  if (existingAgent) {
+    if (existingAgent.status !== AGENT_STATUSES.ACTIVE || existingAgent.type !== AGENT_TYPES.AGENT) {
+      await app.db
+        .update(agents)
+        .set({
+          type: AGENT_TYPES.AGENT,
+          status: AGENT_STATUSES.ACTIVE,
+          clientId,
+          updatedAt: new Date(),
+        })
+        .where(eq(agents.uuid, existingAgent.uuid));
+    }
+  } else {
+    await createAgent(app.db, {
+      name: agentName,
+      type: AGENT_TYPES.AGENT,
+      displayName: "Local Test Agent",
+      managerId: membership.memberId,
+      clientId,
+      source: "portal",
+      visibility: AGENT_VISIBILITY.PRIVATE,
+      metadata: { source: "dev-callback", githubId: data.profile.githubId },
+    });
+  }
+
+  const result = await app.db
+    .update(users)
+    .set({ onboardingCompletedAt: new Date() })
+    .where(and(eq(users.id, data.userId), isNull(users.onboardingCompletedAt)))
+    .returning({ id: users.id });
+  if (result.length > 0) {
+    app.log.info(
+      { event: "onboarding.completed", source: "dev-callback", userId: data.userId },
+      "dev callback completed onboarding",
+    );
+  }
 }
 
 async function completeOauthFlow(
@@ -341,6 +430,7 @@ async function completeOauthFlow(
    * path, that org wins regardless. Null on the plain sign-in flow.
    */
   targetOrganizationId: string | null,
+  options: CompleteOauthFlowOptions = {},
 ) {
   const { userId } = await findOrCreateUserFromGithub(app.db, profile, oauthTokens);
 
@@ -489,6 +579,11 @@ async function completeOauthFlow(
 
   if (!resolved) {
     return reply.status(500).send({ error: "Failed to resolve membership" });
+  }
+
+  if (options.simulateOnboarded === true && resolvedOrganizationId) {
+    await seedDevOnboardedWorkspace(app, { userId, organizationId: resolvedOrganizationId, profile });
+    joinPath = "returning";
   }
 
   const tokens = await signTokensForUser(app.config.secrets.jwtSecret, userId, app.config.auth);

--- a/packages/shared/src/__tests__/oauth.test.ts
+++ b/packages/shared/src/__tests__/oauth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { githubDevCallbackQuerySchema } from "../schemas/oauth.js";
+
+describe("githubDevCallbackQuerySchema", () => {
+  it("accepts the dev-only skipOnboarding flag", () => {
+    const parsed = githubDevCallbackQuerySchema.parse({
+      githubId: "1",
+      login: "devuser",
+      skipOnboarding: "1",
+    });
+
+    expect(parsed.skipOnboarding).toBe("1");
+  });
+
+  it("rejects unsupported skipOnboarding values", () => {
+    expect(() =>
+      githubDevCallbackQuerySchema.parse({
+        githubId: "1",
+        login: "devuser",
+        skipOnboarding: "true",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/schemas/oauth.ts
+++ b/packages/shared/src/schemas/oauth.ts
@@ -56,6 +56,8 @@ export const githubDevCallbackQuerySchema = z.object({
   email: z.string().email().optional(),
   displayName: z.string().optional(),
   next: z.string().max(256).optional(),
+  /** Dev-only local testing shortcut: seed an already-onboarded local workspace after stub sign-in. */
+  skipOnboarding: z.literal("1").optional(),
   /** Synthetic installation id. Required to trigger the App-flow dev bypass. */
   installationId: z.string().regex(/^\d+$/).optional(),
   /** "User" | "Organization". Defaults to "User" when an installationId is set. */

--- a/packages/web/src/pages/__tests__/login-dev-links.test.ts
+++ b/packages/web/src/pages/__tests__/login-dev-links.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("LoginPage dev links", () => {
+  it("exposes a localhost-only dev shortcut that simulates completed onboarding", async () => {
+    const source = await readFile(new URL("../login.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("skipOnboarding=1");
+    expect(source).toContain("Dev: skip onboarding");
+  });
+});

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -14,10 +14,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.
  * insensitive). They click "Continue with GitHub" once and keep their old
  * organization, agents, and history.
  *
- * On localhost a "Dev: skip GitHub" button is rendered alongside; it
- * jumps to `/auth/github/dev-callback` which mints a stub identity in
- * one round-trip without needing a real OAuth client. Production responds
- * 404 on that route, so the button is harmless even if shipped.
+ * On localhost dev shortcuts are rendered alongside; they jump to
+ * `/auth/github/dev-callback` and mint a stub identity in one round-trip
+ * without needing a real OAuth client. Production responds 404 on that
+ * route, so the buttons are harmless even if shipped.
  */
 export function LoginPage() {
   const { isAuthenticated } = useAuth();
@@ -41,6 +41,8 @@ export function LoginPage() {
   // user, agents, and conversations. Using `1` (not the more obvious 42)
   // makes test-suite collisions cheap to spot.
   const devCallbackHref = "/api/v1/auth/github/dev-callback?githubId=1&login=devuser&displayName=Dev+User";
+  const devSkipOnboardingHref =
+    "/api/v1/auth/github/dev-callback?githubId=1&login=devuser&displayName=Dev+User&skipOnboarding=1";
 
   if (isAuthenticated) {
     return <Navigate to={redirectTo} replace />;
@@ -98,6 +100,12 @@ export function LoginPage() {
                   <a href={devCallbackHref}>
                     <Zap className="h-4 w-4" />
                     Dev: skip GitHub
+                  </a>
+                </Button>
+                <Button asChild variant="outline" className="w-full">
+                  <a href={devSkipOnboardingHref}>
+                    <Zap className="h-4 w-4" />
+                    Dev: skip onboarding
                   </a>
                 </Button>
               </>


### PR DESCRIPTION
## Summary

Adds a localhost-only login shortcut for local testing that signs in through the existing dev GitHub callback and simulates a fully onboarded returning user.

Design choice: this does not just dismiss the onboarding UI. When `skipOnboarding=1` is passed to the dev callback, the server seeds the durable facts that `/me` already uses to infer completed onboarding:

- registers a deterministic connected dev client for the resolved user
- creates or reuses a deterministic non-human local test agent managed by the resolved org member
- stamps `users.onboarding_completed_at`
- forces the OAuth fragment to `joinPath=returning`

The normal `Dev: skip GitHub` path remains unchanged and still models a fresh first-run user.

## Testing

- `pnpm --filter @first-tree/shared test -- src/__tests__/oauth.test.ts`
- `CI_DATABASE_URL=postgresql://firsttreehub:firsttreehub@127.0.0.1:55432/firsttreehub pnpm --filter @first-tree/server exec vitest run src/__tests__/oauth-flow.test.ts src/__tests__/me-onboarding.test.ts`
- `pnpm --filter @first-tree/web test -- src/pages/__tests__/login-dev-links.test.ts src/pages/onboarding/__tests__/steps.test.ts`
- `pnpm exec biome check packages/shared/src/schemas/oauth.ts packages/shared/src/__tests__/oauth.test.ts packages/server/src/api/auth/github.ts packages/server/src/__tests__/oauth-flow.test.ts packages/web/src/pages/login.tsx packages/web/src/pages/__tests__/login-dev-links.test.ts`
- `pnpm typecheck`

`pnpm check` was also run, but it fails on existing unrelated non-null assertion lint issues in `packages/github-scan/tests/...` and `packages/server/src/__tests__/inbox-bind-recovery.test.ts`. The scoped Biome check for changed files passes.