### PR TITLE
feat(web): extend the shared focus-ring recipe to filter-pill / tab-bar / segmented-control

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -94,7 +94,8 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
   "Cleanup candidates" section was removed.
 
 **Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
-focus-ring extension to the remaining primitives, and the ✓⚠✗⚙→lucide icon purge.
+and the ✓⚠✗⚙→lucide icon purge (authed surfaces — needs a local-stack by-eye pass).
+*(focus-ring extension — DONE: `filter-pill`/`tab-bar`/`segmented-control`; popover/command don't fit the ring.)*
 *(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
 `:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
 
@@ -153,8 +154,10 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   `.context-live-title`, not this tier).
 - [x] **Inconsistent focus treatment.** **DONE (#662):** one recipe —
   `focus-visible:ring-2 ring-ring ring-offset-2` + a surface-matched `ring-offset` — applied across
-  Button / Badge / Input / Dialog-close / Toast / settings-field. *(Extending it to `tab-bar` /
-  `segmented-control` / `command` / `popover` / `filter-pill` is still a deferred a11y follow-up.)*
+  Button / Badge / Input / Dialog-close / Toast / settings-field. **Extended** to `filter-pill`,
+  `tab-bar` (Tab), and `segmented-control`. `popover` triggers are caller-owned (already ringed via the
+  `Button`/`FilterPill` passed in), and `command` (cmdk) uses its `aria-selected` highlight model with an
+  always-focused input, so the button-style ring doesn't apply there.
 
 ## P2 — Omissions
 
@@ -204,8 +207,8 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
 - **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
-  dead `--sp-*`, the deferred focus-ring extension to the remaining interactive primitives, and the
-  ✓⚠✗⚙→lucide icon purge. *(`--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
+  dead `--sp-*`, and the ✓⚠✗⚙→lucide icon purge (authed surfaces — local-stack by-eye pass). *(focus-ring
+  extension is DONE for filter-pill/tab-bar/segmented-control. `--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
   info callout are DONE — see the P1/P2 marks above.)*
 - Verify after any change: `pnpm --filter @first-tree/web typecheck` (runs tsc + `lint:tokens`).
 
@@ -261,10 +264,11 @@ fold into the phases below.
   matches each control's real surface (`--bg-sunken` for settings-field, `--bg-raised` for toast).
 - [ ] **Follow-ups (deferred):**
   - Line-icon set / purge the ✓ ⚠ ✗ ⚙ glyphs in favor of lucide — layout-affecting, spread
-    across pages; needs a by-eye pass.
-  - Extend the focus ring to the remaining interactive primitives (`tab-bar`,
-    `segmented-control`, `command`, `popover` triggers, `filter-pill`) — they paint no ring
-    today, so no visible mismatch, but it's an a11y coverage gap.
+    across pages (`runtime-state-line`, `working-turn`); needs a by-eye pass on authed surfaces
+    (not reachable from the styleguide), so deferred to a local-stack session. **Still open.**
+  - [x] Extend the focus ring to the remaining interactive primitives — **DONE** for `filter-pill` /
+    `tab-bar` / `segmented-control`; `popover` trigger is caller-owned and `command` uses cmdk
+    `aria-selected` (neither fits the button ring), so the recipe is now applied everywhere it makes sense.
   - Button/Badge base `ring-offset-background` uses the page surface; on a raised card/menu
     a sub-perceptible 2px seam can appear on keyboard focus (a primitive can't know its
     parent surface). Masked by the filled fill; acceptable until a per-surface convention exists.

--- a/packages/web/src/components/ui/filter-pill.tsx
+++ b/packages/web/src/components/ui/filter-pill.tsx
@@ -11,7 +11,10 @@ export function FilterPill({ active, count, warn, className, children, style, ..
   return (
     <button
       type="button"
-      className={cn("mono inline-flex items-center gap-1 text-caption leading-[1.6]", className)}
+      className={cn(
+        "mono inline-flex items-center gap-1 text-caption leading-[1.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
       style={{
         padding: "var(--sp-0_5) var(--sp-1_75)",
         borderRadius: 3,

--- a/packages/web/src/components/ui/segmented-control.tsx
+++ b/packages/web/src/components/ui/segmented-control.tsx
@@ -39,7 +39,10 @@ export function SegmentedControl<T extends string>({ options, value, onChange, c
             onClick={() => {
               if (!active) onChange(opt.value);
             }}
-            className={cn("text-caption cursor-pointer transition-colors", !active && "hover:bg-[var(--bg-hover)]")}
+            className={cn(
+              "text-caption cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              !active && "hover:bg-[var(--bg-hover)]",
+            )}
             style={{
               padding: "var(--sp-0_5) var(--sp-1_5)",
               border: 0,

--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -39,7 +39,7 @@ export function Tab({ active, onClick, children }: TabProps) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1.5 bg-transparent text-body font-medium"
+      className="inline-flex items-center gap-1.5 bg-transparent text-body font-medium rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       style={{
         padding: "var(--sp-1_75) var(--sp-3)",
         marginBottom: -1,


### PR DESCRIPTION
## Focus-ring extension (PR C, stacked on #695)

Extends the canonical focus-visible ring recipe — `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background`, already on `Button`/`Input`/`Badge`/etc. — to the remaining tab-focusable primitives. **a11y / visual consistency only; no behavior change.** Base is `feat/web-ds-state-surface-migration` (#695).

### Ringed
- `FilterPill`, `Tab` (tab-bar), `SegmentedControl` segments — now paint the same keyboard focus ring as every other primitive.
- `Tab` also gains `rounded-[var(--radius-input)]` so the ring has soft corners (the tab is transparent at rest → no visible change otherwise).

### Intentionally not ringed
- **`popover`** — its `trigger` is a caller-provided render-prop wrapped in a non-focusable `<span>`; the focusable element is the caller's `Button`/`FilterPill`, which already carries the ring (the component doc says trigger styling is caller-owned).
- **`command`** (cmdk) — uses an `aria-selected` highlight model with an always-focused input; the button-style ring doesn't fit and would mean an always-on ring.

### Verification
- `pnpm check` (Biome) + `lint:tokens` + `typecheck` — all green
- Independent review ×2 (correctness + design fidelity) — both SHIP
- e2e on `/preview/styleguide`: the 3 primitives report `:focus-visible` active and behave **identically to the proven `Button`** (same recipe, same computed-style behavior — Tailwind v4 composes the ring via custom-property box-shadow); no console errors. (`:focus-visible` only paints on keyboard focus, so this is verified by parity with the known-good Button rather than a programmatic-focus screenshot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
