### PR TITLE
feat(web,server): Team page Phase 2 (lightweight) — last-active, self-edit profile, leaner chips, collapsible groups

### DIFF
--- a/packages/server/src/__tests__/me-profile.test.ts
+++ b/packages/server/src/__tests__/me-profile.test.ts
@@ -69,6 +69,18 @@ describe("PATCH /me/profile", () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  it("rejects a whitespace-only display name (trim → empty)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `me-prof-ws-${Date.now()}` });
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/profile",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { displayName: "   " },
+    });
+    expect(res.statusCode).toBe(400);
+  });
 });
 
 describe("member lastActiveAt (derived from most recent message)", () => {

--- a/packages/server/src/__tests__/me-profile.test.ts
+++ b/packages/server/src/__tests__/me-profile.test.ts
@@ -1,0 +1,109 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { chats } from "../db/schema/chats.js";
+import { messages } from "../db/schema/messages.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Phase 2 lightweight Team features:
+ *   - `PATCH /me/profile` self-service display-name edit (role is never editable).
+ *   - Member `lastActiveAt` derived from the most recent message (口径 B), no column.
+ */
+describe("PATCH /me/profile", () => {
+  const getApp = useTestApp();
+
+  const listMembers = (app: FastifyInstance, admin: { organizationId: string; accessToken: string }) =>
+    app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/members`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+  it("lets the caller rename themselves (mirrored to the member list)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `me-prof-${Date.now()}` });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/profile",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { displayName: "Renamed Self" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ displayName: string }>().displayName).toBe("Renamed Self");
+
+    const me = (await listMembers(app, admin))
+      .json<Array<{ id: string; displayName: string }>>()
+      .find((m) => m.id === admin.memberId);
+    expect(me?.displayName).toBe("Renamed Self");
+  });
+
+  it("ignores a `role` field — self-edit can never change the caller's role", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `me-prof-role-${Date.now()}` });
+
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/profile",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      // role is not part of updateMyProfileSchema — zod strips it; the row stays admin.
+      payload: { displayName: "Still Admin", role: "member" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const me = (await listMembers(app, admin))
+      .json<Array<{ id: string; role: string }>>()
+      .find((m) => m.id === admin.memberId);
+    expect(me?.role).toBe("admin");
+  });
+
+  it("rejects an empty display name", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `me-prof-empty-${Date.now()}` });
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/me/profile",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { displayName: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("member lastActiveAt (derived from most recent message)", () => {
+  const getApp = useTestApp();
+
+  it("is null before any message and set after the member's agent sends one", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `me-active-${Date.now()}` });
+    const list = () =>
+      app.inject({
+        method: "GET",
+        url: `/api/v1/orgs/${admin.organizationId}/members`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+    const before = (await list())
+      .json<Array<{ id: string; lastActiveAt: string | null }>>()
+      .find((m) => m.id === admin.memberId);
+    expect(before?.lastActiveAt).toBeNull();
+
+    // Seed a chat + a message authored by this member's human agent.
+    const chatId = uuidv7();
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(messages).values({
+      id: uuidv7(),
+      chatId,
+      senderId: admin.humanAgentUuid,
+      format: "text",
+      content: "hello team",
+      source: "web",
+    });
+
+    const after = (await list())
+      .json<Array<{ id: string; lastActiveAt: string | null }>>()
+      .find((m) => m.id === admin.memberId);
+    expect(after?.lastActiveAt).not.toBeNull();
+  });
+});

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -4,6 +4,7 @@ import {
   type OnboardingStep,
   onboardingEventSchema,
   patchOnboardingSchema,
+  updateMyProfileSchema,
 } from "@first-tree/shared";
 import { getChannelConfig } from "@first-tree/shared/channel";
 import { and, eq, isNull, ne } from "drizzle-orm";
@@ -23,6 +24,7 @@ import { decryptValue, encryptValue } from "../services/crypto.js";
 import { GithubAppApiError, refreshAppUserToken } from "../services/github-app.js";
 import { GithubApiError, listUserRepos } from "../services/github-oauth.js";
 import { buildInviteUrl, findActiveByToken, getActiveInvitation, recordRedemption } from "../services/invitation.js";
+import { updateOwnProfile } from "../services/member.js";
 import {
   countActiveMembersByOrgs,
   ensureMembership,
@@ -109,6 +111,19 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       },
       inviteUrl,
     };
+  });
+
+  /**
+   * PATCH /me/profile — self-service display-name edit. The caller can rename
+   * themselves (mirrored to `users.display_name` + every human agent backing
+   * their memberships) but cannot change their own role: the schema has no
+   * `role` field, so self-promotion is impossible by construction. Admin role
+   * changes still go through `PATCH /orgs/:orgId/members/:id`.
+   */
+  app.patch("/me/profile", async (request) => {
+    const { userId } = requireUser(request);
+    const { displayName } = updateMyProfileSchema.parse(request.body);
+    return updateOwnProfile(app.db, userId, displayName);
   });
 
   /**

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -62,6 +62,7 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
         runtimeType: a.runtimeType ?? null,
         runtimeState: a.runtimeState ?? null,
         activeSessions: a.activeSessions ?? null,
+        lastSeenAt: a.lastSeenAt?.toISOString() ?? null,
         avatarImageUrl: resolveAvatarImageUrl({
           uuid: a.uuid,
           type: a.type,
@@ -96,6 +97,7 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
         runtimeType: a.runtimeType ?? null,
         runtimeState: a.runtimeState ?? null,
         activeSessions: a.activeSessions ?? null,
+        lastSeenAt: a.lastSeenAt?.toISOString() ?? null,
         avatarImageUrl: resolveAvatarImageUrl({
           uuid: a.uuid,
           type: a.type,

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -651,6 +651,7 @@ export async function listAgents(db: Database, orgId: string, limit: number, cur
       runtimeType: agentPresence.runtimeType,
       runtimeState: agentPresence.runtimeState,
       activeSessions: agentPresence.activeSessions,
+      lastSeenAt: agentPresence.lastSeenAt,
     })
     .from(agents)
     .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
@@ -705,6 +706,7 @@ export async function listAgentsForAdmin(db: Database, scope: OrgScope, limit: n
       runtimeType: agentPresence.runtimeType,
       runtimeState: agentPresence.runtimeState,
       activeSessions: agentPresence.activeSessions,
+      lastSeenAt: agentPresence.lastSeenAt,
     })
     .from(agents)
     .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))
@@ -801,6 +803,7 @@ export async function listAgentsForMember(
       runtimeType: agentPresence.runtimeType,
       runtimeState: agentPresence.runtimeState,
       activeSessions: agentPresence.activeSessions,
+      lastSeenAt: agentPresence.lastSeenAt,
     })
     .from(agents)
     .leftJoin(agentPresence, eq(agents.uuid, agentPresence.agentId))

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -1,16 +1,41 @@
 import { randomBytes } from "node:crypto";
 import type { CreateMember, UpdateMember } from "@first-tree/shared";
 import bcrypt from "bcrypt";
-import { and, desc, eq, ne } from "drizzle-orm";
+import { and, desc, eq, inArray, max, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
+import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { createAgent } from "./agent.js";
 
 const SALT_ROUNDS = 10;
+
+/**
+ * Derive each member's "last active" timestamp from the most recent message
+ * sent by their human agent — `MAX(messages.created_at)` grouped by sender.
+ * Intentionally column-free (no `users.last_active_at`); this is口径 B
+ * ("most recent message"). Returns a Map keyed by agentId → ISO string.
+ *
+ * Cost note: `messages` has no `sender_id` index, so this is a grouped scan.
+ * Acceptable for the occasionally-loaded member list at current scale; a
+ * `(sender_id, created_at)` index would be the lever if it ever gets hot.
+ */
+async function lastActiveByAgent(db: Database, agentIds: string[]): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  if (agentIds.length === 0) return result;
+  const rows = await db
+    .select({ senderId: messages.senderId, last: max(messages.createdAt) })
+    .from(messages)
+    .where(inArray(messages.senderId, agentIds))
+    .groupBy(messages.senderId);
+  for (const r of rows) {
+    if (r.last) result.set(r.senderId, r.last.toISOString());
+  }
+  return result;
+}
 
 /**
  * Create a member in an organization.
@@ -84,6 +109,8 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
       agentId: member.agentId,
       role: member.role,
       createdAt: member.createdAt.toISOString(),
+      // Freshly created — no messages yet, so no derived activity.
+      lastActiveAt: null,
       username: data.username,
       displayName: data.displayName,
       // Only return password for new users
@@ -109,9 +136,14 @@ export async function listMembers(db: Database, orgId: string) {
     .where(eq(members.organizationId, orgId))
     .orderBy(desc(members.createdAt));
 
+  const lastActive = await lastActiveByAgent(
+    db,
+    rows.map((r) => r.agentId),
+  );
   return rows.map((r) => ({
     ...r,
     createdAt: r.createdAt.toISOString(),
+    lastActiveAt: lastActive.get(r.agentId) ?? null,
   }));
 }
 
@@ -133,7 +165,8 @@ export async function getMember(db: Database, id: string) {
     .limit(1);
 
   if (!row) throw new NotFoundError(`Member "${id}" not found`);
-  return { ...row, createdAt: row.createdAt.toISOString() };
+  const lastActive = await lastActiveByAgent(db, [row.agentId]);
+  return { ...row, createdAt: row.createdAt.toISOString(), lastActiveAt: lastActive.get(row.agentId) ?? null };
 }
 
 export async function updateMember(db: Database, id: string, data: UpdateMember, callerOrgId?: string) {
@@ -171,6 +204,24 @@ export async function updateMember(db: Database, id: string, data: UpdateMember,
   });
 
   return getMember(db, id);
+}
+
+/**
+ * Self-service display-name edit. Updates the authoritative `users.display_name`
+ * and mirrors it onto every human agent backing this user's memberships (the
+ * member list + agent-detail views both read from these, so they must not
+ * drift). Role is never touched here — self-promotion is impossible by
+ * construction. Returns the updated `{ id, displayName }`.
+ */
+export async function updateOwnProfile(db: Database, userId: string, displayName: string) {
+  await db.transaction(async (tx) => {
+    await tx.update(users).set({ displayName }).where(eq(users.id, userId));
+    const memberRows = await tx.select({ agentId: members.agentId }).from(members).where(eq(members.userId, userId));
+    for (const m of memberRows) {
+      await tx.update(agents).set({ displayName }).where(eq(agents.uuid, m.agentId));
+    }
+  });
+  return { id: userId, displayName };
 }
 
 export async function deleteMember(db: Database, id: string) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -443,7 +443,9 @@ export {
   memberRoleSchema,
   memberSchema,
   type UpdateMember,
+  type UpdateMyProfile,
   updateMemberSchema,
+  updateMyProfileSchema,
 } from "./schemas/member.js";
 export {
   type ClientMessage,

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -242,6 +242,13 @@ export const agentSchema = z.object({
   avatarImageUrl: z.string().nullable(),
   presenceStatus: presenceStatusSchema.optional(),
   /**
+   * ISO timestamp of the agent's last presence heartbeat
+   * (`agent_presence.last_seen_at`). Drives the "active X ago" hover on the
+   * Team page status cell. Absent on single-agent reads that don't join
+   * presence; null when the agent has never connected.
+   */
+  lastSeenAt: z.string().nullable().optional(),
+  /**
    * Runtime-A business state from `agent_presence.runtime_state` (the M1+
    * authority for "is this agent running"; NULL when not bound). Carried on
    * single-agent reads + mutations so management surfaces can derive

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -45,7 +45,10 @@ export type UpdateMember = z.infer<typeof updateMemberSchema>;
  * route `PATCH /orgs/:orgId/members/:id` remains the only way to change roles.
  */
 export const updateMyProfileSchema = z.object({
-  displayName: z.string().min(1).max(200),
+  // `.trim()` runs before `.min(1)`, so a whitespace-only name collapses to ""
+  // and is rejected — a direct API caller can't write a blank display name
+  // (the web dialog already trims, this closes the server-side hole).
+  displayName: z.string().trim().min(1).max(200),
 });
 export type UpdateMyProfile = z.infer<typeof updateMyProfileSchema>;
 

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -15,6 +15,12 @@ export const memberSchema = z.object({
   agentId: z.string(),
   role: memberRoleSchema,
   createdAt: z.string(),
+  /**
+   * ISO timestamp the member was last active, *derived* from the most recent
+   * message sent by their human agent (no dedicated column — read-time
+   * `MAX(messages.created_at)`). Null when they've never sent a message.
+   */
+  lastActiveAt: z.string().nullable(),
 });
 export type Member = z.infer<typeof memberSchema>;
 
@@ -32,6 +38,16 @@ export const updateMemberSchema = z.object({
   displayName: z.string().min(1).max(200).optional(),
 });
 export type UpdateMember = z.infer<typeof updateMemberSchema>;
+
+/**
+ * Self-service profile edit (`PATCH /me/profile`). `role` is intentionally
+ * absent: a member can rename themselves but cannot self-promote. The admin
+ * route `PATCH /orgs/:orgId/members/:id` remains the only way to change roles.
+ */
+export const updateMyProfileSchema = z.object({
+  displayName: z.string().min(1).max(200),
+});
+export type UpdateMyProfile = z.infer<typeof updateMyProfileSchema>;
 
 /** Response when creating a member — includes the one-time plaintext password. */
 export const memberCreatedSchema = memberSchema.extend({

--- a/packages/web/src/api/members.ts
+++ b/packages/web/src/api/members.ts
@@ -1,4 +1,4 @@
-import type { UpdateMember } from "@first-tree/shared";
+import type { UpdateMember, UpdateMyProfile } from "@first-tree/shared";
 import { api, withOrg } from "./client.js";
 
 type MemberListItem = {
@@ -10,6 +10,8 @@ type MemberListItem = {
   createdAt: string;
   username: string;
   displayName: string;
+  /** Derived from the member's most recent message (口径 B); null = never active. */
+  lastActiveAt: string | null;
 };
 
 export function listMembers(): Promise<MemberListItem[]> {
@@ -22,4 +24,13 @@ export function updateMember(id: string, data: UpdateMember): Promise<MemberList
 
 export function deleteMember(id: string): Promise<void> {
   return api.delete<void>(withOrg(`/members/${encodeURIComponent(id)}`));
+}
+
+/**
+ * Self-service profile edit (`PATCH /me/profile`) — user-scoped, NOT org-scoped
+ * (no `withOrg`). The caller can rename themselves; the server has no `role`
+ * field on this route, so it can never change the caller's own role.
+ */
+export function updateMyProfile(data: UpdateMyProfile): Promise<{ id: string; displayName: string }> {
+  return api.patch<{ id: string; displayName: string }>("/me/profile", data);
 }

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -41,6 +41,7 @@ const member = (id: string, agentId: string, displayName: string, role = "member
   displayName,
   role,
   createdAt: "2026-01-01T00:00:00.000Z",
+  lastActiveAt: null,
 });
 
 describe("fetchAllAgents", () => {
@@ -86,6 +87,22 @@ describe("buildTeamData", () => {
     expect(row.delegate).toEqual({ uuid: "assistant-1", name: "ada-helper", displayName: "Ada Assistant" });
     // Only the user themselves can edit their own delegate (admins cannot).
     expect(row.canEditDelegate).toBe(true);
+  });
+
+  it("derives lastActiveLabel from member.lastActiveAt (null → no label)", () => {
+    const { humans } = buildTeamData({
+      ...base,
+      members: [
+        { ...member("member-1", "human-1", "Active"), lastActiveAt: "2026-05-01T00:00:00.000Z" },
+        { ...member("member-2", "human-2", "Never"), lastActiveAt: null },
+      ],
+      agents: [],
+      agentByUuid: new Map(),
+    });
+    const active = humans.find((h) => h.id === "member-1");
+    const never = humans.find((h) => h.id === "member-2");
+    expect(active?.lastActiveLabel).toBeTruthy();
+    expect(never?.lastActiveLabel).toBeNull();
   });
 
   it("partitions agents into Public/Private with own agents pinned first", () => {

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -90,7 +90,7 @@ export async function fetchAllAgents(
 }
 
 export function TeamPage() {
-  const { role, memberId } = useAuth();
+  const { role, memberId, refreshMe } = useAuth();
   const isAdmin = role === "admin";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -162,7 +162,13 @@ export function TeamPage() {
   // agent's displayName changes too, so refresh agents alongside members.
   const updateMyProfileMut = useMutation({
     mutationFn: async (displayName: string) => updateMyProfile({ displayName }),
-    onSuccess: () => {
+    onSuccess: async () => {
+      // displayName has TWO visible sources of truth: the members/agents React
+      // Query caches AND the AuthProvider's own `/me` state (user-menu, etc.
+      // read useAuth().user.displayName, which is NOT in the query cache).
+      // Refresh both, else the top-right menu shows the old name until the next
+      // natural fetchMe.
+      await refreshMe();
       queryClient.invalidateQueries({ queryKey: ["members"] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -13,7 +13,7 @@ import {
   suspendAgent,
   updateAgent,
 } from "../../api/agents.js";
-import { deleteMember, listMembers, updateMember } from "../../api/members.js";
+import { deleteMember, listMembers, updateMember, updateMyProfile } from "../../api/members.js";
 import { getOrgUsageByAgent, type UsageWindow } from "../../api/usage.js";
 import { useAuth } from "../../auth/auth-context.js";
 import {
@@ -27,6 +27,7 @@ import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
+import { formatRelative } from "../../lib/utils.js";
 import { InviteLinkPanel } from "../invite-link-panel.js";
 import { type AgentRow, type HumanRow, type RowAction, TeamTable } from "./team-table.js";
 
@@ -52,6 +53,8 @@ type MemberListItem = {
   displayName: string;
   role: string;
   createdAt: string;
+  /** Derived from the member's most recent message; null = never active. */
+  lastActiveAt: string | null;
 };
 
 type MemberEditTarget = {
@@ -152,6 +155,17 @@ export function TeamPage() {
     mutationFn: async (vars: { id: string; patch: { displayName?: string; role?: "admin" | "member" } }) =>
       updateMember(vars.id, vars.patch),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["members"] }),
+  });
+  // Self-service display-name edit (PATCH /me/profile). Routed here instead of
+  // the admin member route so a non-admin can rename themselves; the server
+  // strips role, so this can never change the caller's own role. The human
+  // agent's displayName changes too, so refresh agents alongside members.
+  const updateMyProfileMut = useMutation({
+    mutationFn: async (displayName: string) => updateMyProfile({ displayName }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["members"] });
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
   });
   const deleteMemberMut = useMutation({
     mutationFn: deleteMember,
@@ -343,11 +357,19 @@ export function TeamPage() {
       <MemberDetailsDialog
         target={editTarget}
         isAdmin={isAdmin}
-        isSaving={updateMemberMut.isPending}
+        isSelf={editTarget !== null && editTarget.id === memberId}
+        isSaving={updateMemberMut.isPending || updateMyProfileMut.isPending}
         onClose={() => setEditTarget(null)}
         onSave={async (patch) => {
           if (!editTarget) return;
-          await updateMemberMut.mutateAsync({ id: editTarget.id, patch });
+          // Self renaming (no role change) goes through /me/profile so it works
+          // for non-admins; everything else (admin editing others, any role
+          // change) uses the admin member route.
+          if (editTarget.id === memberId && patch.role === undefined && patch.displayName !== undefined) {
+            await updateMyProfileMut.mutateAsync(patch.displayName);
+          } else {
+            await updateMemberMut.mutateAsync({ id: editTarget.id, patch });
+          }
           setEditTarget(null);
         }}
       />
@@ -480,8 +502,8 @@ export function buildTeamData(args: {
         delegate: resolveDelegate(m.agentId),
         // Per spec only the user themselves sets their own delegate (admins don't).
         canEditDelegate: isSelf,
-        // Phase 2 wires the real timestamp; null renders "—" for now.
-        lastActiveLabel: null,
+        // Derived from the member's most recent message (口径 B). Null → "—".
+        lastActiveLabel: m.lastActiveAt ? formatRelative(m.lastActiveAt) : null,
       };
     })
     // Pin (you) to the top of the Humans section.
@@ -502,19 +524,23 @@ export function selectDelegateCandidates(agents: Agent[], managerId: string | nu
 const roleValues = Object.values(MEMBER_ROLES);
 
 /**
- * Member profile dialog. Opened by the row "Details" action. Admins can edit
- * (display name + role); non-admins see a read-only profile for now. Self-edit
- * of one's own profile lands in Phase 2 via `PATCH /me/profile`.
+ * Member profile dialog. Opened by the row "Details" action.
+ *   - Admin: edit anyone's display name + role.
+ *   - Self (any role): edit own display name via `PATCH /me/profile`; the role
+ *     selector stays admin-only, so a member can never self-promote.
+ *   - Otherwise: read-only profile.
  */
 function MemberDetailsDialog({
   target,
   isAdmin,
+  isSelf,
   isSaving,
   onClose,
   onSave,
 }: {
   target: MemberEditTarget | null;
   isAdmin: boolean;
+  isSelf: boolean;
   isSaving: boolean;
   onClose: () => void;
   onSave: (patch: { displayName?: string; role?: "admin" | "member" }) => Promise<void>;
@@ -553,7 +579,8 @@ function MemberDetailsDialog({
   }
 
   const open = target !== null;
-  const readOnly = !isAdmin;
+  // Admins edit anyone; a member can edit their own name (role stays admin-only).
+  const readOnly = !isAdmin && !isSelf;
 
   return (
     <Dialog open={open} onOpenChange={(next) => (next ? undefined : onClose())}>

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -8,7 +8,7 @@ import { Popover } from "../../components/ui/popover.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../../components/ui/row-actions-menu.js";
 import { SegmentedControl } from "../../components/ui/segmented-control.js";
-import { formatCompactCount } from "../../lib/utils.js";
+import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 
 export type { RowAction };
 
@@ -84,6 +84,37 @@ const AGENT_MIDDLE_GRID = "minmax(0, 1.3fr) minmax(0, 1fr) minmax(calc(var(--sp-
 // Compact (<64rem): collapse to Name | Status | Actions; fold the rest into
 // the name cell's meta line, all actions into one always-visible kebab.
 const COMPACT_GRID = "minmax(0, 1fr) auto auto";
+
+/**
+ * Per-section collapse state, persisted to localStorage so a member's
+ * expand/collapse choices survive across visits (default: expanded — a missing
+ * key reads as not-collapsed). One key per section (`team.collapse.<id>`).
+ */
+function useCollapsed(storageKey: string): [boolean, () => void] {
+  const [collapsed, setCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(storageKey) === "1";
+  });
+  const toggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") window.localStorage.setItem(storageKey, next ? "1" : "0");
+      return next;
+    });
+  };
+  return [collapsed, toggle];
+}
+
+/** Disclosure caret for a collapsible section header — points down when open, right when collapsed. */
+function CollapseCaret({ collapsed }: { collapsed: boolean }) {
+  return (
+    <ChevronDown
+      className="h-3.5 w-3.5 shrink-0 transition-transform"
+      aria-hidden
+      style={{ color: "var(--fg-4)", transform: collapsed ? "rotate(-90deg)" : "none" }}
+    />
+  );
+}
 
 /** Collapse the multi-column layout below 64rem. matchMedia keeps lint clean. */
 function useIsCompact(): boolean {
@@ -182,8 +213,22 @@ function AgentSection(props: TeamTableProps & { compact: boolean }) {
         <AgentColumnHeader usageWindow={usageWindow} onUsageWindow={onUsageWindowChange} />
       )}
 
-      <AgentGroup icon={Bot} title="Public" rows={publicAgents} dimOwner={false} {...props} />
-      <AgentGroup icon={Lock} title="Private" rows={privateAgents} dimOwner={props.dimPrivateOwner} {...props} />
+      <AgentGroup
+        icon={Bot}
+        title="Public"
+        rows={publicAgents}
+        dimOwner={false}
+        collapseKey="team.collapse.agents.public"
+        {...props}
+      />
+      <AgentGroup
+        icon={Lock}
+        title="Private"
+        rows={privateAgents}
+        dimOwner={props.dimPrivateOwner}
+        collapseKey="team.collapse.agents.private"
+        {...props}
+      />
     </section>
   );
 }
@@ -312,22 +357,34 @@ function AgentGroup(
     title: string;
     rows: AgentRow[];
     dimOwner: boolean;
+    collapseKey: string;
   },
 ) {
-  const { icon: Icon, title, rows, searchActive } = props;
+  const { icon: Icon, title, rows, searchActive, collapseKey } = props;
+  const [collapsed, toggle] = useCollapsed(collapseKey);
   return (
     <div>
-      <div
-        className="flex items-center"
-        style={{ gap: "var(--sp-2)", padding: "var(--sp-3_5) var(--sp-2) var(--sp-1_5)" }}
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
+        style={{
+          gap: "var(--sp-2)",
+          padding: "var(--sp-3_5) var(--sp-2) var(--sp-1_5)",
+          border: 0,
+          background: "transparent",
+          cursor: "pointer",
+        }}
       >
+        <CollapseCaret collapsed={collapsed} />
         <Icon className="h-3.5 w-3.5" aria-hidden style={{ color: "var(--fg-4)" }} />
         <span className="text-eyebrow" style={{ color: "var(--fg-4)" }}>
           {title}
         </span>
         <DenseBadge tone="outline">{rows.length}</DenseBadge>
-      </div>
-      {rows.length === 0 ? (
+      </button>
+      {collapsed ? null : rows.length === 0 ? (
         <div className="text-caption" style={{ color: "var(--fg-4)", padding: "0 var(--sp-2) var(--sp-3)" }}>
           {searchActive ? "No agents match this search." : "No agents here."}
         </div>
@@ -403,7 +460,7 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
         <RunsOnCell provider={agent.runtimeProvider} host={clientHost} />
         <UsageCell usage={usage} loading={usageLoading} />
       </div>
-      <StatusCell status={runtimeStateToPresence(agent.runtimeState)} />
+      <StatusCell status={runtimeStateToPresence(agent.runtimeState)} lastSeenAt={agent.lastSeenAt} />
       <ActionsCell ariaLabel={`Actions for ${agent.displayName}`} menuActions={kebabActions} />
     </div>
   );
@@ -417,9 +474,10 @@ function OwnerCell({ managerLabel, isSelf, dim }: { managerLabel: string | null;
       </span>
     );
   }
+  // Name only — the Owner chip intentionally drops the avatar (the leftmost
+  // Name column keeps its avatar). Keeps the middle band lean.
   return (
-    <div className="flex items-center min-w-0" style={{ gap: "var(--sp-1_5)", opacity: dim ? 0.5 : 1 }}>
-      <Avatar name={managerLabel} seed={managerLabel} size={18} />
+    <div className="flex items-center min-w-0" style={{ opacity: dim ? 0.5 : 1 }}>
       {isSelf ? (
         <span className="text-body font-semibold truncate" style={{ color: "var(--fg)" }}>
           You
@@ -477,9 +535,12 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
 
 // Right-aligned within its track so it forms a tidy right-hand cluster with
 // the (also right-aligned) Usage column, clear of the columns on the left.
-function StatusCell({ status }: { status: PresenceStatus }) {
+// `lastSeenAt` (from agent_presence) surfaces an "active X ago" hover — free
+// signal, no extra storage.
+function StatusCell({ status, lastSeenAt }: { status: PresenceStatus; lastSeenAt?: string | null }) {
+  const title = lastSeenAt ? `Active ${formatRelative(lastSeenAt)}` : undefined;
   return (
-    <div style={{ justifySelf: "end" }}>
+    <div style={{ justifySelf: "end" }} title={title}>
       <PresenceChip status={status} />
     </div>
   );
@@ -491,9 +552,23 @@ function StatusCell({ status }: { status: PresenceStatus }) {
 
 function HumanSection(props: TeamTableProps & { compact: boolean }) {
   const { humans, compact, searchActive } = props;
+  const [collapsed, toggle] = useCollapsed("team.collapse.humans");
   return (
     <section style={{ marginTop: "var(--sp-6)" }}>
-      <div className="flex items-center" style={{ gap: "var(--sp-2)", padding: "var(--sp-5) var(--sp-1) var(--sp-3)" }}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
+        style={{
+          gap: "var(--sp-2)",
+          padding: "var(--sp-5) var(--sp-1) var(--sp-3)",
+          border: 0,
+          background: "transparent",
+          cursor: "pointer",
+        }}
+      >
+        <CollapseCaret collapsed={collapsed} />
         <User className="h-4 w-4" aria-hidden style={{ color: "var(--fg-3)" }} />
         <h2 className="text-title m-0" style={{ color: "var(--fg)" }}>
           Human teammates
@@ -501,16 +576,19 @@ function HumanSection(props: TeamTableProps & { compact: boolean }) {
         <span className="text-label" style={{ color: "var(--fg-4)" }}>
           {humans.length}
         </span>
-      </div>
+      </button>
 
-      {compact ? null : <HumanColumnHeader />}
-
-      {humans.length === 0 ? (
-        <div className="text-caption" style={{ color: "var(--fg-4)", padding: "0 var(--sp-2) var(--sp-3)" }}>
-          {searchActive ? "No humans match this search." : "No members yet."}
-        </div>
-      ) : (
-        humans.map((row) => <HumanRowView key={row.id} row={row} {...props} />)
+      {collapsed ? null : (
+        <>
+          {compact ? null : <HumanColumnHeader />}
+          {humans.length === 0 ? (
+            <div className="text-caption" style={{ color: "var(--fg-4)", padding: "0 var(--sp-2) var(--sp-3)" }}>
+              {searchActive ? "No humans match this search." : "No members yet."}
+            </div>
+          ) : (
+            humans.map((row) => <HumanRowView key={row.id} row={row} {...props} />)
+          )}
+        </>
       )}
     </section>
   );
@@ -684,9 +762,9 @@ function DelegateCell({
 }
 
 function DelegateChip({ delegate }: { delegate: { uuid: string; name: string | null; displayName: string } }) {
+  // Name only — the Delegate chip drops the avatar (parallels the Owner chip).
   return (
-    <span className="inline-flex items-center min-w-0" style={{ gap: "var(--sp-1_5)" }}>
-      <Avatar name={delegate.displayName} seed={delegate.uuid} size={18} />
+    <span className="inline-flex items-center min-w-0">
       <span className="text-body truncate" style={{ color: "var(--fg-2)" }} title={delegate.displayName}>
         {delegate.displayName}
       </span>


### PR DESCRIPTION
## Summary

Phase 2 of the Team page redesign (Phase 1 = #687). Deliberately **lightweight: zero migrations, zero new columns** — per product direction to keep the surface small after weighing the heavier original plan.

Four changes:

1. **Human "last active"** — derived read-time from `MAX(messages.created_at)` for each member's human agent (口径 B — "most recent message"), surfaced on the member DTO and rendered as a relative `X ago` in the Human section (replaces the `—` placeholder). The agent **Status** cell also gains a free `active X ago` hover from the existing `agent_presence.last_seen_at`.
2. **Self-edit profile** — `PATCH /me/profile` lets a member rename themselves (mirrored to `users.display_name` + every human agent backing their memberships). The route schema has **no `role` field**, so self-promotion is impossible by construction. The admin route `PATCH /orgs/:orgId/members/:id` is unchanged.
3. **Leaner Owner / Delegate chips** — the Owner chip (agent section) and Delegate chip (human section) drop their avatar and keep the name only. The leftmost **Name**-column avatar is unchanged.
4. **Collapsible sections** — Public / Private agents and Human teammates headers collapse; default expanded, collapse state persisted per-section to `localStorage`.

## Dropped vs. the original Phase 2 plan
- **Agent `tagline`** — dropped. (`agents.profile` does not exist; the only agent free-text is `agent_configs.payload.prompt`, the runtime system prompt — unsuitable as a public tagline. No clean zero-column path, so cut.)
- **Custom human-avatar upload** — dropped; we keep reusing the GitHub `users.avatar_url`. (Manager-set agent avatars already exist and are untouched.)

## Known tech debt (accepted)
`lastActiveByAgent` (`packages/server/src/services/member.ts`) runs a grouped aggregation on `messages.sender_id`, which is **not indexed** (existing message indexes are chat/time based). Independent review (codex) flagged this `[P2]`. Accepted as a conscious tradeoff to honor "zero migration" — fine at current scale (member list loads occasionally, small orgs). **When `messages` grows and this endpoint gets hot, add a `(sender_id, created_at)` index** (a follow-up migration).

## Testing
- `@first-tree/server` **1247 passed**, `@first-tree/web` **509 passed**, `@first-tree/shared` **363 passed**.
- `biome check` clean (1222 files); `tsc --noEmit` clean across shared/server/web; `lint:tokens` clean.
- New tests: server `me-profile.test.ts` (self rename, role-strip, empty-name reject, derived last-active null→set); web `buildTeamData` last-active label.
- Independent code review (codex, `--base origin/main`): **GATE PASS**, no `[P1]`; the single `[P2]` is the index note above.
- `apps/cli` suite has pre-existing order-dependent flakiness (daemon-start / post-bundle tests) — this diff touches **zero** cli files, same situation flagged on #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)