### PR TITLE
Enforce suspended agent lifecycle

### DIFF
--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -53,6 +53,21 @@ describe("findStaleAliases", () => {
     expect(stale).toEqual([]);
   });
 
+  it("keeps suspended aliases pinned to this client out of the prune set", async () => {
+    writeAlias(agentsDir, "paused", "agentId: 00000000-0000-0000-0000-00000000ssss\nruntime: claude-code\n");
+
+    const remote: PinnedAgent[] = [
+      { agentId: "00000000-0000-0000-0000-00000000ssss", clientId: THIS_CLIENT, status: "suspended" },
+    ];
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => remote,
+    });
+    expect(stale).toEqual([]);
+  });
+
   it("classifies an agentId pinned to a different client as pinned-elsewhere", async () => {
     writeAlias(agentsDir, "shared-name", "agentId: 00000000-0000-0000-0000-00000000cccc\nruntime: claude-code\n");
 

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -162,6 +162,52 @@ describe("ClientRuntime context-tree wiring", () => {
     RUNTIME_TEST_TIMEOUT_MS,
   );
 
+  it(
+    "reports suspended local aliases as skipped instead of connection failures",
+    async () => {
+      const { print } = await import("../core/output.js");
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://hub.test", "client-test");
+      rt.addAgent("active", {
+        agentId: "agent-active",
+        runtime: "claude-code",
+        session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+        concurrency: 1,
+      } as unknown as Parameters<typeof rt.addAgent>[1]);
+      rt.addAgent("paused", {
+        agentId: "agent-paused",
+        runtime: "claude-code",
+        session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+        concurrency: 1,
+      } as unknown as Parameters<typeof rt.addAgent>[1]);
+      slotInstances[1]?.start.mockRejectedValueOnce(new Error("agent:bind rejected (agent_suspended)"));
+
+      await rt.start();
+
+      expect(print.status).toHaveBeenCalledWith("•", "paused: skipped (suspended)");
+      expect(print.status).toHaveBeenCalledWith("", "1 agent(s) running, 1 skipped. Press Ctrl+C to stop.");
+      expect(print.check).not.toHaveBeenCalledWith(
+        false,
+        "paused: connection failed",
+        expect.stringContaining("agent_suspended"),
+      );
+
+      const pinned = connectionListeners.get("agent:pinned");
+      if (!pinned) throw new Error("agent:pinned listener missing");
+      pinned({
+        agentId: "agent-paused",
+        name: "paused",
+        runtimeProvider: "claude-code",
+      });
+
+      await vi.waitFor(() => expect(slotInstances[1]?.start).toHaveBeenCalledTimes(2));
+      expect(print.status).toHaveBeenCalledWith("", "agent reactivated: paused");
+      expect(print.check).toHaveBeenCalledWith(true, "paused: connected", "agent: paused");
+      await rt.stop();
+    },
+    RUNTIME_TEST_TIMEOUT_MS,
+  );
+
   it("handles connection events, update hooks, and graceful stop", async () => {
     const { print } = await import("../core/output.js");
     const client = await import("@first-tree/client");

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -100,6 +100,17 @@ describe("doctor core checks", () => {
       }),
     ).resolves.toEqual({ label: "Agents", ok: true, detail: "1 configured, all pinned to this client" });
 
+    await expect(
+      reconcileAgentConfigs({
+        clientId: "client-1",
+        listPinnedAgents: async () => [{ agentId: "agent-1", clientId: "client-1", status: "suspended" }],
+      }),
+    ).resolves.toEqual({
+      label: "Agents",
+      ok: true,
+      detail: "1 configured, 0 active and 1 suspended/disabled on this client",
+    });
+
     writeAgent("moved", "agentId: agent-2\nruntime: claude-code\n");
     const stale = await reconcileAgentConfigs({
       clientId: "client-1",

--- a/apps/cli/src/core/agent-prune.ts
+++ b/apps/cli/src/core/agent-prune.ts
@@ -16,6 +16,10 @@ import { z } from "zod";
  * - `pinned-elsewhere`  — agentId belongs to the user but is pinned to a
  *                         *different* client. R-RUN would reject `bind`
  *                         on this machine; the agent is alive on the other.
+ *
+ * Suspended agents pinned to this client are not stale. The server still
+ * returns them from `/me/pinned-agents` with `status: "suspended"` so prune
+ * keeps their local config/workspace/session state for future reactivation.
  */
 export type StaleAliasReason =
   | { kind: "unreadable"; error: string }
@@ -29,7 +33,7 @@ export type StaleAlias = {
   reason: StaleAliasReason;
 };
 
-export type PinnedAgent = { agentId: string; clientId: string };
+export type PinnedAgent = { agentId: string; clientId: string; status?: string };
 
 const minimalAgentYamlSchema = z
   .object({

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -25,7 +25,15 @@ import { CLI_USER_AGENT } from "./version.js";
 type AgentEntry = {
   name: string;
   slot: AgentSlot;
+  state: AgentStartState;
 };
+
+type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "failed";
+
+export function isAgentSuspendedBindError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("agent_suspended");
+}
 
 export type ClientRuntimeOptions = {
   /**
@@ -163,6 +171,12 @@ export class ClientRuntime {
     this.connection.on("agent:pinned", (message) => {
       this.handleAgentPinned(message);
     });
+
+    this.connection.on("agent:unbound", (agentId, reason) => {
+      const entry = this.agents.find((agent) => agent.slot.agentId === agentId);
+      if (!entry || !reason) return;
+      entry.state = reason === "agent_suspended" ? "suspended-skipped" : "idle";
+    });
   }
 
   addAgent(name: string, config: AgentConfig): void {
@@ -186,7 +200,7 @@ export class ClientRuntime {
       clientConnection: this.connection,
       gitMirrorManager: this.gitMirrorManager,
     });
-    this.agents.push({ name, slot });
+    this.agents.push({ name, slot, state: "idle" });
     this.agentNames.add(name);
     this.agentIds.add(config.agentId);
   }
@@ -234,21 +248,13 @@ export class ClientRuntime {
       return;
     }
 
-    await Promise.allSettled(
-      this.agents.map(async (agent) => {
-        try {
-          const identity = await agent.slot.start();
-          print.check(true, `${agent.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          print.check(false, `${agent.name}: connection failed`, msg);
-        }
-      }),
-    );
+    const startupResults = await Promise.all(this.agents.map((agent) => this.startAgentEntry(agent)));
 
-    const connected = this.agents.length;
+    const connected = startupResults.filter((r) => r === "connected").length;
+    const skipped = startupResults.filter((r) => r === "skipped").length;
     print.blank();
-    print.status("", `${connected} agent(s) running. Press Ctrl+C to stop.`);
+    const skippedSuffix = skipped > 0 ? `, ${skipped} skipped` : "";
+    print.status("", `${connected} agent(s) running${skippedSuffix}. Press Ctrl+C to stop.`);
   }
 
   watchAgentsDir(agentsDir: string): void {
@@ -406,10 +412,14 @@ export class ClientRuntime {
    * creating an agent from the admin UI or API.
    */
   private handleAgentPinned(message: AgentPinnedMessage): void {
-    // Skip if we already track this agentId — avoids double-registration when
-    // the user also ran `agent add` manually, or when the server re-fires on
-    // reconnect in the future.
-    if (this.agentIds.has(message.agentId)) return;
+    const existing = this.agents.find((agent) => agent.slot.agentId === message.agentId);
+    if (existing) {
+      if (existing.state === "suspended-skipped") {
+        print.status("", `agent reactivated: ${existing.name}`);
+        this.startAgent(existing.name);
+      }
+      return;
+    }
 
     if (!this.agentsDir) {
       print.status("⚠️", `agent pinned (${message.agentId}) but no agents dir set — cannot auto-register.`);
@@ -469,14 +479,30 @@ export class ClientRuntime {
   private startAgent(name: string): void {
     const entry = this.agents.find((a) => a.name === name);
     if (!entry) return;
-    entry.slot
-      .start()
-      .then((identity) => {
-        print.check(true, `${name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
-      })
-      .catch((err) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        print.check(false, `${name}: connection failed`, msg);
-      });
+    void this.startAgentEntry(entry);
+  }
+
+  private async startAgentEntry(entry: AgentEntry): Promise<"connected" | "skipped" | "failed"> {
+    if (entry.state === "starting" || entry.state === "running") {
+      return entry.state === "running" ? "connected" : "skipped";
+    }
+
+    entry.state = "starting";
+    try {
+      const identity = await entry.slot.start();
+      entry.state = "running";
+      print.check(true, `${entry.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
+      return "connected";
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (isAgentSuspendedBindError(error)) {
+        entry.state = "suspended-skipped";
+        print.status("•", `${entry.name}: skipped (suspended)`);
+        return "skipped";
+      }
+      entry.state = "failed";
+      print.check(false, `${entry.name}: connection failed`, msg);
+      return "failed";
+    }
   }
 }

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
   agentConfigSchema,
@@ -7,6 +7,7 @@ import {
   loadAgents,
   resolveConfigReadonly,
 } from "@first-tree/shared/config";
+import { parse as parseYaml } from "yaml";
 import { findStaleAliases, formatStaleReason, type PinnedAgent, type StaleAlias } from "./agent-prune.js";
 import { cliFetch } from "./cli-fetch.js";
 import { blank, print } from "./output.js";
@@ -108,6 +109,25 @@ export function checkAgentConfigs(): CheckResult {
   }
 }
 
+function countSuspendedLocalAliases(agentsDir: string, suspendedAgentIds: ReadonlySet<string>): number {
+  if (suspendedAgentIds.size === 0 || !existsSync(agentsDir)) return 0;
+
+  let count = 0;
+  for (const entry of readdirSync(agentsDir)) {
+    const yamlPath = join(agentsDir, entry, "agent.yaml");
+    if (!existsSync(yamlPath)) continue;
+    try {
+      const raw = parseYaml(readFileSync(yamlPath, "utf-8"));
+      if (raw === null || typeof raw !== "object") continue;
+      const agentId = (raw as Record<string, unknown>).agentId;
+      if (typeof agentId === "string" && suspendedAgentIds.has(agentId)) count++;
+    } catch {
+      // Malformed aliases are reported by findStaleAliases as unreadable.
+    }
+  }
+  return count;
+}
+
 /**
  * Server-aware agent reconciliation. Walks `agents/<name>/agent.yaml` and
  * cross-references each `agentId` with `/api/v1/me/pinned-agents`,
@@ -115,7 +135,9 @@ export function checkAgentConfigs(): CheckResult {
  * actually accept on this machine.
  *
  * Categorises each local alias into:
- *   - pinned             — bind would succeed on this client.
+ *   - pinned             — owned by you and assigned to this client.
+ *   - suspended          — pinned to this client but disabled; retained
+ *                          locally and skipped at runtime until reactivated.
  *   - pinned-elsewhere   — owned by you, but pinned to a different client
  *                          (alias is dead weight here; real agent is alive
  *                          on the other machine).
@@ -156,10 +178,12 @@ export async function reconcileAgentConfigs(opts: {
   }
 
   let stale: StaleAlias[];
+  let remote: PinnedAgent[];
   try {
+    remote = await opts.listPinnedAgents();
     stale = await findStaleAliases({
       clientId: opts.clientId,
-      listPinnedAgents: opts.listPinnedAgents,
+      listPinnedAgents: async () => remote,
       agentsDir,
     });
   } catch (err) {
@@ -172,12 +196,20 @@ export async function reconcileAgentConfigs(opts: {
   }
 
   const pinnedCount = localCount - stale.length;
+  const suspendedAgentIds = new Set(
+    remote.filter((r) => r.clientId === opts.clientId && r.status === "suspended").map((r) => r.agentId),
+  );
+  const suspendedLocalCount = countSuspendedLocalAliases(agentsDir, suspendedAgentIds);
+  const activePinnedCount = pinnedCount - suspendedLocalCount;
 
   if (stale.length === 0) {
     return {
       label: "Agents",
       ok: true,
-      detail: `${localCount} configured, all pinned to this client`,
+      detail:
+        suspendedLocalCount > 0
+          ? `${localCount} configured, ${activePinnedCount} active and ${suspendedLocalCount} suspended/disabled on this client`
+          : `${localCount} configured, all pinned to this client`,
     };
   }
 
@@ -191,7 +223,8 @@ export async function reconcileAgentConfigs(opts: {
     label: "Agents",
     ok: false,
     detail:
-      `${localCount} configured locally, ${pinnedCount} pinned to this client; ` +
+      `${localCount} configured locally, ${activePinnedCount} active` +
+      `${suspendedLocalCount > 0 ? `, ${suspendedLocalCount} suspended/disabled` : ""}; ` +
       `${stale.length} stale: ${staleSummary}${truncated} — ` +
       "run `first-tree agent prune` to clean up",
   };

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -10,14 +10,17 @@ type AuthoritativePinnedAgent = {
   agentId: string;
   clientId: string;
   runtimeProvider: RuntimeProvider;
+  status?: string;
 };
 
 /**
  * Pre-flight reconciliation called before the agents loop spawns. Pulls
- * authoritative `runtime_provider` for every agent the calling user owns and
- * rewrites any local `agent.yaml` whose `runtime` field disagrees. Best-
- * effort: a transient hub failure logs and falls back to the local YAML
- * value (the in-band repair path catches any remaining drift on first bind).
+ * authoritative `runtime_provider` for every non-deleted agent the calling
+ * user owns and rewrites any local `agent.yaml` whose `runtime` field
+ * disagrees. Suspended agents stay in this ownership list so their local
+ * footprint is preserved while disabled. Best-effort: a transient hub failure
+ * logs and falls back to the local YAML value (the in-band repair path catches
+ * any remaining drift on first bind).
  */
 export async function reconcileLocalRuntimeProviders(opts: {
   serverUrl: string;

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -312,14 +312,36 @@ describe("AgentSlot", () => {
   });
 
   it("wraps runtime config fetch failures with a bind-aborted error", async () => {
-    const { slot, state } = await makeSlot({ configError: new Error("hub offline") });
+    const { slot, connection, state } = await makeSlot({ configError: new Error("hub offline") });
 
     await expect(slot.start()).rejects.toThrow("Hub unreachable while loading agent config: hub offline");
 
+    expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
     expect(state.logger.error).toHaveBeenCalledWith(
       { err: new Error("hub offline") },
       "failed to fetch agent config — bind aborted",
     );
+  });
+
+  it("cleans pre-bind listeners after a failed bind so the same slot can retry", async () => {
+    const { slot, connection } = await makeSlot();
+    connection.bindAgent.mockRejectedValueOnce(new Error("agent:bind rejected (agent_suspended)"));
+
+    await expect(slot.start()).rejects.toThrow("agent_suspended");
+
+    expect(connection.unbindAgent).not.toHaveBeenCalled();
+    expect(connection.listenerCount("inbox:deliver")).toBe(0);
+    expect(connection.listenerCount("agent:bound")).toBe(0);
+    expect(connection.listenerCount("agent:unbound")).toBe(0);
+    expect(connection.listenerCount("session:reconcile:result")).toBe(0);
+
+    await expect(slot.start()).resolves.toMatchObject({ agentId: "agent-1" });
+
+    expect(connection.bindAgent).toHaveBeenCalledTimes(2);
+    expect(connection.listenerCount("inbox:deliver")).toBe(1);
+    expect(connection.listenerCount("agent:bound")).toBe(1);
+    expect(connection.listenerCount("agent:unbound")).toBe(1);
+    expect(connection.listenerCount("session:reconcile:result")).toBe(1);
   });
 
   it("stringifies non-Error runtime config fetch failures", async () => {
@@ -429,6 +451,27 @@ describe("AgentSlot", () => {
 
     connection.emit("inbox:deliver", "inbox-1", makeFrame({ entryId: 99 }));
     expect(session.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops only the matching slot when the server force-unbounds an agent", async () => {
+    const { slot, connection, state } = await makeSlot();
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+
+    connection.emit("agent:unbound", "other-agent", "agent_suspended");
+    await Promise.resolve();
+    expect(connection.unbindAgent).not.toHaveBeenCalled();
+    expect(session.shutdown).not.toHaveBeenCalled();
+
+    connection.emit("agent:unbound", "agent-1", "agent_suspended");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+    expect(session.shutdown).toHaveBeenCalled();
+    connection.emit("inbox:deliver", "inbox-1", makeFrame({ entryId: 99 }));
+    expect(session.dispatch).not.toHaveBeenCalled();
   });
 
   it("logs optional context-tree, push-dispatch, and session-command failures without crashing", async () => {

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -20,8 +20,10 @@ type ClientConnectionPrivate = {
   pausedReason: "auth_rejected" | "auth_refresh_failed" | null;
   nextReconnectMinDelayMs: number;
   desiredBindings: Map<string, { agentId: string; runtimeType: string; runtimeVersion?: string }>;
+  boundAgents: Map<string, BoundAgent>;
   pendingBinds: Map<string, PendingBind>;
   openWebSocket(): Promise<void>;
+  handleMessage(msg: Record<string, unknown>, connectResolve?: () => void): void;
   sendBind(agentId: string, runtimeType: string, runtimeVersion?: string): Promise<BoundAgent>;
   rebindAgents(): void;
   scheduleReconnect(): void;
@@ -254,6 +256,29 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     expect(events).toContain("error:plain reconnect failure");
 
     internal.clearTimers();
+  });
+
+  it("emits force-disconnect reason on agent:unbound", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const events: Array<{ agentId: string; reason?: string }> = [];
+    connection.on("agent:unbound", (agentId, reason) => events.push({ agentId, reason }));
+
+    internal.boundAgents.set("agent-suspended", {
+      agentId: "agent-suspended",
+      displayName: "Suspended Agent",
+      agentType: "agent",
+      sdk: {} as BoundAgent["sdk"],
+    });
+
+    internal.handleMessage({
+      type: "agent:force_disconnect",
+      agentId: "agent-suspended",
+      reason: "agent_suspended",
+    });
+
+    expect(events).toEqual([{ agentId: "agent-suspended", reason: "agent_suspended" }]);
+    expect(internal.boundAgents.has("agent-suspended")).toBe(false);
   });
 
   it("covers proactive refresh rate-limit fallback without Retry-After", async () => {

--- a/packages/client/src/__tests__/sdk-surface.test.ts
+++ b/packages/client/src/__tests__/sdk-surface.test.ts
@@ -143,7 +143,7 @@ describe("FirstTreeHubSDK public surface", () => {
     const responses = [
       jsonResponse({ repo: "https://example.com/tree.git", branch: "main" }),
       jsonResponse({ agentId: "agent-1", version: 3, payload: { gitRepos: [] } }),
-      jsonResponse([{ agentId: "agent-1", clientId: "client-1", runtimeProvider: "codex" }]),
+      jsonResponse([{ agentId: "agent-1", clientId: "client-1", runtimeProvider: "codex", status: "suspended" }]),
       jsonResponse({ items: [{ id: "chat-1" }], nextCursor: "next" }),
       jsonResponse({ id: "chat-1", topic: "Build" }),
       jsonResponse({ items: [{ id: "m1" }], nextCursor: null }),
@@ -157,7 +157,7 @@ describe("FirstTreeHubSDK public surface", () => {
     await expect(sdk.getContextTreeConfig()).resolves.toEqual({ repo: "https://example.com/tree.git", branch: "main" });
     await expect(sdk.fetchAgentConfig()).resolves.toMatchObject({ agentId: "agent-1", version: 3 });
     await expect(sdk.listMyAgents()).resolves.toEqual([
-      { agentId: "agent-1", clientId: "client-1", runtimeProvider: "codex" },
+      { agentId: "agent-1", clientId: "client-1", runtimeProvider: "codex", status: "suspended" },
     ]);
     await expect(sdk.listChats({ limit: 20, cursor: "abc" })).resolves.toMatchObject({ nextCursor: "next" });
     await expect(sdk.getChatDetail("chat-1")).resolves.toMatchObject({ id: "chat-1" });

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -122,7 +122,7 @@ type ClientConnectionEvents = {
   reconnected: [];
   error: [error: Error];
   "agent:bound": [agent: BoundAgent];
-  "agent:unbound": [agentId: string];
+  "agent:unbound": [agentId: string, reason?: string];
   /**
    * Server pushed a fully-assembled inbox entry over the WS data plane.
    * Listeners must call `connection.sendInboxAck(frame.entryId)` once the
@@ -994,7 +994,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       const agentId = msg.agentId as string;
       if (agentId && this.boundAgents.has(agentId)) {
         this.boundAgents.delete(agentId);
-        this.emit("agent:unbound", agentId);
+        this.emit("agent:unbound", agentId, typeof msg.reason === "string" ? msg.reason : "server_forced");
       }
       return;
     }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -42,6 +42,7 @@ export type AgentSlotConfig = {
 type ConnectionListener =
   | { event: "inbox:deliver"; fn: (inboxId: string, frame: InboxDeliverFrame) => void }
   | { event: "agent:bound"; fn: (agent: { agentId: string }) => void }
+  | { event: "agent:unbound"; fn: (agentId: string, reason?: string) => void }
   | { event: "session:command"; fn: (cmd: { agentId: string; chatId: string; type: string }) => void }
   | { event: "session:reconcile:result"; fn: (result: SessionReconcileResult) => void };
 
@@ -52,6 +53,7 @@ export class AgentSlot {
   private agentConfigCache: AgentConfigCache | null = null;
   private reconcileTimer: ReturnType<typeof setInterval> | null = null;
   private listeners: ConnectionListener[] = [];
+  private stopping: Promise<void> | null = null;
   /**
    * The inbox this slot's agent owns — used to filter `inbox:deliver`
    * frames addressed to other agents on the same client. Captured at
@@ -138,140 +140,167 @@ export class AgentSlot {
         this.sessionManager.applyStaleChatIds(result.staleChatIds);
       }
     };
+    const onUnbound = (agentId: string, reason?: string) => {
+      if (agentId !== this.config.agentId || !reason) return;
+      this.stop().catch((err) => {
+        this.logger.error({ err, reason }, "forced agent stop failed");
+      });
+    };
     this.clientConnection.on("inbox:deliver", onInboxDeliver);
     this.clientConnection.on("agent:bound", onBound);
+    this.clientConnection.on("agent:unbound", onUnbound);
     this.clientConnection.on("session:reconcile:result", onReconcileResult);
     this.listeners.push(
       { event: "inbox:deliver", fn: onInboxDeliver },
       { event: "agent:bound", fn: onBound },
+      { event: "agent:unbound", fn: onUnbound },
       { event: "session:reconcile:result", fn: onReconcileResult },
     );
 
-    const bound = await this.clientConnection.bindAgent(
-      this.config.agentId,
-      this.config.runtimeType ?? this.config.type,
-      this.config.runtimeVersion,
-    );
-    const sdk = bound.sdk;
-    const agent = await sdk.register();
-
-    this.logger.info({ displayName: agent.displayName }, "agent bound");
-
-    if (agent.type === "human") {
-      this.logger.info("server reports type=human — message processing disabled");
-      return agent;
-    }
-
-    this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logger });
+    let bindSucceeded = false;
     try {
-      const cfg = await this.agentConfigCache.refresh(agent.agentId);
-      this.logger.info({ version: cfg.version }, "runtime config loaded");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error({ err }, "failed to fetch agent config — bind aborted");
-      throw new Error(`Hub unreachable while loading agent config: ${msg}`);
-    }
-
-    this.inboxId = agent.inboxId;
-    const contextTreeBinding = await syncAgentContextTree(sdk, (msg) => this.logger.info(msg));
-    if (!contextTreeBinding) {
-      this.logger.info("context tree not configured or sync skipped — agent will start without organizational context");
-    }
-
-    const registryPath = join(defaultDataDir(), "sessions", `${this.config.name}.json`);
-
-    // The runtime owns the GitMirrorManager and injects it here — sharing one
-    // manager across slots is what makes `withUrlLock` actually serialise
-    // concurrent worktree adds for the same URL (PRD §5.1.5).
-    const gitMirrorManager = this.config.gitMirrorManager;
-
-    // Ack is fire-and-forget over WS: `ws.send` doesn't block on flush and
-    // SessionManager treats ack as advisory. Wrap in a resolved Promise so
-    // the `(id) => Promise<void>` config signature is satisfied.
-    const ackEntry = (entryId: number) => {
-      this.clientConnection.sendInboxAck(entryId);
-      return Promise.resolve();
-    };
-
-    this.sessionManager = new SessionManager({
-      session: this.config.session,
-      concurrency: this.config.concurrency,
-      handlerFactory: this.config.handlerFactory,
-      handlerConfig: {
-        workspaceRoot: join(defaultDataDir(), "workspaces", this.config.name),
-        agentName: this.config.name,
-        contextTreePath: contextTreeBinding?.path,
-        contextTreeRepoUrl: contextTreeBinding?.repoUrl,
-        gitMirrorManager,
-      },
-      agentIdentity: {
-        agentId: agent.agentId,
-        inboxId: agent.inboxId,
-        displayName: agent.displayName,
-        type: agent.type,
-        visibility: agent.visibility,
-        delegateMention: agent.delegateMention,
-        metadata: agent.metadata,
-      },
-      sdk,
-      log: this.logger,
-      registryPath,
-      agentConfigCache: this.agentConfigCache,
-      ackEntry,
-      onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
-      onRuntimeStateChange: (state) => this.reportRuntimeState(state),
-      onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
-      onSessionRuntimeChange: (chatId, state) => this.reportSessionRuntime(chatId, state),
-    });
-
-    const onCommand = (cmd: { agentId: string; chatId: string; type: string }) => {
-      if (cmd.agentId === this.config.agentId && this.sessionManager) {
-        this.sessionManager
-          .handleCommand(cmd.chatId, cmd.type as "session:suspend" | "session:terminate")
-          .catch((err) => {
-            this.logger.error({ err, chatId: cmd.chatId, type: cmd.type }, "session command error");
-          });
-      }
-    };
-    this.clientConnection.on("session:command", onCommand);
-    this.listeners.push({ event: "session:command", fn: onCommand });
-
-    // Flush any `inbox:deliver` frames the early listener captured
-    // during init. With the bind-time reset+drain path (see design §4)
-    // the server pushes pending entries the instant it processes the
-    // `agent:bind` frame, but the surrounding `sdk.register` +
-    // `agentConfigCache.refresh` + `syncAgentContextTree` chain above
-    // can take anywhere from ~100ms (no Context Tree) to 15s
-    // (cold-clone Context Tree). Without this flush every restart with
-    // an un-acked in-flight message lost the recovery push and the
-    // server row stayed `delivered` indefinitely — the in-process
-    // Deduplicator absorbed every subsequent bind-reset replay so the
-    // entry never re-dispatched and never acked.
-    if (earlyDeliverBuffer.length > 0) {
-      this.logger.info(
-        { buffered: earlyDeliverBuffer.length },
-        "flushing early inbox:deliver buffer — frames received during init window",
+      const bound = await this.clientConnection.bindAgent(
+        this.config.agentId,
+        this.config.runtimeType ?? this.config.type,
+        this.config.runtimeVersion,
       );
-      for (const frame of earlyDeliverBuffer.splice(0)) {
-        this.dispatchPushedFrame(frame).catch((err) => {
-          this.logger.warn({ err, entryId: frame.entryId }, "buffered inbox:deliver dispatch error");
-        });
+      bindSucceeded = true;
+      const sdk = bound.sdk;
+      const agent = await sdk.register();
+
+      this.logger.info({ displayName: agent.displayName }, "agent bound");
+
+      if (agent.type === "human") {
+        this.logger.info("server reports type=human — message processing disabled");
+        return agent;
       }
+
+      this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logger });
+      try {
+        const cfg = await this.agentConfigCache.refresh(agent.agentId);
+        this.logger.info({ version: cfg.version }, "runtime config loaded");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error({ err }, "failed to fetch agent config — bind aborted");
+        throw new Error(`Hub unreachable while loading agent config: ${msg}`);
+      }
+
+      this.inboxId = agent.inboxId;
+      const contextTreeBinding = await syncAgentContextTree(sdk, (msg) => this.logger.info(msg));
+      if (!contextTreeBinding) {
+        this.logger.info(
+          "context tree not configured or sync skipped — agent will start without organizational context",
+        );
+      }
+
+      const registryPath = join(defaultDataDir(), "sessions", `${this.config.name}.json`);
+
+      // The runtime owns the GitMirrorManager and injects it here — sharing one
+      // manager across slots is what makes `withUrlLock` actually serialise
+      // concurrent worktree adds for the same URL (PRD §5.1.5).
+      const gitMirrorManager = this.config.gitMirrorManager;
+
+      // Ack is fire-and-forget over WS: `ws.send` doesn't block on flush and
+      // SessionManager treats ack as advisory. Wrap in a resolved Promise so
+      // the `(id) => Promise<void>` config signature is satisfied.
+      const ackEntry = (entryId: number) => {
+        this.clientConnection.sendInboxAck(entryId);
+        return Promise.resolve();
+      };
+
+      this.sessionManager = new SessionManager({
+        session: this.config.session,
+        concurrency: this.config.concurrency,
+        handlerFactory: this.config.handlerFactory,
+        handlerConfig: {
+          workspaceRoot: join(defaultDataDir(), "workspaces", this.config.name),
+          agentName: this.config.name,
+          contextTreePath: contextTreeBinding?.path,
+          contextTreeRepoUrl: contextTreeBinding?.repoUrl,
+          gitMirrorManager,
+        },
+        agentIdentity: {
+          agentId: agent.agentId,
+          inboxId: agent.inboxId,
+          displayName: agent.displayName,
+          type: agent.type,
+          visibility: agent.visibility,
+          delegateMention: agent.delegateMention,
+          metadata: agent.metadata,
+        },
+        sdk,
+        log: this.logger,
+        registryPath,
+        agentConfigCache: this.agentConfigCache,
+        ackEntry,
+        onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
+        onRuntimeStateChange: (state) => this.reportRuntimeState(state),
+        onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
+        onSessionRuntimeChange: (chatId, state) => this.reportSessionRuntime(chatId, state),
+      });
+
+      const onCommand = (cmd: { agentId: string; chatId: string; type: string }) => {
+        if (cmd.agentId === this.config.agentId && this.sessionManager) {
+          this.sessionManager
+            .handleCommand(cmd.chatId, cmd.type as "session:suspend" | "session:terminate")
+            .catch((err) => {
+              this.logger.error({ err, chatId: cmd.chatId, type: cmd.type }, "session command error");
+            });
+        }
+      };
+      this.clientConnection.on("session:command", onCommand);
+      this.listeners.push({ event: "session:command", fn: onCommand });
+
+      // Flush any `inbox:deliver` frames the early listener captured
+      // during init. With the bind-time reset+drain path (see design §4)
+      // the server pushes pending entries the instant it processes the
+      // `agent:bind` frame, but the surrounding `sdk.register` +
+      // `agentConfigCache.refresh` + `syncAgentContextTree` chain above
+      // can take anywhere from ~100ms (no Context Tree) to 15s
+      // (cold-clone Context Tree). Without this flush every restart with
+      // an un-acked in-flight message lost the recovery push and the
+      // server row stayed `delivered` indefinitely — the in-process
+      // Deduplicator absorbed every subsequent bind-reset replay so the
+      // entry never re-dispatched and never acked.
+      if (earlyDeliverBuffer.length > 0) {
+        this.logger.info(
+          { buffered: earlyDeliverBuffer.length },
+          "flushing early inbox:deliver buffer — frames received during init window",
+        );
+        for (const frame of earlyDeliverBuffer.splice(0)) {
+          this.dispatchPushedFrame(frame).catch((err) => {
+            this.logger.warn({ err, entryId: frame.entryId }, "buffered inbox:deliver dispatch error");
+          });
+        }
+      }
+
+      // Initial-startup fullStateSync. The `on("agent:bound", onBound)`
+      // listener above also fires here now that it's attached pre-bind,
+      // but `sessionManager` was null inside its callback — so its
+      // `fullStateSync()` call was a no-op. Run it explicitly now that
+      // the manager exists.
+      this.fullStateSync();
+
+      this.startReconcileLoop();
+
+      return agent;
+    } catch (err) {
+      await this.cleanupFailedStart({ unbind: bindSucceeded });
+      throw err;
     }
-
-    // Initial-startup fullStateSync. The `on("agent:bound", onBound)`
-    // listener above also fires here now that it's attached pre-bind,
-    // but `sessionManager` was null inside its callback — so its
-    // `fullStateSync()` call was a no-op. Run it explicitly now that
-    // the manager exists.
-    this.fullStateSync();
-
-    this.startReconcileLoop();
-
-    return agent;
   }
 
   async stop(): Promise<void> {
+    if (this.stopping) return this.stopping;
+    this.stopping = this.stopOnce();
+    try {
+      await this.stopping;
+    } finally {
+      this.stopping = null;
+    }
+  }
+
+  private async stopOnce(): Promise<void> {
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
@@ -282,7 +311,32 @@ export class AgentSlot {
     this.listeners = [];
     await this.clientConnection.unbindAgent(this.config.agentId);
     await this.sessionManager?.shutdown();
+    this.sessionManager = null;
+    this.agentConfigCache = null;
+    this.inboxId = null;
     this.logger.info("stopped");
+  }
+
+  private async cleanupFailedStart(opts: { unbind: boolean }): Promise<void> {
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
+    for (const entry of this.listeners) {
+      this.clientConnection.off(entry.event, entry.fn);
+    }
+    this.listeners = [];
+    if (opts.unbind) {
+      try {
+        await this.clientConnection.unbindAgent(this.config.agentId);
+      } catch (err) {
+        this.logger.warn({ err }, "failed to unbind after aborted agent start");
+      }
+    }
+    await this.sessionManager?.shutdown();
+    this.sessionManager = null;
+    this.agentConfigCache = null;
+    this.inboxId = null;
   }
 
   private reportSessionState(chatId: string, state: SessionState): void {

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -260,11 +260,13 @@ export class FirstTreeHubSDK {
   }
 
   /**
-   * Member-scoped: every agent pinned to a client owned by the calling user.
-   * Used by client startup to reconcile the local `agent.yaml::runtime` with
-   * the authoritative `agents.runtime_provider` before spawning handlers.
+   * Member-scoped: every non-deleted agent pinned to a client owned by the
+   * calling user. Includes suspended agents so local reconciliation/prune can
+   * preserve their config, workspace, and saved sessions while disabled.
    */
-  async listMyAgents(): Promise<Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider }>> {
+  async listMyAgents(): Promise<
+    Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider; status?: string }>
+  > {
     return this.requestJson("/api/v1/me/pinned-agents");
   }
 

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -5,7 +5,7 @@ import WebSocket from "ws";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
-import { createAgent } from "../services/agent.js";
+import { createAgent, suspendAgent } from "../services/agent.js";
 import { resolveDefaultOrgId } from "../services/organization.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestApp } from "./helpers.js";
@@ -335,6 +335,121 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
       const b = seenPinned.get(offlineCreated2.uuid);
       expect(b).toBeDefined();
       expect(b?.name).toBe(offlineCreated2.name);
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("does not backfill suspended pinned agents", async () => {
+    const seed = await seedConnectedClient("suspended-backfill");
+    const active = await createAgent(app.db, {
+      name: `pin-active-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Active Pinned",
+      source: "admin-api",
+      managerId: seed.memberId,
+      organizationId: seed.organizationId,
+      clientId: seed.clientId,
+    });
+    const suspended = await createAgent(app.db, {
+      name: `pin-suspended-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Suspended Pinned",
+      source: "admin-api",
+      managerId: seed.memberId,
+      organizationId: seed.organizationId,
+      clientId: seed.clientId,
+    });
+    await suspendAgent(app.db, suspended.uuid);
+
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    try {
+      const seenPinned = new Set<string>();
+      ws.on("message", (raw) => {
+        try {
+          const msg = JSON.parse(raw.toString()) as { type?: string; agentId?: string };
+          if (msg.type === "agent:pinned" && typeof msg.agentId === "string") seenPinned.add(msg.agentId);
+        } catch {
+          // ignore
+        }
+      });
+
+      ws.send(JSON.stringify({ type: "auth", token: seed.token }));
+      await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:ok");
+      ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+      await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:registered");
+      await waitForFrame(
+        ws,
+        (m) => (m as { type?: string; agentId?: string }).type === "agent:pinned" && seenPinned.has(active.uuid),
+        2000,
+      );
+      await new Promise((r) => setTimeout(r, 100));
+      expect(seenPinned.has(active.uuid)).toBe(true);
+      expect(seenPinned.has(suspended.uuid)).toBe(false);
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("suspend sends force-disconnect reason and rejects later runtime frames", async () => {
+    const seed = await seedConnectedClient("suspend-force");
+    const agent = await createAgent(app.db, {
+      name: `pin-force-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Force Suspended",
+      source: "admin-api",
+      managerId: seed.memberId,
+      organizationId: seed.organizationId,
+      clientId: seed.clientId,
+    });
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          type: "agent:bind",
+          ref: "bind-force",
+          agentId: agent.uuid,
+          runtimeType: "claude-code",
+          runtimeVersion: "test",
+        }),
+      );
+      await waitForFrame(
+        ws,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:bound" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+
+      const forcePromise = waitForFrame(
+        ws,
+        (m) => (m as { type?: string; agentId?: string }).type === "agent:force_disconnect",
+      );
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/agents/${agent.uuid}/suspend`,
+        headers: { authorization: `Bearer ${seed.token}` },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const frame = await forcePromise;
+      expect(frame).toMatchObject({
+        type: "agent:force_disconnect",
+        agentId: agent.uuid,
+        reason: "agent_suspended",
+      });
+
+      ws.send(
+        JSON.stringify({ type: "session:state", agentId: agent.uuid, chatId: "chat-after-suspend", state: "active" }),
+      );
+      const error = await waitForFrame(ws, (m) => (m as { type?: string }).type === "error");
+      expect(error.message).toBe("Agent not bound");
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));

--- a/packages/server/src/__tests__/client-service.test.ts
+++ b/packages/server/src/__tests__/client-service.test.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agentPresence } from "../db/schema/agent-presence.js";
+import { createAgent, suspendAgent } from "../services/agent.js";
 import * as clientService from "../services/client.js";
 import * as presenceService from "../services/presence.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -107,5 +108,39 @@ describe("client service: disconnectClient", () => {
     expect(presA?.status).toBe("offline");
     expect(presB?.status).toBe("online");
     expect(presB?.clientId).toBe(clientY);
+  });
+});
+
+describe("client service: pinned agent startup surfaces", () => {
+  const getApp = useTestApp();
+
+  it("excludes suspended agents from startup candidate lists", async () => {
+    const app = getApp();
+    const {
+      agent: active,
+      userId,
+      clientId,
+      memberId,
+      organizationId,
+    } = await createTestAgent(app, {
+      name: `cs-pin-active-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const suspended = await createAgent(app.db, {
+      name: `cs-pin-suspended-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      source: "admin-api",
+      managerId: memberId,
+      organizationId,
+      clientId,
+    });
+    await suspendAgent(app.db, suspended.uuid);
+
+    await expect(clientService.listActiveAgentsPinnedToClient(app.db, clientId)).resolves.toEqual([
+      expect.objectContaining({ uuid: active.uuid }),
+    ]);
+    await expect(clientService.listMyPinnedAgents(app.db, { userId })).resolves.toEqual([
+      expect.objectContaining({ agentId: active.uuid, clientId, status: "active" }),
+      expect.objectContaining({ agentId: suspended.uuid, clientId, status: "suspended" }),
+    ]);
   });
 });

--- a/packages/server/src/__tests__/connection-manager.test.ts
+++ b/packages/server/src/__tests__/connection-manager.test.ts
@@ -207,14 +207,18 @@ describe("connection-manager: forceDisconnect M1 mode", () => {
     bindAgentToClient(clientId, agent2);
 
     // Force disconnect only agent1
-    const result = forceDisconnect(agent1);
+    const result = forceDisconnect(agent1, "agent_suspended");
 
     expect(result).toBe(true);
     // WS should NOT be closed
     expect(closeCalled).toBe(false);
     // Should have sent force_disconnect message
     expect(sentMessages).toHaveLength(1);
-    expect(JSON.parse(sentMessages[0] as string)).toEqual({ type: "agent:force_disconnect", agentId: agent1 });
+    expect(JSON.parse(sentMessages[0] as string)).toEqual({
+      type: "agent:force_disconnect",
+      agentId: agent1,
+      reason: "agent_suspended",
+    });
     // agent1 unbound, agent2 still bound
     expect(getAgentClientId(agent1)).toBeUndefined();
     expect(getAgentClientId(agent2)).toBe(clientId);

--- a/packages/server/src/__tests__/message-recipients.test.ts
+++ b/packages/server/src/__tests__/message-recipients.test.ts
@@ -1,4 +1,7 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { suspendAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -80,5 +83,33 @@ describe("sendMessage returns recipients", () => {
     expect(result.recipients).toContain(a3.inboxId);
     // Sender should not be in recipients
     expect(result.recipients).not.toContain(a1.inboxId);
+  });
+
+  it("rejects explicit routing to a suspended agent and writes no inbox entry", async () => {
+    const app = getApp();
+    const { agent: sender } = await createTestAgent(app, {
+      name: `recip-suspend-src-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const { agent: suspended } = await createTestAgent(app, {
+      name: `recip-suspend-target-${crypto.randomUUID().slice(0, 6)}`,
+      displayName: "Suspended Target",
+    });
+    const chat = await createChat(app.db, sender.uuid, {
+      type: "group",
+      participantIds: [suspended.uuid],
+    });
+    await suspendAgent(app.db, suspended.uuid);
+
+    await expect(
+      sendMessage(app.db, chat.id, sender.uuid, {
+        source: "api",
+        format: "text",
+        content: "wake up",
+        metadata: { mentions: [suspended.uuid] },
+      }),
+    ).rejects.toThrow('Cannot route to "Suspended Target" because the agent is suspended');
+
+    const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.inboxId, suspended.inboxId));
+    expect(rows).toHaveLength(0);
   });
 });

--- a/packages/server/src/__tests__/message-session-creation.test.ts
+++ b/packages/server/src/__tests__/message-session-creation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { suspendAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -118,5 +119,25 @@ describe("sendMessage — predictive session activation (M plan Step 1b)", () =>
     });
     expect(await readSessionState(app, mentioned.uuid, chat.id)).toBe("active");
     expect(await readSessionState(app, silent.uuid, chat.id)).toBeNull();
+  });
+
+  it("does not predictively activate a suspended recipient", async () => {
+    const app = getApp();
+    const { agent: sender } = await createTestAgent(app, { name: `sus-src-${crypto.randomUUID().slice(0, 6)}` });
+    const { agent: suspended } = await createTestAgent(app, { name: `sus-target-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, sender.uuid, {
+      type: "group",
+      participantIds: [suspended.uuid],
+    });
+    await suspendAgent(app.db, suspended.uuid);
+
+    await sendMessage(app.db, chat.id, sender.uuid, {
+      source: "api",
+      format: "text",
+      content: "history only",
+      purpose: "agent-final-text",
+    });
+
+    expect(await readSessionState(app, suspended.uuid, chat.id)).toBeNull();
   });
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -142,6 +142,12 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        */
       const inboxInFlight = new Map<string, number>();
 
+      function isAgentStillRoutedHere(agentId: string): boolean {
+        return (
+          boundAgents.has(agentId) && clientId !== null && connectionManager.getAgentClientId(agentId) === clientId
+        );
+      }
+
       /**
        * Returns `false` when the socket has already moved out of `OPEN` —
        * the only failure mode the caller can observe synchronously.
@@ -215,6 +221,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        */
       function makeInboxPushHandler(agentId: string, inboxId: string): InboxPushHandler {
         return async (messageId: string) => {
+          if (!isAgentStillRoutedHere(agentId)) return;
           const current = inboxInFlight.get(agentId) ?? 0;
           if (current >= inboxMaxInFlightPerAgent) {
             app.log.debug(
@@ -273,6 +280,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        */
       async function drainBacklogForAgent(agentId: string, inboxId: string): Promise<void> {
         if (socket.readyState !== socket.OPEN) return;
+        if (!isAgentStillRoutedHere(agentId)) return;
         const inFlight = inboxInFlight.get(agentId) ?? 0;
         const slotsFree = inboxMaxInFlightPerAgent - inFlight;
         if (slotsFree <= 0) return;
@@ -703,7 +711,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
             } else if (type === "session:state") {
               const agentId = parsed.data.agentId;
-              if (!agentId || !boundAgents.has(agentId)) {
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
                 socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
@@ -757,7 +765,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               });
             } else if (type === "session:runtime") {
               const agentId = parsed.data.agentId;
-              if (!agentId || !boundAgents.has(agentId)) {
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
                 socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
@@ -794,7 +802,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               });
             } else if (type === "session:reconcile") {
               const agentId = parsed.data.agentId;
-              if (!agentId || !boundAgents.has(agentId)) {
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
                 socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
@@ -830,7 +838,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               );
             } else if (type === "runtime:state") {
               const agentId = parsed.data.agentId;
-              if (!agentId || !boundAgents.has(agentId)) {
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
                 socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
@@ -857,7 +865,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               }
             } else if (type === "session:event") {
               const agentId = parsed.data.agentId;
-              if (!agentId || !boundAgents.has(agentId)) {
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
                 socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
                 return;
               }
@@ -951,7 +959,11 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             } else if (type === "heartbeat") {
               if (clientId) {
                 await clientService.heartbeatClient(app.db, clientId);
-                await Promise.all([...boundAgents.keys()].map((id) => presenceService.touchAgent(app.db, id)));
+                await Promise.all(
+                  [...boundAgents.keys()]
+                    .filter((id) => isAgentStillRoutedHere(id))
+                    .map((id) => presenceService.touchAgent(app.db, id)),
+                );
               }
               socket.send(JSON.stringify({ type: "heartbeat:ack" }));
             }

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -138,6 +138,8 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { uuid: string } }>("/:uuid/suspend", async (request) => {
     await requireAgentAccess(request, app.db, "manage");
     const agent = await agentService.suspendAgent(app.db, request.params.uuid);
+    forceDisconnect(request.params.uuid, "agent_suspended");
+    await presenceService.setOffline(app.db, request.params.uuid);
     const userAvatarUrl = await fetchUserAvatarForHumanAgent(app.db, agent);
     return serializeAgent(agent, userAvatarUrl);
   });
@@ -145,6 +147,7 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { uuid: string } }>("/:uuid/reactivate", async (request) => {
     await requireAgentAccess(request, app.db, "manage");
     const agent = await agentService.reactivateAgent(app.db, request.params.uuid);
+    notifyClientAgentPinned(agent);
     const userAvatarUrl = await fetchUserAvatarForHumanAgent(app.db, agent);
     return serializeAgent(agent, userAvatarUrl);
   });

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -395,8 +395,9 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
 
   /**
    * GET /me/pinned-agents — every agent pinned to a client owned by the
-   * caller's user. Used by the SDK reconcile layer to authoritatively map
-   * `agents.runtime_provider` before spawning handlers.
+   * caller's user, excluding deleted agents. Used by the SDK reconcile layer
+   * to authoritatively map `agents.runtime_provider` and retain suspended
+   * local aliases without treating them as unowned.
    */
   app.get("/me/pinned-agents", async (request) => {
     const { userId } = requireUser(request);

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -253,7 +253,9 @@ export function extractCapabilities(metadata: unknown): ClientCapabilities {
  * the client was offline — without it, an admin who pinned an agent during a
  * client outage would still need a manual `first-tree agent add`.
  *
- * Excludes soft-deleted agents (status = "deleted"). Human agents are
+ * Only returns active agents. Suspended/deleted agents are intentionally not
+ * startup candidates, so clients do not attempt binds the server will reject.
+ * Human agents are
  * naturally excluded by the `clientId` filter — they never carry a clientId.
  */
 export async function listActiveAgentsPinnedToClient(db: Database, clientId: string) {
@@ -266,35 +268,34 @@ export async function listActiveAgentsPinnedToClient(db: Database, clientId: str
       runtimeProvider: agents.runtimeProvider,
     })
     .from(agents)
-    .where(and(eq(agents.clientId, clientId), ne(agents.status, "deleted")));
+    .where(and(eq(agents.clientId, clientId), eq(agents.status, "active")));
 }
 
 /**
- * Member-scoped: every active agent pinned to a client owned by this user.
- * Used by client startup to reconcile its local YAML against the authoritative
- * `agents.runtime_provider`. Cross-org by design — a client is owned by a
- * user, not an org (decouple-client-from-identity §4.1).
+ * Member-scoped: every non-deleted agent pinned to a client owned by this
+ * user. This is an ownership/reconciliation surface, not a startup-candidate
+ * surface: suspended agents must stay visible so local config/workspaces are
+ * retained while disabled. Cross-org by design — a client is owned by a user,
+ * not an org (decouple-client-from-identity §4.1).
  */
 export async function listMyPinnedAgents(
   db: Database,
   scope: { userId: string },
-): Promise<Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider }>> {
+): Promise<Array<{ agentId: string; clientId: string; runtimeProvider: RuntimeProvider; status: string }>> {
   const rows = await db
     .select({
       agentId: agents.uuid,
       clientId: agents.clientId,
       runtimeProvider: agents.runtimeProvider,
+      status: agents.status,
     })
     .from(agents)
     .innerJoin(clients, eq(agents.clientId, clients.id))
     .where(and(eq(clients.userId, scope.userId), ne(agents.status, "deleted")));
-  return rows
-    .filter((r): r is { agentId: string; clientId: string; runtimeProvider: string } => r.clientId !== null)
-    .map((r) => ({
-      agentId: r.agentId,
-      clientId: r.clientId,
-      runtimeProvider: r.runtimeProvider as RuntimeProvider,
-    }));
+  return rows.filter(
+    (r): r is { agentId: string; clientId: string; runtimeProvider: RuntimeProvider; status: string } =>
+      r.clientId !== null,
+  );
 }
 
 /**

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -27,13 +27,13 @@ export function removeConnection(agentId: string, ws: WebSocket): boolean {
 }
 
 /** Force-disconnect an agent's active WS connection. Returns true if a connection was closed. */
-export function forceDisconnect(agentId: string): boolean {
+export function forceDisconnect(agentId: string, reason?: string): boolean {
   const clientId = agentToClient.get(agentId);
   if (clientId) {
     // M1 mode: unbind the single agent without closing the shared client WS
     const entry = clientConnections.get(clientId);
     if (entry && entry.ws.readyState <= 1) {
-      entry.ws.send(JSON.stringify({ type: "agent:force_disconnect", agentId }));
+      entry.ws.send(JSON.stringify({ type: "agent:force_disconnect", agentId, ...(reason ? { reason } : {}) }));
     }
     unbindAgentFromClient(agentId);
     return true;

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -157,6 +157,8 @@ async function sendMessageInner(
           agentId: chatMembership.agentId,
           inboxId: agents.inboxId,
           name: agents.name,
+          displayName: agents.displayName,
+          status: agents.status,
         })
         .from(chatMembership)
         .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
@@ -243,6 +245,21 @@ async function sendMessageInner(
     }
 
     const mergedMentions = [...new Set([...explicitMentions, ...resolvedFromNames])];
+    const participantsById = new Map(participants.map((p) => [p.agentId, p]));
+    const routedRecipientIds = new Set([
+      ...mergedMentions.filter((id) => id !== senderId),
+      ...(options.addressedToAgentIds ?? []).filter((id) => id !== senderId),
+    ]);
+    for (const id of routedRecipientIds) {
+      const participant = participantsById.get(id);
+      if (!participant || participant.status === "active") continue;
+      const label = participant.displayName || participant.name || id;
+      const recovery =
+        participant.status === "suspended"
+          ? "Reactivate it before sending."
+          : "Deleted agents cannot receive new messages.";
+      throw new BadRequestError(`Cannot route to "${label}" because the agent is ${participant.status}. ${recovery}`);
+    }
     const metadataToStore = mergedMentions.length > 0 ? { ...incomingMeta, mentions: mergedMentions } : incomingMeta;
 
     // Centralise the bypass contract for `purpose` values. Each flag
@@ -364,6 +381,7 @@ async function sendMessageInner(
     // back out at insert time below.
     const fanout = participants
       .filter((p) => p.agentId !== senderId)
+      .filter((p) => p.status === "active")
       .map((p) => ({
         agentId: p.agentId,
         inboxId: p.inboxId,

--- a/packages/web/src/components/__tests__/agent-lifecycle-confirm-dialog.test.tsx
+++ b/packages/web/src/components/__tests__/agent-lifecycle-confirm-dialog.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+  await flush();
+  return { container, root };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(el: Element | null): Promise<void> {
+  if (!el) throw new Error("Expected element to click");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function input(el: HTMLInputElement | null, value: string): Promise<void> {
+  if (!el) throw new Error("Expected input");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("agent lifecycle confirmation dialogs", () => {
+  it("explains suspend impact and waits for explicit confirmation", async () => {
+    const { AgentSuspendConfirmDialog } = await import("../agent-lifecycle-confirm-dialog.js");
+    const onConfirm = vi.fn();
+    const { root } = await renderDom(
+      <AgentSuspendConfirmDialog
+        open
+        label="Build Agent"
+        pending={false}
+        onOpenChange={() => {}}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(document.body.textContent).toContain('Suspend "Build Agent"?');
+    expect(document.body.textContent).toContain("runtime will be stopped and unbound");
+    expect(document.body.textContent).toContain("New messages and mentions will not wake it");
+    expect(document.body.textContent).toContain(
+      "Existing configuration, workspace, chat history, and saved sessions are kept",
+    );
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await click([...document.querySelectorAll("button")].find((b) => b.textContent === "Suspend agent") ?? null);
+    expect(onConfirm).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+  });
+
+  it("requires typed name before delete confirmation", async () => {
+    const { AgentDeleteConfirmDialog } = await import("../agent-lifecycle-confirm-dialog.js");
+    const onDelete = vi.fn();
+    const { root } = await renderDom(
+      <AgentDeleteConfirmDialog
+        open
+        expected="Build Agent"
+        deleting={false}
+        onOpenChange={() => {}}
+        onDelete={onDelete}
+      />,
+    );
+
+    const deleteButton = [...document.querySelectorAll("button")].find((b) => b.textContent === "Delete agent");
+    expect(deleteButton).toBeInstanceOf(HTMLButtonElement);
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
+
+    await input(document.querySelector("input"), "Build Agent");
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(false);
+    await click(deleteButton ?? null);
+    expect(onDelete).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/components/agent-lifecycle-confirm-dialog.tsx
+++ b/packages/web/src/components/agent-lifecycle-confirm-dialog.tsx
@@ -1,0 +1,102 @@
+import { type FormEvent, useState } from "react";
+import { Button } from "./ui/button.js";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
+import { Input } from "./ui/input.js";
+
+export function AgentSuspendConfirmDialog({
+  open,
+  onOpenChange,
+  label,
+  onConfirm,
+  pending,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: string;
+  onConfirm: () => void;
+  pending: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Suspend "{label}"?</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <DialogDescription style={{ color: "var(--fg-2)" }}>
+            This disables the agent until it is reactivated. Its runtime will be stopped and unbound from the connected
+            computer.
+          </DialogDescription>
+          <p className="text-body" style={{ color: "var(--fg-2)" }}>
+            New messages and mentions will not wake it while suspended. Existing configuration, workspace, chat history,
+            and saved sessions are kept.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button type="button" variant="destructive" onClick={onConfirm} disabled={pending}>
+            {pending ? "Suspending..." : "Suspend agent"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function AgentDeleteConfirmDialog({
+  open,
+  onOpenChange,
+  expected,
+  onDelete,
+  deleting,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  expected: string;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  const [typed, setTyped] = useState("");
+  function submit(e: FormEvent) {
+    e.preventDefault();
+    if (typed === expected) onDelete();
+  }
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) setTyped("");
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete "{expected}"?</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-4">
+          <DialogDescription>
+            This action cannot be undone. Type <span className="font-mono font-medium text-foreground">{expected}</span>{" "}
+            to confirm.
+          </DialogDescription>
+          <Input
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            autoFocus
+            placeholder={expected}
+            className="font-mono"
+          />
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={deleting}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="destructive" disabled={typed !== expected || deleting}>
+              {deleting ? "Deleting..." : "Delete agent"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/pages/agent-detail/danger-zone.tsx
+++ b/packages/web/src/pages/agent-detail/danger-zone.tsx
@@ -1,9 +1,11 @@
 import type { Agent } from "@first-tree/shared";
 import { Trash2 } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { useState } from "react";
+import {
+  AgentDeleteConfirmDialog,
+  AgentSuspendConfirmDialog,
+} from "../../components/agent-lifecycle-confirm-dialog.js";
 import { Button } from "../../components/ui/button.js";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
-import { Input } from "../../components/ui/input.js";
 import { Section } from "../../components/ui/section.js";
 import { ConfigRow } from "./flat-section.js";
 
@@ -44,7 +46,7 @@ export function DangerZone(props: DangerZoneProps) {
         {agent.status === "active" ? (
           <ConfigRow
             label="Suspend agent"
-            description="Pause all active sessions. You can reactivate later; tokens stay revoked until then."
+            description="Stop the connected runtime and prevent new messages from waking this agent until it is reactivated."
             action={
               <Button variant="outline" size="xs" onClick={() => setSuspendOpen(true)} disabled={props.suspendPending}>
                 {props.suspendPending ? "Suspending…" : "Suspend"}
@@ -54,7 +56,7 @@ export function DangerZone(props: DangerZoneProps) {
         ) : (
           <ConfigRow
             label="Reactivate agent"
-            description="Resume sessions. Tokens must be recreated — they are not restored."
+            description="Allow this agent to bind again and receive new routed messages."
             action={
               <Button variant="outline" size="xs" onClick={props.onReactivate} disabled={props.reactivatePending}>
                 {props.reactivatePending ? "Reactivating…" : "Reactivate"}
@@ -91,7 +93,7 @@ export function DangerZone(props: DangerZoneProps) {
         )}
       </Section>
 
-      <SuspendConfirmDialog
+      <AgentSuspendConfirmDialog
         open={suspendOpen}
         onOpenChange={setSuspendOpen}
         label={displayLabel}
@@ -101,7 +103,7 @@ export function DangerZone(props: DangerZoneProps) {
         }}
         pending={props.suspendPending}
       />
-      <DeleteConfirmDialog
+      <AgentDeleteConfirmDialog
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
         expected={displayLabel}
@@ -112,91 +114,5 @@ export function DangerZone(props: DangerZoneProps) {
         deleting={props.deletePending}
       />
     </section>
-  );
-}
-
-type DeleteConfirmProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  expected: string;
-  onDelete: () => void;
-  deleting: boolean;
-};
-
-type SuspendConfirmProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  label: string;
-  onConfirm: () => void;
-  pending: boolean;
-};
-
-function SuspendConfirmDialog({ open, onOpenChange, label, onConfirm, pending }: SuspendConfirmProps) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Suspend "{label}"?</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-3">
-          <p className="text-body" style={{ color: "var(--fg-2)" }}>
-            Runtime binds and HTTP calls will be refused while the agent is suspended. Active sessions end on their next
-            message. You can reactivate later from this same page.
-          </p>
-        </div>
-        <DialogFooter>
-          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
-            Cancel
-          </Button>
-          <Button type="button" variant="destructive" onClick={onConfirm} disabled={pending}>
-            {pending ? "Suspending…" : "Suspend"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function DeleteConfirmDialog({ open, onOpenChange, expected, onDelete, deleting }: DeleteConfirmProps) {
-  const [typed, setTyped] = useState("");
-  function submit(e: FormEvent) {
-    e.preventDefault();
-    if (typed === expected) onDelete();
-  }
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(o) => {
-        onOpenChange(o);
-        if (!o) setTyped("");
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Delete "{expected}"?</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={submit} className="space-y-4">
-          <p className="text-body text-muted-foreground">
-            This action cannot be undone. Type <span className="font-mono font-medium text-foreground">{expected}</span>{" "}
-            to confirm.
-          </p>
-          <Input
-            value={typed}
-            onChange={(e) => setTyped(e.target.value)}
-            autoFocus
-            placeholder={expected}
-            className="font-mono"
-          />
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={deleting}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="destructive" disabled={typed !== expected || deleting}>
-              {deleting ? "Deleting…" : "Delete"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -16,6 +16,10 @@ import {
 import { deleteMember, listMembers, updateMember } from "../../api/members.js";
 import { getOrgUsageByAgent, type UsageWindow } from "../../api/usage.js";
 import { useAuth } from "../../auth/auth-context.js";
+import {
+  AgentDeleteConfirmDialog,
+  AgentSuspendConfirmDialog,
+} from "../../components/agent-lifecycle-confirm-dialog.js";
 import { NewAgentDialog } from "../../components/new-agent-dialog.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
@@ -75,6 +79,11 @@ type DelegateTarget = {
   currentDelegate: string | null;
 };
 
+type AgentLifecycleTarget = {
+  uuid: string;
+  label: string;
+};
+
 type FilterKey = "all" | "yours" | "humans" | "team";
 
 const AGENT_PAGE_SIZE = 100;
@@ -105,6 +114,8 @@ export function TeamPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<MemberEditTarget | null>(null);
   const [delegateTarget, setDelegateTarget] = useState<DelegateTarget | null>(null);
+  const [suspendTarget, setSuspendTarget] = useState<AgentLifecycleTarget | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AgentLifecycleTarget | null>(null);
   const [filter, setFilter] = useState<FilterKey>("all");
   const [query, setQuery] = useState("");
   // 7d / 30d window for the Usage column. Default 30d — matches the
@@ -233,11 +244,17 @@ export function TeamPage() {
   });
   const suspendAgentMut = useMutation({
     mutationFn: suspendAgent,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agents"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+    },
   });
   const reactivateAgentMut = useMutation({
     mutationFn: reactivateAgent,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["agents"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+    },
   });
   const setDelegateMut = useMutation({
     mutationFn: async (vars: { humanAgentId: string; delegateMention: string | null }) =>
@@ -330,18 +347,18 @@ export function TeamPage() {
         actions.push({
           key: "suspend",
           label: "Suspend",
-          onSelect: () => suspendAgentMut.mutate(agent.uuid),
+          onSelect: () => setSuspendTarget({ uuid: agent.uuid, label: agent.displayName || agent.name || agent.uuid }),
         });
       }
       actions.push({
         key: "delete",
-        label: "Delete",
+        label: agent.status === "suspended" ? "Delete" : "Delete (suspend first)",
         destructive: true,
-        onSelect: () => {
-          if (window.confirm(`Delete agent ${agent.displayName}? This cannot be undone.`)) {
-            deleteAgentMut.mutate(agent.uuid);
-          }
-        },
+        disabled: agent.status !== "suspended",
+        onSelect: () =>
+          agent.status === "suspended"
+            ? setDeleteTarget({ uuid: agent.uuid, label: agent.displayName || agent.name || agent.uuid })
+            : undefined,
       });
     }
     return actions;
@@ -449,6 +466,32 @@ export function TeamPage() {
           if (!delegateTarget) return;
           await setDelegateMut.mutateAsync({ humanAgentId: delegateTarget.humanAgentId, delegateMention });
           setDelegateTarget(null);
+        }}
+      />
+
+      <AgentSuspendConfirmDialog
+        open={suspendTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setSuspendTarget(null);
+        }}
+        label={suspendTarget?.label ?? ""}
+        pending={suspendAgentMut.isPending}
+        onConfirm={() => {
+          if (!suspendTarget) return;
+          suspendAgentMut.mutate(suspendTarget.uuid, { onSuccess: () => setSuspendTarget(null) });
+        }}
+      />
+
+      <AgentDeleteConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        expected={deleteTarget?.label ?? ""}
+        deleting={deleteAgentMut.isPending}
+        onDelete={() => {
+          if (!deleteTarget) return;
+          deleteAgentMut.mutate(deleteTarget.uuid, { onSuccess: () => setDeleteTarget(null) });
         }}
       />
     </>


### PR DESCRIPTION
## Summary
- enforce agent-level suspend semantics by force disconnecting bound runtimes and ignoring runtime frames after unbind
- stop message fan-out and predictive activation from waking suspended agents while keeping /me/pinned-agents as non-deleted ownership data
- classify suspended local aliases as skipped at CLI startup and preserve them in prune/doctor
- add shared Web suspend/delete confirmation dialogs for Agent detail and Team entry points

## Tests
- pnpm check
- pnpm typecheck
- pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/message-recipients.test.ts src/__tests__/message-session-creation.test.ts src/__tests__/connection-manager.test.ts src/__tests__/client-service.test.ts src/__tests__/agent-pinned-notification.test.ts
- pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/agent-slot.test.ts src/__tests__/client-connection-websocket-coverage.test.ts
- pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/sdk-surface.test.ts
- pnpm --filter @first-tree/web exec vitest run --maxWorkers=2 --minWorkers=1 src/components/__tests__/agent-lifecycle-confirm-dialog.test.tsx
- pnpm --filter first-tree-dev exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/agent-prune.test.ts src/__tests__/client-runtime-context-tree.test.ts src/__tests__/doctor-core.test.ts