### PR TITLE
feat(web): adapt admin dashboard for mobile / narrow viewports

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -42,13 +42,27 @@ export function Layout() {
   // own width.
   const isSettings = location.pathname.startsWith("/settings");
 
-  // Top-bar progressive collapse: at `md` (768–1279) drop the right controls
-  // (cmdk / theme / user); at `narrow` (<768) also drop the brand cluster.
-  // The four nav tabs always survive — that's the minimum viable header.
+  // Top-bar progressive collapse, tuned so the user menu (sign-out, org-switch)
+  // is reachable at EVERY width — dropping it below `xl` previously stranded
+  // every phone / tablet / sub-1280 desktop window with no way to log out.
+  //   - `xl`     : brand | tabs | [Jump to…] [theme] [avatar]
+  //   - `md`     : brand | tabs | [theme] [avatar]   (Jump to… too wide)
+  //   - `narrow` : tabs | [avatar]                   (also drops brand)
+  // On `narrow` the theme toggle drops too: four full tabs + theme + avatar
+  // overflow a phone-width row and would clip the avatar off the right edge.
+  // Phones
+  // fall back to the OS `prefers-color-scheme` (honoured at boot in index.html);
+  // the toggle returns at `md`. The avatar is the one control that never drops.
   const viewport = useWorkspaceViewport();
-  const dropControls = viewport !== "xl";
+  const showJumpButton = viewport === "xl";
   const dropBrand = viewport === "narrow";
-  const headerColumns = dropBrand ? "1fr" : dropControls ? "1fr auto" : "1fr auto 1fr";
+  const showThemeToggle = viewport !== "narrow";
+  // Brand present → brand | tabs(center) | controls(end). Brand collapsed
+  // (narrow) → tabs(start) | controls(end). The narrow tabs track is
+  // `minmax(0, 1fr)` (not the default `minmax(auto, 1fr)`) so it can shrink
+  // below the tabs' intrinsic width and let them scroll, instead of pushing
+  // the avatar past the right edge.
+  const headerColumns = dropBrand ? "minmax(0, 1fr) auto" : "1fr auto 1fr";
 
   return (
     <div
@@ -98,11 +112,18 @@ export function Layout() {
           className="flex"
           style={{
             gap: 2,
-            pointerEvents: "none",
-            // On `narrow` the header has a single column and tabs become
-            // its sole content — anchor to the start so they don't push
-            // off the right edge.
+            // `pointerEvents: none` lets the centred (xl/md) nav's empty flanks
+            // pass clicks through; on `narrow` the nav is a real scroll
+            // container in a shrunk track, so it needs to receive touch.
+            pointerEvents: dropBrand ? "auto" : "none",
+            // On `narrow` the brand collapses and the tabs share the row with
+            // the compact controls — anchor the tabs to the start so they sit
+            // at the left edge rather than centring against the avatar.
             justifySelf: dropBrand ? "start" : "center",
+            // Narrow track is `minmax(0, 1fr)`: let the row scroll horizontally
+            // if the tabs can't all fit (tiny phones / long i18n labels) rather
+            // than overflow and clip the avatar. No-op when the tabs fit.
+            ...(dropBrand ? { minWidth: 0, overflowX: "auto" } : null),
           }}
         >
           {navTabs.map((tab) => (
@@ -112,7 +133,9 @@ export function Layout() {
               end={tab.end}
               style={{ pointerEvents: "auto" }}
               className={({ isActive }) =>
-                cn("inline-flex items-center transition-colors", isActive ? "" : "hover:text-[var(--fg)]")
+                // `shrink-0` keeps each tab its natural width inside the narrow
+                // scrollable nav, so labels never compress or wrap.
+                cn("inline-flex shrink-0 items-center transition-colors", isActive ? "" : "hover:text-[var(--fg)]")
               }
             >
               {({ isActive }) => (
@@ -133,66 +156,75 @@ export function Layout() {
           ))}
         </nav>
 
-        {/* Right controls — collapse at `md` and below. */}
-        {dropControls ? null : (
-          <div className="flex items-center" style={{ gap: 6, justifySelf: "end" }}>
-            <button
-              type="button"
-              onClick={() => setPaletteOpen(true)}
-              aria-label="Open command palette"
-              className="inline-flex items-center transition-colors text-body"
-              style={{
-                gap: 8,
-                padding: "var(--sp-1) var(--sp-3)",
-                minWidth: 200,
-                color: "var(--fg-3)",
-                border: "var(--hairline) solid var(--border)",
-                borderRadius: "var(--radius-input)",
-                background: "var(--bg-sunken)",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.color = "var(--fg)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.color = "var(--fg-3)";
-              }}
-            >
-              <Search className="h-4 w-4" />
-              <span className="flex-1 text-left">Jump to…</span>
-              <span
-                aria-hidden
-                className="text-caption font-mono"
+        {/* Right controls. The user menu (avatar) renders at every breakpoint
+            so sign-out / org-switch stay reachable on phones and tablets; the
+            theme toggle drops on `narrow` and the wide "Jump to…" button is
+            xl-only (see the collapse comment above). */}
+        <div className="flex items-center shrink-0" style={{ gap: 6, justifySelf: "end" }}>
+          {showJumpButton ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setPaletteOpen(true)}
+                aria-label="Open command palette"
+                className="inline-flex items-center transition-colors text-body"
                 style={{
-                  padding: "var(--sp-0_5) var(--sp-1_5)",
-                  border: "var(--hairline) solid var(--border)",
-                  borderRadius: "var(--sp-1)",
+                  gap: 8,
+                  padding: "var(--sp-1) var(--sp-3)",
+                  minWidth: 200,
                   color: "var(--fg-3)",
-                  background: "var(--bg-raised)",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--radius-input)",
+                  background: "var(--bg-sunken)",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.color = "var(--fg)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.color = "var(--fg-3)";
                 }}
               >
-                ⌘K
-              </span>
-            </button>
-            <span
-              style={{
-                width: 1,
-                height: 18,
-                background: "var(--border)",
-                margin: "0 var(--sp-1)",
-              }}
-            />
-            <ThemeToggle />
-            <span
-              style={{
-                width: 1,
-                height: 18,
-                background: "var(--border)",
-                margin: "0 var(--sp-1)",
-              }}
-            />
-            <UserMenu />
-          </div>
-        )}
+                <Search className="h-4 w-4" />
+                <span className="flex-1 text-left">Jump to…</span>
+                <span
+                  aria-hidden
+                  className="text-caption font-mono"
+                  style={{
+                    padding: "var(--sp-0_5) var(--sp-1_5)",
+                    border: "var(--hairline) solid var(--border)",
+                    borderRadius: "var(--sp-1)",
+                    color: "var(--fg-3)",
+                    background: "var(--bg-raised)",
+                  }}
+                >
+                  ⌘K
+                </span>
+              </button>
+              <span
+                style={{
+                  width: 1,
+                  height: 18,
+                  background: "var(--border)",
+                  margin: "0 var(--sp-1)",
+                }}
+              />
+            </>
+          ) : null}
+          {showThemeToggle ? (
+            <>
+              <ThemeToggle />
+              <span
+                style={{
+                  width: 1,
+                  height: 18,
+                  background: "var(--border)",
+                  margin: "0 var(--sp-1)",
+                }}
+              />
+            </>
+          ) : null}
+          <UserMenu />
+        </div>
       </header>
 
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />

--- a/packages/web/src/components/ui/page-header.tsx
+++ b/packages/web/src/components/ui/page-header.tsx
@@ -15,7 +15,11 @@ type PageHeaderProps = HTMLAttributes<HTMLDivElement> & {
 export function PageHeader({ title, subtitle, right, className, style, ...rest }: PageHeaderProps) {
   return (
     <div
-      className={cn("flex items-baseline gap-3 shrink-0", className)}
+      // `flex-wrap` only changes anything when the title + subtitle + action
+      // slot can't share one line (narrow phones with a long title and a
+      // right-side button); on desktop it's a no-op. The action slot drops
+      // to the next line instead of colliding with the title.
+      className={cn("flex flex-wrap items-baseline gap-3 shrink-0", className)}
       style={{
         padding: "var(--sp-4) var(--sp-5) var(--sp-3)",
         ...style,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1277,6 +1277,12 @@
 
   .context-map-frame {
     min-height: 320px;
+    /* The SVG below keeps a 760px floor so its foreignObject cards stay
+       legible rather than shrinking to unreadable on a phone. The base rule
+       clips overflow (`overflow: hidden`); on narrow viewports that would
+       cut the right half of the map off entirely, so switch to a horizontal
+       scroll — the whole map stays reachable by swiping. */
+    overflow-x: auto;
   }
 
   .context-network-svg {

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -29,6 +29,7 @@ import { Button } from "./../components/ui/button.js";
 import { DenseBadge, type DenseBadgeTone } from "./../components/ui/dense-badge.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./../components/ui/dialog.js";
 import { PresenceChip, runtimeStateToPresence } from "./../components/ui/presence-chip.js";
+import { useWorkspaceViewport } from "./../hooks/use-viewport.js";
 import { humanizeAgentType, humanizeVisibility } from "./../lib/agent-labels.js";
 import { cn, formatDate } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
@@ -78,6 +79,11 @@ export function AgentDetailPage() {
   const queryClient = useQueryClient();
   const location = useLocation();
   const { memberId, role } = useAuth();
+  // On phones the header drops its secondary metadata line (type · visibility,
+  // offline-since) — those are all repeated on the Profile tab — so the
+  // avatar, name, presence chip, and action buttons keep their natural size
+  // instead of being shoved off the row.
+  const isNarrow = useWorkspaceViewport() === "narrow";
   useLegacyAnchorRedirect();
 
   const agentQuery = useQuery({
@@ -485,10 +491,12 @@ export function AgentDetailPage() {
             <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
               @{agent.name ?? shortId}
             </span>
-            <span className="text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
-              · {humanizeAgentType(agent.type)} · {humanizeVisibility(agent.visibility)}
-            </span>
-            {clientStatus?.offlineSince && (
+            {!isNarrow && (
+              <span className="text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
+                · {humanizeAgentType(agent.type)} · {humanizeVisibility(agent.visibility)}
+              </span>
+            )}
+            {!isNarrow && clientStatus?.offlineSince && (
               <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
                 offline since {formatDate(clientStatus.offlineSince)}
               </span>
@@ -679,6 +687,12 @@ function TabsNav({
         className="flex items-end gap-1"
         style={{
           padding: "0 var(--sp-5)",
+          // The full tab set (up to 6) overflows a phone-width row. Let the
+          // row scroll horizontally instead of clipping / wrapping; on
+          // desktop everything fits so no scrollbar appears. Pairs with
+          // `flexShrink: 0` + `whiteSpace: nowrap` on each tab below so the
+          // labels keep their natural width and stay swipeable.
+          overflowX: "auto",
         }}
       >
         {tabs.map((t) => {
@@ -704,6 +718,10 @@ function TabsNav({
                 display: "inline-flex",
                 alignItems: "center",
                 gap: "var(--sp-1_5)",
+                // Keep natural width inside the horizontally-scrollable row
+                // (see tablist `overflowX`) so labels never wrap or squish.
+                flexShrink: 0,
+                whiteSpace: "nowrap",
               }}
             >
               <span>{t.label}</span>

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -82,7 +82,14 @@ function SummaryBlock({
         <ErrorRow message="Failed to load usage summary." />
       ) : (
         <>
-          <div className="grid" style={{ gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: "var(--sp-4)" }}>
+          {/* `auto-fit` + an 8rem floor keeps all four KPIs on one row on
+              desktop but folds to 2×2 on a phone, where four columns would
+              crush the large mono values into cells too narrow to read. No
+              breakpoint / JS needed — the track count follows the width. */}
+          <div
+            className="grid"
+            style={{ gridTemplateColumns: "repeat(auto-fit, minmax(8rem, 1fr))", gap: "var(--sp-4)" }}
+          >
             <Kpi label={`Tokens (${window})`} value={formatCompactCount(totalTokens)} loading={isLoading} />
             <Kpi label="Turns" value={formatCompactCount(totals?.turns ?? null)} loading={isLoading} />
             <Kpi label="Chats" value={formatCompactCount(totals?.chats ?? null)} loading={isLoading} />

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -89,7 +89,18 @@ export function OnboardingShell({ rail, children }: { rail: ReactNode; children:
           paddingInline: "var(--sp-5)",
         }}
       >
-        <div className="flex flex-col md:flex-row md:items-start" style={{ gap: "var(--sp-8)", flexShrink: 0 }}>
+        {/* `maxWidth: 100%` caps this wrapper to the body's content box. Without
+            it the wrapper sizes to its content (the 34rem `main`) and, centred in
+            a phone-width body under the shell's `overflow-hidden`, both ends of
+            every step get clipped (the title and inputs lose ~80 logical units
+            on each side at phone widths). Capped here, the `main` below resolves
+            its own `maxWidth: 100%` against a viewport-bound width and shrinks to
+            fit. On desktop the wrapper is far narrower than the viewport, so this
+            is a no-op. */}
+        <div
+          className="flex flex-col md:flex-row md:items-start"
+          style={{ gap: "var(--sp-8)", flexShrink: 0, maxWidth: "100%" }}
+        >
           {/* Left rail — full step labels, top-aligned with the content. */}
           <aside className="hidden md:block" style={{ width: "13rem", flexShrink: 0, paddingTop: "var(--sp-1)" }}>
             {rail}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2445,7 +2445,9 @@ export function ChatView({
                       // sized by the input element's intrinsic width.
                       style={{
                         fieldSizing: "content",
-                        minWidth: 200,
+                        // Narrower floor on phones — the desktop minimum plus
+                        // the ✓/× buttons overflow a phone-width header row.
+                        minWidth: narrow ? 120 : 200,
                         maxWidth: 480,
                         color: "var(--fg)",
                         background: "var(--bg-sunken)",


### PR DESCRIPTION
## Summary

Makes the admin dashboard usable on phones / narrow viewports. PC stays the
primary target — this is a surgical pass, not a redesign: it reuses the
existing `useWorkspaceViewport` breakpoints (`narrow` <768 / `md` / `xl`),
adds no new responsive system, and sacrifices a couple of low-value controls
on phones rather than reworking them.

## Why

The headline issue was **functional, not cosmetic**: the top-bar right
controls — including the user menu (sign-out, org-switch, create/join team) —
were dropped whenever `viewport !== "xl"`, i.e. below **1280px**, with no
replacement. Every phone, every tablet, and any non-maximized desktop window
under 1280px had **no way to log out or switch org**. The command palette and
settings carried no fallback either.

## What changed

| Area | Change |
|---|---|
| `layout.tsx` | User menu (avatar) now renders at **every** breakpoint. Theme toggle folds into `md`+ (phones follow OS `prefers-color-scheme`); the wide "Jump to…" button stays `xl`-only. Narrow nav uses `minmax(0,1fr)` + horizontal scroll so the avatar is never clipped off the right edge. |
| `onboarding-shell.tsx` | Cap step content to the viewport — the first-run screen was clipping its title/inputs on phones (fixed 34rem content centred under `overflow:hidden`). |
| `agent-detail.tsx` | Tab bar scrolls horizontally on narrow; secondary header metadata (type / visibility / offline-since) hides on narrow (still on the Profile tab). |
| `usage-tab.tsx` | KPI grid uses `auto-fit` → folds to 2×2 on phones instead of crushing four columns. |
| `index.css` | Context update map scrolls horizontally on narrow instead of being clipped by `overflow:hidden`. |
| `chat-view.tsx` | Narrower rename-input floor on phones. |
| `page-header.tsx` | Wrap title / actions on narrow. |

## Verification

Driven in a real browser at **375px** against a local dev stack with seeded
data (login, onboarding, workspace top bar + user-menu dropdown, agent-detail
Usage, team, settings):

- ✅ User menu (incl. **Sign out**) visible and tappable at 375px; 0 header
  overflow.
- ✅ Onboarding: title/inputs no longer clipped (9 → 0 overflowing elements).
- ✅ Agent-detail Usage: KPI grid 2×2, tab bar scrollable, metadata hidden.
- ✅ Team / Settings: no horizontal page scroll; Settings sidebar collapses to
  its pill bar.
- `pnpm check` (Biome, 1227 files) ✅ · `pnpm typecheck` (tsc + design-token
  guard) ✅ · **515/515** web tests ✅

## Notes / deferred

- The Context update-map scroll fix is CSS-only and couldn't be data-triggered
  locally (the dev org has no Context Tree, so the map renders its empty
  state); verified by reading the rule, not in-browser.
- Agent-detail's "Recent turns" table still needs horizontal scroll on phones
  to reveal the Model column (standard wide-table pattern, same as the Team
  table). It is pre-existing and reachable; left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
