### PR TITLE
docs: tighten security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,9 @@ assumed to get backported fixes.
 
 ## Reporting a Vulnerability
 
-Please do not post exploit details in a public GitHub issue.
+First Tree includes authentication, JWT handling, agent runtime, GitHub
+App/webhook, and local daemon surfaces. Please report suspected vulnerabilities
+privately.
 
 Preferred path:
 
@@ -21,23 +23,30 @@ Preferred path:
 
 Fallback path:
 
-1. Open a public issue with only the affected area and impact summary.
-2. Do not include proof-of-concept code, secrets, or reproduction steps that
-   would make the issue exploitable.
-3. Ask the maintainers to provide a private handoff path for the full report.
+1. Email the report to `security@first-tree.ai`.
+2. Do not open public GitHub issues, discussions, PR comments, or other public
+   summaries for suspected vulnerabilities. Even high-level summaries may expose
+   exploitable details.
+3. If you need encrypted or otherwise private follow-up, request it by email and
+   maintainers will arrange an appropriate handoff.
 
 ## What To Include
 
-Helpful reports usually include:
+Helpful private reports usually include:
 
 - affected command or package surface
 - impacted version or commit
 - prerequisites and expected impact
-- reproduction notes that a maintainer can validate privately
+- reproduction notes suitable for maintainer validation in a private channel
 - suggested remediation or patch direction, if you have one
 
 ## Response Expectations
 
+Maintainers will acknowledge or otherwise respond within 3 calendar days. The
+initial response may confirm receipt, ask for additional private details, or
+begin impact triage; it is not a guarantee of full remediation within that
+window.
+
 Maintainers will try to confirm the report, understand the impact, and land a
-fix before requesting public disclosure details. Coordinated disclosure is
-appreciated once a fix or mitigation is available.
+fix or mitigation before requesting public disclosure details. Coordinated
+disclosure is appreciated once a fix or mitigation is available.


### PR DESCRIPTION
## Summary

- Update `SECURITY.md` to make private vulnerability reporting explicit for auth, JWT, agent runtime, GitHub App/webhook, and daemon surfaces.
- Replace the public-issue fallback with `security@first-tree.ai`, clarify that suspected vulnerabilities should not be summarized publicly, and add a 3 calendar day initial response expectation.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] `packages/github-scan` / `first-tree github scan`
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [x] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: `SECURITY.md` only
- follow-up work: none

`pnpm test` was not run because this is a Markdown-only repository policy change.