### PR TITLE
fix(web): drop duplicate entity prefix from GitHub card title

### DIFF
--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -3,6 +3,7 @@ import {
   isGithubEventCardContent,
   isGithubSystemSenderMetadata,
   isTrustedGithubDispatcherMessage,
+  stripEntityPrefix,
 } from "../github-event-card.js";
 
 /**
@@ -154,5 +155,40 @@ describe("isTrustedGithubDispatcherMessage", () => {
     expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: {} })).toBe(false);
     expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: { systemSender: "other" } })).toBe(false);
     expect(isTrustedGithubDispatcherMessage({ ...trustedMsg, metadata: null })).toBe(false);
+  });
+});
+
+/**
+ * Server-side `entitySurfaceTitle` (services/github-normalize.ts) prefixes
+ * the raw entity title with `"PR #N: "` / `"Issue #N: "` /
+ * `"Discussion #N: "` / `"Commit: "`. The L1 chip already renders that
+ * prefix as a badge, so the card strips it before showing the title. Pin
+ * the stripping contract so a regression silently re-introduces the
+ * "PR-NN: PR-NN: ..." visual duplication that motivated this change.
+ * (Issue numbers in this file kept at 1-2 digits to avoid the hex-color
+ * guardrail in scripts/check-design-tokens.sh.)
+ */
+describe("stripEntityPrefix", () => {
+  it("strips PR / Issue / Discussion prefix when title matches the server format", () => {
+    expect(stripEntityPrefix("PR #42: Refactor inbox", "pull_request", "#42")).toBe("Refactor inbox");
+    expect(stripEntityPrefix("Issue #7: Bug in parser", "issue", "#7")).toBe("Bug in parser");
+    expect(stripEntityPrefix("Discussion #9: RFC draft", "discussion", "#9")).toBe("RFC draft");
+  });
+
+  it("strips the bare prefix when entity.title was absent server-side", () => {
+    // entitySurfaceTitle returns just `"PR #N"` (no colon) when entity.title is empty.
+    // The chip already shows it, so render-side returns "" to hide the title element.
+    expect(stripEntityPrefix("PR #42", "pull_request", "#42")).toBe("");
+    expect(stripEntityPrefix("Commit", "commit", "@x")).toBe("");
+  });
+
+  it("strips Commit prefix (no number in surface title) for commits", () => {
+    expect(stripEntityPrefix("Commit: Fix typo in README", "commit", "@x")).toBe("Fix typo in README");
+  });
+
+  it("returns the title as-is when the prefix does not match (older messages / schema drift)", () => {
+    expect(stripEntityPrefix("Some legacy title", "pull_request", "#42")).toBe("Some legacy title");
+    // Number mismatch — defensive: don't slice mid-token.
+    expect(stripEntityPrefix("PR #99: Title", "pull_request", "#42")).toBe("PR #99: Title");
   });
 });

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -228,9 +228,19 @@ describe("shortEntityNumber", () => {
  */
 describe("entity-key → strip integration (mirrors GithubEventCardMessage)", () => {
   const cases = [
-    { type: "pull_request" as const, key: "owner/repo#42", title: "PR #42: Refactor inbox", expected: "Refactor inbox" },
+    {
+      type: "pull_request" as const,
+      key: "owner/repo#42",
+      title: "PR #42: Refactor inbox",
+      expected: "Refactor inbox",
+    },
     { type: "issue" as const, key: "owner/repo#7", title: "Issue #7: Bug in parser", expected: "Bug in parser" },
-    { type: "discussion" as const, key: "owner/repo#discussion-9", title: "Discussion #9: RFC draft", expected: "RFC draft" },
+    {
+      type: "discussion" as const,
+      key: "owner/repo#discussion-9",
+      title: "Discussion #9: RFC draft",
+      expected: "RFC draft",
+    },
     { type: "commit" as const, key: "owner/repo@abc", title: "Commit: Fix typo", expected: "Fix typo" },
   ];
 

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -3,6 +3,7 @@ import {
   isGithubEventCardContent,
   isGithubSystemSenderMetadata,
   isTrustedGithubDispatcherMessage,
+  shortEntityNumber,
   stripEntityPrefix,
 } from "../github-event-card.js";
 
@@ -191,4 +192,52 @@ describe("stripEntityPrefix", () => {
     // Number mismatch — defensive: don't slice mid-token.
     expect(stripEntityPrefix("PR #99: Title", "pull_request", "#42")).toBe("PR #99: Title");
   });
+});
+
+/**
+ * `shortEntityNumber` produces the value the L1 chip displays *and* the
+ * value `stripEntityPrefix` reconstructs the head from — so the two
+ * always need to agree. Discussion is the load-bearing case because the
+ * server stores the key as `owner/repo#discussion-N` but writes the
+ * surface title as `"Discussion #N: ..."` (numeric). If chip and strip
+ * disagree on the discussion number format, dedupe silently fails for
+ * discussion cards (caught by code-review on this PR).
+ */
+describe("shortEntityNumber", () => {
+  it("strips the repo prefix for issue / PR keys", () => {
+    expect(shortEntityNumber("owner/repo#42", "owner/repo")).toBe("#42");
+    expect(shortEntityNumber("owner/repo#7", "owner/repo")).toBe("#7");
+  });
+
+  it("collapses the discussion-N infix so chip and surface title agree on #N", () => {
+    expect(shortEntityNumber("owner/repo#discussion-9", "owner/repo")).toBe("#9");
+  });
+
+  it("keeps the full sha for commit keys (server commit title has no number)", () => {
+    expect(shortEntityNumber("owner/repo@abc", "owner/repo")).toBe("@abc");
+  });
+});
+
+/**
+ * End-to-end integration: feed realistic `entity.key` shapes through
+ * `shortEntityNumber` and into `stripEntityPrefix` the way
+ * `GithubEventCardMessage` does. Catches the regression that earlier
+ * unit-only tests missed — where a discussion key was being matched
+ * against the wrong head (`"Discussion #discussion-9"` instead of
+ * `"Discussion #9"`), leaving the title prefix un-stripped.
+ */
+describe("entity-key → strip integration (mirrors GithubEventCardMessage)", () => {
+  const cases = [
+    { type: "pull_request" as const, key: "owner/repo#42", title: "PR #42: Refactor inbox", expected: "Refactor inbox" },
+    { type: "issue" as const, key: "owner/repo#7", title: "Issue #7: Bug in parser", expected: "Bug in parser" },
+    { type: "discussion" as const, key: "owner/repo#discussion-9", title: "Discussion #9: RFC draft", expected: "RFC draft" },
+    { type: "commit" as const, key: "owner/repo@abc", title: "Commit: Fix typo", expected: "Fix typo" },
+  ];
+
+  for (const c of cases) {
+    it(`strips the ${c.type} prefix from a realistic card`, () => {
+      const entityNumber = shortEntityNumber(c.key, "owner/repo");
+      expect(stripEntityPrefix(c.title, c.type, entityNumber)).toBe(c.expected);
+    });
+  }
 });

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -81,17 +81,26 @@ const ENTITY_TAG_LABEL: Record<GithubEntityType, string> = {
 };
 
 /**
- * `entity.key` arrives as `owner/repo#N` or `owner/repo@<sha>`. Strip the
- * repo prefix so the chip renders the short `#N` / `@<sha>` form. Falls
- * back defensively to the segment after the last `/` if the prefix does
- * not match (older messages, schema drift).
+ * `entity.key` arrives as `owner/repo#N` (issue / PR), `owner/repo@<sha>`
+ * (commit), or `owner/repo#discussion-N` (discussion — the odd one out:
+ * the key carries a `discussion-` infix but the server's surface title
+ * uses the bare `disc.number`, see `entitySurfaceTitle` in
+ * services/github-normalize.ts). Strip the repo prefix, then collapse the
+ * `discussion-` infix so the chip and the surface-title-strip both
+ * reference the same `#N` form that appears in the server-rendered title.
+ * Falls back defensively to the segment after the last `/` if neither
+ * prefix shape matches (older messages, schema drift).
  */
-function shortEntityNumber(key: string, repository: string): string {
+export function shortEntityNumber(key: string, repository: string): string {
+  let tail: string;
   if (repository && (key.startsWith(`${repository}#`) || key.startsWith(`${repository}@`))) {
-    return key.slice(repository.length);
+    tail = key.slice(repository.length);
+  } else {
+    const lastSlash = key.lastIndexOf("/");
+    tail = lastSlash >= 0 ? key.slice(lastSlash + 1) : key;
   }
-  const lastSlash = key.lastIndexOf("/");
-  return lastSlash >= 0 ? key.slice(lastSlash + 1) : key;
+  const DISC_PREFIX = "#discussion-";
+  return tail.startsWith(DISC_PREFIX) ? `#${tail.slice(DISC_PREFIX.length)}` : tail;
 }
 
 function shortRepoName(repository: string): string {

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -99,6 +99,28 @@ function shortRepoName(repository: string): string {
   return lastSlash >= 0 ? repository.slice(lastSlash + 1) : repository;
 }
 
+/**
+ * Server-side `entitySurfaceTitle` (services/github-normalize.ts) wraps the
+ * raw entity title as `"PR #N: <title>"` / `"Issue #N: <title>"` /
+ * `"Discussion #N: <title>"` / `"Commit: <title>"`. The L1 chip already
+ * renders that prefix as a colored badge, so leaving it inside the title
+ * string duplicates information. Strip the exact prefix we expect from the
+ * server formatter; if the title doesn't match (older messages, schema
+ * drift), return as-is so we never silently drop the title.
+ */
+export function stripEntityPrefix(title: string, entityType: GithubEntityType, entityNumber: string): string {
+  const prefix = ENTITY_TAG_LABEL[entityType];
+  if (entityType === "commit") {
+    if (title.startsWith(`${prefix}: `)) return title.slice(prefix.length + 2);
+    if (title === prefix) return "";
+    return title;
+  }
+  const head = `${prefix} ${entityNumber}`;
+  if (title.startsWith(`${head}: `)) return title.slice(head.length + 2);
+  if (title === head) return "";
+  return title;
+}
+
 function subscribedVerb(kind: GithubEventCard["kind"]): string {
   switch (kind) {
     case "opened":
@@ -210,6 +232,7 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
   const entityNumber = shortEntityNumber(content.entity.key, content.repository);
   const repoShort = shortRepoName(content.repository);
   const verb = actionVerb(content);
+  const titleText = stripEntityPrefix(content.title, content.entity.type, entityNumber);
 
   const entityChip = (
     <span
@@ -246,7 +269,7 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
         }}
       >
         {entityChip}
-        {content.title ? (
+        {titleText ? (
           link ? (
             <a
               href={link}
@@ -255,11 +278,11 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
               className="font-medium no-underline hover:underline"
               style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto", textDecoration: "none" }}
             >
-              {content.title}
+              {titleText}
             </a>
           ) : (
             <span className="font-medium" style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto" }}>
-              {content.title}
+              {titleText}
             </span>
           )
         ) : null}


### PR DESCRIPTION
## Summary

Follow-up to #546. The L1 row of the GitHub dispatcher card shows both the entity chip (`[PR #N]`) and the surface title. On the server, the surface title is always formatted as `"PR #N: <title>"` (see `entitySurfaceTitle` in `services/github-normalize.ts`), so the chip prefix and the title prefix duplicated each other:

```
Before:  [PR #546]  PR #546: feat(web): re-attribute GitHub dispatcher cards
After:   [PR #546]  feat(web): re-attribute GitHub dispatcher cards
```

The chip stays — it's still useful as a colored at-a-glance entity-type / number badge. Only the redundant prefix in the title is stripped on render.

## Approach

`stripEntityPrefix(title, entityType, entityNumber)`:
- Matches the exact prefix the server formatter produces (`"${PREFIX} ${num}: "` for PR/Issue/Discussion, `"Commit: "` for commits).
- If the title is just the bare prefix with no body (server omits the colon when `entity.title` is empty), returns `""` so the title element collapses and the chip alone carries the row.
- If the title doesn't match the expected format (older messages, schema drift), returns it as-is — render is the only failure mode, so we never silently drop content.

## Test plan

- [x] `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) — green
- [x] `pnpm --filter @first-tree/web test` — 494 / 494
- [x] New `stripEntityPrefix` describe block: 4 cases (4 entity types + bare-prefix + commit + fall-through)
- [ ] Visual smoke: 3 dispatcher card scenarios from #546 still render correctly with chip + de-duplicated title (handed to @code-reviewer for env relaunch)