### PR TITLE
feat(client): claude-code-tui capability probe (claude + tmux>=3.0)

### DIFF
--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -2,7 +2,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeExecutableResolution } from "../handlers/claude-executable.js";
 import { probeClaudeCodeCapability } from "../runtime/capabilities/claude-code.js";
+import { parseTmuxVersion, probeClaudeCodeTuiCapability } from "../runtime/capabilities/claude-code-tui.js";
 import { probeCodexCapability } from "../runtime/capabilities/codex.js";
 import { probeCapabilities } from "../runtime/capabilities/index.js";
 
@@ -301,6 +303,142 @@ describe("probeCodexCapability", () => {
   });
 });
 
+describe("probeClaudeCodeTuiCapability", () => {
+  const onPath = (): ClaudeExecutableResolution => ({ path: "/usr/local/bin/claude", source: "path" });
+  const notOnPath = (): ClaudeExecutableResolution => ({ path: undefined, source: "default" });
+  const tmux34 = () => ({ raw: "tmux 3.4", major: 3, minor: 4 });
+  const authed = () => ({ authenticated: true, method: "oauth" as const });
+  const noAuth = () => ({ authenticated: false, method: "none" as const });
+  const claudeVer = () => "1.0.42";
+
+  it("`ok` when claude is on PATH, tmux >= 3.0, and authenticated", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: tmux34,
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("ok");
+    expect(entry.available).toBe(true);
+    expect(entry.authenticated).toBe(true);
+    expect(entry.authMethod).toBe("oauth");
+    // sdkVersion carries the claude CLI version (the runtime engine), not tmux.
+    expect(entry.sdkVersion).toBe("1.0.42");
+  });
+
+  it("`unauthenticated` when claude + tmux are present but not logged in", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: tmux34,
+      probeClaudeVersion: claudeVer,
+      detectAuth: noAuth,
+    });
+    expect(entry.state).toBe("unauthenticated");
+    expect(entry.available).toBe(true);
+    expect(entry.authenticated).toBe(false);
+    expect(entry.authMethod).toBe("none");
+  });
+
+  it("`missing` when claude resolves only to the SDK bundle (source=default)", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: notOnPath,
+      probeTmux: tmux34,
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.available).toBe(false);
+    expect(entry.error).toContain("`claude` not found");
+  });
+
+  it("`missing` when tmux is absent", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: () => null,
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.error).toContain("tmux not found");
+  });
+
+  it("`missing` when tmux is older than 3.0", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: () => ({ raw: "tmux 2.9", major: 2, minor: 9 }),
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.error).toContain("older than 3.0");
+  });
+
+  it("accepts tmux 3.0 exactly (boundary)", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: () => ({ raw: "tmux 3.0", major: 3, minor: 0 }),
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("ok");
+  });
+
+  it("accepts a future major (e.g. tmux 4.0)", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: () => ({ raw: "tmux 4.0", major: 4, minor: 0 }),
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("ok");
+  });
+
+  it("reports both missing reasons when claude and tmux are absent", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: notOnPath,
+      probeTmux: () => null,
+      probeClaudeVersion: claudeVer,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.error).toContain("`claude` not found");
+    expect(entry.error).toContain("tmux not found");
+  });
+
+  it("surfaces a thrown dependency as state=error", async () => {
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: () => {
+        throw new Error("resolve blew up");
+      },
+    });
+    expect(entry.state).toBe("error");
+    expect(entry.available).toBe(false);
+    expect(entry.error).toBe("resolve blew up");
+  });
+});
+
+describe("parseTmuxVersion", () => {
+  it("parses plain `tmux 3.4`", () => {
+    expect(parseTmuxVersion("tmux 3.4")).toMatchObject({ major: 3, minor: 4 });
+  });
+
+  it("parses a letter-suffixed patch release `tmux 3.2a`", () => {
+    expect(parseTmuxVersion("tmux 3.2a")).toMatchObject({ major: 3, minor: 2 });
+  });
+
+  it("parses a pre-release build `tmux next-3.5`", () => {
+    expect(parseTmuxVersion("tmux next-3.5")).toMatchObject({ major: 3, minor: 5 });
+  });
+
+  it("trims trailing whitespace/newline into `raw`", () => {
+    expect(parseTmuxVersion("tmux 3.4\n")?.raw).toBe("tmux 3.4");
+  });
+
+  it("returns null when no version is present", () => {
+    expect(parseTmuxVersion("tmux: command not found")).toBeNull();
+  });
+});
+
 describe("probeCapabilities (aggregator)", () => {
   let tmpHome: string;
   let tmpCodexHome: string;
@@ -324,8 +462,8 @@ describe("probeCapabilities (aggregator)", () => {
 
   it("returns one entry per built-in provider, each with a valid state", async () => {
     const caps = await probeCapabilities();
-    expect(Object.keys(caps).sort()).toEqual(["claude-code", "codex"]);
-    for (const k of ["claude-code", "codex"] as const) {
+    expect(Object.keys(caps).sort()).toEqual(["claude-code", "claude-code-tui", "codex"]);
+    for (const k of ["claude-code", "claude-code-tui", "codex"] as const) {
       const entry = caps[k];
       if (!entry) throw new Error(`missing entry for ${k}`);
       expect(["ok", "unauthenticated", "missing", "error"]).toContain(entry.state);
@@ -334,7 +472,10 @@ describe("probeCapabilities (aggregator)", () => {
     }
   });
 
-  it("unauthenticated machine reports both providers as state=unauthenticated", async () => {
+  it("unauthenticated machine reports the SDK providers as state=unauthenticated", async () => {
+    // claude-code-tui's state depends on real `claude`/`tmux` presence on the
+    // host, so it is intentionally not asserted here (covered hermetically in
+    // the probeClaudeCodeTuiCapability block above).
     const caps = await probeCapabilities();
     expect(caps["claude-code"]?.state).toBe("unauthenticated");
     expect(caps.codex?.state).toBe("unauthenticated");
@@ -355,6 +496,11 @@ describe("probeCapabilities (aggregator)", () => {
     vi.doMock("../runtime/capabilities/codex.js", () => ({
       probeCodexCapability: vi.fn().mockRejectedValue("codex probe failed"),
     }));
+    // Mock the TUI probe too so the aggregator never spawns a real tmux/claude
+    // in this unit test (keeps it hermetic + fast on any host).
+    vi.doMock("../runtime/capabilities/claude-code-tui.js", () => ({
+      probeClaudeCodeTuiCapability: vi.fn().mockRejectedValue("tui probe failed"),
+    }));
     const mod = await import("../runtime/capabilities/index.js");
 
     const caps = await mod.probeCapabilities();
@@ -373,9 +519,17 @@ describe("probeCapabilities (aggregator)", () => {
       authMethod: "none",
       error: "codex probe failed",
     });
+    expect(caps["claude-code-tui"]).toMatchObject({
+      state: "error",
+      available: false,
+      authenticated: false,
+      authMethod: "none",
+      error: "tui probe failed",
+    });
 
     vi.doUnmock("../runtime/capabilities/claude-code.js");
     vi.doUnmock("../runtime/capabilities/codex.js");
+    vi.doUnmock("../runtime/capabilities/claude-code-tui.js");
     vi.resetModules();
   });
 });

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -351,6 +351,22 @@ describe("probeClaudeCodeTuiCapability", () => {
     expect(entry.error).toContain("`claude` not found");
   });
 
+  it("`missing` when claude resolves but cannot be executed (`claude --version` fails)", async () => {
+    // existsSync passed (resolveExecutable found a path) but the binary is
+    // broken / non-executable, so probeClaudeVersion returns null. Must NOT
+    // report `ok` — the runtime could not actually spawn the CLI.
+    const entry = await probeClaudeCodeTuiCapability({
+      resolveExecutable: onPath,
+      probeTmux: tmux34,
+      probeClaudeVersion: () => null,
+      detectAuth: authed,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.available).toBe(false);
+    expect(entry.error).toContain("could not be executed");
+    expect(entry.sdkVersion).toBeNull();
+  });
+
   it("`missing` when tmux is absent", async () => {
     const entry = await probeClaudeCodeTuiCapability({
       resolveExecutable: onPath,

--- a/packages/client/src/runtime/capabilities/claude-code-tui.ts
+++ b/packages/client/src/runtime/capabilities/claude-code-tui.ts
@@ -79,17 +79,24 @@ export type ClaudeCodeTuiProbeDeps = {
  *
  * Unlike `claude-code` (which can fall back to the SDK's bundled native binary),
  * the TUI runtime spawns the real `claude` CLI inside a tmux pane — so it needs
- * BOTH a resolvable `claude` executable (env override or PATH; the SDK bundle's
- * `source: "default"` does not count) AND tmux >= 3.0. Auth is the same Claude
- * login the SDK path uses, so it reuses the shared detector.
+ * BOTH a resolvable AND runnable `claude` executable (env override or PATH; the
+ * SDK bundle's `source: "default"` does not count) AND tmux >= 3.0. Auth is the
+ * same Claude login the SDK path uses, so it reuses the shared detector.
+ *
+ * "Runnable" matters: `resolveClaudeCodeExecutable` only does `existsSync`, so a
+ * present-but-broken binary (non-executable, wrong arch, or a
+ * `CLAUDE_CODE_EXECUTABLE` pointing at a dud) still resolves. We require a
+ * successful `claude --version` — if it cannot be executed the runtime would
+ * fail to spawn at session time, so we report `missing` here rather than let the
+ * server gate bind a machine that cannot actually run the CLI.
  *
  * `sdkVersion` carries the `claude` CLI version (the runtime engine), matching
  * how `claude-code` reports the SDK version — the web surface renders it as the
  * runtime version. tmux is infrastructure, so its version only surfaces in the
  * failure `error` reason when it is missing or too old.
  *
- * State precedence: missing (no claude / no tmux / tmux too old) > unauthenticated
- * (runtime present, not logged in) > ok.
+ * State precedence: missing (claude absent/not runnable / no tmux / tmux too old)
+ * > unauthenticated (runtime present, not logged in) > ok.
  */
 export async function probeClaudeCodeTuiCapability(deps: ClaudeCodeTuiProbeDeps = {}): Promise<CapabilityEntry> {
   const detectedAt = new Date().toISOString();
@@ -103,34 +110,40 @@ export async function probeClaudeCodeTuiCapability(deps: ClaudeCodeTuiProbeDeps 
     // `source: "default"` means no real binary was found — the SDK bundle is
     // not usable by the tmux runtime, so treat it as missing.
     const claudeBinary = resolution.source === "default" ? undefined : resolution.path;
+    // existsSync is not enough — confirm the binary actually runs. A null here
+    // (absent / non-executable / non-zero `--version`) means the CLI cannot be
+    // spawned, so it fails the gate rather than reporting a false-positive `ok`.
+    const claudeVersion = claudeBinary ? probeClaudeVersion(claudeBinary) : null;
+    const claudeRunnable = claudeBinary !== undefined && claudeVersion !== null;
 
     const tmux = probeTmux();
     const tmuxOk = tmux !== null && tmuxMeetsMinimum(tmux);
 
-    if (!claudeBinary || !tmuxOk) {
+    if (!claudeRunnable || !tmuxOk) {
       const reasons: string[] = [];
       if (!claudeBinary) reasons.push("`claude` not found on PATH (and CLAUDE_CODE_EXECUTABLE unset)");
+      else if (claudeVersion === null)
+        reasons.push(`\`claude\` at ${claudeBinary} could not be executed (\`claude --version\` failed)`);
       if (tmux === null) reasons.push("tmux not found");
       else if (!tmuxOk) reasons.push(`tmux ${tmux.raw} is older than ${MIN_TMUX_MAJOR}.${MIN_TMUX_MINOR}`);
       return {
         state: "missing",
         available: false,
         authenticated: false,
-        sdkVersion: claudeBinary ? probeClaudeVersion(claudeBinary) : null,
+        sdkVersion: claudeVersion,
         authMethod: "none",
         error: reasons.join("; "),
         detectedAt,
       };
     }
 
-    const sdkVersion = probeClaudeVersion(claudeBinary);
     const auth = detectAuth();
     if (!auth.authenticated) {
       return {
         state: "unauthenticated",
         available: true,
         authenticated: false,
-        sdkVersion,
+        sdkVersion: claudeVersion,
         authMethod: "none",
         detectedAt,
       };
@@ -140,7 +153,7 @@ export async function probeClaudeCodeTuiCapability(deps: ClaudeCodeTuiProbeDeps 
       state: "ok",
       available: true,
       authenticated: true,
-      sdkVersion,
+      sdkVersion: claudeVersion,
       authMethod: auth.method,
       detectedAt,
     };

--- a/packages/client/src/runtime/capabilities/claude-code-tui.ts
+++ b/packages/client/src/runtime/capabilities/claude-code-tui.ts
@@ -1,0 +1,158 @@
+import { spawnSync } from "node:child_process";
+import type { CapabilityEntry } from "@first-tree/shared";
+import { type ClaudeExecutableResolution, resolveClaudeCodeExecutable } from "../../handlers/claude-executable.js";
+import { detectClaudeAuth } from "./claude-shared.js";
+
+/**
+ * Minimum tmux version the TUI runtime requires. 3.0 is the first release with
+ * the stable `-f /dev/null` + `set-hook` + `capture-pane -p -S -` behaviour the
+ * handler relies on (PR3). Older tmux silently differs on hook firing and
+ * scrollback capture, so we gate at probe time rather than fail mid-session.
+ */
+export const MIN_TMUX_MAJOR = 3;
+export const MIN_TMUX_MINOR = 0;
+
+type TmuxVersion = { raw: string; major: number; minor: number };
+
+/**
+ * Parse `tmux -V` output. Accepts the common shapes:
+ *   "tmux 3.4"        → {3, 4}
+ *   "tmux 3.2a"       → {3, 2}   (letter suffix on patch releases)
+ *   "tmux next-3.5"   → {3, 5}   (pre-release builds)
+ * Returns null when no `<major>.<minor>` pair can be found.
+ */
+export function parseTmuxVersion(output: string): TmuxVersion | null {
+  const match = output.match(/(\d+)\.(\d+)/);
+  if (!match || match[1] === undefined || match[2] === undefined) return null;
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  if (Number.isNaN(major) || Number.isNaN(minor)) return null;
+  return { raw: output.trim(), major, minor };
+}
+
+function tmuxMeetsMinimum(v: TmuxVersion): boolean {
+  if (v.major !== MIN_TMUX_MAJOR) return v.major > MIN_TMUX_MAJOR;
+  return v.minor >= MIN_TMUX_MINOR;
+}
+
+/** Real `tmux -V` probe. Returns null when tmux is absent or unreadable. */
+function defaultProbeTmux(): TmuxVersion | null {
+  try {
+    const res = spawnSync("tmux", ["-V"], { encoding: "utf-8", timeout: 5000 });
+    if (res.error || res.status !== 0 || typeof res.stdout !== "string") return null;
+    return parseTmuxVersion(res.stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Real `claude --version` probe. Returns the version string (e.g. "1.0.42") or
+ * null when the binary is absent / unreadable / prints no recognizable version.
+ * Output shapes vary ("1.0.42 (Claude Code)", "claude 1.0.42"), so we extract
+ * the first dotted-number triplet/pair.
+ */
+function defaultProbeClaudeVersion(binary: string): string | null {
+  try {
+    const res = spawnSync(binary, ["--version"], { encoding: "utf-8", timeout: 5000 });
+    if (res.error || res.status !== 0 || typeof res.stdout !== "string") return null;
+    const match = res.stdout.match(/\d+\.\d+(?:\.\d+)?/);
+    return match ? match[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Injectable seams so the probe is deterministic under test without spawning a
+ * real tmux/claude or touching the developer's PATH (mirrors `resolveClaudeCodeExecutable`).
+ */
+export type ClaudeCodeTuiProbeDeps = {
+  resolveExecutable?: (opts?: { env?: NodeJS.ProcessEnv }) => ClaudeExecutableResolution;
+  probeTmux?: () => TmuxVersion | null;
+  probeClaudeVersion?: (binary: string) => string | null;
+  detectAuth?: () => { authenticated: boolean; method: "api_key" | "oauth" | "none" };
+};
+
+/**
+ * Probe whether the `claude-code-tui` runtime is usable on this machine.
+ *
+ * Unlike `claude-code` (which can fall back to the SDK's bundled native binary),
+ * the TUI runtime spawns the real `claude` CLI inside a tmux pane — so it needs
+ * BOTH a resolvable `claude` executable (env override or PATH; the SDK bundle's
+ * `source: "default"` does not count) AND tmux >= 3.0. Auth is the same Claude
+ * login the SDK path uses, so it reuses the shared detector.
+ *
+ * `sdkVersion` carries the `claude` CLI version (the runtime engine), matching
+ * how `claude-code` reports the SDK version — the web surface renders it as the
+ * runtime version. tmux is infrastructure, so its version only surfaces in the
+ * failure `error` reason when it is missing or too old.
+ *
+ * State precedence: missing (no claude / no tmux / tmux too old) > unauthenticated
+ * (runtime present, not logged in) > ok.
+ */
+export async function probeClaudeCodeTuiCapability(deps: ClaudeCodeTuiProbeDeps = {}): Promise<CapabilityEntry> {
+  const detectedAt = new Date().toISOString();
+  const resolveExecutable = deps.resolveExecutable ?? resolveClaudeCodeExecutable;
+  const probeTmux = deps.probeTmux ?? defaultProbeTmux;
+  const probeClaudeVersion = deps.probeClaudeVersion ?? defaultProbeClaudeVersion;
+  const detectAuth = deps.detectAuth ?? detectClaudeAuth;
+
+  try {
+    const resolution = resolveExecutable();
+    // `source: "default"` means no real binary was found — the SDK bundle is
+    // not usable by the tmux runtime, so treat it as missing.
+    const claudeBinary = resolution.source === "default" ? undefined : resolution.path;
+
+    const tmux = probeTmux();
+    const tmuxOk = tmux !== null && tmuxMeetsMinimum(tmux);
+
+    if (!claudeBinary || !tmuxOk) {
+      const reasons: string[] = [];
+      if (!claudeBinary) reasons.push("`claude` not found on PATH (and CLAUDE_CODE_EXECUTABLE unset)");
+      if (tmux === null) reasons.push("tmux not found");
+      else if (!tmuxOk) reasons.push(`tmux ${tmux.raw} is older than ${MIN_TMUX_MAJOR}.${MIN_TMUX_MINOR}`);
+      return {
+        state: "missing",
+        available: false,
+        authenticated: false,
+        sdkVersion: claudeBinary ? probeClaudeVersion(claudeBinary) : null,
+        authMethod: "none",
+        error: reasons.join("; "),
+        detectedAt,
+      };
+    }
+
+    const sdkVersion = probeClaudeVersion(claudeBinary);
+    const auth = detectAuth();
+    if (!auth.authenticated) {
+      return {
+        state: "unauthenticated",
+        available: true,
+        authenticated: false,
+        sdkVersion,
+        authMethod: "none",
+        detectedAt,
+      };
+    }
+
+    return {
+      state: "ok",
+      available: true,
+      authenticated: true,
+      sdkVersion,
+      authMethod: auth.method,
+      detectedAt,
+    };
+  } catch (err) {
+    return {
+      state: "error",
+      available: false,
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      error: err instanceof Error ? err.message : String(err),
+      detectedAt,
+    };
+  }
+}

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -1,29 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CapabilityEntry } from "@first-tree/shared";
-
-/**
- * Top-level marker file Claude Code writes after a successful OAuth login.
- * Path is platform-agnostic (`~/.claude.json`); the access token itself lives
- * in the platform credential store (macOS Keychain entry "Claude Code-
- * credentials", or libsecret on Linux), so we treat the presence of an
- * `oauthAccount.accountUuid` field as the canonical "logged in" signal.
- */
-const CLAUDE_PROFILE_PATH = () => join(homedir(), ".claude.json");
-
-function hasClaudeOAuthAccount(): boolean {
-  try {
-    const path = CLAUDE_PROFILE_PATH();
-    if (!existsSync(path)) return false;
-    const raw = readFileSync(path, "utf-8");
-    const obj = JSON.parse(raw) as { oauthAccount?: { accountUuid?: unknown } };
-    return typeof obj.oauthAccount?.accountUuid === "string" && obj.oauthAccount.accountUuid.length > 0;
-  } catch {
-    return false;
-  }
-}
+import { detectClaudeAuth } from "./claude-shared.js";
 
 async function readSdkVersion(): Promise<string | null> {
   // The Anthropic SDK does not expose `./package.json` via `exports` and only
@@ -46,16 +25,6 @@ async function readSdkVersion(): Promise<string | null> {
     // fall through
   }
   return null;
-}
-
-function detectAuth(): { authenticated: boolean; method: "api_key" | "oauth" | "none" } {
-  if (process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.length > 0) {
-    return { authenticated: true, method: "api_key" };
-  }
-  if (hasClaudeOAuthAccount()) {
-    return { authenticated: true, method: "oauth" };
-  }
-  return { authenticated: false, method: "none" };
 }
 
 /**
@@ -88,7 +57,7 @@ export async function probeClaudeCodeCapability(): Promise<CapabilityEntry> {
     }
 
     const sdkVersion = await readSdkVersion();
-    const auth = detectAuth();
+    const auth = detectClaudeAuth();
     if (!auth.authenticated) {
       return {
         state: "unauthenticated",

--- a/packages/client/src/runtime/capabilities/claude-shared.ts
+++ b/packages/client/src/runtime/capabilities/claude-shared.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Auth detection shared by every probe that drives the `claude` CLI —
+ * currently `claude-code` (SDK) and `claude-code-tui` (tmux). Both authenticate
+ * the exact same way (there is only one Claude login on a machine), so the
+ * detection lives here instead of being duplicated per probe.
+ */
+export type ClaudeAuthMethod = "api_key" | "oauth" | "none";
+
+/**
+ * Top-level marker file Claude Code writes after a successful OAuth login.
+ * Path is platform-agnostic (`~/.claude.json`); the access token itself lives
+ * in the platform credential store (macOS Keychain entry "Claude Code-
+ * credentials", or libsecret on Linux), so we treat the presence of an
+ * `oauthAccount.accountUuid` field as the canonical "logged in" signal.
+ */
+const claudeProfilePath = (): string => join(homedir(), ".claude.json");
+
+export function hasClaudeOAuthAccount(): boolean {
+  try {
+    const path = claudeProfilePath();
+    if (!existsSync(path)) return false;
+    const raw = readFileSync(path, "utf-8");
+    const obj = JSON.parse(raw) as { oauthAccount?: { accountUuid?: unknown } };
+    return typeof obj.oauthAccount?.accountUuid === "string" && obj.oauthAccount.accountUuid.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the Claude auth state from the environment + OAuth marker file.
+ *
+ * `ANTHROPIC_API_KEY` takes precedence over the OAuth marker — an explicit key
+ * overrides whatever login the local CLI happens to have cached.
+ */
+export function detectClaudeAuth(): { authenticated: boolean; method: ClaudeAuthMethod } {
+  if (process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_API_KEY.length > 0) {
+    return { authenticated: true, method: "api_key" };
+  }
+  if (hasClaudeOAuthAccount()) {
+    return { authenticated: true, method: "oauth" };
+  }
+  return { authenticated: false, method: "none" };
+}

--- a/packages/client/src/runtime/capabilities/index.ts
+++ b/packages/client/src/runtime/capabilities/index.ts
@@ -1,5 +1,6 @@
 import type { ClientCapabilities, RuntimeProvider } from "@first-tree/shared";
 import { probeClaudeCodeCapability } from "./claude-code.js";
+import { probeClaudeCodeTuiCapability } from "./claude-code-tui.js";
 import { probeCodexCapability } from "./codex.js";
 
 /**
@@ -15,6 +16,7 @@ import { probeCodexCapability } from "./codex.js";
 export async function probeCapabilities(): Promise<ClientCapabilities> {
   const probes: Array<readonly [RuntimeProvider, ReturnType<typeof probeClaudeCodeCapability>]> = [
     ["claude-code", probeClaudeCodeCapability()],
+    ["claude-code-tui", probeClaudeCodeTuiCapability()],
     ["codex", probeCodexCapability()],
   ];
 


### PR DESCRIPTION
## PR2 of the claude-code-tui slice series — client capability probe

**Stacked on #678** (base = `feat/runtime-provider-claude-code-tui`) so it carries the `claude-code-tui` enum/schema. Rebase onto `main` once #678 merges.

### Scope (client only)
No `shared` / `web` / `server` changes — purely the on-machine capability probe the runtime gate uses to decide whether a `claude-code-tui` agent can bind.

| File | Change |
|---|---|
| `capabilities/claude-shared.ts` *(new)* | Extracted `detectClaudeAuth()` + `hasClaudeOAuthAccount()`. `claude-code` and `claude-code-tui` drive the same `claude` CLI and share one machine login, so auth detection is shared, not duplicated per probe. |
| `capabilities/claude-code.ts` | Refactored to import from claude-shared — behavior unchanged (existing probe tests still green). |
| `capabilities/claude-code-tui.ts` *(new)* | `probeClaudeCodeTuiCapability()`. |
| `capabilities/index.ts` | Registered in the aggregator. |
| `__tests__/capability-probes.test.ts` | +18 tests. |

### Why the TUI gate differs from claude-code
`claude-code` can fall back to the SDK's bundled native binary, so its probe only checks the SDK import + auth. The TUI runtime instead spawns the **real `claude` CLI inside a tmux pane**, so it requires BOTH:
- a resolvable `claude` executable — `CLAUDE_CODE_EXECUTABLE` or `claude` on PATH. The SDK bundle's `source: "default"` does **not** count.
- `tmux >= 3.0` — the first release with the stable `set-hook` + `capture-pane -p -S -` behaviour the PR3 handler relies on.

State precedence: `missing` (no claude / no tmux / tmux too old) > `unauthenticated` (runtime present, not logged in) > `ok`.

### Design notes
- **`sdkVersion` carries the `claude` CLI version** (the runtime engine), matching how `claude-code` reports the SDK version — the web surface renders it as the runtime version. tmux is infrastructure, so its version only surfaces in the failure `error` reason.
- **DI seams** (`resolveExecutable` / `probeTmux` / `probeClaudeVersion` / `detectAuth`) keep the probe hermetic under test — no real tmux/claude spawn, deterministic on any host.
- **Probe ships ahead of the handler (PR3).** Reporting a `claude-code-tui` capability never instantiates a handler (capability detection is decoupled from `HandlerFactory` by design), so the server gate can correctly report "this machine could run it" before the handler lands.

### Verification
- typecheck 13/13 · biome clean · `capability-probes` 32/32 · full client suite 953 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
