### PR TITLE
refactor(web): prune 9 unused --sp-* spacing tokens

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -160,8 +160,14 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 - [x] **No `--state-*-soft` companions.** **DONE:** added
   `--state-{working,idle,needs-you,blocked,error,offline}-soft` (one canonical 14% translucent mix; raw
-  on `:root`, `--color-state-*-soft` aliases in `@theme`). Migrating `lib/tones.ts` /
-  `.context-change-breakdown` onto them is the follow-up cleanup PR.
+  on `:root`, `--color-state-*-soft` aliases in `@theme`). **`lib/tones.ts` + the ad-hoc call-site
+  background fills (connect/disconnect chips, clients retire/load banners, agent-detail changed-chips)
+  migrated onto them** — normalizing those fills to the canonical 14% (the only deltas: `tones.ts` warn
+  16→14, and the call sites 12→14). Borders (28–38%) and `fg` (50–80%) stay `color-mix` — no `-line`/
+  strong soft token exists yet (see P2 follow-up below). Still TODO: `.context-change-breakdown` (raw
+  `oklch(.../0.12)` literals, and its "edited" swatch is hue 58) — folded into the `.context-*` palette PR.
+  One deliberate hold-out: `chat-view` keeps a 6% error wash (fainter than `--state-error-soft`, by a
+  solid error border), commented in place.
 - [x] **`.dark` missing `color-scheme: dark`.** **DONE:** added `color-scheme: dark` to `.dark` (and
   `color-scheme: light` to `:root`); native form controls / scrollbars now match the canvas in both modes.
 - [x] **`--color-*` semantic alias layer is unadopted.** `--color-text-*` / `--color-surface-*` /
@@ -272,7 +278,7 @@ fold into the phases below.
 
 **Phase 3 — rollout + folded cleanup:**
 - [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
-- [x] Add `--state-*-soft` tokens — DONE (definitions). *(Migrating `tones.ts` / call sites onto them is the follow-up cleanup PR.)*
+- [x] Add `--state-*-soft` tokens — DONE (definitions + `tones.ts`/call-site migration). *(`.context-change-breakdown` still raw — folded into the `.context-*` palette PR. Follow-up idea: add `--state-*-line` (~30%) border tokens so the borders that still hand-roll `color-mix` can converge too.)*
 - [~] `color-scheme: dark` on `.dark` — DONE; bringing the off-palette `.context-live-*` blues into tokens — still open.
 
 **Phase 4 — close-out:**

--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -93,8 +93,8 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
 - Styleguide updated: real tokens, new Feedback swatches, idle shows the new tone; the temporary
   "Cleanup candidates" section was removed.
 
-**Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
-and the ✓⚠✗⚙→lucide icon purge (authed surfaces — needs a local-stack by-eye pass).
+**Still open:** spacing rhythm, dead `--sp-*`, multi-line lint detection, and the ✓⚠✗⚙→lucide icon
+purge (authed surfaces — needs a local-stack by-eye pass).
 *(focus-ring extension — DONE: `filter-pill`/`tab-bar`/`segmented-control`; popover/command don't fit the ring.)*
 *(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
 `:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
@@ -186,8 +186,12 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 ## P3 — Discipline
 
-- [ ] **`.context-live-*` is off-palette.** ~40 lines in index.css hardcode blue hues 255–265
-  (e.g. `oklch(0.2 0.04 265)`) that exist in no token. Bring them into the token system.
+- [x] **`.context-live-*` is off-palette.** **DONE:** the hardcoded blue inks (255–265), faint-green
+  card surfaces, brand-green fills, and the `.context-change-breakdown` chips are now a value-preserving
+  `--context-*` token family in `:root` (reusing `--brand-bg` / `--state-*-soft` where exact). 1:1 lift —
+  a later pass can rationalize the near-duplicate inks. Dark mode unchanged (the page is light-only; tokens
+  are `:root`-only) — adding `.dark { --context-* }` overrides is now a trivial follow-up if the page
+  should become dark-aware.
 - [ ] **Spacing rhythm.** Half-steps (`--sp-1_25`=5px, `--sp-1_75`=7px) are used 12× / 23×, signalling
   pixel-nudging off a 4/8 rhythm. Converge to 4/8; mark half-steps as explicit exceptions.
 - [ ] **Prune dead `--sp-*`.** Defined but unused in components: `--sp-2_75`, `--sp-3_25`, `--sp-3_75`,
@@ -206,7 +210,7 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 ## Notes for whoever picks this up
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
-- **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
+- **Still open (none blocking):** P0.5 multi-line detection, spacing rhythm,
   dead `--sp-*`, and the ✓⚠✗⚙→lucide icon purge (authed surfaces — local-stack by-eye pass). *(focus-ring
   extension is DONE for filter-pill/tab-bar/segmented-control. `--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
   info callout are DONE — see the P1/P2 marks above.)*
@@ -283,7 +287,7 @@ fold into the phases below.
 **Phase 3 — rollout + folded cleanup:**
 - [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
 - [x] Add `--state-*-soft` tokens — DONE (definitions + `tones.ts`/call-site migration). *(`.context-change-breakdown` still raw — folded into the `.context-*` palette PR. Follow-up idea: add `--state-*-line` (~30%) border tokens so the borders that still hand-roll `color-mix` can converge too.)*
-- [~] `color-scheme: dark` on `.dark` — DONE; bringing the off-palette `.context-live-*` blues into tokens — still open.
+- [x] `color-scheme: dark` on `.dark` — DONE; the off-palette `.context-live-*` blues are now in the `--context-*` token family — DONE.
 
 **Phase 4 — close-out:**
 - [ ] QA in light + dark.

--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -93,9 +93,10 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
 - Styleguide updated: real tokens, new Feedback swatches, idle shows the new tone; the temporary
   "Cleanup candidates" section was removed.
 
-**Still open (as of #672):** `--text-live` adopt/drop, `--state-*-soft` companions,
-`color-scheme: dark` on `.dark`, info callout, `.context-live-*` palette, spacing rhythm, dead `--sp-*`.
-*(focus-ring unification — done in #662, see Phase 1.)*
+**Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
+focus-ring extension to the remaining primitives, and the ✓⚠✗⚙→lucide icon purge.
+*(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
+`:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
 
 ---
 
@@ -147,9 +148,9 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   `surface-overlay` / the `--shadow-*` scale. `Badge` uses `rounded-md` while `DenseBadge` uses
   `--radius-chip`. **DONE (#662):** standardized on the semantic four; migrated `rounded-md`/`rounded-lg`,
   fixed `Dialog`/`Badge`, retired `--radius-sm/md/lg/xl` (rule 8 now bans `rounded-(sm|md|lg|xl)`).
-- [ ] **Near-dead token.** `--text-live` (32px tier) is referenced **once** — the `/preview/styleguide`
-  demo (`styleguide-preview.tsx:136`) — and **never in product**. Adopt it (it's meant for the
-  live-status hero) or delete it.
+- [x] **Near-dead token.** `--text-live` (32px tier) was referenced **once** — the `/preview/styleguide`
+  demo — and **never in product**. **DONE:** removed the tier (the "Context tree is live" hero uses
+  `.context-live-title`, not this tier).
 - [x] **Inconsistent focus treatment.** **DONE (#662):** one recipe —
   `focus-visible:ring-2 ring-ring ring-offset-2` + a surface-matched `ring-offset` — applied across
   Button / Badge / Input / Dialog-close / Toast / settings-field. *(Extending it to `tab-bar` /
@@ -157,11 +158,12 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 ## P2 — Omissions
 
-- [ ] **No `--state-*-soft` companions.** Callouts have soft+strong pairs; state colors only have the
-  strong tone, so `lib/tones.ts` and `.context-change-breakdown` compute `color-mix(... 12-14%)` /
-  hardcode `oklch(.../0.12)` at the call site. Add `--state-idle-soft` … `--state-error-soft`.
-- [ ] **`.dark` missing `color-scheme: dark`** (only `.landing-marketing` sets it). Native form
-  controls / scrollbars don't get dark UA rendering in app dark mode.
+- [x] **No `--state-*-soft` companions.** **DONE:** added
+  `--state-{working,idle,needs-you,blocked,error,offline}-soft` (one canonical 14% translucent mix; raw
+  on `:root`, `--color-state-*-soft` aliases in `@theme`). Migrating `lib/tones.ts` /
+  `.context-change-breakdown` onto them is the follow-up cleanup PR.
+- [x] **`.dark` missing `color-scheme: dark`.** **DONE:** added `color-scheme: dark` to `.dark` (and
+  `color-scheme: light` to `:root`); native form controls / scrollbars now match the canvas in both modes.
 - [x] **`--color-*` semantic alias layer is unadopted.** `--color-text-*` / `--color-surface-*` /
   `--color-border-*` were each referenced once (only the styleguide). **DONE (#662):** deleted the alias
   layer; `--fg`/`--bg-*`/`--border` are canonical. Kept only the shadcn-compat aliases the primitives
@@ -169,7 +171,9 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 - [ ] **Marketing surface contrast gap.** `.landing-marketing` overrides `--bg`/`--fg`/`--border` but
   not the callout soft/strong pairs or `--state-*` — a notice on the near-black marketing canvas
   resolves to light-mode values. Define them in scope or guard against callouts there.
-- [ ] **No `info` (blue) callout pair** — only error/warn/success.
+- [x] **No `info` (blue) callout pair.** **DONE:** added `--color-info` / `--color-info-soft` (blue hue
+  245 — the presence-idle hue, following the same callout↔state hue pairing as error/warn/success),
+  light + dark.
 
 ## P3 — Discipline
 
@@ -193,9 +197,10 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 ## Notes for whoever picks this up
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
-- **Still open (none blocking):** P0.5 multi-line detection, `--text-live` adopt/drop, `--state-*-soft`,
-  `.dark color-scheme`, info callout, `.context-live-*` palette, spacing rhythm, dead `--sp-*`, and the
-  deferred focus-ring extension to the remaining interactive primitives.
+- **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
+  dead `--sp-*`, the deferred focus-ring extension to the remaining interactive primitives, and the
+  ✓⚠✗⚙→lucide icon purge. *(`--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
+  info callout are DONE — see the P1/P2 marks above.)*
 - Verify after any change: `pnpm --filter @first-tree/web typecheck` (runs tsc + `lint:tokens`).
 
 ---
@@ -267,8 +272,8 @@ fold into the phases below.
 
 **Phase 3 — rollout + folded cleanup:**
 - [ ] Apply across remaining pages (Team roster, Settings, onboarding, …).
-- [ ] Add `--state-*-soft` tokens (so `tones.ts` stops computing `color-mix` at call sites).
-- [ ] `color-scheme: dark` on `.dark`; bring the off-palette `.context-live-*` blues into tokens.
+- [x] Add `--state-*-soft` tokens — DONE (definitions). *(Migrating `tones.ts` / call sites onto them is the follow-up cleanup PR.)*
+- [~] `color-scheme: dark` on `.dark` — DONE; bringing the off-palette `.context-live-*` blues into tokens — still open.
 
 **Phase 4 — close-out:**
 - [ ] QA in light + dark.

--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -94,7 +94,8 @@ Verified after each stage with `pnpm --filter @first-tree/web typecheck` (tsc + 
   "Cleanup candidates" section was removed.
 
 **Still open:** `.context-live-*` palette, spacing rhythm, dead `--sp-*`, multi-line lint detection,
-focus-ring extension to the remaining primitives, and the ✓⚠✗⚙→lucide icon purge.
+and the ✓⚠✗⚙→lucide icon purge (authed surfaces — needs a local-stack by-eye pass).
+*(focus-ring extension — DONE: `filter-pill`/`tab-bar`/`segmented-control`; popover/command don't fit the ring.)*
 *(DONE in the low-risk-tokens PR: `--text-live` drop, `--state-*-soft` companions, `color-scheme` on
 `:root`/`.dark`, info callout — see P1/P2 marks. focus-ring unification — done in #662, see Phase 1.)*
 
@@ -153,8 +154,10 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   `.context-live-title`, not this tier).
 - [x] **Inconsistent focus treatment.** **DONE (#662):** one recipe —
   `focus-visible:ring-2 ring-ring ring-offset-2` + a surface-matched `ring-offset` — applied across
-  Button / Badge / Input / Dialog-close / Toast / settings-field. *(Extending it to `tab-bar` /
-  `segmented-control` / `command` / `popover` / `filter-pill` is still a deferred a11y follow-up.)*
+  Button / Badge / Input / Dialog-close / Toast / settings-field. **Extended** to `filter-pill`,
+  `tab-bar` (Tab), and `segmented-control`. `popover` triggers are caller-owned (already ringed via the
+  `Button`/`FilterPill` passed in), and `command` (cmdk) uses its `aria-selected` highlight model with an
+  always-focused input, so the button-style ring doesn't apply there.
 
 ## P2 — Omissions
 
@@ -204,8 +207,8 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 
 - **Done:** P0, P0.5 rule 7, all P1 decisions, P2 `--color-*` alias (#656/#662); green-liveness colour (#672).
 - **Still open (none blocking):** P0.5 multi-line detection, `.context-live-*` palette, spacing rhythm,
-  dead `--sp-*`, the deferred focus-ring extension to the remaining interactive primitives, and the
-  ✓⚠✗⚙→lucide icon purge. *(`--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
+  dead `--sp-*`, and the ✓⚠✗⚙→lucide icon purge (authed surfaces — local-stack by-eye pass). *(focus-ring
+  extension is DONE for filter-pill/tab-bar/segmented-control. `--text-live` drop, `--state-*-soft`, `.dark`/`:root` color-scheme, and the
   info callout are DONE — see the P1/P2 marks above.)*
 - Verify after any change: `pnpm --filter @first-tree/web typecheck` (runs tsc + `lint:tokens`).
 
@@ -261,10 +264,11 @@ fold into the phases below.
   matches each control's real surface (`--bg-sunken` for settings-field, `--bg-raised` for toast).
 - [ ] **Follow-ups (deferred):**
   - Line-icon set / purge the ✓ ⚠ ✗ ⚙ glyphs in favor of lucide — layout-affecting, spread
-    across pages; needs a by-eye pass.
-  - Extend the focus ring to the remaining interactive primitives (`tab-bar`,
-    `segmented-control`, `command`, `popover` triggers, `filter-pill`) — they paint no ring
-    today, so no visible mismatch, but it's an a11y coverage gap.
+    across pages (`runtime-state-line`, `working-turn`); needs a by-eye pass on authed surfaces
+    (not reachable from the styleguide), so deferred to a local-stack session. **Still open.**
+  - [x] Extend the focus ring to the remaining interactive primitives — **DONE** for `filter-pill` /
+    `tab-bar` / `segmented-control`; `popover` trigger is caller-owned and `command` uses cmdk
+    `aria-selected` (neither fits the button ring), so the recipe is now applied everywhere it makes sense.
   - Button/Badge base `ring-offset-background` uses the page surface; on a raised card/menu
     a sub-perceptible 2px seam can appear on keyboard focus (a primitive can't know its
     parent surface). Masked by the filled fill; acceptable until a per-surface convention exists.

--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -194,9 +194,12 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   should become dark-aware.
 - [ ] **Spacing rhythm.** Half-steps (`--sp-1_25`=5px, `--sp-1_75`=7px) are used 12× / 23×, signalling
   pixel-nudging off a 4/8 rhythm. Converge to 4/8; mark half-steps as explicit exceptions.
-- [ ] **Prune dead `--sp-*`.** Defined but unused in components: `--sp-2_75`, `--sp-3_25`, `--sp-3_75`,
-  `--sp-4_5`, `--sp-8_5`, `--sp-15`, `--sp-16`, `--sp-20`, `--sp-45`, `--sp-60`, `--sp-80`, `--sp-90`
-  (verify against index.css's own usage before removing).
+- [x] **Prune dead `--sp-*`.** **DONE:** removed the 9 genuinely-unused tokens (verified 0 `var()`
+  refs across `src/`, incl. index.css's own rules and the styleguide's dynamic swatch refs):
+  `--sp-15`, `--sp-240`, `--sp-2_75`, `--sp-3_25`, `--sp-3_75`, `--sp-4_5`, `--sp-80`, `--sp-8_5`,
+  `--sp-90`. (The earlier candidate list was stale — `--sp-16/20/45/60` are now in use; `--sp-0` kept as
+  the ladder's zero anchor.) The half-step **rhythm normalization** (5px/7px → 4/8) is a *visual* change
+  and stays open — it needs a by-eye pass.
 
 ---
 

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -205,7 +205,7 @@ Three marketing tiers for the public landing page only.
 **Spacing** — Tailwind utilities first; for compound inline `padding`/`gap`
 strings that can't be classes, use the `--sp-*` ladder (mirror of Tailwind:
 `--sp-N ≈ N × 0.25rem`, with 2/6/10/14px half-steps), range `--sp-0` →
-`--sp-240` (960px). Hairlines: `--hairline` (1px) / `--hairline-bold` (2px) —
+`--sp-75` (300px). Hairlines: `--hairline` (1px) / `--hairline-bold` (2px) —
 never write `"1px"`.
 
 **Radius** — semantic, ascending with surface importance:

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -147,6 +147,11 @@ for text sitting on a saturated colored surface (badges, avatars) and does
 | `--state-offline` | dim gray | offline |
 | `--state-unread` | = error | notification/attention (kept separate identifier on purpose) |
 
+Each state also ships a **soft** companion fill — `--state-working-soft` …
+`--state-offline-soft` (one canonical 14% translucent mix). Use these for
+state-tinted surfaces (chips, wells, `.context-change-breakdown`) instead of
+hand-rolling `color-mix(... var(--state-*) ..., transparent)` at the call site.
+
 ### Feedback / severity
 A named set, aliased to shared base hues (one value per color):
 `--success` (green, = brand hue) · `--warning` (orange, = `--state-blocked`; the caution/blocked hue, distinct from needs-you amber) · `--danger` (red).
@@ -155,7 +160,10 @@ A named set, aliased to shared base hues (one value per color):
 Each state ships a **soft** background + a **strong** text/border tone, so you
 never reach for `bg-red-50 / text-red-900`:
 `--color-error` / `--color-error-soft`, `--color-warn` / `--color-warn-soft`,
-`--color-success` / `--color-success-soft`.
+`--color-success` / `--color-success-soft`, and `--color-info` /
+`--color-info-soft` (blue, hue 245 — the presence-idle hue, following the same
+callout↔state hue pairing; for **static** informational notices, not the
+dynamic working/idle agent state).
 
 ### Overlay
 `--color-overlay-scrim` — dialog/lightbox scrim (`oklch(0 0 0 / 0.55)`,
@@ -182,7 +190,6 @@ Three marketing tiers for the public landing page only.
 | `text-body` | 12px | 400 | body copy, buttons |
 | `text-subtitle` | 13px | 600 | row titles (**default body size**) |
 | `text-title` | 16px | 600 | section / page titles |
-| `text-live` | 32px | 600 | the "live" status hero number |
 | — marketing — | | | |
 | `text-lead` | 18px | 400 | landing lead copy |
 | `text-headline` | 24px | 600 | landing section headings |
@@ -300,6 +307,10 @@ automatically):
 3. **Marketing** (`.landing-marketing`) — pinned to the first-tree.ai brand:
    near-black `#040404` canvas + cool-tinted light text, regardless of the
    dashboard toggle. `color-scheme: dark`. Same green brand.
+
+Each palette declares `color-scheme` (`light` on `:root`, `dark` on `.dark` and
+`.landing-marketing`) so native form controls, scrollbars, and `<input>` widgets
+render in the matching mode.
 
 ---
 

--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -139,7 +139,7 @@ export function ConnectCommandPanel({
           style={{
             gap: "var(--sp-2_5)",
             padding: "var(--sp-2_5) var(--sp-3)",
-            background: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",
+            background: "var(--state-blocked-soft)",
             border: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 35%, transparent)",
             borderRadius: "var(--radius-input)",
             color: "color-mix(in oklch, var(--state-blocked) 35%, var(--fg))",
@@ -172,7 +172,7 @@ export function ConnectCommandPanel({
           className="text-body"
           style={{
             padding: "var(--sp-2_5) var(--sp-3)",
-            background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+            background: "var(--state-error-soft)",
             border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
             borderRadius: "var(--radius-input)",
             color: "var(--state-error)",

--- a/packages/web/src/components/disconnect-chip.tsx
+++ b/packages/web/src/components/disconnect-chip.tsx
@@ -34,7 +34,7 @@ export function DisconnectChip() {
         border: 0,
         outline: "var(--hairline) solid color-mix(in oklch, var(--state-error) 38%, transparent)",
         outlineOffset: -1,
-        background: "color-mix(in oklch, var(--state-error) 14%, transparent)",
+        background: "var(--state-error-soft)",
         color: "color-mix(in oklch, var(--state-error) 80%, var(--fg))",
         minWidth: 0,
       }}

--- a/packages/web/src/components/ui/filter-pill.tsx
+++ b/packages/web/src/components/ui/filter-pill.tsx
@@ -11,7 +11,10 @@ export function FilterPill({ active, count, warn, className, children, style, ..
   return (
     <button
       type="button"
-      className={cn("mono inline-flex items-center gap-1 text-caption leading-[1.6]", className)}
+      className={cn(
+        "mono inline-flex items-center gap-1 text-caption leading-[1.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
       style={{
         padding: "var(--sp-0_5) var(--sp-1_75)",
         borderRadius: 3,

--- a/packages/web/src/components/ui/segmented-control.tsx
+++ b/packages/web/src/components/ui/segmented-control.tsx
@@ -39,7 +39,10 @@ export function SegmentedControl<T extends string>({ options, value, onChange, c
             onClick={() => {
               if (!active) onChange(opt.value);
             }}
-            className={cn("text-caption cursor-pointer transition-colors", !active && "hover:bg-[var(--bg-hover)]")}
+            className={cn(
+              "text-caption cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+              !active && "hover:bg-[var(--bg-hover)]",
+            )}
             style={{
               padding: "var(--sp-0_5) var(--sp-1_5)",
               border: 0,

--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -39,7 +39,7 @@ export function Tab({ active, onClick, children }: TabProps) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1.5 bg-transparent text-body font-medium"
+      className="inline-flex items-center gap-1.5 bg-transparent text-body font-medium rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       style={{
         padding: "var(--sp-1_75) var(--sp-3)",
         marginBottom: -1,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -110,10 +110,6 @@
   --text-title--letter-spacing: -0.2px;
   --text-title--font-weight: 600;
 
-  --text-live: 32px;
-  --text-live--line-height: 1.08;
-  --text-live--font-weight: 600;
-
   /* Marketing-tier typography — used by the public landing page only.
      Dashboard surfaces should keep using the dense scale above (eyebrow → title);
      these three tiers exist so the landing hero / section headings / lead
@@ -198,6 +194,17 @@
   --color-state-error: var(--state-error);
   --color-state-offline: var(--state-offline);
 
+  /* Soft state-tinted surface fills. Translucent (alpha-composited), so each
+     reads correctly over any background and needs no .dark override. Replaces
+     the ad-hoc color-mix(... var(--state-*) ..., transparent) hand-rolled in
+     lib/tones.ts and .context-change-breakdown; raw values defined on :root. */
+  --color-state-idle-soft: var(--state-idle-soft);
+  --color-state-working-soft: var(--state-working-soft);
+  --color-state-needs-you-soft: var(--state-needs-you-soft);
+  --color-state-blocked-soft: var(--state-blocked-soft);
+  --color-state-error-soft: var(--state-error-soft);
+  --color-state-offline-soft: var(--state-offline-soft);
+
   /* ---- Semantic inline-callout tokens ------------------------------------- */
   /* Each state exposes two Tailwind-addressable colors: the strong variant
      (for text and border utilities) and the soft variant (for background
@@ -210,6 +217,11 @@
   --color-warn-soft: var(--bg-warn-soft);
   --color-success: var(--fg-success-strong);
   --color-success-soft: var(--bg-success-soft);
+  /* info — blue (hue 245, matching the presence-idle state so the callout set
+     follows the same callout↔state hue pairing as error/warn/success). For
+     STATIC informational notices, not the dynamic working/idle agent state. */
+  --color-info: var(--fg-info-strong);
+  --color-info-soft: var(--bg-info-soft);
 
   /* Overlay scrim for dialogs / lightboxes — replaces hardcoded rgba(0,0,0,...). */
   --color-overlay-scrim: var(--overlay-scrim);
@@ -267,6 +279,18 @@
      "this is a notification" stays distinguishable from "this is a
      destructive-action warning" at the consumer site. */
   --state-unread: var(--state-error);
+
+  /* Soft state-tinted fills — one canonical 14% mix per state so lib/tones.ts,
+     .context-change-breakdown, and other state surfaces stop hand-rolling
+     color-mix at the call site. Alpha-composited, so this single definition
+     resolves correctly in both light and dark (the --state-* hues are not
+     redefined under .dark). */
+  --state-working-soft: color-mix(in oklch, var(--state-working) 14%, transparent);
+  --state-idle-soft: color-mix(in oklch, var(--state-idle) 14%, transparent);
+  --state-needs-you-soft: color-mix(in oklch, var(--state-needs-you) 14%, transparent);
+  --state-blocked-soft: color-mix(in oklch, var(--state-blocked) 14%, transparent);
+  --state-error-soft: color-mix(in oklch, var(--state-error) 14%, transparent);
+  --state-offline-soft: color-mix(in oklch, var(--state-offline) 14%, transparent);
 
   /* Feedback / severity vocabulary (success / warning / error). Aliased to the
      shared base hues so there is ONE value per color — distinct *names* from the
@@ -333,6 +357,10 @@
   --fg-warn-strong: oklch(0.48 0.14 58);
   --bg-success-soft: oklch(0.96 0.04 150);
   --fg-success-strong: oklch(0.42 0.12 150);
+  /* info — blue (hue 245, the presence-idle hue). Matched L/C to the other
+     callout pairs so the set reads with even weight. */
+  --bg-info-soft: oklch(0.96 0.03 245);
+  --fg-info-strong: oklch(0.45 0.14 245);
 
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
@@ -386,6 +414,10 @@
   --sp-80: 20rem; /* 320px */
   --sp-90: 22.5rem; /* 360px */
   --sp-240: 60rem; /* 960px */
+
+  /* Default color-scheme so native form controls, scrollbars, and the
+     canvas match the light theme (.dark flips this to dark below). */
+  color-scheme: light;
 
   /* Firefox / Windows scrollbar hint — keeps widths visually close to
      macOS overlay scrollbars so layout doesn't jump between platforms. */
@@ -472,6 +504,12 @@
   --fg-warn-strong: oklch(0.86 0.14 58);
   --bg-success-soft: oklch(0.28 0.05 150);
   --fg-success-strong: oklch(0.82 0.14 150);
+  --bg-info-soft: oklch(0.28 0.06 245);
+  --fg-info-strong: oklch(0.82 0.14 245);
+
+  /* Flip native form controls / scrollbars to dark to match the canvas
+     (previously only .landing-marketing set this). */
+  color-scheme: dark;
 }
 
 @layer base {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -413,32 +413,23 @@
   --sp-2: 0.5rem; /* 8px */
   --sp-2_25: 0.5625rem; /* 9px */
   --sp-2_5: 0.625rem; /* 10px */
-  --sp-2_75: 0.6875rem; /* 11px */
   --sp-3: 0.75rem; /* 12px */
-  --sp-3_25: 0.8125rem; /* 13px */
   --sp-3_5: 0.875rem; /* 14px */
-  --sp-3_75: 0.9375rem; /* 15px */
   --sp-4: 1rem; /* 16px */
-  --sp-4_5: 1.125rem; /* 18px */
   --sp-5: 1.25rem; /* 20px */
   --sp-6: 1.5rem; /* 24px */
   --sp-6_5: 1.625rem; /* 26px */
   --sp-7: 1.75rem; /* 28px */
   --sp-7_5: 1.875rem; /* 30px */
   --sp-8: 2rem; /* 32px */
-  --sp-8_5: 2.125rem; /* 34px */
   --sp-10: 2.5rem; /* 40px */
   --sp-11: 2.75rem; /* 44px */
   --sp-12: 3rem; /* 48px */
-  --sp-15: 3.75rem; /* 60px */
   --sp-16: 4rem; /* 64px */
   --sp-20: 5rem; /* 80px */
   --sp-45: 11.25rem; /* 180px */
   --sp-60: 15rem; /* 240px */
   --sp-75: 18.75rem; /* 300px */
-  --sp-80: 20rem; /* 320px */
-  --sp-90: 22.5rem; /* 360px */
-  --sp-240: 60rem; /* 960px */
 
   /* Default color-scheme so native form controls, scrollbars, and the
      canvas match the light theme (.dark flips this to dark below). */

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -365,6 +365,31 @@
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
 
+  /* ── Context-tree "live" page palette (/context hero) ─────────────────────
+     A bespoke set — cool blue "ink" + faint-green card surfaces — lifted here
+     from the hardcoded oklch in the .context-live-* rules below so the page's
+     palette lives in one place. Value-preserving 1:1 lift (a later pass can
+     rationalize the near-duplicate inks). Light-only: the page predates dark
+     theming and these values are mode-independent (unchanged behavior). */
+  --context-ink: oklch(0.2 0.04 265);
+  --context-ink-em: oklch(0.25 0.04 265);
+  --context-ink-dim: oklch(0.52 0.035 255);
+  --context-ink-summary: oklch(0.2 0.035 255);
+  --context-ink-scale: oklch(0.18 0.04 255);
+  --context-ink-node: oklch(0.23 0.025 255);
+  --context-ink-mark: oklch(0.22 0.04 255);
+  --context-mark-bg: oklch(0.91 0.01 255 / 0.72);
+  --context-shadow: oklch(0.25 0.04 255 / 0.08);
+  --context-card-edge: oklch(0.89 0.008 150);
+  --context-card-edge-hover: oklch(0.78 0.09 150);
+  --context-card-edge-live: oklch(0.78 0.13 150);
+  --context-card-bg: oklch(0.98 0.003 150 / 0.9);
+  --context-card-bg-live: oklch(0.985 0.012 150 / 0.94);
+  --context-summary-edge: oklch(0.88 0.008 150);
+  --context-summary-bg: oklch(1 0 0 / 0.86);
+  --context-halo: oklch(0.72 0.17 150 / 0.34);
+  --context-pin-glow: oklch(0.72 0.17 150 / 0.18);
+
   /* Hairline widths. Exposing these as vars lets component inline styles
      reference --hairline / --hairline-bold instead of writing "1px" /
      "2px" literals — keeps the src/ tree free of raw px strings. */
@@ -808,18 +833,18 @@
 }
 
 .context-live-title {
-  color: oklch(0.2 0.04 265);
+  color: var(--context-ink);
   font-size: 44px;
   font-weight: 700;
   line-height: 1.05;
 }
 
 .context-live-subtitle {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
 }
 
 .context-live-subtitle strong {
-  color: oklch(0.25 0.04 265);
+  color: var(--context-ink-em);
   font-weight: 700;
 }
 
@@ -837,7 +862,7 @@
 }
 
 .context-map-kicker {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
   font-size: 12px;
   font-weight: 700;
 }
@@ -862,7 +887,7 @@
   transform-box: fill-box;
   transform-origin: center;
   fill: transparent;
-  stroke: oklch(0.72 0.17 150 / 0.34);
+  stroke: var(--context-halo);
   stroke-width: 1.25;
   animation: context-live-halo-breathe 3.6s ease-in-out infinite;
 }
@@ -877,10 +902,10 @@
   justify-content: center;
   gap: var(--sp-1);
   padding: var(--sp-3) var(--sp-4);
-  border: var(--hairline) solid oklch(0.89 0.008 150);
+  border: var(--hairline) solid var(--context-card-edge);
   border-radius: var(--radius-dialog);
-  background: oklch(0.98 0.003 150 / 0.9);
-  box-shadow: 0 8px 28px oklch(0.25 0.04 255 / 0.08);
+  background: var(--context-card-bg);
+  box-shadow: 0 8px 28px var(--context-shadow);
   color: var(--fg);
   text-align: left;
   transition:
@@ -891,12 +916,12 @@
 
 .context-network-card:hover {
   transform: translateY(-1px);
-  border-color: oklch(0.78 0.09 150);
+  border-color: var(--context-card-edge-hover);
 }
 
 .context-network-card.is-live {
-  border-color: oklch(0.78 0.13 150);
-  background: oklch(0.985 0.012 150 / 0.94);
+  border-color: var(--context-card-edge-live);
+  background: var(--context-card-bg-live);
 }
 
 .context-network-summary-card {
@@ -907,10 +932,10 @@
   align-items: center;
   justify-content: center;
   gap: var(--sp-1);
-  border: var(--hairline) solid oklch(0.88 0.008 150);
+  border: var(--hairline) solid var(--context-summary-edge);
   border-radius: var(--radius-dialog);
-  background: oklch(1 0 0 / 0.86);
-  box-shadow: 0 14px 36px oklch(0.25 0.04 255 / 0.08);
+  background: var(--context-summary-bg);
+  box-shadow: 0 14px 36px var(--context-shadow);
   color: var(--fg);
   text-align: center;
 }
@@ -921,12 +946,12 @@
   height: var(--sp-11);
   place-items: center;
   border-radius: 50%;
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
 }
 
 .context-network-summary-title {
-  color: oklch(0.2 0.035 255);
+  color: var(--context-ink-summary);
   font-size: 13px;
   font-weight: 700;
   line-height: 1.15;
@@ -938,14 +963,14 @@
   align-items: baseline;
   justify-content: center;
   gap: var(--sp-1);
-  color: oklch(0.18 0.04 255);
+  color: var(--context-ink-scale);
   font-size: 40px;
   font-weight: 500;
   line-height: 1;
 }
 
 .context-network-summary-scale span {
-  color: oklch(0.52 0.035 255);
+  color: var(--context-ink-dim);
   font-size: 12px;
   font-weight: 500;
 }
@@ -953,7 +978,7 @@
 .context-network-summary-badge {
   padding: var(--sp-0_5) var(--sp-2);
   border-radius: var(--radius-chip);
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
   font-weight: 600;
 }
@@ -966,12 +991,12 @@
   height: var(--sp-3);
   border-radius: 50%;
   background: var(--success);
-  box-shadow: 0 0 0 var(--sp-0_75) oklch(0.72 0.17 150 / 0.18);
+  box-shadow: 0 0 0 var(--sp-0_75) var(--context-pin-glow);
 }
 
 .context-network-title {
   max-width: 100%;
-  color: oklch(0.23 0.025 255);
+  color: var(--context-ink-node);
   text-transform: uppercase;
   letter-spacing: 0;
 }
@@ -993,17 +1018,17 @@
 }
 
 .context-change-breakdown span[data-change-type="added"] {
-  background: oklch(0.72 0.17 150 / 0.12);
+  background: var(--brand-bg);
   color: var(--success);
 }
 
 .context-change-breakdown span[data-change-type="edited"] {
-  background: oklch(0.74 0.18 58 / 0.14);
+  background: var(--state-blocked-soft);
   color: var(--warning);
 }
 
 .context-change-breakdown span[data-change-type="removed"] {
-  background: oklch(0.68 0.22 25 / 0.12);
+  background: var(--state-error-soft);
   color: var(--danger);
 }
 
@@ -1022,8 +1047,8 @@
   margin: 0 var(--sp-0_5);
   padding: 0 var(--sp-1);
   border-radius: var(--radius-input);
-  background: oklch(0.91 0.01 255 / 0.72);
-  color: oklch(0.22 0.04 255);
+  background: var(--context-mark-bg);
+  color: var(--context-ink-mark);
   font-weight: 700;
 }
 

--- a/packages/web/src/lib/tones.ts
+++ b/packages/web/src/lib/tones.ts
@@ -49,12 +49,13 @@ export const TONE_STYLES: Record<Tone, ToneStyle> = {
     bd: "color-mix(in oklch, var(--brand) 30%, transparent)",
   },
   warn: {
-    bg: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+    // bg normalized 16% → the canonical --state-blocked-soft (14%).
+    bg: "var(--state-blocked-soft)",
     fg: "color-mix(in oklch, var(--state-blocked) 50%, var(--fg))",
     bd: "color-mix(in oklch, var(--state-blocked) 30%, transparent)",
   },
   error: {
-    bg: "color-mix(in oklch, var(--state-error) 14%, transparent)",
+    bg: "var(--state-error-soft)",
     fg: "var(--state-error)",
     bd: "color-mix(in oklch, var(--state-error) 30%, transparent)",
   },
@@ -64,27 +65,27 @@ export const TONE_STYLES: Record<Tone, ToneStyle> = {
     bd: "var(--border)",
   },
   idle: {
-    bg: "color-mix(in oklch, var(--state-idle) 14%, transparent)",
+    bg: "var(--state-idle-soft)",
     fg: "var(--state-idle)",
     bd: "color-mix(in oklch, var(--state-idle) 30%, transparent)",
   },
   working: {
-    bg: "color-mix(in oklch, var(--state-working) 14%, transparent)",
+    bg: "var(--state-working-soft)",
     fg: "var(--state-working)",
     bd: "color-mix(in oklch, var(--state-working) 30%, transparent)",
   },
   "needs-you": {
-    bg: "color-mix(in oklch, var(--state-needs-you) 14%, transparent)",
+    bg: "var(--state-needs-you-soft)",
     fg: "color-mix(in oklch, var(--state-needs-you) 50%, var(--fg))",
     bd: "color-mix(in oklch, var(--state-needs-you) 30%, transparent)",
   },
   blocked: {
-    bg: "color-mix(in oklch, var(--state-blocked) 14%, transparent)",
+    bg: "var(--state-blocked-soft)",
     fg: "color-mix(in oklch, var(--state-blocked) 50%, var(--fg))",
     bd: "color-mix(in oklch, var(--state-blocked) 30%, transparent)",
   },
   offline: {
-    bg: "color-mix(in oklch, var(--state-offline) 14%, transparent)",
+    bg: "var(--state-offline-soft)",
     fg: "var(--state-offline)",
     bd: "color-mix(in oklch, var(--state-offline) 30%, transparent)",
   },

--- a/packages/web/src/pages/agent-detail/option-dropdown.tsx
+++ b/packages/web/src/pages/agent-detail/option-dropdown.tsx
@@ -17,7 +17,7 @@ export function ChangedChip() {
       style={{
         padding: "var(--hairline) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
-        background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+        background: "var(--state-blocked-soft)",
         color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
       }}
     >

--- a/packages/web/src/pages/agent-detail/prompt-section.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-section.tsx
@@ -111,7 +111,7 @@ function ChangedChip() {
       style={{
         padding: "var(--hairline) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
-        background: "color-mix(in oklch, var(--state-blocked) 16%, transparent)",
+        background: "var(--state-blocked-soft)",
         color: "color-mix(in oklch, var(--state-blocked) 60%, var(--fg))",
       }}
     >

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -372,7 +372,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                 <div
                   className="mb-3 p-2 rounded"
                   style={{
-                    background: "color-mix(in oklch, var(--state-blocked) 12%, transparent)",
+                    background: "var(--state-blocked-soft)",
                     border: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 28%, transparent)",
                   }}
                 >
@@ -390,7 +390,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                 <div
                   className="mb-3 p-2 rounded text-body"
                   style={{
-                    background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+                    background: "var(--state-error-soft)",
                     border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
                     color: "var(--state-error)",
                   }}
@@ -834,7 +834,7 @@ function TeamLoadErrorBanner() {
         margin: "var(--sp-3) var(--sp-3) 0",
         padding: "var(--sp-2_5) var(--sp-3)",
         borderRadius: "var(--radius-panel)",
-        background: "color-mix(in oklch, var(--state-error) 12%, transparent)",
+        background: "var(--state-error-soft)",
         border: "var(--hairline) solid color-mix(in oklch, var(--state-error) 28%, transparent)",
         color: "var(--state-error)",
       }}

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -27,10 +27,7 @@ export function StepHeading({ title, why }: { title: string; why?: string | null
 /** Error / warning note. Tone "error" (red) or "info" (neutral ink). */
 export function FlowNote({ children, tone = "error" }: { children: ReactNode; tone?: "error" | "info" }) {
   const color = tone === "error" ? "var(--state-error)" : "var(--fg-2)";
-  const bg =
-    tone === "error"
-      ? "color-mix(in oklch, var(--state-error) 12%, transparent)"
-      : "color-mix(in oklch, var(--primary) 8%, transparent)";
+  const bg = tone === "error" ? "var(--state-error-soft)" : "color-mix(in oklch, var(--primary) 8%, transparent)";
   const border =
     tone === "error"
       ? "color-mix(in oklch, var(--state-error) 28%, transparent)"

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -104,6 +104,17 @@ const STATE_COLORS: SwatchDef[] = [
   { name: "--state-offline", token: "var(--state-offline)", note: "offline · gray" },
 ];
 
+// Soft state fills — the canonical translucent tint per state (replaces ad-hoc
+// color-mix at call sites). Swatches sit on the page bg so the tint reads true.
+const STATE_SOFT_COLORS: SwatchDef[] = [
+  { name: "--state-working-soft", token: "var(--state-working-soft)" },
+  { name: "--state-idle-soft", token: "var(--state-idle-soft)" },
+  { name: "--state-needs-you-soft", token: "var(--state-needs-you-soft)" },
+  { name: "--state-blocked-soft", token: "var(--state-blocked-soft)" },
+  { name: "--state-error-soft", token: "var(--state-error-soft)" },
+  { name: "--state-offline-soft", token: "var(--state-offline-soft)" },
+];
+
 // Feedback / severity vocabulary — distinct names, aliased to shared base hues.
 const FEEDBACK_COLORS: SwatchDef[] = [
   { name: "--success", token: "var(--success)", note: "= brand green" },
@@ -118,6 +129,8 @@ const CALLOUT_COLORS: SwatchDef[] = [
   { name: "--color-warn-soft", token: "var(--color-warn-soft)" },
   { name: "--color-success", token: "var(--color-success)" },
   { name: "--color-success-soft", token: "var(--color-success-soft)" },
+  { name: "--color-info", token: "var(--color-info)", note: "static notices" },
+  { name: "--color-info-soft", token: "var(--color-info-soft)" },
 ];
 
 const AVATAR_HUES: SwatchDef[] = Array.from({ length: 8 }, (_, i) => ({
@@ -136,7 +149,6 @@ const APP_TIERS: TypeTier[] = [
   { cls: "text-body", name: "text-body", meta: "12 / 400", sample: "Body copy and button text." },
   { cls: "text-subtitle", name: "text-subtitle", meta: "13 / 600 · default", sample: "Row title / subtitle" },
   { cls: "text-title", name: "text-title", meta: "16 / 600", sample: "Section & page title" },
-  { cls: "text-live", name: "text-live", meta: "32 / 600", sample: "Live" },
 ];
 
 const MARKETING_TIERS: TypeTier[] = [
@@ -407,6 +419,8 @@ export function StyleguidePreviewPage() {
           <SwatchGrid items={BRAND_COLORS} />
           <Subhead>State (agent vocabulary)</Subhead>
           <SwatchGrid items={STATE_COLORS} />
+          <Subhead>State soft fills (tinted surfaces)</Subhead>
+          <SwatchGrid items={STATE_SOFT_COLORS} />
           <Subhead>Feedback / severity</Subhead>
           <SwatchGrid items={FEEDBACK_COLORS} />
           <Subhead>Callout pairs (soft fill + strong text/border)</Subhead>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -183,6 +183,8 @@ function ErrorRow({ event, agentNameFn }: { event: SessionEventRow; agentNameFn?
       style={{
         padding: "var(--sp-1_5) var(--sp-2_5)",
         borderLeft: "var(--hairline-bold) solid var(--state-error)",
+        // Intentionally fainter than --state-error-soft (14%): this inline error row
+        // already carries a solid --hairline-bold error borderLeft, so the wash stays at 6%.
         background: "color-mix(in oklch, var(--state-error) 6%, transparent)",
         borderRadius: "0 var(--radius-input) var(--radius-input) 0",
       }}


### PR DESCRIPTION
## Dead `--sp-*` prune (PR E, stacked on #697)

Removes 9 `--sp-*` spacing-ladder tokens with **zero `var()` references** anywhere in `packages/web/src` (verified incl. `index.css`'s own rules and the styleguide's dynamic swatch refs): `--sp-15`, `--sp-240`, `--sp-2_75`, `--sp-3_25`, `--sp-3_75`, `--sp-4_5`, `--sp-80`, `--sp-8_5`, `--sp-90`. **Pure dead-code removal — value-preserving** (nothing referenced them, so no visual change). Base is `feat/web-ds-context-palette` (#697).

### Notes
- The audit's earlier candidate list was **stale** — `--sp-16` / `-20` / `-45` / `-60` are now in use and are kept; `--sp-0` is kept as the ladder's zero anchor.
- The half-step **rhythm normalization** (5px/7px → 4/8) is a *visual* change and stays open as a separate by-eye pass.
- `DESIGN.md` ladder range updated `--sp-240` (960px) → `--sp-75` (300px).

### Verification
- `pnpm check` (Biome) + `lint:tokens` (**rule #7 undefined-token** — guarantees no dangling `var(--sp-*)`) + `typecheck` — all green
- Independent review ×2 — both **SHIP**; one independently audited the *full* remaining ladder and confirmed every token except the kept `--sp-0` anchor is in use (nothing dead missed, no used token removed)
- e2e on `/preview/styleguide` — renders; kept tokens resolve (`--sp-16`→4rem, `--sp-75`→18.75rem); removed tokens now empty; zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
