### PR TITLE
feat(attachments): PostgreSQL object-storage primitive

### DIFF
--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -3,6 +3,8 @@ import {
   type Agent,
   type AgentRuntimeConfig,
   type AgentVisibility,
+  ATTACHMENT_FILENAME_HEADER,
+  ATTACHMENT_MIME_HEADER,
   type Attention,
   attentionRecordSchema,
   type CancelAttentionInput,
@@ -15,6 +17,8 @@ import {
   type RaiseAttentionInput,
   type RuntimeProvider,
   type SendMessage,
+  type UploadAttachmentResponse,
+  uploadAttachmentResponseSchema,
 } from "@first-tree/shared";
 import { z } from "zod";
 
@@ -379,6 +383,58 @@ export class FirstTreeHubSDK {
     },
   };
 
+  /**
+   * Upload bytes to the server's object-storage primitive. Returns the
+   * stored attachment's metadata; the `id` is what upstream consumers
+   * (image messages, future bookmarks / attention attachments) reference.
+   *
+   * Pass `orgId` when the caller user is a member of multiple organizations
+   * — the server rejects ambiguous uploads with 400 to keep `uploaded_by`
+   * deterministic. Single-org users may omit it.
+   */
+  public async uploadAttachment(opts: {
+    bytes: Uint8Array | Buffer;
+    mimeType: string;
+    filename: string;
+    orgId?: string;
+  }): Promise<UploadAttachmentResponse> {
+    const qs = opts.orgId ? `?orgId=${encodeURIComponent(opts.orgId)}` : "";
+    const json = await this.requestJson<unknown>(`/api/v1/attachments${qs}`, {
+      method: "POST",
+      body: opts.bytes,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: opts.mimeType,
+        [ATTACHMENT_FILENAME_HEADER]: opts.filename,
+      },
+    });
+    return uploadAttachmentResponseSchema.parse(json);
+  }
+
+  /**
+   * Fetch attachment bytes. Pass `chatId` when the caller is not the
+   * uploader (or the manager of the uploader's agent) — the server will
+   * verify chat membership in that case.
+   */
+  public async fetchAttachment(opts: {
+    id: string;
+    chatId?: string;
+  }): Promise<{ bytes: Buffer; mimeType: string; filename: string; size: number }> {
+    const qs = opts.chatId ? `?chatId=${encodeURIComponent(opts.chatId)}` : "";
+    const response = await this.doFetch(`/api/v1/attachments/${encodeURIComponent(opts.id)}${qs}`);
+    if (!response.ok) {
+      throw await this.toSdkError(response);
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const bytes = Buffer.from(arrayBuffer);
+    return {
+      bytes,
+      mimeType: response.headers.get("content-type") ?? "application/octet-stream",
+      filename: parseContentDispositionFilename(response.headers.get("content-disposition")) ?? "blob",
+      size: bytes.byteLength,
+    };
+  }
+
   private attentionQueryString(filter?: Partial<ListAttentionsQuery>): string {
     if (!filter) return "";
     const params = new URLSearchParams();
@@ -480,6 +536,14 @@ export class FirstTreeHubSDK {
     if (init?.body) {
       headers["Content-Type"] = "application/json";
     }
+    // Merge caller-supplied headers last so attachment uploads can set
+    // Content-Type: application/octet-stream and the X-Attachment-* metadata
+    // headers without the default JSON Content-Type clobbering them. No
+    // existing SDK call path passes init.headers, so this is backwards
+    // compatible.
+    if (init?.headers) {
+      Object.assign(headers, init.headers as Record<string, string>);
+    }
     const timeout = AbortSignal.timeout(opts?.timeoutMs ?? FETCH_TIMEOUT_MS);
     const signal = init?.signal ? AbortSignal.any([init.signal, timeout]) : timeout;
     return fetch(url, { ...init, headers, signal });
@@ -505,5 +569,25 @@ export class SdkError extends Error {
   ) {
     super(message);
     this.name = "SdkError";
+  }
+}
+
+/**
+ * Parse the `filename="..."` directive from a `Content-Disposition` header.
+ * Returns `null` when the header is absent or has no filename. Handles only
+ * the quoted-string form the attachment route emits — the unquoted /
+ * RFC 5987 `filename*=UTF-8''...` forms are outside our wire contract.
+ */
+function parseContentDispositionFilename(header: string | null): string | null {
+  if (!header) return null;
+  const match = /filename="([^"]*)"/.exec(header);
+  if (!match || !match[1]) return null;
+  // The server percent-encodes the limited set { CR, LF, ", \ } — reverse it
+  // so callers get a clean filename. decodeURIComponent throws on malformed
+  // sequences; fall back to the raw match in that case.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
   }
 }

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -388,18 +388,16 @@ export class FirstTreeHubSDK {
    * stored attachment's metadata; the `id` is what upstream consumers
    * (image messages, future bookmarks / attention attachments) reference.
    *
-   * Pass `orgId` when the caller user is a member of multiple organizations
-   * — the server rejects ambiguous uploads with 400 to keep `uploaded_by`
-   * deterministic. Single-org users may omit it.
+   * `orgId` is required: upload is org-scoped (`uploaded_by` resolves to the
+   * caller's member identity in that org), so the org rides in the path.
    */
   public async uploadAttachment(opts: {
     bytes: Uint8Array | Buffer;
     mimeType: string;
     filename: string;
-    orgId?: string;
+    orgId: string;
   }): Promise<UploadAttachmentResponse> {
-    const qs = opts.orgId ? `?orgId=${encodeURIComponent(opts.orgId)}` : "";
-    const json = await this.requestJson<unknown>(`/api/v1/attachments${qs}`, {
+    const json = await this.requestJson<unknown>(`/api/v1/orgs/${encodeURIComponent(opts.orgId)}/attachments`, {
       method: "POST",
       body: opts.bytes,
       headers: {
@@ -412,16 +410,13 @@ export class FirstTreeHubSDK {
   }
 
   /**
-   * Fetch attachment bytes. Pass `chatId` when the caller is not the
-   * uploader (or the manager of the uploader's agent) — the server will
-   * verify chat membership in that case.
+   * Fetch attachment bytes. Download is a capability model — a valid session
+   * plus the unguessable id is sufficient; there is no per-attachment ACL.
    */
   public async fetchAttachment(opts: {
     id: string;
-    chatId?: string;
   }): Promise<{ bytes: Buffer; mimeType: string; filename: string; size: number }> {
-    const qs = opts.chatId ? `?chatId=${encodeURIComponent(opts.chatId)}` : "";
-    const response = await this.doFetch(`/api/v1/attachments/${encodeURIComponent(opts.id)}${qs}`);
+    const response = await this.doFetch(`/api/v1/attachments/${encodeURIComponent(opts.id)}`);
     if (!response.ok) {
       throw await this.toSdkError(response);
     }

--- a/packages/server/drizzle/0054_attachments.sql
+++ b/packages/server/drizzle/0054_attachments.sql
@@ -1,0 +1,38 @@
+-- attachments — first-tree object-storage primitive.
+--
+-- See packages/server/src/db/schema/attachments.ts for the read/write
+-- story and design rationale.
+--
+-- Independent blob — NO chat_id / message_id columns. Upstream consumers
+-- (messages.content jsonb today, attentions / bookmark / avatar metadata
+-- tomorrow) hold the `attachments.id` reference. No foreign keys —
+-- consistent with messages.sender_id, which drops its FK so soft-deleting
+-- an agent leaves existing rows intact. v1 keeps every row forever;
+-- refcount / orphan-sweep is a follow-up only if storage growth demands.
+--
+-- Auth happens at the route layer: caller is the uploader (or manages
+-- the agent that uploaded), or the caller supplies an additional `chatId`
+-- they have access to. The id itself is a UUIDv4 — unguessable — as a
+-- baseline.
+--
+-- Hand-authored alongside the journal + LATEST bump because drizzle-kit
+-- generate fails on this repo's pre-existing snapshot drift (see the 0052
+-- header note for the same rationale).
+
+CREATE TABLE IF NOT EXISTS "attachments" (
+  "id" text PRIMARY KEY NOT NULL,
+  "mime_type" text NOT NULL,
+  "filename" text NOT NULL,
+  "size_bytes" integer NOT NULL,
+  "data" bytea NOT NULL,
+  "uploaded_by" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "attachments_uploaded_by_idx"
+  ON "attachments" ("uploaded_by");
+
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "attachments_created_at_idx"
+  ON "attachments" ("created_at");

--- a/packages/server/drizzle/0054_attachments.sql
+++ b/packages/server/drizzle/0054_attachments.sql
@@ -10,10 +10,12 @@
 -- an agent leaves existing rows intact. v1 keeps every row forever;
 -- refcount / orphan-sweep is a follow-up only if storage growth demands.
 --
--- Auth happens at the route layer: caller is the uploader (or manages
--- the agent that uploaded), or the caller supplies an additional `chatId`
--- they have access to. The id itself is a UUIDv4 — unguessable — as a
--- baseline.
+-- Auth happens at the route layer as a capability model: download requires
+-- a valid user JWT plus knowledge of the unguessable UUIDv4 id; there is no
+-- per-attachment ACL. Stronger, attachment-scoped authorization is the
+-- consumer's responsibility. Upload is org-scoped
+-- (POST /api/v1/orgs/:orgId/attachments) so uploaded_by resolves to a stable
+-- member identity.
 --
 -- Hand-authored alongside the journal + LATEST bump because drizzle-kit
 -- generate fails on this repo's pre-existing snapshot drift (see the 0052

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0053_session_events_token_usage_index
+0054_attachments

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1780617600000,
       "tag": "0053_session_events_token_usage_index",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1780704000000,
+      "tag": "0054_attachments",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -1,12 +1,9 @@
 import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
-import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
-import { attachments } from "../db/schema/attachments.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
-import { createChat } from "../services/chat.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -16,11 +13,12 @@ function postAttachment(
   app: FastifyInstance,
   caller: Admin,
   payload: Buffer,
-  overrides: Partial<{ mime: string; filename: string; contentType: string }> = {},
+  overrides: Partial<{ mime: string; filename: string; contentType: string; orgId: string }> = {},
 ) {
+  const orgId = overrides.orgId ?? caller.organizationId;
   return app.inject({
     method: "POST",
-    url: "/api/v1/attachments",
+    url: `/api/v1/orgs/${orgId}/attachments`,
     headers: {
       authorization: `Bearer ${caller.accessToken}`,
       "content-type": overrides.contentType ?? "application/octet-stream",
@@ -31,19 +29,18 @@ function postAttachment(
   });
 }
 
-function getAttachment(app: FastifyInstance, caller: Admin, id: string, chatId?: string) {
-  const qs = chatId ? `?chatId=${encodeURIComponent(chatId)}` : "";
+function getAttachment(app: FastifyInstance, caller: Admin, id: string) {
   return app.inject({
     method: "GET",
-    url: `/api/v1/attachments/${id}${qs}`,
+    url: `/api/v1/attachments/${id}`,
     headers: { authorization: `Bearer ${caller.accessToken}` },
   });
 }
 
-describe("attachments route — upload + auth + download", () => {
+describe("attachments route — upload + capability download", () => {
   const getApp = useTestApp();
 
-  it("uploads then downloads via uploader (uploader-relation auth)", async () => {
+  it("uploads then downloads via uploader", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `up-self-${crypto.randomUUID().slice(0, 6)}` });
 
@@ -64,6 +61,33 @@ describe("attachments route — upload + auth + download", () => {
     expect(download.headers.etag).toBe(`"${body.id}"`);
     expect(download.headers["content-disposition"]).toBe('inline; filename="kitten.png"');
     expect(download.rawPayload.equals(bytes)).toBe(true);
+  });
+
+  it("capability model: any authenticated user with the id can download", async () => {
+    const app = getApp();
+    const uploader = await createAdminContext(app, { username: `cap-up-${crypto.randomUUID().slice(0, 6)}` });
+    const other = await createAdminContext(app, { username: `cap-ot-${crypto.randomUUID().slice(0, 6)}` });
+
+    const bytes = Buffer.from("shared-by-capability");
+    const upload = await postAttachment(app, uploader, bytes);
+    const id = (upload.json() as { id: string }).id;
+
+    // A different authenticated user who knows the id downloads it — the
+    // unguessable id is the bearer capability; no chat/uploader relation
+    // required. Stronger ACL is the consumer's job, not the primitive's.
+    const download = await getAttachment(app, other, id);
+    expect(download.statusCode).toBe(200);
+    expect(download.rawPayload.equals(bytes)).toBe(true);
+  });
+
+  it("rejects download without a JWT (401)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `noauth-${crypto.randomUUID().slice(0, 6)}` });
+    const upload = await postAttachment(app, admin, Buffer.from("guarded"));
+    const id = (upload.json() as { id: string }).id;
+
+    const reply = await app.inject({ method: "GET", url: `/api/v1/attachments/${id}` });
+    expect(reply.statusCode).toBe(401);
   });
 
   it("ETag 304 on If-None-Match hit", async () => {
@@ -95,7 +119,7 @@ describe("attachments route — upload + auth + download", () => {
     const admin = await createTestAdmin(app, { username: `mh-${crypto.randomUUID().slice(0, 6)}` });
     const reply = await app.inject({
       method: "POST",
-      url: "/api/v1/attachments",
+      url: `/api/v1/orgs/${admin.organizationId}/attachments`,
       headers: {
         authorization: `Bearer ${admin.accessToken}`,
         "content-type": "application/octet-stream",
@@ -130,130 +154,30 @@ describe("attachments route — upload + auth + download", () => {
     expect(reply.statusCode).toBe(404);
   });
 
-  it("stranger without chatId → 403; with chatId where they are a member → 200", async () => {
+  it("rejects upload to an org the caller is not a member of (403)", async () => {
     const app = getApp();
-    const uploader = await createAdminContext(app, { username: `up-${crypto.randomUUID().slice(0, 6)}` });
-    const stranger = await createAdminContext(app, { username: `st-${crypto.randomUUID().slice(0, 6)}` });
+    const admin = await createTestAdmin(app, { username: `noorg-${crypto.randomUUID().slice(0, 6)}` });
 
-    const bytes = Buffer.from("share");
-    const upload = await postAttachment(app, uploader, bytes);
-    const id = (upload.json() as { id: string }).id;
+    const foreignOrgId = uuidv7();
+    await app.db
+      .insert(organizations)
+      .values({ id: foreignOrgId, name: foreignOrgId.slice(0, 30), displayName: "Foreign Org" });
 
-    // No chatId: stranger has no relation to uploader -> 403.
-    const denied = await getAttachment(app, stranger, id);
-    expect(denied.statusCode).toBe(403);
-
-    // Create a chat that includes both uploader's human agent and stranger's
-    // human agent; stranger now has chat-context access.
-    const chat = await createChat(app.db, uploader.humanAgentUuid, {
-      type: "group",
-      participantIds: [stranger.humanAgentUuid],
-    });
-
-    const allowed = await getAttachment(app, stranger, id, chat.id);
-    expect(allowed.statusCode).toBe(200);
-    expect(allowed.rawPayload.equals(bytes)).toBe(true);
+    const reply = await postAttachment(app, admin, Buffer.from("nope"), { orgId: foreignOrgId });
+    expect(reply.statusCode).toBe(403);
   });
 
-  it("stranger with chatId they are not in → 403", async () => {
-    const app = getApp();
-    const uploader = await createAdminContext(app, { username: `up2-${crypto.randomUUID().slice(0, 6)}` });
-    const stranger = await createAdminContext(app, { username: `st2-${crypto.randomUUID().slice(0, 6)}` });
-    const bystander = await createAdminContext(app, { username: `by-${crypto.randomUUID().slice(0, 6)}` });
-
-    const upload = await postAttachment(app, uploader, Buffer.from("private"));
-    const id = (upload.json() as { id: string }).id;
-
-    // Chat between uploader and bystander; stranger is not a member.
-    const chat = await createChat(app.db, uploader.humanAgentUuid, {
-      type: "group",
-      participantIds: [bystander.humanAgentUuid],
-    });
-
-    const denied = await getAttachment(app, stranger, id, chat.id);
-    expect(denied.statusCode).toBe(403);
-  });
-
-  it("multi-org caller without ?orgId → 400; with ?orgId → 201; with wrong orgId → 403", async () => {
+  it("uploaded_by is determined by the org in the path (multi-org caller)", async () => {
     const app = getApp();
     const admin = await createAdminContext(app, { username: `mo-${crypto.randomUUID().slice(0, 6)}` });
 
-    // Seed a second org and add the caller as an active member with a
-    // brand-new humanAgent. Now the user has 2 active memberships and the
-    // upload route should refuse to pick.
+    // Seed a second org with a brand-new humanAgent for the same user.
     const otherOrgId = uuidv7();
     await app.db
       .insert(organizations)
       .values({ id: otherOrgId, name: otherOrgId.slice(0, 30), displayName: "Other Org" });
-
     const otherAgent = await createAgent(app.db, {
       name: `mo-agent-${crypto.randomUUID().slice(0, 6)}`,
-      type: "human",
-      displayName: "Other Org Agent",
-      managerId: admin.memberId,
-      organizationId: otherOrgId,
-    });
-    const otherMemberId = uuidv7();
-    await app.db.insert(members).values({
-      id: otherMemberId,
-      userId: admin.userId,
-      organizationId: otherOrgId,
-      agentId: otherAgent.uuid,
-      role: "member",
-    });
-
-    // No orgId on a multi-org caller → 400.
-    const ambiguous = await postAttachment(app, admin, Buffer.from("multi"));
-    expect(ambiguous.statusCode).toBe(400);
-
-    // With orgId pointing at the second org → 201, uploaded_by is that
-    // org's humanAgentId (not the first one).
-    const targeted = await app.inject({
-      method: "POST",
-      url: `/api/v1/attachments?orgId=${encodeURIComponent(otherOrgId)}`,
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-        "content-type": "application/octet-stream",
-        [ATTACHMENT_MIME_HEADER]: "image/png",
-        [ATTACHMENT_FILENAME_HEADER]: "x.png",
-      },
-      payload: Buffer.from("ok"),
-    });
-    expect(targeted.statusCode).toBe(201);
-    expect((targeted.json() as { uploadedBy: string }).uploadedBy).toBe(otherAgent.uuid);
-
-    // With an orgId the caller is not a member of → 403.
-    const wrongOrgId = uuidv7();
-    await app.db
-      .insert(organizations)
-      .values({ id: wrongOrgId, name: wrongOrgId.slice(0, 30), displayName: "Wrong Org" });
-    const wrong = await app.inject({
-      method: "POST",
-      url: `/api/v1/attachments?orgId=${encodeURIComponent(wrongOrgId)}`,
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-        "content-type": "application/octet-stream",
-        [ATTACHMENT_MIME_HEADER]: "image/png",
-        [ATTACHMENT_FILENAME_HEADER]: "x.png",
-      },
-      payload: Buffer.from("ok"),
-    });
-    expect(wrong.statusCode).toBe(403);
-  });
-
-  it("multi-org uploader downloads own attachment without chatId (manager-join self-resolution)", async () => {
-    const app = getApp();
-    const admin = await createAdminContext(app, { username: `mos-${crypto.randomUUID().slice(0, 6)}` });
-
-    // Second org + a brand-new humanAgent for the same user. Now the caller
-    // has 2 active memberships, so the download-path `resolveCallerHumanAgentId`
-    // (LIMIT 1, no ORDER BY) may pick *either* humanAgentId.
-    const otherOrgId = uuidv7();
-    await app.db
-      .insert(organizations)
-      .values({ id: otherOrgId, name: otherOrgId.slice(0, 30), displayName: "Other Org" });
-    const otherAgent = await createAgent(app.db, {
-      name: `mos-agent-${crypto.randomUUID().slice(0, 6)}`,
       type: "human",
       displayName: "Other Org Agent",
       managerId: admin.memberId,
@@ -267,62 +191,14 @@ describe("attachments route — upload + auth + download", () => {
       role: "member",
     });
 
-    // Upload pinned to the second org → uploaded_by = otherAgent.uuid.
-    const bytes = Buffer.from("self-multi-org");
-    const upload = await app.inject({
-      method: "POST",
-      url: `/api/v1/attachments?orgId=${encodeURIComponent(otherOrgId)}`,
-      headers: {
-        authorization: `Bearer ${admin.accessToken}`,
-        "content-type": "application/octet-stream",
-        [ATTACHMENT_MIME_HEADER]: "image/png",
-        [ATTACHMENT_FILENAME_HEADER]: "self.png",
-      },
-      payload: bytes,
-    });
-    expect(upload.statusCode).toBe(201);
-    const id = (upload.json() as { id: string }).id;
+    // Upload via the first org → uploaded_by = first org's humanAgent.
+    const first = await postAttachment(app, admin, Buffer.from("first"));
+    expect(first.statusCode).toBe(201);
+    expect((first.json() as { uploadedBy: string }).uploadedBy).toBe(admin.humanAgentUuid);
 
-    // Download with no chatId. Even when the picked humanAgentId differs from
-    // uploaded_by, the manager-join falls back on userId (human agents
-    // self-manage), so the uploader still gets their own bytes.
-    const download = await getAttachment(app, admin, id);
-    expect(download.statusCode).toBe(200);
-    expect(download.rawPayload.equals(bytes)).toBe(true);
-  });
-
-  it("manager of uploading agent has uploader-relation access", async () => {
-    const app = getApp();
-    const admin = await createAdminContext(app, { username: `mgr-${crypto.randomUUID().slice(0, 6)}` });
-
-    // Create a non-human agent the admin manages; simulate it uploading by
-    // writing the row directly with `uploaded_by = agent.uuid`.
-    const subAgent = await createAgent(app.db, {
-      name: `sub-${crypto.randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "Sub Agent",
-      managerId: admin.memberId,
-      clientId: admin.clientId,
-    });
-
-    const bytes = Buffer.from("by-sub");
-    const id = crypto.randomUUID();
-    await app.db.insert(attachments).values({
-      id,
-      mimeType: "text/plain",
-      filename: "x.txt",
-      sizeBytes: bytes.byteLength,
-      data: bytes,
-      uploadedBy: subAgent.uuid,
-    });
-
-    // Sanity — the row landed.
-    const [row] = await app.db.select().from(attachments).where(eq(attachments.id, id)).limit(1);
-    expect(row?.uploadedBy).toBe(subAgent.uuid);
-
-    // Admin is the agent's manager, so download succeeds without chatId.
-    const reply = await getAttachment(app, admin, id);
-    expect(reply.statusCode).toBe(200);
-    expect(reply.rawPayload.equals(bytes)).toBe(true);
+    // Upload via the second org → uploaded_by = second org's humanAgent.
+    const second = await postAttachment(app, admin, Buffer.from("second"), { orgId: otherOrgId });
+    expect(second.statusCode).toBe(201);
+    expect((second.json() as { uploadedBy: string }).uploadedBy).toBe(otherAgent.uuid);
   });
 });

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -1,0 +1,328 @@
+import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { attachments } from "../db/schema/attachments.js";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
+
+type Admin = Awaited<ReturnType<typeof createTestAdmin>>;
+
+function postAttachment(
+  app: FastifyInstance,
+  caller: Admin,
+  payload: Buffer,
+  overrides: Partial<{ mime: string; filename: string; contentType: string }> = {},
+) {
+  return app.inject({
+    method: "POST",
+    url: "/api/v1/attachments",
+    headers: {
+      authorization: `Bearer ${caller.accessToken}`,
+      "content-type": overrides.contentType ?? "application/octet-stream",
+      [ATTACHMENT_MIME_HEADER]: overrides.mime ?? "image/png",
+      [ATTACHMENT_FILENAME_HEADER]: overrides.filename ?? "test.png",
+    },
+    payload,
+  });
+}
+
+function getAttachment(app: FastifyInstance, caller: Admin, id: string, chatId?: string) {
+  const qs = chatId ? `?chatId=${encodeURIComponent(chatId)}` : "";
+  return app.inject({
+    method: "GET",
+    url: `/api/v1/attachments/${id}${qs}`,
+    headers: { authorization: `Bearer ${caller.accessToken}` },
+  });
+}
+
+describe("attachments route — upload + auth + download", () => {
+  const getApp = useTestApp();
+
+  it("uploads then downloads via uploader (uploader-relation auth)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `up-self-${crypto.randomUUID().slice(0, 6)}` });
+
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const upload = await postAttachment(app, admin, bytes, { filename: "kitten.png" });
+    expect(upload.statusCode).toBe(201);
+    const body = upload.json() as { id: string; sizeBytes: number; uploadedBy: string };
+    expect(body.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(body.sizeBytes).toBe(bytes.byteLength);
+    expect(body.uploadedBy).toBe(admin.humanAgentUuid);
+
+    const download = await getAttachment(app, admin, body.id);
+    expect(download.statusCode).toBe(200);
+    expect(download.headers["content-type"]).toBe("image/png");
+    expect(download.headers["content-length"]).toBe(String(bytes.byteLength));
+    expect(download.headers["x-content-type-options"]).toBe("nosniff");
+    expect(download.headers["cache-control"]).toBe("private, max-age=31536000, immutable");
+    expect(download.headers.etag).toBe(`"${body.id}"`);
+    expect(download.headers["content-disposition"]).toBe('inline; filename="kitten.png"');
+    expect(download.rawPayload.equals(bytes)).toBe(true);
+  });
+
+  it("ETag 304 on If-None-Match hit", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `etag-${crypto.randomUUID().slice(0, 6)}` });
+    const upload = await postAttachment(app, admin, Buffer.from("hi"));
+    const id = (upload.json() as { id: string }).id;
+
+    const reply = await app.inject({
+      method: "GET",
+      url: `/api/v1/attachments/${id}`,
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "if-none-match": `"${id}"`,
+      },
+    });
+    expect(reply.statusCode).toBe(304);
+  });
+
+  it("rejects upload with wrong Content-Type", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `wct-${crypto.randomUUID().slice(0, 6)}` });
+    const reply = await postAttachment(app, admin, Buffer.from("hi"), { contentType: "application/json" });
+    expect(reply.statusCode).toBe(400);
+  });
+
+  it("rejects upload missing the mime header", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `mh-${crypto.randomUUID().slice(0, 6)}` });
+    const reply = await app.inject({
+      method: "POST",
+      url: "/api/v1/attachments",
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": "application/octet-stream",
+        [ATTACHMENT_FILENAME_HEADER]: "x.bin",
+      },
+      payload: Buffer.from("hi"),
+    });
+    expect(reply.statusCode).toBe(400);
+  });
+
+  it("rejects empty body", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `eb-${crypto.randomUUID().slice(0, 6)}` });
+    const reply = await postAttachment(app, admin, Buffer.alloc(0));
+    expect(reply.statusCode).toBe(400);
+  });
+
+  it("rejects oversize at bodyLimit (413) or service cap (400)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `os-${crypto.randomUUID().slice(0, 6)}` });
+    // 1 KB over the cap — well under the route bodyLimit, so the service-
+    // layer cap is what fires.
+    const oversize = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1024);
+    const reply = await postAttachment(app, admin, oversize);
+    expect([400, 413]).toContain(reply.statusCode);
+  });
+
+  it("returns 404 for unknown attachment id", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `nf-${crypto.randomUUID().slice(0, 6)}` });
+    const reply = await getAttachment(app, admin, "00000000-0000-4000-8000-000000000000");
+    expect(reply.statusCode).toBe(404);
+  });
+
+  it("stranger without chatId → 403; with chatId where they are a member → 200", async () => {
+    const app = getApp();
+    const uploader = await createAdminContext(app, { username: `up-${crypto.randomUUID().slice(0, 6)}` });
+    const stranger = await createAdminContext(app, { username: `st-${crypto.randomUUID().slice(0, 6)}` });
+
+    const bytes = Buffer.from("share");
+    const upload = await postAttachment(app, uploader, bytes);
+    const id = (upload.json() as { id: string }).id;
+
+    // No chatId: stranger has no relation to uploader -> 403.
+    const denied = await getAttachment(app, stranger, id);
+    expect(denied.statusCode).toBe(403);
+
+    // Create a chat that includes both uploader's human agent and stranger's
+    // human agent; stranger now has chat-context access.
+    const chat = await createChat(app.db, uploader.humanAgentUuid, {
+      type: "group",
+      participantIds: [stranger.humanAgentUuid],
+    });
+
+    const allowed = await getAttachment(app, stranger, id, chat.id);
+    expect(allowed.statusCode).toBe(200);
+    expect(allowed.rawPayload.equals(bytes)).toBe(true);
+  });
+
+  it("stranger with chatId they are not in → 403", async () => {
+    const app = getApp();
+    const uploader = await createAdminContext(app, { username: `up2-${crypto.randomUUID().slice(0, 6)}` });
+    const stranger = await createAdminContext(app, { username: `st2-${crypto.randomUUID().slice(0, 6)}` });
+    const bystander = await createAdminContext(app, { username: `by-${crypto.randomUUID().slice(0, 6)}` });
+
+    const upload = await postAttachment(app, uploader, Buffer.from("private"));
+    const id = (upload.json() as { id: string }).id;
+
+    // Chat between uploader and bystander; stranger is not a member.
+    const chat = await createChat(app.db, uploader.humanAgentUuid, {
+      type: "group",
+      participantIds: [bystander.humanAgentUuid],
+    });
+
+    const denied = await getAttachment(app, stranger, id, chat.id);
+    expect(denied.statusCode).toBe(403);
+  });
+
+  it("multi-org caller without ?orgId → 400; with ?orgId → 201; with wrong orgId → 403", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `mo-${crypto.randomUUID().slice(0, 6)}` });
+
+    // Seed a second org and add the caller as an active member with a
+    // brand-new humanAgent. Now the user has 2 active memberships and the
+    // upload route should refuse to pick.
+    const otherOrgId = uuidv7();
+    await app.db
+      .insert(organizations)
+      .values({ id: otherOrgId, name: otherOrgId.slice(0, 30), displayName: "Other Org" });
+
+    const otherAgent = await createAgent(app.db, {
+      name: `mo-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "Other Org Agent",
+      managerId: admin.memberId,
+      organizationId: otherOrgId,
+    });
+    const otherMemberId = uuidv7();
+    await app.db.insert(members).values({
+      id: otherMemberId,
+      userId: admin.userId,
+      organizationId: otherOrgId,
+      agentId: otherAgent.uuid,
+      role: "member",
+    });
+
+    // No orgId on a multi-org caller → 400.
+    const ambiguous = await postAttachment(app, admin, Buffer.from("multi"));
+    expect(ambiguous.statusCode).toBe(400);
+
+    // With orgId pointing at the second org → 201, uploaded_by is that
+    // org's humanAgentId (not the first one).
+    const targeted = await app.inject({
+      method: "POST",
+      url: `/api/v1/attachments?orgId=${encodeURIComponent(otherOrgId)}`,
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: "image/png",
+        [ATTACHMENT_FILENAME_HEADER]: "x.png",
+      },
+      payload: Buffer.from("ok"),
+    });
+    expect(targeted.statusCode).toBe(201);
+    expect((targeted.json() as { uploadedBy: string }).uploadedBy).toBe(otherAgent.uuid);
+
+    // With an orgId the caller is not a member of → 403.
+    const wrongOrgId = uuidv7();
+    await app.db
+      .insert(organizations)
+      .values({ id: wrongOrgId, name: wrongOrgId.slice(0, 30), displayName: "Wrong Org" });
+    const wrong = await app.inject({
+      method: "POST",
+      url: `/api/v1/attachments?orgId=${encodeURIComponent(wrongOrgId)}`,
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: "image/png",
+        [ATTACHMENT_FILENAME_HEADER]: "x.png",
+      },
+      payload: Buffer.from("ok"),
+    });
+    expect(wrong.statusCode).toBe(403);
+  });
+
+  it("multi-org uploader downloads own attachment without chatId (manager-join self-resolution)", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `mos-${crypto.randomUUID().slice(0, 6)}` });
+
+    // Second org + a brand-new humanAgent for the same user. Now the caller
+    // has 2 active memberships, so the download-path `resolveCallerHumanAgentId`
+    // (LIMIT 1, no ORDER BY) may pick *either* humanAgentId.
+    const otherOrgId = uuidv7();
+    await app.db
+      .insert(organizations)
+      .values({ id: otherOrgId, name: otherOrgId.slice(0, 30), displayName: "Other Org" });
+    const otherAgent = await createAgent(app.db, {
+      name: `mos-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "Other Org Agent",
+      managerId: admin.memberId,
+      organizationId: otherOrgId,
+    });
+    await app.db.insert(members).values({
+      id: uuidv7(),
+      userId: admin.userId,
+      organizationId: otherOrgId,
+      agentId: otherAgent.uuid,
+      role: "member",
+    });
+
+    // Upload pinned to the second org → uploaded_by = otherAgent.uuid.
+    const bytes = Buffer.from("self-multi-org");
+    const upload = await app.inject({
+      method: "POST",
+      url: `/api/v1/attachments?orgId=${encodeURIComponent(otherOrgId)}`,
+      headers: {
+        authorization: `Bearer ${admin.accessToken}`,
+        "content-type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: "image/png",
+        [ATTACHMENT_FILENAME_HEADER]: "self.png",
+      },
+      payload: bytes,
+    });
+    expect(upload.statusCode).toBe(201);
+    const id = (upload.json() as { id: string }).id;
+
+    // Download with no chatId. Even when the picked humanAgentId differs from
+    // uploaded_by, the manager-join falls back on userId (human agents
+    // self-manage), so the uploader still gets their own bytes.
+    const download = await getAttachment(app, admin, id);
+    expect(download.statusCode).toBe(200);
+    expect(download.rawPayload.equals(bytes)).toBe(true);
+  });
+
+  it("manager of uploading agent has uploader-relation access", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `mgr-${crypto.randomUUID().slice(0, 6)}` });
+
+    // Create a non-human agent the admin manages; simulate it uploading by
+    // writing the row directly with `uploaded_by = agent.uuid`.
+    const subAgent = await createAgent(app.db, {
+      name: `sub-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Sub Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    const bytes = Buffer.from("by-sub");
+    const id = crypto.randomUUID();
+    await app.db.insert(attachments).values({
+      id,
+      mimeType: "text/plain",
+      filename: "x.txt",
+      sizeBytes: bytes.byteLength,
+      data: bytes,
+      uploadedBy: subAgent.uuid,
+    });
+
+    // Sanity — the row landed.
+    const [row] = await app.db.select().from(attachments).where(eq(attachments.id, id)).limit(1);
+    expect(row?.uploadedBy).toBe(subAgent.uuid);
+
+    // Admin is the agent's manager, so download succeeds without chatId.
+    const reply = await getAttachment(app, admin, id);
+    expect(reply.statusCode).toBe(200);
+    expect(reply.rawPayload.equals(bytes)).toBe(true);
+  });
+});

--- a/packages/server/src/api/attachments.ts
+++ b/packages/server/src/api/attachments.ts
@@ -1,0 +1,293 @@
+import {
+  ATTACHMENT_FILENAME_HEADER,
+  ATTACHMENT_MIME_HEADER,
+  MAX_ATTACHMENT_BYTES,
+  type UploadAttachmentResponse,
+} from "@first-tree/shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { chats } from "../db/schema/chats.js";
+import { members } from "../db/schema/members.js";
+import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
+import { requireUser } from "../scope/require-user.js";
+import {
+  createAttachment,
+  isCallerUploaderOrManager,
+  loadAttachmentData,
+  loadAttachmentMeta,
+} from "../services/attachment.js";
+
+/**
+ * Object-storage primitive — first-tree's generic attachment surface.
+ *
+ *   POST /api/v1/attachments                        — upload bytes
+ *   GET  /api/v1/attachments/:id[?chatId=...]       — download bytes
+ *
+ * Both require a valid user JWT (mounted under `userScope` in app.ts).
+ * Upload protocol: `Content-Type: application/octet-stream` + the
+ * `x-attachment-mime` / `x-attachment-filename` headers carry the logical
+ * metadata. This keeps the body parser uniform and avoids pulling in a
+ * multipart dependency.
+ *
+ * Download auth (short-circuit, in order):
+ *   1. caller is the uploader or manages the agent that uploaded
+ *   2. caller passed `?chatId=...` AND is a member of that chat
+ *
+ * The unguessable UUIDv4 id acts as a baseline against blind enumeration —
+ * the `chatId` fallback exists so cross-member visibility (the only chat
+ * primitive we expose today) Just Works without the upstream business
+ * layer needing to mint per-recipient ACL rows.
+ */
+export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
+  // Single value for both client visibility (415 if wrong type) and route
+  // bodyLimit. 16 KB headroom beyond MAX_ATTACHMENT_BYTES leaves space for
+  // misc small request overhead without inflating the cap.
+  const UPLOAD_BODY_LIMIT = MAX_ATTACHMENT_BYTES + 16 * 1024;
+
+  app.post<{ Querystring: { orgId?: string } }>(
+    "/",
+    {
+      bodyLimit: UPLOAD_BODY_LIMIT,
+      config: { otelRecordBody: false },
+    },
+    async (request, reply) => {
+      const { userId } = requireUser(request);
+      const { orgId } = request.query;
+
+      const contentType = String(request.headers["content-type"] ?? "")
+        .split(";")[0]
+        ?.trim()
+        .toLowerCase();
+      if (contentType !== "application/octet-stream") {
+        // Reject explicitly so callers can't smuggle a parsed body shape
+        // and rely on the JSON parser eating the bytes.
+        throw new BadRequestError(`Content-Type must be application/octet-stream (got "${contentType || "missing"}")`);
+      }
+
+      const body = request.body;
+      if (!Buffer.isBuffer(body)) {
+        throw new BadRequestError("Request body must be raw bytes");
+      }
+
+      const mimeHeader = request.headers[ATTACHMENT_MIME_HEADER];
+      const mimeType = (Array.isArray(mimeHeader) ? mimeHeader[0] : mimeHeader)?.trim() ?? "";
+      if (!mimeType) {
+        throw new BadRequestError(`Missing ${ATTACHMENT_MIME_HEADER} header`);
+      }
+
+      const filenameHeader = request.headers[ATTACHMENT_FILENAME_HEADER];
+      const filename = (Array.isArray(filenameHeader) ? filenameHeader[0] : filenameHeader)?.trim() || "blob";
+
+      // Resolve the caller's `agents.uuid` to use as `uploaded_by`. The JWT
+      // carries only `userId`; for single-org users the unique active
+      // membership is picked automatically. Multi-org users MUST pass
+      // `?orgId=...` so the uploader identity is stable instead of
+      // depending on PG row-order — without that hint the same caller's
+      // uploads could land under different `humanAgentId`s across requests.
+      const humanAgentId = await resolveUploaderHumanAgentId(app.db, userId, orgId);
+
+      const row = await createAttachment(app.db, {
+        mimeType,
+        filename,
+        data: body,
+        uploadedBy: humanAgentId,
+      });
+
+      const response: UploadAttachmentResponse = {
+        id: row.id,
+        mimeType: row.mimeType,
+        filename: row.filename,
+        sizeBytes: row.sizeBytes,
+        uploadedBy: row.uploadedBy,
+        createdAt: row.createdAt.toISOString(),
+      };
+      return reply.status(201).send(response);
+    },
+  );
+
+  app.get<{ Params: { id: string }; Querystring: { chatId?: string } }>("/:id", async (request, reply) => {
+    const { userId } = requireUser(request);
+    const { id } = request.params;
+    const { chatId } = request.query;
+
+    // Load metadata only — auth + ETag run off this, so a 304 cache hit
+    // never drags the bytea payload out of PG.
+    const meta = await loadAttachmentMeta(app.db, id);
+    if (!meta) {
+      throw new NotFoundError(`Attachment "${id}" not found`);
+    }
+
+    const callerHumanAgentId = await resolveCallerHumanAgentId(app.db, userId);
+    const uploaderRelation =
+      callerHumanAgentId !== null &&
+      (await isCallerUploaderOrManager(app.db, meta.uploadedBy, {
+        userId,
+        humanAgentId: callerHumanAgentId,
+      }));
+
+    if (!uploaderRelation) {
+      if (!chatId) {
+        throw new ForbiddenError("Attachment access requires uploader relation or ?chatId context");
+      }
+      await assertChatAccessByUserId(app.db, userId, chatId);
+    }
+
+    // If-None-Match: cheap ETag check. id is content-stable (UUIDv4 +
+    // bytes are immutable once written), so we never need to vary on
+    // anything else. Checked after auth so a 304 can't confirm existence
+    // of an attachment the caller may not access.
+    const ifNoneMatch = request.headers["if-none-match"];
+    const etag = `"${meta.id}"`;
+    if (ifNoneMatch === etag) {
+      return reply.status(304).send();
+    }
+
+    const data = await loadAttachmentData(app.db, id);
+    if (!data) {
+      // Deleted between the metadata read and now — vanishingly rare, but
+      // surface it honestly rather than streaming an empty body.
+      throw new NotFoundError(`Attachment "${id}" not found`);
+    }
+
+    reply
+      .header("Content-Type", meta.mimeType)
+      .header("Content-Length", meta.sizeBytes)
+      .header("Cache-Control", "private, max-age=31536000, immutable")
+      .header("ETag", etag)
+      .header("X-Content-Type-Options", "nosniff")
+      .header("Content-Disposition", `inline; filename="${encodeRfc6266Filename(meta.filename)}"`);
+    return reply.send(data);
+  });
+}
+
+/**
+ * For uploads — `uploaded_by` must be stable. Pick a deterministic
+ * `humanAgentId` for the caller:
+ *
+ *  - With `?orgId=`: look up `members(userId, orgId, status='active')`. If
+ *    the row is absent (caller not in that org, or member left), 403.
+ *  - Without `?orgId=`: count active memberships. Exactly one → use it.
+ *    Two or more → 400 telling the caller to supply `?orgId=...` so the
+ *    uploaded_by isn't picked by PG row-order. Zero → 403.
+ *
+ * Throws `ForbiddenError` / `BadRequestError` with messages that surface
+ * the actual fix the caller can apply.
+ */
+async function resolveUploaderHumanAgentId(db: Database, userId: string, orgId: string | undefined): Promise<string> {
+  if (orgId !== undefined) {
+    const [row] = await db
+      .select({ agentId: members.agentId })
+      .from(members)
+      .where(and(eq(members.userId, userId), eq(members.organizationId, orgId), eq(members.status, "active")))
+      .limit(1);
+    if (!row) {
+      throw new ForbiddenError(`Caller is not an active member of organization "${orgId}"`);
+    }
+    return row.agentId;
+  }
+
+  // Pull up to two rows — the second only exists to detect ambiguity, no
+  // need for COUNT(*) when LIMIT 2 + .length carries the same signal.
+  const rows = await db
+    .select({ agentId: members.agentId, organizationId: members.organizationId })
+    .from(members)
+    .where(and(eq(members.userId, userId), eq(members.status, "active")))
+    .limit(2);
+  if (rows.length === 0) {
+    throw new ForbiddenError("Caller is not a member of any organization");
+  }
+  if (rows.length > 1) {
+    throw new BadRequestError(
+      "Caller belongs to multiple organizations; specify ?orgId=... to pin the uploader identity",
+    );
+  }
+  // length === 1 — safe to non-null assert because we just checked
+  const only = rows[0];
+  if (!only) throw new ForbiddenError("Caller is not a member of any organization");
+  return only.agentId;
+}
+
+/**
+ * For downloads — read-side resolution. Tolerant of multi-org callers
+ * because the second auth layer (`isCallerUploaderOrManager` / chat
+ * fallback) works off `userId`, not the picked humanAgentId. Returns
+ * `null` when the user has no active membership at all.
+ */
+async function resolveCallerHumanAgentId(db: Database, userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ agentId: members.agentId })
+    .from(members)
+    .where(and(eq(members.userId, userId), eq(members.status, "active")))
+    .limit(1);
+  return row?.agentId ?? null;
+}
+
+/**
+ * Request-independent version of `requireChatAccess`. The standard helper
+ * takes `chatId` from `request.params`, but here it comes from a query
+ * parameter, so we replay the same join logic without round-tripping
+ * through a forged request. Throws `ForbiddenError` instead of the
+ * helper's `NotFoundError` because the attachment route should not lie
+ * about chat existence — the caller already knows the chat id since they
+ * supplied it.
+ */
+async function assertChatAccessByUserId(db: Database, userId: string, chatId: string): Promise<void> {
+  const [chat] = await db
+    .select({ id: chats.id, organizationId: chats.organizationId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+  if (!chat) {
+    throw new ForbiddenError(`Attachment access denied: chat "${chatId}" not accessible`);
+  }
+
+  const [member] = await db
+    .select({ memberId: members.id, agentId: members.agentId })
+    .from(members)
+    .where(
+      and(eq(members.userId, userId), eq(members.organizationId, chat.organizationId), eq(members.status, "active")),
+    )
+    .limit(1);
+  if (!member) {
+    throw new ForbiddenError(`Attachment access denied: caller not in chat "${chatId}"`);
+  }
+
+  // Direct membership — caller's own human agent is a participant.
+  const [direct] = await db
+    .select({ chatId: chatMembership.chatId })
+    .from(chatMembership)
+    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, member.agentId)))
+    .limit(1);
+  if (direct) return;
+
+  // Supervised access — any agent the caller manages speaks in this chat.
+  const participantRows = await db
+    .select({ agentId: chatMembership.agentId })
+    .from(chatMembership)
+    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
+  if (participantRows.length === 0) {
+    throw new ForbiddenError(`Attachment access denied: chat "${chatId}" not accessible`);
+  }
+  const participantIds = participantRows.map((p) => p.agentId);
+  const [managed] = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(and(inArray(agents.uuid, participantIds), eq(agents.managerId, member.memberId)))
+    .limit(1);
+  if (!managed) {
+    throw new ForbiddenError(`Attachment access denied: caller not in chat "${chatId}"`);
+  }
+}
+
+/**
+ * RFC 6266 percent-encoding for the `filename` directive — `inline; filename="..."`.
+ * Only percent-encodes characters that would break the quoted-string parser
+ * (CR/LF, quote, backslash). Browsers tolerate non-ASCII inside the quoted
+ * form, but raw quotes / control chars would smuggle headers.
+ */
+function encodeRfc6266Filename(name: string): string {
+  return name.replace(/[\r\n"\\]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
+}

--- a/packages/server/src/api/attachments.ts
+++ b/packages/server/src/api/attachments.ts
@@ -1,144 +1,38 @@
-import {
-  ATTACHMENT_FILENAME_HEADER,
-  ATTACHMENT_MIME_HEADER,
-  MAX_ATTACHMENT_BYTES,
-  type UploadAttachmentResponse,
-} from "@first-tree/shared";
-import { and, eq, inArray } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import type { Database } from "../db/connection.js";
-import { agents } from "../db/schema/agents.js";
-import { chatMembership } from "../db/schema/chat-membership.js";
-import { chats } from "../db/schema/chats.js";
-import { members } from "../db/schema/members.js";
-import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
-import { requireUser } from "../scope/require-user.js";
-import {
-  createAttachment,
-  isCallerUploaderOrManager,
-  loadAttachmentData,
-  loadAttachmentMeta,
-} from "../services/attachment.js";
+import { NotFoundError } from "../errors.js";
+import { loadAttachmentData, loadAttachmentMeta } from "../services/attachment.js";
 
 /**
- * Object-storage primitive — first-tree's generic attachment surface.
+ * Object-storage primitive — download surface.
  *
- *   POST /api/v1/attachments                        — upload bytes
- *   GET  /api/v1/attachments/:id[?chatId=...]       — download bytes
+ *   GET /api/v1/attachments/:id   — download bytes
  *
- * Both require a valid user JWT (mounted under `userScope` in app.ts).
- * Upload protocol: `Content-Type: application/octet-stream` + the
- * `x-attachment-mime` / `x-attachment-filename` headers carry the logical
- * metadata. This keeps the body parser uniform and avoids pulling in a
- * multipart dependency.
+ * Mounted under `userScope` (app.ts), so a valid user JWT is required.
  *
- * Download auth (short-circuit, in order):
- *   1. caller is the uploader or manages the agent that uploaded
- *   2. caller passed `?chatId=...` AND is a member of that chat
+ * Download auth is a **capability model**: the only gates are (1) a valid
+ * user JWT — enforced by the scope's `userAuth` hook — and (2) knowledge of
+ * the unguessable UUIDv4 id. There is no per-attachment ACL: the id itself
+ * is the bearer capability. A consumer that wants stronger, attachment-scoped
+ * authorization layers it on top (e.g. an image message hands the id only to
+ * its legitimate recipients); the primitive deliberately stays thin.
  *
- * The unguessable UUIDv4 id acts as a baseline against blind enumeration —
- * the `chatId` fallback exists so cross-member visibility (the only chat
- * primitive we expose today) Just Works without the upstream business
- * layer needing to mint per-recipient ACL rows.
+ * Upload lives separately at `POST /api/v1/orgs/:orgId/attachments`
+ * (Class B) because the uploader identity is org-scoped — see
+ * api/orgs/attachments.ts.
  */
 export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
-  // Single value for both client visibility (415 if wrong type) and route
-  // bodyLimit. 16 KB headroom beyond MAX_ATTACHMENT_BYTES leaves space for
-  // misc small request overhead without inflating the cap.
-  const UPLOAD_BODY_LIMIT = MAX_ATTACHMENT_BYTES + 16 * 1024;
-
-  app.post<{ Querystring: { orgId?: string } }>(
-    "/",
-    {
-      bodyLimit: UPLOAD_BODY_LIMIT,
-      config: { otelRecordBody: false },
-    },
-    async (request, reply) => {
-      const { userId } = requireUser(request);
-      const { orgId } = request.query;
-
-      const contentType = String(request.headers["content-type"] ?? "")
-        .split(";")[0]
-        ?.trim()
-        .toLowerCase();
-      if (contentType !== "application/octet-stream") {
-        // Reject explicitly so callers can't smuggle a parsed body shape
-        // and rely on the JSON parser eating the bytes.
-        throw new BadRequestError(`Content-Type must be application/octet-stream (got "${contentType || "missing"}")`);
-      }
-
-      const body = request.body;
-      if (!Buffer.isBuffer(body)) {
-        throw new BadRequestError("Request body must be raw bytes");
-      }
-
-      const mimeHeader = request.headers[ATTACHMENT_MIME_HEADER];
-      const mimeType = (Array.isArray(mimeHeader) ? mimeHeader[0] : mimeHeader)?.trim() ?? "";
-      if (!mimeType) {
-        throw new BadRequestError(`Missing ${ATTACHMENT_MIME_HEADER} header`);
-      }
-
-      const filenameHeader = request.headers[ATTACHMENT_FILENAME_HEADER];
-      const filename = (Array.isArray(filenameHeader) ? filenameHeader[0] : filenameHeader)?.trim() || "blob";
-
-      // Resolve the caller's `agents.uuid` to use as `uploaded_by`. The JWT
-      // carries only `userId`; for single-org users the unique active
-      // membership is picked automatically. Multi-org users MUST pass
-      // `?orgId=...` so the uploader identity is stable instead of
-      // depending on PG row-order — without that hint the same caller's
-      // uploads could land under different `humanAgentId`s across requests.
-      const humanAgentId = await resolveUploaderHumanAgentId(app.db, userId, orgId);
-
-      const row = await createAttachment(app.db, {
-        mimeType,
-        filename,
-        data: body,
-        uploadedBy: humanAgentId,
-      });
-
-      const response: UploadAttachmentResponse = {
-        id: row.id,
-        mimeType: row.mimeType,
-        filename: row.filename,
-        sizeBytes: row.sizeBytes,
-        uploadedBy: row.uploadedBy,
-        createdAt: row.createdAt.toISOString(),
-      };
-      return reply.status(201).send(response);
-    },
-  );
-
-  app.get<{ Params: { id: string }; Querystring: { chatId?: string } }>("/:id", async (request, reply) => {
-    const { userId } = requireUser(request);
+  app.get<{ Params: { id: string } }>("/:id", async (request, reply) => {
     const { id } = request.params;
-    const { chatId } = request.query;
 
-    // Load metadata only — auth + ETag run off this, so a 304 cache hit
+    // Load metadata only — the ETag check runs off this, so a 304 cache hit
     // never drags the bytea payload out of PG.
     const meta = await loadAttachmentMeta(app.db, id);
     if (!meta) {
       throw new NotFoundError(`Attachment "${id}" not found`);
     }
 
-    const callerHumanAgentId = await resolveCallerHumanAgentId(app.db, userId);
-    const uploaderRelation =
-      callerHumanAgentId !== null &&
-      (await isCallerUploaderOrManager(app.db, meta.uploadedBy, {
-        userId,
-        humanAgentId: callerHumanAgentId,
-      }));
-
-    if (!uploaderRelation) {
-      if (!chatId) {
-        throw new ForbiddenError("Attachment access requires uploader relation or ?chatId context");
-      }
-      await assertChatAccessByUserId(app.db, userId, chatId);
-    }
-
-    // If-None-Match: cheap ETag check. id is content-stable (UUIDv4 +
-    // bytes are immutable once written), so we never need to vary on
-    // anything else. Checked after auth so a 304 can't confirm existence
-    // of an attachment the caller may not access.
+    // If-None-Match: cheap ETag check. id is content-stable (UUIDv4 + bytes
+    // are immutable once written), so we never need to vary on anything else.
     const ifNoneMatch = request.headers["if-none-match"];
     const etag = `"${meta.id}"`;
     if (ifNoneMatch === etag) {
@@ -161,125 +55,6 @@ export async function attachmentRoutes(app: FastifyInstance): Promise<void> {
       .header("Content-Disposition", `inline; filename="${encodeRfc6266Filename(meta.filename)}"`);
     return reply.send(data);
   });
-}
-
-/**
- * For uploads — `uploaded_by` must be stable. Pick a deterministic
- * `humanAgentId` for the caller:
- *
- *  - With `?orgId=`: look up `members(userId, orgId, status='active')`. If
- *    the row is absent (caller not in that org, or member left), 403.
- *  - Without `?orgId=`: count active memberships. Exactly one → use it.
- *    Two or more → 400 telling the caller to supply `?orgId=...` so the
- *    uploaded_by isn't picked by PG row-order. Zero → 403.
- *
- * Throws `ForbiddenError` / `BadRequestError` with messages that surface
- * the actual fix the caller can apply.
- */
-async function resolveUploaderHumanAgentId(db: Database, userId: string, orgId: string | undefined): Promise<string> {
-  if (orgId !== undefined) {
-    const [row] = await db
-      .select({ agentId: members.agentId })
-      .from(members)
-      .where(and(eq(members.userId, userId), eq(members.organizationId, orgId), eq(members.status, "active")))
-      .limit(1);
-    if (!row) {
-      throw new ForbiddenError(`Caller is not an active member of organization "${orgId}"`);
-    }
-    return row.agentId;
-  }
-
-  // Pull up to two rows — the second only exists to detect ambiguity, no
-  // need for COUNT(*) when LIMIT 2 + .length carries the same signal.
-  const rows = await db
-    .select({ agentId: members.agentId, organizationId: members.organizationId })
-    .from(members)
-    .where(and(eq(members.userId, userId), eq(members.status, "active")))
-    .limit(2);
-  if (rows.length === 0) {
-    throw new ForbiddenError("Caller is not a member of any organization");
-  }
-  if (rows.length > 1) {
-    throw new BadRequestError(
-      "Caller belongs to multiple organizations; specify ?orgId=... to pin the uploader identity",
-    );
-  }
-  // length === 1 — safe to non-null assert because we just checked
-  const only = rows[0];
-  if (!only) throw new ForbiddenError("Caller is not a member of any organization");
-  return only.agentId;
-}
-
-/**
- * For downloads — read-side resolution. Tolerant of multi-org callers
- * because the second auth layer (`isCallerUploaderOrManager` / chat
- * fallback) works off `userId`, not the picked humanAgentId. Returns
- * `null` when the user has no active membership at all.
- */
-async function resolveCallerHumanAgentId(db: Database, userId: string): Promise<string | null> {
-  const [row] = await db
-    .select({ agentId: members.agentId })
-    .from(members)
-    .where(and(eq(members.userId, userId), eq(members.status, "active")))
-    .limit(1);
-  return row?.agentId ?? null;
-}
-
-/**
- * Request-independent version of `requireChatAccess`. The standard helper
- * takes `chatId` from `request.params`, but here it comes from a query
- * parameter, so we replay the same join logic without round-tripping
- * through a forged request. Throws `ForbiddenError` instead of the
- * helper's `NotFoundError` because the attachment route should not lie
- * about chat existence — the caller already knows the chat id since they
- * supplied it.
- */
-async function assertChatAccessByUserId(db: Database, userId: string, chatId: string): Promise<void> {
-  const [chat] = await db
-    .select({ id: chats.id, organizationId: chats.organizationId })
-    .from(chats)
-    .where(eq(chats.id, chatId))
-    .limit(1);
-  if (!chat) {
-    throw new ForbiddenError(`Attachment access denied: chat "${chatId}" not accessible`);
-  }
-
-  const [member] = await db
-    .select({ memberId: members.id, agentId: members.agentId })
-    .from(members)
-    .where(
-      and(eq(members.userId, userId), eq(members.organizationId, chat.organizationId), eq(members.status, "active")),
-    )
-    .limit(1);
-  if (!member) {
-    throw new ForbiddenError(`Attachment access denied: caller not in chat "${chatId}"`);
-  }
-
-  // Direct membership — caller's own human agent is a participant.
-  const [direct] = await db
-    .select({ chatId: chatMembership.chatId })
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, member.agentId)))
-    .limit(1);
-  if (direct) return;
-
-  // Supervised access — any agent the caller manages speaks in this chat.
-  const participantRows = await db
-    .select({ agentId: chatMembership.agentId })
-    .from(chatMembership)
-    .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
-  if (participantRows.length === 0) {
-    throw new ForbiddenError(`Attachment access denied: chat "${chatId}" not accessible`);
-  }
-  const participantIds = participantRows.map((p) => p.agentId);
-  const [managed] = await db
-    .select({ uuid: agents.uuid })
-    .from(agents)
-    .where(and(inArray(agents.uuid, participantIds), eq(agents.managerId, member.memberId)))
-    .limit(1);
-  if (!managed) {
-    throw new ForbiddenError(`Attachment access denied: caller not in chat "${chatId}"`);
-  }
 }
 
 /**

--- a/packages/server/src/api/orgs/attachments.ts
+++ b/packages/server/src/api/orgs/attachments.ts
@@ -1,0 +1,89 @@
+import {
+  ATTACHMENT_FILENAME_HEADER,
+  ATTACHMENT_MIME_HEADER,
+  MAX_ATTACHMENT_BYTES,
+  type UploadAttachmentResponse,
+} from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { BadRequestError } from "../../errors.js";
+import { requireOrgMembership } from "../../scope/require-org.js";
+import { createAttachment } from "../../services/attachment.js";
+
+/**
+ * Object-storage primitive — upload surface (Class B, org-scoped).
+ *
+ *   POST /api/v1/orgs/:orgId/attachments   — upload bytes
+ *
+ * Org-scoped because `uploaded_by` must resolve to a stable team identity:
+ * `requireOrgMembership` reads the caller's active member in `:orgId` and
+ * yields their `humanAgentId` deterministically. Putting the org in the path
+ * (rather than a `?orgId=` query) follows the repo's HTTP path convention and
+ * removes the multi-org ambiguity a query param would leave open.
+ *
+ * Upload protocol: `Content-Type: application/octet-stream` body + the
+ * `x-attachment-mime` / `x-attachment-filename` headers carry the logical
+ * metadata. This keeps the body parser uniform and avoids a multipart
+ * dependency. The byte cap is enforced both as a route `bodyLimit` and again
+ * in the service layer.
+ *
+ * Download lives separately at `GET /api/v1/attachments/:id` — see
+ * api/attachments.ts.
+ */
+export async function orgAttachmentRoutes(app: FastifyInstance): Promise<void> {
+  // Single value for both client visibility (415 if wrong type) and route
+  // bodyLimit. 16 KB headroom beyond MAX_ATTACHMENT_BYTES leaves space for
+  // misc small request overhead without inflating the cap.
+  const UPLOAD_BODY_LIMIT = MAX_ATTACHMENT_BYTES + 16 * 1024;
+
+  app.post<{ Params: { orgId: string } }>(
+    "/",
+    {
+      bodyLimit: UPLOAD_BODY_LIMIT,
+      config: { otelRecordBody: false },
+    },
+    async (request, reply) => {
+      const scope = await requireOrgMembership(request, app.db);
+
+      const contentType = String(request.headers["content-type"] ?? "")
+        .split(";")[0]
+        ?.trim()
+        .toLowerCase();
+      if (contentType !== "application/octet-stream") {
+        // Reject explicitly so callers can't smuggle a parsed body shape
+        // and rely on the JSON parser eating the bytes.
+        throw new BadRequestError(`Content-Type must be application/octet-stream (got "${contentType || "missing"}")`);
+      }
+
+      const body = request.body;
+      if (!Buffer.isBuffer(body)) {
+        throw new BadRequestError("Request body must be raw bytes");
+      }
+
+      const mimeHeader = request.headers[ATTACHMENT_MIME_HEADER];
+      const mimeType = (Array.isArray(mimeHeader) ? mimeHeader[0] : mimeHeader)?.trim() ?? "";
+      if (!mimeType) {
+        throw new BadRequestError(`Missing ${ATTACHMENT_MIME_HEADER} header`);
+      }
+
+      const filenameHeader = request.headers[ATTACHMENT_FILENAME_HEADER];
+      const filename = (Array.isArray(filenameHeader) ? filenameHeader[0] : filenameHeader)?.trim() || "blob";
+
+      const row = await createAttachment(app.db, {
+        mimeType,
+        filename,
+        data: body,
+        uploadedBy: scope.humanAgentId,
+      });
+
+      const response: UploadAttachmentResponse = {
+        id: row.id,
+        mimeType: row.mimeType,
+        filename: row.filename,
+        sizeBytes: row.sizeBytes,
+        uploadedBy: row.uploadedBy,
+        createdAt: row.createdAt.toISOString(),
+      };
+      return reply.status(201).send(response);
+    },
+  );
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -25,6 +25,7 @@ import { agentActivityRoutes } from "./api/agent-activity.js";
 import { agentUsageRoutes } from "./api/agent-usage.js";
 import { agentRoutes, publicAgentAvatarRoutes } from "./api/agents.js";
 import { agentConfigRoutes } from "./api/agents-config.js";
+import { attachmentRoutes } from "./api/attachments.js";
 import { attentionRoutes } from "./api/attention.js";
 import { githubOauthRoutes } from "./api/auth/github.js";
 import { authRoutes } from "./api/auth.js";
@@ -329,6 +330,16 @@ export async function buildApp(config: Config) {
     options: { maxPayload: config.ws?.maxPayload ?? 65_536 },
   });
 
+  // Body parser for `application/octet-stream` — needed by the attachment
+  // upload route. Fastify's built-in parsers cover json / text only; without
+  // this registration `request.body` would be undefined on an octet-stream
+  // POST and the route would 415. Registered globally because Fastify only
+  // supports global content-type parsers; the route still owns its own
+  // `bodyLimit` so the byte cap is route-local.
+  app.addContentTypeParser("application/octet-stream", { parseAs: "buffer" }, (_req, body, done) => {
+    done(null, body);
+  });
+
   // CORS — explicit origins if configured; allow all in dev; same-origin in production
   const corsOrigin = config.cors?.origin;
   const isDev = process.env.NODE_ENV !== "production";
@@ -496,6 +507,16 @@ export async function buildApp(config: Config) {
           await scope.register(attentionRoutes);
         }),
         { prefix: "/attention" },
+      );
+
+      // Object-storage primitive (Class B, user-JWT). Generic binary blob
+      // upload + download; not bound to any business surface. See
+      // api/attachments.ts for the upload protocol and download auth.
+      await api.register(
+        userScope("attachmentRoutesScope", async (scope) => {
+          await scope.register(attachmentRoutes);
+        }),
+        { prefix: "/attachments" },
       );
 
       // ── Class B — `/orgs/:orgId/...` (org-scoped) ───────────────────────

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -43,6 +43,7 @@ import { meDocsRoutes } from "./api/me-docs.js";
 import { orgActivityRoutes } from "./api/orgs/activity.js";
 import { orgAdapterRoutes } from "./api/orgs/adapters.js";
 import { orgAgentRoutes } from "./api/orgs/agents.js";
+import { orgAttachmentRoutes } from "./api/orgs/attachments.js";
 import { orgChatRoutes } from "./api/orgs/chats.js";
 import { orgClientRoutes } from "./api/orgs/clients.js";
 import { orgContextTreeSnapshotRoutes } from "./api/orgs/context-tree-snapshot.js";
@@ -509,9 +510,10 @@ export async function buildApp(config: Config) {
         { prefix: "/attention" },
       );
 
-      // Object-storage primitive (Class B, user-JWT). Generic binary blob
-      // upload + download; not bound to any business surface. See
-      // api/attachments.ts for the upload protocol and download auth.
+      // Object-storage primitive — download surface (user-JWT). Generic
+      // binary blob download; not bound to any business surface. Auth is a
+      // capability model: valid JWT + knowledge of the unguessable id. Upload
+      // lives under the org scope below. See api/attachments.ts.
       await api.register(
         userScope("attachmentRoutesScope", async (scope) => {
           await scope.register(attachmentRoutes);
@@ -536,6 +538,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgSettingsRoutes, { prefix: "/settings" });
           await scope.register(orgGithubAppRoutes, { prefix: "/github-app-installation" });
           await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
+          await scope.register(orgAttachmentRoutes, { prefix: "/attachments" });
         }),
         { prefix: "/orgs/:orgId" },
       );

--- a/packages/server/src/db/schema/attachments.ts
+++ b/packages/server/src/db/schema/attachments.ts
@@ -1,0 +1,54 @@
+import { customType, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * `bytea` column type. Drizzle ships pg primitives but not bytea out of the
+ * box. Reads come back as Node `Buffer` (postgres-js); writes accept any
+ * `Uint8Array`. Mirrors the helper in `agents.ts` — kept local to this file
+ * so the two columns can diverge independently if one ever needs a different
+ * marshalling story.
+ */
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType: () => "bytea",
+});
+
+/**
+ * Server-side blob storage primitive. The first-tree object-storage layer.
+ *
+ * Independent blob — intentionally NO `chat_id` / `message_id` columns.
+ * Upstream consumers (the `imageId` field inside `messages.content` jsonb,
+ * future `attentions` / bookmark metadata, agent avatar references) hold the
+ * `attachments.id` reference. One byte sequence, many consumers.
+ *
+ * Auth happens at the route layer: either the caller is the uploader (or
+ * manages the agent that uploaded), or the caller passes a `chatId` they
+ * have access to. The id is a UUIDv4 — unguessable — as a baseline.
+ *
+ * Lifecycle: write-once. v1 keeps every row forever. A refcount /
+ * orphan-sweep job is a follow-up only if storage growth demands it; it
+ * would have to scan every known upstream reference site.
+ */
+export const attachments = pgTable(
+  "attachments",
+  {
+    /** UUIDv4. Same value upstream references store. */
+    id: text("id").primaryKey(),
+    /** MIME as declared by the uploader. v1 does not restrict. */
+    mimeType: text("mime_type").notNull(),
+    filename: text("filename").notNull(),
+    /** Server-measured byte length; clients do not get to lie about this. */
+    sizeBytes: integer("size_bytes").notNull(),
+    data: bytea("data").notNull(),
+    /**
+     * `agents.uuid` of the team member who uploaded these bytes. Humans
+     * store their `humanAgentId`; AI agents store their own uuid. No FK —
+     * mirrors `messages.sender_id`, which dropped its FK so soft-deleting
+     * an agent does not cascade or orphan existing rows.
+     */
+    uploadedBy: text("uploaded_by").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("attachments_uploaded_by_idx").on(table.uploadedBy),
+    index("attachments_created_at_idx").on(table.createdAt),
+  ],
+);

--- a/packages/server/src/db/schema/attachments.ts
+++ b/packages/server/src/db/schema/attachments.ts
@@ -19,9 +19,12 @@ const bytea = customType<{ data: Buffer; driverData: Buffer }>({
  * future `attentions` / bookmark metadata, agent avatar references) hold the
  * `attachments.id` reference. One byte sequence, many consumers.
  *
- * Auth happens at the route layer: either the caller is the uploader (or
- * manages the agent that uploaded), or the caller passes a `chatId` they
- * have access to. The id is a UUIDv4 — unguessable — as a baseline.
+ * Auth happens at the route layer as a capability model: download requires
+ * a valid user JWT plus knowledge of the unguessable UUIDv4 id; there is no
+ * per-attachment ACL. Stronger, attachment-scoped authorization is the
+ * consumer's responsibility. Upload is org-scoped
+ * (`POST /api/v1/orgs/:orgId/attachments`) so `uploaded_by` resolves to a
+ * stable member identity.
  *
  * Lifecycle: write-once. v1 keeps every row forever. A refcount /
  * orphan-sweep job is a follow-up only if storage growth demands it; it

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -3,6 +3,7 @@ export { agentChatSessions } from "./agent-chat-sessions.js";
 export { agentConfigs } from "./agent-configs.js";
 export { agentPresence } from "./agent-presence.js";
 export { agents } from "./agents.js";
+export { attachments } from "./attachments.js";
 export { attentions } from "./attentions.js";
 export { authIdentities } from "./auth-identities.js";
 export { chatMembership } from "./chat-membership.js";

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -2,9 +2,7 @@ import { randomUUID } from "node:crypto";
 import { MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
-import { agents } from "../db/schema/agents.js";
 import { attachments } from "../db/schema/attachments.js";
-import { members } from "../db/schema/members.js";
 import { BadRequestError } from "../errors.js";
 
 /**
@@ -13,14 +11,14 @@ import { BadRequestError } from "../errors.js";
  * - `createAttachment` writes a row, returns the inserted record.
  * - `loadAttachmentMeta` looks up by id WITHOUT the `bytea` payload; returns
  *   `null` on miss so the route layer can emit a 404 cleanly. The download
- *   route runs auth + ETag off the metadata so a cache hit (304) never pulls
- *   the blob out of PG.
+ *   route runs the ETag check off the metadata so a cache hit (304) never
+ *   pulls the blob out of PG.
  * - `loadAttachmentData` fetches just the `bytea` payload, called only once
  *   the route has decided to actually stream bytes.
- * - `isCallerUploaderOrManager` is the first auth gate for downloads. The
- *   second gate (`?chatId=...` -> chat membership) lives in the route
- *   layer where `requireChatAccess` already knows how to throw a clean
- *   404 / 403 split.
+ *
+ * Download authorization is a capability model handled at the route layer:
+ * a valid user JWT plus knowledge of the unguessable id. The service holds no
+ * ACL logic.
  *
  * Service throws `BadRequestError` for input validation (oversize / empty
  * bytes / blank mime). Route layer maps service exceptions to HTTP.
@@ -95,30 +93,4 @@ export async function loadAttachmentMeta(db: Database, id: string): Promise<Atta
 export async function loadAttachmentData(db: Database, id: string): Promise<Buffer | null> {
   const [row] = await db.select({ data: attachments.data }).from(attachments).where(eq(attachments.id, id)).limit(1);
   return row?.data ?? null;
-}
-
-/**
- * Returns true when the caller either uploaded the attachment themselves or
- * is the user who manages the agent that did. The route layer should call
- * this first; on `false` it falls through to the `?chatId` membership check.
- *
- * Implementation: a single `agents -> members` join keyed on
- * `agents.uuid = uploadedBy` resolves the uploader's owning user id. For a
- * direct match (`caller.humanAgentId === uploadedBy`) we skip the query.
- */
-export async function isCallerUploaderOrManager(
-  db: Database,
-  uploadedBy: string,
-  caller: { userId: string; humanAgentId: string },
-): Promise<boolean> {
-  if (caller.humanAgentId === uploadedBy) return true;
-
-  const [row] = await db
-    .select({ ownerUserId: members.userId })
-    .from(agents)
-    .innerJoin(members, eq(members.id, agents.managerId))
-    .where(eq(agents.uuid, uploadedBy))
-    .limit(1);
-
-  return row?.ownerUserId === caller.userId;
 }

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import { MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { attachments } from "../db/schema/attachments.js";
+import { members } from "../db/schema/members.js";
+import { BadRequestError } from "../errors.js";
+
+/**
+ * Object-storage primitive (M1).
+ *
+ * - `createAttachment` writes a row, returns the inserted record.
+ * - `loadAttachmentMeta` looks up by id WITHOUT the `bytea` payload; returns
+ *   `null` on miss so the route layer can emit a 404 cleanly. The download
+ *   route runs auth + ETag off the metadata so a cache hit (304) never pulls
+ *   the blob out of PG.
+ * - `loadAttachmentData` fetches just the `bytea` payload, called only once
+ *   the route has decided to actually stream bytes.
+ * - `isCallerUploaderOrManager` is the first auth gate for downloads. The
+ *   second gate (`?chatId=...` -> chat membership) lives in the route
+ *   layer where `requireChatAccess` already knows how to throw a clean
+ *   404 / 403 split.
+ *
+ * Service throws `BadRequestError` for input validation (oversize / empty
+ * bytes / blank mime). Route layer maps service exceptions to HTTP.
+ */
+
+export type AttachmentRow = typeof attachments.$inferSelect;
+
+export type CreateAttachmentInput = {
+  /** Optional caller-supplied id (UUIDv4). Generated when absent. */
+  id?: string;
+  mimeType: string;
+  filename: string;
+  data: Buffer;
+  /** `agents.uuid` of the uploader; humans pass their humanAgentId. */
+  uploadedBy: string;
+};
+
+export async function createAttachment(db: Database, input: CreateAttachmentInput): Promise<AttachmentRow> {
+  if (input.data.byteLength === 0) {
+    throw new BadRequestError("Attachment is empty");
+  }
+  if (input.data.byteLength > MAX_ATTACHMENT_BYTES) {
+    throw new BadRequestError(`Attachment exceeds maximum size of ${MAX_ATTACHMENT_BYTES} bytes`);
+  }
+  if (input.mimeType.trim().length === 0) {
+    throw new BadRequestError("Attachment mime type is required");
+  }
+  if (input.filename.trim().length === 0) {
+    throw new BadRequestError("Attachment filename is required");
+  }
+
+  const id = input.id ?? randomUUID();
+  const [row] = await db
+    .insert(attachments)
+    .values({
+      id,
+      mimeType: input.mimeType,
+      filename: input.filename,
+      sizeBytes: input.data.byteLength,
+      data: input.data,
+      uploadedBy: input.uploadedBy,
+    })
+    .returning();
+  if (!row) {
+    // Drizzle returns the inserted row(s); empty array would only happen on
+    // a driver bug. Throw rather than swallow — caller would see a wrong-
+    // shape return otherwise.
+    throw new Error("Attachment insert returned no row");
+  }
+  return row;
+}
+
+/** Everything in `AttachmentRow` except the `bytea` payload. */
+export type AttachmentMeta = Omit<AttachmentRow, "data">;
+
+export async function loadAttachmentMeta(db: Database, id: string): Promise<AttachmentMeta | null> {
+  const [row] = await db
+    .select({
+      id: attachments.id,
+      mimeType: attachments.mimeType,
+      filename: attachments.filename,
+      sizeBytes: attachments.sizeBytes,
+      uploadedBy: attachments.uploadedBy,
+      createdAt: attachments.createdAt,
+    })
+    .from(attachments)
+    .where(eq(attachments.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function loadAttachmentData(db: Database, id: string): Promise<Buffer | null> {
+  const [row] = await db.select({ data: attachments.data }).from(attachments).where(eq(attachments.id, id)).limit(1);
+  return row?.data ?? null;
+}
+
+/**
+ * Returns true when the caller either uploaded the attachment themselves or
+ * is the user who manages the agent that did. The route layer should call
+ * this first; on `false` it falls through to the `?chatId` membership check.
+ *
+ * Implementation: a single `agents -> members` join keyed on
+ * `agents.uuid = uploadedBy` resolves the uploader's owning user id. For a
+ * direct match (`caller.humanAgentId === uploadedBy`) we skip the query.
+ */
+export async function isCallerUploaderOrManager(
+  db: Database,
+  uploadedBy: string,
+  caller: { userId: string; humanAgentId: string },
+): Promise<boolean> {
+  if (caller.humanAgentId === uploadedBy) return true;
+
+  const [row] = await db
+    .select({ ownerUserId: members.userId })
+    .from(agents)
+    .innerJoin(members, eq(members.id, agents.managerId))
+    .where(eq(agents.uuid, uploadedBy))
+    .limit(1);
+
+  return row?.ownerUserId === caller.userId;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,6 +122,15 @@ export {
   RUNTIME_STALE_MS,
 } from "./schemas/agent-status.js";
 export {
+  ATTACHMENT_FILENAME_HEADER,
+  ATTACHMENT_MIME_HEADER,
+  type AttachmentMetadata,
+  attachmentMetadataSchema,
+  MAX_ATTACHMENT_BYTES,
+  type UploadAttachmentResponse,
+  uploadAttachmentResponseSchema,
+} from "./schemas/attachment.js";
+export {
   ATTENTION_STATES,
   type Attention,
   type AttentionCancelledFrame,

--- a/packages/shared/src/schemas/attachment.ts
+++ b/packages/shared/src/schemas/attachment.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * Per-attachment hard byte cap enforced server-side.
+ *
+ * Sized for the foreseeable upload mix (mostly images, occasional small docs)
+ * while keeping a single `attachments.data` bytea row comfortably inside
+ * PostgreSQL TOAST's compressed-out-of-line sweet spot. Bumping requires both
+ * a route-level `bodyLimit` raise and a re-examination of any downstream
+ * consumer that streams the bytes back through Node's heap.
+ */
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Header name (case-insensitive) carrying the original filename on upload.
+ * Octet-stream uploads do not carry a filename in `Content-Disposition`, so
+ * the SDK forwards the user-visible name in this header. Server falls back
+ * to a generic name when the header is absent or empty.
+ */
+export const ATTACHMENT_FILENAME_HEADER = "x-attachment-filename";
+
+/**
+ * Header name (case-insensitive) carrying the original MIME type on upload.
+ * The wire-level `Content-Type` is always `application/octet-stream` so the
+ * server's body parser stays uniform; the *logical* mime (e.g. `image/png`)
+ * rides in this header and is what we persist into `attachments.mime_type`.
+ */
+export const ATTACHMENT_MIME_HEADER = "x-attachment-mime";
+
+/**
+ * What the server returns on successful upload and what GET responses for
+ * an `?meta=1` style probe would return. Today GET only streams bytes, but
+ * the shape is the canonical metadata contract.
+ */
+export const attachmentMetadataSchema = z.object({
+  id: z.string().uuid(),
+  mimeType: z.string().min(1),
+  filename: z.string().min(1),
+  sizeBytes: z.number().int().nonnegative(),
+  uploadedBy: z.string().min(1),
+  createdAt: z.string().datetime(),
+});
+export type AttachmentMetadata = z.infer<typeof attachmentMetadataSchema>;
+
+export const uploadAttachmentResponseSchema = attachmentMetadataSchema;
+export type UploadAttachmentResponse = z.infer<typeof uploadAttachmentResponseSchema>;


### PR DESCRIPTION
## Summary

First phase (PR-1) of the "group-chat images aren't visible to others" work: build the **object-storage primitive** only. No business logic — image messages are a separate follow-up. This PR adds a generic, reusable binary-blob surface; upstream consumers will hold `attachments.id` references later.

- **shared**: Zod contract (`attachmentMetadataSchema`), upload header constants (`x-attachment-mime` / `x-attachment-filename`), 10 MiB size cap
- **server**: independent `attachments` table (`bytea` payload, migration `0054`), service layer, upload route `POST /api/v1/orgs/:orgId/attachments`, download route `GET /api/v1/attachments/:id`
- **client**: `uploadAttachment` / `fetchAttachment` SDK methods

### Design notes

- **Independent blob**: no `chat_id` / `message_id` columns and no foreign keys — consumers hold the id; mirrors `messages.sender_id` soft-delete tolerance.
- **Upload protocol**: `application/octet-stream` body + metadata headers, avoiding a multipart dependency. Route-local `bodyLimit`.
- **Upload auth** (org-scoped, Class B): `POST /api/v1/orgs/:orgId/attachments` + `requireOrgMembership`. The org in the path makes `uploaded_by` deterministic for multi-org callers (a `?orgId=` query was rejected — leaves uploader identity ambiguous and violates the HTTP path convention).
- **Download auth** (capability model): a valid user JWT plus knowledge of the unguessable UUIDv4 id is sufficient; there is **no** per-attachment ACL. The id *is* the bearer capability (cf. signed object URLs). A `?chatId=` membership check was considered and rejected: with no attachment↔chat binding it could only prove "caller is in *some* chat", not "this attachment belongs to *that* chat". Stronger, attachment-scoped authorization is the **consumer's** responsibility.
- **304 path** splits metadata from payload so an `If-None-Match` cache hit never drags the `bytea` out of PG.

## Test plan

- [x] `pnpm check` (Biome)
- [x] `pnpm typecheck` — shared / server / client
- [x] `vitest run attachments-route` (upload by org member, capability-model download by any authenticated user with the id, 401 without JWT, ETag 304, wrong content-type, missing mime header, empty/oversize, 404 unknown id, 403 upload to non-member org, multi-org uploader determined by path)
- [x] `node scripts/check-migrations.mjs`
- [x] Local real-server + PostgreSQL smoke verified by QA (persistence, capability download, 304, org-scoped upload, 10 MiB boundary, SDK round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)