### PR TITLE
refactor(web): tokenize the .context-* page palette into a --context-* family

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -93,8 +93,8 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
 - Styleguide updated: real tokens, new Feedback swatches, idle shows the new tone; the temporary
   "Cleanup candidates" section was removed.
 
-**Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
-and the ✓⚠✗⚙→lucide icon purge (authed surfaces — needs a local-stack by-eye pass).
+**Still open:** spacing rhythm, dead `--sp-*`, multi-line lint detection, and the ✓⚠✗⚙→lucide icon
+purge (authed surfaces — needs a local-stack by-eye pass).
 *(focus-ring extension — DONE: `filter-pill`/`tab-bar`/`segmented-control`; popover/command don't fit the ring.)*
 *(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
 `:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
@@ -186,8 +186,12 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 ## P3 — Discipline
 
-- [ ] **`.context-live-*` is off-palette.** ~40 lines in index.css hardcode blue hues 255–265
-  (e.g. `oklch(0.2 0.04 265)`) that exist in no token. Bring them into the token system.
+- [x] **`.context-live-*` is off-palette.** **DONE:** the hardcoded blue inks (255–265), faint-green
+  card surfaces, brand-green fills, and the `.context-change-breakdown` chips are now a value-preserving
+  `--context-*` token family in `:root` (reusing `--brand-bg` / `--state-*-soft` where exact). 1:1 lift —
+  a later pass can rationalize the near-duplicate inks. Dark mode unchanged (the page is light-only; tokens
+  are `:root`-only) — adding `.dark { --context-* }` overrides is now a trivial follow-up if the page
+  should become dark-aware.
 - [ ] **Spacing rhythm.** Half-steps (`--sp-1_25`=5px, `--sp-1_75`=7px) are used 12× / 23×, signalling
   pixel-nudging off a 4/8 rhythm. Converge to 4/8; mark half-steps as explicit exceptions.
 - [ ] **Prune dead `--sp-*`.** Defined but unused in components: `--sp-2_75`, `--sp-3_25`, `--sp-3_75`,
@@ -206,7 +210,7 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 ## Notes for whoever picks this up
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
-- **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
+- **Still open (none blocking):** P0.5 multi-line detection, spacing rhythm,
   dead `--sp-*`, and the ✓⚠✗⚙→lucide icon purge (authed surfaces — local-stack by-eye pass). *(focus-ring
   extension is DONE for filter-pill/tab-bar/segmented-control. `--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
   info callout are DONE — see the P1/P2 marks above.)*
@@ -283,7 +287,7 @@ fold into the phases below.
 **Phase 3 — rollout + folded cleanup:**
 - [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
 - [x] Add `--state-*-soft` tokens — DONE (definitions + `tones.ts`/call-site migration). *(`.context-change-breakdown` still raw — folded into the `.context-*` palette PR. Follow-up idea: add `--state-*-line` (~30%) border tokens so the borders that still hand-roll `color-mix` can converge too.)*
-- [~] `color-scheme: dark` on `.dark` — DONE; bringing the off-palette `.context-live-*` blues into tokens — still open.
+- [x] `color-scheme: dark` on `.dark` — DONE; the off-palette `.context-live-*` blues are now in the `--context-*` token family — DONE.
 
 **Phase 4 — close-out:**
 - [ ] QA in light + dark.

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -365,6 +365,31 @@
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
 
+  /* ── Context-tree "live" page palette (/context hero) ─────────────────────
+     A bespoke set — cool blue "ink" + faint-green card surfaces — lifted here
+     from the hardcoded oklch in the .context-live-* rules below so the page's
+     palette lives in one place. Value-preserving 1:1 lift (a later pass can
+     rationalize the near-duplicate inks). Light-only: the page predates dark
+     theming and these values are mode-independent (unchanged behavior). */
+  --context-ink: oklch(0.2 0.04 265);
+  --context-ink-em: oklch(0.25 0.04 265);
+  --context-ink-dim: oklch(0.52 0.035 255);
+  --context-ink-summary: oklch(0.2 0.035 255);
+  --context-ink-scale: oklch(0.18 0.04 255);
+  --context-ink-node: oklch(0.23 0.025 255);
+  --context-ink-mark: oklch(0.22 0.04 255);
+  --context-mark-bg: oklch(0.91 0.01 255 / 0.72);
+  --context-shadow: oklch(0.25 0.04 255 / 0.08);
+  --context-card-edge: oklch(0.89 0.008 150);
+  --context-card-edge-hover: oklch(0.78 0.09 150);
+  --context-card-edge-live: oklch(0.78 0.13 150);
+  --context-card-bg: oklch(0.98 0.003 150 / 0.9);
+  --context-card-bg-live: oklch(0.985 0.012 150 / 0.94);
+  --context-summary-edge: oklch(0.88 0.008 150);
+  --context-summary-bg: oklch(1 0 0 / 0.86);
+  --context-halo: oklch(0.72 0.17 150 / 0.34);
+  --context-pin-glow: oklch(0.72 0.17 150 / 0.18);
+
   /* Hairline widths. Exposing these as vars lets component inline styles
      reference --hairline / --hairline-bold instead of writing "1px" /
      "2px" literals — keeps the src/ tree free of raw px strings. */
@@ -808,18 +833,18 @@
 }
 
 .context-live-title {
-  color: oklch(0.2 0.04 265);
+  color: var(--context-ink);
   font-size: 44px;
   font-weight: 700;
   line-height: 1.05;
 }
 
 .context-live-subtitle {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
 }
 
 .context-live-subtitle strong {
-  color: oklch(0.25 0.04 265);
+  color: var(--context-ink-em);
   font-weight: 700;
 }
 
@@ -837,7 +862,7 @@
 }
 
 .context-map-kicker {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
   font-size: 12px;
   font-weight: 700;
 }
@@ -862,7 +887,7 @@
   transform-box: fill-box;
   transform-origin: center;
   fill: transparent;
-  stroke: oklch(0.72 0.17 150 / 0.34);
+  stroke: var(--context-halo);
   stroke-width: 1.25;
   animation: context-live-halo-breathe 3.6s ease-in-out infinite;
 }
@@ -877,10 +902,10 @@
   justify-content: center;
   gap: var(--sp-1);
   padding: var(--sp-3) var(--sp-4);
-  border: var(--hairline) solid oklch(0.89 0.008 150);
+  border: var(--hairline) solid var(--context-card-edge);
   border-radius: var(--radius-dialog);
-  background: oklch(0.98 0.003 150 / 0.9);
-  box-shadow: 0 8px 28px oklch(0.25 0.04 255 / 0.08);
+  background: var(--context-card-bg);
+  box-shadow: 0 8px 28px var(--context-shadow);
   color: var(--fg);
   text-align: left;
   transition:
@@ -891,12 +916,12 @@
 
 .context-network-card:hover {
   transform: translateY(-1px);
-  border-color: oklch(0.78 0.09 150);
+  border-color: var(--context-card-edge-hover);
 }
 
 .context-network-card.is-live {
-  border-color: oklch(0.78 0.13 150);
-  background: oklch(0.985 0.012 150 / 0.94);
+  border-color: var(--context-card-edge-live);
+  background: var(--context-card-bg-live);
 }
 
 .context-network-summary-card {
@@ -907,10 +932,10 @@
   align-items: center;
   justify-content: center;
   gap: var(--sp-1);
-  border: var(--hairline) solid oklch(0.88 0.008 150);
+  border: var(--hairline) solid var(--context-summary-edge);
   border-radius: var(--radius-dialog);
-  background: oklch(1 0 0 / 0.86);
-  box-shadow: 0 14px 36px oklch(0.25 0.04 255 / 0.08);
+  background: var(--context-summary-bg);
+  box-shadow: 0 14px 36px var(--context-shadow);
   color: var(--fg);
   text-align: center;
 }
@@ -921,12 +946,12 @@
   height: var(--sp-11);
   place-items: center;
   border-radius: 50%;
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
 }
 
 .context-network-summary-title {
-  color: oklch(0.2 0.035 255);
+  color: var(--context-ink-summary);
   font-size: 13px;
   font-weight: 700;
   line-height: 1.15;
@@ -938,14 +963,14 @@
   align-items: baseline;
   justify-content: center;
   gap: var(--sp-1);
-  color: oklch(0.18 0.04 255);
+  color: var(--context-ink-scale);
   font-size: 40px;
   font-weight: 500;
   line-height: 1;
 }
 
 .context-network-summary-scale span {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
   font-size: 12px;
   font-weight: 500;
 }
@@ -953,7 +978,7 @@
 .context-network-summary-badge {
   padding: var(--sp-0_5) var(--sp-2);
   border-radius: var(--radius-chip);
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
   font-weight: 600;
 }
@@ -966,12 +991,12 @@
   height: var(--sp-3);
   border-radius: 50%;
   background: var(--success);
-  box-shadow: 0 0 0 var(--sp-0_75) oklch(0.72 0.17 150 / 0.18);
+  box-shadow: 0 0 0 var(--sp-0_75) var(--context-pin-glow);
 }
 
 .context-network-title {
   max-width: 100%;
-  color: oklch(0.23 0.025 255);
+  color: var(--context-ink-node);
   text-transform: uppercase;
   letter-spacing: 0;
 }
@@ -993,17 +1018,17 @@
 }
 
 .context-change-breakdown span[data-change-type="added"] {
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
 }
 
 .context-change-breakdown span[data-change-type="edited"] {
-  background: oklch(0.74 0.18 58 / 0.14);
+  background: var(--state-blocked-soft);
   color: var(--warning);
 }
 
 .context-change-breakdown span[data-change-type="removed"] {
-  background: oklch(0.68 0.22 25 / 0.12);
+  background: var(--state-error-soft);
   color: var(--danger);
 }
 
@@ -1022,8 +1047,8 @@
   margin: 0 var(--sp-0_5);
   padding: 0 var(--sp-1);
   border-radius: var(--radius-input);
-  background: oklch(0.91 0.01 255 / 0.72);
-  color: oklch(0.22 0.04 255);
+  background: var(--context-mark-bg);
+  color: var(--context-ink-mark);
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Context-palette tokenization (PR D, stacked on #696)

Lifts the bespoke hardcoded oklch in the `/context` hero (`.context-live-*` / `.context-network-*` / `.context-change-breakdown`) into a `--context-*` token family in `:root`. **Visual design language / centralization only; value-preserving.** Base is `feat/web-ds-focus-and-icons` (#696). Closes the audit's P3 `.context-live-* off-palette` item (+ the folded P2 `.context-change-breakdown`).

### What changed (`index.css` only)
- **18 `--context-*` tokens** — cool blue inks (hue 255–265) + faint-green card surfaces — a **byte-exact 1:1 lift** of the literals previously hardcoded in the rule bodies (comment notes a later pass can rationalize the near-duplicate inks).
- **Reuse where exact:** brand-green `/0.12` fills → `var(--brand-bg)`; change-breakdown `edited`/`removed` chips → `var(--state-blocked-soft)` / `var(--state-error-soft)` — so each chip's background now shares the hue of its `--warning`/`--danger` text.
- **Light-only preserved:** tokens are `:root`-only, so dark mode renders exactly as before (the page predates dark theming). Adding `.dark { --context-* }` overrides is now a trivial follow-up if the page should become dark-aware.

### Verification
- `pnpm check` (Biome) + `lint:tokens` + `typecheck` — all green
- Independent review ×2 — both **SHIP** (R1 verified all 18 tokens byte-exact + the one pre-authorized `/0.12→/0.14` removed-chip delta; R2 confirmed it fully closes P3, the family is coherent, and `--context-summary-bg` correctly stays translucent for frosted-glass layering over the network SVG)
- e2e on `/preview/context` **light + dark** — title/cards/summary/breakdown render identically (`.context-live-title` computes to the same `oklch(0.2 0.04 265)`), zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
