### PR TITLE
fix: use Apache-2.0 license metadata

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run --passWithNoTests",
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/agent-team-foundation/first-tree.git",

--- a/apps/doc-website/package.json
+++ b/apps/doc-website/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "keywords": [],
-  "license": "ISC",
+  "license": "Apache-2.0",
   "author": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "first-tree-monorepo",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@first-tree/client",
   "version": "0.1.2",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "description": "First Tree SDK — programmatic client for the First Tree cloud (Hub) server",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@first-tree/e2e",
   "version": "0.0.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "description": "Cross-process E2E framework — real pg + server + client processes, no fastify.inject. Standalone package: `rm -rf packages/e2e` must leave the published CLI tarball untouched (see proposals/hub-local-e2e-framework.20260518.md §三).",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@first-tree/server",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.3",
   "type": "module",
   "description": "First Tree shared schemas, types, and configuration (internal to the monorepo)",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/agent-team-foundation/first-tree.git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@first-tree/web",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Set all workspace package manifests to `Apache-2.0` license metadata.
- Add explicit license metadata to manifests that previously omitted it.
- Leave package versions and the root LICENSE text unchanged.

## Validation
- `pnpm check`
- `pnpm typecheck`
- Verified every tracked `package.json` has `license: Apache-2.0` and unchanged `version` metadata.