### PR TITLE
feat(web): design tokens — soft state fills (×6), info callout, color-scheme; drop dead --text-live

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -93,9 +93,10 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
 - Styleguide updated: real tokens, new Feedback swatches, idle shows the new tone; the temporary
   "Cleanup candidates" section was removed.
 
-**Still open (as of #672):** `--text-live` adopt/drop, `--state-*-soft` companions,
-`color-scheme: dark` on `.dark`, info callout, `.context-live-*` palette, spacing rhythm, dead `--sp-*`.
-*(focus-ring unification — done in #662, see Phase 1.)*
+**Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
+focus-ring extension to the remaining primitives, and the ✓⚠✗⚙→lucide icon purge.
+*(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
+`:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
 
 ---
 
@@ -147,9 +148,9 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   `surface-overlay` / the `--shadow-*` scale. `Badge` uses `rounded-md` while `DenseBadge` uses
   `--radius-chip`. **DONE (#662):** standardized on the semantic four; migrated `rounded-md`/`rounded-lg`,
   fixed `Dialog`/`Badge`, retired `--radius-sm/md/lg/xl` (rule 8 now bans `rounded-(sm|md|lg|xl)`).
-- [ ] **Near-dead token.** `--text-live` (32px tier) is referenced **once** — the `/preview/styleguide`
-  demo (`styleguide-preview.tsx:136`) — and **never in product**. Adopt it (it's meant for the
-  live-status hero) or delete it.
+- [x] **Near-dead token.** `--text-live` (32px tier) was referenced **once** — the `/preview/styleguide`
+  demo — and **never in product**. **DONE:** removed the tier (the "Context tree is live" hero uses
+  `.context-live-title`, not this tier).
 - [x] **Inconsistent focus treatment.** **DONE (#662):** one recipe —
   `focus-visible:ring-2 ring-ring ring-offset-2` + a surface-matched `ring-offset` — applied across
   Button / Badge / Input / Dialog-close / Toast / settings-field. *(Extending it to `tab-bar` /
@@ -157,11 +158,12 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 ## P2 — Omissions
 
-- [ ] **No `--state-*-soft` companions.** Callouts have soft+strong pairs; state colors only have the
-  strong tone, so `lib/tones.ts` and `.context-change-breakdown` compute `color-mix(... 12-14%)` /
-  hardcode `oklch(.../0.12)` at the call site. Add `--state-idle-soft` … `--state-error-soft`.
-- [ ] **`.dark` missing `color-scheme: dark`** (only `.landing-marketing` sets it). Native form
-  controls / scrollbars don't get dark UA rendering in app dark mode.
+- [x] **No `--state-*-soft` companions.** **DONE:** added
+  `--state-{working,idle,needs-you,blocked,error,offline}-soft` (one canonical 14% translucent mix; raw
+  on `:root`, `--color-state-*-soft` aliases in `@theme`). Migrating `lib/tones.ts` /
+  `.context-change-breakdown` onto them is the follow-up cleanup PR.
+- [x] **`.dark` missing `color-scheme: dark`.** **DONE:** added `color-scheme: dark` to `.dark` (and
+  `color-scheme: light` to `:root`); native form controls / scrollbars now match the canvas in both modes.
 - [x] **`--color-*` semantic alias layer is unadopted.** `--color-text-*` / `--color-surface-*` /
   `--color-border-*` were each referenced once (only the styleguide). **DONE (#662):** deleted the alias
   layer; `--fg`/`--bg-*`/`--border` are canonical. Kept only the shadcn-compat aliases the primitives
@@ -169,7 +171,9 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 - [ ] **Marketing surface contrast gap.** `.landing-marketing` overrides `--bg`/`--fg`/`--border` but
   not the callout soft/strong pairs or `--state-*` — a notice on the near-black marketing canvas
   resolves to light-mode values. Define them in scope or guard against callouts there.
-- [ ] **No `info` (blue) callout pair** — only error/warn/success.
+- [x] **No `info` (blue) callout pair.** **DONE:** added `--color-info` / `--color-info-soft` (blue hue
+  245 — the presence-idle hue, following the same callout↔state hue pairing as error/warn/success),
+  light + dark.
 
 ## P3 — Discipline
 
@@ -193,9 +197,10 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 ## Notes for whoever picks this up
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
-- **Still open (none blocking):** P0.5 multi-line detection, `--text-live` adopt/drop, `--state-*-soft`,
-  `.dark color-scheme`, info callout, `.context-live-*` palette, spacing rhythm, dead `--sp-*`, and the
-  deferred focus-ring extension to the remaining interactive primitives.
+- **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
+  dead `--sp-*`, the deferred focus-ring extension to the remaining interactive primitives, and the
+  ✓⚠✗⚙→lucide icon purge. *(`--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
+  info callout are DONE — see the P1/P2 marks above.)*
 - Verify after any change: `pnpm --filter @first-tree/web typecheck` (runs tsc + `lint:tokens`).
 
 ---
@@ -267,8 +272,8 @@ fold into the phases below.
 
 **Phase 3 — rollout + folded cleanup:**
 - [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
-- [ ] Add `--state-*-soft` tokens (so `tones.ts` stops computing `color-mix` at call sites).
-- [ ] `color-scheme: dark` on `.dark`; bring the off-palette `.context-live-*` blues into tokens.
+- [x] Add `--state-*-soft` tokens — DONE (definitions). *(Migrating `tones.ts` / call sites onto them is the follow-up cleanup PR.)*
+- [~] `color-scheme: dark` on `.dark` — DONE; bringing the off-palette `.context-live-*` blues into tokens — still open.
 
 **Phase 4 — close-out:**
 - [ ] QA in light + dark.

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -147,6 +147,11 @@ for text sitting on a saturated colored surface (badges, avatars) and does
 | `--state-offline` | dim gray | offline |
 | `--state-unread` | = error | notification/attention (kept separate identifier on purpose) |
 
+Each state also ships a **soft** companion fill — `--state-working-soft` …
+`--state-offline-soft` (one canonical 14% translucent mix). Use these for
+state-tinted surfaces (chips, wells, `.context-change-breakdown`) instead of
+hand-rolling `color-mix(... var(--state-*) ..., transparent)` at the call site.
+
 ### Feedback / severity
 A named set, aliased to shared base hues (one value per color):
 `--success` (green, = brand hue) · `--warning` (orange, = `--state-blocked`; the caution/blocked hue, distinct from needs-you amber) · `--danger` (red).
@@ -155,7 +160,10 @@ A named set, aliased to shared base hues (one value per color):
 Each state ships a **soft** background + a **strong** text/border tone, so you
 never reach for `bg-red-50 / text-red-900`:
 `--color-error` / `--color-error-soft`, `--color-warn` / `--color-warn-soft`,
-`--color-success` / `--color-success-soft`.
+`--color-success` / `--color-success-soft`, and `--color-info` /
+`--color-info-soft` (blue, hue 245 — the presence-idle hue, following the same
+callout↔state hue pairing; for **static** informational notices, not the
+dynamic working/idle agent state).
 
 ### Overlay
 `--color-overlay-scrim` — dialog/lightbox scrim (`oklch(0 0 0 / 0.55)`,
@@ -182,7 +190,6 @@ Three marketing tiers for the public landing page only.
 | `text-body` | 12px | 400 | body copy, buttons |
 | `text-subtitle` | 13px | 600 | row titles (**default body size**) |
 | `text-title` | 16px | 600 | section / page titles |
-| `text-live` | 32px | 600 | the "live" status hero number |
 | — marketing — | | | |
 | `text-lead` | 18px | 400 | landing lead copy |
 | `text-headline` | 24px | 600 | landing section headings |
@@ -300,6 +307,10 @@ automatically):
 3. **Marketing** (`.landing-marketing`) — pinned to the first-tree.ai brand:
    near-black `#040404` canvas + cool-tinted light text, regardless of the
    dashboard toggle. `color-scheme: dark`. Same green brand.
+
+Each palette declares `color-scheme` (`light` on `:root`, `dark` on `.dark` and
+`.landing-marketing`) so native form controls, scrollbars, and `<input>` widgets
+render in the matching mode.
 
 ---
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -110,10 +110,6 @@
   --text-title--letter-spacing: -0.2px;
   --text-title--font-weight: 600;
 
-  --text-live: 32px;
-  --text-live--line-height: 1.08;
-  --text-live--font-weight: 600;
-
   /* Marketing-tier typography — used by the public landing page only.
      Dashboard surfaces should keep using the dense scale above (eyebrow → title);
      these three tiers exist so the landing hero / section headings / lead
@@ -198,6 +194,17 @@
   --color-state-error: var(--state-error);
   --color-state-offline: var(--state-offline);
 
+  /* Soft state-tinted surface fills. Translucent (alpha-composited), so each
+     reads correctly over any background and needs no .dark override. Replaces
+     the ad-hoc color-mix(... var(--state-*) ..., transparent) hand-rolled in
+     lib/tones.ts and .context-change-breakdown; raw values defined on :root. */
+  --color-state-idle-soft: var(--state-idle-soft);
+  --color-state-working-soft: var(--state-working-soft);
+  --color-state-needs-you-soft: var(--state-needs-you-soft);
+  --color-state-blocked-soft: var(--state-blocked-soft);
+  --color-state-error-soft: var(--state-error-soft);
+  --color-state-offline-soft: var(--state-offline-soft);
+
   /* ---- Semantic inline-callout tokens ------------------------------------- */
   /* Each state exposes two Tailwind-addressable colors: the strong variant
      (for text and border utilities) and the soft variant (for background
@@ -210,6 +217,11 @@
   --color-warn-soft: var(--bg-warn-soft);
   --color-success: var(--fg-success-strong);
   --color-success-soft: var(--bg-success-soft);
+  /* info — blue (hue 245, matching the presence-idle state so the callout set
+     follows the same callout↔state hue pairing as error/warn/success). For
+     STATIC informational notices, not the dynamic working/idle agent state. */
+  --color-info: var(--fg-info-strong);
+  --color-info-soft: var(--bg-info-soft);
 
   /* Overlay scrim for dialogs / lightboxes — replaces hardcoded rgba(0,0,0,...). */
   --color-overlay-scrim: var(--overlay-scrim);
@@ -267,6 +279,18 @@
      "this is a notification" stays distinguishable from "this is a
      destructive-action warning" at the consumer site. */
   --state-unread: var(--state-error);
+
+  /* Soft state-tinted fills — one canonical 14% mix per state so lib/tones.ts,
+     .context-change-breakdown, and other state surfaces stop hand-rolling
+     color-mix at the call site. Alpha-composited, so this single definition
+     resolves correctly in both light and dark (the --state-* hues are not
+     redefined under .dark). */
+  --state-working-soft: color-mix(in oklch, var(--state-working) 14%, transparent);
+  --state-idle-soft: color-mix(in oklch, var(--state-idle) 14%, transparent);
+  --state-needs-you-soft: color-mix(in oklch, var(--state-needs-you) 14%, transparent);
+  --state-blocked-soft: color-mix(in oklch, var(--state-blocked) 14%, transparent);
+  --state-error-soft: color-mix(in oklch, var(--state-error) 14%, transparent);
+  --state-offline-soft: color-mix(in oklch, var(--state-offline) 14%, transparent);
 
   /* Feedback / severity vocabulary (success / warning / error). Aliased to the
      shared base hues so there is ONE value per color — distinct *names* from the
@@ -333,6 +357,10 @@
   --fg-warn-strong: oklch(0.48 0.14 58);
   --bg-success-soft: oklch(0.96 0.04 150);
   --fg-success-strong: oklch(0.42 0.12 150);
+  /* info — blue (hue 245, the presence-idle hue). Matched L/C to the other
+     callout pairs so the set reads with even weight. */
+  --bg-info-soft: oklch(0.96 0.03 245);
+  --fg-info-strong: oklch(0.45 0.14 245);
 
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
@@ -386,6 +414,10 @@
   --sp-80: 20rem; /* 320px */
   --sp-90: 22.5rem; /* 360px */
   --sp-240: 60rem; /* 960px */
+
+  /* Default color-scheme so native form controls, scrollbars, and the
+     canvas match the light theme (.dark flips this to dark below). */
+  color-scheme: light;
 
   /* Firefox / Windows scrollbar hint — keeps widths visually close to
      macOS overlay scrollbars so layout doesn't jump between platforms. */
@@ -472,6 +504,12 @@
   --fg-warn-strong: oklch(0.86 0.14 58);
   --bg-success-soft: oklch(0.28 0.05 150);
   --fg-success-strong: oklch(0.82 0.14 150);
+  --bg-info-soft: oklch(0.28 0.06 245);
+  --fg-info-strong: oklch(0.82 0.14 245);
+
+  /* Flip native form controls / scrollbars to dark to match the canvas
+     (previously only .landing-marketing set this). */
+  color-scheme: dark;
 }
 
 @layer base {

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -104,6 +104,17 @@ const STATE_COLORS: SwatchDef[] = [
   { name: "--state-offline", token: "var(--state-offline)", note: "offline · gray" },
 ];
 
+// Soft state fills — the canonical translucent tint per state (replaces ad-hoc
+// color-mix at call sites). Swatches sit on the page bg so the tint reads true.
+const STATE_SOFT_COLORS: SwatchDef[] = [
+  { name: "--state-working-soft", token: "var(--state-working-soft)" },
+  { name: "--state-idle-soft", token: "var(--state-idle-soft)" },
+  { name: "--state-needs-you-soft", token: "var(--state-needs-you-soft)" },
+  { name: "--state-blocked-soft", token: "var(--state-blocked-soft)" },
+  { name: "--state-error-soft", token: "var(--state-error-soft)" },
+  { name: "--state-offline-soft", token: "var(--state-offline-soft)" },
+];
+
 // Feedback / severity vocabulary — distinct names, aliased to shared base hues.
 const FEEDBACK_COLORS: SwatchDef[] = [
   { name: "--success", token: "var(--success)", note: "= brand green" },
@@ -118,6 +129,8 @@ const CALLOUT_COLORS: SwatchDef[] = [
   { name: "--color-warn-soft", token: "var(--color-warn-soft)" },
   { name: "--color-success", token: "var(--color-success)" },
   { name: "--color-success-soft", token: "var(--color-success-soft)" },
+  { name: "--color-info", token: "var(--color-info)", note: "static notices" },
+  { name: "--color-info-soft", token: "var(--color-info-soft)" },
 ];
 
 const AVATAR_HUES: SwatchDef[] = Array.from({ length: 8 }, (_, i) => ({
@@ -136,7 +149,6 @@ const APP_TIERS: TypeTier[] = [
   { cls: "text-body", name: "text-body", meta: "12 / 400", sample: "Body copy and button text." },
   { cls: "text-subtitle", name: "text-subtitle", meta: "13 / 600 · default", sample: "Row title / subtitle" },
   { cls: "text-title", name: "text-title", meta: "16 / 600", sample: "Section & page title" },
-  { cls: "text-live", name: "text-live", meta: "32 / 600", sample: "Live" },
 ];
 
 const MARKETING_TIERS: TypeTier[] = [
@@ -407,6 +419,8 @@ export function StyleguidePreviewPage() {
           <SwatchGrid items={BRAND_COLORS} />
           <Subhead>State (agent vocabulary)</Subhead>
           <SwatchGrid items={STATE_COLORS} />
+          <Subhead>State soft fills (tinted surfaces)</Subhead>
+          <SwatchGrid items={STATE_SOFT_COLORS} />
           <Subhead>Feedback / severity</Subhead>
           <SwatchGrid items={FEEDBACK_COLORS} />
           <Subhead>Callout pairs (soft fill + strong text/border)</Subhead>


### PR DESCRIPTION
## Low-risk design tokens (rollout, on `main`)

First implementation PR of the web design-system rollout, **based on `main`** and on top of its green-liveness 6-state model. **Visual design language only — no product functionality, data, APIs, routing, or copy.**

> Re-grounded from an earlier draft that was mistakenly stacked on the stale `feat/web-design-system-rollout` branch (19 commits behind `main`, pre-green-liveness). This PR targets current `main`.

### Changes (`packages/web/src/index.css`)
- **`--state-*-soft` fills for all 6 states** (`working`/`idle`/`needs-you`/`blocked`/`error`/`offline`) — one canonical 14% translucent mix; raw on `:root`, `--color-state-*-soft` aliases in `@theme`. Alpha-composited, so one definition is correct in both modes. Gives `lib/tones.ts` + `.context-change-breakdown` a token to replace their hand-rolled `color-mix` (the surface migration is a later PR).
- **`info` callout pair** — `--color-info` / `--color-info-soft`, blue **hue 245** (the presence-idle hue, following the same callout↔state hue pairing as error↔25 / warn↔58 / success↔150). Light + dark, L/C matched to the sibling pairs. For *static* informational notices.
- **`color-scheme`** — `light` on `:root`, `dark` on `.dark` (previously only `.landing-marketing` set it) so native form controls / scrollbars match the canvas in app dark mode.
- **Removed dead `--text-live`** — unused; the "Context tree is live" hero uses `.context-live-title`, not this tier.

### Styleguide + docs
- `/preview/styleguide`: 6 State-soft swatches + info callout swatches; removed the `text-live` tier row.
- `DESIGN.md` + `DESIGN-AUDIT.md` (`main`'s current green-liveness docs): updated state/callout/theming/typography sections and flipped the matching audit items to done.

### Out of scope / deferred
- Migrating `lib/tones.ts` + `.context-change-breakdown` onto `--state-*-soft` (next PR). Note `tones.ts` `warn` is 16% → normalizes to the canonical 14% there (a deliberate ~2% shift, not silent).
- Multi-line inline-style lint guardrail, `.context-live-*` tokenization, marketing-surface contrast, focus-ring extension, and the ✓⚠✗⚙→lucide icon purge remain open in `DESIGN-AUDIT.md` for subsequent PRs.

### Verification
- `pnpm --filter @first-tree/web lint:tokens` — green
- `pnpm --filter @first-tree/web typecheck` (`tsc --noEmit`) — green
- Independent review ×2 (correctness + design fidelity) — both SHIP
- e2e: `/preview/styleguide` in **light + dark** — all 6 soft tokens + info pair resolve at runtime, swatches render, `--text-live` gone, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
