### PR TITLE
feat(web): green-liveness status model (bold green) → main

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -13,6 +13,33 @@
 
 ---
 
+## Decisions (2026-05-29) — Green-liveness status model
+
+Owner re-opened the color strategy to use green more boldly. Net change from the shipped
+Strategy A (F): green is no longer "signature + success **only**" — it now also carries
+**liveness**, while the neutral chrome and the no-green-on-dense-buttons discipline stay.
+Implemented on branch `refactor/web-green-liveness-status`.
+
+- **Status palette re-coloured.** `--state-working` cyan → **green** (alive, pulses);
+  `--state-idle` neutral-cool → **blue** (present/idle); added `--state-needs-you` =
+  **amber**; `--state-blocked` → **orange** (warmer than needs-you, and the shared
+  caution/warning hue). error=red, offline=gray unchanged. Cool (green/blue) = healthy;
+  warm (amber/orange/red) = wants your attention, so problems pop against the live baseline.
+- **working == success at the token level**, told apart by **form** (pulsing dot + glow vs
+  a static ✓ glyph), not hue.
+- **`--state-idle` disentangled.** It had doubled as the generic "✓ ok / ready / success"
+  colour; those ~8 sites moved to `--success` (green) so idle could become a true
+  presence-blue without turning every ✓ blue.
+- **Liveness / arrival = green.** The new-message **divider** and **pill** went
+  `--primary` → green — this **reverses** the Phase-0 choice that made them neutral
+  (intentional). The selected conversation gets a **green left-rail + green-tint** (was
+  neutral `--bg-active`). A soft green **glow** on the chat working chip.
+- **Green hero CTA.** Added a `cta` Button variant (`bg-brand`), applied to the one
+  creation/launch moment per surface (Create agent, onboarding Start). Dense/repeated
+  actions stay neutral `default`.
+
+---
+
 ## Decisions (2026-05-28)
 
 Owner picked the optimization direction. These are now committed targets (implementation pending):

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -22,13 +22,20 @@
 
 1. **Near-monochrome, content-first.** The UI is grays + near-black / near-white.
    Color is rare and always *means* something — it never decorates.
-2. **Neutral primary.** Primary actions (buttons, send, primary CTAs, selected
-   state) use a **neutral** tone — near-black in light, near-white in dark
-   (auto-inverting). Not green, not blue. (Linear / Vercel restraint.)
-3. **Green = signature + success only.** The brand green lives on the logo, on
-   Context-Tree surfaces (node glyphs, "writing to tree"), and on `success`
-   semantics. It is **never** the generic button / link / selected color — that
-   collision (brand == success == idle) is exactly what this strategy retires.
+2. **Neutral primary, green hero.** Everyday actions (buttons, send, menus,
+   selected tabs, links) use a **neutral** tone — near-black in light,
+   near-white in dark (auto-inverting). The one exception is the *hero /
+   creation* moment per surface ("Create agent", onboarding "Start", marketing
+   CTA), which uses the brand-green `cta` button variant. Dense or repeated
+   actions never go green — that's the green-primary (E2) collision.
+3. **Green = the living system.** Brand green carries three related jobs —
+   brand signature (logo, Context-Tree nodes, @mentions), **success** (✓,
+   "ready to merge"), and **liveness** (a working agent pulses green; live
+   arrivals — the new-message pill + divider — are green). Working-green is told
+   apart from success-green by **form** (pulsing dot + glow vs a static ✓
+   glyph), not hue. The states that want your attention are **warm** so they pop
+   against the green/blue live baseline: needs-you = amber, blocked = orange,
+   error = red. Present-but-idle = blue; offline = gray.
 4. **Lark / Arco craft, not Lark color.** Borrow the *discipline* — a neutral
    gray token ramp, hairline borders, soft low-opacity elevation, thin line
    icons, search + underline tabs, rounded-square avatars, comfortable aligned
@@ -38,14 +45,17 @@
 
 | Meaning | Color |
 |---------|-------|
-| primary action / selected | neutral (near-black ↔ near-white) |
-| brand / Context-Tree | green (`--brand`) |
-| success / passing | green (`--success`) |
-| working / processing | blue |
-| blocked / waiting | amber |
-| error / attention | red |
-| idle / standby | neutral |
-| offline | dim neutral |
+| everyday action / selected tab | neutral (near-black ↔ near-white) |
+| hero / creation CTA | green (`cta` variant — sparingly) |
+| brand / Context-Tree / @mention | green (`--brand`) |
+| success / passing / done | green (`--success`) |
+| working / alive (pulses + glow) | green (`--state-working`) |
+| live arrival (new-message pill + divider) | green |
+| idle / present | blue (`--state-idle`) |
+| needs-you | amber (`--state-needs-you`) |
+| blocked / stuck | orange (`--state-blocked`) |
+| error / failed | red (`--state-error`) |
+| offline | dim gray (`--state-offline`) |
 
 Per-agent **avatars** keep their own identity hues (wayfinding, not brand).
 
@@ -100,11 +110,12 @@ ever touch the semantic layer.
 ### Primary & brand
 | Token | Value | Role |
 |-------|-------|------|
-| `--primary` | neutral — near-black (light) / near-white (dark), auto-inverting | primary actions, send, primary CTAs, selected state |
-| `--brand` | green `oklch(0.72 0.17 150)` | logo, Context-Tree surfaces, brand moments — **never** a generic action / link / selected color |
+| `--primary` | neutral — near-black (light) / near-white (dark), auto-inverting | everyday actions, send, selected tabs, links |
+| `--brand` | green `oklch(0.72 0.17 150)` | logo, Context-Tree, @mentions, success, liveness (working / arrival), and the hero `cta` button — **never** a dense / repeated action color |
 
 Color is sparse and meaningful: most of the UI is neutral, and the green only
-appears where it signals brand or success.
+appears where it signals brand, success, or a *living* system (a working agent,
+a fresh arrival).
 
 The short `--fg*` / `--bg*` / `--border*` names below are canonical; write those.
 
@@ -123,16 +134,17 @@ for text sitting on a saturated colored surface (badges, avatars) and does
 ### State / status (agent-centric)
 | Token | Hue | Meaning |
 |-------|-----|---------|
-| `--state-idle` | cool neutral `240` | idle / standby |
-| `--state-working` | cyan `195` | actively working |
-| `--state-blocked` | amber `75` | blocked |
-| `--state-error` | red `25` | error |
-| `--state-offline` | neutral | offline |
+| `--state-working` | green `150` | alive / working — pulses (+ glow on the chat chip); told apart from success by form, not hue |
+| `--state-idle` | blue `245` | present / idle (at rest) |
+| `--state-needs-you` | amber `75` | waiting for you |
+| `--state-blocked` | orange `58` | blocked / stuck — also the shared caution / warning hue |
+| `--state-error` | red `25` | error / failed |
+| `--state-offline` | dim gray | offline |
 | `--state-unread` | = error | notification/attention (kept separate identifier on purpose) |
 
 ### Feedback / severity
 A named set, aliased to shared base hues (one value per color):
-`--success` (green, = brand hue) · `--warning` (amber) · `--danger` (red).
+`--success` (green, = brand hue) · `--warning` (orange, = `--state-blocked`; the caution/blocked hue, distinct from needs-you amber) · `--danger` (red).
 
 ### Inline callouts (notices)
 Each state ships a **soft** background + a **strong** text/border tone, so you

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -203,7 +203,7 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
           anchored={isJumpable(mounted, "needs_you", status.agentId)}
           ariaLabel="Jump to this agent's question in the timeline"
         >
-          <StatePill tone="blocked" label="Needs reply" />
+          <StatePill tone="needs-you" label="Needs reply" />
         </TimelineJumpButton>
       </div>
     );
@@ -240,7 +240,7 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
  * sans (not mono): the status word is natural language. Geometry mirrors
  * DenseBadge; tone colours come from the shared `tones` map.
  */
-function StatePill({ tone, label }: { tone: "blocked" | "error"; label: string }) {
+function StatePill({ tone, label }: { tone: "blocked" | "error" | "needs-you"; label: string }) {
   const t = toneOf(tone);
   return (
     <span

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -429,7 +429,13 @@ function SegMore({ count, fontSize }: { count: number; fontSize: number }) {
  */
 function AttentionBadge({ failed, needsYou, unread }: { failed: boolean; needsYou: boolean; unread: number }) {
   if (failed) return <CornerBadge background="var(--state-error)">!</CornerBadge>;
-  if (needsYou) return <CornerBadge background="var(--state-blocked)">?</CornerBadge>;
+  // Dark glyph on the light amber fill — white-on-amber (L≈0.82) is too low-contrast.
+  if (needsYou)
+    return (
+      <CornerBadge background="var(--state-needs-you)" fg="oklch(0.28 0.07 75)">
+        ?
+      </CornerBadge>
+    );
   const label = formatUnreadLabel(unread);
   if (label === null) return null;
   return (
@@ -453,10 +459,12 @@ function CornerBadge({
   background,
   children,
   wide = false,
+  fg = "var(--fg-on-vivid)",
 }: {
   background: string;
   children: ReactNode;
   wide?: boolean;
+  fg?: string;
 }) {
   return (
     <span
@@ -473,7 +481,7 @@ function CornerBadge({
         padding: wide ? "0 var(--sp-1)" : 0,
         borderRadius: wide ? CORNER_BADGE_SIZE / 2 : "50%",
         background,
-        color: "var(--fg-on-vivid)",
+        color: fg,
         fontSize: "var(--text-caption)",
         fontWeight: 700,
         lineHeight: 1,

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -264,7 +264,7 @@ function RailRow({
             background: "transparent",
             padding: 0,
             cursor: "pointer",
-            color: "var(--state-blocked)",
+            color: "var(--state-needs-you)",
           }}
         >
           Reply

--- a/packages/web/src/components/chat/working-chip.tsx
+++ b/packages/web/src/components/chat/working-chip.tsx
@@ -88,6 +88,9 @@ export function WorkingChip({
             height: 6,
             borderRadius: "50%",
             background: "var(--state-working)",
+            // Soft "alive" glow — box-shadow only (no layout footprint), so it
+            // doesn't disturb any aligned column; reinforces working=green=live.
+            boxShadow: "0 0 var(--sp-1_5) color-mix(in oklch, var(--state-working) 40%, transparent)",
           }}
         />
       ) : null}

--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -156,10 +156,10 @@ export function ConnectCommandPanel({
           style={{
             gap: "var(--sp-2_5)",
             padding: "var(--sp-2_5) var(--sp-3)",
-            background: "color-mix(in oklch, var(--state-idle) 14%, transparent)",
-            border: "var(--hairline) solid color-mix(in oklch, var(--state-idle) 35%, transparent)",
+            background: "color-mix(in oklch, var(--success) 14%, transparent)",
+            border: "var(--hairline) solid color-mix(in oklch, var(--success) 35%, transparent)",
             borderRadius: "var(--radius-input)",
-            color: "color-mix(in oklch, var(--state-idle) 45%, var(--fg))",
+            color: "color-mix(in oklch, var(--success) 45%, var(--fg))",
           }}
         >
           <Check className="h-3.5 w-3.5" style={{ flexShrink: 0 }} />

--- a/packages/web/src/components/last-step-modal.tsx
+++ b/packages/web/src/components/last-step-modal.tsx
@@ -122,7 +122,7 @@ export function LastStepModal({ agent, open, onClose, onBound }: Props) {
             </code>
             <Button variant="outline" size="icon" className="shrink-0" onClick={handleCopy} disabled={!command}>
               {copied ? (
-                <Check className="h-4 w-4" style={{ color: "var(--state-idle)" }} />
+                <Check className="h-4 w-4" style={{ color: "var(--success)" }} />
               ) : (
                 <Copy className="h-4 w-4" />
               )}

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -618,7 +618,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
                   style={{
                     color:
                       availability.status === "ok"
-                        ? "var(--state-idle)"
+                        ? "var(--success)"
                         : availability.status === "checking"
                           ? "var(--fg-3)"
                           : "var(--fg-4)",
@@ -804,7 +804,7 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
           )}
 
           <DialogFooter>
-            <Button type="submit" disabled={!canSubmit}>
+            <Button type="submit" variant="cta" disabled={!canSubmit}>
               {createMut.isPending ? "Creating…" : "Create"}
             </Button>
           </DialogFooter>

--- a/packages/web/src/components/new-messages-pill.tsx
+++ b/packages/web/src/components/new-messages-pill.tsx
@@ -24,20 +24,21 @@ export function NewMessagesPill({ count, onClick }: { count: number; onClick: ()
       type="button"
       onClick={onClick}
       aria-label={label}
-      className="absolute inline-flex items-center font-medium shadow-md"
+      className="absolute inline-flex items-center font-medium shadow-[var(--shadow-md)]"
       style={{
         // Sit above the input composer with comfortable breathing
         // room; offset from the right so it does not collide with
-        // the timeline content.
+        // the timeline content. Filled brand-green = a live "new arrival"
+        // nudge (distinct from the red unread-backlog badges).
         bottom: "var(--sp-3)",
         right: "var(--sp-4)",
         gap: "var(--sp-1_5)",
         height: "var(--sp-7)",
         padding: "0 var(--sp-3)",
         borderRadius: 999,
-        border: "var(--hairline) solid var(--primary)",
-        background: "var(--bg-raised)",
-        color: "var(--primary)",
+        border: "none",
+        background: "var(--brand)",
+        color: "var(--fg-on-vivid)",
         cursor: "pointer",
         zIndex: 5,
       }}

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -9,6 +9,11 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary-hover",
+        // Brand-green CTA. Reserve for the one hero/creation moment per surface
+        // (onboarding "Get started", "Create agent", marketing) — NOT for dense
+        // or repeated actions, which stay neutral (`default`). Green-on-buttons
+        // beyond hero moments slides back into the green-primary (E2) collision.
+        cta: "bg-brand text-[color:var(--fg-on-vivid)] hover:bg-brand-dim",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/packages/web/src/components/unread-divider.tsx
+++ b/packages/web/src/components/unread-divider.tsx
@@ -33,14 +33,14 @@ export const UnreadDivider = forwardRef<HTMLDivElement>(function UnreadDivider(_
       style={{
         margin: "var(--sp-2) 0",
         gap: "var(--sp-2)",
-        color: "var(--primary)",
+        color: "var(--brand)",
       }}
     >
-      <span aria-hidden="true" style={{ flex: 1, height: "var(--hairline)", background: "var(--primary)" }} />
+      <span aria-hidden="true" style={{ flex: 1, height: "var(--hairline)", background: "var(--brand)" }} />
       <span className="text-caption font-medium" style={{ whiteSpace: "nowrap" }}>
         New Messages
       </span>
-      <span aria-hidden="true" style={{ flex: 1, height: "var(--hairline)", background: "var(--primary)" }} />
+      <span aria-hidden="true" style={{ flex: 1, height: "var(--hairline)", background: "var(--brand)" }} />
     </div>
   );
 });

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -193,6 +193,7 @@
 
   --color-state-idle: var(--state-idle);
   --color-state-working: var(--state-working);
+  --color-state-needs-you: var(--state-needs-you);
   --color-state-blocked: var(--state-blocked);
   --color-state-error: var(--state-error);
   --color-state-offline: var(--state-offline);
@@ -246,12 +247,19 @@
      alpha so it reads in both themes without introducing a hue. */
   --ring: oklch(0.21 0 0 / 0.4);
 
-  /* idle = neutral cool "standby" tone. Deliberately NOT the brand/success
-     green (see --success) and distinct from --state-offline's dim gray, so an
-     idle agent reads as "present, at rest" rather than "healthy/success". */
-  --state-idle: oklch(0.7 0.03 240);
-  --state-working: oklch(0.78 0.16 195);
-  --state-blocked: oklch(0.82 0.18 75);
+  /* Agent-state vocabulary — "green-liveness" model. The system's living
+     states are COOL (green = alive+working, blue = present/idle); the states
+     that want your attention are WARM (amber = needs-you, orange = blocked,
+     red = error) so problems pop against the live baseline. Offline is gray
+     (absent — falls out of both families). working == brand green at the token
+     level; it is told apart from the success ✓ by FORM (pulsing dot + halo for
+     working, a static ✓ glyph for done), not by hue. */
+  --state-working: oklch(0.72 0.17 150); /* alive + working — brand green, pulses */
+  --state-idle: oklch(0.62 0.14 245); /* present, at rest — calm blue */
+  --state-needs-you: oklch(0.82 0.18 75); /* waiting for you — amber */
+  --state-blocked: oklch(
+    0.74 0.18 58
+  ); /* stuck / blocked + the shared caution/warning hue — a warmer orange than needs-you, still clearly not error-red */
   --state-error: oklch(0.68 0.22 25);
   --state-offline: oklch(0.5 0 0);
   /* Unread / attention semantic. Aliased to --state-error today because
@@ -321,8 +329,8 @@
      separate border color — one saturated tone covers both roles. */
   --bg-error-soft: oklch(0.97 0.02 25);
   --fg-error-strong: oklch(0.42 0.17 25);
-  --bg-warn-soft: oklch(0.97 0.04 75);
-  --fg-warn-strong: oklch(0.48 0.14 75);
+  --bg-warn-soft: oklch(0.97 0.04 58);
+  --fg-warn-strong: oklch(0.48 0.14 58);
   --bg-success-soft: oklch(0.96 0.04 150);
   --fg-success-strong: oklch(0.42 0.12 150);
 
@@ -460,8 +468,8 @@
   /* State pairs — dark-mode variants (softer bg, higher-L fg for contrast). */
   --bg-error-soft: oklch(0.28 0.06 25);
   --fg-error-strong: oklch(0.82 0.14 25);
-  --bg-warn-soft: oklch(0.3 0.06 75);
-  --fg-warn-strong: oklch(0.86 0.14 75);
+  --bg-warn-soft: oklch(0.3 0.06 58);
+  --fg-warn-strong: oklch(0.86 0.14 58);
   --bg-success-soft: oklch(0.28 0.05 150);
   --fg-success-strong: oklch(0.82 0.14 150);
 }
@@ -952,7 +960,7 @@
 }
 
 .context-change-breakdown span[data-change-type="edited"] {
-  background: oklch(0.82 0.18 75 / 0.14);
+  background: oklch(0.74 0.18 58 / 0.14);
   color: var(--warning);
 }
 

--- a/packages/web/src/lib/__tests__/agent-status-view.test.ts
+++ b/packages/web/src/lib/__tests__/agent-status-view.test.ts
@@ -5,7 +5,7 @@ import { type AgentStatusView, sessionStateToMain, viewOf } from "../agent-statu
 const ALL: AgentMainStatus[] = ["offline", "failed", "needs_you", "working", "paused", "ready"];
 
 describe("viewOf — §9.1 visual vocabulary", () => {
-  it("working = blue solid dot with the working pulse", () => {
+  it("working = green solid dot with the working pulse", () => {
     const v = viewOf("working");
     expect(v.colorVar).toBe("var(--state-working)");
     expect(v.shape).toBe("dot");
@@ -15,7 +15,7 @@ describe("viewOf — §9.1 visual vocabulary", () => {
 
   it("needs_you = amber solid dot with the calm pulse", () => {
     const v = viewOf("needs_you");
-    expect(v.colorVar).toBe("var(--state-blocked)");
+    expect(v.colorVar).toBe("var(--state-needs-you)");
     expect(v.shape).toBe("dot");
     expect(v.pulse).toBe("needs-you");
     expect(v.animationClass).toBe("agent-status-pulse--needs-you");
@@ -35,7 +35,7 @@ describe("viewOf — §9.1 visual vocabulary", () => {
     expect(v.pulse).toBeNull();
   });
 
-  it("ready = green solid dot, static", () => {
+  it("ready = blue (idle/present) solid dot, static", () => {
     const v = viewOf("ready");
     expect(v.colorVar).toBe("var(--state-idle)");
     expect(v.shape).toBe("dot");

--- a/packages/web/src/lib/agent-status-view.ts
+++ b/packages/web/src/lib/agent-status-view.ts
@@ -74,9 +74,10 @@ export type AgentStatusView = {
  * treatment, per the §9.1 visual vocabulary of the agent-status-ui design.
  * Pure and side-effect-free.
  *
- * Colors are the shared `--state-*` tokens (working = blue everywhere, etc.)
- * so this composite vocabulary and the runtime-A StateDot render with one
- * palette; shapes follow StateDot's shape+color double-encoding. This is the
+ * Colors are the shared `--state-*` tokens (working = green/alive, idle = blue,
+ * needs-you = amber, blocked = orange, etc.) so this composite vocabulary and
+ * the runtime-A StateDot render with one palette; shapes follow StateDot's
+ * shape+color double-encoding. This is the
  * *composite* mapping — it does NOT replace StateChip/StateDot, which keep
  * rendering the agent-global runtime vocabulary for the management pages.
  */
@@ -92,7 +93,7 @@ export function viewOf(main: AgentMainStatus): AgentStatusView {
       };
     case "needs_you":
       return {
-        colorVar: "var(--state-blocked)",
+        colorVar: "var(--state-needs-you)",
         shape: "dot",
         pulse: "needs-you",
         animationClass: "agent-status-pulse--needs-you",

--- a/packages/web/src/lib/tones.ts
+++ b/packages/web/src/lib/tones.ts
@@ -10,7 +10,17 @@
  * Adding a new tone? Define it here once and all consumers pick it up.
  */
 
-export type Tone = "neutral" | "accent" | "warn" | "error" | "outline" | "idle" | "working" | "blocked" | "offline";
+export type Tone =
+  | "neutral"
+  | "accent"
+  | "warn"
+  | "error"
+  | "outline"
+  | "idle"
+  | "working"
+  | "needs-you"
+  | "blocked"
+  | "offline";
 
 export type ToneStyle = {
   /** Background color. */
@@ -62,6 +72,11 @@ export const TONE_STYLES: Record<Tone, ToneStyle> = {
     bg: "color-mix(in oklch, var(--state-working) 14%, transparent)",
     fg: "var(--state-working)",
     bd: "color-mix(in oklch, var(--state-working) 30%, transparent)",
+  },
+  "needs-you": {
+    bg: "color-mix(in oklch, var(--state-needs-you) 14%, transparent)",
+    fg: "color-mix(in oklch, var(--state-needs-you) 50%, var(--fg))",
+    bd: "color-mix(in oklch, var(--state-needs-you) 30%, transparent)",
   },
   blocked: {
     bg: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -816,7 +816,7 @@ function BindClientList({
             >
               <span
                 className={cn("inline-block h-2 w-2 rounded-full shrink-0")}
-                style={{ background: isBindableClient(c) ? "var(--state-idle)" : "var(--fg-4)" }}
+                style={{ background: isBindableClient(c) ? "var(--success)" : "var(--fg-4)" }}
                 aria-hidden
               />
               <span className="flex-1 min-w-0">
@@ -846,7 +846,7 @@ const STATUS_LABELS: Record<TestResult["status"], string> = {
 };
 
 const TEST_RESULT_BORDER: Record<TestResult["status"], string> = {
-  success: "var(--state-idle)",
+  success: "var(--success)",
   offline: "var(--state-offline)",
   stale: "var(--state-blocked)",
   error: "var(--state-error)",

--- a/packages/web/src/pages/agent-detail/option-dropdown.tsx
+++ b/packages/web/src/pages/agent-detail/option-dropdown.tsx
@@ -142,7 +142,7 @@ export function OptionDropdown({
                 >
                   <Check
                     className="h-3.5 w-3.5 flex-shrink-0"
-                    style={{ visibility: active ? "visible" : "hidden", color: "var(--state-idle)" }}
+                    style={{ visibility: active ? "visible" : "hidden", color: "var(--success)" }}
                   />
                   <span className="flex-1 truncate">{o.label}</span>
                   {o.hint && (

--- a/packages/web/src/pages/agent-detail/save-bar.tsx
+++ b/packages/web/src/pages/agent-detail/save-bar.tsx
@@ -85,10 +85,7 @@ export function SaveBar(props: SaveBarProps) {
             </div>
           )}
           {props.justSaved && !props.summary.anyDirty && !props.errorMessage && !props.conflictMessage && (
-            <div
-              className="inline-flex items-center gap-1.5 text-body font-medium"
-              style={{ color: "var(--state-idle)" }}
-            >
+            <div className="inline-flex items-center gap-1.5 text-body font-medium" style={{ color: "var(--success)" }}>
               <Check className="h-3.5 w-3.5" />
               Saved
             </div>

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -778,7 +778,7 @@ function ProviderRow({
           <span className="font-medium" style={{ minWidth: 140 }}>
             {label}
           </span>
-          <span className="text-caption" style={{ color: "var(--state-idle)" }}>
+          <span className="text-caption" style={{ color: "var(--success)" }}>
             ✓{entry.sdkVersion ? ` v${entry.sdkVersion}` : " authenticated"}
           </span>
         </div>

--- a/packages/web/src/pages/clients/__tests__/computer-status-pill.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/computer-status-pill.test.tsx
@@ -8,15 +8,15 @@ import { PILL_VIEW } from "../computer-status-pill.js";
  * a regression. Matches the convention used by `presence-chip.test.ts`.
  */
 describe("PILL_VIEW — 4-state computer pill view model", () => {
-  it("ready maps to 'Ready' + idle (green) color", () => {
-    expect(PILL_VIEW.ready).toEqual({ label: "Ready", color: "var(--state-idle)" });
+  it("ready maps to 'Ready' + success (green) color", () => {
+    expect(PILL_VIEW.ready).toEqual({ label: "Ready", color: "var(--success)" });
   });
 
   it("auth_expired maps to 'Auth expired' + error (red) color", () => {
     expect(PILL_VIEW.auth_expired).toEqual({ label: "Auth expired", color: "var(--state-error)" });
   });
 
-  it("setup_incomplete maps to 'Setup incomplete' + blocked (amber) color", () => {
+  it("setup_incomplete maps to 'Setup incomplete' + blocked (orange) color", () => {
     expect(PILL_VIEW.setup_incomplete).toEqual({ label: "Setup incomplete", color: "var(--state-blocked)" });
   });
 

--- a/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
@@ -34,7 +34,7 @@ export function RuntimeStateLine({
     case "ok":
       return (
         <div className="text-body" style={{ color: "var(--fg-2)" }}>
-          <span style={{ color: "var(--state-idle)" }}>✓</span> {label}
+          <span style={{ color: "var(--success)" }}>✓</span> {label}
           {entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}
         </div>
       );

--- a/packages/web/src/pages/clients/computer-status-pill.tsx
+++ b/packages/web/src/pages/clients/computer-status-pill.tsx
@@ -13,7 +13,7 @@ type ComputerStatusPillProps = {
  * chip's DOM) can drive the same normalization.
  */
 export const PILL_VIEW: Record<PillName, { label: string; color: string }> = {
-  ready: { label: "Ready", color: "var(--state-idle)" },
+  ready: { label: "Ready", color: "var(--success)" },
   auth_expired: { label: "Auth expired", color: "var(--state-error)" },
   setup_incomplete: { label: "Setup incomplete", color: "var(--state-blocked)" },
   offline: { label: "Offline", color: "var(--fg-3)" },

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -177,7 +177,7 @@ export function StepCreateAgent() {
       {agentError && <FlowNote>{COPY.errors.agentFailed}</FlowNote>}
 
       <div className="flex">
-        <Button type="button" onClick={handleCreate} disabled={!canCreate}>
+        <Button type="button" variant="cta" onClick={handleCreate} disabled={!canCreate}>
           <span>Create {trimmed || "your agent"}</span>
           <ArrowRight className="h-4 w-4" />
         </Button>

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -192,7 +192,7 @@ function AdminKickoff() {
           <FlowNote tone="info">{COPY.kickoff.noProjectBody}</FlowNote>
           {error && <FlowNote>{error}</FlowNote>}
           <div className="flex">
-            <Button type="button" onClick={() => void handleStart()} disabled={!canStart}>
+            <Button type="button" variant="cta" onClick={() => void handleStart()} disabled={!canStart}>
               <span>{COPY.kickoff.start}</span>
               <ArrowRight className="h-4 w-4" />
             </Button>
@@ -487,7 +487,7 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
             preserves the "continue with intro only" path so users can't
             soft-lock themselves. */}
         <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
-          <Button type="button" onClick={() => void handleStart(chosen)} disabled={chosen.length === 0}>
+          <Button type="button" variant="cta" onClick={() => void handleStart(chosen)} disabled={chosen.length === 0}>
             <span>{COPY.kickoff.start}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -93,18 +93,21 @@ const BRAND_COLORS: SwatchDef[] = [
   { name: "--brand-ring", token: "var(--brand-ring)", note: "selection band" },
 ];
 
+// Green-liveness model: cool = alive (green working / blue idle); warm = wants
+// attention (amber needs-you / orange blocked / red error); gray = offline.
 const STATE_COLORS: SwatchDef[] = [
-  { name: "--state-idle", token: "var(--state-idle)", note: "neutral standby" },
-  { name: "--state-working", token: "var(--state-working)" },
-  { name: "--state-blocked", token: "var(--state-blocked)" },
-  { name: "--state-error", token: "var(--state-error)" },
-  { name: "--state-offline", token: "var(--state-offline)" },
+  { name: "--state-working", token: "var(--state-working)", note: "alive · green (pulses)" },
+  { name: "--state-idle", token: "var(--state-idle)", note: "present · blue" },
+  { name: "--state-needs-you", token: "var(--state-needs-you)", note: "waiting for you · amber" },
+  { name: "--state-blocked", token: "var(--state-blocked)", note: "stuck · orange" },
+  { name: "--state-error", token: "var(--state-error)", note: "error · red" },
+  { name: "--state-offline", token: "var(--state-offline)", note: "offline · gray" },
 ];
 
 // Feedback / severity vocabulary — distinct names, aliased to shared base hues.
 const FEEDBACK_COLORS: SwatchDef[] = [
   { name: "--success", token: "var(--success)", note: "= brand green" },
-  { name: "--warning", token: "var(--warning)", note: "= blocked amber" },
+  { name: "--warning", token: "var(--warning)", note: "= blocked orange" },
   { name: "--danger", token: "var(--danger)", note: "= error red" },
 ];
 
@@ -498,6 +501,7 @@ export function StyleguidePreviewPage() {
           <Subhead>Variants</Subhead>
           <Row>
             <Button>Default</Button>
+            <Button variant="cta">CTA (hero)</Button>
             <Button variant="destructive">Destructive</Button>
             <Button variant="outline">Outline</Button>
             <Button variant="secondary">Secondary</Button>
@@ -562,7 +566,12 @@ export function StyleguidePreviewPage() {
               <StatusGlyph colorVar="var(--state-offline)" shape="hollow" ariaLabel="hollow" />
               <StatusGlyph colorVar="var(--state-blocked)" shape="pause" ariaLabel="pause" />
               <StatusGlyph colorVar="var(--state-working)" shape="dot" pulse="working" ariaLabel="working pulse" />
-              <StatusGlyph colorVar="var(--state-error)" shape="dot" pulse="needs-you" ariaLabel="needs-you pulse" />
+              <StatusGlyph
+                colorVar="var(--state-needs-you)"
+                shape="dot"
+                pulse="needs-you"
+                ariaLabel="needs-you pulse"
+              />
             </span>
           </Row>
           <Subhead>FilterPill</Subhead>

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -648,14 +648,14 @@ export function ConversationList({
                         style={{
                           padding: "var(--sp-2) var(--sp-3)",
                           gap: "var(--sp-2_5)",
-                          background: isSelected ? "var(--bg-active)" : "transparent",
+                          background: isSelected ? "var(--brand-bg)" : "transparent",
                           borderLeft: `var(--hairline-bold) solid ${
                             isSelected
-                              ? "var(--primary)"
+                              ? "var(--brand)"
                               : failed
                                 ? "var(--state-error)"
                                 : needsYou
-                                  ? "var(--state-blocked)"
+                                  ? "var(--state-needs-you)"
                                   : "transparent"
                           }`,
                         }}


### PR DESCRIPTION
## Summary

Re-targets the green-liveness work onto **main**. The original PR (#668) accidentally merged into the `refactor/web-design-tokens-strategy-a` branch *after* that branch had already merged to main (#662), so its changes never reached main and would not deploy. This branch is a clean cherry-pick of the green-liveness commit onto the latest main (cleanly rebased over #652's divider/pill work — verified the divider/pill diff is purely the colour change, nothing from #652 reverted).

Uses green **boldly** as the "living system" colour, on top of Strategy A's neutral chrome:
- **Status palette:** `--state-working` cyan → **green** (alive, pulses); `--state-idle` neutral → **blue** (present/idle); added `--state-needs-you` = **amber**; `--state-blocked` → **orange** (also the shared caution/warning hue). Cool = healthy, warm = wants attention.
- **`--state-idle` disentangled** from its old double-duty as the generic "✓ ok/ready/success" colour → those ~8 sites moved to `--success`.
- **Liveness / arrival = green:** new-message divider + filled pill, selected-conversation green rail + tint, soft glow on the chat working chip.
- **Green `cta` Button variant** on hero/creation CTAs (Create agent, onboarding Start); dense actions stay neutral. working==success disambiguated by form (pulse/glow vs ✓), not hue.
- Styleguide + DESIGN.md / DESIGN-AUDIT updated.

## Review & test
- Carried over the **2 independent review rounds** from #668 (unified caution hue, needs-you badge contrast, 2 stale-test fixes).
- `pnpm --filter @first-tree/web typecheck` (tsc + token guardrail) clean; Biome clean; **vitest 488/488** (all 55 suites).
- Browser E2E (light + dark, no console errors) on `/preview/styleguide`: computed tokens verified, cool→warm state row reads correctly both themes.

## Known tradeoff
- Green `cta` button + filled pill use white text on `--brand` (~2.2:1 rest) — below strict AA, consistent with the shipped marketing green CTA and inherent to the fixed brand green. Kept per the bold-green direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)