### PR TITLE
feat: enforce AskUserQuestion deny -> NHA at prompt/skill layer

### DIFF
--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -1048,5 +1048,7 @@ this command.
 ## When You Need a Human (Need-Human-Attention)
 
 Use \`${bin} attention raise --requires-response\` before any irreversible or externally-visible action that needs the human's go-ahead (ask), use \`${bin} attention raise\` without the flag right after such an action completes while the human is not watching (notify), and use plain \`chat send\` for everything else — full trigger lists, body templates, and waiting behaviour live in the attention skill (\`.claude/skills/attention/SKILL.md\` or \`.agents/skills/attention/SKILL.md\`).
+
+**\`AskUserQuestion\` is NOT available in this Hub — it is denied on call.** If you ever invoke \`AskUserQuestion\` (or any built-in "ask the user" tool) and it is denied, you MUST re-issue the request as a request-type NHA via \`${bin} attention raise --requires-response\`. Do NOT fall back to asking the question as plain final-text or a \`chat send\`: a request-NHA is the only mechanism that targets a specific human, carries a response expectation, and resumes your turn when they reply. Convert each choice you would have offered into the NHA body (and \`metadata.options\` / \`metadata.questions\` when the human should click rather than type).
 `;
 }

--- a/skills/attention/SKILL.md
+++ b/skills/attention/SKILL.md
@@ -32,6 +32,12 @@ NHA (Need-Human-Attention) is the structured "I need a human" primitive. You rai
 
 The system layer is intentionally thin. It stores, routes, and delivers; it does **not** decide whether you should raise, how long to wait, or what to do on timeout. Those are your job — that's why this skill exists.
 
+## `AskUserQuestion` is not available — a denial means raise an NHA
+
+This Hub does **not** bridge the runtime's built-in `AskUserQuestion` (or any equivalent "ask the user" tool). Calling it is **denied** with a message redirecting you here. When that happens you MUST re-issue the request as a request-type NHA (`first-tree attention raise --requires-response`) — that is a hard rule, not a suggestion.
+
+Do **not** fall back to asking the question as plain final-text or a `chat send`. Final text does not target a named human, carries no response expectation, and does not resume your turn on reply; a request-NHA does all three. Convert each option you would have offered into the NHA body, and use `metadata.options` / `metadata.questions` (see `references/metadata-shape.md`) when the human should click rather than type.
+
 ## Attention vs Chat message — when to use which
 
 Attention and message are **separate substrates by design**, not two views on the same data. Pick deliberately:


### PR DESCRIPTION
## Summary

- `AskUserQuestion` is no longer bridged in the Hub (NHA M0, #578). The claude-code handler soft-denies it and redirects to NHA, but nothing at the prompt/skill layer stopped an agent from falling back to a plain final-text question — which does not target a named human, carries no response expectation, and does not resume the turn on reply.
- Add a hard constraint in the per-agent `tools.md` ("When You Need a Human" section, generated by `generateToolsDoc()` in `bootstrap.ts`): a `AskUserQuestion` deny MUST be re-issued as a request-type NHA via `attention raise --requires-response`, never plain final-text or `chat send`. This is the most reliable location because `tools.md` is injected into every agent regardless of which skills are loaded.
- Mirror the same rule in `skills/attention/SKILL.md` (new section right after North Star), which is exactly where the deny message points.

## Why

The deny+redirect introduced by #578 is only a soft nudge; NHA fires only if the agent voluntarily calls `attention raise`. This closes that gap by making the conversion mandatory in the agent's standing instructions.

## Test plan

- [x] `pnpm check` (biome) passes
- [x] `pnpm typecheck` passes (13/13 tasks)
- [ ] Manual: trigger an `AskUserQuestion` call in a running agent and confirm it converts to a request-NHA instead of a plain-text question

🤖 Generated with [Claude Code](https://claude.com/claude-code)