### PR TITLE
fix: bind Codex-created GitHub PRs

### DIFF
--- a/packages/server/src/__tests__/github-entity-extractor.test.ts
+++ b/packages/server/src/__tests__/github-entity-extractor.test.ts
@@ -29,6 +29,22 @@ describe("extractGithubEntity", () => {
     });
   });
 
+  it("extracts a pull_request entity from Codex command_execution events", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        name: "command",
+        args: { command: 'gh pr create --title "Codex PR" --body "body"' },
+        resultPreview: "https://github.com/agent-team-foundation/first-tree/pull/456\n",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "pull_request",
+      entityKey: "agent-team-foundation/first-tree#456",
+      entityUrl: "https://github.com/agent-team-foundation/first-tree/pull/456",
+      source: "bash-gh-pr",
+    });
+  });
+
   it("extracts an issue entity from `gh issue create` output", () => {
     const result = extractGithubEntity(
       basePayload({
@@ -68,7 +84,7 @@ describe("extractGithubEntity", () => {
     ).toBeNull();
   });
 
-  it("returns null when tool name is not Bash", () => {
+  it("returns null when tool name is not a supported shell tool", () => {
     expect(
       extractGithubEntity(
         basePayload({

--- a/packages/server/src/services/github-entity-extractor.ts
+++ b/packages/server/src/services/github-entity-extractor.ts
@@ -11,9 +11,10 @@ import type { ToolCallEventPayload } from "@first-tree/shared";
  * API lands, prefer adding callers there over expanding this file.
  *
  * Detect "the agent just created a PR or Issue" from a tool_call session
- * event. Phase 1 allowlist only — `Bash gh pr create` / `Bash gh issue
- * create`. These two tools emit a single-line URL on stdout (well under
- * the 400-char `resultPreview` cap), so detection is lossless. curl /
+ * event. Phase 1 allowlist only — shell-backed `gh pr create` / `gh issue
+ * create`. Claude Code reports shell calls as `Bash`; Codex reports command
+ * executions as `command`. These two tools emit a single-line URL on stdout
+ * (well under the 400-char `resultPreview` cap), so detection is lossless. curl /
  * GitHub MCP tools are out of scope until Phase 2 (their JSON responses
  * can overflow the preview).
  *
@@ -34,10 +35,11 @@ const PR_COMMAND_RE = /\bgh\s+pr\s+create\b/;
 const ISSUE_COMMAND_RE = /\bgh\s+issue\s+create\b/;
 const PR_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/;
 const ISSUE_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/;
+const SHELL_TOOL_NAMES = new Set(["Bash", "command"]);
 
 export function extractGithubEntity(payload: ToolCallEventPayload): ExtractedEntity | null {
   if (payload.status !== "ok") return null;
-  if (payload.name !== "Bash") return null;
+  if (!SHELL_TOOL_NAMES.has(payload.name)) return null;
 
   const args = payload.args;
   if (typeof args !== "object" || args === null) return null;


### PR DESCRIPTION
## Summary
- accept Codex command execution events as shell-backed gh create calls in the GitHub entity extractor
- add a regression test for Codex command_execution PR URL extraction
- update the stale non-shell tool test wording

## Review
- codex-reviewer passed review in chat 2dfc9b3b-6533-439c-ba85-33c6bad9cda6

## Tests
- pnpm --filter @first-tree/server test -- github-entity-extractor (ran full server suite: 152 files / 1244 tests)
- pnpm --filter @first-tree/server typecheck
- pnpm exec biome check packages/server/src/services/github-entity-extractor.ts packages/server/src/__tests__/github-entity-extractor.test.ts
- pnpm --filter @first-tree/server exec vitest run src/__tests__/github-entity-extractor.test.ts