### PR TITLE
test: expand unit coverage

### DIFF
--- a/apps/cli/src/__tests__/agent-config-fetchers.test.ts
+++ b/apps/cli/src/__tests__/agent-config-fetchers.test.ts
@@ -1,0 +1,128 @@
+import type { AgentRuntimeConfig } from "@first-tree/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.hoisted(() => vi.fn());
+const failMock = vi.hoisted(() =>
+  vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+);
+const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: fetchMock,
+}));
+
+vi.mock("../cli/output.js", () => ({
+  fail: failMock,
+}));
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Nope",
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+function config(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConfig {
+  return {
+    agentId: overrides.agentId ?? "agent-1",
+    version: overrides.version ?? 7,
+    payload: overrides.payload ?? {
+      kind: "claude-code",
+      prompt: { append: "Use short answers.\nExplain risks." },
+      model: "sonnet",
+      reasoningEffort: "high",
+      mcpServers: [
+        { name: "filesystem", transport: "stdio", command: "npx", args: ["-y", "server"] },
+        { name: "docs", transport: "http", url: "https://docs.example/mcp", headers: { Authorization: "Bearer test" } },
+      ],
+      env: [
+        { key: "FIRST_TREE_ENV", value: "test", sensitive: false },
+        { key: "OPENAI_API_KEY", value: "***", sensitive: true },
+      ],
+      gitRepos: [{ url: "https://github.com/acme/web.git", localPath: "web", ref: "main" }],
+    },
+    updatedAt: overrides.updatedAt ?? "2026-05-28T12:00:00.000Z",
+    updatedBy: overrides.updatedBy ?? "member-1",
+  };
+}
+
+function output(): string {
+  return stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+}
+
+describe("agent config fetch helpers", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    failMock.mockClear();
+    stdoutSpy.mockClear();
+  });
+
+  it("adds auth and content headers, then parses JSON", async () => {
+    const { adminFetch } = await import("../commands/agent/config/_shared/fetchers.js");
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await expect(
+      adminFetch<{ ok: boolean }>("https://hub.example/api/v1/agents/agent-1/config", {
+        method: "PATCH",
+        adminToken: "admin-token",
+        headers: { "X-Test": "1" },
+        body: JSON.stringify({ expectedVersion: 1, payload: {} }),
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/api/v1/agents/agent-1/config",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ expectedVersion: 1, payload: {} }),
+        headers: {
+          Authorization: "Bearer admin-token",
+          "Content-Type": "application/json",
+          "X-Test": "1",
+        },
+      }),
+    );
+  });
+
+  it("maps HTTP errors and wraps get/patch URLs", async () => {
+    const { getCurrent, patchConfig } = await import("../commands/agent/config/_shared/fetchers.js");
+    fetchMock.mockResolvedValueOnce(jsonResponse("unauthorized", false, 401));
+
+    await expect(getCurrent("https://hub.example", "admin-token", "agent-1")).rejects.toMatchObject({
+      code: "HTTP_401",
+      exitCode: 3,
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(config({ version: 8 })));
+    await expect(
+      patchConfig("https://hub.example", "admin-token", "agent-1", 7, { model: "opus" }),
+    ).resolves.toMatchObject({ version: 8 });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://hub.example/api/v1/agents/agent-1/config",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ expectedVersion: 7, payload: { model: "opus" } }),
+      }),
+    );
+  });
+
+  it("prints a readable runtime config summary", async () => {
+    const { printConfig } = await import("../commands/agent/config/_shared/fetchers.js");
+
+    printConfig(config());
+
+    expect(output()).toContain("Agent: agent-1");
+    expect(output()).toContain("Version: 7");
+    expect(output()).toContain("Model:    sonnet");
+    expect(output()).toContain("Reasoning effort: high");
+    expect(output()).toContain("> Use short answers.");
+    expect(output()).toContain("filesystem [stdio]");
+    expect(output()).toContain("OPENAI_API_KEY=*** (sensitive)");
+    expect(output()).toContain("https://github.com/acme/web.git@main");
+  });
+});

--- a/apps/cli/src/__tests__/agent-status-command.test.ts
+++ b/apps/cli/src/__tests__/agent-status-command.test.ts
@@ -1,0 +1,171 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bootstrapMocks = vi.hoisted(() => ({
+  ensureFreshAccessToken: vi.fn(),
+  resolveServerUrl: vi.fn(),
+}));
+
+const fetchMock = vi.hoisted(() => vi.fn());
+const printLineMock = vi.hoisted(() => vi.fn());
+const failMock = vi.hoisted(() =>
+  vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+);
+
+vi.mock("../core/bootstrap.js", () => bootstrapMocks);
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: fetchMock,
+}));
+vi.mock("../core/output.js", () => ({
+  print: { line: printLineMock },
+}));
+vi.mock("../cli/output.js", () => ({
+  fail: failMock,
+}));
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Failed",
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+async function runStatus(args: string[] = []): Promise<void> {
+  const { registerAgentStatusCommand } = await import("../commands/agent/status.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  const agent = program.command("agent");
+  registerAgentStatusCommand(agent);
+  await program.parseAsync(["node", "test", "agent", "status", ...args]);
+}
+
+function output(): string {
+  return printLineMock.mock.calls.map((call) => String(call[0])).join("");
+}
+
+describe("agent status command", () => {
+  beforeEach(() => {
+    bootstrapMocks.resolveServerUrl.mockReset();
+    bootstrapMocks.ensureFreshAccessToken.mockReset();
+    fetchMock.mockReset();
+    printLineMock.mockReset();
+    failMock.mockClear();
+
+    bootstrapMocks.resolveServerUrl.mockReturnValue("https://hub.example");
+    bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+  });
+
+  it("aggregates runtime activity across all memberships", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }, { organizationId: "org-b" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total: 2,
+          running: 1,
+          byState: { idle: 1, working: 0, blocked: 0, error: 1 },
+          clients: 1,
+          agents: [
+            {
+              agentId: "agent-a",
+              clientId: "client-a",
+              runtimeType: "claude-code",
+              runtimeState: "idle",
+              activeSessions: 1,
+              totalSessions: 3,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total: 1,
+          running: 1,
+          byState: { idle: 0, working: 1, blocked: 0, error: 0 },
+          clients: 2,
+          agents: [
+            {
+              agentId: "agent-b",
+              clientId: null,
+              runtimeType: "codex",
+              runtimeState: "working",
+              activeSessions: null,
+              totalSessions: null,
+            },
+          ],
+        }),
+      );
+
+    await runStatus(["--server", "https://override.example"]);
+
+    expect(bootstrapMocks.resolveServerUrl).toHaveBeenCalledWith("https://override.example");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/api/v1/orgs/org-a/activity",
+      expect.objectContaining({ headers: { Authorization: "Bearer access-token" } }),
+    );
+    expect(output()).toContain("Clients: 3 connected");
+    expect(output()).toContain("Agents: 2 running / 3 total");
+    expect(output()).toContain("agent-a");
+    expect(output()).toContain("agent-b");
+  });
+
+  it("renders a specific agent status and the not-running branch", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }] })).mockResolvedValueOnce(
+      jsonResponse({
+        total: 1,
+        running: 1,
+        byState: { idle: 0, working: 1, blocked: 0, error: 0 },
+        clients: 1,
+        agents: [
+          {
+            agentId: "agent-a",
+            clientId: "client-a",
+            runtimeType: "claude-code",
+            runtimeState: "working",
+            activeSessions: 2,
+            totalSessions: 4,
+          },
+        ],
+      }),
+    );
+
+    await runStatus(["agent-a"]);
+    expect(output()).toContain("Agent: agent-a");
+    expect(output()).toContain("Sessions: 2 active / 4 total");
+    expect(output()).toContain("Client: client-a");
+
+    printLineMock.mockClear();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }] })).mockResolvedValueOnce(
+      jsonResponse({
+        total: 0,
+        running: 0,
+        byState: { idle: 0, working: 0, blocked: 0, error: 0 },
+        clients: 0,
+        agents: [],
+      }),
+    );
+
+    await runStatus(["missing-agent"]);
+    expect(output()).toContain('Agent "missing-agent" is not running');
+  });
+
+  it("maps /me failures and unexpected errors to clean CLI failures", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
+
+    await expect(runStatus()).rejects.toMatchObject({ code: "STATUS_ERROR" });
+    expect(failMock).toHaveBeenCalledWith("FETCH_ERROR", "/me HTTP 503", 1);
+    expect(failMock).toHaveBeenLastCalledWith("STATUS_ERROR", "/me HTTP 503");
+
+    failMock.mockClear();
+    fetchMock.mockReset();
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce(new Error("credentials missing"));
+
+    await expect(runStatus()).rejects.toMatchObject({ code: "STATUS_ERROR" });
+    expect(failMock).toHaveBeenCalledWith("STATUS_ERROR", "credentials missing");
+  });
+});

--- a/apps/cli/src/__tests__/attention-list-command.test.ts
+++ b/apps/cli/src/__tests__/attention-list-command.test.ts
@@ -1,0 +1,145 @@
+import type { Attention } from "@first-tree/shared";
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const attentionMocks = vi.hoisted(() => ({
+  listAttentions: vi.fn(),
+}));
+
+const localAgentMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error;
+  }),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  success: vi.fn(),
+}));
+
+const printLineMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/attention/index.js", () => attentionMocks);
+vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
+vi.mock("../cli/output.js", () => outputMocks);
+vi.mock("../core/output.js", () => ({
+  print: { line: printLineMock },
+}));
+
+function attention(overrides: Partial<Attention> = {}): Attention {
+  return {
+    id: overrides.id ?? "attention-123456789",
+    originAgentId: overrides.originAgentId ?? "agent-1",
+    originChatId: overrides.originChatId ?? "chat-1",
+    targetHumanId: overrides.targetHumanId ?? "human-1",
+    subject: overrides.subject ?? "Choose release window",
+    body: overrides.body ?? "",
+    requiresResponse: overrides.requiresResponse ?? true,
+    state: overrides.state ?? "open",
+    response: overrides.response ?? null,
+    respondedBy: overrides.respondedBy ?? null,
+    respondedAt: overrides.respondedAt ?? null,
+    cancelled: overrides.cancelled ?? false,
+    cancelledReason: overrides.cancelledReason ?? null,
+    metadata: overrides.metadata ?? {},
+    createdAt: overrides.createdAt ?? "2026-05-28T12:00:00.000Z",
+    closedAt: overrides.closedAt ?? null,
+  };
+}
+
+async function runList(args: string[] = []): Promise<void> {
+  const { registerAttentionListCommand } = await import("../commands/attention/list.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  const attentionCommand = program.command("attention");
+  registerAttentionListCommand(attentionCommand);
+  await program.parseAsync(["node", "test", "attention", "list", ...args]);
+}
+
+describe("attention list command", () => {
+  beforeEach(() => {
+    attentionMocks.listAttentions.mockReset();
+    localAgentMocks.createSdk.mockReset();
+    localAgentMocks.handleSdkError.mockClear();
+    outputMocks.fail.mockClear();
+    outputMocks.success.mockClear();
+    printLineMock.mockClear();
+
+    localAgentMocks.createSdk.mockReturnValue({ agentId: "agent-self" });
+    attentionMocks.listAttentions.mockResolvedValue([attention()]);
+  });
+
+  it("defaults to attentions raised by the resolved local agent", async () => {
+    await runList();
+
+    expect(localAgentMocks.createSdk).toHaveBeenCalledWith(undefined);
+    expect(attentionMocks.listAttentions).toHaveBeenCalledWith({ agentId: "agent-self" }, { agent: "agent-self" });
+    expect(outputMocks.success).toHaveBeenCalledWith([expect.objectContaining({ id: "attention-123456789" })]);
+  });
+
+  it("validates filters and forwards explicit query options", async () => {
+    await runList([
+      "--agent",
+      "kael",
+      "--state",
+      "closed",
+      "--from-agent",
+      "agent-origin",
+      "--in-chat",
+      "chat-1",
+      "--limit",
+      "25",
+    ]);
+
+    expect(localAgentMocks.createSdk).toHaveBeenCalledWith("kael");
+    expect(attentionMocks.listAttentions).toHaveBeenCalledWith(
+      { agentId: "agent-self" },
+      { agent: "agent-origin", chat: "chat-1", limit: 25, state: "closed" },
+    );
+
+    await expect(runList(["--state", "weird"])).rejects.toMatchObject({ code: "INVALID_STATE", exitCode: 2 });
+    await expect(runList(["--limit", "999"])).rejects.toMatchObject({ code: "INVALID_LIMIT", exitCode: 2 });
+  });
+
+  it("renders chat grouping and handles missing agent context", async () => {
+    attentionMocks.listAttentions.mockResolvedValueOnce([
+      attention({
+        id: "open-ask-123456",
+        originChatId: "chat-b",
+        subject: "Open ask",
+        createdAt: "2026-05-28T12:02:00.000Z",
+      }),
+      attention({
+        id: "closed-note-123456",
+        originChatId: "chat-a",
+        subject: "Closed note",
+        requiresResponse: false,
+        state: "closed",
+        createdAt: "2026-05-28T12:01:00.000Z",
+      }),
+    ]);
+
+    await runList(["--group-by-chat"]);
+
+    const grouped = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(grouped).toContain("chat chat-b  (1 open ask)");
+    expect(grouped).toContain("! ask");
+    expect(grouped).toContain("chat chat-a");
+    expect(grouped).toContain("· note");
+
+    localAgentMocks.createSdk.mockReturnValueOnce({});
+    await expect(runList()).rejects.toMatchObject({ code: "AGENT_REQUIRED", exitCode: 2 });
+  });
+
+  it("delegates SDK failures to the shared SDK error mapper", async () => {
+    const error = new Error("network down");
+    attentionMocks.listAttentions.mockRejectedValueOnce(error);
+
+    await expect(runList()).rejects.toThrow("network down");
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/cli/src/__tests__/attention-meta.test.ts
+++ b/apps/cli/src/__tests__/attention-meta.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
+  throw new Error("process.exit");
+}) as never);
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "ft-attention-meta-"));
+  exitMock.mockClear();
+  stderrMock.mockClear();
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("attention metadata helpers", () => {
+  it("parses dotted paths, array indexes, and scalar values", async () => {
+    const { parseMetaFlags } = await import("../commands/attention/_shared/meta.js");
+
+    expect(
+      parseMetaFlags([
+        "subject=deploy",
+        "options.mode=single",
+        "options.items[0].label=Ship now",
+        "options.items[0].value=now",
+        "options.items[1].label=Wait",
+        "requiresResponse=true",
+        "priority=3",
+        "ratio=-1.5",
+        "empty=",
+        "nullable=null",
+      ]),
+    ).toEqual({
+      subject: "deploy",
+      options: {
+        mode: "single",
+        items: [{ label: "Ship now", value: "now" }, { label: "Wait" }],
+      },
+      requiresResponse: true,
+      priority: 3,
+      ratio: -1.5,
+      empty: "",
+      nullable: null,
+    });
+  });
+
+  it("merges inline and file JSON over flat metadata", async () => {
+    const { mergeMetaJson, parseMetaFlags } = await import("../commands/attention/_shared/meta.js");
+    const file = join(tempDir, "meta.json");
+    writeFileSync(file, JSON.stringify({ priority: "high", nested: { source: "file" } }));
+
+    expect(mergeMetaJson(parseMetaFlags(["priority=1", "subject=deploy"]), '{"priority":2}')).toEqual({
+      priority: 2,
+      subject: "deploy",
+    });
+    expect(mergeMetaJson({ subject: "deploy" }, `@${file}`)).toEqual({
+      subject: "deploy",
+      priority: "high",
+      nested: { source: "file" },
+    });
+  });
+
+  it("collects repeated metadata flags", async () => {
+    const { collectMeta } = await import("../commands/attention/_shared/meta.js");
+
+    expect(collectMeta("b=2", collectMeta("a=1", []))).toEqual(["a=1", "b=2"]);
+  });
+
+  it("fails on malformed flat metadata and malformed JSON", async () => {
+    const { mergeMetaJson, parseMetaFlags } = await import("../commands/attention/_shared/meta.js");
+
+    expect(() => parseMetaFlags(["bad"])).toThrow("process.exit");
+    expect(() => parseMetaFlags(["a..b=1"])).toThrow("process.exit");
+    expect(() => parseMetaFlags(["items[0].name=ok", "items.name=bad"])).toThrow("process.exit");
+    expect(() => mergeMetaJson({}, "{bad json")).toThrow("process.exit");
+    expect(() => mergeMetaJson({}, "[]")).toThrow("process.exit");
+    expect(exitMock).toHaveBeenCalledWith(2);
+  });
+});

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -110,6 +110,7 @@ describe("ClientRuntime context-tree wiring", () => {
   let home: string;
 
   beforeEach(() => {
+    vi.resetModules();
     home = mkdtempSync(join(tmpdir(), "ft-client-runtime-"));
     process.env.FIRST_TREE_HOME = home;
     slotInstances.length = 0;
@@ -153,6 +154,7 @@ describe("ClientRuntime context-tree wiring", () => {
     if (!slot) throw new Error("slot not constructed");
     expect(slot.start).toHaveBeenCalledTimes(1);
     expect(slot.start.mock.calls[0]).toEqual([]);
+    await rt.stop();
   });
 
   it("handles connection events, update hooks, and graceful stop", async () => {
@@ -244,6 +246,7 @@ describe("ClientRuntime context-tree wiring", () => {
     });
     expect(readFileSync(join(agentsDir, "agent-019e70b300007000", "agent.yaml"), "utf8")).toContain("codex");
     expect(slotInstances.map((slot) => slot.name)).toEqual(["kael", "agent-019e70b300007000"]);
+    await rt.stop();
   });
 
   it("reports pinned agents when no agent directory is set and ignores duplicate watched agents", async () => {
@@ -279,6 +282,7 @@ describe("ClientRuntime context-tree wiring", () => {
       runtimeProvider: "claude-code",
     });
     expect(slotInstances.filter((slot) => slot.name === "newcomer")).toHaveLength(1);
+    await rt.stop();
   });
 
   it("registers paused-mode recovery and reports auth lifecycle events", async () => {

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -19,6 +19,7 @@ const slotInstances: Array<{
   getQuietGateSnapshot: ReturnType<typeof vi.fn>;
 }> = [];
 const connectionListeners = new Map<string, (...args: unknown[]) => void>();
+const RUNTIME_TEST_TIMEOUT_MS = 15_000;
 const disposeMock = vi.fn();
 const killAllMock = vi.fn(async () => undefined);
 const sweepMock = vi.fn(async () => ({ scanned: 0, deleted: 0, failed: 0 }));
@@ -155,7 +156,7 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(slot.start).toHaveBeenCalledTimes(1);
     expect(slot.start.mock.calls[0]).toEqual([]);
     await rt.stop();
-  });
+  }, RUNTIME_TEST_TIMEOUT_MS);
 
   it("handles connection events, update hooks, and graceful stop", async () => {
     const { print } = await import("../core/output.js");

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -138,25 +138,29 @@ describe("ClientRuntime context-tree wiring", () => {
     vi.clearAllMocks();
   });
 
-  it("starts eager slots without a shared Context Tree binding", async () => {
-    const { ClientRuntime } = await import("../core/client-runtime.js");
-    const rt = new ClientRuntime("https://hub.test", "client-test");
-    rt.addAgent("alpha", {
-      agentId: "agent-alpha",
-      runtime: "claude-code",
-      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
-      concurrency: 1,
-    } as unknown as Parameters<typeof rt.addAgent>[1]);
+  it(
+    "starts eager slots without a shared Context Tree binding",
+    async () => {
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://hub.test", "client-test");
+      rt.addAgent("alpha", {
+        agentId: "agent-alpha",
+        runtime: "claude-code",
+        session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+        concurrency: 1,
+      } as unknown as Parameters<typeof rt.addAgent>[1]);
 
-    await rt.start();
+      await rt.start();
 
-    expect(slotInstances).toHaveLength(1);
-    const slot = slotInstances[0];
-    if (!slot) throw new Error("slot not constructed");
-    expect(slot.start).toHaveBeenCalledTimes(1);
-    expect(slot.start.mock.calls[0]).toEqual([]);
-    await rt.stop();
-  }, RUNTIME_TEST_TIMEOUT_MS);
+      expect(slotInstances).toHaveLength(1);
+      const slot = slotInstances[0];
+      if (!slot) throw new Error("slot not constructed");
+      expect(slot.start).toHaveBeenCalledTimes(1);
+      expect(slot.start.mock.calls[0]).toEqual([]);
+      await rt.stop();
+    },
+    RUNTIME_TEST_TIMEOUT_MS,
+  );
 
   it("handles connection events, update hooks, and graceful stop", async () => {
     const { print } = await import("../core/output.js");

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ClientPausedReason } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -8,11 +12,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const slotInstances: Array<{
+  agentId: string;
+  name: string;
   start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
   getQuietGateSnapshot: ReturnType<typeof vi.fn>;
 }> = [];
 const connectionListeners = new Map<string, (...args: unknown[]) => void>();
+const disposeMock = vi.fn();
+const killAllMock = vi.fn(async () => undefined);
+const sweepMock = vi.fn(async () => ({ scanned: 0, deleted: 0, failed: 0 }));
 const connectionMock = {
   clientId: "client-test",
   on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
@@ -20,14 +29,20 @@ const connectionMock = {
   }),
   connect: vi.fn(async () => undefined),
   disconnect: vi.fn(async () => undefined),
+  emit: vi.fn(),
+  isPaused: vi.fn(() => false),
+  getPausedReason: vi.fn<() => ClientPausedReason | null>(() => null),
+  clearPaused: vi.fn(),
 };
 vi.mock("@first-tree/client", () => {
   class FakeAgentSlot {
+    public readonly agentId: string;
     public readonly name: string;
     public start = vi.fn(async () => ({ displayName: this.name, agentId: this.name }));
     public stop = vi.fn(async () => undefined);
     public getQuietGateSnapshot = vi.fn(() => ({ activeCount: 0, lastActivityMs: 0 }));
-    constructor(opts: { name: string }) {
+    constructor(opts: { agentId: string; name: string }) {
+      this.agentId = opts.agentId;
       this.name = opts.name;
       slotInstances.push(this);
     }
@@ -39,15 +54,19 @@ vi.mock("@first-tree/client", () => {
       on = connectionMock.on;
       connect = connectionMock.connect;
       disconnect = connectionMock.disconnect;
+      emit = connectionMock.emit;
+      isPaused = connectionMock.isPaused;
+      getPausedReason = connectionMock.getPausedReason;
+      clearPaused = connectionMock.clearPaused;
     },
-    UpdateManager: { attach: vi.fn(() => ({ dispose: vi.fn() })) },
+    UpdateManager: { attach: vi.fn(() => ({ dispose: disposeMock })) },
     createGitMirrorManager: vi.fn(() => ({
       ensureMirror: vi.fn(),
       fetchMirror: vi.fn(),
       createWorktree: vi.fn(),
       removeWorktree: vi.fn(),
       gcMirrors: vi.fn(async () => ({ removed: [] })),
-      gcOrphanSessionBranches: vi.fn(async () => ({ scanned: 0, deleted: 0, failed: 0 })),
+      gcOrphanSessionBranches: sweepMock,
       mirrorsRoot: "/tmp/fake-mirrors",
     })),
     createLogger: vi.fn(() => ({
@@ -59,6 +78,7 @@ vi.mock("@first-tree/client", () => {
       fatal: vi.fn(),
       child: vi.fn().mockReturnThis(),
     })),
+    getChildProcessRegistry: vi.fn(() => ({ killAll: killAllMock })),
     getHandlerFactory: vi.fn(() => vi.fn()),
     registerBuiltinHandlers: vi.fn(),
   };
@@ -86,15 +106,33 @@ vi.mock("../core/version.js", () => ({
 }));
 
 describe("ClientRuntime context-tree wiring", () => {
+  const originalHome = process.env.FIRST_TREE_HOME;
+  let home: string;
+
   beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "ft-client-runtime-"));
+    process.env.FIRST_TREE_HOME = home;
     slotInstances.length = 0;
     connectionListeners.clear();
     connectionMock.on.mockClear();
     connectionMock.connect.mockClear();
     connectionMock.disconnect.mockClear();
+    connectionMock.emit.mockClear();
+    connectionMock.isPaused.mockReset();
+    connectionMock.isPaused.mockReturnValue(false);
+    connectionMock.getPausedReason.mockReset();
+    connectionMock.getPausedReason.mockReturnValue(null);
+    connectionMock.clearPaused.mockClear();
+    disposeMock.mockClear();
+    killAllMock.mockClear();
+    sweepMock.mockReset();
+    sweepMock.mockResolvedValue({ scanned: 0, deleted: 0, failed: 0 });
   });
 
   afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+    else process.env.FIRST_TREE_HOME = originalHome;
     vi.clearAllMocks();
   });
 
@@ -115,5 +153,165 @@ describe("ClientRuntime context-tree wiring", () => {
     if (!slot) throw new Error("slot not constructed");
     expect(slot.start).toHaveBeenCalledTimes(1);
     expect(slot.start.mock.calls[0]).toEqual([]);
+  });
+
+  it("handles connection events, update hooks, and graceful stop", async () => {
+    const { print } = await import("../core/output.js");
+    const client = await import("@first-tree/client");
+    sweepMock.mockResolvedValueOnce({ scanned: 3, deleted: 2, failed: 1 });
+    slotInstances.length = 0;
+
+    const update = {
+      updateConfig: { policy: "prompt" },
+      prompt: vi.fn(),
+      executeUpdate: vi.fn(),
+    } as unknown as NonNullable<
+      ConstructorParameters<typeof import("../core/client-runtime.js").ClientRuntime>[2]
+    >["update"];
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://hub.test", "client-test", { currentVersion: "0.0.1", update });
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+
+    await rt.start();
+    expect(client.UpdateManager.attach).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ currentVersion: "0.0.1", updateConfig: { policy: "prompt" } }),
+    );
+    expect(print.status).toHaveBeenCalledWith(
+      "[git-mirror]",
+      "swept orphan session branches — scanned=3 deleted=2 failed=1",
+    );
+
+    connectionMock.isPaused.mockReturnValue(true);
+    connectionMock.getPausedReason.mockReturnValue("auth_refresh_failed");
+    expect(rt.isPaused()).toBe(true);
+    expect(rt.pausedReason()).toBe("auth_refresh_failed");
+    rt.emitConnectionResilienceEvent("resilience.update.failed", {
+      targetVersion: "0.0.2",
+      retryable: true,
+      reasonCode: "INSTALL_FAILED",
+    });
+    expect(connectionMock.emit).toHaveBeenCalledWith("resilience.update.failed", {
+      targetVersion: "0.0.2",
+      retryable: true,
+      reasonCode: "INSTALL_FAILED",
+    });
+
+    await rt.stop();
+    expect(disposeMock).toHaveBeenCalled();
+    expect(slotInstances[0]?.stop).toHaveBeenCalled();
+    expect(connectionMock.disconnect).toHaveBeenCalled();
+    expect(killAllMock).toHaveBeenCalledWith("client-runtime-stop");
+  });
+
+  it("auto-adds server-pinned agents and skips duplicates", async () => {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://hub.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    rt.watchAgentsDir(agentsDir);
+
+    const pinned = connectionListeners.get("agent:pinned");
+    if (!pinned) throw new Error("agent:pinned listener missing");
+    pinned({
+      agentId: "019e70b3-0000-7000-8000-000000000001",
+      name: "kael",
+      runtimeProvider: "claude-code",
+    });
+
+    const text = readFileSync(join(agentsDir, "kael", "agent.yaml"), "utf8");
+    expect(text).toContain("019e70b3-0000-7000-8000-000000000001");
+    expect(text).toContain("claude-code");
+    expect(slotInstances.map((slot) => slot.name)).toEqual(["kael"]);
+    expect(slotInstances[0]?.start).toHaveBeenCalled();
+
+    pinned({
+      agentId: "019e70b3-0000-7000-8000-000000000001",
+      name: "kael",
+      runtimeProvider: "claude-code",
+    });
+    expect(slotInstances).toHaveLength(1);
+
+    pinned({
+      agentId: "019e70b3-0000-7000-8000-000000000002",
+      name: "kael",
+      runtimeProvider: "codex",
+    });
+    expect(readFileSync(join(agentsDir, "agent-019e70b300007000", "agent.yaml"), "utf8")).toContain("codex");
+    expect(slotInstances.map((slot) => slot.name)).toEqual(["kael", "agent-019e70b300007000"]);
+  });
+
+  it("reports pinned agents when no agent directory is set and ignores duplicate watched agents", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://hub.test", "client-test");
+
+    const pinned = connectionListeners.get("agent:pinned");
+    if (!pinned) throw new Error("agent:pinned listener missing");
+    pinned({
+      agentId: "agent-missing-dir",
+      name: "missing",
+      runtimeProvider: "claude-code",
+    });
+    expect(print.status).toHaveBeenCalledWith(
+      "⚠️",
+      "agent pinned (agent-missing-dir) but no agents dir set — cannot auto-register.",
+    );
+
+    const agentsDir = join(home, "config", "agents");
+    mkdirSync(join(agentsDir, "newcomer"), { recursive: true });
+    writeFileSync(join(agentsDir, "newcomer", "agent.yaml"), "agentId: agent-new\nruntime: claude-code\n");
+    rt.watchAgentsDir(agentsDir);
+    pinned({
+      agentId: "agent-new",
+      name: "newcomer",
+      runtimeProvider: "claude-code",
+    });
+    expect(slotInstances.map((slot) => slot.name)).toContain("newcomer");
+    pinned({
+      agentId: "agent-new",
+      name: "newcomer",
+      runtimeProvider: "claude-code",
+    });
+    expect(slotInstances.filter((slot) => slot.name === "newcomer")).toHaveLength(1);
+  });
+
+  it("registers paused-mode recovery and reports auth lifecycle events", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    mkdirSync(join(home, "config"), { recursive: true });
+    writeFileSync(join(home, "config", "credentials.json"), JSON.stringify({ refreshToken: "old" }));
+    const rt = new ClientRuntime("https://hub.test", "client-test");
+    connectionMock.isPaused.mockReturnValue(true);
+
+    const paused = connectionListeners.get("auth:paused");
+    if (!paused) throw new Error("auth:paused listener missing");
+    paused("auth_refresh_failed", new Error("refresh rejected"));
+    expect(print.status).toHaveBeenCalledWith("✗", "auth rejected — pausing agents until fresh credentials arrive.");
+    expect(rt.isPaused()).toBe(true);
+
+    const resumed = connectionListeners.get("auth:resumed");
+    if (!resumed) throw new Error("auth:resumed listener missing");
+    resumed("auth_refresh_failed");
+    expect(print.status).toHaveBeenCalledWith(
+      "✓",
+      "credentials refreshed — resuming agents (was paused: auth_refresh_failed)",
+    );
+
+    const expired = connectionListeners.get("auth:expired");
+    if (!expired) throw new Error("auth:expired listener missing");
+    expired();
+    expect(print.status).toHaveBeenCalledWith("⚠️", "access token expired — reconnecting after refresh...");
+
+    const error = connectionListeners.get("error");
+    if (!error) throw new Error("error listener missing");
+    error(new Error("socket reset"));
+    expect(print.status).toHaveBeenCalledWith("⚠️", "client connection error: socket reset");
+    await rt.stop();
   });
 });

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -1,0 +1,168 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerAgentCommands } from "../commands/agent/index.js";
+import { registerAttentionCommands } from "../commands/attention/index.js";
+import { registerChatCommands } from "../commands/chat/index.js";
+import { registerConfigCommands } from "../commands/config/index.js";
+import { registerDaemonCommands } from "../commands/daemon/index.js";
+import { registerDoctorCommand } from "../commands/doctor.js";
+import { registerGithubCommands } from "../commands/github/index.js";
+import { registerLoginCommand } from "../commands/login.js";
+import { registerLogoutCommand } from "../commands/logout.js";
+import { registerOrgCommands } from "../commands/org/index.js";
+import { registerStatusCommand } from "../commands/status.js";
+import { registerTreeCommands } from "../commands/tree/index.js";
+import { registerUpgradeCommand } from "../commands/upgrade.js";
+
+function command(root: Command, name: string): Command {
+  const found = root.commands.find((entry) => entry.name() === name);
+  if (!found) throw new Error(`Missing command ${name}`);
+  return found;
+}
+
+function subcommands(root: Command, name: string): string[] {
+  return command(root, name)
+    .commands.map((entry) => entry.name())
+    .sort();
+}
+
+describe("CLI command registration", () => {
+  it("registers the top-level command surface", () => {
+    const root = new Command();
+
+    registerLoginCommand(root);
+    registerLogoutCommand(root);
+    registerStatusCommand(root);
+    registerDoctorCommand(root);
+    registerUpgradeCommand(root);
+    registerAgentCommands(root);
+    registerAttentionCommands(root);
+    registerChatCommands(root);
+    registerOrgCommands(root);
+    registerDaemonCommands(root);
+    registerConfigCommands(root);
+    registerTreeCommands(root);
+    registerGithubCommands(root);
+
+    expect(root.commands.map((entry) => entry.name()).sort()).toEqual([
+      "agent",
+      "attention",
+      "chat",
+      "config",
+      "daemon",
+      "doctor",
+      "github",
+      "login",
+      "logout",
+      "org",
+      "status",
+      "tree",
+      "upgrade",
+    ]);
+  });
+
+  it("registers agent, chat, attention, daemon, config, and org subcommands", () => {
+    const root = new Command();
+    registerAgentCommands(root);
+    registerAttentionCommands(root);
+    registerChatCommands(root);
+    registerDaemonCommands(root);
+    registerConfigCommands(root);
+    registerOrgCommands(root);
+
+    expect(subcommands(root, "agent")).toEqual([
+      "add",
+      "bind",
+      "claim",
+      "config",
+      "create",
+      "debug",
+      "list",
+      "prune",
+      "remove",
+      "reset",
+      "session",
+      "status",
+      "workspace",
+    ]);
+    expect(subcommands(root, "attention")).toEqual(["cancel", "list", "raise", "respond", "show"]);
+    expect(subcommands(root, "chat")).toEqual(["history", "invite", "list", "open", "send"]);
+    expect(subcommands(root, "daemon")).toEqual([
+      "doctor",
+      "home-info",
+      "refresh-unit",
+      "restart",
+      "start",
+      "status",
+      "stop",
+    ]);
+    expect(subcommands(root, "config")).toEqual(["get", "set", "show"]);
+    expect(subcommands(root, "org")).toEqual(["bind-tree"]);
+  });
+
+  it("registers nested agent and tree command groups", () => {
+    const root = new Command();
+    registerAgentCommands(root);
+    registerTreeCommands(root);
+    registerGithubCommands(root);
+
+    const agent = command(root, "agent");
+    expect(subcommands(agent, "bind")).toEqual(["bot", "client", "user"]);
+    expect(subcommands(agent, "session")).toEqual(["list", "suspend", "terminate"]);
+    expect(subcommands(agent, "workspace")).toEqual(["clean"]);
+
+    const tree = command(root, "tree");
+    expect(tree.commands.map((entry) => entry.name()).sort()).toEqual([
+      "automation",
+      "bind",
+      "bootstrap",
+      "claude-hook",
+      "codeowners",
+      "help",
+      "init",
+      "inject",
+      "inspect",
+      "integrate",
+      "publish",
+      "review",
+      "skill",
+      "status",
+      "upgrade",
+      "verify",
+      "workspace",
+    ]);
+    expect(subcommands(tree, "workspace")).toEqual(["sync"]);
+    expect(subcommands(tree, "skill")).toEqual(["doctor", "install", "link", "list", "upgrade"]);
+    expect(subcommands(root, "github")).toEqual(["scan"]);
+  });
+
+  it("keeps important options on high-risk commands", () => {
+    const root = new Command();
+    registerLoginCommand(root);
+    registerAgentCommands(root);
+    registerDaemonCommands(root);
+    registerTreeCommands(root);
+
+    const optionNames = (cmd: Command) => cmd.options.map((option) => option.long).sort();
+
+    expect(optionNames(command(root, "login"))).toEqual(["--no-start", "--override"]);
+    expect(optionNames(command(command(root, "agent"), "create"))).toEqual([
+      "--client-id",
+      "--display-name",
+      "--org",
+      "--runtime",
+      "--server",
+      "--type",
+    ]);
+    expect(optionNames(command(command(root, "daemon"), "start"))).toEqual(["--foreground", "--no-interactive"]);
+    expect(optionNames(command(command(root, "tree"), "bind"))).toEqual([
+      "--entrypoint",
+      "--mode",
+      "--tree-mode",
+      "--tree-path",
+      "--tree-url",
+      "--workspace-id",
+      "--workspace-root",
+    ]);
+  });
+});

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -132,7 +132,7 @@ describe("CLI command registration", () => {
       "workspace",
     ]);
     expect(subcommands(tree, "workspace")).toEqual(["sync"]);
-    expect(subcommands(tree, "skill")).toEqual(["doctor", "install", "link", "list", "upgrade"]);
+    expect(subcommands(tree, "skill")).toEqual(["doctor", "install", "install-core", "link", "list", "upgrade"]);
     expect(subcommands(root, "github")).toEqual(["scan"]);
   });
 

--- a/apps/cli/src/__tests__/config-format-chat-io.test.ts
+++ b/apps/cli/src/__tests__/config-format-chat-io.test.ts
@@ -133,9 +133,9 @@ describe("chat io helpers", () => {
     setProcessStdin(stdin);
 
     const result = readStdin();
-    stdin.emit("data", Buffer.alloc(10 * 1024 * 1024 + 1));
+    stdin.emit("data", Buffer.alloc(5 * 1024 * 1024 + 1));
 
-    await expect(result).rejects.toThrow("stdin exceeds 10485760 bytes");
+    await expect(result).rejects.toThrow("stdin exceeds 5242880 bytes");
     expect(stdin.destroy).toHaveBeenCalled();
   });
 

--- a/apps/cli/src/__tests__/config-format-chat-io.test.ts
+++ b/apps/cli/src/__tests__/config-format-chat-io.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseLimit, readStdin } from "../commands/chat/_shared/io.js";
+import { isSecretField, printFlat } from "../commands/config/_shared/format.js";
+
+const outputMocks = vi.hoisted(() => ({
+  line: vi.fn(),
+  fail: vi.fn((code: string, message: string, exitCode: number) => {
+    throw new Error(`${code}:${message}:${exitCode}`);
+  }),
+}));
+
+vi.mock("../core/output.js", () => ({
+  print: {
+    line: outputMocks.line,
+  },
+}));
+
+vi.mock("../cli/output.js", () => ({
+  fail: outputMocks.fail,
+}));
+
+const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, "stdin");
+
+class MockStdin extends EventEmitter {
+  isTTY = false;
+  destroy = vi.fn();
+}
+
+function setProcessStdin(stdin: unknown): void {
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: stdin,
+  });
+}
+
+beforeEach(() => {
+  outputMocks.line.mockClear();
+  outputMocks.fail.mockClear();
+});
+
+afterEach(() => {
+  if (originalStdinDescriptor) {
+    Object.defineProperty(process, "stdin", originalStdinDescriptor);
+  }
+});
+
+describe("config formatting helpers", () => {
+  const schema = {
+    server: {
+      url: { _tag: "field" },
+      token: { _tag: "field", options: { secret: true } },
+    },
+    agent: {
+      runtime: {
+        _tag: "optional",
+        shape: {
+          model: { _tag: "field" },
+          apiKey: { _tag: "field", options: { secret: true } },
+        },
+      },
+    },
+    feature: { _tag: "field" },
+  };
+
+  it("detects secret fields across nested and optional schema shapes", () => {
+    expect(isSecretField(schema, "server.token")).toBe(true);
+    expect(isSecretField(schema, "agent.runtime.apiKey")).toBe(true);
+    expect(isSecretField(schema, "server.url")).toBe(false);
+    expect(isSecretField(schema, "feature.enabled")).toBe(false);
+    expect(isSecretField(schema, "missing.path")).toBe(false);
+  });
+
+  it("prints nested config values and masks secrets by default", () => {
+    printFlat(
+      {
+        server: { url: "https://hub.example", token: "secret-token" },
+        agent: { runtime: { model: "codex", apiKey: "sk-test" } },
+        retry: 3,
+        tags: ["prod", "dev"],
+      },
+      schema,
+      "",
+      false,
+    );
+
+    const output = outputMocks.line.mock.calls.map((call) => call[0]).join("");
+    expect(output).toContain("server.url");
+    expect(output).toContain("https://hub.example");
+    expect(output).toContain("server.token");
+    expect(output).toContain("***");
+    expect(output).toContain("agent.runtime.model");
+    expect(output).toContain("codex");
+    expect(output).toContain("agent.runtime.apiKey");
+    expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("sk-test");
+    expect(output).toContain("retry");
+    expect(output).toContain("3");
+    expect(output).toContain("tags");
+    expect(output).toContain("prod,dev");
+  });
+
+  it("prints secret values when explicitly requested", () => {
+    printFlat({ server: { token: "secret-token" } }, schema, "", true);
+
+    const output = outputMocks.line.mock.calls.map((call) => call[0]).join("");
+    expect(output).toContain("secret-token");
+  });
+});
+
+describe("chat io helpers", () => {
+  it("returns null when stdin is interactive", async () => {
+    setProcessStdin({ isTTY: true });
+
+    await expect(readStdin()).resolves.toBeNull();
+  });
+
+  it("buffers piped stdin as utf-8 text", async () => {
+    const stdin = new MockStdin();
+    setProcessStdin(stdin);
+
+    const result = readStdin();
+    stdin.emit("data", Buffer.from("hello "));
+    stdin.emit("data", Buffer.from("world"));
+    stdin.emit("end");
+
+    await expect(result).resolves.toBe("hello world");
+    expect(stdin.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized stdin and destroys the stream", async () => {
+    const stdin = new MockStdin();
+    setProcessStdin(stdin);
+
+    const result = readStdin();
+    stdin.emit("data", Buffer.alloc(10 * 1024 * 1024 + 1));
+
+    await expect(result).rejects.toThrow("stdin exceeds 10485760 bytes");
+    expect(stdin.destroy).toHaveBeenCalled();
+  });
+
+  it("parses bounded positive limits and fails invalid values", () => {
+    expect(parseLimit("25", 100)).toBe(25);
+    expect(() => parseLimit("0", 100)).toThrow("INVALID_LIMIT:Limit must be between 1 and 100.:2");
+    expect(() => parseLimit("101", 100)).toThrow("INVALID_LIMIT:Limit must be between 1 and 100.:2");
+    expect(() => parseLimit("nope", 100)).toThrow("INVALID_LIMIT:Limit must be between 1 and 100.:2");
+    expect(outputMocks.fail).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -1,0 +1,266 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientMocks = vi.hoisted(() => ({
+  applyClientLoggerConfig: vi.fn(),
+  configureClientLoggerForService: vi.fn(),
+  discoverClaudeCodeSkills: vi.fn(),
+  probeCapabilities: vi.fn(),
+}));
+
+const coreMocks = vi.hoisted(() => ({
+  ClientRuntime: vi.fn(),
+  createApiNameResolver: vi.fn(),
+  createExecuteUpdate: vi.fn(),
+  declineUpdate: vi.fn(),
+  ensureFreshAccessToken: vi.fn(),
+  getClientServiceStatus: vi.fn(),
+  handleClientOrgMismatch: vi.fn(),
+  isServiceSupported: vi.fn(),
+  loadCredentials: vi.fn(),
+  migrateLocalAgentDirs: vi.fn(),
+  promptMissingFields: vi.fn(),
+  promptUpdate: vi.fn(),
+  reconcileLocalRuntimeProviders: vi.fn(),
+  startClientService: vi.fn(),
+  uploadAgentSkills: vi.fn(),
+  uploadClientCapabilities: vi.fn(),
+}));
+
+const failMock = vi.hoisted(() =>
+  vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+);
+
+vi.mock("@first-tree/client", () => ({
+  ...clientMocks,
+  ClientOrgMismatchError: class ClientOrgMismatchError extends Error {},
+  ClientUserMismatchError: class ClientUserMismatchError extends Error {},
+}));
+
+vi.mock("../core/index.js", () => ({
+  ...coreMocks,
+  COMMAND_VERSION: "0.0.0-test",
+}));
+
+vi.mock("../cli/output.js", () => ({
+  fail: failMock,
+}));
+
+const originalHome = process.env.FIRST_TREE_HOME;
+const originalServiceMode = process.env.FIRST_TREE_SERVICE_MODE;
+const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+  throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+});
+
+let home: string;
+let runtimeInstance: {
+  addAgent: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  watchAgentsDir: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "ft-daemon-start-"));
+  mkdirSync(join(home, "config", "agents", "kael"), { recursive: true });
+  writeFileSync(
+    join(home, "config", "client.yaml"),
+    "server:\n  url: https://hub.example\nclient:\n  id: client_1234abcd\n",
+  );
+  writeFileSync(join(home, "config", "agents", "kael", "agent.yaml"), "agentId: agent-1\nruntime: claude-code\n");
+  process.env.FIRST_TREE_HOME = home;
+  delete process.env.FIRST_TREE_SERVICE_MODE;
+
+  for (const mock of Object.values(clientMocks)) mock.mockReset();
+  for (const mock of Object.values(coreMocks)) mock.mockReset();
+  failMock.mockClear();
+  stderrSpy.mockClear();
+
+  clientMocks.probeCapabilities.mockResolvedValue({ "claude-code": { state: "ok" } });
+  clientMocks.discoverClaudeCodeSkills.mockResolvedValue([{ name: "review", description: "Review code." }]);
+  coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
+  coreMocks.isServiceSupported.mockReturnValue(false);
+  coreMocks.getClientServiceStatus.mockReturnValue({
+    platform: "launchd",
+    state: "not-installed",
+    label: "dev.first-tree",
+    logDir: join(home, "logs"),
+  });
+  coreMocks.startClientService.mockReturnValue({ ok: true });
+  coreMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+  coreMocks.promptMissingFields.mockResolvedValue(undefined);
+  coreMocks.createApiNameResolver.mockReturnValue(async () => "kael");
+  coreMocks.createExecuteUpdate.mockReturnValue(async () => undefined);
+  coreMocks.migrateLocalAgentDirs.mockResolvedValue(undefined);
+  coreMocks.reconcileLocalRuntimeProviders.mockResolvedValue(undefined);
+  coreMocks.uploadClientCapabilities.mockResolvedValue(undefined);
+  coreMocks.uploadAgentSkills.mockResolvedValue(undefined);
+
+  runtimeInstance = {
+    addAgent: vi.fn(),
+    start: vi.fn(async () => undefined),
+    watchAgentsDir: vi.fn(() => {
+      throw new Error("stop after watch");
+    }),
+  };
+  coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalHome;
+  if (originalServiceMode === undefined) delete process.env.FIRST_TREE_SERVICE_MODE;
+  else process.env.FIRST_TREE_SERVICE_MODE = originalServiceMode;
+});
+
+async function runStart(args: string[] = []): Promise<unknown> {
+  const { resetConfig, resetConfigMeta } = await import("@first-tree/shared/config");
+  resetConfig();
+  resetConfigMeta();
+  const { registerDaemonStartCommand } = await import("../commands/daemon/start.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  const daemon = program.command("daemon");
+  registerDaemonStartCommand(daemon);
+  return program.parseAsync(["node", "test", "daemon", "start", ...args]);
+}
+
+function output(): string {
+  return stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+}
+
+describe("daemon start command", () => {
+  it("fails closed when credentials are missing", async () => {
+    coreMocks.loadCredentials.mockReturnValueOnce(null);
+
+    await expect(runStart()).rejects.toMatchObject({ code: "NO_CREDENTIALS", exitCode: 1 });
+    expect(failMock).toHaveBeenCalledWith("NO_CREDENTIALS", expect.stringContaining("no credentials"), 1);
+  });
+
+  it("refuses when the background service is already active", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "systemd",
+      state: "active",
+      label: "first-tree.service",
+      detail: "pid 123",
+      logDir: "/logs",
+    });
+
+    await expect(runStart()).resolves.toBeTruthy();
+    expect(output()).toContain("Service is already running");
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+  });
+
+  it("starts an inactive service and prints log hints", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus
+      .mockReturnValueOnce({ platform: "systemd", state: "inactive", label: "first-tree.service", logDir: "/logs" })
+      .mockReturnValueOnce({
+        platform: "systemd",
+        state: "active",
+        label: "first-tree.service",
+        detail: "pid 123",
+        logDir: "/logs",
+      });
+
+    await expect(runStart()).resolves.toBeTruthy();
+    expect(coreMocks.startClientService).toHaveBeenCalled();
+    expect(output()).toContain("Started systemd service");
+    expect(output()).toContain("journalctl --user -u first-tree");
+  });
+
+  it("prints WSL repair guidance when service startup fails", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "systemd",
+      state: "inactive",
+      label: "first-tree.service",
+      logDir: "/logs",
+    });
+    coreMocks.startClientService.mockReturnValueOnce({
+      ok: false,
+      reason: "Failed to connect to bus: No such file or directory",
+    });
+
+    await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
+    expect(output()).toContain("Failed to start service");
+    expect(output()).toContain("Try `--foreground` to run inline instead.");
+  });
+
+  it("refuses unknown service state", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "launchd",
+      state: "unknown",
+      label: "dev.first-tree",
+      detail: "confused",
+      logDir: "/logs",
+    });
+
+    await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
+    expect(output()).toContain("Service state could not be determined");
+  });
+
+  it("runs inline, reconciles local state, uploads capabilities and skills", async () => {
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(coreMocks.promptMissingFields).toHaveBeenCalledWith(expect.objectContaining({ noInteractive: false }));
+    expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
+    expect(coreMocks.migrateLocalAgentDirs).toHaveBeenCalled();
+    expect(clientMocks.probeCapabilities).toHaveBeenCalled();
+    expect(coreMocks.reconcileLocalRuntimeProviders).toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
+      "https://hub.example",
+      "client_1234abcd",
+      expect.objectContaining({ currentVersion: "0.0.0-test" }),
+    );
+    expect(runtimeInstance.addAgent).toHaveBeenCalledWith("kael", expect.objectContaining({ agentId: "agent-1" }));
+    expect(runtimeInstance.start).toHaveBeenCalled();
+    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: "client_1234abcd", capabilities: { "claude-code": { state: "ok" } } }),
+    );
+    expect(coreMocks.uploadAgentSkills).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "agent-1", skills: [{ name: "review", description: "Review code." }] }),
+    );
+    expect(runtimeInstance.watchAgentsDir).toHaveBeenCalledWith(join(home, "config", "agents"));
+    expect(output()).toContain("Error: stop after watch");
+  });
+
+  it("uses service-mode logging and non-interactive prompts for supervisor children", async () => {
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(coreMocks.promptMissingFields).toHaveBeenCalledWith(expect.objectContaining({ noInteractive: true }));
+    expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
+    expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
+      "https://hub.example",
+      "client_1234abcd",
+      expect.objectContaining({
+        update: expect.objectContaining({ prompt: coreMocks.declineUpdate }),
+      }),
+    );
+  });
+
+  it("continues when best-effort reconciliation and uploads fail", async () => {
+    coreMocks.migrateLocalAgentDirs.mockRejectedValueOnce(new Error("rename failed"));
+    coreMocks.reconcileLocalRuntimeProviders.mockRejectedValueOnce(new Error("runtime probe failed"));
+    coreMocks.uploadClientCapabilities.mockRejectedValueOnce(new Error("capabilities failed"));
+    clientMocks.discoverClaudeCodeSkills.mockRejectedValueOnce(new Error("skill scan failed"));
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    const text = output();
+    expect(text).toContain("agent-dir migration skipped: rename failed");
+    expect(text).toContain("runtime-provider reconcile skipped: runtime probe failed");
+    expect(text).toContain("capabilities upload skipped: capabilities failed");
+    expect(text).toContain("skills upload skipped: skill scan failed");
+  });
+});

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -1,0 +1,194 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cliFetchMock = vi.hoisted(() => vi.fn());
+const serviceStatusMock = vi.hoisted(() => vi.fn());
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: cliFetchMock,
+}));
+
+vi.mock("../core/service-install.js", () => ({
+  getClientServiceStatus: serviceStatusMock,
+}));
+
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+
+let home: string;
+
+function writeAgent(name: string, body: string): void {
+  const dir = join(home, "config", "agents", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "agent.yaml"), body);
+}
+
+beforeEach(() => {
+  home = join(tmpdir(), `ft-doctor-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(home, "config"), { recursive: true });
+  process.env.FIRST_TREE_HOME = home;
+  delete process.env.FIRST_TREE_SERVER_URL;
+  cliFetchMock.mockReset();
+  serviceStatusMock.mockReset();
+  stderrMock.mockClear();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
+  else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+});
+
+describe("doctor core checks", () => {
+  it("checks config, server reachability, websocket reachability, and local agents", async () => {
+    const { checkAgentConfigs, checkClientConfig, checkServerReachable, checkWebSocket, reconcileAgentConfigs } =
+      await import("../core/doctor.js");
+
+    expect(checkClientConfig()).toEqual({
+      label: "Config",
+      ok: false,
+      detail: "no config file or env vars found",
+    });
+
+    process.env.FIRST_TREE_SERVER_URL = "http://env.test";
+    expect(checkClientConfig()).toEqual({ label: "Config", ok: true, detail: "via environment variables" });
+
+    writeFileSync(
+      join(home, "config", "client.yaml"),
+      "server:\n  url: http://hub.test\nclient:\n  id: client_1234abcd\n",
+    );
+    delete process.env.FIRST_TREE_SERVER_URL;
+    expect(checkClientConfig().detail).toContain("client.yaml");
+
+    cliFetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    await expect(checkServerReachable()).resolves.toEqual({ label: "Server URL", ok: true, detail: "http://hub.test" });
+
+    cliFetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    await expect(checkServerReachable()).resolves.toEqual({
+      label: "Server URL",
+      ok: false,
+      detail: "unhealthy (HTTP 503) at http://hub.test",
+    });
+
+    cliFetchMock.mockRejectedValueOnce(new Error("network"));
+    await expect(checkWebSocket()).resolves.toEqual({
+      label: "WebSocket",
+      ok: false,
+      detail: "server unreachable at http://hub.test",
+    });
+
+    cliFetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    await expect(checkWebSocket()).resolves.toEqual({
+      label: "WebSocket",
+      ok: true,
+      detail: "ws://hub.test (server reachable)",
+    });
+
+    expect(checkAgentConfigs()).toEqual({ label: "Agents", ok: false, detail: "no agents configured" });
+    writeAgent("kael", "agentId: agent-1\nruntime: claude-code\n");
+    expect(checkAgentConfigs()).toEqual({ label: "Agents", ok: true, detail: "1 configured (kael)" });
+
+    await expect(
+      reconcileAgentConfigs({
+        clientId: "client-1",
+        listPinnedAgents: async () => [{ agentId: "agent-1", clientId: "client-1" }],
+      }),
+    ).resolves.toEqual({ label: "Agents", ok: true, detail: "1 configured, all pinned to this client" });
+
+    writeAgent("moved", "agentId: agent-2\nruntime: claude-code\n");
+    const stale = await reconcileAgentConfigs({
+      clientId: "client-1",
+      listPinnedAgents: async () => [{ agentId: "agent-2", clientId: "client-2" }],
+    });
+    expect(stale.ok).toBe(false);
+    expect(stale.detail).toContain("moved [pinned to another client: client-2]");
+    expect(stale.detail).toContain("run `first-tree agent prune`");
+  });
+
+  it("handles reconciliation failures and background-service states", async () => {
+    const { checkBackgroundService, printResults, reconcileAgentConfigs } = await import("../core/doctor.js");
+
+    await expect(
+      reconcileAgentConfigs({
+        clientId: "client-1",
+        agentsDir: join(home, "missing-agents"),
+        listPinnedAgents: async () => [],
+      }),
+    ).resolves.toEqual({ label: "Agents", ok: false, detail: "no agents configured" });
+
+    writeAgent("kael", "agentId: agent-1\nruntime: claude-code\n");
+    const failed = await reconcileAgentConfigs({
+      clientId: "client-1",
+      listPinnedAgents: async () => {
+        throw new Error("hub unavailable".repeat(10));
+      },
+    });
+    expect(failed.ok).toBe(false);
+    expect(failed.detail).toContain("server reconciliation failed");
+
+    serviceStatusMock.mockReturnValueOnce({
+      platform: "unsupported",
+      label: "",
+      unitPath: "",
+      logDir: "/logs",
+      state: "not-installed",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: true,
+      detail: `not supported on ${process.platform} — runs inline`,
+    });
+
+    serviceStatusMock.mockReturnValueOnce({
+      platform: "systemd",
+      label: "first-tree.service",
+      unitPath: "/unit",
+      logDir: "/logs",
+      state: "active",
+      detail: "pid 123",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: true,
+      detail: "running (systemd, pid 123); logs at /logs",
+    });
+
+    serviceStatusMock.mockReturnValueOnce({
+      platform: "launchd",
+      label: "dev.first-tree",
+      unitPath: "/unit",
+      logDir: "/logs",
+      state: "inactive",
+      detail: "loaded",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: false,
+      detail: "installed but not running — loaded; unit at /unit",
+    });
+
+    serviceStatusMock.mockReturnValueOnce({
+      platform: "launchd",
+      label: "dev.first-tree",
+      unitPath: "/unit",
+      logDir: "/logs",
+      state: "not-installed",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: false,
+      detail: "not installed — re-run `first-tree login <token>` to install",
+    });
+
+    printResults([
+      { label: "One", ok: true, detail: "ok" },
+      { label: "Two", ok: false, detail: "bad" },
+    ]);
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("1 issue(s) found.");
+  });
+});

--- a/apps/cli/src/__tests__/github-scan-command.test.ts
+++ b/apps/cli/src/__tests__/github-scan-command.test.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runGitHubScanMock = vi.hoisted(() => vi.fn());
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+const consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+vi.mock("../../../../packages/github-scan/src/index.js", () => ({
+  runGitHubScan: runGitHubScanMock,
+}));
+
+const originalCwd = process.cwd();
+const originalTreeRepoEnv = process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+
+let tempDir: string;
+
+async function runScan(args: string[], cwd = tempDir): Promise<void> {
+  process.chdir(cwd);
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: (value) => process.stderr.write(value) });
+  const { registerGithubCommands } = await import("../commands/github/index.js");
+  registerGithubCommands(program);
+  await program.parseAsync(["github", "scan", ...args], { from: "user" });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  tempDir = join(tmpdir(), `ft-github-scan-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tempDir, { recursive: true });
+  runGitHubScanMock.mockReset();
+  stderrMock.mockClear();
+  consoleErrorMock.mockClear();
+  delete process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tempDir, { recursive: true, force: true });
+  if (originalTreeRepoEnv === undefined) delete process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+  else process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO = originalTreeRepoEnv;
+  process.exitCode = undefined;
+});
+
+describe("github scan command", () => {
+  it("forwards args and temporarily injects explicit tree repo", async () => {
+    runGitHubScanMock.mockImplementationOnce(async () => {
+      expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBe("agent-team/context");
+      return 3;
+    });
+
+    await runScan(["run", "--tree-repo", "agent-team/context", "--limit", "1"]);
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["run", "--limit", "1"]);
+    expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBeUndefined();
+    expect(process.exitCode).toBe(3);
+  });
+
+  it("derives the bound tree repo from source metadata in parent directories", async () => {
+    mkdirSync(join(tempDir, ".first-tree"), { recursive: true });
+    mkdirSync(join(tempDir, "nested", "repo"), { recursive: true });
+    writeFileSync(
+      join(tempDir, ".first-tree", "source.json"),
+      JSON.stringify({ tree: { remoteUrl: "git@github.com:agent-team/first-tree-context.git" } }),
+    );
+    runGitHubScanMock.mockImplementationOnce(async () => {
+      expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBe("agent-team/first-tree-context");
+      return 0;
+    });
+
+    await runScan(["daemon", "--once"], join(tempDir, "nested", "repo"));
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["daemon", "--once"]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("requires a tree repo for commands that operate on bound source repos", async () => {
+    await runScan(["install"]);
+
+    expect(runGitHubScanMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(consoleErrorMock.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "requires a bound tree repo before it can start scanning",
+    );
+  });
+
+  it("reports malformed tree repo values and keeps existing env values", async () => {
+    process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO = "existing/repo";
+
+    await runScan(["run", "--tree-repo=bad"]);
+
+    expect(runGitHubScanMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBe("existing/repo");
+    expect(consoleErrorMock.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "Invalid `--tree-repo` value",
+    );
+  });
+
+  it("does not require binding for help-like delegated commands", async () => {
+    runGitHubScanMock.mockResolvedValueOnce(0);
+
+    await runScan(["status"]);
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["status"]);
+    expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBeUndefined();
+  });
+});

--- a/apps/cli/src/__tests__/github-scan-legacy-command.test.ts
+++ b/apps/cli/src/__tests__/github-scan-legacy-command.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runGitHubScanMock = vi.hoisted(() => vi.fn());
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+vi.mock("../../../../packages/github-scan/src/index.js", () => ({
+  runGitHubScan: runGitHubScanMock,
+}));
+
+const originalCwd = process.cwd();
+const originalTreeRepoEnv = process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+
+let tempDir: string;
+
+async function runLegacyScan(args: string[], cwd = tempDir): Promise<void> {
+  process.chdir(cwd);
+  const program = new Command();
+  program.exitOverride();
+  const { githubScanCommand } = await import("../commands/github/scan.js");
+  githubScanCommand.register(program);
+  await program.parseAsync(["scan", ...args], { from: "user" });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  tempDir = join(tmpdir(), `ft-github-scan-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tempDir, { recursive: true });
+  runGitHubScanMock.mockReset();
+  stderrMock.mockClear();
+  delete process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tempDir, { recursive: true, force: true });
+  if (originalTreeRepoEnv === undefined) delete process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO;
+  else process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO = originalTreeRepoEnv;
+  process.exitCode = undefined;
+});
+
+describe("legacy github scan command module", () => {
+  it("forwards args and restores an explicit tree repo environment", async () => {
+    process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO = "existing/repo";
+    runGitHubScanMock.mockImplementationOnce(async () => {
+      expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBe("agent-team/context");
+      return 2;
+    });
+
+    await runLegacyScan(["run", "--tree-repo=agent-team/context", "--limit", "1"]);
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["run", "--limit", "1"]);
+    expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBe("existing/repo");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("derives tree repo from .first-tree/source.json", async () => {
+    mkdirSync(join(tempDir, ".first-tree"), { recursive: true });
+    mkdirSync(join(tempDir, "nested"), { recursive: true });
+    writeFileSync(
+      join(tempDir, ".first-tree", "source.json"),
+      JSON.stringify({ tree: { remoteUrl: "https://github.com/agent-team/context.git" } }),
+    );
+    runGitHubScanMock.mockResolvedValueOnce(0);
+
+    await runLegacyScan(["daemon", "--once"], join(tempDir, "nested"));
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["daemon", "--once"]);
+    expect(process.env.FIRST_TREE_GITHUB_SCAN_TREE_REPO).toBeUndefined();
+  });
+
+  it("rejects missing and malformed --tree-repo input before delegation", async () => {
+    await runLegacyScan(["run", "--tree-repo"]);
+    expect(process.exitCode).toBe(1);
+    expect(runGitHubScanMock).not.toHaveBeenCalled();
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("missing value");
+
+    process.exitCode = undefined;
+    stderrMock.mockClear();
+    await runLegacyScan(["install"]);
+    expect(process.exitCode).toBe(1);
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("requires a bound tree repo");
+  });
+
+  it("delegates help-like commands without a binding", async () => {
+    runGitHubScanMock.mockResolvedValueOnce(0);
+
+    await runLegacyScan(["status"]);
+
+    expect(runGitHubScanMock).toHaveBeenCalledWith(["status"]);
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -1,0 +1,163 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cliFetchMock = vi.hoisted(() => vi.fn());
+const installClientServiceMock = vi.hoisted(() => vi.fn());
+const isServiceSupportedMock = vi.hoisted(() => vi.fn());
+const postClaimMock = vi.hoisted(() => vi.fn());
+const cleanupStaleAliasesAfterClaimMock = vi.hoisted(() => vi.fn());
+const selectMock = vi.hoisted(() => vi.fn());
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+const exitMock = vi.spyOn(process, "exit").mockImplementation((() => {
+  throw new Error("process.exit");
+}) as never);
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: cliFetchMock,
+}));
+
+vi.mock("../core/service-install.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/service-install.js")>()),
+  installClientService: installClientServiceMock,
+  isServiceSupported: isServiceSupportedMock,
+}));
+
+vi.mock("../commands/_shared/account-transfer.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commands/_shared/account-transfer.js")>()),
+  cleanupStaleAliasesAfterClaim: cleanupStaleAliasesAfterClaimMock,
+  postClaim: postClaimMock,
+}));
+
+vi.mock("@inquirer/prompts", () => ({
+  select: selectMock,
+}));
+
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+
+let home: string;
+
+function jwt(payload: Record<string, unknown>): string {
+  return `h.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.s`;
+}
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function runLogin(args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  const { registerLoginCommand } = await import("../commands/login.js");
+  registerLoginCommand(program);
+  await program.parseAsync(args, { from: "user" });
+}
+
+function credentialsPath(): string {
+  return join(home, "config", "credentials.json");
+}
+
+function writeCredentials(memberId: string, serverUrl = "http://old.test"): void {
+  mkdirSync(join(home, "config"), { recursive: true });
+  writeFileSync(
+    credentialsPath(),
+    JSON.stringify({
+      accessToken: jwt({ memberId, exp: Math.floor(Date.now() / 1000) + 3600 }),
+      refreshToken: "old-refresh",
+      serverUrl,
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  home = join(tmpdir(), `ft-login-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(home, "config"), { recursive: true });
+  process.env.FIRST_TREE_HOME = home;
+  delete process.env.FIRST_TREE_SERVER_URL;
+  cliFetchMock.mockReset();
+  installClientServiceMock.mockReset();
+  isServiceSupportedMock.mockReset();
+  postClaimMock.mockReset();
+  cleanupStaleAliasesAfterClaimMock.mockReset();
+  selectMock.mockReset();
+  stderrMock.mockClear();
+  exitMock.mockClear();
+  process.exitCode = undefined;
+  cliFetchMock.mockResolvedValue(response(200, { accessToken: jwt({ memberId: "member-new" }), refreshToken: "r1" }));
+  isServiceSupportedMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
+  else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+  process.exitCode = undefined;
+});
+
+describe("login command", () => {
+  it("exchanges a connect token, writes credentials/config, and honors --no-start", async () => {
+    await runLogin(["login", jwt({ iss: "http://hub.test/", memberId: "member-new" }), "--no-start"]);
+
+    expect(cliFetchMock).toHaveBeenCalledWith(
+      "http://hub.test/api/v1/auth/connect-token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(JSON.parse(readFileSync(credentialsPath(), "utf8"))).toMatchObject({
+      refreshToken: "r1",
+      serverUrl: "http://hub.test",
+    });
+    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).toContain("url: http://hub.test");
+    expect(installClientServiceMock).not.toHaveBeenCalled();
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("--no-start");
+  });
+
+  it("prompts before replacing a different local account", async () => {
+    writeCredentials("member-old");
+    selectMock.mockResolvedValueOnce("cancel");
+
+    await runLogin(["login", jwt({ iss: "http://hub.test", memberId: "member-new" })]);
+
+    expect(selectMock).toHaveBeenCalled();
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("old-refresh");
+  });
+
+  it("transfers ownership in override mode and starts supported services", async () => {
+    postClaimMock.mockResolvedValueOnce({ clientId: "client-1", previousUserId: "old", unpinnedAgentCount: 2 });
+    cleanupStaleAliasesAfterClaimMock.mockResolvedValueOnce(undefined);
+    isServiceSupportedMock.mockReturnValueOnce(true);
+    installClientServiceMock.mockReturnValueOnce({ platform: "launchd", logDir: join(home, "logs") });
+
+    await runLogin(["login", jwt({ iss: "http://hub.test", memberId: "member-new" }), "--override"]);
+
+    expect(postClaimMock).toHaveBeenCalledWith("http://hub.test", expect.any(String));
+    expect(cleanupStaleAliasesAfterClaimMock).toHaveBeenCalledWith(
+      expect.objectContaining({ serverUrl: "http://hub.test", nonInteractive: true }),
+    );
+    expect(installClientServiceMock).toHaveBeenCalled();
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Ownership transferred");
+  });
+
+  it("maps invalid tokens and token exchange failures to CLI errors", async () => {
+    await expect(runLogin(["login", "not-a-jwt"])).rejects.toThrow("process.exit");
+    expect(exitMock).toHaveBeenCalledWith(1);
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("INVALID_TOKEN");
+
+    stderrMock.mockClear();
+    exitMock.mockClear();
+    cliFetchMock.mockResolvedValueOnce(response(403, { error: "expired token" }));
+    await expect(
+      runLogin(["login", jwt({ iss: "http://hub.test", memberId: "member-new" }), "--no-start"]),
+    ).rejects.toThrow("process.exit");
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("expired token");
+  });
+});

--- a/apps/cli/src/__tests__/onboard-core.test.ts
+++ b/apps/cli/src/__tests__/onboard-core.test.ts
@@ -1,0 +1,193 @@
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cliFetchMock = vi.hoisted(() => vi.fn());
+const ensureFreshAccessTokenMock = vi.hoisted(() => vi.fn());
+const loadCredentialsMock = vi.hoisted(() => vi.fn());
+const bindFeishuBotMock = vi.hoisted(() => vi.fn());
+const stderrMock = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: cliFetchMock,
+}));
+
+vi.mock("../core/feishu.js", () => ({
+  bindFeishuBot: bindFeishuBotMock,
+}));
+
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+
+let home: string;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  home = join(tmpdir(), `ft-onboard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(home, "config"), { recursive: true });
+  process.env.FIRST_TREE_HOME = home;
+  delete process.env.FIRST_TREE_SERVER_URL;
+  cliFetchMock.mockReset();
+  ensureFreshAccessTokenMock.mockReset();
+  loadCredentialsMock.mockReset();
+  bindFeishuBotMock.mockReset();
+  stderrMock.mockClear();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
+  else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+});
+
+describe("onboard core", () => {
+  it("persists and loads resumable onboard state", async () => {
+    const { loadOnboardState, saveOnboardState } = await import("../core/onboard.js");
+
+    expect(loadOnboardState()).toBeNull();
+    saveOnboardState({ id: "kael", type: "agent", domains: "runtime,tools" });
+
+    expect(loadOnboardState()).toEqual({ id: "kael", type: "agent", domains: "runtime,tools" });
+  });
+
+  it("checks credentials, server health, and required inputs", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      loadCredentials: loadCredentialsMock,
+    }));
+    const { formatCheckReport, onboardCheck } = await import("../core/onboard.js");
+
+    loadCredentialsMock.mockReturnValueOnce({ accessToken: "a", refreshToken: "r", serverUrl: "http://hub.test" });
+    process.env.FIRST_TREE_SERVER_URL = "http://hub.test";
+    cliFetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const ok = await onboardCheck({ id: "kael", type: "agent", clientId: "client-1" });
+    expect(ok.map((item) => [item.key, item.status, item.value])).toEqual([
+      ["connect", "ok", "http://hub.test"],
+      ["server", "ok", "http://hub.test"],
+      ["server_reachable", "ok", "healthy"],
+      ["id", "ok", "kael"],
+      ["type", "ok", "agent"],
+      ["client", "ok", "client-1"],
+    ]);
+    expect(formatCheckReport(ok)).toContain("Signed in");
+
+    loadCredentialsMock.mockReturnValueOnce(null);
+    delete process.env.FIRST_TREE_SERVER_URL;
+    const missing = await onboardCheck({ id: "", type: "human" });
+    expect(missing.map((item) => [item.key, item.status])).toEqual([
+      ["connect", "missing_required"],
+      ["server", "missing_required"],
+      ["id", "missing_required"],
+      ["type", "ok"],
+    ]);
+    expect(formatCheckReport(missing)).toContain("Run `first-tree login <token>` first");
+  });
+
+  it("creates agent and assistant rows, writes local config, and binds Feishu", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+    }));
+    const { onboardCreate, saveOnboardState } = await import("../core/onboard.js");
+
+    process.env.FIRST_TREE_SERVER_URL = "http://hub.test/";
+    ensureFreshAccessTokenMock.mockResolvedValue("access-1");
+    cliFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          memberships: [{ organizationId: "org-1", organizationName: "Acme" }],
+          defaultOrganizationId: "org-1",
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { uuid: "human-uuid", name: "gandy" }))
+      .mockResolvedValueOnce(jsonResponse(200, { uuid: "assistant-uuid", name: "gandy-assistant" }));
+    bindFeishuBotMock.mockResolvedValue(undefined);
+    saveOnboardState({ id: "gandy" });
+
+    await onboardCreate({
+      id: "gandy",
+      type: "human",
+      displayName: "Gandy",
+      assistant: "helper",
+      role: "Lead",
+      domains: "runtime, tools",
+      clientId: "client-1",
+      feishuBotAppId: "cli_app",
+      feishuBotAppSecret: "secret",
+    });
+
+    expect(cliFetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+      "http://hub.test/api/v1/me",
+      "http://hub.test/api/v1/orgs/org-1/agents",
+      "http://hub.test/api/v1/orgs/org-1/agents",
+    ]);
+    expect(JSON.parse(String(cliFetchMock.mock.calls[1]?.[1]?.body))).toMatchObject({
+      name: "gandy",
+      type: "human",
+      displayName: "Gandy",
+      delegateMention: "helper",
+      metadata: { role: "Lead", domains: ["runtime", "tools"] },
+    });
+    expect(JSON.parse(String(cliFetchMock.mock.calls[2]?.[1]?.body))).toMatchObject({
+      name: "helper",
+      type: "agent",
+      visibility: "private",
+      clientId: "client-1",
+    });
+    expect(bindFeishuBotMock).toHaveBeenCalledWith(
+      "http://hub.test",
+      "access-1",
+      "assistant-uuid",
+      "cli_app",
+      "secret",
+    );
+    expect(readFileSync(join(home, "config", "agents", "gandy-assistant", "agent.yaml"), "utf8")).toContain(
+      'agentId: "assistant-uuid"',
+    );
+    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).toContain("url: http://hub.test");
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Onboard complete");
+  });
+
+  it("surfaces organization ambiguity and agent creation errors", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+    }));
+    const { onboardCreate } = await import("../core/onboard.js");
+
+    process.env.FIRST_TREE_SERVER_URL = "http://hub.test";
+    ensureFreshAccessTokenMock.mockResolvedValue("access-1");
+    cliFetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        memberships: [
+          { organizationId: "org-1", organizationName: "Acme" },
+          { organizationId: "org-2", organizationName: "Other" },
+        ],
+      }),
+    );
+
+    await expect(onboardCreate({ id: "kael", type: "agent" })).rejects.toThrow(
+      "Multiple organizations — pass --org explicitly to onboard",
+    );
+
+    cliFetchMock.mockReset();
+    cliFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { memberships: [{ organizationId: "org-1", organizationName: "Acme" }] }),
+      )
+      .mockResolvedValueOnce(jsonResponse(409, { error: "name already exists" }));
+
+    await expect(onboardCreate({ id: "kael", type: "agent" })).rejects.toThrow("name already exists");
+  });
+});

--- a/apps/cli/src/__tests__/prompt-core.test.ts
+++ b/apps/cli/src/__tests__/prompt-core.test.ts
@@ -1,0 +1,187 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cliFetchMock = vi.hoisted(() => vi.fn());
+const ensureFreshAccessTokenMock = vi.hoisted(() => vi.fn());
+const inputMock = vi.hoisted(() => vi.fn());
+const passwordMock = vi.hoisted(() => vi.fn());
+const selectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: cliFetchMock,
+}));
+
+vi.mock("@inquirer/prompts", () => ({
+  input: inputMock,
+  password: passwordMock,
+  select: selectMock,
+}));
+
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+const originalIsTty = process.stdin.isTTY;
+
+let home: string;
+
+function setTty(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value });
+}
+
+function writeCredentials(serverUrl = "http://hub.test"): void {
+  mkdirSync(join(home, "config"), { recursive: true });
+  const credentialsPath = join(home, "config", "credentials.json");
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })).toString("base64url");
+  const token = `h.${payload}.s`;
+  writeFileSync(credentialsPath, JSON.stringify({ accessToken: token, refreshToken: "refresh", serverUrl }));
+}
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  home = join(tmpdir(), `ft-prompt-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(home, "config"), { recursive: true });
+  process.env.FIRST_TREE_HOME = home;
+  delete process.env.FIRST_TREE_SERVER_URL;
+  cliFetchMock.mockReset();
+  ensureFreshAccessTokenMock.mockReset();
+  inputMock.mockReset();
+  passwordMock.mockReset();
+  selectMock.mockReset();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
+  else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalIsTty });
+});
+
+describe("prompt core", () => {
+  it("detects interactive availability", async () => {
+    const { isInteractive } = await import("../core/prompt.js");
+
+    setTty(true);
+    expect(isInteractive()).toBe(true);
+    expect(isInteractive(true)).toBe(false);
+    setTty(false);
+    expect(isInteractive()).toBe(false);
+  });
+
+  it("reports missing fields with environment hints in non-interactive mode", async () => {
+    const { promptMissingFields } = await import("../core/prompt.js");
+    const schema = {
+      server: {
+        url: { _tag: "field", options: { prompt: { message: "Server URL" }, env: "FIRST_TREE_SERVER_URL" } },
+      },
+      token: { _tag: "field", options: { prompt: { message: "Token", type: "password" }, env: "TOKEN" } },
+    };
+
+    await expect(
+      promptMissingFields({
+        schema,
+        role: "client",
+        configDir: join(home, "config"),
+        noInteractive: true,
+      }),
+    ).rejects.toThrow("server.url  (env: FIRST_TREE_SERVER_URL)");
+  });
+
+  it("writes prompted input, password, select, and follow-up input values", async () => {
+    const { promptMissingFields } = await import("../core/prompt.js");
+    const schema = {
+      server: {
+        url: { _tag: "field", options: { prompt: { message: "Server URL" } } },
+      },
+      secret: { _tag: "field", options: { prompt: { message: "Secret", type: "password" } } },
+      runtime: {
+        _tag: "field",
+        options: {
+          prompt: {
+            message: "Runtime",
+            type: "select",
+            choices: [
+              { name: "Claude Code", value: "claude-code" },
+              { name: "Other", value: "__input__" },
+            ],
+          },
+        },
+      },
+      skip: {
+        _tag: "field",
+        options: {
+          prompt: {
+            message: "Skip",
+            type: "select",
+            choices: [{ name: "Auto", value: "__auto__" }],
+          },
+        },
+      },
+    };
+    setTty(true);
+    inputMock.mockResolvedValueOnce("http://hub.test").mockResolvedValueOnce("custom-runtime");
+    passwordMock.mockResolvedValueOnce("secret-value");
+    selectMock.mockResolvedValueOnce("__input__").mockResolvedValueOnce("__auto__");
+
+    await expect(promptMissingFields({ schema, role: "client", configDir: join(home, "config") })).resolves.toEqual({
+      server: { url: "http://hub.test" },
+      secret: "secret-value",
+      runtime: "custom-runtime",
+    });
+
+    const yaml = readFileSync(join(home, "config", "client.yaml"), "utf8");
+    expect(yaml).toContain("url: http://hub.test");
+    expect(yaml).toContain("secret: secret-value");
+    expect(yaml).toContain("runtime: custom-runtime");
+    expect(yaml).not.toContain("skip:");
+  });
+
+  it("resolves add-agent canonical names and rejects missing setup or tombstones", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+    }));
+    const { promptAddAgent } = await import("../core/prompt.js");
+
+    await expect(promptAddAgent({ agentId: "agent-1" })).rejects.toThrow("first-tree login <token>");
+
+    writeCredentials();
+    process.env.FIRST_TREE_SERVER_URL = "http://hub.test";
+    ensureFreshAccessTokenMock.mockResolvedValue("access-1");
+    cliFetchMock.mockResolvedValueOnce(response(200, { name: "kael" }));
+    await expect(promptAddAgent({ agentId: "agent-1" })).resolves.toEqual({ name: "kael", agentId: "agent-1" });
+    expect(cliFetchMock.mock.calls[0]?.[0]).toBe("http://hub.test/api/v1/agents/agent-1");
+
+    cliFetchMock.mockResolvedValueOnce(response(404, { error: "missing" }));
+    await expect(promptAddAgent({ agentId: "missing" })).rejects.toThrow("HTTP 404");
+
+    cliFetchMock.mockResolvedValueOnce(response(200, { name: null }));
+    await expect(promptAddAgent({ agentId: "tombstone" })).rejects.toThrow("has no hub name");
+  });
+
+  it("prompts for an agent id when omitted", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+    }));
+    const { promptAddAgent } = await import("../core/prompt.js");
+
+    writeCredentials("http://hub.test/");
+    process.env.FIRST_TREE_SERVER_URL = "http://override.test";
+    inputMock.mockResolvedValueOnce("agent-from-prompt");
+    ensureFreshAccessTokenMock.mockResolvedValue("access-1");
+    cliFetchMock.mockResolvedValueOnce(response(200, { name: "prompted" }));
+
+    await expect(promptAddAgent()).resolves.toEqual({ name: "prompted", agentId: "agent-from-prompt" });
+    expect(cliFetchMock.mock.calls[0]?.[0]).toBe("http://override.test/api/v1/agents/agent-from-prompt");
+  });
+});

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -1,0 +1,383 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { channelConfig } from "../core/channel.js";
+import {
+  collectProxyEnv,
+  getClientServiceStatus,
+  installClientService,
+  isServiceSupported,
+  isServiceUnitDriftDetected,
+  renderLaunchdWrapper,
+  renderPlist,
+  renderSystemdUnit,
+  resolveCliInvocation,
+  restartClientService,
+  startClientService,
+  stopClientService,
+  uninstallClientService,
+} from "../core/service-install.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+const userInfoMock = vi.hoisted(() => vi.fn(() => ({ uid: 501, username: "gandy" })));
+const homedirMock = vi.hoisted(() => vi.fn(() => "/Users/gandy"));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+  execFileSync: execFileSyncMock,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: homedirMock,
+    userInfo: userInfoMock,
+  };
+});
+
+const originalPlatform = process.platform;
+const originalArgv = [...process.argv];
+const originalExecPath = process.execPath;
+const originalCwd = process.cwd;
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function setExecPath(value: string): void {
+  Object.defineProperty(process, "execPath", { configurable: true, value });
+}
+
+function tempHome(): string {
+  return join(tmpdir(), `ft-service-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+let home: string;
+
+beforeEach(() => {
+  home = tempHome();
+  mkdirSync(home, { recursive: true });
+  process.env.FIRST_TREE_HOME = join(home, "ft-home");
+  process.env.XDG_CONFIG_HOME = join(home, "xdg");
+  process.argv = ["node", "/repo/dist/cli/index.mjs"];
+  setExecPath("/opt/node/bin/node");
+  process.cwd = () => "/repo";
+  execFileSyncMock.mockReset();
+  spawnSyncMock.mockReset();
+  homedirMock.mockReturnValue(home);
+  userInfoMock.mockReturnValue({ uid: 501, username: "gandy" });
+  setPlatform(originalPlatform);
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  process.argv = [...originalArgv];
+  setExecPath(originalExecPath);
+  process.cwd = originalCwd;
+  setPlatform(originalPlatform);
+});
+
+describe("service install helpers", () => {
+  it("collects only non-empty proxy environment variables", () => {
+    expect(
+      collectProxyEnv({
+        HTTP_PROXY: "http://proxy.test",
+        HTTPS_PROXY: "",
+        no_proxy: "localhost,127.0.0.1",
+        OTHER: "ignored",
+      }),
+    ).toEqual({
+      HTTP_PROXY: "http://proxy.test",
+      no_proxy: "localhost,127.0.0.1",
+    });
+  });
+
+  it("resolves the channel bin when it is on PATH and falls back to node plus script", () => {
+    execFileSyncMock.mockReturnValueOnce(`/tmp/bin/${channelConfig.binName}\n`);
+    expect(resolveCliInvocation()).toEqual({ kind: "bin", program: `/tmp/bin/${channelConfig.binName}` });
+
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+    process.argv = ["node", "dist/cli/index.mjs"];
+    expect(resolveCliInvocation()).toEqual({
+      kind: "node",
+      program: "/opt/node/bin/node",
+      args: ["/repo/dist/cli/index.mjs"],
+    });
+  });
+
+  it("renders service templates with escaped values and quoted shell arguments", () => {
+    const plist = renderPlist("/tmp/First & Tree", { HTTP_PROXY: "http://a&b.test/<x>" });
+    expect(plist).toContain("<string>/tmp/First &amp; Tree</string>");
+    expect(plist).toContain("<key>HTTP_PROXY</key>");
+    expect(plist).toContain("<string>http://a&amp;b.test/&lt;x&gt;</string>");
+    expect(plist).toContain("<key>FIRST_TREE_HOME</key>");
+    expect(plist).toContain(process.env.FIRST_TREE_HOME);
+
+    const wrapper = renderLaunchdWrapper({
+      kind: "node",
+      program: "/opt/My Node/node",
+      args: ["/tmp/cli path/index.mjs"],
+    });
+    expect(wrapper).toContain('exec "/opt/My Node/node" "/tmp/cli path/index.mjs" daemon start --no-interactive');
+
+    const unit = renderSystemdUnit(
+      { kind: "bin", program: "/usr/local/bin/first tree" },
+      { HTTPS_PROXY: "http://user:pa ss@example.test" },
+    );
+    expect(unit).toContain('ExecStart="/usr/local/bin/first tree" daemon start --no-interactive');
+    expect(unit).toContain('Environment=HTTPS_PROXY="http://user:pa ss@example.test"');
+    expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
+  });
+
+  it("reports support by platform", () => {
+    setPlatform("darwin");
+    expect(isServiceSupported()).toBe(true);
+    setPlatform("linux");
+    expect(isServiceSupported()).toBe(true);
+    setPlatform("win32");
+    expect(isServiceSupported()).toBe(false);
+  });
+
+  it("reports launchd states without leaking launchctl stderr", () => {
+    setPlatform("darwin");
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: "state = running\npid = 123\n",
+      stderr: "",
+    });
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "launchd",
+      state: "active",
+      pid: 123,
+      detail: "pid 123",
+    });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 3, stdout: "", stderr: "Could not find service" });
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "launchd",
+      state: "inactive",
+      detail: "plist present but not loaded",
+    });
+  });
+
+  it("reports systemd states and main pid", () => {
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "unit");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "456\n", stderr: "" });
+
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "systemd",
+      state: "active",
+      pid: 456,
+      detail: "pid 456",
+    });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 3, stdout: "inactive\n", stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "systemd",
+      state: "inactive",
+      detail: "inactive",
+    });
+  });
+
+  it("detects service unit drift from missing and changed files", () => {
+    setPlatform("linux");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    expect(isServiceUnitDriftDetected()).toBe(true);
+
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "stale");
+    expect(isServiceUnitDriftDetected()).toBe(true);
+
+    writeFileSync(
+      unitPath,
+      renderSystemdUnit({ kind: "node", program: process.execPath, args: [process.argv[1] ?? ""] }),
+    );
+    expect(isServiceUnitDriftDetected()).toBe(false);
+  });
+
+  it("starts, stops, and restarts services through the platform manager", () => {
+    setPlatform("linux");
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: true });
+    expect(stopClientService()).toEqual({ ok: true });
+    expect(restartClientService()).toEqual({ ok: true });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "Unit not found" });
+    expect(stopClientService()).toEqual({ ok: true, detail: "not running" });
+
+    setPlatform("win32");
+    expect(startClientService()).toEqual({ ok: false, reason: "service control not supported on win32" });
+    expect(stopClientService()).toEqual({ ok: false, reason: "service control not supported on win32" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "service control not supported on win32" });
+  });
+
+  it("uses launchctl bootstrap and kickstart paths for launchd control", () => {
+    setPlatform("darwin");
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "not loaded" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: true });
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "loaded", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: true });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "not loaded" });
+    expect(stopClientService()).toEqual({ ok: true, detail: "not running" });
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "not loaded" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: true });
+  });
+
+  it("installs a systemd user service, enables linger, and reports the running process", () => {
+    setPlatform("linux");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "no\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "789\n", stderr: "" });
+
+    const info = installClientService();
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    const unit = readFileSync(unitPath, "utf-8");
+
+    expect(info).toMatchObject({
+      platform: "systemd",
+      label: channelConfig.serviceUnitFile,
+      state: "active",
+      pid: 789,
+      detail: "pid 789",
+      unitPath,
+    });
+    expect(existsSync(join(process.env.FIRST_TREE_HOME ?? "", "logs"))).toBe(true);
+    expect(unit).toContain(`${process.execPath} ${process.argv[1]} daemon start --no-interactive`);
+    expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["systemctl", ["--user", "daemon-reload"]],
+      ["loginctl", ["show-user", "gandy", "-p", "Linger", "--value"]],
+      ["loginctl", ["enable-linger", "gandy"]],
+      ["systemctl", ["--user", "enable", "--now", channelConfig.serviceUnitFile]],
+      ["systemctl", ["--user", "is-active", channelConfig.serviceUnitFile]],
+      ["systemctl", ["--user", "show", channelConfig.serviceUnitFile, "-p", "MainPID", "--value"]],
+    ]);
+  });
+
+  it("uninstalls a systemd service and reloads the user manager", () => {
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "stale");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "Unit not found" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+
+    expect(uninstallClientService()).toMatchObject({
+      platform: "systemd",
+      label: channelConfig.serviceUnitFile,
+      state: "not-installed",
+      unitPath,
+    });
+    expect(existsSync(unitPath)).toBe(false);
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["systemctl", ["--user", "disable", "--now", channelConfig.serviceUnitFile]],
+      ["systemctl", ["--user", "daemon-reload"]],
+    ]);
+  });
+
+  it("installs launchd service files and tolerates an initially unloaded label", () => {
+    setPlatform("darwin");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "service not loaded" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "Could not find service" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "state = running\npid = 321\n", stderr: "" });
+
+    const info = installClientService();
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    const wrapperPath = join(process.env.FIRST_TREE_HOME ?? "", "service", channelConfig.displayName);
+
+    expect(info).toMatchObject({
+      platform: "launchd",
+      label: channelConfig.launchdLabel,
+      state: "active",
+      pid: 321,
+      detail: "pid 321",
+      unitPath: plistPath,
+    });
+    expect(readFileSync(wrapperPath, "utf-8")).toContain(
+      `exec ${process.execPath} ${process.argv[1]} daemon start --no-interactive`,
+    );
+    expect(readFileSync(plistPath, "utf-8")).toContain(`<string>${wrapperPath}</string>`);
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["launchctl", ["bootout", `gui/501/${channelConfig.launchdLabel}`]],
+      ["launchctl", ["print", `gui/501/${channelConfig.launchdLabel}`]],
+      ["launchctl", ["bootstrap", "gui/501", plistPath]],
+      ["launchctl", ["enable", `gui/501/${channelConfig.launchdLabel}`]],
+      ["launchctl", ["print", `gui/501/${channelConfig.launchdLabel}`]],
+    ]);
+  });
+
+  it("uninstalls launchd files even when bootout reports the label is absent", () => {
+    setPlatform("darwin");
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    const wrapperPath = join(process.env.FIRST_TREE_HOME ?? "", "service", channelConfig.displayName);
+    mkdirSync(dirname(plistPath), { recursive: true });
+    mkdirSync(dirname(wrapperPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+    writeFileSync(wrapperPath, "wrapper");
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "Could not find service" });
+
+    expect(uninstallClientService()).toMatchObject({
+      platform: "launchd",
+      label: channelConfig.launchdLabel,
+      state: "not-installed",
+      unitPath: plistPath,
+    });
+    expect(existsSync(plistPath)).toBe(false);
+    expect(existsSync(wrapperPath)).toBe(false);
+  });
+
+  it("returns unsupported status for uninstall and throws install errors on unsupported platforms", () => {
+    setPlatform("win32");
+    expect(() => installClientService()).toThrow("Background service install is not supported on win32");
+    expect(uninstallClientService()).toMatchObject({
+      platform: "unsupported",
+      label: "",
+      state: "not-installed",
+      detail: "platform win32 not supported",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/status-blocks.test.ts
+++ b/apps/cli/src/__tests__/status-blocks.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const credentialsMock = vi.hoisted(() => vi.fn());
+const serviceSupportedMock = vi.hoisted(() => vi.fn());
+const serviceStatusMock = vi.hoisted(() => vi.fn());
+const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+vi.mock("../core/bootstrap.js", () => ({
+  loadCredentials: credentialsMock,
+}));
+
+vi.mock("../core/service-install.js", () => ({
+  getClientServiceStatus: serviceStatusMock,
+  isServiceSupported: serviceSupportedMock,
+}));
+
+const originalHome = process.env.FIRST_TREE_HOME;
+let home: string;
+
+beforeEach(() => {
+  home = join(tmpdir(), `ft-status-blocks-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(home, "config"), { recursive: true });
+  process.env.FIRST_TREE_HOME = home;
+  credentialsMock.mockReset();
+  serviceSupportedMock.mockReset();
+  serviceStatusMock.mockReset();
+  stderrSpy.mockClear();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalHome;
+});
+
+function output(): string {
+  return stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+}
+
+function refreshTokenWithExp(exp: number): string {
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+describe("status block renderers", () => {
+  it("renders CLI version, unsupported services, and service states", async () => {
+    const { renderCliVersionBlock, renderServiceBlock } = await import("../commands/_shared/status-blocks.js");
+
+    renderCliVersionBlock();
+    expect(output()).toContain("CLI:");
+
+    serviceSupportedMock.mockReturnValueOnce(false);
+    renderServiceBlock();
+    expect(output()).toContain(`not supported on ${process.platform}`);
+
+    stderrSpy.mockClear();
+    serviceSupportedMock.mockReturnValue(true);
+    for (const [state, expected] of [
+      ["active", "running"],
+      ["inactive", "stopped"],
+      ["not-installed", "not installed"],
+      ["unknown", "unknown"],
+    ] as const) {
+      serviceStatusMock.mockReturnValueOnce({
+        platform: state === "active" ? "systemd" : "launchd",
+        label: state === "active" ? "first-tree-dev.service" : "dev.first-tree",
+        state,
+        detail: state === "active" ? "pid 123" : "",
+      });
+      renderServiceBlock();
+      expect(output()).toContain(expected);
+    }
+    expect(output()).toContain("journalctl --user -u first-tree-dev -f");
+  });
+
+  it("renders hub configuration states", async () => {
+    const { renderHubBlock } = await import("../commands/_shared/status-blocks.js");
+
+    renderHubBlock();
+    expect(output()).toContain("not configured");
+
+    stderrSpy.mockClear();
+    writeFileSync(
+      join(home, "config", "client.yaml"),
+      "server:\n  url: https://hub.example\nclient:\n  id: client-1\n",
+    );
+    renderHubBlock();
+    expect(output()).toContain("https://hub.example");
+    expect(output()).toContain("client-1");
+
+    stderrSpy.mockClear();
+    writeFileSync(join(home, "config", "client.yaml"), "server: [");
+    renderHubBlock();
+    expect(output()).toContain("could not read");
+  });
+
+  it("renders auth token states", async () => {
+    const { renderAuthBlock } = await import("../commands/_shared/status-blocks.js");
+    const now = Math.floor(Date.now() / 1000);
+
+    credentialsMock.mockReturnValueOnce(null);
+    renderAuthBlock();
+    expect(output()).toContain("no credentials");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: "bad-token" });
+    renderAuthBlock();
+    expect(output()).toContain("could not parse refresh token");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: refreshTokenWithExp(now - 10) });
+    renderAuthBlock();
+    expect(output()).toContain("refresh token EXPIRED");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: refreshTokenWithExp(now + 3600) });
+    renderAuthBlock();
+    expect(output()).toContain("expires in ~1h");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: refreshTokenWithExp(now + 5 * 86400) });
+    renderAuthBlock();
+    expect(output()).toContain("valid for ~5d");
+  });
+
+  it("renders agent configuration counts and entries", async () => {
+    const { renderAgentsBlock } = await import("../commands/_shared/status-blocks.js");
+
+    renderAgentsBlock();
+    expect(output()).toContain("0 configured");
+
+    stderrSpy.mockClear();
+    const agentDir = join(home, "config", "agents", "kael");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "agent.yaml"), "agentId: agent-1\nruntime: claude-code\n");
+    renderAgentsBlock();
+    expect(output()).toContain("1 configured");
+    expect(output()).toContain("kael");
+    expect(output()).toContain("agent-1");
+  });
+});

--- a/apps/cli/src/__tests__/tree-binding-state.test.ts
+++ b/apps/cli/src/__tests__/tree-binding-state.test.ts
@@ -1,0 +1,277 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type BoundTreeReference,
+  buildStableSourceId,
+  buildTreeId,
+  deriveDefaultEntrypoint,
+  determineScope,
+  listTreeBindings,
+  readSourceState,
+  readTreeBinding,
+  readTreeState,
+  relativePathWithin,
+  removeSourceState,
+  type SourceState,
+  sourceStatePath,
+  type TreeBindingState,
+  treeBindingPath,
+  treeBindingsDir,
+  treeStatePath,
+  upsertWorkspaceMember,
+  type WorkspaceMember,
+  writeSourceState,
+  writeTreeBinding,
+  writeTreeState,
+} from "../commands/tree/binding-state.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-tree-binding-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function tree(overrides: Partial<BoundTreeReference> = {}): BoundTreeReference {
+  return {
+    entrypoint: overrides.entrypoint ?? "/repos/app",
+    remoteUrl: overrides.remoteUrl ?? "https://github.com/acme/context-tree.git",
+    treeId: overrides.treeId ?? "context-tree",
+    treeMode: overrides.treeMode ?? "shared",
+    treeRepoName: overrides.treeRepoName ?? "context-tree",
+  };
+}
+
+function sourceState(overrides: Partial<Omit<SourceState, "schemaVersion">> = {}): Omit<SourceState, "schemaVersion"> {
+  return {
+    bindingMode: overrides.bindingMode ?? "workspace-root",
+    rootKind: overrides.rootKind ?? "git-repo",
+    scope: overrides.scope ?? "workspace",
+    sourceId: overrides.sourceId ?? "workspace-root",
+    sourceName: overrides.sourceName ?? "First Tree Workspace",
+    tree: overrides.tree ?? tree({ entrypoint: "/workspaces/first-tree" }),
+    workspaceId: overrides.workspaceId ?? "first-tree",
+    ...(overrides.members ? { members: overrides.members } : {}),
+  };
+}
+
+function binding(
+  overrides: Partial<Omit<TreeBindingState, "schemaVersion">> = {},
+): Omit<TreeBindingState, "schemaVersion"> {
+  return {
+    bindingMode: overrides.bindingMode ?? "workspace-member",
+    entrypoint: overrides.entrypoint ?? "/workspaces/first-tree/repos/api",
+    remoteUrl: overrides.remoteUrl ?? "git@github.com:acme/api.git",
+    rootKind: overrides.rootKind ?? "git-repo",
+    scope: overrides.scope ?? "workspace",
+    sourceId: overrides.sourceId ?? "api",
+    sourceName: overrides.sourceName ?? "api",
+    treeMode: overrides.treeMode ?? "shared",
+    treeRepoName: overrides.treeRepoName ?? "context-tree",
+    workspaceId: overrides.workspaceId ?? "first-tree",
+  };
+}
+
+describe("tree binding state helpers", () => {
+  it("round-trips source and tree state with schema defaults", () => {
+    writeSourceState(root, sourceState());
+    writeTreeState(root, {
+      published: { remoteUrl: "git@github.com:acme/context-tree.git" },
+      treeId: "context-tree",
+      treeMode: "shared",
+      treeRepoName: "context-tree",
+    });
+
+    expect(readSourceState(root)).toMatchObject({
+      bindingMode: "workspace-root",
+      schemaVersion: 1,
+      sourceId: "workspace-root",
+      tree: { entrypoint: "/workspaces/first-tree" },
+    });
+    expect(readTreeState(root)).toEqual({
+      published: { remoteUrl: "git@github.com:acme/context-tree.git" },
+      schemaVersion: 1,
+      treeId: "context-tree",
+      treeMode: "shared",
+      treeRepoName: "context-tree",
+    });
+    expect(sourceStatePath(root)).toBe(join(root, ".first-tree", "source.json"));
+    expect(treeStatePath(root)).toBe(join(root, ".first-tree", "tree.json"));
+  });
+
+  it("rejects malformed source, tree, and binding documents", () => {
+    mkdirSync(treeBindingsDir(root), { recursive: true });
+    writeFileSync(sourceStatePath(root), JSON.stringify({ bindingMode: "workspace-root", sourceId: "missing-tree" }));
+    writeFileSync(treeStatePath(root), JSON.stringify({ treeId: "tree", treeMode: "invalid", treeRepoName: "tree" }));
+    writeFileSync(treeBindingPath(root, "bad"), JSON.stringify({ sourceId: "bad", treeMode: "shared" }));
+
+    expect(readSourceState(root)).toBeNull();
+    expect(readTreeState(root)).toBeNull();
+    expect(readTreeBinding(root, "bad")).toBeNull();
+  });
+
+  it("round-trips and sorts tree bindings while ignoring invalid files", () => {
+    writeTreeBinding(root, "zeta", binding({ sourceId: "zeta", sourceName: "zeta" }));
+    writeTreeBinding(root, "alpha", binding({ sourceId: "alpha", sourceName: "alpha" }));
+    writeFileSync(join(treeBindingsDir(root), "ignored.txt"), "{}");
+    writeFileSync(treeBindingPath(root, "broken"), JSON.stringify({ sourceId: "broken" }));
+
+    expect(readTreeBinding(root, "alpha")).toMatchObject({
+      sourceId: "alpha",
+      schemaVersion: 1,
+      remoteUrl: "git@github.com:acme/api.git",
+    });
+    expect(listTreeBindings(root).map((row) => row.sourceId)).toEqual(["alpha", "zeta"]);
+  });
+
+  it("returns null or empty values for missing state files", () => {
+    expect(readSourceState(root)).toBeNull();
+    expect(readTreeState(root)).toBeNull();
+    expect(readTreeBinding(root, "missing")).toBeNull();
+    expect(listTreeBindings(root)).toEqual([]);
+  });
+
+  it("builds stable identifiers and default entrypoints", () => {
+    expect(buildStableSourceId("Ignored", { remoteUrl: "git@github.com:Acme/API.git" })).toBe("github-com-acme-api");
+    expect(buildStableSourceId("Web App", { remoteUrl: "https://github.com/Acme/Web.git" })).toBe(
+      "github-com-acme-web",
+    );
+    expect(buildStableSourceId("Private App", { remoteUrl: "ssh://git@example.com/acme/private.git" })).toBe(
+      "example-com-acme-private",
+    );
+
+    expect(buildStableSourceId("Internal App", { remoteUrl: "ssh://git@gitlab.example/acme/internal.git" })).toBe(
+      "gitlab-example-acme-internal",
+    );
+
+    const custom = buildStableSourceId("Internal App", { remoteUrl: "not a remote url" });
+    expect(custom).toMatch(/^internal-app-[a-f0-9]{8}$/u);
+
+    const folder = buildStableSourceId("", { fallbackRoot: join(root, "My Folder") });
+    expect(folder).toMatch(/^my-folder-[a-f0-9]{8}$/u);
+    expect(buildTreeId("Context Tree!")).toBe("context-tree");
+    expect(determineScope("workspace-root")).toBe("workspace");
+    expect(determineScope("workspace-member")).toBe("workspace");
+    expect(determineScope("shared-source")).toBe("repo");
+    expect(determineScope("standalone-source")).toBe("repo");
+    expect(deriveDefaultEntrypoint("workspace-root", "Source Repo", "First Tree All")).toBe(
+      "/workspaces/first-tree-all",
+    );
+    expect(deriveDefaultEntrypoint("workspace-member", "First Tree", "First Tree All")).toBe(
+      "/workspaces/first-tree-all/repos/first-tree",
+    );
+    expect(deriveDefaultEntrypoint("shared-source", "First Tree")).toBe("/repos/first-tree");
+    expect(deriveDefaultEntrypoint("standalone-source", "First Tree")).toBe("/");
+    expect(relativePathWithin(root, join(root, "repos", "first-tree"))).toBe("repos/first-tree");
+  });
+
+  it("upserts workspace members without overwriting the root tree entrypoint", () => {
+    const existingMember: WorkspaceMember = {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/alpha",
+      rootKind: "git-repo",
+      sourceId: "alpha",
+      sourceName: "alpha",
+    };
+    writeSourceState(root, sourceState({ members: [existingMember] }));
+
+    upsertWorkspaceMember(root, "first-tree", tree({ entrypoint: "/workspaces/first-tree/repos/api" }), {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/api",
+      relativePath: "repos/api",
+      remoteUrl: "https://github.com/acme/api.git",
+      rootKind: "git-repo",
+      sourceId: "api",
+      sourceName: "api",
+    });
+    upsertWorkspaceMember(root, "first-tree", tree({ entrypoint: "/workspaces/first-tree/repos/api-v2" }), {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/api-v2",
+      rootKind: "git-repo",
+      sourceId: "api",
+      sourceName: "api",
+    });
+
+    const current = readSourceState(root);
+    expect(current?.tree.entrypoint).toBe("/workspaces/first-tree");
+    expect(current?.members?.map((member) => [member.sourceName, member.entrypoint])).toEqual([
+      ["alpha", "/workspaces/first-tree/repos/alpha"],
+      ["api", "/workspaces/first-tree/repos/api-v2"],
+    ]);
+  });
+
+  it("throws when upserting a member without workspace state and removes source state", () => {
+    expect(() =>
+      upsertWorkspaceMember(root, "first-tree", tree(), {
+        bindingMode: "workspace-member",
+        entrypoint: "/workspaces/first-tree/repos/api",
+        rootKind: "git-repo",
+        sourceId: "api",
+        sourceName: "api",
+      }),
+    ).toThrow("Cannot upsert workspace member");
+
+    writeSourceState(root, sourceState());
+    expect(existsSync(sourceStatePath(root))).toBe(true);
+    removeSourceState(root);
+    expect(existsSync(sourceStatePath(root))).toBe(false);
+  });
+
+  it("filters invalid workspace members when reading source state", () => {
+    mkdirSync(join(root, ".first-tree"), { recursive: true });
+    writeFileSync(
+      sourceStatePath(root),
+      JSON.stringify({
+        ...sourceState(),
+        members: [
+          { sourceId: "bad" },
+          {
+            bindingMode: "workspace-member",
+            entrypoint: "/workspaces/first-tree/repos/web",
+            relativePath: "repos/web",
+            remoteUrl: "https://github.com/acme/web.git",
+            rootKind: "git-repo",
+            sourceId: "web",
+            sourceName: "web",
+          },
+        ],
+      }),
+    );
+
+    expect(readSourceState(root)?.members).toEqual([
+      {
+        bindingMode: "workspace-member",
+        entrypoint: "/workspaces/first-tree/repos/web",
+        relativePath: "repos/web",
+        remoteUrl: "https://github.com/acme/web.git",
+        rootKind: "git-repo",
+        sourceId: "web",
+        sourceName: "web",
+      },
+    ]);
+  });
+
+  it("writes deterministic JSON documents", () => {
+    writeTreeBinding(root, "api", {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/api",
+      rootKind: "git-repo",
+      scope: "workspace",
+      sourceId: "api",
+      sourceName: "api",
+      treeMode: "shared",
+      treeRepoName: "context-tree",
+      workspaceId: "first-tree",
+    });
+    const text = readFileSync(treeBindingPath(root, "api"), "utf8");
+
+    expect(text).toContain('"schemaVersion": 1');
+    expect(text.endsWith("\n")).toBe(true);
+    expect(text).not.toContain("remoteUrl");
+  });
+});

--- a/apps/cli/src/__tests__/tree-repo-registry.test.ts
+++ b/apps/cli/src/__tests__/tree-repo-registry.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeTreeBinding } from "../commands/tree/binding-state.js";
+import {
+  buildTreeCodeRepoIndexNote,
+  listKnownTreeCodeRepos,
+  syncTreeCodeRepoRegistry,
+  upsertTreeCodeRepoRegistry,
+} from "../commands/tree/tree-repo-registry.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-tree-repo-registry-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function writePromptFile(name: "AGENTS.md" | "CLAUDE.md", text = "BEGIN CONTEXT-TREE FRAMEWORK\n"): string {
+  const path = join(root, name);
+  writeFileSync(path, text);
+  return path;
+}
+
+describe("tree code repo registry", () => {
+  it("creates managed blocks in existing prompt files with normalized, deduped GitHub repos", () => {
+    writePromptFile("AGENTS.md");
+    writePromptFile("CLAUDE.md", "# Project-Specific Instructions\n\nExisting notes\n");
+
+    const action = syncTreeCodeRepoRegistry(root, [
+      "git@github.com:acme/api.git",
+      "https://github.com/acme/web.git",
+      "https://gitlab.example/acme/ignored.git",
+      "https://github.com/acme/api",
+    ]);
+
+    expect(action).toBe("updated");
+    const agents = readFileSync(join(root, "AGENTS.md"), "utf8");
+    expect(agents).toContain("BEGIN FIRST-TREE-CODE-REPO-REGISTRY");
+    expect(agents).toContain("- [acme/api](https://github.com/acme/api)");
+    expect(agents).toContain("- [acme/web](https://github.com/acme/web)");
+    expect(agents).not.toContain("gitlab.example");
+
+    const claude = readFileSync(join(root, "CLAUDE.md"), "utf8");
+    expect(claude.indexOf("BEGIN FIRST-TREE-CODE-REPO-REGISTRY")).toBeLessThan(
+      claude.indexOf("# Project-Specific Instructions"),
+    );
+    expect(listKnownTreeCodeRepos(root).map((repo) => repo.slug)).toEqual(["acme/api", "acme/web"]);
+  });
+
+  it("updates an existing managed block and reports unchanged on a second identical sync", () => {
+    writePromptFile(
+      "AGENTS.md",
+      [
+        "Intro",
+        "<!-- BEGIN FIRST-TREE-CODE-REPO-REGISTRY -->",
+        "old block",
+        "<!--",
+        "FIRST-TREE-CODE-REPO-REGISTRY: managed-block-v1",
+        "FIRST-TREE-CODE-REPO: `https://github.com/acme/old`",
+        "-->",
+        "<!-- END FIRST-TREE-CODE-REPO-REGISTRY -->",
+        "Tail",
+        "",
+      ].join("\n"),
+    );
+
+    expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/new.git"])).toBe("updated");
+    const current = readFileSync(join(root, "AGENTS.md"), "utf8");
+    expect(current).toContain("- [acme/new](https://github.com/acme/new)");
+    expect(current).not.toContain("acme/old");
+    expect(current).toContain("Tail");
+    expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/new.git"])).toBe("unchanged");
+  });
+
+  it("falls back to tree bindings when prompt files do not have a managed block", () => {
+    writePromptFile("AGENTS.md", "No managed registry here\n");
+    mkdirSync(join(root, ".first-tree"), { recursive: true });
+    writeTreeBinding(root, "web", {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/acme/repos/web",
+      remoteUrl: "git@github.com:acme/web.git",
+      rootKind: "git-repo",
+      scope: "workspace",
+      sourceId: "web",
+      sourceName: "web",
+      treeMode: "shared",
+      treeRepoName: "context-tree",
+      workspaceId: "acme",
+    });
+    writeTreeBinding(root, "invalid", {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/acme/repos/internal",
+      remoteUrl: "https://gitlab.example/acme/internal.git",
+      rootKind: "git-repo",
+      scope: "workspace",
+      sourceId: "internal",
+      sourceName: "internal",
+      treeMode: "shared",
+      treeRepoName: "context-tree",
+      workspaceId: "acme",
+    });
+
+    expect(listKnownTreeCodeRepos(root)).toEqual([
+      { name: "web", slug: "acme/web", url: "https://github.com/acme/web" },
+    ]);
+  });
+
+  it("upserts one repository while preserving known entries and skips invalid input or missing files", () => {
+    writePromptFile("AGENTS.md");
+    expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git"])).toBe("updated");
+
+    expect(upsertTreeCodeRepoRegistry(root, "git@github.com:acme/api.git")).toBe("updated");
+    expect(listKnownTreeCodeRepos(root).map((repo) => repo.slug)).toEqual(["acme/api", "acme/web"]);
+    expect(upsertTreeCodeRepoRegistry(root, "not a github remote")).toBe("skipped");
+
+    const missingRoot = mkdtempSync(join(tmpdir(), "ft-tree-repo-registry-missing-"));
+    try {
+      expect(syncTreeCodeRepoRegistry(missingRoot, ["https://github.com/acme/web.git"])).toBe("skipped");
+      expect(existsSync(join(missingRoot, "AGENTS.md"))).toBe(false);
+    } finally {
+      rmSync(missingRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("builds the source repo index note", () => {
+    expect(buildTreeCodeRepoIndexNote()).toContain("source-repos.md");
+  });
+});

--- a/apps/cli/src/__tests__/tree-skill-command.test.ts
+++ b/apps/cli/src/__tests__/tree-skill-command.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { skillSubcommands } from "../commands/tree/skill.js";
+
+let root: string;
+let stdout = "";
+const stdoutSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+  stdout += `${args.join(" ")}\n`;
+});
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-tree-skill-command-"));
+  stdout = "";
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  stdoutSpy.mockClear();
+  process.exitCode = undefined;
+});
+
+function installSkill(name: string, options: { cliCompat?: string; link?: boolean; version?: string } = {}): void {
+  const skillRoot = join(root, ".agents", "skills", name);
+  mkdirSync(join(skillRoot, "agents"), { recursive: true });
+  const version = options.version ?? "1.0.0";
+  writeFileSync(
+    join(skillRoot, "SKILL.md"),
+    `---\nname: ${name}\nversion: ${version}\ncliCompat:\n  first-tree: "${options.cliCompat ?? ">=0.0.0"}"\n---\n# ${name}\n`,
+  );
+  writeFileSync(join(skillRoot, "VERSION"), `${version}\n`);
+  writeFileSync(join(skillRoot, "agents", "openai.yaml"), "name: test\n");
+  if (options.link ?? true) {
+    mkdirSync(join(root, ".claude", "skills"), { recursive: true });
+    symlinkSync(join("..", "..", ".agents", "skills", name), join(root, ".claude", "skills", name));
+  }
+}
+
+async function runSkillCommand(argv: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  const group = program.command("skill");
+  for (const subcommand of skillSubcommands) {
+    const command = group.command(subcommand.name).description(subcommand.description);
+    subcommand.configure?.(command);
+    command.option("--json", "json output");
+    command.action(async () => {
+      const options = command.opts() as { json?: boolean };
+      await subcommand.action({ command, options: { debug: false, json: options.json === true, quiet: false } });
+    });
+  }
+
+  await program.parseAsync(["node", "test", "skill", ...argv]);
+}
+
+describe("tree skill command actions", () => {
+  it("prints list output in table and JSON modes", async () => {
+    installSkill("attention");
+
+    await runSkillCommand(["list", "--root", root]);
+    expect(stdout).toContain("NAME");
+    expect(stdout).toContain("attention");
+    expect(stdout).toContain("installed");
+    expect(stdout).toContain("first-tree");
+    expect(stdout).toContain("missing");
+
+    stdout = "";
+    await runSkillCommand(["list", "--root", root, "--json"]);
+    const rows = JSON.parse(stdout) as Array<{ name: string; installed: boolean }>;
+    expect(rows.find((row) => row.name === "attention")).toMatchObject({ installed: true });
+  });
+
+  it("reports doctor failures, incompatible ranges, and repair hints", async () => {
+    installSkill("attention", { cliCompat: ">999.0.0" });
+    installSkill("github-scan", { link: false });
+
+    await runSkillCommand(["doctor", "--root", root]);
+
+    expect(process.exitCode).toBe(1);
+    expect(stdout).toContain("=== first-tree tree skill doctor ===");
+    expect(stdout).toContain("FAIL attention");
+    expect(stdout).toContain("requires first-tree >999.0.0");
+    expect(stdout).toContain("Repair shipped skill payloads with:");
+    expect(stdout).toContain("first-tree tree skill link");
+  });
+
+  it("prints doctor JSON without human repair hints", async () => {
+    await runSkillCommand(["doctor", "--root", root, "--json"]);
+
+    expect(process.exitCode).toBe(1);
+    const rows = JSON.parse(stdout) as Array<{ name: string; ok: boolean }>;
+    expect(rows.some((row) => row.name === "first-tree" && !row.ok)).toBe(true);
+  });
+
+  it("links missing Claude aliases", async () => {
+    installSkill("attention", { link: false });
+    await runSkillCommand(["link", "--root", root]);
+
+    expect(stdout).toContain("linked .claude/skills/attention -> ../../.agents/skills/attention");
+    expect(stdout).toContain("Linked 1 symlink(s)");
+  });
+
+  it("installs and upgrades shipped skills", async () => {
+    await runSkillCommand(["install", "--root", root]);
+    expect(stdout).toContain("Installed 7 shipped first-tree skills");
+
+    stdout = "";
+    await runSkillCommand(["upgrade", "--root", root]);
+    expect(stdout).toContain("Upgraded 7 shipped first-tree skills");
+  });
+});

--- a/apps/cli/src/__tests__/tree-skill-lib.test.ts
+++ b/apps/cli/src/__tests__/tree-skill-lib.test.ts
@@ -1,0 +1,216 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  collectSkillDiagnosis,
+  collectSkillStatus,
+  inspectSkillEntry,
+  repairClaudeSkillLinks,
+  SKILL_NAMES,
+  type SkillName,
+  upsertWhitepaperFile,
+} from "../commands/tree/skill-lib.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-tree-skill-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function installSkill(
+  name: SkillName,
+  options: {
+    cliCompat?: string;
+    frontmatterVersion?: string;
+    includeFrontmatter?: boolean;
+    includeOpenAiConfig?: boolean;
+    version?: string;
+  } = {},
+): string {
+  const skillRoot = join(root, ".agents", "skills", name);
+  mkdirSync(join(skillRoot, "agents"), { recursive: true });
+  const version = options.version ?? "1.2.3";
+  const includeFrontmatter = options.includeFrontmatter ?? true;
+  const cliCompat = options.cliCompat ?? ">=0.0.0";
+  const frontmatterVersion = options.frontmatterVersion ?? version;
+  const frontmatter = includeFrontmatter
+    ? `---\nname: ${name}\nversion: ${frontmatterVersion}\ncliCompat:\n  first-tree: "${cliCompat}"\n---\n`
+    : "";
+
+  writeFileSync(join(skillRoot, "SKILL.md"), `${frontmatter}# ${name}\n`);
+  writeFileSync(join(skillRoot, "VERSION"), `${version}\n`);
+  if (options.includeOpenAiConfig ?? true) {
+    writeFileSync(join(skillRoot, "agents", "openai.yaml"), "name: test\n");
+  }
+
+  return skillRoot;
+}
+
+function linkClaudeSkill(name: SkillName, target = join("..", "..", ".agents", "skills", name)): void {
+  const claudeRoot = join(root, ".claude", "skills");
+  mkdirSync(claudeRoot, { recursive: true });
+  symlinkSync(target, join(claudeRoot, name));
+}
+
+describe("tree skill library", () => {
+  it("inspects missing entries, directories, and symlinks", () => {
+    const directory = join(root, "skill-dir");
+    const symlink = join(root, "skill-link");
+    mkdirSync(directory);
+    symlinkSync("skill-dir", symlink);
+
+    expect(inspectSkillEntry(join(root, "missing"))).toEqual({ kind: "missing", target: null });
+    expect(inspectSkillEntry(directory)).toEqual({ kind: "directory", target: null });
+    expect(inspectSkillEntry(symlink)).toEqual({ kind: "symlink", target: "skill-dir" });
+  });
+
+  it("collects installed status with version and compatibility metadata", () => {
+    installSkill("attention", { cliCompat: ">=0.0.0 <999.0.0" });
+    linkClaudeSkill("attention");
+
+    const rows = collectSkillStatus(root);
+    const attention = rows.find((row) => row.name === "attention");
+    const firstTree = rows.find((row) => row.name === "first-tree");
+
+    expect(rows).toHaveLength(SKILL_NAMES.length);
+    expect(attention).toMatchObject({
+      agentsKind: "directory",
+      claudeKind: "symlink",
+      cliCompat: ">=0.0.0 <999.0.0",
+      compatible: true,
+      installed: true,
+      name: "attention",
+      version: "1.2.3",
+    });
+    expect(attention?.claudeTarget).toBe("../../.agents/skills/attention");
+    expect(firstTree).toMatchObject({
+      installed: false,
+      compatible: null,
+      version: null,
+    });
+  });
+
+  it("diagnoses missing files, bad frontmatter, bad symlinks, and incompatible CLI ranges", () => {
+    installSkill("attention", { includeOpenAiConfig: false });
+    linkClaudeSkill("attention", "wrong-target");
+
+    installSkill("github-scan", { includeFrontmatter: false });
+    linkClaudeSkill("github-scan");
+
+    installSkill("first-tree-sync", { version: "2.0.0", frontmatterVersion: "3.0.0" });
+    linkClaudeSkill("first-tree-sync");
+
+    installSkill("first-tree-write", { cliCompat: ">999.0.0" });
+    linkClaudeSkill("first-tree-write");
+
+    installSkill("first-tree-onboarding", { cliCompat: "not-a-range" });
+    linkClaudeSkill("first-tree-onboarding");
+
+    const rows = collectSkillDiagnosis(root);
+    const byName = new Map(rows.map((row) => [row.name, row]));
+
+    expect(byName.get("attention")?.problems).toEqual(
+      expect.arrayContaining([
+        ".agents/skills/attention/agents/openai.yaml does not exist",
+        ".claude/skills/attention -> wrong-target, expected ../../.agents/skills/attention",
+      ]),
+    );
+    expect(byName.get("github-scan")?.problems).toEqual(
+      expect.arrayContaining([
+        ".agents/skills/github-scan/SKILL.md frontmatter is missing version",
+        ".agents/skills/github-scan/SKILL.md frontmatter is missing cliCompat.first-tree",
+      ]),
+    );
+    expect(byName.get("first-tree-sync")?.problems).toContain(
+      ".agents/skills/first-tree-sync/SKILL.md version 3.0.0 does not match VERSION 2.0.0",
+    );
+    expect(byName.get("first-tree-write")?.incompatibleCliCompat).toBe(">999.0.0");
+    expect(byName.get("first-tree-write")?.problems.join("\n")).toContain("requires first-tree >999.0.0");
+    expect(byName.get("first-tree-onboarding")?.problems).toContain(
+      "first-tree-onboarding has an unreadable cliCompat range: not-a-range",
+    );
+    expect(byName.get("first-tree")?.problems).toEqual(
+      expect.arrayContaining(["missing: .agents/skills/first-tree", "missing: .claude/skills/first-tree"]),
+    );
+  });
+
+  it("accepts a complete first-tree skill with reference files", () => {
+    const skillRoot = installSkill("first-tree");
+    for (const file of [
+      join("references", "structure.md"),
+      join("references", "functions.md"),
+      join("references", "anti-patterns.md"),
+      join("references", "maintenance.md"),
+      join("references", "cli-manual.md"),
+      join("references", "llms.txt"),
+    ]) {
+      mkdirSync(join(skillRoot, "references"), { recursive: true });
+      writeFileSync(join(skillRoot, file), "content\n");
+    }
+    linkClaudeSkill("first-tree");
+
+    const row = collectSkillDiagnosis(root).find((candidate) => candidate.name === "first-tree");
+    expect(row).toMatchObject({ ok: true, problems: [] });
+  });
+
+  it("repairs Claude skill links for installed agent skills and skips missing installs", () => {
+    installSkill("attention");
+    installSkill("github-scan");
+    mkdirSync(join(root, ".claude", "skills", "attention"), { recursive: true });
+
+    const result = repairClaudeSkillLinks(root);
+
+    expect(result.linked).toBe(2);
+    expect(result.skipped).toBe(SKILL_NAMES.length - 2);
+    expect(result.messages).toEqual(
+      expect.arrayContaining([
+        "linked .claude/skills/attention -> ../../.agents/skills/attention",
+        "linked .claude/skills/github-scan -> ../../.agents/skills/github-scan",
+      ]),
+    );
+    expect(readlinkSync(join(root, ".claude", "skills", "attention"))).toBe("../../.agents/skills/attention");
+    expect(readlinkSync(join(root, ".claude", "skills", "github-scan"))).toBe("../../.agents/skills/github-scan");
+  });
+
+  it("leaves already-correct Claude skill links unchanged", () => {
+    installSkill("attention");
+    linkClaudeSkill("attention");
+
+    expect(repairClaudeSkillLinks(root)).toEqual({ linked: 0, skipped: SKILL_NAMES.length - 1, messages: [] });
+  });
+
+  it("manages the WHITEPAPER symlink without replacing user files or directories", () => {
+    expect(upsertWhitepaperFile(root)).toBe("created");
+    expect(readlinkSync(join(root, "WHITEPAPER.md"))).toBe(join(".agents", "skills", "first-tree", "SKILL.md"));
+    expect(upsertWhitepaperFile(root)).toBe("unchanged");
+
+    rmSync(join(root, "WHITEPAPER.md"));
+    symlinkSync("old-target", join(root, "WHITEPAPER.md"));
+    expect(upsertWhitepaperFile(root)).toBe("updated");
+    expect(readlinkSync(join(root, "WHITEPAPER.md"))).toBe(join(".agents", "skills", "first-tree", "SKILL.md"));
+
+    rmSync(join(root, "WHITEPAPER.md"));
+    writeFileSync(join(root, "WHITEPAPER.md"), "custom\n");
+    expect(upsertWhitepaperFile(root)).toBe("skipped");
+    expect(readFileSync(join(root, "WHITEPAPER.md"), "utf8")).toBe("custom\n");
+
+    rmSync(join(root, "WHITEPAPER.md"));
+    mkdirSync(join(root, "WHITEPAPER.md"));
+    expect(upsertWhitepaperFile(root)).toBe("skipped");
+    expect(existsSync(join(root, "WHITEPAPER.md"))).toBe(true);
+  });
+});

--- a/apps/cli/src/__tests__/tree-verify-workspace-sync.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-workspace-sync.test.ts
@@ -1,0 +1,227 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeTreeState } from "../commands/tree/binding-state.js";
+import { buildSourceIntegrationBlock } from "../commands/tree/source-integration.js";
+import { syncTreeIdentityFiles } from "../commands/tree/tree-identity.js";
+import type { CommandContext } from "../commands/types.js";
+
+const tempDirs: string[] = [];
+const originalCwd = process.cwd();
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function context(command: Command, json = false): CommandContext {
+  return {
+    command,
+    options: {
+      debug: false,
+      json,
+      quiet: false,
+    },
+  };
+}
+
+function commandWithOptions(options: Record<string, unknown>): Command {
+  const command = new Command("test");
+  for (const [key, value] of Object.entries(options)) {
+    command.setOptionValue(key, value);
+  }
+  return command;
+}
+
+function writeValidTree(root: string): void {
+  mkdirSync(join(root, ".first-tree"), { recursive: true });
+  writeFileSync(join(root, ".git"), "gitdir: /tmp/tree\n");
+  writeFileSync(join(root, "NODE.md"), ["---", "title: Root", "owners: [team]", "---", "", "# Root", ""].join("\n"));
+  writeFileSync(join(root, "AGENTS.md"), "BEGIN CONTEXT-TREE FRAMEWORK\n");
+  writeFileSync(join(root, "CLAUDE.md"), "BEGIN CONTEXT-TREE FRAMEWORK\n");
+  writeFileSync(join(root, ".first-tree", "VERSION"), "1\n");
+  writeFileSync(join(root, ".first-tree", "progress.md"), "- [x] done\n");
+  mkdirSync(join(root, "members", "gandy"), { recursive: true });
+  writeFileSync(
+    join(root, "members", "gandy", "NODE.md"),
+    [
+      "---",
+      "title: Gandy",
+      "owners: [gandy]",
+      "type: human",
+      "role: Engineer",
+      "domains: [platform]",
+      "---",
+      "",
+      "# Gandy",
+      "",
+    ].join("\n"),
+  );
+  writeTreeState(root, {
+    treeId: "context-tree",
+    treeMode: "shared",
+    treeRepoName: "context-tree",
+    published: { remoteUrl: "https://github.com/acme/context-tree.git" },
+  });
+  syncTreeIdentityFiles(root, {
+    treeMode: "shared",
+    treeRepoName: "context-tree",
+    publishedTreeUrl: "https://github.com/acme/context-tree.git",
+  });
+}
+
+function makeGitRepo(root: string): void {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, ".git"), "gitdir: /tmp/mock\n");
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+  process.exitCode = undefined;
+});
+
+describe("tree verify command", () => {
+  it("reports successful validation as JSON", async () => {
+    const root = makeTempDir("ft-tree-verify-ok-");
+    writeValidTree(root);
+    const { verifyCommand } = await import("../commands/tree/verify.js");
+
+    verifyCommand.action(context(commandWithOptions({ treePath: root }), true));
+
+    const payload = JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])) as {
+      ok: boolean;
+      targetRoot: string;
+      checks: { progress: { uncheckedItems: string[] } };
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.targetRoot).toBe(root);
+    expect(payload.checks.progress.uncheckedItems).toEqual([]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("reports missing files, invalid frontmatter, validator errors, and unchecked progress", async () => {
+    const root = makeTempDir("ft-tree-verify-fail-");
+    mkdirSync(join(root, ".first-tree"), { recursive: true });
+    writeFileSync(join(root, ".git"), "gitdir: /tmp/tree\n");
+    writeFileSync(join(root, "NODE.md"), "---\ntitle: Missing owners\n---\n# Root\n");
+    writeFileSync(join(root, "AGENTS.md"), "no framework marker\n");
+    writeFileSync(join(root, ".first-tree", "progress.md"), "- [ ] Decide owner\n");
+
+    const { verifyCommand } = await import("../commands/tree/verify.js");
+    verifyCommand.action(context(commandWithOptions({ treePath: root }), false));
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("[FAIL] framework version");
+    expect(output).toContain("Root NODE.md is missing owners");
+    expect(output).toContain("Unchecked progress item: Decide owner");
+    expect(output).toContain("Some checks failed");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("explains when verify is run from a source integration instead of the tree repo", async () => {
+    const root = makeTempDir("ft-tree-verify-source-");
+    makeGitRepo(root);
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      buildSourceIntegrationBlock("context-tree", {
+        bindingMode: "shared-source",
+        treeMode: "shared",
+        treeRepoName: "context-tree",
+        treeRepoUrl: "https://github.com/acme/context-tree.git",
+      }),
+    );
+    const { verifyCommand } = await import("../commands/tree/verify.js");
+
+    verifyCommand.action(context(commandWithOptions({ treePath: root }), false));
+
+    expect(
+      vi
+        .mocked(console.error)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("Verify the tree repo instead");
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe("tree workspace sync command", () => {
+  it("prints a dry-run plan for child repos", async () => {
+    const workspace = makeTempDir("ft-workspace-sync-dry-");
+    makeGitRepo(join(workspace, "repo-a"));
+    makeGitRepo(join(workspace, "nested", "repo-b"));
+    const tree = makeTempDir("ft-workspace-sync-tree-");
+    writeValidTree(tree);
+    process.chdir(workspace);
+    const { workspaceSyncCommand } = await import("../commands/tree/workspace-sync.js");
+
+    workspaceSyncCommand.action(
+      context(commandWithOptions({ dryRun: true, treePath: tree, workspaceId: "acme-workspace" }), false),
+    );
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("Context Tree Workspace Sync");
+    expect(output).toContain("Workspace id:   acme-workspace");
+    expect(output).toContain("repo-a");
+    expect(output).toContain(join("nested", "repo-b"));
+  });
+
+  it("binds child repositories and updates workspace gitignore", async () => {
+    const workspace = makeTempDir("ft-workspace-sync-apply-");
+    makeGitRepo(workspace);
+    const repoA = join(workspace, "repo-a");
+    const repoB = join(workspace, "repo-b");
+    makeGitRepo(repoA);
+    makeGitRepo(repoB);
+    const tree = makeTempDir("ft-workspace-sync-apply-tree-");
+    writeValidTree(tree);
+    const { syncWorkspaceMembersFromRoot } = await import("../commands/tree/workspace-sync.js");
+
+    const hadFailure = syncWorkspaceMembersFromRoot({
+      workspaceRoot: workspace,
+      workspaceId: "acme-workspace",
+      treePath: tree,
+      treeUrl: "https://github.com/acme/context-tree.git",
+    });
+
+    expect(hadFailure).toBe(false);
+    expect(readFileSync(join(workspace, ".gitignore"), "utf8")).toContain(".first-tree/tmp/");
+    expect(readFileSync(join(repoA, "AGENTS.md"), "utf8")).toContain("workspace member");
+    expect(readFileSync(join(repoA, "AGENTS.md"), "utf8")).toContain("acme-workspace");
+    expect(readFileSync(join(repoB, "CLAUDE.md"), "utf8")).toContain("context-tree");
+  });
+
+  it("sets exitCode when no shared tree can be resolved", async () => {
+    const workspace = makeTempDir("ft-workspace-sync-missing-tree-");
+    process.chdir(workspace);
+    const { workspaceSyncCommand } = await import("../commands/tree/workspace-sync.js");
+
+    workspaceSyncCommand.action(context(commandWithOptions({}), false));
+
+    expect(
+      vi
+        .mocked(console.error)
+        .mock.calls.map((call) => String(call[0]))
+        .join("\n"),
+    ).toContain("Could not resolve the shared tree");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelConfig } from "../core/channel.js";
+
+const updateMocks = vi.hoisted(() => ({
+  detectInstallMode: vi.fn(),
+  installGlobalSpec: vi.fn(),
+  PACKAGE_NAME: "first-tree",
+}));
+
+const updateStateMocks = vi.hoisted(() => ({
+  isLoopGuarded: vi.fn(),
+  recordUpdateAttempt: vi.fn(),
+}));
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const printLineMock = vi.hoisted(() => vi.fn());
+const exitMock = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+  throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+});
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+vi.mock("../core/update.js", () => updateMocks);
+vi.mock("../core/update-state.js", () => updateStateMocks);
+vi.mock("../core/output.js", () => ({
+  print: { line: printLineMock },
+}));
+
+function output(): string {
+  return printLineMock.mock.calls.map((call) => String(call[0])).join("");
+}
+
+describe("update glue", () => {
+  beforeEach(() => {
+    updateMocks.detectInstallMode.mockReset();
+    updateMocks.installGlobalSpec.mockReset();
+    updateStateMocks.isLoopGuarded.mockReset();
+    updateStateMocks.recordUpdateAttempt.mockReset();
+    spawnSyncMock.mockReset();
+    printLineMock.mockClear();
+    exitMock.mockClear();
+
+    updateMocks.detectInstallMode.mockReturnValue("global");
+    updateMocks.installGlobalSpec.mockResolvedValue({
+      ok: true,
+      mode: "global",
+      installedVersion: "0.6.0",
+    });
+    updateStateMocks.isLoopGuarded.mockReturnValue(false);
+    spawnSyncMock.mockReturnValue({ status: 0, signal: null });
+  });
+
+  it("declines prompts and skips unsupported install modes", async () => {
+    const { createExecuteUpdate, declineUpdate, promptUpdate } = await import("../core/update-glue.js");
+
+    await expect(declineUpdate({ currentVersion: "0.5.0", targetVersion: "0.6.0", timeoutSeconds: 1 })).resolves.toBe(
+      false,
+    );
+    await expect(promptUpdate({ currentVersion: "0.5.0", targetVersion: "0.6.0", timeoutSeconds: 0 })).resolves.toBe(
+      false,
+    );
+
+    updateMocks.detectInstallMode.mockReturnValueOnce("source");
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: false });
+    expect(output()).toContain("Running from source checkout");
+
+    printLineMock.mockClear();
+    updateMocks.detectInstallMode.mockReturnValueOnce("npx");
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: false });
+    expect(output()).toContain("Cannot self-update");
+  });
+
+  it("refuses loop-guarded targets and records install failures", async () => {
+    const { createExecuteUpdate } = await import("../core/update-glue.js");
+    updateStateMocks.isLoopGuarded.mockReturnValueOnce(true);
+
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(updateMocks.installGlobalSpec).not.toHaveBeenCalled();
+    expect(output()).toContain("Refusing to retry 0.6.0");
+
+    const onUpdateFailed = vi.fn();
+    updateMocks.installGlobalSpec.mockResolvedValueOnce({
+      ok: false,
+      mode: "global",
+      reason: "network down",
+      retryable: true,
+      reasonCode: "network",
+    });
+
+    await expect(
+      createExecuteUpdate({ managed: false, onUpdateFailed })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: false });
+    expect(updateStateMocks.recordUpdateAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ result: "failed", reason: "network down", target: "0.6.0" }),
+    );
+    expect(onUpdateFailed).toHaveBeenCalledWith({
+      targetVersion: "0.6.0",
+      retryable: true,
+      reasonCode: "network",
+    });
+  });
+
+  it("blocks stale installs and returns manual restart hints for foreground clients", async () => {
+    const { createExecuteUpdate } = await import("../core/update-glue.js");
+    updateMocks.installGlobalSpec.mockResolvedValueOnce({
+      ok: true,
+      mode: "global",
+      installedVersion: "0.5.5",
+    });
+
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(updateStateMocks.recordUpdateAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ result: "blocked", installedVersion: "0.5.5" }),
+    );
+    expect(output()).toContain("Skipping restart to avoid");
+
+    printLineMock.mockClear();
+    updateMocks.installGlobalSpec.mockResolvedValueOnce({
+      ok: true,
+      mode: "global",
+      installedVersion: null,
+    });
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(updateStateMocks.recordUpdateAttempt).toHaveBeenLastCalledWith(
+      expect.objectContaining({ result: "ok", installedVersion: null }),
+    );
+    expect(output()).toContain("Restart the client manually");
+  });
+
+  it("refreshes the service unit and exits with the self-restart code for managed clients", async () => {
+    const { SELF_RESTART_EXIT_CODE, createExecuteUpdate } = await import("../core/update-glue.js");
+
+    await expect(
+      createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      channelConfig.binName,
+      ["daemon", "refresh-unit"],
+      expect.objectContaining({ timeout: 45_000 }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(SELF_RESTART_EXIT_CODE);
+
+    printLineMock.mockClear();
+    spawnSyncMock.mockReturnValueOnce({ status: 7, signal: "SIGTERM" });
+    await expect(
+      createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+    expect(output()).toContain("warning: 'daemon refresh-unit' exited with status 7");
+  });
+});

--- a/packages/client/src/__tests__/child-process-registry.test.ts
+++ b/packages/client/src/__tests__/child-process-registry.test.ts
@@ -59,7 +59,26 @@ describe("ChildProcessRegistry", () => {
     const registry = getChildProcessRegistry();
     // `node` subprocess that traps SIGTERM and stays alive — we use a small
     // inline script so the test does not need extra fixtures.
-    const child = spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setTimeout(() => {}, 60000);"]);
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.on('SIGTERM', () => {}); process.stdout.write('ready\\n'); setTimeout(() => {}, 60000);"],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const stdout = child.stdout;
+    if (!stdout) throw new Error("child stdout unavailable");
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("child did not become ready")), 5_000);
+      const onError = (error: Error) => {
+        clearTimeout(timer);
+        reject(error);
+      };
+      stdout.once("data", () => {
+        clearTimeout(timer);
+        child.off("error", onError);
+        resolve();
+      });
+      child.once("error", onError);
+    });
     const record = registry.adopt(child, {
       category: "other",
       label: "ignore-sigterm",

--- a/packages/client/src/__tests__/doc-snapshots.fs-mocks.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.fs-mocks.test.ts
@@ -199,6 +199,7 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
     const outsideTarget = join(outside, "external.md");
     await writeFile(target, "# flip\n", "utf8");
     await writeFile(outsideTarget, "# external\n", "utf8");
+    const targetReal = await realpath(target);
     const outsideReal = await realpath(outsideTarget);
     let targetRealpathCalls = 0;
 
@@ -208,7 +209,7 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
       return {
         ...actual,
         realpath: async (path: string) => {
-          if (path === target) {
+          if (path === targetReal) {
             targetRealpathCalls += 1;
             if (targetRealpathCalls === 2) return outsideReal;
           }
@@ -236,6 +237,7 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
     await mkdir(join(root, ".agent"), { recursive: true });
     await writeFile(target, "# flip\n", "utf8");
     await writeFile(hiddenTarget, "# secret\n", "utf8");
+    const targetReal = await realpath(target);
     const hiddenReal = await realpath(hiddenTarget);
     let targetRealpathCalls = 0;
 
@@ -245,7 +247,7 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
       return {
         ...actual,
         realpath: async (path: string) => {
-          if (path === target) {
+          if (path === targetReal) {
             targetRealpathCalls += 1;
             if (targetRealpathCalls === 2) return hiddenReal;
           }

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -883,7 +883,7 @@ describe("buildMessageDocumentSnapshots — wide self-fence over agent home", ()
       const rejected = join(rootScoped, "query?x", "note.md");
       await mkdir(join(rootScoped, "query?x"), { recursive: true });
       await writeFile(rejected, "# rejected\n", "utf8");
-      const relativeToRoot = abs.startsWith("/") ? abs.slice(1) : abs;
+      const relativeToRoot = (await realpath(abs)).replace(/^\/+/, "");
 
       const absoluteOut = await buildMessageDocumentSnapshots(`see ${abs}`, "/");
       const relativeOut = await buildMessageDocumentSnapshots(`see ${relativeToRoot}`, "/");

--- a/packages/github-scan/tests/github-scan/github-scan-auto-revert.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-auto-revert.test.ts
@@ -36,6 +36,13 @@ import type { InboxEntry } from "../../src/github-scan/engine/runtime/types.js";
 const AGENT = "first-tree-bot";
 const LABEL_TS = "2026-04-30T10:00:00Z";
 
+function pageFromArgs(args: readonly string[]): number {
+  const url = args[1] ?? "";
+  const match = /[?&]page=(\d+)/.exec(url);
+  const page = match?.[1];
+  return page ? Number.parseInt(page, 10) : 1;
+}
+
 function makeEntry(overrides: Partial<InboxEntry> = {}): InboxEntry {
   return {
     id: "n-1",
@@ -384,9 +391,7 @@ describe("fetchHumanLabelAppliedAt — pagination (issue #365)", () => {
     const state = { calls: 0 };
     const run = (args: readonly string[]): GhExecResult => {
       state.calls++;
-      const url = args[1] ?? "";
-      const match = /[?&]page=(\d+)/.exec(url);
-      const page = match ? Number.parseInt(match[1]!, 10) : 1;
+      const page = pageFromArgs(args);
       const body = pages[page - 1] ?? [];
       return { status: 0, stdout: JSON.stringify(body), stderr: "" };
     };
@@ -472,9 +477,7 @@ describe("fetchIssueComments — pagination (issue #365)", () => {
     const state = { calls: 0, requestedPages: [] as number[] };
     const run = (args: readonly string[]): GhExecResult => {
       state.calls++;
-      const url = args[1] ?? "";
-      const match = /[?&]page=(\d+)/.exec(url);
-      const page = match ? Number.parseInt(match[1]!, 10) : 1;
+      const page = pageFromArgs(args);
       state.requestedPages.push(page);
       const body = pages[page - 1] ?? [];
       return { status: 0, stdout: JSON.stringify(body), stderr: "" };
@@ -527,9 +530,7 @@ describe("fetchIssueComments — pagination (issue #365)", () => {
     const stub = makeRunStub([fullPage1, fullPage2]);
     const explodingRun = (args: readonly string[]): GhExecResult => {
       const result = stub.run(args);
-      const url = args[1] ?? "";
-      const match = /[?&]page=(\d+)/.exec(url);
-      const page = match ? Number.parseInt(match[1]!, 10) : 1;
+      const page = pageFromArgs(args);
       if (page >= 3) throw new Error("page 3 should not be fetched (early-exit failed)");
       return result;
     };
@@ -809,9 +810,7 @@ describe("fetchPrCommits — pagination (issue #383)", () => {
     const state = { calls: 0, requestedPages: [] as number[] };
     const run = (args: readonly string[]): GhExecResult => {
       state.calls++;
-      const url = args[1] ?? "";
-      const match = /[?&]page=(\d+)/.exec(url);
-      const page = match ? Number.parseInt(match[1]!, 10) : 1;
+      const page = pageFromArgs(args);
       state.requestedPages.push(page);
       const body = pages[page - 1] ?? [];
       return { status: 0, stdout: JSON.stringify(body), stderr: "" };

--- a/packages/github-scan/tests/github-scan/github-scan-daemon-bus.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-daemon-bus.test.ts
@@ -190,7 +190,9 @@ describe("toSseBus", () => {
 
     expect(seen).toHaveLength(1);
     expect(seen[0].kind).toBe("activity");
-    const parsed = JSON.parse(seen[0].line!) as Record<string, unknown>;
+    const line = seen[0].line;
+    if (!line) throw new Error("expected activity line");
+    const parsed = JSON.parse(line) as Record<string, unknown>;
     expect(parsed).toEqual({
       event: "task_completed",
       task_id: "task-42",
@@ -214,7 +216,9 @@ describe("toSseBus", () => {
     });
 
     expect(seen).toHaveLength(1);
-    const parsed = JSON.parse(seen[0].line!) as Record<string, unknown>;
+    const line = seen[0].line;
+    if (!line) throw new Error("expected activity line");
+    const parsed = JSON.parse(line) as Record<string, unknown>;
     expect(parsed).toEqual({
       event: "task_dispatched",
       task_id: "task-7",

--- a/packages/github-scan/tests/github-scan/github-scan-daemon-gh-client.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-daemon-gh-client.test.ts
@@ -422,7 +422,8 @@ describe("pure helpers", () => {
       apiUrl: "https://api.github.com/repos/o/r/pulls/1",
       latestCommentApiUrl: "",
       updatedAt: "2026-04-15T00:00:00Z",
-    })!;
+    });
+    if (!a) throw new Error("expected notification candidate");
     const b = { ...a, title: "B" };
     expect(deduplicate([a, b])).toHaveLength(1);
     expect(deduplicate([a, b])[0].title).toBe("A");

--- a/packages/github-scan/tests/github-scan/github-scan-status-manager.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-status-manager.test.ts
@@ -426,7 +426,8 @@ describe("status-manager: ensure-labels", () => {
     expect(labels).toEqual(["github-scan:done", "github-scan:human", "github-scan:new", "github-scan:wip"]);
     // Colors match spec §7.
     const colorFor = (label: string): string => {
-      const call = calls.find((c) => c[2] === label)!;
+      const call = calls.find((c) => c[2] === label);
+      if (!call) throw new Error(`missing label create call for ${label}`);
       return call[call.indexOf("--color") + 1];
     };
     expect(colorFor("github-scan:new")).toBe("0075ca");

--- a/packages/github-scan/tests/github-scan/github-scan-store.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-store.test.ts
@@ -55,11 +55,12 @@ describe("readInbox / writeInbox", () => {
     };
     const discussion = onDisk.notifications.find((n) => n.type === "Discussion");
     expect(discussion).toBeDefined();
+    if (!discussion) throw new Error("expected Discussion fixture entry");
     // Explicitly confirm these keys exist with null values (not omitted).
-    expect(Object.hasOwn(discussion!, "number")).toBe(true);
-    expect(Object.hasOwn(discussion!, "gh_state")).toBe(true);
-    expect(discussion?.number).toBeNull();
-    expect(discussion?.gh_state).toBeNull();
+    expect(Object.hasOwn(discussion, "number")).toBe(true);
+    expect(Object.hasOwn(discussion, "gh_state")).toBe(true);
+    expect(discussion.number).toBeNull();
+    expect(discussion.gh_state).toBeNull();
   });
 
   it("writes atomically (no .tmp file left after success)", () => {

--- a/packages/github-scan/tests/github-scan/github-scan-task-util.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-task-util.test.ts
@@ -95,7 +95,8 @@ describe("parseGithubTimestampEpoch / isRecentGithubTimestamp", () => {
   });
 
   it("isRecentGithubTimestamp compares against now - lookback", () => {
-    const now = parseGithubTimestampEpoch("2026-04-15T12:00:00Z")!;
+    const now = parseGithubTimestampEpoch("2026-04-15T12:00:00Z");
+    if (now === undefined) throw new Error("expected valid timestamp");
     expect(isRecentGithubTimestamp("2026-04-15T11:59:00Z", now, 120)).toBe(true);
     expect(isRecentGithubTimestamp("2026-04-15T11:57:00Z", now, 120)).toBe(false);
   });

--- a/packages/github-scan/tests/github-scan/github-scan-task.test.ts
+++ b/packages/github-scan/tests/github-scan/github-scan-task.test.ts
@@ -28,10 +28,11 @@ describe("buildNotificationCandidate", () => {
       updatedAt: "2026-01-01T00:00:00Z",
     });
     expect(candidate).toBeDefined();
+    if (!candidate) throw new Error("expected review request candidate");
     expect(candidate?.kind).toBe("review_request");
     expect(candidate?.priority).toBe(100);
     expect(candidate?.threadKey).toBe("/repos/owner/repo/pulls/12");
-    expect(taskPrNumber(candidate!)).toBe(12);
+    expect(taskPrNumber(candidate)).toBe(12);
   });
 
   it("builds candidates for mentions referencing comments with anchor urls", () => {
@@ -45,9 +46,10 @@ describe("buildNotificationCandidate", () => {
       latestCommentApiUrl: "https://api.github.com/repos/bingran-you/github-scan/issues/comments/4247540715",
       updatedAt: "2026-04-14T22:18:56Z",
     });
+    if (!candidate) throw new Error("expected mention candidate");
     expect(candidate?.kind).toBe("mention");
-    expect(taskPrNumber(candidate!)).toBe(98);
-    expect(taskUrl(candidate!)).toBe("https://github.com/bingran-you/github-scan/pull/98#issuecomment-4247540715");
+    expect(taskPrNumber(candidate)).toBe(98);
+    expect(taskUrl(candidate)).toBe("https://github.com/bingran-you/github-scan/pull/98#issuecomment-4247540715");
   });
 
   it("returns undefined for non-actionable reasons", () => {
@@ -89,7 +91,8 @@ describe("buildNotificationCandidate", () => {
       latestCommentApiUrl: "",
       updatedAt: "2026-01-01T00:00:00Z",
     });
-    expect(taskUrl(candidate!)).toBe("https://github.com/o/r/issues/7");
+    if (!candidate) throw new Error("expected issue candidate");
+    expect(taskUrl(candidate)).toBe("https://github.com/o/r/issues/7");
   });
 });
 
@@ -125,7 +128,8 @@ describe("candidateFromTaskMetadata", () => {
     expect(c?.kind).toBe("review_request");
     expect(c?.apiUrl).toBe("https://api.github.com/repos/owner/repo/pulls/12");
     expect(c?.webUrl).toBe("https://github.com/owner/repo/pull/12");
-    expect(effectiveWorkspaceRepo(c!)).toBe("bingran-you/bingran-you");
+    if (!c) throw new Error("expected metadata candidate");
+    expect(effectiveWorkspaceRepo(c)).toBe("bingran-you/bingran-you");
   });
 
   it("returns undefined when required fields are missing", () => {

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -39,6 +39,8 @@ async function initRepoAt(cwd: string): Promise<string> {
   await git(cwd, ["init", "--initial-branch=main"]);
   await git(cwd, ["config", "user.name", "Context Reviewer"]);
   await git(cwd, ["config", "user.email", "context-reviewer@example.com"]);
+  await git(cwd, ["config", "commit.gpgsign", "false"]);
+  await git(cwd, ["config", "tag.gpgSign", "false"]);
   return cwd;
 }
 

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+import { GITHUB_API_BASE } from "../services/github-api-base.js";
+import { __testing, resolveChatGithubEntity } from "../services/github-entity-live.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("github entity live helpers", () => {
+  it("parses numeric and sha entity keys", () => {
+    expect(__testing.parseEntityKey("pull_request", "owner/repo#42")).toEqual({
+      kind: "numeric",
+      owner: "owner",
+      repo: "repo",
+      number: 42,
+    });
+    expect(__testing.parseEntityKey("issue", "owner/repo#7")).toEqual({
+      kind: "numeric",
+      owner: "owner",
+      repo: "repo",
+      number: 7,
+    });
+    expect(__testing.parseEntityKey("commit", "owner/repo@abcdef1")).toEqual({
+      kind: "sha",
+      owner: "owner",
+      repo: "repo",
+      sha: "abcdef1",
+    });
+    expect(__testing.parseEntityKey("commit", "owner/repo#42")).toBeNull();
+    expect(__testing.parseEntityKey("issue", "owner/repo@abcdef1")).toBeNull();
+    expect(__testing.parseEntityKey("pull_request", "owner/repo#not-a-number")).toBeNull();
+  });
+
+  it("builds canonical GitHub URLs", () => {
+    expect(__testing.buildHtmlUrl("pull_request", { kind: "numeric", owner: "o", repo: "r", number: 1 })).toBe(
+      "https://github.com/o/r/pull/1",
+    );
+    expect(__testing.buildHtmlUrl("issue", { kind: "numeric", owner: "o", repo: "r", number: 2 })).toBe(
+      "https://github.com/o/r/issues/2",
+    );
+    expect(__testing.buildHtmlUrl("discussion", { kind: "numeric", owner: "o", repo: "r", number: 3 })).toBe(
+      "https://github.com/o/r/discussions/3",
+    );
+    expect(__testing.buildHtmlUrl("commit", { kind: "sha", owner: "o", repo: "r", sha: "abcdef1" })).toBe(
+      "https://github.com/o/r/commit/abcdef1",
+    );
+  });
+});
+
+describe("fetchEntityLiveFields", () => {
+  it("maps pull request live states", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ title: "Open PR", state: "open", draft: false, merged: false }))
+      .mockResolvedValueOnce(jsonResponse({ title: "Draft PR", state: "open", draft: true, merged: false }))
+      .mockResolvedValueOnce(jsonResponse({ title: "Merged PR", state: "closed", draft: false, merged: true }));
+    const parsed = { kind: "numeric" as const, owner: "owner", repo: "repo", number: 42 };
+
+    await expect(__testing.fetchEntityLiveFields("pull_request", parsed, "token", fetcher)).resolves.toEqual({
+      title: "Open PR",
+      state: "open",
+    });
+    await expect(__testing.fetchEntityLiveFields("pull_request", parsed, "token", fetcher)).resolves.toEqual({
+      title: "Draft PR",
+      state: "draft",
+    });
+    await expect(__testing.fetchEntityLiveFields("pull_request", parsed, "token", fetcher)).resolves.toEqual({
+      title: "Merged PR",
+      state: "merged",
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      `${GITHUB_API_BASE}/repos/owner/repo/pulls/42`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "token token" }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("fetches issue state and commit title", async () => {
+    const issueFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "closed" }));
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "issue",
+        { kind: "numeric", owner: "owner", repo: "repo", number: 9 },
+        "token",
+        issueFetcher,
+      ),
+    ).resolves.toEqual({ title: "Bug", state: "closed" });
+
+    const commitFetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ commit: { message: "Fix startup\n\nBody" } }));
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "commit",
+        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
+        "token",
+        commitFetcher,
+      ),
+    ).resolves.toEqual({ title: "Fix startup", state: null });
+  });
+
+  it("returns empty live fields when fetch fails or entity type has no live endpoint", async () => {
+    const nonOkFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 404 }));
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "issue",
+        { kind: "numeric", owner: "owner", repo: "repo", number: 1 },
+        "token",
+        nonOkFetcher,
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    const throwingFetcher = vi.fn<typeof fetch>().mockRejectedValueOnce(new Error("network down"));
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "pull_request",
+        { kind: "numeric", owner: "owner", repo: "repo", number: 1 },
+        "token",
+        throwingFetcher,
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    const unusedFetcher = vi.fn<typeof fetch>();
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "discussion",
+        { kind: "numeric", owner: "owner", repo: "repo", number: 1 },
+        "token",
+        unusedFetcher,
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+    expect(unusedFetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveChatGithubEntity", () => {
+  it("materializes wire entities with optional live fields", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "open" }));
+
+    await expect(
+      resolveChatGithubEntity(
+        { entityType: "issue", entityKey: "owner/repo#12", boundVia: "direct" },
+        "token",
+        fetcher,
+      ),
+    ).resolves.toEqual({
+      entityType: "issue",
+      entityKey: "owner/repo#12",
+      boundVia: "direct",
+      htmlUrl: "https://github.com/owner/repo/issues/12",
+      title: "Bug",
+      state: "open",
+      number: 12,
+    });
+  });
+
+  it("does not fetch live fields without a token", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+
+    await expect(
+      resolveChatGithubEntity(
+        { entityType: "commit", entityKey: "owner/repo@abcdef1", boundVia: "agent_created" },
+        null,
+        fetcher,
+      ),
+    ).resolves.toEqual({
+      entityType: "commit",
+      entityKey: "owner/repo@abcdef1",
+      boundVia: "agent_created",
+      htmlUrl: "https://github.com/owner/repo/commit/abcdef1",
+      title: null,
+      state: null,
+      number: null,
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown entity types, invalid boundVia values, and malformed keys", async () => {
+    await expect(
+      resolveChatGithubEntity({ entityType: "release", entityKey: "owner/repo#1", boundVia: "direct" }, "token"),
+    ).resolves.toBeNull();
+    await expect(
+      resolveChatGithubEntity({ entityType: "issue", entityKey: "owner/repo#1", boundVia: "manual" }, "token"),
+    ).resolves.toBeNull();
+    await expect(
+      resolveChatGithubEntity({ entityType: "issue", entityKey: "owner/repo@abcdef1", boundVia: "direct" }, "token"),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -58,14 +58,21 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
       .from(inboxEntries)
       .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)));
     expect(rows.length).toBe(3);
-    const claimedFirst = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, rows[0]!.messageId);
-    const claimedSecond = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, rows[1]!.messageId);
+    const firstRow = rows[0];
+    const secondRow = rows[1];
+    const thirdRow = rows[2];
+    if (!firstRow || !secondRow || !thirdRow) throw new Error("expected three notify rows");
+    const claimedFirst = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, firstRow.messageId);
+    const claimedSecond = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, secondRow.messageId);
     expect(claimedFirst).toHaveLength(1);
     expect(claimedSecond).toHaveLength(1);
+    const claimedFirstRow = claimedFirst[0];
+    const claimedSecondRow = claimedSecond[0];
+    if (!claimedFirstRow || !claimedSecondRow) throw new Error("expected claimed inbox rows");
 
     // Mark `claimedSecond` as acked so we have all three statuses represented
     // for a2's inbox at the point of the reset call.
-    await app.db.update(inboxEntries).set({ status: "acked" }).where(eq(inboxEntries.id, claimedSecond[0]!.id));
+    await app.db.update(inboxEntries).set({ status: "acked" }).where(eq(inboxEntries.id, claimedSecondRow.id));
 
     // Drive the reset for a2's inbox only.
     const resetCount = await inboxService.resetDeliveredForInboxes(app.db, [a2.agent.inboxId]);
@@ -77,9 +84,9 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
       .from(inboxEntries)
       .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)));
     const byId = new Map(a2Final.map((r) => [r.id, r.status]));
-    expect(byId.get(claimedFirst[0]!.id)).toBe("pending"); // was delivered → reset
-    expect(byId.get(claimedSecond[0]!.id)).toBe("acked"); // untouched
-    expect(byId.get(rows[2]!.id)).toBe("pending"); // was already pending
+    expect(byId.get(claimedFirstRow.id)).toBe("pending"); // was delivered → reset
+    expect(byId.get(claimedSecondRow.id)).toBe("acked"); // untouched
+    expect(byId.get(thirdRow.id)).toBe("pending"); // was already pending
 
     // a3's mention row must be untouched by a reset that targeted only a2.
     // a3 received the dedicated @mention plus three silent fan-out rows from
@@ -143,11 +150,13 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
     // Claim → delivered (retryCount stays 0 per the claim path).
     const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
     expect(claimed).toHaveLength(1);
+    const claimedRow = claimed[0];
+    if (!claimedRow) throw new Error("expected claimed inbox row");
 
     const before = await app.db
       .select({ retryCount: inboxEntries.retryCount })
       .from(inboxEntries)
-      .where(inArray(inboxEntries.id, [claimed[0]!.id]));
+      .where(inArray(inboxEntries.id, [claimedRow.id]));
     expect(before[0]?.retryCount).toBe(0);
 
     const reset = await inboxService.resetDeliveredForInboxes(app.db, [a2.agent.inboxId]);
@@ -156,7 +165,7 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
     const after = await app.db
       .select({ retryCount: inboxEntries.retryCount, status: inboxEntries.status })
       .from(inboxEntries)
-      .where(inArray(inboxEntries.id, [claimed[0]!.id]));
+      .where(inArray(inboxEntries.id, [claimedRow.id]));
     expect(after[0]?.status).toBe("pending");
     // Critical invariant: bind-time reset is NOT a retry bump. A flaky client
     // that crashes mid-turn must not push genuinely-stuck messages into

--- a/packages/server/src/__tests__/stats-service.test.ts
+++ b/packages/server/src/__tests__/stats-service.test.ts
@@ -1,0 +1,109 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chats } from "../db/schema/chats.js";
+import { messages } from "../db/schema/messages.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import { getStats } from "../services/stats.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("stats service", () => {
+  const getApp = useTestApp();
+
+  it("merges agent, chat, and message counts by organization", async () => {
+    const app = getApp();
+    const orgA = await createAdminContext(app, { username: `stats-a-${crypto.randomUUID().slice(0, 6)}` });
+    const baseline = await getStats(app.db, orgA.organizationId);
+
+    const activeAgent = await createAgent(app.db, {
+      name: `stats-active-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Stats Active",
+      managerId: orgA.memberId,
+      clientId: orgA.clientId,
+      organizationId: orgA.organizationId,
+    });
+    const deletedAgent = await createAgent(app.db, {
+      name: `stats-deleted-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Stats Deleted",
+      managerId: orgA.memberId,
+      clientId: orgA.clientId,
+      organizationId: orgA.organizationId,
+    });
+    await app.db.update(agents).set({ status: "deleted" }).where(eq(agents.uuid, deletedAgent.uuid));
+    const chat = await createChat(app.db, orgA.humanAgentUuid, {
+      type: "group",
+      participantIds: [activeAgent.uuid],
+      topic: "Stats chat",
+    });
+    await app.db.insert(messages).values([
+      {
+        id: uuidv7(),
+        chatId: chat.id,
+        senderId: orgA.humanAgentUuid,
+        format: "text",
+        content: "hello",
+        metadata: {},
+        source: "api",
+      },
+      {
+        id: uuidv7(),
+        chatId: chat.id,
+        senderId: activeAgent.uuid,
+        format: "text",
+        content: "hi",
+        metadata: {},
+        source: "agent",
+      },
+    ]);
+
+    const orgBChatId = uuidv7();
+    const orgBId = uuidv7();
+    await app.db.insert(organizations).values({
+      id: orgBId,
+      name: `stats-b-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Stats B",
+    });
+    await app.db.insert(chats).values({
+      id: orgBChatId,
+      organizationId: orgBId,
+      type: "group",
+      topic: "Other org chat",
+      metadata: {},
+    });
+
+    const filtered = await getStats(app.db, orgA.organizationId);
+    expect(filtered.totalAgents).toBe(baseline.totalAgents + 1);
+    expect(filtered.totalChats).toBe(baseline.totalChats + 1);
+    expect(filtered.totalMessages).toBe(baseline.totalMessages + 2);
+    expect(filtered.byOrganization).toHaveLength(1);
+    expect(filtered.byOrganization[0]).toEqual({
+      organizationId: orgA.organizationId,
+      agentCount: baseline.totalAgents + 1,
+      chatCount: baseline.totalChats + 1,
+      messageCount: baseline.totalMessages + 2,
+    });
+
+    const all = await getStats(app.db);
+    const orgABreakdown = all.byOrganization.find((entry) => entry.organizationId === orgA.organizationId);
+    const orgBBreakdown = all.byOrganization.find((entry) => entry.organizationId === orgBId);
+
+    expect(orgABreakdown).toMatchObject({
+      agentCount: baseline.totalAgents + 1,
+      chatCount: baseline.totalChats + 1,
+      messageCount: baseline.totalMessages + 2,
+    });
+    expect(orgBBreakdown).toMatchObject({
+      agentCount: 0,
+      chatCount: 1,
+      messageCount: 0,
+    });
+    expect(all.totalAgents).toBeGreaterThanOrEqual(filtered.totalAgents);
+    expect(all.totalChats).toBeGreaterThanOrEqual(filtered.totalChats + 1);
+    expect(all.totalMessages).toBeGreaterThanOrEqual(filtered.totalMessages);
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -44,6 +44,7 @@
     "@vitejs/plugin-react": "^4.5.0",
     "@vitest/coverage-v8": "3.2.4",
     "fake-indexeddb": "^6.2.5",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4.2.2",
     "tailwindcss-animate": "^1.0.7",
     "vite": "^6.3.0",

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../auth/auth-context.js", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../auth/require-auth.js", async () => {
+  const { Outlet } = await import("react-router");
+  return { RequireAuth: () => <Outlet /> };
+});
+
+vi.mock("../hooks/pulse-context.js", () => ({
+  PulseProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../components/ui/toast.js", () => ({
+  ToastProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../components/layout.js", async () => {
+  const { Outlet } = await import("react-router");
+  return {
+    Layout: () => (
+      <div data-testid="layout">
+        <Outlet />
+      </div>
+    ),
+  };
+});
+
+vi.mock("../pages/login.js", () => ({ LoginPage: () => <div>login page</div> }));
+vi.mock("../pages/oauth-complete.js", () => ({ OAuthCompletePage: () => <div>oauth complete</div> }));
+vi.mock("../pages/invite-accept.js", () => ({ InviteAcceptPage: () => <div>invite accept</div> }));
+vi.mock("../pages/onboarding/onboarding-page.js", () => ({ OnboardingPage: () => <div>onboarding page</div> }));
+vi.mock("../pages/workspace/index.js", () => ({ WorkspacePage: () => <div>workspace page</div> }));
+vi.mock("../pages/context.js", () => ({ ContextPage: () => <div>context page</div> }));
+vi.mock("../pages/team/index.js", () => ({ TeamPage: () => <div>team page</div> }));
+vi.mock("../pages/settings.js", async () => {
+  const { Outlet } = await import("react-router");
+  return {
+    SettingsLayout: () => (
+      <div>
+        settings layout
+        <Outlet />
+      </div>
+    ),
+  };
+});
+vi.mock("../pages/settings/computers.js", () => ({ SettingsComputersPage: () => <div>settings computers</div> }));
+vi.mock("../pages/settings/github.js", () => ({ SettingsGithubPage: () => <div>settings github</div> }));
+vi.mock("../pages/settings/integrations.js", () => ({
+  SettingsIntegrationsPage: () => <div>settings integrations</div>,
+}));
+vi.mock("../pages/settings/onboarding.js", () => ({ SettingsOnboardingPage: () => <div>settings onboarding</div> }));
+vi.mock("../pages/team/settings.js", () => ({ TeamSettingsPage: () => <div>team settings</div> }));
+vi.mock("../pages/agent-detail.js", async () => {
+  const { Outlet } = await import("react-router");
+  return {
+    AgentDetailPage: () => (
+      <div>
+        agent detail
+        <Outlet />
+      </div>
+    ),
+  };
+});
+vi.mock("../pages/agent-detail/profile-tab.js", () => ({ ProfileTab: () => <div>profile tab</div> }));
+vi.mock("../pages/agent-detail/setup-tab.js", () => ({ SetupTab: () => <div>setup tab</div> }));
+vi.mock("../pages/agent-detail/prompt-tab.js", () => ({ PromptTab: () => <div>prompt tab</div> }));
+vi.mock("../pages/agent-detail/tools-tab.js", () => ({ ToolsTab: () => <div>tools tab</div> }));
+vi.mock("../pages/agent-detail/resources-tab.js", () => ({ ResourcesTab: () => <div>resources tab</div> }));
+vi.mock("../pages/styleguide-preview.js", () => ({ StyleguidePreviewPage: () => <div>styleguide preview</div> }));
+
+let root: Root | null = null;
+
+async function renderAppAt(path: string): Promise<string> {
+  window.history.pushState({}, "", path);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const { App } = await import("../app.js");
+  await act(async () => {
+    root?.render(<App />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  return document.body.textContent ?? "";
+}
+
+describe("App routes", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    root = null;
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    document.body.innerHTML = "";
+  });
+
+  it("routes public, protected, nested, preview, and redirect paths", async () => {
+    expect(await renderAppAt("/login")).toContain("login page");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/auth/github/complete")).toContain("oauth complete");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/invite/token-1")).toContain("invite accept");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/onboarding")).toContain("onboarding page");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/agents/agent-1/tools")).toContain("tools tab");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/settings/github")).toContain("settings github");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/settings/setup")).toContain("settings onboarding");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/admin#bindings")).toContain("settings integrations");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/preview/styleguide")).toContain("styleguide preview");
+  });
+});

--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -1,0 +1,328 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => ({
+  delete: vi.fn(),
+  get: vi.fn(),
+  patch: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+}));
+
+vi.mock("../client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../client.js")>();
+  return {
+    ...actual,
+    api: apiMock,
+    withOrg: (path: string) => `/orgs/current${path}`,
+    withOrgAt: (orgId: string, path: string) => `/orgs/${encodeURIComponent(orgId)}${path}`,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.get.mockResolvedValue({});
+  apiMock.post.mockResolvedValue({});
+  apiMock.patch.mockResolvedValue({});
+  apiMock.put.mockResolvedValue({});
+  apiMock.delete.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("api wrapper paths", () => {
+  it("formats activity, adapter, org setting, organization, and overview requests", async () => {
+    const activity = await import("../activity.js");
+    const adapterMappings = await import("../adapter-mappings.js");
+    const adapterStatus = await import("../adapter-status.js");
+    const adapters = await import("../adapters.js");
+    const contextTree = await import("../context-tree.js");
+    const orgSettings = await import("../org-settings.js");
+    const organizations = await import("../organizations.js");
+    const overview = await import("../overview.js");
+
+    await activity.retireClient("client/id");
+    await activity.getActivityOverview();
+    await activity.listClients();
+    await activity.listOrgClients();
+    await activity.getClient("client-1");
+    await activity.getClientCapabilities("client-2");
+    await activity.disconnectClient("client-3");
+    await activity.resetAgentActivity("agent/id");
+    await activity.generateConnectToken();
+
+    await adapterMappings.listAdapterMappings();
+    await adapterMappings.createAdapterMapping({
+      platform: "feishu",
+      agentId: "agent-1",
+      externalUserId: "ou_1",
+      boundVia: "manual",
+    });
+    await adapterMappings.deleteAdapterMapping(7);
+    await adapterStatus.getAdapterStatuses();
+    await adapters.listAdapters();
+    await adapters.getAdapter(8);
+    await adapters.createAdapter({ platform: "feishu", agentId: "agent-1", credentials: {}, status: "active" });
+    await adapters.updateAdapter(9, { agentId: "agent-2" });
+    await adapters.deleteAdapter(10);
+
+    await contextTree.getContextTreeSnapshot("org/id", "7d");
+    await orgSettings.getContextTreeSetting("org/id");
+    await orgSettings.putContextTreeSetting("org/id", { repo: "https://github.com/acme/tree", branch: "main" });
+    await orgSettings.deleteContextTreeSetting("org/id");
+    await orgSettings.getSourceReposSetting("org/id");
+    await orgSettings.putSourceReposSetting("org/id", { repos: [{ url: "https://github.com/acme/web.git" }] });
+    await orgSettings.deleteSourceReposSetting("org/id");
+    await organizations.getOrganization("org/id");
+    await organizations.updateOrganization("org/id", { displayName: "Acme" });
+    await overview.getOverview();
+
+    expect(apiMock.delete).toHaveBeenCalledWith("/clients/client%2Fid");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/activity");
+    expect(apiMock.get).toHaveBeenCalledWith("/me/clients");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/clients");
+    expect(apiMock.get).toHaveBeenCalledWith("/clients/client-1");
+    expect(apiMock.post).toHaveBeenCalledWith("/clients/client-3/disconnect");
+    expect(apiMock.post).toHaveBeenCalledWith("/agents/agent%2Fid/reset-activity");
+    expect(apiMock.post).toHaveBeenCalledWith("/me/connect-tokens");
+    expect(apiMock.post).toHaveBeenCalledWith("/orgs/current/adapter-mappings", {
+      platform: "feishu",
+      agentId: "agent-1",
+      externalUserId: "ou_1",
+      boundVia: "manual",
+    });
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/adapters/status");
+    expect(apiMock.patch).toHaveBeenCalledWith("/adapters/9", { agentId: "agent-2" });
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/org%2Fid/context-tree/snapshot?window=7d");
+    expect(apiMock.put).toHaveBeenCalledWith("/orgs/org%2Fid/settings/context_tree", {
+      repo: "https://github.com/acme/tree",
+      branch: "main",
+    });
+    expect(apiMock.put).toHaveBeenCalledWith("/orgs/org%2Fid/settings/source_repos", {
+      repos: [{ url: "https://github.com/acme/web.git" }],
+    });
+    expect(apiMock.patch).toHaveBeenCalledWith("/orgs/org%2Fid", { displayName: "Acme" });
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/overview");
+  });
+
+  it("formats agent, attention, chat, member, and session requests", async () => {
+    const agentConfig = await import("../agent-config.js");
+    const agentStatus = await import("../agent-status.js");
+    const agents = await import("../agents.js");
+    const attention = await import("../attention.js");
+    const chats = await import("../chats.js");
+    const meChats = await import("../me-chats.js");
+    const meDocs = await import("../me-docs.js");
+    const members = await import("../members.js");
+    const sessions = await import("../sessions.js");
+
+    await agentConfig.getAgentConfig("agent/id");
+    await agentConfig.updateAgentConfig("agent/id", { expectedVersion: 3, payload: { model: "sonnet" } });
+    await agentConfig.dryRunAgentConfig("agent/id", { gitRepos: [] });
+    await agentConfig.getAgentClientStatus("agent/id");
+    await agentStatus.fetchChatAgentStatuses("chat/id");
+
+    await agents.listAgents({ limit: 10, cursor: "next", type: "agent", query: "kael" });
+    await agents.listAllAgents({ limit: 5, cursor: "older" });
+    await agents.listManagedAgents();
+    await agents.getAgent("agent/id");
+    await agents.getAgentSkills("agent/id");
+    await agents.createAgent({ name: "kael", type: "agent", displayName: "Kael" });
+    await agents.checkAgentNameAvailability("name with spaces");
+    await agents.updateAgent("agent/id", { displayName: "New" });
+    await agents.rebindAgent("agent/id", { clientId: "client-2", runtimeProvider: "claude-code" });
+    await agents.deleteAgent("agent/id");
+    await agents.deleteAgentAvatar("agent/id");
+    await agents.suspendAgent("agent/id");
+    await agents.reactivateAgent("agent/id");
+    await agents.testAgentConnection("agent/id");
+
+    expect(attention.attentionsInChatQueryKey("chat-1")).toEqual(["attentions", "chat", "chat-1"]);
+    expect(attention.respondAttentionMutationKey("att-1")).toEqual(["attentions", "respond", "att-1"]);
+    await attention.respondAttention("att/id", { text: "yes" });
+    await attention.listAttentionsInChat("chat/id");
+    await attention.listMyAttentions();
+
+    await chats.listChats({ limit: 3, cursor: "next" });
+    await chats.getChat("chat/id");
+    await chats.listChatGithubEntities("chat/id");
+    await chats.renameChat("chat/id", "Topic");
+    await chats.patchChatEngagement("chat/id", "archived");
+    await chats.sendChatMessage("chat/id", "hello", ["agent-1"]);
+    await chats.sendChatMessage("chat/id", "no route", []);
+    await chats.sendFileMessageBatch(
+      "chat/id",
+      { attachments: [{ data: "a", mimeType: "image/png", filename: "a.png", size: 1 }] },
+      {
+        mentions: ["agent-1"],
+      },
+    );
+    await chats.sendFileMessageBatch("chat/id", { attachments: [] }, { mentions: [] });
+    await chats.createAgentChat("agent/id");
+    await chats.listChatMessages("chat/id", { limit: 20, cursor: "older" });
+
+    await meChats.listMeChats({
+      limit: 10,
+      cursor: "next",
+      filter: "unread",
+      engagement: "active",
+      origin: ["manual", "github"],
+      with: ["agent-1", "agent-2"],
+      watching: true,
+    });
+    await meChats.listMeChatSourceCounts({ engagement: "archived" });
+    await meChats.createMeChat({ participantIds: ["agent-1"] });
+    await meChats.markMeChatRead("chat/id");
+    await meChats.markMeChatUnread("chat/id");
+    await meChats.addMeChatParticipants("chat/id", { participantIds: ["agent-2"] });
+    await meChats.joinMeChat("chat/id");
+    await meChats.leaveMeChat("chat/id");
+
+    await meDocs.getMeDoc("chat/id", { agentId: "agent/id", path: "docs/plan.md", basePath: "/workspace" });
+    await members.listMembers();
+    await members.updateMember("member/id", { role: "admin" });
+    await members.deleteMember("member/id");
+
+    expect(sessions.sessionQueryKey("agent-1", "chat-1")).toEqual(["session", "agent-1", "chat-1"]);
+    expect(sessions.agentSessionsQueryKey("agent-1")).toEqual(["agent-sessions", "agent-1"]);
+    expect(sessions.asToolCallPayload({ toolUseId: "tool-1", name: "Bash", args: {}, status: "ok" })).toEqual({
+      toolUseId: "tool-1",
+      name: "Bash",
+      args: {},
+      status: "ok",
+      durationMs: undefined,
+      resultPreview: undefined,
+    });
+    expect(sessions.asToolCallPayload({ toolUseId: "tool-1", status: "ok" })).toBeNull();
+    expect(sessions.asErrorPayload({ source: "runtime", message: "failed" })).toEqual({
+      source: "runtime",
+      message: "failed",
+    });
+    expect(sessions.asErrorPayload({ source: "other", message: "failed" })).toBeNull();
+    expect(sessions.asAssistantTextPayload({ text: "partial" })).toEqual({ text: "partial" });
+    expect(sessions.asTurnEndPayload({ status: "success" })).toEqual({ status: "success" });
+    await sessions.listSessions({ limit: 10, cursor: "c", state: "active", agentId: "agent-1" });
+    await sessions.listAgentSessions("agent/id", { state: "active", runtimeState: "working" });
+    await sessions.getSession("agent/id", "chat/id");
+    await sessions.listSessionEvents("agent/id", "chat/id", { limit: 30, cursor: 5, direction: "asc" });
+    await sessions.suspendSession("agent/id", "chat/id");
+    await sessions.terminateSession("agent/id", "chat/id");
+
+    expect(apiMock.get).toHaveBeenCalledWith("/agents/agent/id/config");
+    expect(apiMock.post).toHaveBeenCalledWith("/agents/agent/id/config/dry-run", { payload: { gitRepos: [] } });
+    expect(apiMock.get).toHaveBeenCalledWith("/chats/chat/id/agent-status");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents?limit=10&cursor=next&type=agent&query=kael");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents/all?limit=5&cursor=older");
+    expect(apiMock.get).toHaveBeenCalledWith("/agents/agent%2Fid/skills");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents/names/name%20with%20spaces/availability");
+    expect(apiMock.patch).toHaveBeenCalledWith("/agents/agent%2Fid/rebind", {
+      clientId: "client-2",
+      runtimeProvider: "claude-code",
+    });
+    expect(apiMock.post).toHaveBeenCalledWith("/attention/att%2Fid/respond", { text: "yes" });
+    expect(apiMock.get).toHaveBeenCalledWith("/attention?chat=chat%2Fid&state=all");
+    expect(apiMock.get).toHaveBeenCalledWith("/attention?state=open&limit=200");
+    expect(apiMock.post).toHaveBeenCalledWith("/chats/chat%2Fid/messages", {
+      format: "text",
+      content: "hello",
+      metadata: { mentions: ["agent-1"] },
+    });
+    expect(apiMock.post).toHaveBeenCalledWith("/chats/chat%2Fid/messages", {
+      format: "text",
+      content: "no route",
+    });
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/orgs/current/chats?limit=10&cursor=next&filter=unread&engagement=active&origin=manual%2Cgithub&with=agent-1%2Cagent-2&watching=1",
+    );
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/chats/chat%2Fid/docs/preview?agentId=agent%2Fid&path=docs%2Fplan.md&basePath=%2Fworkspace",
+    );
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/agents/agent/id/sessions/chat/id/events?limit=30&cursor=5&direction=asc",
+    );
+  });
+
+  it("handles GitHub App helpers, legacy auth, file reading, and swallowed onboarding events", async () => {
+    const { ApiError } = await import("../client.js");
+    const githubApp = await import("../github-app.js");
+    const github = await import("../github.js");
+    const auth = await import("../auth.js");
+    const chats = await import("../chats.js");
+    const onboarding = await import("../onboarding-events.js");
+
+    apiMock.get.mockRejectedValueOnce(new ApiError(404, "missing"));
+    await expect(githubApp.getGithubAppInstallation("org-1")).resolves.toBeNull();
+    apiMock.get.mockRejectedValueOnce(new ApiError(500, "boom"));
+    await expect(githubApp.getGithubAppInstallation("org-1")).rejects.toMatchObject({ status: 500 });
+    apiMock.get.mockResolvedValueOnce({ exists: true });
+    await expect(githubApp.getGithubAppInstallationExists("org-1")).resolves.toBe(true);
+    apiMock.get.mockResolvedValueOnce({ installUrl: "https://github.com/apps/first-tree/installations/new" });
+    await expect(githubApp.getGithubAppInstallUrl("org-1", "/onboarding")).resolves.toContain("github.com");
+
+    apiMock.get.mockResolvedValueOnce({ repos: [{ fullName: "acme/web" }] });
+    await expect(github.listGithubRepos()).resolves.toEqual([{ fullName: "acme/web" }]);
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ accessToken: "a", refreshToken: "r" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(auth.login("gandy", "secret")).resolves.toEqual({ accessToken: "a", refreshToken: "r" });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: "bad login" }), { status: 401 }));
+    await expect(auth.login("gandy", "bad")).rejects.toThrow("bad login");
+    fetchMock.mockResolvedValueOnce(new Response("plain failure", { status: 500 }));
+    await expect(auth.login("gandy", "bad")).rejects.toThrow("plain failure");
+
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    const originalFileReader = globalThis.FileReader;
+    class SuccessFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsDataURL(): void {
+        this.result = "data:text/plain;base64,aGVsbG8=";
+        this.onload?.();
+      }
+    }
+    class BadResultFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsDataURL(): void {
+        this.result = new ArrayBuffer(0);
+        this.onload?.();
+      }
+    }
+    class ErrorFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = new DOMException("read failed");
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsDataURL(): void {
+        this.onerror?.();
+      }
+    }
+    Object.defineProperty(globalThis, "FileReader", { configurable: true, value: SuccessFileReader });
+    await expect(chats.readFileAsBase64(file)).resolves.toBe("aGVsbG8=");
+    Object.defineProperty(globalThis, "FileReader", { configurable: true, value: BadResultFileReader });
+    await expect(chats.readFileAsBase64(file)).rejects.toThrow("Unexpected FileReader result");
+    Object.defineProperty(globalThis, "FileReader", { configurable: true, value: ErrorFileReader });
+    await expect(chats.readFileAsBase64(file)).rejects.toThrow("read failed");
+    Object.defineProperty(globalThis, "FileReader", { configurable: true, value: originalFileReader });
+
+    apiMock.post.mockRejectedValueOnce(new Error("offline"));
+    await expect(
+      onboarding.reportOnboardingEvent("agent_created", { runtimeProvider: "codex" }),
+    ).resolves.toBeUndefined();
+    apiMock.post.mockRejectedValueOnce(new Error("offline"));
+    await expect(onboarding.markOnboardingCompleted()).resolves.toBeUndefined();
+  });
+});

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -1,0 +1,78 @@
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadImageStore() {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  return import("../image-store.js");
+}
+
+async function loadReadStateStore() {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  return import("../read-state-store.js");
+}
+
+describe("image-store", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("stores and retrieves image bytes by id", async () => {
+    const { getImage, putImage } = await loadImageStore();
+
+    await expect(putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" })).resolves.toBeUndefined();
+    await expect(getImage("img-1")).resolves.toEqual({ base64: "abc123", mimeType: "image/png" });
+    await expect(getImage("missing")).resolves.toBeNull();
+  });
+
+  it("rejects writes and returns null when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { getImage, putImage } = await import("../image-store.js");
+
+    await expect(putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" })).rejects.toThrow(
+      "Image storage unavailable",
+    );
+    await expect(getImage("img-1")).resolves.toBeNull();
+  });
+});
+
+describe("read-state-store", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("sets, gets, overwrites, and clears a chat read state", async () => {
+    const { clearReadState, getReadState, setReadState } = await loadReadStateStore();
+
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+    await setReadState("chat-1", "msg-1", "msg-3");
+    await expect(getReadState("chat-1")).resolves.toMatchObject({
+      chatId: "chat-1",
+      bottomVisibleMessageId: "msg-1",
+      latestKnownMessageId: "msg-3",
+    });
+
+    await setReadState("chat-1", "msg-4", "msg-5");
+    await expect(getReadState("chat-1")).resolves.toMatchObject({
+      chatId: "chat-1",
+      bottomVisibleMessageId: "msg-4",
+      latestKnownMessageId: "msg-5",
+    });
+
+    await clearReadState("chat-1");
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+  });
+
+  it("silently no-ops when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { clearReadState, getReadState, setReadState } = await import("../read-state-store.js");
+
+    await expect(setReadState("chat-1", "msg-1", "msg-2")).resolves.toBeUndefined();
+    await expect(clearReadState("chat-1")).resolves.toBeUndefined();
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+  });
+});

--- a/packages/web/src/api/__tests__/client-request.test.ts
+++ b/packages/web/src/api/__tests__/client-request.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  const storage = createStorage();
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function response(status: number, body: unknown): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("api client request flow", () => {
+  it("stores tokens, sends auth headers, and parses 204 responses", async () => {
+    const { api, clearStoredTokens, getStoredTokens, setStoredTokens } = await import("../client.js");
+    setStoredTokens({ accessToken: "access-1", refreshToken: "refresh-1" });
+    expect(getStoredTokens()).toEqual({ accessToken: "access-1", refreshToken: "refresh-1" });
+
+    fetchMock
+      .mockResolvedValueOnce(response(200, { ok: true }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(api.get<{ ok: true }>("/me")).resolves.toEqual({ ok: true });
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "GET",
+      headers: { Authorization: "Bearer access-1" },
+    });
+
+    await expect(api.delete<void>("/clients/client-1")).resolves.toBeUndefined();
+    clearStoredTokens();
+    expect(getStoredTokens()).toBeNull();
+  });
+
+  it("refreshes on 401 and retries with the new access token", async () => {
+    const { api, getStoredTokens, setStoredTokens } = await import("../client.js");
+    setStoredTokens({ accessToken: "expired", refreshToken: "refresh-1" });
+    fetchMock
+      .mockResolvedValueOnce(response(401, { error: "expired" }))
+      .mockResolvedValueOnce(response(200, { accessToken: "access-2", refreshToken: "refresh-2" }))
+      .mockResolvedValueOnce(response(200, { ok: true }));
+
+    await expect(api.get<{ ok: true }>("/me")).resolves.toEqual({ ok: true });
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/v1/auth/refresh");
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer access-2" },
+    });
+    expect(getStoredTokens()).toEqual({ accessToken: "access-2", refreshToken: "refresh-2" });
+  });
+
+  it("throws ApiError with validation issues and dispatches auth logout on unrecovered 401", async () => {
+    const { api, getStoredTokens, setStoredTokens } = await import("../client.js");
+    setStoredTokens({ accessToken: "bad", refreshToken: "refresh-bad" });
+    const logout = vi.fn();
+    window.addEventListener("auth:logout", logout);
+    fetchMock
+      .mockResolvedValueOnce(response(400, { error: "Invalid", details: [{ path: ["name"], message: "Required" }] }))
+      .mockResolvedValueOnce(response(401, { error: "expired" }))
+      .mockResolvedValueOnce(response(500, { error: "refresh failed" }));
+
+    await expect(api.post("/agents", { name: "" })).rejects.toMatchObject({
+      status: 400,
+      message: "Invalid",
+      issues: [{ path: ["name"], message: "Required" }],
+    });
+    await expect(api.get("/me")).rejects.toMatchObject({ status: 401 });
+    expect(logout).toHaveBeenCalled();
+    expect(getStoredTokens()).toBeNull();
+  });
+
+  it("formats org paths and handles malformed stored token JSON", async () => {
+    const { getStoredTokens, setApiSelectedOrganizationId, withOrg, withOrgAt } = await import("../client.js");
+    localStorage.setItem("first-tree:tokens", "{bad");
+    expect(getStoredTokens()).toBeNull();
+
+    setApiSelectedOrganizationId("org/with space");
+    expect(withOrg("/agents?limit=1")).toBe("/orgs/org%2Fwith%20space/agents?limit=1");
+    expect(withOrgAt("other/org", "/members")).toBe("/orgs/other%2Forg/members");
+    setApiSelectedOrganizationId(null);
+    expect(() => withOrg("/agents")).toThrow(/before an organization is selected/);
+  });
+});

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+
+import type { MeMembership } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const apiMocks = vi.hoisted(() => ({
+  clearStoredTokens: vi.fn(),
+  getStoredTokens: vi.fn(),
+  setApiSelectedOrganizationId: vi.fn(),
+  setStoredTokens: vi.fn(),
+  apiGet: vi.fn(),
+  apiPatch: vi.fn(),
+}));
+
+const loginMock = vi.hoisted(() => vi.fn());
+const onboardingCompletedMock = vi.hoisted(() => vi.fn());
+const flagsMocks = vi.hoisted(() => ({
+  clearOnboardingJoinPath: vi.fn(),
+  clearOnboardingSessionFlags: vi.fn(),
+}));
+
+vi.mock("../../api/client.js", () => ({
+  api: {
+    get: apiMocks.apiGet,
+    patch: apiMocks.apiPatch,
+  },
+  clearStoredTokens: apiMocks.clearStoredTokens,
+  getStoredTokens: apiMocks.getStoredTokens,
+  setApiSelectedOrganizationId: apiMocks.setApiSelectedOrganizationId,
+  setStoredTokens: apiMocks.setStoredTokens,
+}));
+
+vi.mock("../../api/auth.js", () => ({
+  login: loginMock,
+}));
+
+vi.mock("../../api/onboarding-events.js", () => ({
+  markOnboardingCompleted: onboardingCompletedMock,
+}));
+
+vi.mock("../../utils/onboarding-flags.js", () => flagsMocks);
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let latestAuth: ReturnType<typeof import("../auth-context.js").useAuth> | null = null;
+
+const MEMBERSHIPS: MeMembership[] = [
+  {
+    id: "member-1",
+    organizationId: "org-1",
+    organizationName: "Acme",
+    role: "admin",
+    agentId: "human-agent-1",
+    orgHasOtherMembers: true,
+  },
+  {
+    id: "member-2",
+    organizationId: "org-2",
+    organizationName: "Other",
+    role: "member",
+    agentId: "human-agent-2",
+    orgHasOtherMembers: false,
+  },
+];
+
+function setupDom(): void {
+  const storage = createStorage();
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: createStorage() });
+}
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderAuth(children?: ReactNode): Promise<void> {
+  const { AuthProvider, useAuth } = await import("../auth-context.js");
+  function Probe() {
+    latestAuth = useAuth();
+    return <div data-auth={latestAuth.isAuthenticated ? "yes" : "no"}>{children}</div>;
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Probe />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  setupDom();
+  document.body.innerHTML = "";
+  latestAuth = null;
+  root = null;
+  container = null;
+  vi.clearAllMocks();
+  apiMocks.getStoredTokens.mockReturnValue(null);
+  apiMocks.apiGet.mockResolvedValue({
+    user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
+    memberships: MEMBERSHIPS,
+    defaultOrganizationId: "org-1",
+    onboarding: {
+      step: "completed",
+      dismissedAt: null,
+      completedAt: "2026-05-01T00:00:00.000Z",
+    },
+  });
+  apiMocks.apiPatch.mockResolvedValue({ dismissedAt: "2026-05-28T00:00:00.000Z" });
+  loginMock.mockResolvedValue({ accessToken: "access-login", refreshToken: "refresh-login" });
+  onboardingCompletedMock.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+  }
+  document.body.innerHTML = "";
+});
+
+describe("AuthProvider", () => {
+  it("loads stored tokens, reconciles organization selection, and exposes current membership", async () => {
+    localStorage.setItem("first-tree:selectedOrganizationId", "org-2");
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
+
+    await renderAuth();
+
+    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenCalledWith("org-2");
+    expect(latestAuth?.meLoaded).toBe(true);
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
+    expect(latestAuth?.role).toBe("member");
+    expect(flagsMocks.clearOnboardingJoinPath).toHaveBeenCalled();
+  });
+
+  it("logs in, switches organizations, and clears auth state on logout events", async () => {
+    await renderAuth();
+    await act(async () => {
+      await latestAuth?.login("gandy", "secret");
+    });
+    await flush();
+
+    expect(loginMock).toHaveBeenCalledWith("gandy", "secret");
+    expect(apiMocks.setStoredTokens).toHaveBeenCalledWith({
+      accessToken: "access-login",
+      refreshToken: "refresh-login",
+    });
+    expect(latestAuth?.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await latestAuth?.selectOrganization("org-2");
+    });
+    expect(localStorage.getItem("first-tree:selectedOrganizationId")).toBe("org-2");
+    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenCalledWith("org-2");
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("auth:logout"));
+    });
+    expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
+    expect(flagsMocks.clearOnboardingSessionFlags).toHaveBeenCalled();
+    expect(latestAuth?.isAuthenticated).toBe(false);
+  });
+
+  it("optimistically dismisses, restores, and completes onboarding with rollback on patch failure", async () => {
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.dismissOnboarding();
+    });
+    expect(latestAuth?.onboardingDismissedAt).toBe("2026-05-28T00:00:00.000Z");
+
+    apiMocks.apiPatch.mockRejectedValueOnce(new Error("network"));
+    await act(async () => {
+      await latestAuth?.restoreOnboarding();
+    });
+    expect(latestAuth?.onboardingDismissedAt).toBe("2026-05-28T00:00:00.000Z");
+
+    await act(async () => {
+      await latestAuth?.markOnboardingCompleted();
+    });
+    expect(onboardingCompletedMock).toHaveBeenCalled();
+    expect(latestAuth?.onboardingCompletedAt).toBeTruthy();
+  });
+
+  it("adopts external token pairs and falls back when /me fails", async () => {
+    apiMocks.apiGet.mockRejectedValueOnce(new Error("offline"));
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.adoptTokens({ accessToken: "oauth-access", refreshToken: "oauth-refresh" });
+    });
+    await flush();
+
+    expect(apiMocks.setStoredTokens).toHaveBeenCalledWith({
+      accessToken: "oauth-access",
+      refreshToken: "oauth-refresh",
+    });
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    expect(latestAuth?.meLoaded).toBe(true);
+  });
+});

--- a/packages/web/src/auth/__tests__/require-auth-app.test.tsx
+++ b/packages/web/src/auth/__tests__/require-auth-app.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import type { MeMembership } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { RequireAuth } from "../require-auth.js";
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    isAuthenticated: false,
+    meLoaded: false,
+    user: null,
+    memberships: [] as MeMembership[],
+    currentMembership: null as MeMembership | null,
+    organizationId: null,
+    memberId: null,
+    role: null,
+    agentId: null,
+    teamDisplayName: null,
+    orgHasOtherMembers: false,
+    onboardingStep: null,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: null,
+    dismissOnboarding: async () => undefined,
+    restoreOnboarding: async () => undefined,
+    markOnboardingCompleted: async () => undefined,
+    login: async () => undefined,
+    adoptTokens: async () => undefined,
+    selectOrganization: async () => undefined,
+    refreshMe: async () => undefined,
+    logout: () => undefined,
+  },
+}));
+
+vi.mock("../auth-context.js", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => authMock.value,
+}));
+
+vi.mock("../../pages/landing/index.js", () => ({
+  LandingPage: () => <div>Landing content</div>,
+}));
+
+function renderRoute(path: string): string {
+  const queryClient = new QueryClient();
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <QueryClientProvider client={queryClient}>
+        <Routes>
+          <Route element={<RequireAuth />}>
+            <Route index element={<div>Dashboard</div>} />
+            <Route path="/settings" element={<div>Settings</div>} />
+          </Route>
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("RequireAuth", () => {
+  it("renders public landing on unauthenticated root", () => {
+    authMock.value = { ...authMock.value, isAuthenticated: false, meLoaded: false };
+    expect(renderRoute("/")).toContain("landing-marketing");
+  });
+
+  it("redirects unauthenticated deep links to login", () => {
+    authMock.value = { ...authMock.value, isAuthenticated: false, meLoaded: false };
+    expect(renderRoute("/settings")).toBe("");
+  });
+
+  it("blocks authenticated routes until /me is loaded, then renders children", () => {
+    authMock.value = { ...authMock.value, isAuthenticated: true, meLoaded: false };
+    expect(renderRoute("/settings")).not.toContain("Settings");
+
+    authMock.value = { ...authMock.value, isAuthenticated: true, meLoaded: true };
+    expect(renderRoute("/settings")).toContain("Settings");
+  });
+});

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { docSnapshotQueryKey } from "../../pages/workspace/center/chat-view.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const meDocsMocks = vi.hoisted(() => ({
+  getMeDoc: vi.fn(),
+}));
+
+vi.mock("../../api/me-docs.js", () => meDocsMocks);
+vi.mock("../../lib/use-agent-name-map.js", () => ({
+  useAgentSlugToIdMap: () => (slug: string | null | undefined) => (slug === "kael" ? "agent-owner" : null),
+}));
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let queryClient: QueryClient;
+let latestSearch = "";
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function setupDom(mobile = false): void {
+  const storage = createStorage();
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: mobile ? 390 : 1400 });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: mobile && query.includes("47.999rem"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  latestSearch = location.search;
+  return null;
+}
+
+async function renderAt(
+  route: string,
+  element: ReactElement,
+  seed?: (client: QueryClient) => void,
+): Promise<HTMLElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+  });
+  seed?.(queryClient);
+  await act(async () => {
+    root?.render(
+      <MemoryRouter initialEntries={[route]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <>
+                  <LocationProbe />
+                  {element}
+                </>
+              }
+            />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return container;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("missing clickable");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  setupDom();
+  document.body.innerHTML = "";
+  latestSearch = "";
+  root = null;
+  container = null;
+  meDocsMocks.getMeDoc.mockReset();
+  meDocsMocks.getMeDoc.mockResolvedValue({
+    path: "docs/guide.md",
+    content: "# Guide\nSee [next](next.md).",
+    ref: { path: "docs/guide.md" },
+  });
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+describe("DocPreviewDrawer", () => {
+  it("renders inline snapshots, follows markdown links, closes, and resizes", async () => {
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      client.setQueryData(docSnapshotQueryKey("chat-1", "msg-1", "docs/plan.md"), {
+        path: "docs/plan.md",
+        content: "# Plan\nSee [details](details.md).",
+        sha256: "sha",
+        size: 28,
+      });
+    });
+
+    expect(dom.textContent).toContain("Plan");
+    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
+
+    const resize = dom.querySelector<HTMLButtonElement>('button[aria-label="Resize document preview"]');
+    await act(async () => {
+      resize?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+      resize?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    expect(localStorage.getItem("first-tree:doc-preview-drawer:width:v1")).toBeTruthy();
+
+    await click(dom.querySelector<HTMLAnchorElement>('a[href="details.md"]'));
+    expect(latestSearch).toContain("docPath=docs%2Fdetails.md");
+
+    await click(dom.querySelector('button[aria-label="Close document preview"]'));
+    expect(latestSearch).not.toContain("docPath=");
+  });
+
+  it("loads fallback previews for cross-agent paths and renders API errors", async () => {
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const dom = await renderAt(
+      "/?docChat=chat-1&docAgent=sender&docPath=kael%2Fchat-1%2Fdocs%2Fguide.md",
+      <DocPreviewDrawer />,
+    );
+
+    await flush();
+    expect(meDocsMocks.getMeDoc).toHaveBeenCalledWith("chat-1", {
+      agentId: "agent-owner",
+      basePath: undefined,
+      path: "docs/guide.md",
+    });
+    expect(dom.textContent).toContain("Guide");
+
+    await act(async () => root?.unmount());
+    meDocsMocks.getMeDoc.mockRejectedValueOnce(new Error("Unable to load"));
+    const errored = await renderAt("/?docChat=chat-1&docAgent=sender&docPath=docs%2Fmissing.md", <DocPreviewDrawer />);
+    await flush();
+    expect(errored.textContent).toContain("Unable to load");
+  });
+
+  it("uses mobile focus handling and escape close", async () => {
+    setupDom(true);
+    const previous = document.createElement("button");
+    previous.textContent = "previous";
+    document.body.appendChild(previous);
+    previous.focus();
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const dom = await renderAt("/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fguide.md", <DocPreviewDrawer />);
+    await flush();
+
+    expect(dom.querySelector('[aria-modal="true"]')).toBeTruthy();
+    await act(async () => {
+      dom.querySelector("aside")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(latestSearch).not.toContain("docPath=");
+  });
+});

--- a/packages/web/src/components/__tests__/low-coverage-components.test.tsx
+++ b/packages/web/src/components/__tests__/low-coverage-components.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const disconnectedMocks = vi.hoisted(() => ({
+  useDisconnectedComputers: vi.fn(),
+}));
+
+const sessionApiMocks = vi.hoisted(() => ({
+  listAgentSessions: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-disconnected-computers.js", () => disconnectedMocks);
+vi.mock("../../api/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/sessions.js")>()),
+  listAgentSessions: sessionApiMocks.listAgentSessions,
+}));
+
+vi.mock("../../pages/workspace/context/agent-context.js", () => ({
+  AgentContext: ({ agentId }: { agentId: string }) => <div>Agent context {agentId}</div>,
+}));
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return { container, root };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("Expected element to click");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  const storage = createStorage();
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes("dark"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  disconnectedMocks.useDisconnectedComputers.mockReset();
+  sessionApiMocks.listAgentSessions.mockReset();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+});
+
+describe("low coverage UI components", () => {
+  it("renders simple display primitives and AgentChip variants", async () => {
+    const { AgentChip } = await import("../agent-chip.js");
+    const { HistoryGapBanner } = await import("../history-gap-banner.js");
+    const { NewMessagesPill } = await import("../new-messages-pill.js");
+    const { UnreadDivider } = await import("../unread-divider.js");
+    const { FlatSectionHeader } = await import("../ui/flat-section-header.js");
+    const { SectionDivider, SectionShell } = await import("../../pages/agent-detail/section-shell.js");
+    const onPillClick = vi.fn();
+
+    const { container, root } = await renderDom(
+      <>
+        <AgentChip name="kael" displayName="Kael" tone="accent" />
+        <AgentChip name="design" displayName="Design" variant="stacked" />
+        <AgentChip name={null} displayName={null} emptyLabel="No agent" />
+        <HistoryGapBanner />
+        <UnreadDivider />
+        <div style={{ position: "relative" }}>
+          <NewMessagesPill count={1} onClick={onPillClick} />
+          <NewMessagesPill count={3} onClick={onPillClick} />
+        </div>
+        <FlatSectionHeader count={2} right={<button type="button">Action</button>}>
+          Section title
+        </FlatSectionHeader>
+        <SectionShell anchorId="runtime" title="Runtime" caption="Provider details" right={<span>Right slot</span>}>
+          <div>Section body</div>
+        </SectionShell>
+        <SectionDivider />
+      </>,
+    );
+
+    expect(container.textContent).toContain("Kael");
+    expect(container.textContent).toContain("@design");
+    expect(container.textContent).toContain("No agent");
+    expect(container.textContent).toContain("Some older messages may not be loaded");
+    expect(container.textContent).toContain("New Messages");
+    expect(container.textContent).toContain("1 new message");
+    expect(container.textContent).toContain("3 new messages");
+    expect(container.querySelector("#runtime")).toBeTruthy();
+    await click(container.querySelector('button[aria-label="1 new message"]'));
+    expect(onPillClick).toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it("renders DisconnectChip healthy, single, and multi states", async () => {
+    const { DisconnectChip } = await import("../disconnect-chip.js");
+
+    disconnectedMocks.useDisconnectedComputers.mockReturnValueOnce({ firstHostname: null, rows: [] });
+    const healthy = await renderDom(<DisconnectChip />);
+    expect(healthy.container.textContent).toBe("");
+    await act(async () => healthy.root.unmount());
+
+    disconnectedMocks.useDisconnectedComputers.mockReturnValueOnce({
+      firstHostname: "gandy-macbook",
+      rows: [{ clientId: "client-1" }],
+    });
+    const single = await renderDom(<DisconnectChip />);
+    expect(single.container.textContent).toContain("gandy-macbook");
+    expect(single.container.querySelector("button")?.getAttribute("aria-label")).toContain("gandy-macbook");
+    await act(async () => single.root.unmount());
+
+    disconnectedMocks.useDisconnectedComputers.mockReturnValueOnce({
+      firstHostname: "gandy-macbook",
+      rows: [{ clientId: "client-1" }, { clientId: "client-2" }],
+    });
+    const multi = await renderDom(<DisconnectChip />);
+    expect(multi.container.textContent).toContain("2 computers disconnected");
+    expect(multi.container.querySelector("button")?.getAttribute("title")).toContain("2 computers disconnected");
+    await act(async () => multi.root.unmount());
+  });
+
+  it("toggles theme and renders toast actions and dismissal", async () => {
+    const { ThemeToggle } = await import("../ui/theme-toggle.js");
+    const { ToastProvider, useToast } = await import("../ui/toast.js");
+    const action = vi.fn();
+
+    function AddToastButton() {
+      const toast = useToast();
+      return (
+        <button
+          type="button"
+          onClick={() =>
+            toast.addToast({
+              title: "Saved",
+              description: "Changes persisted",
+              action: { label: "Undo", onClick: action },
+              durationMs: null,
+            })
+          }
+        >
+          Add toast
+        </button>
+      );
+    }
+
+    const { container, root } = await renderDom(
+      <ToastProvider>
+        <ThemeToggle />
+        <AddToastButton />
+      </ToastProvider>,
+    );
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await click(container.querySelector('button[aria-label="Switch to light theme"]'));
+    expect(window.localStorage.getItem("theme")).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Add toast") ?? null);
+    expect(container.textContent).toContain("Saved");
+    expect(container.textContent).toContain("Changes persisted");
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Undo") ?? null);
+    expect(action).toHaveBeenCalled();
+    expect(container.textContent).not.toContain("Saved");
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Add toast") ?? null);
+    await click(container.querySelector('button[aria-label="Dismiss"]'));
+    expect(container.textContent).not.toContain("Saved");
+    await act(async () => root.unmount());
+  });
+
+  it("renders ContextPanel session, agent, and empty states", async () => {
+    const { ContextPanel } = await import("../../pages/workspace/context/index.js");
+    sessionApiMocks.listAgentSessions.mockResolvedValue([
+      {
+        agentId: "agent-1",
+        chatId: "chat-1",
+        state: "active",
+        runtimeState: "working",
+        startedAt: "2026-05-28T12:00:00.000Z",
+        lastActivityAt: "2026-05-28T12:05:00.000Z",
+        messageCount: 4,
+      },
+    ]);
+
+    const session = await renderDom(<ContextPanel selectedAgentId="agent-1" selectedChatId="chat-1" />);
+    await flush();
+    expect(session.container.textContent).toContain("Session");
+    expect(session.container.textContent).toContain("chat-1");
+    expect(session.container.textContent).toContain("Agent context agent-1");
+    await act(async () => session.root.unmount());
+
+    const agent = await renderDom(<ContextPanel selectedAgentId="agent-2" selectedChatId={null} />);
+    expect(agent.container.textContent).toContain("Agent context agent-2");
+    await act(async () => agent.root.unmount());
+
+    const empty = await renderDom(<ContextPanel selectedAgentId={null} selectedChatId={null} />);
+    expect(empty.container.textContent).toBe("");
+    await act(async () => empty.root.unmount());
+  });
+});

--- a/packages/web/src/components/chat/__tests__/attention-card-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/attention-card-dom.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment happy-dom
+
+import type { Attention } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../ui/toast.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const attentionApiMocks = vi.hoisted(() => ({
+  respondAttention: vi.fn(),
+}));
+
+vi.mock("../../../api/attention.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/attention.js")>()),
+  respondAttention: attentionApiMocks.respondAttention,
+}));
+
+vi.mock("../../../lib/use-agent-name-map.js", () => ({
+  useAgentNameMap: () => (id: string | null | undefined) => (id === "agent-1" ? "Kael" : (id ?? "unknown")),
+}));
+
+function attention(overrides: Partial<Attention> = {}): Attention {
+  return {
+    id: overrides.id ?? "attention-123456789",
+    originAgentId: overrides.originAgentId ?? "agent-1",
+    originChatId: overrides.originChatId ?? "chat-1",
+    targetHumanId: overrides.targetHumanId ?? "human-agent-self",
+    subject: overrides.subject ?? "Choose rollout scope",
+    body: overrides.body ?? "The deploy can proceed now or wait for the next maintenance window.",
+    requiresResponse: overrides.requiresResponse ?? true,
+    state: overrides.state ?? "open",
+    response: overrides.response ?? null,
+    respondedBy: overrides.respondedBy ?? null,
+    respondedAt: overrides.respondedAt ?? null,
+    cancelled: overrides.cancelled ?? false,
+    cancelledReason: overrides.cancelledReason ?? null,
+    metadata:
+      overrides.metadata ??
+      ({
+        options: {
+          mode: "single",
+          defaultValue: "now",
+          items: [
+            { value: "now", label: "Ship now", hint: "Proceed with the current release." },
+            { value: "later", label: "Wait", hint: "Defer until the next window." },
+          ],
+        },
+      } satisfies Attention["metadata"]),
+    createdAt: overrides.createdAt ?? new Date(Date.now() - 60_000).toISOString(),
+    closedAt: overrides.closedAt ?? null,
+  };
+}
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{element}</ToastProvider>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return { container, root };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("Expected element to click");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setValue(el: HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+  });
+  await flush();
+}
+
+function button(container: HTMLElement, text: string): HTMLButtonElement {
+  const found = [...container.querySelectorAll("button")].find((entry) => entry.textContent?.includes(text));
+  if (!found) throw new Error(`Missing button: ${text}`);
+  return found;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  attentionApiMocks.respondAttention.mockReset();
+  attentionApiMocks.respondAttention.mockImplementation(
+    async (id: string, body: { text?: string; answers?: Record<string, unknown> }) => ({
+      ...attention({ id }),
+      response: body,
+      state: "closed",
+      closedAt: "2026-05-28T12:01:00.000Z",
+    }),
+  );
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("AttentionCard DOM interactions", () => {
+  it("submits the selected single-choice answer and the collapsed recommended answer", async () => {
+    const { AttentionCard } = await import("../attention-card.js");
+    const onResponded = vi.fn();
+    const { container, root } = await renderDom(<AttentionCard attention={attention()} onResponded={onResponded} />);
+
+    expect(container.textContent).toContain("Choose rollout scope");
+    await click(button(container, "Wait"));
+    await click(button(container, "Submit selection"));
+
+    expect(attentionApiMocks.respondAttention).toHaveBeenCalledWith("attention-123456789", {
+      answers: { default: "later" },
+    });
+    await flush();
+    expect(onResponded).toHaveBeenCalled();
+
+    attentionApiMocks.respondAttention.mockClear();
+    await click(button(container, "Collapse"));
+    await click(button(container, "Ship now"));
+    expect(attentionApiMocks.respondAttention).toHaveBeenCalledWith("attention-123456789", {
+      answers: { default: "now" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("handles multi-question answers, escape clearing, and free-form replies", async () => {
+    const { AttentionCard } = await import("../attention-card.js");
+    const multi = attention({
+      metadata: {
+        questions: [
+          {
+            id: "scope",
+            prompt: "Which scope?",
+            context: "Pick a deployment target.",
+            options: {
+              mode: "multi",
+              min: 1,
+              max: 2,
+              defaultValue: ["api"],
+              items: [
+                { value: "api", label: "API" },
+                { value: "web", label: "Web" },
+              ],
+            },
+          },
+          {
+            id: "window",
+            prompt: "When?",
+            options: {
+              mode: "single",
+              items: [
+                { value: "now", label: "Now" },
+                { value: "later", label: "Later" },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    const { container, root } = await renderDom(<AttentionCard attention={multi} />);
+
+    await click(button(container, "Web"));
+    await click(button(container, "Later"));
+    await act(async () => {
+      container
+        .querySelector("[data-attention-id]")
+        ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(button(container, "Submit selection").disabled).toBe(true);
+
+    await click(button(container, "API"));
+    await click(button(container, "Now"));
+    await act(async () => {
+      container
+        .querySelector("[data-attention-id]")
+        ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(attentionApiMocks.respondAttention).toHaveBeenCalledWith("attention-123456789", {
+      answers: { scope: ["api"], window: "now" },
+    });
+
+    attentionApiMocks.respondAttention.mockClear();
+    await click(button(container, "Switch to free-form"));
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Expected free-form textarea");
+    await setValue(textarea, "Please wait for the database window.");
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true, bubbles: true }));
+    });
+    await flush();
+    expect(attentionApiMocks.respondAttention).toHaveBeenCalledWith("attention-123456789", {
+      text: "Please wait for the database window.",
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders free-form-only, collapsed multi-select, and submit errors", async () => {
+    const { AttentionCard } = await import("../attention-card.js");
+    attentionApiMocks.respondAttention.mockRejectedValueOnce(new Error("server rejected answer"));
+
+    const freeOnly = attention({ metadata: {}, body: "" });
+    const free = await renderDom(<AttentionCard attention={freeOnly} />);
+    const textarea = free.container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Expected textarea");
+    await setValue(textarea, "Approved with caution.");
+    await click(button(free.container, "Reply"));
+    await flush();
+    expect(free.container.textContent).toContain("server rejected answer");
+    await act(async () => free.root.unmount());
+
+    const multiSelect = attention({
+      metadata: {
+        options: {
+          mode: "multi",
+          defaultValue: ["api"],
+          items: [
+            { value: "api", label: "API" },
+            { value: "web", label: "Web" },
+          ],
+        },
+      },
+    });
+    const collapsed = await renderDom(<AttentionCard attention={multiSelect} />);
+    await click(button(collapsed.container, "Collapse"));
+    expect(collapsed.container.textContent).toContain("Multi-select");
+    await click(button(collapsed.container, "expand"));
+    expect(collapsed.container.textContent).toContain("Choose rollout scope");
+    await act(async () => collapsed.root.unmount());
+  });
+});

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
@@ -1,0 +1,117 @@
+import type { GithubEventCard } from "@first-tree/shared";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  GITHUB_SYSTEM_SENDER_NAME,
+  GithubEventCardMessage,
+  GithubSystemAvatar,
+  isGithubEventCardContent,
+  isGithubSystemSenderMetadata,
+  isTrustedGithubDispatcherMessage,
+} from "../github-event-card.js";
+
+function card(overrides: Partial<GithubEventCard> = {}): GithubEventCard {
+  return {
+    type: "github_event",
+    reason: overrides.reason ?? "mentioned",
+    event: overrides.event ?? "pull_request",
+    action: overrides.action ?? "opened",
+    kind: overrides.kind ?? "opened",
+    repository: overrides.repository ?? "acme/web",
+    sender: overrides.sender ?? "alice",
+    title: overrides.title ?? "Ship the release",
+    body: overrides.body ?? "Please review @gandy before merge.",
+    url: overrides.url ?? "https://github.com/acme/web/pull/42",
+    entity: overrides.entity ?? {
+      type: "pull_request",
+      key: "acme/web#42",
+      url: "https://github.com/acme/web/pull/42",
+    },
+    mentionedUser: overrides.mentionedUser ?? "gandy",
+  };
+}
+
+describe("GitHub event card", () => {
+  it("validates trusted dispatcher messages and metadata gates", () => {
+    const content = card();
+    expect(isGithubEventCardContent(content)).toBe(true);
+    expect(isGithubEventCardContent({ ...content, type: "github_mention" })).toBe(false);
+    expect(isGithubSystemSenderMetadata({ systemSender: "github" })).toBe(true);
+    expect(isGithubSystemSenderMetadata({ systemSender: "agent" })).toBe(false);
+
+    expect(
+      isTrustedGithubDispatcherMessage({
+        source: "github",
+        format: "card",
+        content,
+        metadata: { systemSender: "github" },
+      }),
+    ).toBe(true);
+    expect(
+      isTrustedGithubDispatcherMessage({
+        source: "web",
+        format: "card",
+        content,
+        metadata: { systemSender: "github" },
+      }),
+    ).toBe(false);
+  });
+
+  it("renders entity labels, action verbs, sender avatar, mention highlights, and fallbacks", () => {
+    const html = renderToStaticMarkup(<GithubEventCardMessage content={card()} />);
+    expect(html).toContain("PR");
+    expect(html).toContain("#42");
+    expect(html).toContain("Ship the release");
+    expect(html).toContain("@alice");
+    expect(html).toContain("mentioned you");
+    expect(html).toContain("@gandy");
+    expect(renderToStaticMarkup(<GithubSystemAvatar />)).toContain(GITHUB_SYSTEM_SENDER_NAME);
+
+    const noEntityUrl = renderToStaticMarkup(
+      <GithubEventCardMessage
+        content={card({
+          reason: "subscribed",
+          kind: "review_requested",
+          body: "",
+          entity: { type: "issue", key: "other/repo#7", url: null },
+          repository: "other/repo",
+          url: "",
+          title: "",
+        })}
+      />,
+    );
+    expect(noEntityUrl).toContain("Issue");
+    expect(noEntityUrl).toContain("#7");
+    expect(noEntityUrl).toContain("repo");
+    expect(noEntityUrl).toContain("requested a review");
+  });
+
+  it("covers subscribed verbs and long body truncation", () => {
+    const kinds: Array<GithubEventCard["kind"]> = [
+      "closed",
+      "merged",
+      "reopened",
+      "commented",
+      "reviewed",
+      "review_comment",
+      "synchronized",
+      "commit_commented",
+      "assigned",
+      "edited",
+      "other",
+    ];
+    for (const kind of kinds) {
+      const html = renderToStaticMarkup(
+        <GithubEventCardMessage
+          content={card({
+            reason: "subscribed",
+            kind,
+            body: kind === "commented" ? "gandy should see this bare mention" : "x".repeat(400),
+            mentionedUser: "gandy",
+          })}
+        />,
+      );
+      expect(html).toContain("@alice");
+    }
+  });
+});

--- a/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment happy-dom
+
+import type { AgentChatStatus } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const clientMocks = vi.hoisted(() => ({
+  getStoredTokens: vi.fn(),
+  refreshAccessToken: vi.fn(),
+}));
+
+vi.mock("../../api/client.js", () => clientMocks);
+
+type WsHandler = ((event: MessageEvent<string>) => void) | null;
+type CloseHandler = ((event: CloseEvent) => void) | null;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  onmessage: WsHandler = null;
+  onopen: (() => void) | null = null;
+  onclose: CloseHandler = null;
+  closed = false;
+  readonly url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(data: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  open(): void {
+    this.onopen?.();
+  }
+
+  closeWith(code: number): void {
+    this.onclose?.(new CloseEvent("close", { code }));
+  }
+}
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let queryClient: QueryClient;
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderHook(enabled = true, onMessage = vi.fn()): Promise<typeof onMessage> {
+  const { useAdminWs } = await import("../use-admin-ws.js");
+  function Probe() {
+    useAdminWs({ enabled, onMessage });
+    return <div>mounted</div>;
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return onMessage;
+}
+
+function makeStatus(overrides: Partial<AgentChatStatus> = {}): AgentChatStatus {
+  return {
+    agentId: overrides.agentId ?? "agent-1",
+    main: overrides.main ?? "working",
+    reachable: overrides.reachable ?? true,
+    engagement: overrides.engagement ?? "active",
+    working: overrides.working ?? true,
+    needsYou: overrides.needsYou ?? false,
+    errored: overrides.errored ?? false,
+    activity: overrides.activity ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  FakeWebSocket.instances = [];
+  Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: FakeWebSocket });
+  Object.defineProperty(window, "WebSocket", { configurable: true, value: FakeWebSocket });
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { protocol: "https:", host: "hub.test" },
+  });
+  const storage = createStorage();
+  storage.setItem("first-tree:selectedOrganizationId", "org-1");
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  clientMocks.getStoredTokens.mockReturnValue({ accessToken: "access-1", refreshToken: "refresh-1" });
+  clientMocks.refreshAccessToken.mockResolvedValue({ accessToken: "access-2", refreshToken: "refresh-2" });
+  root = null;
+  container = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+describe("useAdminWs", () => {
+  it("connects once, broadcasts messages, patches status, and invalidates affected queries", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    queryClient = new QueryClient();
+    const onMessage = await renderHook();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+
+    expect(socket.url).toBe("wss://hub.test/api/v1/orgs/org-1/ws/?token=access-1");
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [makeStatus({ agentId: "agent-1", main: "ready", working: false })],
+    );
+
+    await act(async () => {
+      socket.emit({ type: "session:state", agentId: "agent-1", chatId: "chat-1", status: makeStatus() });
+    });
+
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ type: "session:state" }));
+    expect(queryClient.getQueryData<AgentChatStatus[]>(["chat-agent-status", "chat-1"])?.[0]?.main).toBe("working");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["activity"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["sessions"] });
+
+    await act(async () => {
+      socket.emit({ type: "session:event", agentId: "agent-1", chatId: "chat-1", status: makeStatus() });
+      socket.emit({ type: "chat:message", chatId: "chat-1" });
+      socket.emit({ type: "attention:opened", chatId: "chat-1" });
+      socket.emit({ type: "pulse:tick" });
+      socket.emit("not json");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["session-events", "agent-1", "chat-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-messages", "chat-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-detail", "chat-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["attentions", "chat", "chat-1"] });
+  });
+
+  it("refreshes access tokens on auth close and reconnects immediately", async () => {
+    const onMessage = await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+
+    await act(async () => {
+      first.closeWith(4001);
+    });
+    await flush();
+
+    expect(clientMocks.refreshAccessToken).toHaveBeenCalled();
+    const second = FakeWebSocket.instances[1];
+    expect(second).toBeTruthy();
+
+    await act(async () => {
+      second?.open();
+    });
+    expect(onMessage).not.toHaveBeenCalledWith({ type: "ws:reconnect" });
+  });
+
+  it("skips disabled hooks and tears down the shared socket when the last subscriber unmounts", async () => {
+    await renderHook(false);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    await renderHook(true);
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+    await act(async () => root?.unmount());
+    expect(socket.closed).toBe(true);
+  });
+});

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1,0 +1,1367 @@
+import type {
+  Agent,
+  AgentChatStatus,
+  AgentRuntimeConfig,
+  Attention,
+  ChatDetail,
+  ChatParticipantDetail,
+  MeChatRow,
+  MeMembership,
+  Message,
+  OrgContextTreeOutput,
+  OrgSourceReposOutput,
+} from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubClient, RuntimeAgent } from "../../api/activity.js";
+import { chatAgentStatusQueryKey } from "../../api/agent-status.js";
+import { attentionsInChatQueryKey } from "../../api/attention.js";
+import type { PaginatedMessages } from "../../api/chats.js";
+import type { GithubRepo } from "../../api/github.js";
+import { agentSessionsQueryKey, type SessionEventRow } from "../../api/sessions.js";
+import { ToastProvider } from "../../components/ui/toast.js";
+import type { OnboardingFlowValue } from "../onboarding/onboarding-flow.js";
+import { ADMIN_STEPS, INVITEE_STEPS, type OnboardingPath, type StepId } from "../onboarding/steps.js";
+
+const authMock = vi.hoisted(() => {
+  const memberships: MeMembership[] = [];
+  const currentMembership: MeMembership | null = null;
+  const nullableString = (value: string | null): string | null => value;
+  const onboardingStep = (value: "connect" | "create_agent" | "completed" | null) => value;
+  return {
+    value: {
+      isAuthenticated: true,
+      meLoaded: true,
+      user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships,
+      currentMembership,
+      organizationId: nullableString("org-1"),
+      memberId: nullableString("member-self"),
+      role: nullableString("admin"),
+      agentId: nullableString("human-agent-self"),
+      teamDisplayName: nullableString("Acme"),
+      orgHasOtherMembers: true,
+      onboardingStep: onboardingStep("completed"),
+      onboardingDismissedAt: nullableString(null),
+      onboardingCompletedAt: nullableString("2026-05-01T00:00:00.000Z"),
+      dismissOnboarding: async () => undefined,
+      restoreOnboarding: async () => undefined,
+      markOnboardingCompleted: async () => undefined,
+      login: async () => undefined,
+      adoptTokens: async () => undefined,
+      selectOrganization: async () => undefined,
+      refreshMe: async () => undefined,
+      logout: () => undefined,
+    },
+  };
+});
+
+vi.mock("../../auth/auth-context.js", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => authMock.value,
+}));
+
+vi.mock("../../hooks/use-admin-ws.js", () => ({
+  useAdminWs: () => undefined,
+}));
+
+vi.mock("../../lib/use-agent-name-map.js", () => ({
+  useAgentNameMap: () => (id: string | null | undefined) => {
+    if (!id) return "unknown";
+    return AGENT_NAMES[id] ?? id;
+  },
+  useAgentIdentityMap: () => (id: string | null | undefined) => {
+    if (!id) return null;
+    return {
+      name: AGENT_SLUGS[id] ?? id,
+      displayName: AGENT_NAMES[id] ?? id,
+      avatarImageUrl: null,
+      avatarColorToken: null,
+    };
+  },
+  useAgentSlugToIdMap: () => (slug: string | null | undefined) => {
+    if (!slug) return null;
+    const lower = slug.toLowerCase();
+    return Object.entries(AGENT_SLUGS).find(([, value]) => value === lower)?.[0] ?? null;
+  },
+}));
+
+vi.mock("../../lib/use-member-name-map.js", () => ({
+  useMemberNameMap: () => (id: string | null | undefined) => {
+    if (!id) return "unknown";
+    return MEMBER_NAMES[id] ?? id;
+  },
+}));
+
+const NOW = "2026-05-28T12:00:00.000Z";
+
+const MEMBER_NAMES: Record<string, string> = {
+  "member-self": "Gandy",
+  "member-alice": "Alice",
+};
+
+const AGENT_NAMES: Record<string, string> = {
+  "agent-1": "Kael",
+  "agent-2": "Design Critique",
+  "human-agent-self": "Gandy",
+  "human-agent-alice": "Alice",
+};
+
+const AGENT_SLUGS: Record<string, string> = {
+  "agent-1": "kael",
+  "agent-2": "design",
+  "human-agent-self": "gandy",
+  "human-agent-alice": "alice",
+};
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "kael",
+    displayName: overrides.displayName ?? "Kael",
+    type: overrides.type ?? "agent",
+    managerId: overrides.managerId ?? "member-self",
+    visibility: overrides.visibility ?? "organization",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    status: overrides.status ?? "active",
+    organizationId: overrides.organizationId ?? "org-1",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? `${overrides.uuid ?? "agent-1"}-inbox`,
+    metadata: overrides.metadata ?? {},
+    source: overrides.source ?? "portal",
+    clientId: overrides.clientId ?? "client-1",
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    runtimeState: overrides.runtimeState ?? "idle",
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+const MEMBERS = [
+  {
+    id: "member-self",
+    agentId: "human-agent-self",
+    userId: "user-self",
+    username: "gandy",
+    displayName: "Gandy",
+    role: "admin",
+    createdAt: NOW,
+  },
+  {
+    id: "member-alice",
+    agentId: "human-agent-alice",
+    userId: "user-alice",
+    username: "alice",
+    displayName: "Alice",
+    role: "member",
+    createdAt: NOW,
+  },
+];
+
+const CLIENTS: HubClient[] = [
+  {
+    id: "client-1",
+    userId: "user-self",
+    status: "connected",
+    authState: "ok",
+    sdkVersion: "0.5.0",
+    hostname: "gandy-macbook",
+    os: "darwin",
+    agentCount: 1,
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    capabilities: {
+      "claude-code": {
+        state: "ok",
+        available: true,
+        authenticated: true,
+        sdkVersion: "0.2.84",
+        authMethod: "oauth",
+        detectedAt: NOW,
+      },
+      codex: {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion: "0.134.0",
+        authMethod: "none",
+        detectedAt: NOW,
+      },
+    },
+  },
+  {
+    id: "client-2",
+    userId: "user-alice",
+    status: "disconnected",
+    authState: "expired",
+    sdkVersion: "0.5.0",
+    hostname: "alice-linux",
+    os: "linux",
+    agentCount: 1,
+    connectedAt: null,
+    lastSeenAt: "2026-05-28T11:00:00.000Z",
+    capabilities: {},
+  },
+];
+
+const RUNTIME_AGENTS: RuntimeAgent[] = [
+  {
+    agentId: "agent-1",
+    type: "agent",
+    clientId: "client-1",
+    runtimeState: "idle",
+    runtimeType: "claude-code",
+    activeSessions: 1,
+    totalSessions: 2,
+    runtimeUpdatedAt: NOW,
+    managedByMe: true,
+  },
+  {
+    agentId: "agent-2",
+    type: "agent",
+    clientId: "client-2",
+    runtimeState: "offline",
+    runtimeType: "codex",
+    activeSessions: 0,
+    totalSessions: 1,
+    runtimeUpdatedAt: "2026-05-28T11:00:00.000Z",
+    managedByMe: false,
+  },
+  {
+    agentId: "human-agent-self",
+    type: "human",
+    clientId: null,
+    runtimeState: null,
+    runtimeType: null,
+    activeSessions: null,
+    totalSessions: null,
+    runtimeUpdatedAt: null,
+    managedByMe: true,
+  },
+];
+
+function participant(overrides: Partial<ChatParticipantDetail> & { agentId: string }): ChatParticipantDetail {
+  return {
+    agentId: overrides.agentId,
+    role: overrides.role ?? "member",
+    mode: overrides.mode ?? "full",
+    joinedAt: overrides.joinedAt ?? NOW,
+    name: overrides.name ?? (overrides.type === "human" ? "gandy" : "kael"),
+    displayName: overrides.displayName ?? AGENT_NAMES[overrides.agentId] ?? overrides.agentId,
+    type: overrides.type ?? "agent",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+  };
+}
+
+const CHAT_PARTICIPANTS: ChatParticipantDetail[] = [
+  participant({ agentId: "human-agent-self", name: "gandy", displayName: "Gandy", type: "human" }),
+  participant({ agentId: "human-agent-alice", name: "alice", displayName: "Alice", type: "human" }),
+  participant({ agentId: "agent-1", name: "kael", displayName: "Kael", type: "agent", avatarColorToken: "hue-2" }),
+  participant({ agentId: "agent-2", name: "design", displayName: "Design Critique", type: "agent" }),
+];
+
+function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
+  return {
+    chatId: overrides.chatId ?? "chat-1",
+    type: overrides.type ?? "group",
+    membershipKind: overrides.membershipKind ?? "participant",
+    source: overrides.source ?? "manual",
+    entityType: overrides.entityType ?? null,
+    title: overrides.title ?? "Launch planning",
+    topic: overrides.topic ?? "Launch planning",
+    participants: overrides.participants ?? CHAT_PARTICIPANTS,
+    participantCount: overrides.participantCount ?? CHAT_PARTICIPANTS.length,
+    lastMessageAt: overrides.lastMessageAt ?? NOW,
+    lastMessagePreview: overrides.lastMessagePreview ?? "Please review the launch checklist.",
+    unreadMentionCount: overrides.unreadMentionCount ?? 1,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    liveActivity:
+      overrides.liveActivity ??
+      ({
+        agentId: "agent-1",
+        kind: "tool_call",
+        label: "Using Bash",
+        startedAt: "2026-05-28T11:59:00.000Z",
+      } satisfies MeChatRow["liveActivity"]),
+    pendingQuestionAgentIds: overrides.pendingQuestionAgentIds ?? ["agent-1"],
+    failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? ["agent-1"],
+    chatHasOpenQuestion: overrides.chatHasOpenQuestion ?? true,
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? true,
+  };
+}
+
+function chatDetail(overrides: Partial<ChatDetail> = {}): ChatDetail {
+  return {
+    id: overrides.id ?? "chat-1",
+    organizationId: overrides.organizationId ?? "org-1",
+    type: overrides.type ?? "group",
+    topic: overrides.topic ?? "Launch planning",
+    lifecyclePolicy: overrides.lifecyclePolicy ?? null,
+    metadata:
+      overrides.metadata ??
+      ({
+        source: "github",
+        entityUrl: "https://github.com/acme/web/pull/42",
+      } satisfies Record<string, unknown>),
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+    participants: overrides.participants ?? CHAT_PARTICIPANTS,
+    title: overrides.title ?? "Launch planning",
+    firstMessagePreview: overrides.firstMessagePreview ?? "Please review the launch checklist.",
+    engagementStatus: overrides.engagementStatus ?? "active",
+    viewerMembershipKind: overrides.viewerMembershipKind ?? "participant",
+  };
+}
+
+function message(overrides: Partial<Message> & { id: string; senderId: string; content?: unknown }): Message {
+  return {
+    id: overrides.id,
+    chatId: overrides.chatId ?? "chat-1",
+    senderId: overrides.senderId,
+    format: overrides.format ?? "text",
+    content: overrides.content ?? "Please review `docs/plan.md` and @kael for rollout risks.",
+    metadata: overrides.metadata ?? {},
+    inReplyTo: overrides.inReplyTo ?? null,
+    source: overrides.source ?? "web",
+    createdAt: overrides.createdAt ?? NOW,
+  };
+}
+
+const CHAT_MESSAGES: PaginatedMessages = {
+  items: [
+    message({
+      id: "msg-1",
+      senderId: "human-agent-self",
+      createdAt: "2026-05-28T11:55:00.000Z",
+      content: "Please review `docs/plan.md` and @kael for rollout risks.",
+      metadata: {
+        documentContext: {
+          basePath: "/workspace/acme",
+          files: [
+            {
+              path: "docs/plan.md",
+              status: "included",
+              content: "# Plan\nShip carefully.",
+            },
+          ],
+          failedMentions: [{ path: "secrets.env", reason: "hidden" }],
+        },
+        mentions: ["agent-1"],
+      },
+    }),
+    message({
+      id: "msg-2",
+      senderId: "agent-1",
+      createdAt: "2026-05-28T11:57:00.000Z",
+      content: "I found one deployment risk and opened an ask.",
+      metadata: {},
+      source: "api",
+    }),
+    message({
+      id: "msg-3",
+      senderId: "agent-2",
+      format: "file",
+      createdAt: "2026-05-28T11:58:00.000Z",
+      content: {
+        caption: "Here is the preview.",
+        attachments: [{ imageId: "image-1", mimeType: "image/png", filename: "preview.png", size: 42 }],
+      },
+      metadata: {},
+      source: "api",
+    }),
+  ],
+  nextCursor: null,
+};
+
+const SESSION_EVENTS: { items: SessionEventRow[]; nextCursor: number | null } = {
+  items: [
+    {
+      id: "event-1",
+      agentId: "agent-1",
+      chatId: "chat-1",
+      seq: 1,
+      kind: "tool_call",
+      payload: { toolUseId: "tool-1", name: "Bash", args: { cmd: "pnpm test" }, status: "pending" },
+      createdAt: "2026-05-28T11:56:00.000Z",
+    },
+    {
+      id: "event-2",
+      agentId: "agent-1",
+      chatId: "chat-1",
+      seq: 2,
+      kind: "assistant_text",
+      payload: { text: "Checking the route behavior now." },
+      createdAt: "2026-05-28T11:56:10.000Z",
+    },
+    {
+      id: "event-3",
+      agentId: "agent-1",
+      chatId: "chat-1",
+      seq: 3,
+      kind: "error",
+      payload: { source: "runtime", message: "Example recoverable runtime error" },
+      createdAt: "2026-05-28T11:56:20.000Z",
+    },
+  ],
+  nextCursor: null,
+};
+
+function attention(overrides: Partial<Attention> = {}): Attention {
+  return {
+    id: overrides.id ?? "attention-123456789",
+    originAgentId: overrides.originAgentId ?? "agent-1",
+    originChatId: overrides.originChatId ?? "chat-1",
+    targetHumanId: overrides.targetHumanId ?? "human-agent-self",
+    subject: overrides.subject ?? "Choose rollout scope",
+    body: overrides.body ?? "The deploy can proceed now or wait for the next maintenance window.",
+    requiresResponse: overrides.requiresResponse ?? true,
+    state: overrides.state ?? "open",
+    response: overrides.response ?? null,
+    respondedBy: overrides.respondedBy ?? null,
+    respondedAt: overrides.respondedAt ?? null,
+    cancelled: overrides.cancelled ?? false,
+    cancelledReason: overrides.cancelledReason ?? null,
+    metadata:
+      overrides.metadata ??
+      ({
+        options: {
+          mode: "single",
+          defaultValue: "now",
+          items: [
+            { value: "now", label: "Ship now", hint: "Proceed with the current release." },
+            { value: "later", label: "Wait", hint: "Defer until the next window." },
+          ],
+        },
+      } satisfies Attention["metadata"]),
+    createdAt: overrides.createdAt ?? "2026-05-28T11:54:00.000Z",
+    closedAt: overrides.closedAt ?? null,
+  };
+}
+
+const CHAT_STATUSES: AgentChatStatus[] = [
+  {
+    agentId: "agent-1",
+    main: "working",
+    reachable: true,
+    engagement: "active",
+    working: true,
+    needsYou: false,
+    errored: false,
+    activity: {
+      agentId: "agent-1",
+      kind: "tool_call",
+      label: "Bash",
+      detail: "pnpm test",
+      startedAt: "2026-05-28T11:59:00.000Z",
+      turnText: "Checking the rollout path.",
+    },
+  },
+  {
+    agentId: "agent-2",
+    main: "needs_you",
+    reachable: true,
+    engagement: "active",
+    working: false,
+    needsYou: true,
+    errored: false,
+    activity: null,
+  },
+];
+
+const GITHUB_REPOS: GithubRepo[] = [
+  {
+    fullName: "acme/web",
+    cloneUrl: "https://github.com/acme/web.git",
+    htmlUrl: "https://github.com/acme/web",
+    private: false,
+    defaultBranch: "main",
+    pushedAt: NOW,
+  },
+  {
+    fullName: "acme/api",
+    cloneUrl: "git@github.com:acme/api.git",
+    htmlUrl: "https://github.com/acme/api",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: NOW,
+  },
+];
+
+const CONTEXT_TREE_SETTING: OrgContextTreeOutput = {
+  repo: "https://github.com/acme/context-tree",
+  branch: "main",
+};
+
+const SOURCE_REPOS_SETTING: OrgSourceReposOutput = {
+  repos: [
+    { url: "https://github.com/acme/web.git", defaultBranch: "main" },
+    { url: "git@github.com:acme/api.git", defaultBranch: "main" },
+  ],
+};
+
+const AGENT_CONFIG: AgentRuntimeConfig = {
+  agentId: "agent-1",
+  version: 7,
+  payload: {
+    kind: "claude-code",
+    prompt: { append: "Always explain tradeoffs." },
+    model: "sonnet",
+    reasoningEffort: "high",
+    mcpServers: [
+      {
+        name: "filesystem",
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+      },
+      {
+        name: "docs",
+        transport: "http",
+        url: "https://docs.example.com/mcp",
+        headers: { Authorization: "Bearer test" },
+      },
+    ],
+    env: [
+      { key: "FIRST_TREE_ENV", value: "test", sensitive: false },
+      { key: "OPENAI_API_KEY", value: "***", sensitive: true },
+    ],
+    gitRepos: [
+      { url: "https://github.com/acme/web.git", localPath: "web", ref: "main" },
+      { url: "git@github.com:acme/api.git", localPath: "api" },
+    ],
+  },
+  updatedAt: NOW,
+  updatedBy: "member-self",
+};
+
+function createClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const agents = [agent(), agent({ uuid: "agent-2", name: "design-critique", displayName: "Design Critique" })];
+  const humanAgent = agent({
+    uuid: "human-agent-self",
+    name: "gandy",
+    displayName: "Gandy",
+    type: "human",
+    clientId: null,
+    delegateMention: "agent-1",
+  });
+  const orgAgents = [humanAgent, ...agents];
+  queryClient.setQueryData(["clients", "org"], CLIENTS);
+  queryClient.setQueryData(
+    ["clients", "me"],
+    CLIENTS.filter((c) => c.userId === "user-self"),
+  );
+  queryClient.setQueryData(["clients"], CLIENTS);
+  queryClient.setQueryData(["clients", "team-page"], CLIENTS);
+  queryClient.setQueryData(["members"], MEMBERS);
+  queryClient.setQueryData(["activity"], { agents: RUNTIME_AGENTS, clients: CLIENTS });
+  queryClient.setQueryData(["agents", "team-page", "admin"], agents);
+  queryClient.setQueryData(["agents"], { items: agents, nextCursor: null });
+  queryClient.setQueryData(["agents", "org-list"], { items: orgAgents, nextCursor: null });
+  queryClient.setQueryData(["agents", "org-list", "search", ""], { items: orgAgents, nextCursor: null });
+  queryClient.setQueryData(["managed-agents", "name-map"], agents);
+  queryClient.setQueryData(["agent", "agent-1"], agents[0]);
+  queryClient.setQueryData(["agent-config", "agent-1"], AGENT_CONFIG);
+  queryClient.setQueryData(["agent-client-status", "agent-1"], {
+    clientId: "client-1",
+    clientStatus: "connected",
+    clientAuthState: "ok",
+    hostname: "gandy-macbook",
+    lastSeenAt: NOW,
+  });
+  queryClient.setQueryData(["agent-sessions-active", "agent-1"], []);
+  queryClient.setQueryData(agentSessionsQueryKey("agent-1"), [
+    {
+      agentId: "agent-1",
+      chatId: "chat-1",
+      state: "active",
+      runtimeState: "working",
+      startedAt: "2026-05-28T11:52:00.000Z",
+      lastActivityAt: NOW,
+      messageCount: 3,
+      summary: "Launch checklist review",
+      topic: "Launch planning",
+    },
+  ]);
+  queryClient.setQueryData(["me", "chats", "all", "active", false, null, null], {
+    rows: [
+      chatRow(),
+      chatRow({
+        chatId: "chat-2",
+        title: "Archived design review",
+        source: "github",
+        entityType: "pull_request",
+        unreadMentionCount: 0,
+        busyAgentIds: [],
+        pendingQuestionAgentIds: [],
+        chatHasOpenQuestion: false,
+        chatHasExplicitMentionToMe: false,
+        engagementStatus: "archived",
+        lastMessageAt: "2026-05-27T09:00:00.000Z",
+        lastMessagePreview: "Looks good.",
+      }),
+    ],
+    nextCursor: null,
+  });
+  queryClient.setQueryData(["me", "chats", "unread", "active", true, "manual", "agent-1"], {
+    rows: [chatRow()],
+    nextCursor: null,
+  });
+  queryClient.setQueryData(["me", "chats", "all", "archived", false, null, null], {
+    rows: [
+      chatRow({
+        chatId: "chat-2",
+        title: "Archived design review",
+        source: "github",
+        entityType: "pull_request",
+        unreadMentionCount: 0,
+        busyAgentIds: [],
+        pendingQuestionAgentIds: [],
+        chatHasOpenQuestion: false,
+        chatHasExplicitMentionToMe: false,
+        engagementStatus: "archived",
+      }),
+    ],
+    nextCursor: null,
+  });
+  queryClient.setQueryData(["chat-detail", "chat-1"], chatDetail());
+  queryClient.setQueryData(["chat-messages-cache", "chat-1"], CHAT_MESSAGES.items.slice(0, 1));
+  queryClient.setQueryData(["chat-messages", "chat-1"], CHAT_MESSAGES);
+  queryClient.setQueryData(["session-events", "agent-1", "chat-1"], SESSION_EVENTS);
+  queryClient.setQueryData(["chat-read-state", "chat-1"], {
+    chatId: "chat-1",
+    bottomVisibleMessageId: "msg-1",
+    latestKnownMessageId: "msg-1",
+    updatedAt: Date.now(),
+  });
+  queryClient.setQueryData(attentionsInChatQueryKey("chat-1"), [
+    attention(),
+    attention({
+      id: "attention-notify",
+      requiresResponse: false,
+      state: "closed",
+      subject: "Rollout noted",
+      closedAt: NOW,
+    }),
+  ]);
+  queryClient.setQueryData(chatAgentStatusQueryKey("chat-1"), CHAT_STATUSES);
+  queryClient.setQueryData(["agent-skills", "agent-1"], {
+    skills: [{ name: "review", description: "Review a change list." }],
+  });
+  queryClient.setQueryData(["chat-right-sidebar", "github-entities", "chat-1"], {
+    items: [
+      {
+        entityType: "pull_request",
+        entityKey: "acme/web#42",
+        htmlUrl: "https://github.com/acme/web/pull/42",
+        title: "Release checklist",
+        state: "open",
+        boundVia: "direct",
+      },
+    ],
+  });
+  queryClient.setQueryData(["onboarding", "installation", "org-1"], {
+    installationId: 42,
+    accountLogin: "acme",
+    accountType: "Organization",
+    accountGithubId: 12345,
+    repositorySelection: "selected",
+    permissions: { contents: "read", pull_requests: "write" },
+    events: ["pull_request", "issues"],
+    suspended: false,
+    manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  queryClient.setQueryData(["onboarding", "github-repos"], GITHUB_REPOS);
+  queryClient.setQueryData(["onboarding", "context-tree", "org-1"], CONTEXT_TREE_SETTING);
+  queryClient.setQueryData(["onboarding", "team-config", "org-1"], {
+    treeUrl: CONTEXT_TREE_SETTING.repo,
+    teamRepoUrls: SOURCE_REPOS_SETTING.repos.map((repo) => repo.url),
+    hasInstallation: true,
+    installationKnown: true,
+  });
+  queryClient.setQueryData(["org-setting", "org-1", "context_tree"], CONTEXT_TREE_SETTING);
+  queryClient.setQueryData(["org-setting", "org-1", "source_repos"], SOURCE_REPOS_SETTING);
+  queryClient.setQueryData(["github-app-installation", "org-1"], {
+    installationId: 42,
+    accountLogin: "acme",
+    accountType: "Organization",
+    accountGithubId: 12345,
+    repositorySelection: "selected",
+    permissions: { contents: "read", pull_requests: "write" },
+    events: ["pull_request", "issues"],
+    suspended: true,
+    manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+    createdAt: NOW,
+    updatedAt: NOW,
+  });
+  queryClient.setQueryData(
+    ["adapters"],
+    [
+      {
+        id: 1,
+        platform: "feishu",
+        agentId: "agent-1",
+        status: "active",
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
+  );
+  queryClient.setQueryData(
+    ["adapter-mappings"],
+    [
+      {
+        id: 2,
+        platform: "feishu",
+        agentId: "agent-1",
+        externalUserId: "ou_1",
+        displayName: "Gandy Feishu",
+        boundVia: "manual",
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
+  );
+  queryClient.setQueryData(["adapter-statuses"], [{ configId: 1, connected: true, lastSeenAt: NOW }]);
+  return queryClient;
+}
+
+function renderWithClient(element: ReactElement, queryClient: QueryClient, route = "/"): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[route]}>
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{element}</ToastProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+function renderPage(element: ReactElement, route = "/"): string {
+  return renderWithClient(element, createClient(), route);
+}
+
+function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): OnboardingFlowValue {
+  const path: OnboardingPath = overrides.path ?? "admin";
+  const sequence: readonly StepId[] = path === "admin" ? ADMIN_STEPS : INVITEE_STEPS;
+  const fallbackStep: StepId = path === "admin" ? "team" : "welcome";
+  const requestedActiveStep = overrides.activeStep;
+  const activeStep: StepId =
+    requestedActiveStep && sequence.some((step) => step === requestedActiveStep) ? requestedActiveStep : fallbackStep;
+  const activeIndex = sequence.indexOf(activeStep);
+  return {
+    path,
+    sequence,
+    activeIndex: overrides.activeIndex ?? Math.max(0, activeIndex),
+    activeStep,
+    goNext: () => undefined,
+    goTo: () => undefined,
+    organizationId: "org-1",
+    memberId: "member-self",
+    role: path === "admin" ? "admin" : "member",
+    username: "gandy",
+    teamDisplayName: "Acme",
+    orgHasOtherMembers: true,
+    computer: {
+      connectedClient: CLIENTS[0] ?? null,
+      capabilitiesLoaded: true,
+      okRuntimes: ["claude-code", "codex"],
+      selectedRuntime: "claude-code",
+      setSelectedRuntime: () => undefined,
+      cliCommand: "npm install -g first-tree\nfirst-tree login connect-token",
+      tokenError: null,
+    },
+    agentDisplayName: "Gandy's assistant",
+    setAgentDisplayName: () => undefined,
+    visibility: "organization",
+    setVisibility: () => undefined,
+    agentPhase: "idle",
+    agentError: null,
+    createAgent: async () => undefined,
+    retryAgent: async () => undefined,
+    createdAgentUuid: "agent-1",
+    hasAgent: true,
+    selectedRepoUrls: ["https://github.com/acme/web.git"],
+    setSelectedRepoUrls: () => undefined,
+    treeMode: "existing",
+    setTreeMode: () => undefined,
+    treeUrl: "https://github.com/acme/context-tree",
+    setTreeUrl: () => undefined,
+    treeAutoInitDone: true,
+    markTreeAutoInitDone: () => undefined,
+    completeAndEnterChat: async () => undefined,
+    finishLater: async () => undefined,
+    ...overrides,
+  };
+}
+
+async function renderOnboardingStep(
+  element: ReactElement,
+  overrides: Partial<OnboardingFlowValue> = {},
+  queryClient = createClient(),
+): Promise<string> {
+  const { OnboardingFlowContext } = await import("../onboarding/onboarding-flow.js");
+  return renderWithClient(
+    <OnboardingFlowContext.Provider value={createFlowValue(overrides)}>{element}</OnboardingFlowContext.Provider>,
+    queryClient,
+    "/onboarding",
+  );
+}
+
+function installBrowserStubs(pathname = "/preview/onboarding"): void {
+  const localStorageData = new Map<string, string>();
+  const sessionStorageData = new Map<string, string>();
+  const documentElement = {
+    classList: {
+      contains: () => false,
+      toggle: () => false,
+    },
+  };
+  const doc = {
+    title: "First Tree",
+    body: {
+      appendChild: () => undefined,
+      removeChild: () => undefined,
+    },
+    documentElement,
+    activeElement: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    createElement: (tag: string) => ({
+      tagName: tag.toUpperCase(),
+      style: {},
+      setAttribute: () => undefined,
+      appendChild: () => undefined,
+      removeChild: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      getBoundingClientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }),
+    }),
+  };
+  const win = {
+    document: doc,
+    fetch: globalThis.fetch,
+    innerWidth: 1280,
+    matchMedia: (query: string) => ({
+      matches: query.includes(`1024${"px"}`),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+    localStorage: {
+      getItem: (key: string) => localStorageData.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        localStorageData.set(key, value);
+      },
+      removeItem: (key: string) => {
+        localStorageData.delete(key);
+      },
+    },
+    location: { pathname, search: "" },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+    sessionStorage: {
+      getItem: (key: string) => sessionStorageData.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        sessionStorageData.set(key, value);
+      },
+      removeItem: (key: string) => {
+        sessionStorageData.delete(key);
+      },
+    },
+    requestAnimationFrame: (cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    },
+  };
+  Object.defineProperty(globalThis, "window", { configurable: true, value: win });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: doc });
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: win.localStorage });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: win.sessionStorage });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { clipboard: { writeText: async () => undefined } },
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", { configurable: true, value: win.requestAnimationFrame });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", { configurable: true, value: () => undefined });
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: { randomUUID: () => "00000000-0000-4000-8000-000000000000" },
+  });
+  Object.defineProperty(globalThis, "URL", {
+    configurable: true,
+    value: {
+      ...URL,
+      createObjectURL: () => "blob:test",
+      revokeObjectURL: () => undefined,
+    },
+  });
+}
+
+describe("page SSR smoke coverage", () => {
+  beforeEach(() => {
+    installBrowserStubs();
+    authMock.value = {
+      ...authMock.value,
+      role: "admin",
+      memberId: "member-self",
+      organizationId: "org-1",
+      user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+    };
+  });
+
+  it("renders the large preview pages", async () => {
+    const { ChatRowAvatarPreviewPage } = await import("../chat-row-avatar-preview.js");
+    const { ContextPreviewPage } = await import("../context-preview.js");
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+    const { StyleguidePreviewPage } = await import("../styleguide-preview.js");
+
+    expect(renderPage(<StyleguidePreviewPage />)).toContain("First Tree");
+    expect(renderPage(<OnboardingPreviewPage />)).toContain("Onboarding");
+    expect(renderPage(<ChatRowAvatarPreviewPage />)).toContain("Chat Row Avatar");
+    expect(renderPage(<ContextPreviewPage />)).toContain("Context tree");
+  });
+
+  it("renders public and settings pages with seeded query data", async () => {
+    const { BindingsPage } = await import("../bindings.js");
+    const { ClientsPage } = await import("../clients.js");
+    const { IntegrationsPage } = await import("../integrations.js");
+    const { LandingPage } = await import("../landing/index.js");
+    const { OrgSettingsPage } = await import("../org-settings.js");
+    const { SettingsComputersPage } = await import("../settings/computers.js");
+    const { SettingsGithubPage } = await import("../settings/github.js");
+    const { SettingsIntegrationsPage } = await import("../settings/integrations.js");
+    const { TeamPage } = await import("../team/index.js");
+    const { TeamSettingsPage } = await import("../team/settings.js");
+
+    expect(renderPage(<LandingPage />)).toContain("AI-native teams");
+    expect(renderPage(<ClientsPage />)).toContain("Computers");
+    expect(renderPage(<TeamPage />)).toContain("Team");
+    expect(renderPage(<IntegrationsPage />)).toContain("Messaging");
+    expect(renderPage(<BindingsPage />, "/integrations?agent=agent-1")).toContain("Bot bindings");
+    expect(renderPage(<SettingsComputersPage />)).toContain("Computers");
+    expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
+    expect(renderPage(<SettingsIntegrationsPage />)).toContain("Messaging");
+    expect(renderPage(<TeamSettingsPage />)).toContain("Identity");
+    expect(renderPage(<OrgSettingsPage />)).toContain("Source repos");
+
+    authMock.value = { ...authMock.value, role: "member" };
+    expect(renderPage(<SettingsGithubPage />)).toBe("");
+    expect(renderPage(<TeamSettingsPage />)).toContain("Repos your team");
+    expect(renderPage(<OrgSettingsPage />)).not.toContain("Identity");
+
+    authMock.value = { ...authMock.value, role: null };
+    expect(renderPage(<SettingsGithubPage />)).toContain("Loading");
+    expect(renderPage(<TeamSettingsPage />)).toContain("Loading");
+  });
+
+  it("renders the agent detail layout with configuration data", async () => {
+    const { AgentDetailPage } = await import("../agent-detail.js");
+    const { ProfileTab } = await import("../agent-detail/profile-tab.js");
+    const { PromptTab } = await import("../agent-detail/prompt-tab.js");
+    const { ResourcesTab } = await import("../agent-detail/resources-tab.js");
+    const { SetupTab } = await import("../agent-detail/setup-tab.js");
+    const { ToolsTab } = await import("../agent-detail/tools-tab.js");
+
+    const html = renderPage(
+      <Routes>
+        <Route path="/agents/:uuid" element={<AgentDetailPage />}>
+          <Route path="profile" element={<ProfileTab />} />
+          <Route path="setup" element={<SetupTab />} />
+          <Route path="prompt" element={<PromptTab />} />
+          <Route path="tools" element={<ToolsTab />} />
+          <Route path="resources" element={<ResourcesTab />} />
+        </Route>
+      </Routes>,
+      "/agents/agent-1/profile",
+    );
+
+    expect(html).toContain("Kael");
+    expect(html).toContain("Profile");
+
+    for (const [route, expected] of [
+      ["/agents/agent-1/setup", "Runtime"],
+      ["/agents/agent-1/prompt", "System prompt append"],
+      ["/agents/agent-1/tools", "MCP servers"],
+      ["/agents/agent-1/resources", "Environment variables"],
+    ] as const) {
+      expect(
+        renderPage(
+          <Routes>
+            <Route path="/agents/:uuid" element={<AgentDetailPage />}>
+              <Route path="profile" element={<ProfileTab />} />
+              <Route path="setup" element={<SetupTab />} />
+              <Route path="prompt" element={<PromptTab />} />
+              <Route path="tools" element={<ToolsTab />} />
+              <Route path="resources" element={<ResourcesTab />} />
+            </Route>
+          </Routes>,
+          route,
+        ),
+      ).toContain(expected);
+    }
+  });
+
+  it("renders agent detail sections with populated draft rows", async () => {
+    const { AppearanceSection } = await import("../agent-detail/appearance-section.js");
+    const { EnvSection } = await import("../agent-detail/env-section.js");
+    const { GitSection } = await import("../agent-detail/git-section.js");
+    const { IdentitySection } = await import("../agent-detail/identity-section.js");
+    const { McpSection } = await import("../agent-detail/mcp-section.js");
+    const { ModelSection } = await import("../agent-detail/model-section.js");
+    const { PromptSection } = await import("../agent-detail/prompt-section.js");
+    const { ReasoningEffortSection } = await import("../agent-detail/reasoning-effort-section.js");
+    const { SetupSection } = await import("../agent-detail/setup-section.js");
+
+    const noop = () => undefined;
+    const asyncNoop = async () => undefined;
+    const row = <T,>(key: string, value: T) => ({ key, value, baseline: value, status: "unchanged" as const });
+    const rendered = renderPage(
+      <>
+        <IdentitySection agent={agent()} onSave={asyncNoop} />
+        <AppearanceSection agent={agent()} onSave={asyncNoop} onRefresh={asyncNoop} />
+        <SetupSection
+          runtimeProvider="claude-code"
+          computerLabel="gandy-macbook"
+          canBindComputer={false}
+          onBindComputer={noop}
+          modelSlot={<ModelSection value="sonnet" baseline="opus" onChange={noop} onRevert={noop} />}
+          effortSlot={<ReasoningEffortSection value="high" baseline="" onChange={noop} onRevert={noop} />}
+        />
+        <PromptSection value={AGENT_CONFIG.payload.prompt.append} baseline="" onChange={noop} onRevert={noop} />
+        <McpSection
+          items={AGENT_CONFIG.payload.mcpServers.map((item, index) => row(`mcp-${index}`, item))}
+          otherNames={() => new Set()}
+          toolHealth={() => "working"}
+          onAdd={noop}
+          onUpdate={noop}
+          onDelete={noop}
+          onUndoDelete={noop}
+        />
+        <EnvSection
+          items={AGENT_CONFIG.payload.env.map((item, index) => row(`env-${index}`, item))}
+          otherKeys={() => new Set()}
+          onAdd={noop}
+          onUpdate={noop}
+          onDelete={noop}
+          onUndoDelete={noop}
+        />
+        <GitSection
+          items={AGENT_CONFIG.payload.gitRepos.map((item, index) => row(`git-${index}`, item))}
+          otherPaths={() => new Set()}
+          onAdd={noop}
+          onUpdate={noop}
+          onDelete={noop}
+          onUndoDelete={noop}
+        />
+      </>,
+    );
+
+    expect(rendered).toContain("Identity");
+    expect(rendered).toContain("Appearance");
+    expect(rendered).toContain("gandy-macbook");
+    expect(rendered).toContain("Always explain tradeoffs.");
+    expect(rendered).toContain("filesystem");
+    expect(rendered).toContain("FIRST_TREE_ENV");
+    expect(rendered).toContain("https://github.com/acme/web.git");
+  });
+
+  it("renders workspace surfaces with seeded chat data", async () => {
+    const { AttentionCard } = await import("../../components/chat/attention-card.js");
+    const { AgentStatusPanel } = await import("../../components/chat/agent-status-panel.js");
+    const { ComposeStatusBar } = await import("../../components/chat/compose-status-bar.js");
+    const { NewAgentDialog } = await import("../../components/new-agent-dialog.js");
+    const { ChatView } = await import("../workspace/center/chat-view.js");
+    const { ConversationList } = await import("../workspace/conversations/index.js");
+    const { NewChatDraft } = await import("../workspace/conversations/new-chat-draft.js");
+    const { WorkspacePage } = await import("../workspace/index.js");
+    const { AgentRoster } = await import("../workspace/roster/index.js");
+    const { ChatRightSidebar } = await import("../workspace/right-sidebar/index.js");
+    const { AgentContext } = await import("../workspace/context/agent-context.js");
+
+    const noop = () => undefined;
+    expect(
+      renderPage(
+        <ConversationList
+          selectedChatId="chat-1"
+          onSelectChat={noop}
+          onNewChat={noop}
+          engagement="active"
+          onEngagementChange={noop}
+          unread
+          onUnreadChange={noop}
+          watching
+          onWatchingChange={noop}
+          origin={["manual"]}
+          onOriginChange={noop}
+          participants={["agent-1"]}
+          onParticipantsChange={noop}
+          onClearFilters={noop}
+          group="source"
+          onGroupChange={noop}
+        />,
+      ),
+    ).toContain("Launch planning");
+
+    expect(renderPage(<NewChatDraft onCreated={noop} onShowConversations={noop} />)).toContain("task?");
+    expect(
+      renderPage(
+        <AgentRoster selectedAgentId="agent-1" selectedChatId="chat-1" onSelectAgent={noop} onSelectChat={noop} />,
+      ),
+    ).toContain("Launch planning");
+    expect(renderPage(<AttentionCard attention={attention()} />)).toContain("Choose rollout scope");
+    expect(() => renderPage(<NewAgentDialog open onOpenChange={noop} onCreated={noop} />)).not.toThrow();
+    expect(
+      renderPage(
+        <ChatRightSidebar
+          chatId="chat-1"
+          participants={CHAT_PARTICIPANTS}
+          participantsLoading={false}
+          managedByMe={new Map([["agent-1", true]])}
+          onAdded={noop}
+          readOnly={false}
+        />,
+      ),
+    ).toContain("Participants");
+    expect(
+      renderPage(
+        <AgentStatusPanel
+          chatId="chat-1"
+          agents={CHAT_PARTICIPANTS.filter((participant) => participant.type !== "human")}
+          canManage={() => true}
+          order="priority"
+        />,
+      ),
+    ).toContain("Working");
+    expect(
+      renderPage(
+        <ComposeStatusBar
+          chatId="chat-1"
+          agents={CHAT_PARTICIPANTS.filter((participant) => participant.type !== "human")}
+        />,
+      ),
+    ).toContain("needs reply");
+    expect(renderPage(<AgentContext agentId="agent-1" />)).toContain("Computer");
+    expect(renderPage(<ChatView agentId="agent-1" chatId="chat-1" />)).toContain("Launch planning");
+    expect(renderPage(<WorkspacePage />, "/?c=chat-1&origin=manual&with=agent-1&unread=1&watching=1")).toContain(
+      "Launch planning",
+    );
+  });
+
+  it("renders ChatView alternate chrome, composer, and recovery states", async () => {
+    const { ChatView } = await import("../workspace/center/chat-view.js");
+
+    const noAttentionClient = createClient();
+    noAttentionClient.setQueryData(attentionsInChatQueryKey("chat-1"), []);
+    expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" />, noAttentionClient)).toContain(
+      "Type @ to pick a recipient",
+    );
+
+    const readOnlyClient = createClient();
+    expect(
+      renderWithClient(
+        <ChatView
+          agentId="agent-1"
+          chatId="chat-1"
+          readOnly
+          titleFallback="Fallback title"
+          joinAction={{ error: "Join failed", joining: false, onJoin: () => undefined }}
+          onShowConversations={() => undefined}
+        />,
+        readOnlyClient,
+      ),
+    ).toContain("Join to reply");
+
+    expect(
+      renderWithClient(
+        <ChatView
+          agentId="agent-1"
+          chatId="chat-1"
+          readOnly
+          joinAction={{ error: null, joining: true, onJoin: () => undefined }}
+        />,
+        createClient(),
+      ),
+    ).toContain("Joining");
+
+    const deletedClient = createClient();
+    deletedClient.setQueryData(
+      ["chat-detail", "chat-1"],
+      chatDetail({ engagementStatus: "deleted", title: "Archived launch" }),
+    );
+    deletedClient.setQueryData(attentionsInChatQueryKey("chat-1"), []);
+    expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" />, deletedClient)).toContain("Restore");
+
+    const emptyClient = createClient();
+    emptyClient.setQueryData(["chat-detail", "chat-empty"], chatDetail({ id: "chat-empty", title: "Empty chat" }));
+    emptyClient.setQueryData(["chat-messages-cache", "chat-empty"], []);
+    emptyClient.setQueryData(["chat-messages", "chat-empty"], { items: [], nextCursor: null });
+    emptyClient.setQueryData(["session-events", "agent-1", "chat-empty"], { items: [], nextCursor: null });
+    emptyClient.setQueryData(attentionsInChatQueryKey("chat-empty"), []);
+    expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-empty" />, emptyClient)).toContain(
+      "Send a message to start",
+    );
+
+    localStorage.setItem("first-tree:chat-right-sidebar:open:v1", "1");
+    const sidebarClient = createClient();
+    sidebarClient.setQueryData(attentionsInChatQueryKey("chat-1"), []);
+    expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" narrow />, sidebarClient)).toContain(
+      "Participants",
+    );
+  });
+
+  it("renders onboarding steps and reusable onboarding UI states", async () => {
+    const { ConnectCommandPanel } = await import("../../components/connect-command-panel.js");
+    const { ConnectStuckPanel } = await import("../../components/connect-stuck-panel.js");
+    const { CommandBox, FlowNote, RepoPicker, StatusRow, WorkingState } = await import("../onboarding/flow-ui.js");
+    const { InstallGuide, ShowMeHow, TerminalGuide } = await import("../onboarding/guides.js");
+    const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
+    const { StepConnectComputer } = await import("../onboarding/steps/step-connect-computer.js");
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+    const { StepTeam } = await import("../onboarding/steps/step-team.js");
+    const { StepWelcome } = await import("../onboarding/steps/step-welcome.js");
+
+    const html = renderPage(
+      <>
+        <CommandBox command="npm install -g first-tree\nfirst-tree login token" />
+        <FlowNote tone="info">Heads up</FlowNote>
+        <StatusRow state="waiting" label="Waiting now" />
+        <StatusRow state="ok" label="Connected now" />
+        <WorkingState label="Working now" hint="A short hint" />
+        <RepoPicker repos={GITHUB_REPOS} selected={["https://github.com/acme/web.git"]} onToggle={() => undefined} />
+        <ConnectCommandPanel
+          command="first-tree login token"
+          expiresInSeconds={600}
+          phase="success"
+          successContent="gandy-macbook connected"
+        />
+        <ConnectCommandPanel command={null} phase="error" errorContent="Could not mint a token" />
+        <ConnectStuckPanel />
+        <ShowMeHow>
+          <TerminalGuide />
+          <InstallGuide />
+        </ShowMeHow>
+      </>,
+    );
+    expect(html).toContain("first-tree login token");
+    expect(html).toContain("Heads up");
+    expect(html).toContain("gandy-macbook connected");
+    expect(html).toContain("Install Node.js");
+    expect(html).toContain("Choose your projects");
+
+    expect(await renderOnboardingStep(<StepTeam />, { activeStep: "team" })).toContain("Team name");
+    expect(await renderOnboardingStep(<StepWelcome />, { path: "invitee", activeStep: "welcome" })).toContain("Acme");
+    expect(await renderOnboardingStep(<StepConnectComputer />, { activeStep: "connect-computer" })).toContain(
+      "gandy-macbook",
+    );
+    expect(await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent" })).toContain(
+      "Gandy&#x27;s assistant",
+    );
+    expect(
+      await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "creating" }),
+    ).toContain("Setting up your agent");
+    expect(
+      await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "timeout" }),
+    ).toContain("longer than expected");
+    expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Which projects");
+    expect(await renderOnboardingStep(<StepKickoff />, { activeStep: "kickoff" })).toContain(
+      "Use your team&#x27;s Context Tree",
+    );
+    expect(
+      await renderOnboardingStep(<StepKickoff />, {
+        activeStep: "kickoff",
+        selectedRepoUrls: [],
+        treeMode: "new",
+        treeUrl: "",
+      }),
+    ).toContain("Start your agent");
+    expect(
+      await renderOnboardingStep(<StepKickoff />, {
+        path: "invitee",
+        activeStep: "kickoff",
+        selectedRepoUrls: [],
+      }),
+    ).toContain("Your team is ready");
+  });
+
+  it("renders invite, GitHub App, settings, and layout surfaces", async () => {
+    const { Layout } = await import("../../components/layout.js");
+    const { TeamSetupModal } = await import("../../components/team-setup-modal.js");
+    const { UserMenu } = await import("../../components/user-menu.js");
+    const { InviteAcceptCard, InviteAcceptError, InviteAcceptShell, InviteAcceptSkeleton } = await import(
+      "../invite-accept.js"
+    );
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    const { SourceReposSettingsPanel } = await import("../source-repos-settings-panel.js");
+    const { SettingsLayout } = await import("../settings.js");
+
+    const preview = {
+      organizationId: "org-1",
+      organizationName: "acme",
+      organizationDisplayName: "Acme",
+      role: "member",
+      expiresAt: "2026-05-29T12:00:00.000Z",
+    };
+
+    expect(
+      renderPage(
+        <InviteAcceptShell>
+          <InviteAcceptSkeleton />
+          <InviteAcceptError message="No invite" />
+        </InviteAcceptShell>,
+      ),
+    ).toContain("Back to home");
+    expect(
+      renderPage(
+        <InviteAcceptCard
+          preview={preview}
+          isAuthenticated
+          currentTeamName="Other Team"
+          busy={false}
+          onJoin={() => undefined}
+          oauthHref="/api/v1/auth/github/start"
+        />,
+      ),
+    ).toContain("Join Acme");
+    expect(renderPage(<GithubAppInstallationPanel />)).toContain("GitHub App");
+    expect(renderPage(<ContextTreeSettingsPanel />)).toContain("Context tree");
+    expect(renderPage(<SourceReposSettingsPanel />)).toContain("Source repos");
+    expect(renderPage(<UserMenu />)).toContain("user-menu");
+    expect(() => renderPage(<TeamSetupModal action="create" onClose={() => undefined} />)).not.toThrow();
+    expect(renderPage(<SettingsLayout />)).toContain("Settings");
+    expect(
+      renderPage(
+        <Routes>
+          <Route element={<Layout />}>
+            <Route index element={<div>Workspace child</div>} />
+            <Route path="settings" element={<div>Settings child</div>} />
+          </Route>
+        </Routes>,
+      ),
+    ).toContain("Workspace child");
+  });
+});

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1,0 +1,1610 @@
+// @vitest-environment happy-dom
+
+import type { Agent, MeMembership } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubClient, RuntimeAgent } from "../../api/activity.js";
+import { ToastProvider } from "../../components/ui/toast.js";
+import type { OnboardingFlowValue } from "../onboarding/onboarding-flow.js";
+import { ADMIN_STEPS, INVITEE_STEPS, type OnboardingPath, type StepId } from "../onboarding/steps.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const activityMocks = vi.hoisted(() => ({
+  disconnectClient: vi.fn(),
+  generateConnectToken: vi.fn(),
+  getActivityOverview: vi.fn(),
+  getClientCapabilities: vi.fn(),
+  listClients: vi.fn(),
+  listOrgClients: vi.fn(),
+  retireClient: vi.fn(),
+}));
+
+const agentApiMocks = vi.hoisted(() => ({
+  checkAgentNameAvailability: vi.fn(),
+  createAgent: vi.fn(),
+  getAgent: vi.fn(),
+  listAgents: vi.fn(),
+  listManagedAgents: vi.fn(),
+}));
+
+const agentConfigMocks = vi.hoisted(() => ({
+  getAgentConfig: vi.fn(),
+  updateAgentConfig: vi.fn(),
+}));
+
+const chatApiMocks = vi.hoisted(() => ({
+  createAgentChat: vi.fn(),
+  readFileAsBase64: vi.fn(),
+  sendChatMessage: vi.fn(),
+  sendFileMessageBatch: vi.fn(),
+}));
+
+const githubMocks = vi.hoisted(() => ({
+  listGithubRepos: vi.fn(),
+}));
+
+const githubAppMocks = vi.hoisted(() => ({
+  getGithubAppInstallation: vi.fn(),
+  getGithubAppInstallationExists: vi.fn(),
+  getGithubAppInstallUrl: vi.fn(),
+}));
+
+const imageStoreMocks = vi.hoisted(() => ({
+  putImage: vi.fn(),
+}));
+
+const memberApiMocks = vi.hoisted(() => ({
+  listMembers: vi.fn(),
+}));
+
+const orgSettingsMocks = vi.hoisted(() => ({
+  getContextTreeSetting: vi.fn(),
+  getSourceReposSetting: vi.fn(),
+  putContextTreeSetting: vi.fn(),
+  putSourceReposSetting: vi.fn(),
+}));
+
+const onboardingEventMocks = vi.hoisted(() => ({
+  reportOnboardingEvent: vi.fn(),
+}));
+
+const meChatMocks = vi.hoisted(() => ({
+  addMeChatParticipants: vi.fn(),
+  createMeChat: vi.fn(),
+}));
+
+const clientApiMocks = vi.hoisted(() => ({
+  post: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => {
+  const memberships: MeMembership[] = [];
+  const currentMembership: MeMembership | null = null;
+  const nullableString = (value: string | null): string | null => value;
+  const onboardingStep = (value: "connect" | "create_agent" | "completed" | null) => value;
+  return {
+    value: {
+      isAuthenticated: true,
+      meLoaded: true,
+      user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships,
+      currentMembership,
+      organizationId: nullableString("org-1"),
+      memberId: nullableString("member-self"),
+      role: nullableString("admin"),
+      agentId: nullableString("human-agent-self"),
+      teamDisplayName: nullableString("Acme"),
+      orgHasOtherMembers: true,
+      onboardingStep: onboardingStep("completed"),
+      onboardingDismissedAt: nullableString(null),
+      onboardingCompletedAt: nullableString("2026-05-01T00:00:00.000Z"),
+      dismissOnboarding: vi.fn(async () => undefined),
+      restoreOnboarding: vi.fn(async () => undefined),
+      markOnboardingCompleted: vi.fn(async () => undefined),
+      login: vi.fn(async () => undefined),
+      adoptTokens: vi.fn(async () => undefined),
+      selectOrganization: vi.fn(async () => undefined),
+      refreshMe: vi.fn(async () => undefined),
+      logout: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../api/activity.js", () => activityMocks);
+vi.mock("../../api/agent-config.js", () => agentConfigMocks);
+vi.mock("../../api/agents.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/agents.js")>()),
+  ...agentApiMocks,
+}));
+vi.mock("../../api/chats.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/chats.js")>()),
+  ...chatApiMocks,
+}));
+vi.mock("../../api/github.js", () => githubMocks);
+vi.mock("../../api/github-app.js", () => githubAppMocks);
+vi.mock("../../api/image-store.js", () => imageStoreMocks);
+vi.mock("../../api/members.js", () => memberApiMocks);
+vi.mock("../../api/me-chats.js", () => meChatMocks);
+vi.mock("../../api/onboarding-events.js", () => onboardingEventMocks);
+vi.mock("../../api/org-settings.js", () => orgSettingsMocks);
+vi.mock("../../api/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client.js")>();
+  return {
+    ...actual,
+    api: { ...actual.api, post: clientApiMocks.post },
+  };
+});
+vi.mock("../../auth/auth-context.js", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => authMock.value,
+}));
+vi.mock("../../lib/use-agent-name-map.js", () => ({
+  useAgentNameMap: () => (id: string | null | undefined) => (id ? (AGENT_NAMES[id] ?? id) : "unknown"),
+  useAgentIdentityMap: () => (id: string | null | undefined) =>
+    id
+      ? {
+          name: AGENT_SLUGS[id] ?? id,
+          displayName: AGENT_NAMES[id] ?? id,
+          avatarImageUrl: null,
+          avatarColorToken: null,
+        }
+      : null,
+  useAgentSlugToIdMap: () => (slug: string | null | undefined) => {
+    if (!slug) return null;
+    return Object.entries(AGENT_SLUGS).find(([, value]) => value === slug)?.[0] ?? null;
+  },
+}));
+vi.mock("../../lib/use-member-name-map.js", () => ({
+  useMemberNameMap: () => (id: string | null | undefined) => (id ? (MEMBER_NAMES[id] ?? id) : "unknown"),
+}));
+vi.mock("../../lib/visibility-interval.js", () => ({
+  runVisibilityAwareInterval: (tick: () => void | Promise<void>) => {
+    void tick();
+    return () => undefined;
+  },
+}));
+
+const NOW = "2026-05-28T12:00:00.000Z";
+
+const AGENT_NAMES: Record<string, string> = {
+  "agent-1": "Kael",
+  "agent-2": "Design Critique",
+  "human-agent-self": "Gandy",
+};
+
+const AGENT_SLUGS: Record<string, string> = {
+  "agent-1": "kael",
+  "agent-2": "design",
+  "human-agent-self": "gandy",
+};
+
+const MEMBER_NAMES: Record<string, string> = {
+  "member-self": "Gandy",
+  "member-alice": "Alice",
+};
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "kael",
+    organizationId: overrides.organizationId ?? "org-1",
+    type: overrides.type ?? "agent",
+    displayName: overrides.displayName ?? "Kael",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? "inbox-1",
+    status: overrides.status ?? "active",
+    source: overrides.source ?? "portal",
+    visibility: overrides.visibility ?? "organization",
+    metadata: overrides.metadata ?? {},
+    managerId: overrides.managerId ?? "member-self",
+    clientId: overrides.clientId ?? "client-1",
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    runtimeState: overrides.runtimeState ?? "idle",
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+const CLIENTS: HubClient[] = [
+  {
+    id: "client-1",
+    userId: "user-self",
+    status: "connected",
+    authState: "ok",
+    sdkVersion: "0.5.0",
+    hostname: "gandy-macbook",
+    os: "darwin",
+    agentCount: 1,
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    capabilities: {
+      "claude-code": {
+        state: "ok",
+        available: true,
+        authenticated: true,
+        sdkVersion: "0.2.84",
+        authMethod: "oauth",
+        detectedAt: NOW,
+      },
+      codex: {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion: "0.134.0",
+        authMethod: "none",
+        detectedAt: NOW,
+      },
+    },
+  },
+  {
+    id: "client-2",
+    userId: "user-alice",
+    status: "disconnected",
+    authState: "expired",
+    sdkVersion: "0.5.0",
+    hostname: "alice-linux",
+    os: "linux",
+    agentCount: 1,
+    connectedAt: null,
+    lastSeenAt: "2026-05-28T11:00:00.000Z",
+    capabilities: {},
+  },
+];
+
+const GITHUB_REPOS = [
+  {
+    fullName: "acme/web",
+    cloneUrl: "https://github.com/acme/web.git",
+    htmlUrl: "https://github.com/acme/web",
+    private: false,
+    defaultBranch: "main",
+    pushedAt: NOW,
+  },
+  {
+    fullName: "acme/api",
+    cloneUrl: "git@github.com:acme/api.git",
+    htmlUrl: "https://github.com/acme/api",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: NOW,
+  },
+];
+
+const RUNTIME_AGENTS: RuntimeAgent[] = [
+  {
+    agentId: "agent-1",
+    clientId: "client-1",
+    runtimeType: "claude-code",
+    runtimeState: "working",
+    activeSessions: 1,
+    totalSessions: 2,
+    runtimeUpdatedAt: NOW,
+    type: "agent",
+    managedByMe: true,
+  },
+  {
+    agentId: "agent-2",
+    clientId: "client-2",
+    runtimeType: "codex",
+    runtimeState: "offline",
+    activeSessions: 0,
+    totalSessions: 0,
+    runtimeUpdatedAt: NOW,
+    type: "agent",
+    managedByMe: false,
+  },
+];
+
+const ORG_AGENTS = [
+  agent({
+    uuid: "human-agent-self",
+    name: "gandy",
+    displayName: "Gandy",
+    type: "human",
+    clientId: null,
+    delegateMention: "agent-1",
+  }),
+  agent(),
+  agent({ uuid: "agent-2", name: "design", displayName: "Design Critique", managerId: "member-alice" }),
+];
+
+function setupDom(): void {
+  const storage = createStorage();
+  window.HTMLElement.prototype.scrollIntoView = () => undefined;
+  window.URL.createObjectURL = () => "blob:test";
+  window.URL.revokeObjectURL = () => undefined;
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: createStorage() });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes(`1024${"px"}`),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn(async () => undefined) },
+  });
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: { randomUUID: () => "00000000-0000-4000-8000-000000000000" },
+  });
+}
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+async function renderDom(
+  element: ReactElement,
+  route = "/",
+  seed?: (queryClient: QueryClient) => void,
+): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = createClient();
+  queryClient.setQueryData(["agents", "org-list"], { items: ORG_AGENTS, nextCursor: null });
+  seed?.(queryClient);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[route]}>
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>{element}</ToastProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return { container, root };
+}
+
+function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): OnboardingFlowValue {
+  const path: OnboardingPath = overrides.path ?? "admin";
+  const sequence: readonly StepId[] = path === "admin" ? ADMIN_STEPS : INVITEE_STEPS;
+  const fallbackStep: StepId = path === "admin" ? "team" : "welcome";
+  const requestedActiveStep = overrides.activeStep;
+  const activeStep: StepId =
+    requestedActiveStep && sequence.some((step) => step === requestedActiveStep) ? requestedActiveStep : fallbackStep;
+  const activeIndex = sequence.indexOf(activeStep);
+  return {
+    path,
+    sequence,
+    activeIndex: overrides.activeIndex ?? Math.max(0, activeIndex),
+    activeStep,
+    goNext: vi.fn(),
+    goTo: vi.fn(),
+    organizationId: "org-1",
+    memberId: "member-self",
+    role: path === "admin" ? "admin" : "member",
+    username: "gandy",
+    teamDisplayName: "Acme",
+    orgHasOtherMembers: true,
+    computer: {
+      connectedClient: CLIENTS[0] ?? null,
+      capabilitiesLoaded: true,
+      okRuntimes: ["claude-code", "codex"],
+      selectedRuntime: "claude-code",
+      setSelectedRuntime: vi.fn(),
+      cliCommand: "first-tree-dev login token",
+      tokenError: null,
+    },
+    agentDisplayName: "Gandy's assistant",
+    setAgentDisplayName: vi.fn(),
+    visibility: "organization",
+    setVisibility: vi.fn(),
+    agentPhase: "idle",
+    agentError: null,
+    createAgent: vi.fn(async () => undefined),
+    retryAgent: vi.fn(async () => undefined),
+    createdAgentUuid: "agent-1",
+    hasAgent: true,
+    selectedRepoUrls: ["https://github.com/acme/web.git"],
+    setSelectedRepoUrls: vi.fn(),
+    treeMode: "existing",
+    setTreeMode: vi.fn(),
+    treeUrl: "https://github.com/acme/context-tree",
+    setTreeUrl: vi.fn(),
+    treeAutoInitDone: true,
+    markTreeAutoInitDone: vi.fn(),
+    completeAndEnterChat: vi.fn(async () => undefined),
+    finishLater: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+async function renderOnboardingDom(
+  element: ReactElement,
+  overrides: Partial<OnboardingFlowValue> = {},
+): Promise<{ container: HTMLElement; root: Root; flow: OnboardingFlowValue }> {
+  const { OnboardingFlowContext } = await import("../onboarding/onboarding-flow.js");
+  const flow = createFlowValue(overrides);
+  const rendered = await renderDom(
+    <OnboardingFlowContext.Provider value={flow}>{element}</OnboardingFlowContext.Provider>,
+  );
+  return { ...rendered, flow };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function setValue(el: HTMLInputElement | HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const proto = el instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("Expected element to click");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function waitForText(text: string, container: HTMLElement = document.body): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Missing text: ${text}\n${container.textContent ?? ""}`);
+}
+
+beforeEach(() => {
+  setupDom();
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  authMock.value = {
+    ...authMock.value,
+    role: "admin",
+    memberId: "member-self",
+    agentId: "human-agent-self",
+    organizationId: "org-1",
+    user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+  };
+  activityMocks.listClients.mockResolvedValue(CLIENTS.filter((client) => client.userId === "user-self"));
+  activityMocks.listOrgClients.mockResolvedValue(CLIENTS);
+  activityMocks.getActivityOverview.mockResolvedValue({
+    total: 2,
+    running: 1,
+    byState: { idle: 1, working: 1, blocked: 0, error: 0 },
+    clients: 2,
+    agents: RUNTIME_AGENTS,
+  });
+  activityMocks.getClientCapabilities.mockResolvedValue(CLIENTS[0]);
+  activityMocks.generateConnectToken.mockResolvedValue({
+    token: "connect-token",
+    expiresIn: 600,
+    command: "first-tree-dev login connect-token",
+    bootstrapCommand: "first-tree-dev login connect-token",
+    npmSpec: null,
+    binName: "first-tree-dev",
+  });
+  activityMocks.disconnectClient.mockResolvedValue({ disconnected: true, agentIds: ["agent-1"] });
+  activityMocks.retireClient.mockResolvedValue(undefined);
+  agentApiMocks.checkAgentNameAvailability.mockResolvedValue({ available: true });
+  agentApiMocks.createAgent.mockResolvedValue(
+    agent({ uuid: "agent-created", name: "deploy-bot", displayName: "Deploy Bot" }),
+  );
+  agentApiMocks.getAgent.mockResolvedValue(agent({ clientId: "client-bound" }));
+  agentApiMocks.listAgents.mockResolvedValue({ items: ORG_AGENTS, nextCursor: null });
+  agentApiMocks.listManagedAgents.mockResolvedValue([
+    {
+      uuid: "agent-1",
+      name: "kael",
+      displayName: "Kael",
+      type: "agent",
+      organizationId: "org-1",
+      inboxId: "inbox-1",
+      visibility: "organization",
+      runtimeProvider: "claude-code",
+      clientId: "client-1",
+      avatarImageUrl: null,
+    },
+  ]);
+  agentConfigMocks.getAgentConfig.mockResolvedValue({
+    agentId: "agent-1",
+    version: 7,
+    payload: {
+      kind: "claude-code",
+      gitRepos: [],
+      prompt: { append: "" },
+      mcpServers: [],
+      env: [],
+    },
+    updatedAt: NOW,
+    updatedBy: "member-self",
+  });
+  agentConfigMocks.updateAgentConfig.mockResolvedValue({
+    agentId: "agent-1",
+    version: 8,
+    payload: {
+      kind: "claude-code",
+      gitRepos: [{ url: "https://github.com/acme/web.git" }],
+      prompt: { append: "" },
+      mcpServers: [],
+      env: [],
+    },
+    updatedAt: NOW,
+    updatedBy: "member-self",
+  });
+  chatApiMocks.createAgentChat.mockResolvedValue({ id: "chat-onboarding" });
+  chatApiMocks.readFileAsBase64.mockResolvedValue("base64");
+  chatApiMocks.sendChatMessage.mockResolvedValue(undefined);
+  chatApiMocks.sendFileMessageBatch.mockResolvedValue(undefined);
+  githubMocks.listGithubRepos.mockResolvedValue(GITHUB_REPOS);
+  githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+  githubAppMocks.getGithubAppInstallationExists.mockResolvedValue(true);
+  githubAppMocks.getGithubAppInstallUrl.mockResolvedValue("https://github.com/apps/first-tree/installations/new");
+  imageStoreMocks.putImage.mockResolvedValue(undefined);
+  memberApiMocks.listMembers.mockResolvedValue([
+    {
+      id: "member-self",
+      userId: "user-self",
+      agentId: "human-agent-self",
+      username: "gandy",
+      displayName: "Gandy",
+      role: "admin",
+      createdAt: NOW,
+    },
+    {
+      id: "member-alice",
+      userId: "user-alice",
+      agentId: null,
+      username: "alice",
+      displayName: "Alice",
+      role: "member",
+      createdAt: NOW,
+    },
+  ]);
+  meChatMocks.addMeChatParticipants.mockResolvedValue({ ok: true });
+  meChatMocks.createMeChat.mockResolvedValue({ chatId: "chat-created" });
+  onboardingEventMocks.reportOnboardingEvent.mockResolvedValue(undefined);
+  orgSettingsMocks.getContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree",
+    branch: "main",
+  });
+  orgSettingsMocks.getSourceReposSetting.mockResolvedValue({
+    repos: [
+      { url: "https://github.com/acme/web.git", defaultBranch: "main" },
+      { url: "git@github.com:acme/api.git", defaultBranch: "main" },
+    ],
+  });
+  orgSettingsMocks.putContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree",
+    branch: "main",
+  });
+  orgSettingsMocks.putSourceReposSetting.mockResolvedValue({ repos: [] });
+  clientApiMocks.post.mockResolvedValue({
+    token: "connect-token",
+    expiresIn: 600,
+    command: "first-tree-dev login connect-token",
+    bootstrapCommand: "first-tree-dev login connect-token",
+    npmSpec: null,
+    binName: "first-tree-dev",
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("web DOM interaction coverage", () => {
+  it("loads NewAgentDialog computer/runtime state and submits an agent", async () => {
+    const { NewAgentDialog } = await import("../../components/new-agent-dialog.js");
+    const onCreated = vi.fn();
+    const { root } = await renderDom(<NewAgentDialog open onOpenChange={() => undefined} onCreated={onCreated} />);
+
+    await waitForText("gandy-macbook");
+    await waitForText("Claude Code");
+    const input = document.body.querySelector<HTMLInputElement>("#new-agent-display-name");
+    if (!input) throw new Error("Display name input missing");
+    await setValue(input, "Deploy Bot");
+    await click(
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Create") ?? null,
+    );
+
+    expect(agentApiMocks.createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "deploy-bot",
+        displayName: "Deploy Bot",
+        clientId: "client-1",
+        runtimeProvider: "claude-code",
+        visibility: "private",
+        organizationId: "org-1",
+      }),
+    );
+    expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ uuid: "agent-created" }), "claude-code");
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders NewAgentDialog zero-computer recovery command", async () => {
+    activityMocks.listClients.mockResolvedValue([]);
+    const { NewAgentDialog } = await import("../../components/new-agent-dialog.js");
+    await renderDom(<NewAgentDialog open onOpenChange={() => undefined} onCreated={() => undefined} />);
+
+    await waitForText("No computer connected yet.");
+    await waitForText("first-tree-dev login connect-token");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Copy") ?? null);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("first-tree-dev login connect-token");
+  });
+
+  it("renders ClientsPage admin groups, member empty state, and fallback banner", async () => {
+    const { ClientsPage } = await import("../clients.js");
+    const seedAdmin = (queryClient: QueryClient) => {
+      queryClient.setQueryData(["clients", "org"], CLIENTS);
+      queryClient.setQueryData(
+        ["members"],
+        [
+          { userId: "user-self", displayName: "Gandy" },
+          { userId: "user-alice", displayName: "Alice" },
+        ],
+      );
+      queryClient.setQueryData(["activity"], { agents: RUNTIME_AGENTS, clients: CLIENTS });
+    };
+    const admin = await renderDom(<ClientsPage />, "/", seedAdmin);
+    await waitForText("Your computers", admin.container);
+    await waitForText("Team computers", admin.container);
+    await click(
+      [...admin.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Show")) ?? null,
+    );
+    await waitForText("Alice", admin.container);
+    await waitForText("Auth expired", admin.container);
+
+    await act(async () => admin.root.unmount());
+
+    authMock.value = { ...authMock.value, role: "member" };
+    activityMocks.listClients.mockResolvedValue([]);
+    const member = await renderDom(<ClientsPage />, "/", (queryClient) => {
+      queryClient.setQueryData(["clients", "me"], []);
+      queryClient.setQueryData(["activity"], { agents: [], clients: [] });
+    });
+    await waitForText("No computers connected yet.", member.container);
+    await act(async () => member.root.unmount());
+
+    authMock.value = { ...authMock.value, role: "admin" };
+    activityMocks.listOrgClients.mockRejectedValue(new Error("forbidden"));
+    activityMocks.listClients.mockResolvedValue([CLIENTS[0]]);
+    const fallback = await renderDom(<ClientsPage />);
+    await waitForText("Failed to load team computers", fallback.container);
+    await waitForText("gandy-macbook", fallback.container);
+  });
+
+  it("creates one-on-one and group chats from NewChatDraft", async () => {
+    const { NewChatDraft } = await import("../workspace/conversations/new-chat-draft.js");
+    const onCreated = vi.fn();
+    const first = await renderDom(<NewChatDraft onCreated={onCreated} onShowConversations={() => undefined} />);
+    await waitForText("Kael", first.container);
+    const textarea = first.container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Draft textarea missing");
+    await setValue(textarea, "hello");
+    await click(first.container.querySelector('button[aria-label="Send"]'));
+
+    expect(meChatMocks.createMeChat).toHaveBeenCalledWith({ participantIds: ["agent-1"] });
+    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-created", "hello", ["agent-1"]);
+    expect(onCreated).toHaveBeenCalledWith("chat-created");
+    await act(async () => first.root.unmount());
+
+    meChatMocks.createMeChat.mockClear();
+    chatApiMocks.sendChatMessage.mockClear();
+    const second = await renderDom(<NewChatDraft onCreated={() => undefined} />);
+    await waitForText("Kael", second.container);
+    await click(second.container.querySelector('button[aria-label="Add participant"]'));
+    await waitForText("Design Critique", second.container);
+    await click(
+      [...second.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Design Critique"),
+      ) ?? null,
+    );
+    await waitForText("Design Critique", second.container);
+    const groupTextarea = second.container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!groupTextarea) throw new Error("Group draft textarea missing");
+    await setValue(groupTextarea, "please review @design");
+    await click(second.container.querySelector('button[aria-label="Send"]'));
+
+    expect(meChatMocks.createMeChat).toHaveBeenCalledWith({ participantIds: ["agent-1", "agent-2"] });
+    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-created", "please review @design", ["agent-2"]);
+  });
+
+  it("searches, keyboard-selects, and closes AddParticipantDropdown", async () => {
+    const { AddParticipantDropdown } = await import("../../components/add-participant-dropdown.js");
+    const onAdded = vi.fn();
+    const first = await renderDom(
+      <AddParticipantDropdown chatId="chat-1" participantIds={["agent-1"]} onAdded={onAdded} variant="inline" />,
+    );
+
+    await click(first.container.querySelector("button"));
+    await waitForText("Kael", first.container);
+    await waitForText("Design Critique", first.container);
+    expect(first.container.querySelector('[aria-label="Already in chat"]')).toBeTruthy();
+    const input = first.container.querySelector<HTMLInputElement>('input[aria-label="Search agents"]');
+    if (!input) throw new Error("search input missing");
+
+    await setValue(input, "Design");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    await flush();
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    await flush();
+
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-2"] });
+    expect(onAdded).toHaveBeenCalled();
+    await act(async () => first.root.unmount());
+
+    const second = await renderDom(
+      <AddParticipantDropdown
+        chatId="chat-1"
+        participantIds={["agent-1", "agent-2"]}
+        onAdded={() => undefined}
+        variant="icon"
+      />,
+    );
+    await click(second.container.querySelector('button[aria-label="Add participant"]'));
+    await waitForText("Kael", second.container);
+    expect(second.container.querySelector('[aria-label="Already in chat"]')).toBeTruthy();
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    await flush();
+    expect(second.container.querySelector('input[aria-label="Search agents"]')).toBeNull();
+  });
+
+  it("renders login states and builds safe OAuth links", async () => {
+    const { LoginPage } = await import("../login.js");
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, hostname: "localhost" },
+    });
+    authMock.value = { ...authMock.value, isAuthenticated: false };
+    const local = await renderDom(<LoginPage />, "/login", undefined);
+    await waitForText("Sign in with GitHub", local.container);
+    await waitForText("Dev: skip GitHub", local.container);
+    expect(local.container.querySelector<HTMLAnchorElement>('a[href="/api/v1/auth/github/start"]')).toBeTruthy();
+    await act(async () => local.root.unmount());
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, hostname: "app.example.com" },
+    });
+    const deepLink = await renderDom(<LoginPage />, "/login", undefined);
+    expect(deepLink.container.textContent).not.toContain("Dev: skip GitHub");
+    await act(async () => deepLink.root.unmount());
+
+    authMock.value = { ...authMock.value, isAuthenticated: true };
+    const authed = await renderDom(<LoginPage />, "/login", undefined);
+    expect(authed.container.textContent).toBe("");
+  });
+
+  it("consumes OAuth fragments and reports missing tokens", async () => {
+    const { OAuthCompletePage } = await import("../oauth-complete.js");
+    const replaceState = vi.fn();
+    Object.defineProperty(window, "history", { configurable: true, value: { replaceState } });
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#access=access-token&refresh=refresh-token&next=/team&joinPath=invite",
+        pathname: "/auth/github/complete",
+      },
+    });
+
+    authMock.value = { ...authMock.value, adoptTokens: vi.fn(async () => undefined) };
+    const success = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await flush();
+    expect(authMock.value.adoptTokens).toHaveBeenCalledWith({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, "", "/auth/github/complete");
+    expect(sessionStorage.getItem("onboarding:joinPath")).toBe("invite");
+    await act(async () => success.root.unmount());
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, hash: "#access=only-access", pathname: "/auth/github/complete" },
+    });
+    const failure = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await waitForText("Sign-in did not complete", failure.container);
+  });
+
+  it("renders SettingsOnboardingPage resume, hide, disabled, and completed states", async () => {
+    const { SettingsOnboardingPage } = await import("../settings/onboarding.js");
+
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "create_agent",
+      onboardingDismissedAt: null,
+      onboardingCompletedAt: null,
+      dismissOnboarding: vi.fn(async () => undefined),
+    };
+    const disabled = await renderDom(<SettingsOnboardingPage />);
+    const hideDisabled = [...disabled.container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Hide setup guide"),
+    );
+    expect(hideDisabled).toBeTruthy();
+    expect(hideDisabled?.hasAttribute("disabled")).toBe(true);
+    await act(async () => disabled.root.unmount());
+
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      onboardingDismissedAt: null,
+      onboardingCompletedAt: null,
+      dismissOnboarding: vi.fn(async () => undefined),
+    };
+    const active = await renderDom(<SettingsOnboardingPage />);
+    await click(
+      [...active.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Hide setup guide"),
+      ) ?? null,
+    );
+    expect(authMock.value.dismissOnboarding).toHaveBeenCalled();
+    await act(async () => active.root.unmount());
+
+    authMock.value = {
+      ...authMock.value,
+      onboardingDismissedAt: "2026-05-01T00:00:00.000Z",
+      onboardingCompletedAt: null,
+      restoreOnboarding: vi.fn(async () => undefined),
+    };
+    const dismissed = await renderDom(<SettingsOnboardingPage />);
+    await waitForText("Setup is hidden", dismissed.container);
+    await click(
+      [...dismissed.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Resume setup"),
+      ) ?? null,
+    );
+    expect(authMock.value.restoreOnboarding).toHaveBeenCalled();
+    await act(async () => dismissed.root.unmount());
+
+    authMock.value = { ...authMock.value, onboardingCompletedAt: "2026-05-02T00:00:00.000Z" };
+    const completed = await renderDom(<SettingsOnboardingPage />);
+    expect(completed.container.textContent).toBe("");
+  });
+
+  it("builds LastStepModal command, copies it, skips install on dev, and fires onBound", async () => {
+    const { LastStepModal } = await import("../../components/last-step-modal.js");
+    const onBound = vi.fn();
+    const onClose = vi.fn();
+
+    const unboundAgent = { ...agent({ name: "deploy bot", uuid: "agent-new" }), clientId: null };
+    const modal = await renderDom(<LastStepModal agent={unboundAgent} open onClose={onClose} onBound={onBound} />);
+    await waitForText("first-tree-dev agent add", document.body);
+    expect(document.body.textContent).toContain(
+      "first-tree-dev agent add 'deploy bot' --agent-id agent-new && first-tree-dev login connect-token",
+    );
+    expect(document.body.textContent).not.toContain("npm install -g");
+    await click(document.body.querySelector("button"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "first-tree-dev agent add 'deploy bot' --agent-id agent-new && first-tree-dev login connect-token",
+    );
+    await waitForText("Waiting for your computer to connect", document.body);
+    for (let index = 0; index < 20 && onBound.mock.calls.length === 0; index += 1) {
+      await flush();
+    }
+    expect(onBound).toHaveBeenCalledWith(expect.objectContaining({ clientId: "client-bound" }));
+    await click(
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent?.includes("Skip for now")) ??
+        null,
+    );
+    expect(onClose).toHaveBeenCalled();
+    await act(async () => modal.root.unmount());
+
+    activityMocks.generateConnectToken.mockResolvedValueOnce({
+      token: "prod-token",
+      expiresIn: 600,
+      command: "first-tree login prod-token",
+      bootstrapCommand: "npm install -g first-tree\nfirst-tree login prod-token",
+      npmSpec: "first-tree",
+      binName: "first-tree",
+    });
+    await renderDom(
+      <LastStepModal
+        agent={agent({ clientId: "client-1", name: "kael" })}
+        open
+        onClose={() => undefined}
+        onBound={() => undefined}
+      />,
+    );
+    await waitForText("npm install -g first-tree", document.body);
+  });
+
+  it("opens UserMenu, switches orgs, opens setup actions, and signs out", async () => {
+    clientApiMocks.post.mockResolvedValue({});
+    const { UserMenu } = await import("../../components/user-menu.js");
+    const selectOrganization = vi.fn(async () => undefined);
+    const logout = vi.fn();
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-1",
+      selectOrganization,
+      logout,
+    };
+    const getMock = async <T,>(): Promise<T> =>
+      [
+        { id: "org-1", displayName: "Acme", role: "admin" },
+        { id: "org-2", displayName: "Beta", role: "member" },
+      ] as T;
+    const { api } = await import("../../api/client.js");
+    const originalGet = api.get;
+    api.get = getMock;
+
+    const menu = await renderDom(<UserMenu />);
+    await waitForText("", menu.container);
+    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await waitForText("Acme", menu.container);
+    await click(
+      [...menu.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Beta")) ?? null,
+    );
+    expect(selectOrganization).toHaveBeenCalledWith("org-2");
+
+    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(
+      [...menu.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Create new team"),
+      ) ?? null,
+    );
+    await waitForText("Create", document.body);
+
+    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(
+      [...menu.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Join with invite link"),
+      ) ?? null,
+    );
+    await waitForText("Join", document.body);
+
+    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(
+      [...menu.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ?? null,
+    );
+    expect(logout).toHaveBeenCalled();
+    api.get = originalGet;
+  });
+
+  it("loads, copies, rotates, and errors InviteLinkPanel", async () => {
+    const { InviteLinkPanel } = await import("../invite-link-panel.js");
+    const { api } = await import("../../api/client.js");
+    const originalGet = api.get;
+    const originalPost = api.post;
+    const invite = {
+      id: "invite-1",
+      inviteUrl: "https://hub.example/invite/token-1",
+      token: "token-1",
+      organizationId: "org-1",
+      role: "member",
+      createdAt: "2026-05-28T00:00:00.000Z",
+      expiresAt: "2026-06-04T00:00:00.000Z",
+      revokedAt: null,
+    };
+    api.get = async <T,>(): Promise<T> => invite as T;
+    api.post = async <T,>(): Promise<T> => ({ ...invite, inviteUrl: "https://hub.example/invite/token-2" }) as T;
+
+    const panel = await renderDom(<InviteLinkPanel />);
+    await waitForText("Created", panel.container);
+    expect(panel.container.querySelector<HTMLInputElement>("input")?.value).toBe("https://hub.example/invite/token-1");
+    await click(
+      [...panel.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Copy")) ?? null,
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://hub.example/invite/token-1");
+    await click(
+      [...panel.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Rotate")) ?? null,
+    );
+    for (
+      let index = 0;
+      index < 20 &&
+      panel.container.querySelector<HTMLInputElement>("input")?.value !== "https://hub.example/invite/token-2";
+      index += 1
+    ) {
+      await flush();
+    }
+    expect(panel.container.querySelector<HTMLInputElement>("input")?.value).toBe("https://hub.example/invite/token-2");
+    await act(async () => panel.root.unmount());
+
+    api.get = vi.fn(async () => {
+      throw new Error("load failed");
+    });
+    const failed = await renderDom(<InviteLinkPanel />);
+    await waitForText("load failed", failed.container);
+    api.get = originalGet;
+    api.post = originalPost;
+  });
+
+  it("drives StepConnectCode install, skip, connected picker, and error states", async () => {
+    const { ApiError } = await import("../../api/client.js");
+    const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
+    const assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign, href: "http://localhost/onboarding" },
+    });
+
+    const disconnected = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Install First Tree on GitHub", disconnected.container);
+    await click(
+      [...disconnected.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Install First Tree on GitHub"),
+      ) ?? null,
+    );
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding");
+    expect(sessionStorage.getItem("onboarding:connect-code:install-attempt")).toBeTruthy();
+    expect(assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
+
+    await click(
+      [...disconnected.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Skip for now"),
+      ) ?? null,
+    );
+    await waitForText("Skip connecting code?", disconnected.container);
+    await click(
+      [...disconnected.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Cancel")) ??
+        null,
+    );
+    expect(disconnected.container.textContent).not.toContain("Skip connecting code?");
+    await click(
+      [...disconnected.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Skip for now"),
+      ) ?? null,
+    );
+    await click(
+      [...disconnected.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Skip anyway"),
+      ) ?? null,
+    );
+    expect(disconnected.flow.goNext).toHaveBeenCalled();
+    await act(async () => disconnected.root.unmount());
+
+    githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
+      installationId: 42,
+      accountLogin: "acme",
+      accountType: "Organization",
+      accountGithubId: 123,
+      repositorySelection: "selected",
+      permissions: {},
+      events: [],
+      suspended: false,
+      manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    const setSelectedRepoUrls = vi.fn();
+    const connected = await renderOnboardingDom(<StepConnectCode />, {
+      activeStep: "connect-code",
+      selectedRepoUrls: [],
+      setSelectedRepoUrls,
+      goNext: vi.fn(),
+    });
+    await waitForText("Which projects should your agent work on?", connected.container);
+    await waitForText("acme/web", connected.container);
+    await click(
+      [...connected.container.querySelectorAll("label")].find((label) => label.textContent?.includes("acme/web")) ??
+        null,
+    );
+    expect(setSelectedRepoUrls).toHaveBeenCalledWith(["https://github.com/acme/web.git"]);
+    await click(
+      [...connected.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Continue without a project"),
+      ) ?? null,
+    );
+    expect(connected.flow.goNext).toHaveBeenCalled();
+    await act(async () => connected.root.unmount());
+
+    githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
+      installationId: 42,
+      accountLogin: "acme",
+      accountType: "Organization",
+      accountGithubId: 123,
+      repositorySelection: "selected",
+      permissions: {},
+      events: [],
+      suspended: false,
+      manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
+    const scopeMissing = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Reconnect GitHub with project access", scopeMissing.container);
+    await act(async () => scopeMissing.root.unmount());
+
+    githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "not configured"));
+    const notConfigured = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Install First Tree on GitHub", notConfigured.container);
+    await click(
+      [...notConfigured.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Install First Tree on GitHub"),
+      ) ?? null,
+    );
+    await waitForText("Code connection isn't set up here yet.", notConfigured.container);
+    await click(
+      [...notConfigured.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Continue without connecting code"),
+      ) ?? null,
+    );
+    expect(notConfigured.flow.goNext).toHaveBeenCalled();
+  });
+
+  it("drives StepKickoff admin and invitee start flows", async () => {
+    const { ApiError } = await import("../../api/client.js");
+    const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+
+    const setTreeMode = vi.fn();
+    const setTreeUrl = vi.fn();
+    const markTreeAutoInitDone = vi.fn();
+    const adminAutoDetect = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: ["https://github.com/acme/web.git"],
+      treeMode: "new",
+      treeUrl: "",
+      treeAutoInitDone: false,
+      setTreeMode,
+      setTreeUrl,
+      markTreeAutoInitDone,
+    });
+    await waitForText("Start building your Context Tree", adminAutoDetect.container);
+    expect(markTreeAutoInitDone).toHaveBeenCalled();
+    expect(setTreeMode).toHaveBeenCalledWith("existing");
+    expect(setTreeUrl).toHaveBeenCalledWith("https://github.com/acme/context-tree");
+    await act(async () => adminAutoDetect.root.unmount());
+
+    const adminExisting = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: ["https://github.com/acme/web.git"],
+      treeMode: "existing",
+      treeUrl: "https://github.com/acme/context-tree",
+    });
+    await waitForText("Use your team's Context Tree", adminExisting.container);
+    await click(
+      [...adminExisting.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Start")) ??
+        null,
+    );
+    await waitForText("Starting your agent", adminExisting.container);
+    expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
+    expect(chatApiMocks.createAgentChat).toHaveBeenCalledWith("agent-1");
+    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith(
+      "chat-onboarding",
+      expect.stringContaining("https://github.com/acme/context-tree"),
+      ["agent-1"],
+    );
+    expect(orgSettingsMocks.putSourceReposSetting).toHaveBeenCalledWith("org-1", {
+      repos: [{ url: "https://github.com/acme/web.git" }],
+    });
+    expect(orgSettingsMocks.putContextTreeSetting).toHaveBeenCalledWith("org-1", {
+      repo: "https://github.com/acme/context-tree",
+    });
+    expect(adminExisting.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
+    await act(async () => adminExisting.root.unmount());
+
+    const setTreeModeNew = vi.fn();
+    const setTreeUrlNew = vi.fn();
+    const adminNew = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: ["https://github.com/acme/web.git"],
+      treeMode: "existing",
+      treeUrl: "git@github.com:acme/context-tree.git",
+      setTreeMode: setTreeModeNew,
+      setTreeUrl: setTreeUrlNew,
+    });
+    await waitForText("That doesn't look like a web link", adminNew.container);
+    const startButton = [...adminNew.container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Start"),
+    );
+    expect(startButton?.hasAttribute("disabled")).toBe(true);
+    await click(
+      [...adminNew.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Create new instead"),
+      ) ?? null,
+    );
+    expect(setTreeUrlNew).toHaveBeenCalledWith("");
+    expect(setTreeModeNew).toHaveBeenCalledWith("new");
+    await act(async () => adminNew.root.unmount());
+
+    chatApiMocks.sendChatMessage.mockRejectedValueOnce(new Error("message failed"));
+    const adminNoProject = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: [],
+      treeMode: "new",
+      treeUrl: "",
+    });
+    await waitForText("Start your agent", adminNoProject.container);
+    await click(
+      [...adminNoProject.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Start"),
+      ) ?? null,
+    );
+    expect(chatApiMocks.createAgentChat).toHaveBeenLastCalledWith("agent-1");
+    expect(adminNoProject.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
+    await act(async () => adminNoProject.root.unmount());
+
+    orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
+    const inviteeWaiting = await renderOnboardingDom(<StepKickoff />, {
+      path: "invitee",
+      activeStep: "kickoff",
+    });
+    await waitForText("Waiting for your team to set up", inviteeWaiting.container);
+    await click(
+      [...inviteeWaiting.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Start chatting anyway"),
+      ) ?? null,
+    );
+    expect(inviteeWaiting.flow.finishLater).toHaveBeenCalled();
+    await act(async () => inviteeWaiting.root.unmount());
+
+    githubAppMocks.getGithubAppInstallationExists.mockResolvedValueOnce(false);
+    const inviteeNoInstall = await renderOnboardingDom(<StepKickoff />, {
+      path: "invitee",
+      activeStep: "kickoff",
+    });
+    await waitForText("your team's code isn't connected yet", inviteeNoInstall.container);
+    await click(
+      [...inviteeNoInstall.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Copy"),
+      ) ?? null,
+    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    await act(async () => inviteeNoInstall.root.unmount());
+
+    const inviteeConfirm = await renderOnboardingDom(<StepKickoff />, {
+      path: "invitee",
+      activeStep: "kickoff",
+    });
+    await waitForText("Your team is ready", inviteeConfirm.container);
+    await click(
+      [...inviteeConfirm.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Continue without a project"),
+      ) ?? null,
+    );
+    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-onboarding", expect.any(String), ["agent-1"]);
+    expect(onboardingEventMocks.reportOnboardingEvent).toHaveBeenCalledWith(
+      "tree_chat_started",
+      expect.objectContaining({ joinPath: "invite" }),
+    );
+    await act(async () => inviteeConfirm.root.unmount());
+
+    orgSettingsMocks.getSourceReposSetting.mockResolvedValueOnce({ repos: [] });
+    githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
+    const inviteePickerScope = await renderOnboardingDom(<StepKickoff />, {
+      path: "invitee",
+      activeStep: "kickoff",
+    });
+    await waitForText("Reconnect GitHub with project access", inviteePickerScope.container);
+    await act(async () => inviteePickerScope.root.unmount());
+
+    orgSettingsMocks.getSourceReposSetting.mockResolvedValueOnce({ repos: [] });
+    githubMocks.listGithubRepos.mockRejectedValueOnce(new Error("network"));
+    const inviteePickerNetwork = await renderOnboardingDom(<StepKickoff />, {
+      path: "invitee",
+      activeStep: "kickoff",
+    });
+    await waitForText("Couldn't load your projects", inviteePickerNetwork.container);
+  });
+
+  it("edits MCP server rows through validation, stdio, and HTTP submissions", async () => {
+    const { McpSection } = await import("../agent-detail/mcp-section.js");
+    const onAdd = vi.fn();
+    const onUpdate = vi.fn();
+    const onDelete = vi.fn();
+    const onUndoDelete = vi.fn();
+    const items = [
+      {
+        key: "stdio",
+        status: "unchanged" as const,
+        baseline: { name: "filesystem", transport: "stdio" as const, command: "npx", args: ["-y", "server"] },
+        value: { name: "filesystem", transport: "stdio" as const, command: "npx", args: ["-y", "server"] },
+      },
+      {
+        key: "http",
+        status: "deleted" as const,
+        baseline: { name: "docs", transport: "http" as const, url: "https://docs.example/mcp" },
+        value: { name: "docs", transport: "http" as const, url: "https://docs.example/mcp" },
+      },
+    ];
+
+    const { container, root } = await renderDom(
+      <McpSection
+        items={items}
+        otherNames={(exceptKey) => new Set(exceptKey === "stdio" ? ["docs"] : ["filesystem", "docs"])}
+        toolHealth={(name) => (name === "filesystem" ? "working" : "error")}
+        onAdd={onAdd}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        onUndoDelete={onUndoDelete}
+      />,
+    );
+
+    expect(container.textContent).toContain("Working");
+    expect(container.textContent).toContain("will be removed on save");
+    await click(container.querySelector('button[title="Delete"]'));
+    expect(onDelete).toHaveBeenCalledWith("stdio");
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Undo")) ?? null,
+    );
+    expect(onUndoDelete).toHaveBeenCalledWith("http");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Add")) ?? null,
+    );
+    await waitForText("Add MCP server", document.body);
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText("Name must start alphanumeric", document.body);
+
+    const name = document.body.querySelector<HTMLInputElement>("#mcp-name");
+    const command = document.body.querySelector<HTMLInputElement>("#mcp-command");
+    const args = document.body.querySelector<HTMLTextAreaElement>("#mcp-args");
+    if (!name || !command || !args) throw new Error("MCP stdio fields missing");
+    await setValue(name, "filesystem");
+    await setValue(command, "node");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText('Another MCP server is already named "filesystem".', document.body);
+
+    await setValue(name, "browser");
+    await setValue(args, '{"bad": true}');
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText("Args must be a JSON array of strings.", document.body);
+
+    await setValue(args, '["--port", "3000"]');
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    expect(onAdd).toHaveBeenCalledWith({
+      name: "browser",
+      transport: "stdio",
+      command: "node",
+      args: ["--port", "3000"],
+    });
+
+    await click(container.querySelector('button[title="Edit"]'));
+    await waitForText("Edit MCP server", document.body);
+    const transport = document.body.querySelector<HTMLSelectElement>("#mcp-transport");
+    if (!transport) throw new Error("MCP transport select missing");
+    await act(async () => {
+      transport.value = "http";
+      transport.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+
+    const url = document.body.querySelector<HTMLInputElement>("#mcp-url");
+    const headers = document.body.querySelector<HTMLTextAreaElement>("#mcp-headers");
+    if (!url || !headers) throw new Error("MCP http fields missing");
+    await setValue(url, "not a url");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
+    await waitForText("URL is not valid.", document.body);
+
+    await setValue(url, "https://browser.example/mcp");
+    await setValue(headers, '{"Authorization": 123}');
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
+    await waitForText("Headers must be a JSON object with string values.", document.body);
+
+    await setValue(headers, '{"Authorization": "Bearer token"}');
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
+    expect(onUpdate).toHaveBeenCalledWith("stdio", {
+      name: "filesystem",
+      transport: "http",
+      url: "https://browser.example/mcp",
+      headers: { Authorization: "Bearer token" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("edits environment variable rows, reveal state, and sensitive keep-existing behavior", async () => {
+    const { ENV_REDACTED_PLACEHOLDER } = await import("@first-tree/shared");
+    const { EnvSection } = await import("../agent-detail/env-section.js");
+    const onAdd = vi.fn();
+    const onUpdate = vi.fn();
+    const onDelete = vi.fn();
+    const onUndoDelete = vi.fn();
+    const items = [
+      {
+        key: "plain",
+        status: "unchanged" as const,
+        baseline: { key: "FIRST_TREE_ENV", value: "test", sensitive: false },
+        value: { key: "FIRST_TREE_ENV", value: "test", sensitive: false },
+      },
+      {
+        key: "secret",
+        status: "unchanged" as const,
+        baseline: { key: "OPENAI_API_KEY", value: ENV_REDACTED_PLACEHOLDER, sensitive: true },
+        value: { key: "OPENAI_API_KEY", value: ENV_REDACTED_PLACEHOLDER, sensitive: true },
+      },
+      {
+        key: "draft-secret",
+        status: "added" as const,
+        baseline: { key: "TOKEN", value: "secret-value", sensitive: true },
+        value: { key: "TOKEN", value: "secret-value", sensitive: true },
+      },
+    ];
+
+    const { container, root } = await renderDom(
+      <EnvSection
+        items={items}
+        otherKeys={(exceptKey) => new Set(exceptKey === "secret" ? ["FIRST_TREE_ENV", "TOKEN"] : ["FIRST_TREE_ENV"])}
+        onAdd={onAdd}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        onUndoDelete={onUndoDelete}
+      />,
+    );
+
+    await click(
+      [...container.querySelectorAll<HTMLButtonElement>('button[aria-label="Reveal value"]')].find(
+        (button) => !button.disabled,
+      ) ?? null,
+    );
+    expect(container.textContent).toContain("secret-value");
+    await click(container.querySelector('button[aria-label="Hide value"]'));
+    expect(container.textContent).not.toContain("secret-value");
+    await click(container.querySelector('button[title="Delete"]'));
+    expect(onDelete).toHaveBeenCalledWith("plain");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Add")) ?? null,
+    );
+    await waitForText("Add environment variable", document.body);
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText("Key must match", document.body);
+
+    const key = document.body.querySelector<HTMLInputElement>("#env-key");
+    const value = document.body.querySelector<HTMLInputElement>("#env-value");
+    const sensitive = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!key || !value || !sensitive) throw new Error("Env fields missing");
+    await setValue(key, "first_tree_env");
+    expect(key.value).toBe("FIRST_TREE_ENV");
+    await setValue(value, "duplicate");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText('Another entry already uses key "FIRST_TREE_ENV".', document.body);
+
+    await setValue(key, "NEW_SECRET");
+    await setValue(value, "");
+    await click(sensitive);
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText("Value is required for sensitive entries.", document.body);
+    await setValue(value, "super-secret");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    expect(onAdd).toHaveBeenCalledWith({ key: "NEW_SECRET", value: "super-secret", sensitive: true });
+
+    await click([...container.querySelectorAll('button[title="Edit"]')][1] ?? null);
+    await waitForText("Edit environment variable", document.body);
+    const editValue = document.body.querySelector<HTMLInputElement>("#env-value");
+    if (!editValue) throw new Error("Env edit value missing");
+    expect(editValue.placeholder).toBe("Leave empty to keep existing value");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
+    expect(onUpdate).toHaveBeenCalledWith("secret", {
+      key: "OPENAI_API_KEY",
+      value: ENV_REDACTED_PLACEHOLDER,
+      sensitive: true,
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("edits Git repository rows and validates derived local path collisions", async () => {
+    const { GitSection } = await import("../agent-detail/git-section.js");
+    const onAdd = vi.fn();
+    const onUpdate = vi.fn();
+    const onDelete = vi.fn();
+    const onUndoDelete = vi.fn();
+    const items = [
+      {
+        key: "web",
+        status: "unchanged" as const,
+        baseline: { url: "https://github.com/acme/web.git", localPath: "web", ref: "main" },
+        value: { url: "https://github.com/acme/web.git", localPath: "web", ref: "main" },
+      },
+      {
+        key: "api",
+        status: "deleted" as const,
+        baseline: { url: "git@github.com:acme/api.git", localPath: "api" },
+        value: { url: "git@github.com:acme/api.git", localPath: "api" },
+      },
+    ];
+
+    const { container, root } = await renderDom(
+      <GitSection
+        items={items}
+        otherPaths={(exceptKey) => new Set(exceptKey === "web" ? ["api"] : ["web", "api"])}
+        onAdd={onAdd}
+        onUpdate={onUpdate}
+        onDelete={onDelete}
+        onUndoDelete={onUndoDelete}
+      />,
+    );
+
+    expect(container.textContent).toContain("@ main");
+    await click(container.querySelector('button[title="Delete"]'));
+    expect(onDelete).toHaveBeenCalledWith("web");
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Undo")) ?? null,
+    );
+    expect(onUndoDelete).toHaveBeenCalledWith("api");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Add")) ?? null,
+    );
+    await waitForText("Add Git repository", document.body);
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText("URL is required.", document.body);
+
+    const url = document.body.querySelector<HTMLInputElement>("#git-url");
+    const ref = document.body.querySelector<HTMLInputElement>("#git-ref");
+    const path = document.body.querySelector<HTMLInputElement>("#git-path");
+    if (!url || !ref || !path) throw new Error("Git fields missing");
+    await setValue(url, "https://github.com/acme/web.git");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    await waitForText('Another repo already occupies local path "web".', document.body);
+
+    await setValue(url, "git@github.com:acme/docs.git");
+    await setValue(ref, "main");
+    await setValue(path, "docs-local");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add") ?? null);
+    expect(onAdd).toHaveBeenCalledWith({
+      url: "git@github.com:acme/docs.git",
+      ref: "main",
+      localPath: "docs-local",
+    });
+
+    await click(container.querySelector('button[title="Edit"]'));
+    await waitForText("Edit Git repository", document.body);
+    const editRef = document.body.querySelector<HTMLInputElement>("#git-ref");
+    const editPath = document.body.querySelector<HTMLInputElement>("#git-path");
+    if (!editRef || !editPath) throw new Error("Git edit fields missing");
+    await setValue(editRef, "");
+    await setValue(editPath, "");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
+    expect(onUpdate).toHaveBeenCalledWith("web", { url: "https://github.com/acme/web.git" });
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -12,6 +12,7 @@ import type { OnboardingFlowValue } from "../onboarding/onboarding-flow.js";
 import { ADMIN_STEPS, INVITEE_STEPS, type OnboardingPath, type StepId } from "../onboarding/steps.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+const WAIT_FOR_TEXT_TIMEOUT_MS = 3_000;
 
 const activityMocks = vi.hoisted(() => ({
   disconnectClient: vi.fn(),
@@ -314,6 +315,8 @@ const ORG_AGENTS = [
   agent({ uuid: "agent-2", name: "design", displayName: "Design Critique", managerId: "member-alice" }),
 ];
 
+const mountedRoots = new Set<Root>();
+
 function setupDom(): void {
   const storage = createStorage();
   window.HTMLElement.prototype.scrollIntoView = () => undefined;
@@ -380,6 +383,7 @@ async function renderDom(
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
+  mountedRoots.add(root);
   const queryClient = createClient();
   queryClient.setQueryData(["agents", "org-list"], { items: ORG_AGENTS, nextCursor: null });
   seed?.(queryClient);
@@ -394,6 +398,11 @@ async function renderDom(
   });
   await flush();
   return { container, root };
+}
+
+async function unmountRoot(root: Root): Promise<void> {
+  mountedRoots.delete(root);
+  await act(async () => root.unmount());
 }
 
 function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): OnboardingFlowValue {
@@ -490,10 +499,11 @@ async function click(el: Element | null): Promise<void> {
 }
 
 async function waitForText(text: string, container: HTMLElement = document.body): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
+  const deadline = Date.now() + WAIT_FOR_TEXT_TIMEOUT_MS;
+  do {
     if (container.textContent?.includes(text)) return;
     await flush();
-  }
+  } while (Date.now() < deadline);
   throw new Error(`Missing text: ${text}\n${container.textContent ?? ""}`);
 }
 
@@ -632,7 +642,8 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  for (const root of [...mountedRoots]) await unmountRoot(root);
   document.body.innerHTML = "";
 });
 
@@ -663,7 +674,7 @@ describe("web DOM interaction coverage", () => {
     );
     expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ uuid: "agent-created" }), "claude-code");
 
-    await act(async () => root.unmount());
+    await unmountRoot(root);
   });
 
   it("renders NewAgentDialog zero-computer recovery command", async () => {
@@ -699,7 +710,7 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Alice", admin.container);
     await waitForText("Auth expired", admin.container);
 
-    await act(async () => admin.root.unmount());
+    await unmountRoot(admin.root);
 
     authMock.value = { ...authMock.value, role: "member" };
     activityMocks.listClients.mockResolvedValue([]);
@@ -708,7 +719,7 @@ describe("web DOM interaction coverage", () => {
       queryClient.setQueryData(["activity"], { agents: [], clients: [] });
     });
     await waitForText("No computers connected yet.", member.container);
-    await act(async () => member.root.unmount());
+    await unmountRoot(member.root);
 
     authMock.value = { ...authMock.value, role: "admin" };
     activityMocks.listOrgClients.mockRejectedValue(new Error("forbidden"));
@@ -731,7 +742,7 @@ describe("web DOM interaction coverage", () => {
     expect(meChatMocks.createMeChat).toHaveBeenCalledWith({ participantIds: ["agent-1"] });
     expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-created", "hello", ["agent-1"]);
     expect(onCreated).toHaveBeenCalledWith("chat-created");
-    await act(async () => first.root.unmount());
+    await unmountRoot(first.root);
 
     meChatMocks.createMeChat.mockClear();
     chatApiMocks.sendChatMessage.mockClear();
@@ -782,7 +793,7 @@ describe("web DOM interaction coverage", () => {
 
     expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-2"] });
     expect(onAdded).toHaveBeenCalled();
-    await act(async () => first.root.unmount());
+    await unmountRoot(first.root);
 
     const second = await renderDom(
       <AddParticipantDropdown
@@ -814,7 +825,7 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Sign in with GitHub", local.container);
     await waitForText("Dev: skip GitHub", local.container);
     expect(local.container.querySelector<HTMLAnchorElement>('a[href="/api/v1/auth/github/start"]')).toBeTruthy();
-    await act(async () => local.root.unmount());
+    await unmountRoot(local.root);
 
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -822,7 +833,7 @@ describe("web DOM interaction coverage", () => {
     });
     const deepLink = await renderDom(<LoginPage />, "/login", undefined);
     expect(deepLink.container.textContent).not.toContain("Dev: skip GitHub");
-    await act(async () => deepLink.root.unmount());
+    await unmountRoot(deepLink.root);
 
     authMock.value = { ...authMock.value, isAuthenticated: true };
     const authed = await renderDom(<LoginPage />, "/login", undefined);
@@ -851,7 +862,7 @@ describe("web DOM interaction coverage", () => {
     });
     expect(replaceState).toHaveBeenCalledWith(null, "", "/auth/github/complete");
     expect(sessionStorage.getItem("onboarding:joinPath")).toBe("invite");
-    await act(async () => success.root.unmount());
+    await unmountRoot(success.root);
 
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -877,7 +888,7 @@ describe("web DOM interaction coverage", () => {
     );
     expect(hideDisabled).toBeTruthy();
     expect(hideDisabled?.hasAttribute("disabled")).toBe(true);
-    await act(async () => disabled.root.unmount());
+    await unmountRoot(disabled.root);
 
     authMock.value = {
       ...authMock.value,
@@ -893,7 +904,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(authMock.value.dismissOnboarding).toHaveBeenCalled();
-    await act(async () => active.root.unmount());
+    await unmountRoot(active.root);
 
     authMock.value = {
       ...authMock.value,
@@ -909,7 +920,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(authMock.value.restoreOnboarding).toHaveBeenCalled();
-    await act(async () => dismissed.root.unmount());
+    await unmountRoot(dismissed.root);
 
     authMock.value = { ...authMock.value, onboardingCompletedAt: "2026-05-02T00:00:00.000Z" };
     const completed = await renderDom(<SettingsOnboardingPage />);
@@ -942,7 +953,7 @@ describe("web DOM interaction coverage", () => {
         null,
     );
     expect(onClose).toHaveBeenCalled();
-    await act(async () => modal.root.unmount());
+    await unmountRoot(modal.root);
 
     activityMocks.generateConnectToken.mockResolvedValueOnce({
       token: "prod-token",
@@ -1053,7 +1064,7 @@ describe("web DOM interaction coverage", () => {
       await flush();
     }
     expect(panel.container.querySelector<HTMLInputElement>("input")?.value).toBe("https://hub.example/invite/token-2");
-    await act(async () => panel.root.unmount());
+    await unmountRoot(panel.root);
 
     api.get = vi.fn(async () => {
       throw new Error("load failed");
@@ -1106,7 +1117,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(disconnected.flow.goNext).toHaveBeenCalled();
-    await act(async () => disconnected.root.unmount());
+    await unmountRoot(disconnected.root);
 
     githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
       installationId: 42,
@@ -1141,7 +1152,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(connected.flow.goNext).toHaveBeenCalled();
-    await act(async () => connected.root.unmount());
+    await unmountRoot(connected.root);
 
     githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
       installationId: 42,
@@ -1159,7 +1170,7 @@ describe("web DOM interaction coverage", () => {
     githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
     const scopeMissing = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
     await waitForText("Reconnect GitHub with project access", scopeMissing.container);
-    await act(async () => scopeMissing.root.unmount());
+    await unmountRoot(scopeMissing.root);
 
     githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "not configured"));
     const notConfigured = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
@@ -1199,7 +1210,7 @@ describe("web DOM interaction coverage", () => {
     expect(markTreeAutoInitDone).toHaveBeenCalled();
     expect(setTreeMode).toHaveBeenCalledWith("existing");
     expect(setTreeUrl).toHaveBeenCalledWith("https://github.com/acme/context-tree");
-    await act(async () => adminAutoDetect.root.unmount());
+    await unmountRoot(adminAutoDetect.root);
 
     const adminExisting = await renderOnboardingDom(<StepKickoff />, {
       activeStep: "kickoff",
@@ -1227,7 +1238,7 @@ describe("web DOM interaction coverage", () => {
       repo: "https://github.com/acme/context-tree",
     });
     expect(adminExisting.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
-    await act(async () => adminExisting.root.unmount());
+    await unmountRoot(adminExisting.root);
 
     const setTreeModeNew = vi.fn();
     const setTreeUrlNew = vi.fn();
@@ -1251,7 +1262,7 @@ describe("web DOM interaction coverage", () => {
     );
     expect(setTreeUrlNew).toHaveBeenCalledWith("");
     expect(setTreeModeNew).toHaveBeenCalledWith("new");
-    await act(async () => adminNew.root.unmount());
+    await unmountRoot(adminNew.root);
 
     chatApiMocks.sendChatMessage.mockRejectedValueOnce(new Error("message failed"));
     const adminNoProject = await renderOnboardingDom(<StepKickoff />, {
@@ -1268,7 +1279,7 @@ describe("web DOM interaction coverage", () => {
     );
     expect(chatApiMocks.createAgentChat).toHaveBeenLastCalledWith("agent-1");
     expect(adminNoProject.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
-    await act(async () => adminNoProject.root.unmount());
+    await unmountRoot(adminNoProject.root);
 
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
     const inviteeWaiting = await renderOnboardingDom(<StepKickoff />, {
@@ -1282,7 +1293,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(inviteeWaiting.flow.finishLater).toHaveBeenCalled();
-    await act(async () => inviteeWaiting.root.unmount());
+    await unmountRoot(inviteeWaiting.root);
 
     githubAppMocks.getGithubAppInstallationExists.mockResolvedValueOnce(false);
     const inviteeNoInstall = await renderOnboardingDom(<StepKickoff />, {
@@ -1296,7 +1307,7 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
-    await act(async () => inviteeNoInstall.root.unmount());
+    await unmountRoot(inviteeNoInstall.root);
 
     const inviteeConfirm = await renderOnboardingDom(<StepKickoff />, {
       path: "invitee",
@@ -1313,7 +1324,7 @@ describe("web DOM interaction coverage", () => {
       "tree_chat_started",
       expect.objectContaining({ joinPath: "invite" }),
     );
-    await act(async () => inviteeConfirm.root.unmount());
+    await unmountRoot(inviteeConfirm.root);
 
     orgSettingsMocks.getSourceReposSetting.mockResolvedValueOnce({ repos: [] });
     githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
@@ -1322,7 +1333,7 @@ describe("web DOM interaction coverage", () => {
       activeStep: "kickoff",
     });
     await waitForText("Reconnect GitHub with project access", inviteePickerScope.container);
-    await act(async () => inviteePickerScope.root.unmount());
+    await unmountRoot(inviteePickerScope.root);
 
     orgSettingsMocks.getSourceReposSetting.mockResolvedValueOnce({ repos: [] });
     githubMocks.listGithubRepos.mockRejectedValueOnce(new Error("network"));
@@ -1436,7 +1447,7 @@ describe("web DOM interaction coverage", () => {
       headers: { Authorization: "Bearer token" },
     });
 
-    await act(async () => root.unmount());
+    await unmountRoot(root);
   });
 
   it("edits environment variable rows, reveal state, and sensitive keep-existing behavior", async () => {
@@ -1527,7 +1538,7 @@ describe("web DOM interaction coverage", () => {
       sensitive: true,
     });
 
-    await act(async () => root.unmount());
+    await unmountRoot(root);
   });
 
   it("edits Git repository rows and validates derived local path collisions", async () => {
@@ -1605,6 +1616,6 @@ describe("web DOM interaction coverage", () => {
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
     expect(onUpdate).toHaveBeenCalledWith("web", { url: "https://github.com/acme/web.git" });
 
-    await act(async () => root.unmount());
+    await unmountRoot(root);
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+
+import type { AgentRuntimeConfig } from "@first-tree/shared";
+import { ENV_REDACTED_PLACEHOLDER } from "@first-tree/shared";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { UseConfigDraftResult } from "../use-config-draft.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let latest: UseConfigDraftResult | null = null;
+
+const BASE_CONFIG: AgentRuntimeConfig = {
+  agentId: "agent-1",
+  version: 1,
+  payload: {
+    kind: "claude-code",
+    prompt: { append: "Be concise." },
+    model: "sonnet",
+    reasoningEffort: "medium",
+    mcpServers: [{ name: "fs", transport: "stdio", command: "npx", args: ["server"] }],
+    env: [
+      { key: "OPENAI_API_KEY", value: ENV_REDACTED_PLACEHOLDER, sensitive: true },
+      { key: "MODE", value: "dev", sensitive: false },
+    ],
+    gitRepos: [{ url: "https://github.com/acme/web.git", localPath: "web", ref: "main" }],
+  },
+  updatedAt: "2026-05-28T00:00:00.000Z",
+  updatedBy: "member-1",
+};
+
+async function renderHook(config: AgentRuntimeConfig | undefined = BASE_CONFIG): Promise<void> {
+  const { useConfigDraft } = await import("../use-config-draft.js");
+  function Probe({ cfg }: { cfg: AgentRuntimeConfig | undefined }) {
+    latest = useConfigDraft(cfg);
+    return <div>{latest.summary.anyDirty ? "dirty" : "clean"}</div>;
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<Probe cfg={config} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  latest = null;
+  container = null;
+  root = null;
+  document.body.innerHTML = "";
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+describe("useConfigDraft", () => {
+  it("creates clean drafts and builds scalar patches", async () => {
+    await renderHook();
+
+    expect(latest?.summary.anyDirty).toBe(false);
+    act(() => {
+      latest?.setPromptAppend("Explain tradeoffs.");
+      latest?.setModel("opus");
+      latest?.setReasoningEffort("high");
+    });
+
+    expect(latest?.summary.dirtySections).toEqual(["prompt", "model", "effort"]);
+    expect(latest?.buildPayloadPatch()).toMatchObject({
+      prompt: { append: "Explain tradeoffs." },
+      model: "opus",
+      reasoningEffort: "high",
+    });
+
+    act(() => {
+      latest?.revertPrompt();
+      latest?.revertModel();
+      latest?.revertReasoningEffort();
+    });
+    expect(latest?.summary.anyDirty).toBe(false);
+  });
+
+  it("tracks list add/update/delete/undo and redacts sensitive env patches", async () => {
+    await renderHook();
+
+    act(() => {
+      latest?.updateMcp("mcp-1", { name: "docs", transport: "http", url: "https://docs.example.com/mcp" });
+      latest?.addEnv({ key: "NEW_FLAG", value: "1", sensitive: false });
+      latest?.deleteEnv("env-1");
+      latest?.addGit({ url: "git@github.com:acme/api.git", localPath: "api" });
+    });
+
+    expect(latest?.summary.counts).toMatchObject({ mcp: 1, env: 2, git: 1 });
+    expect(latest?.buildPayloadPatch()).toMatchObject({
+      mcpServers: [{ name: "docs", transport: "http", url: "https://docs.example.com/mcp" }],
+      env: [
+        { key: "MODE", value: "dev", sensitive: false },
+        { key: "NEW_FLAG", value: "1", sensitive: false },
+      ],
+      gitRepos: [
+        { url: "https://github.com/acme/web.git", localPath: "web", ref: "main" },
+        { url: "git@github.com:acme/api.git", localPath: "api" },
+      ],
+    });
+
+    act(() => {
+      latest?.undoDeleteEnv("env-1");
+      latest?.updateEnv("env-1", { key: "OPENAI_API_KEY", value: ENV_REDACTED_PLACEHOLDER, sensitive: true });
+    });
+    expect(latest?.buildPayloadPatch().env).toContainEqual({
+      key: "OPENAI_API_KEY",
+      value: ENV_REDACTED_PLACEHOLDER,
+      sensitive: true,
+    });
+  });
+
+  it("drops newly added list rows, resets all, and resets to a supplied config", async () => {
+    await renderHook();
+
+    act(() => {
+      latest?.addMcp({ name: "temp", transport: "stdio", command: "node" });
+    });
+    const addedKey = latest?.draft.mcp.find((item) => item.baseline === null)?.key;
+    expect(addedKey).toBeTruthy();
+
+    act(() => {
+      if (addedKey) latest?.deleteMcp(addedKey);
+    });
+    expect(latest?.draft.mcp.some((item) => item.baseline === null)).toBe(false);
+
+    act(() => {
+      latest?.resetAll();
+    });
+    expect(latest?.summary.anyDirty).toBe(false);
+    expect(latest?.draft.mcp).toHaveLength(1);
+
+    const nextConfig: AgentRuntimeConfig = {
+      ...BASE_CONFIG,
+      version: 2,
+      payload: { ...BASE_CONFIG.payload, model: "gpt-5.1" },
+    };
+    act(() => {
+      latest?.resetToConfig(nextConfig);
+    });
+    expect(latest?.draft.model).toBe("gpt-5.1");
+    expect(latest?.buildPayloadPatch()).toEqual({});
+  });
+
+  it("returns an empty patch before config loads", async () => {
+    await renderHook(undefined);
+    expect(latest?.buildPayloadPatch()).toEqual({});
+  });
+});

--- a/packages/web/src/pages/clients/__tests__/demo-navigator.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/demo-navigator.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEMO_SCENARIOS } from "../dev-fixtures.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+async function render(element: React.ReactElement): Promise<HTMLElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(element);
+  });
+  return container;
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("missing clickable");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  root = null;
+  container = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+describe("DemoNavigator", () => {
+  it("renders scenario details, selects adjacent scenarios, collapses notes, and exits", async () => {
+    const { DemoNavigator } = await import("../demo-navigator.js");
+    const onSelect = vi.fn();
+    const onExit = vi.fn();
+    const active = DEMO_SCENARIOS[1]?.key ?? "ready-both";
+    const firstTitle = DEMO_SCENARIOS[0]?.title ?? "";
+    const thirdTitle = DEMO_SCENARIOS[2]?.title ?? "";
+
+    const dom = await render(<DemoNavigator activeKey={active} onSelect={onSelect} onExit={onExit} />);
+    expect(dom.textContent).toContain("DEMO 2/");
+    expect(dom.textContent).toContain("What to check");
+
+    await click(
+      [...dom.querySelectorAll("button")].find((button) => button.textContent?.includes("Hide notes")) ?? null,
+    );
+    expect(dom.textContent).not.toContain("What to check");
+
+    await click(
+      [...dom.querySelectorAll("button")].find((button) => button.textContent?.includes(firstTitle.slice(0, 12))) ??
+        null,
+    );
+    expect(onSelect).toHaveBeenCalledWith(DEMO_SCENARIOS[0]?.key);
+
+    await click(
+      [...dom.querySelectorAll("button")].find((button) => button.textContent?.includes(thirdTitle.slice(0, 12))) ??
+        null,
+    );
+    expect(onSelect).toHaveBeenCalledWith(DEMO_SCENARIOS[2]?.key);
+
+    const select = dom.querySelector<HTMLSelectElement>('select[aria-label="Scenario"]');
+    const fourthScenario = DEMO_SCENARIOS[3];
+    if (!select || !fourthScenario) throw new Error("scenario select missing");
+    await act(async () => {
+      select.value = fourthScenario.key;
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(onSelect).toHaveBeenCalledWith(fourthScenario.key);
+
+    await click([...dom.querySelectorAll("button")].find((button) => button.textContent === "Exit") ?? null);
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  it("returns null for unknown active keys", async () => {
+    const { DemoNavigator } = await import("../demo-navigator.js");
+    const dom = await render(<DemoNavigator activeKey="missing" onSelect={() => undefined} onExit={() => undefined} />);
+    expect(dom.textContent).toBe("");
+  });
+
+  it("syncs ?demo state with URL and browser history", async () => {
+    window.history.replaceState({}, "", `/?demo=${DEMO_SCENARIOS[0]?.key ?? "ready-both"}`);
+    const { useDemoScenarioParam } = await import("../demo-navigator.js");
+    let latest: readonly [string | null, (key: string | null) => void] = [null, () => undefined];
+    function Probe() {
+      latest = useDemoScenarioParam();
+      return <div>{latest[0]}</div>;
+    }
+
+    const dom = await render(<Probe />);
+    expect(dom.textContent).toBe(DEMO_SCENARIOS[0]?.key);
+
+    const secondScenario = DEMO_SCENARIOS[1];
+    if (!secondScenario) throw new Error("second demo scenario missing");
+    await act(async () => latest[1](secondScenario.key));
+    expect(window.location.search).toContain(`demo=${secondScenario.key}`);
+    expect(dom.textContent).toBe(secondScenario.key);
+
+    window.history.pushState({}, "", "/?demo=not-a-scenario");
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(dom.textContent).toBe("");
+
+    await act(async () => latest[1](null));
+    expect(window.location.search).not.toContain("demo=");
+  });
+});

--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -1,0 +1,348 @@
+// @vitest-environment happy-dom
+
+import type { MeMembership } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OnboardingFlowProvider, type OnboardingFlowValue, useOnboardingFlow } from "../onboarding-flow.js";
+import { useAgentCreation } from "../use-agent-creation.js";
+import type { ComputerConnection } from "../use-computer-connection.js";
+import { useComputerConnection } from "../use-computer-connection.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function expectHookValue<T>(value: T): NonNullable<T> {
+  if (value === null || value === undefined) throw new Error("hook value was not captured");
+  return value;
+}
+
+const activityMocks = vi.hoisted(() => ({
+  getClientCapabilities: vi.fn(),
+  listClients: vi.fn(),
+}));
+
+const agentConfigMocks = vi.hoisted(() => ({
+  getAgentClientStatus: vi.fn(),
+}));
+
+const clientMocks = vi.hoisted(() => ({
+  api: {
+    post: vi.fn(),
+  },
+  withOrg: vi.fn((path: string) => `/orgs/org-1${path}`),
+}));
+
+const eventMocks = vi.hoisted(() => ({
+  reportOnboardingEvent: vi.fn(),
+}));
+
+const visibilityMocks = vi.hoisted(() => ({
+  runVisibilityAwareInterval: vi.fn((tick: () => void | Promise<void>) => {
+    void tick();
+    return vi.fn();
+  }),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    isAuthenticated: true,
+    meLoaded: true,
+    user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+    memberships: [] as MeMembership[],
+    currentMembership: null as MeMembership | null,
+    organizationId: "org-1",
+    memberId: "member-self",
+    role: "admin",
+    agentId: "human-agent-self",
+    teamDisplayName: "Acme",
+    orgHasOtherMembers: true,
+    onboardingStep: "connect" as const,
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: null,
+    dismissOnboarding: vi.fn(async () => undefined),
+    restoreOnboarding: vi.fn(async () => undefined),
+    markOnboardingCompleted: vi.fn(async () => undefined),
+    login: vi.fn(async () => undefined),
+    adoptTokens: vi.fn(async () => undefined),
+    selectOrganization: vi.fn(async () => undefined),
+    refreshMe: vi.fn(async () => undefined),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock("../../../api/activity.js", () => activityMocks);
+vi.mock("../../../api/agent-config.js", () => agentConfigMocks);
+vi.mock("../../../api/client.js", () => clientMocks);
+vi.mock("../../../api/onboarding-events.js", () => eventMocks);
+vi.mock("../../../lib/visibility-interval.js", () => visibilityMocks);
+vi.mock("../../../auth/auth-context.js", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => authMock.value,
+}));
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+  const storage = createStorage();
+  Object.defineProperty(window, "sessionStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: createStorage() });
+  authMock.value = {
+    ...authMock.value,
+    role: "admin",
+    onboardingStep: "connect",
+    dismissOnboarding: vi.fn(async () => undefined),
+    markOnboardingCompleted: vi.fn(async () => undefined),
+    refreshMe: vi.fn(async () => undefined),
+  };
+  root = null;
+  container = null;
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+async function renderProbe(element: ReactNode, route = "/onboarding"): Promise<HTMLElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <MemoryRouter initialEntries={[route]}>
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+          {element}
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return container;
+}
+
+describe("onboarding hooks and flow", () => {
+  it("detects connected computers, capabilities, preferred runtime, and command token failures", async () => {
+    const latest = { current: null as ComputerConnection | null };
+    const client = {
+      id: "client-1",
+      userId: "user-self",
+      status: "connected",
+      authState: "ok",
+      sdkVersion: "0.5.0",
+      hostname: "gandy-macbook",
+      os: "darwin",
+      agentCount: 1,
+      connectedAt: "2026-05-28T00:00:00.000Z",
+      lastSeenAt: "2026-05-28T12:00:00.000Z",
+      capabilities: {},
+    };
+    activityMocks.listClients.mockResolvedValue([client]);
+    activityMocks.getClientCapabilities.mockResolvedValue({
+      ...client,
+      capabilities: {
+        codex: {
+          state: "ok",
+          available: true,
+          authenticated: true,
+          authMethod: "api_key",
+          detectedAt: "2026-05-28T12:00:00.000Z",
+        },
+        "claude-code": {
+          state: "unauthenticated",
+          available: true,
+          authenticated: false,
+          authMethod: "none",
+          detectedAt: "2026-05-28T12:00:00.000Z",
+        },
+      },
+    });
+
+    function Probe() {
+      latest.current = useComputerConnection(true);
+      return <div>{latest.current.selectedRuntime ?? "none"}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await flush();
+    await flush();
+    expect(expectHookValue(latest.current).connectedClient?.id).toBe("client-1");
+    expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(true);
+    expect(expectHookValue(latest.current).okRuntimes).toEqual(["codex"]);
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("codex");
+
+    await act(async () => expectHookValue(latest.current).setSelectedRuntime("manual"));
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("manual");
+
+    await act(async () => root?.unmount());
+    root = null;
+    activityMocks.listClients.mockResolvedValue([]);
+    clientMocks.api.post.mockRejectedValueOnce(new Error("token failed"));
+    await renderProbe(<Probe />);
+    await flush();
+    expect(expectHookValue(latest.current).tokenError).toBe("token failed");
+  });
+
+  it("creates an agent, stores its uuid, reports onboarding, and reaches online", async () => {
+    const latest = { current: null as ReturnType<typeof useAgentCreation> | null };
+    const onOnline = vi.fn();
+    clientMocks.api.post.mockResolvedValueOnce({ uuid: "agent-created" });
+    agentConfigMocks.getAgentClientStatus
+      .mockResolvedValueOnce({ online: false })
+      .mockResolvedValueOnce({ online: true });
+
+    function Probe() {
+      latest.current = useAgentCreation(onOnline);
+      return <div>{latest.current.phase}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await act(async () => {
+      await expectHookValue(latest.current).create({
+        displayName: "Deploy Bot",
+        clientId: "client-1",
+        runtimeProvider: "claude-code",
+        visibility: "organization",
+        organizationId: "org-1",
+      });
+    });
+
+    expect(clientMocks.api.post).toHaveBeenCalledWith(
+      "/orgs/org-1/agents",
+      expect.objectContaining({
+        displayName: "Deploy Bot",
+        name: "deploy-bot",
+        clientId: "client-1",
+        runtimeProvider: "claude-code",
+      }),
+    );
+    expect(sessionStorage.getItem("onboarding:agentUuid")).toBe("agent-created");
+    expect(eventMocks.reportOnboardingEvent).toHaveBeenCalledWith("agent_created", { runtimeProvider: "claude-code" });
+    expect(onOnline).toHaveBeenCalledWith("agent-created");
+    expect(expectHookValue(latest.current).phase).toBe("online");
+  });
+
+  it("handles create errors, blank names, retry, and timeout", async () => {
+    vi.useFakeTimers();
+    const latest = { current: null as ReturnType<typeof useAgentCreation> | null };
+    clientMocks.api.post
+      .mockRejectedValueOnce(new Error("create failed"))
+      .mockResolvedValueOnce({ uuid: "agent-slow" });
+    agentConfigMocks.getAgentClientStatus.mockResolvedValue({ online: false });
+
+    function Probe() {
+      latest.current = useAgentCreation(() => undefined);
+      return <div>{latest.current.phase}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await act(async () => {
+      await expectHookValue(latest.current).create({
+        displayName: "   ",
+        clientId: "client-1",
+        runtimeProvider: "claude-code",
+        visibility: "private",
+        organizationId: null,
+      });
+    });
+    expect(clientMocks.api.post).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await expectHookValue(latest.current).create({
+        displayName: "Broken",
+        clientId: "client-1",
+        runtimeProvider: "claude-code",
+        visibility: "private",
+        organizationId: null,
+      });
+    });
+    expect(expectHookValue(latest.current).error).toBe("create failed");
+    expect(expectHookValue(latest.current).phase).toBe("idle");
+
+    const slowCreate = act(async () => {
+      const promise = expectHookValue(latest.current).create({
+        displayName: "Slow Bot",
+        clientId: "client-1",
+        runtimeProvider: "codex",
+        visibility: "private",
+        organizationId: null,
+      });
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(31_000);
+      await promise;
+    });
+    await slowCreate;
+    expect(expectHookValue(latest.current).phase).toBe("timeout");
+
+    const retry = act(async () => {
+      const promise = expectHookValue(latest.current).retry();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(31_000);
+      await promise;
+    });
+    await retry;
+    expect(expectHookValue(latest.current).phase).toBe("timeout");
+  });
+
+  it("persists flow progress and navigates on finish actions", async () => {
+    const latest = { current: null as OnboardingFlowValue | null };
+
+    function Probe() {
+      function Inner() {
+        latest.current = useOnboardingFlow();
+        return <div>{latest.current.activeStep}</div>;
+      }
+      return (
+        <OnboardingFlowProvider path="admin">
+          <Inner />
+        </OnboardingFlowProvider>
+      );
+    }
+
+    const host = await renderProbe(<Probe />);
+    expect(host.textContent).toContain("team");
+    await act(async () => expectHookValue(latest.current).goTo(1));
+    expect(expectHookValue(latest.current).activeStep).toBe("connect-computer");
+    expect(sessionStorage.getItem("onboarding:stepIndex:admin")).toBe("1");
+
+    await act(async () => expectHookValue(latest.current).finishLater());
+    expect(authMock.value.dismissOnboarding).toHaveBeenCalled();
+
+    await act(async () => expectHookValue(latest.current).completeAndEnterChat("chat 1"));
+    expect(authMock.value.dismissOnboarding).toHaveBeenCalledTimes(2);
+    expect(authMock.value.markOnboardingCompleted).toHaveBeenCalled();
+    expect(sessionStorage.getItem("onboarding:stepIndex:admin")).toBeNull();
+  });
+});

--- a/packages/web/src/test-globals.d.ts
+++ b/packages/web/src/test-globals.d.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -3,13 +3,14 @@ import { defineConfig } from "vitest/config";
 import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
 
-// Web tests don't render React, but many of them import `.tsx` modules
-// (e.g. `pages/team/index.tsx` for its non-component helpers) — the React
-// plugin is needed at transform time to strip the JSX.
+// Many web tests import `.tsx` modules, and the DOM smoke tests render React
+// directly, so the React plugin is needed at transform time to strip JSX.
 export default defineConfig({
   plugins: [react()],
   test: {
     coverage: unitCoverageConfig(),
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
   },
   resolve: {
     alias: monorepoSourceAliases,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -80,7 +80,7 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
@@ -92,7 +92,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/client:
     dependencies:
@@ -132,13 +132,13 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       tsdown:
         specifier: ^0.21.4
         version: 0.21.4(typescript@5.9.3)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/e2e:
     devDependencies:
@@ -180,7 +180,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -217,7 +217,7 @@ importers:
         version: 19.2.14
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       ink-testing-library:
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.14)
@@ -229,7 +229,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server:
     dependencies:
@@ -311,7 +311,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10
@@ -326,7 +326,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -345,13 +345,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       tsdown:
         specifier: ^0.21.4
         version: 0.21.4(typescript@5.9.3)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/web:
     dependencies:
@@ -430,10 +430,13 @@ importers:
         version: 4.7.0(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -445,7 +448,7 @@ importers:
         version: 6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -2689,6 +2692,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -3335,6 +3341,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3578,6 +3588,10 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5049,6 +5063,10 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -7258,6 +7276,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.15
@@ -7276,7 +7296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -7291,11 +7311,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -7310,11 +7330,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -7329,7 +7349,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7340,6 +7360,22 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -7850,6 +7886,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
@@ -8163,6 +8201,18 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 22.19.19
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -9966,11 +10016,11 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9994,6 +10044,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.15
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -10008,11 +10059,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10036,6 +10087,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.15
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -10050,7 +10102,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.19)(happy-dom@20.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -10078,6 +10130,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.19
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -10093,6 +10146,8 @@ snapshots:
       - yaml
 
   web-streams-polyfill@3.3.3: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,7 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "coverage": {
+      "dependsOn": ["^build"],
       "cache": false,
       "passThroughEnv": ["CI_DATABASE_URL", "DATABASE_URL", "DOCKER_HOST", "TESTCONTAINERS_*"],
       "outputs": ["coverage/**"]


### PR DESCRIPTION
## Summary
- Add broad CLI unit coverage for command registration, login, daemon, doctor, onboarding, prompt, attention, github-scan, status, update glue, and Context Tree helpers.
- Add server/client coverage for snapshots, stats, GitHub entity lookup, and Context Tree snapshot expectations.
- Add web unit/DOM coverage for API wrappers, auth, routing, onboarding hooks, chat cards, pages, and config draft behavior.

## Validation
- `pnpm check && pnpm typecheck`

Note: `pnpm check` currently emits 24 Biome warnings from pre-existing `origin/main` test files under `packages/github-scan/tests/...` and `packages/server/src/__tests__/inbox-bind-recovery.test.ts` for `lint/style/noNonNullAssertion`; this PR does not add those warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive Vitest suites across CLI, web, server, and client packages covering commands, helpers, hooks, pages, DOM/SSR flows, and GitHub/scan tooling.
* **Test Infrastructure**
  * Improved browser/DOM, IndexedDB, WebSocket, filesystem and SSR shims; introduced happy-dom and extended test timeouts for stability.
* **Chores**
  * Ensure coverage task runs after build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-team-foundation/first-tree/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->