### PR TITLE
fix(web): give .landing-marketing the dark inline-callout pairs

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -177,9 +177,11 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
   `--color-border-*` were each referenced once (only the styleguide). **DONE (#662):** deleted the alias
   layer; `--fg`/`--bg-*`/`--border` are canonical. Kept only the shadcn-compat aliases the primitives
   need (`--color-primary`, `--color-destructive`, `--color-ring`, etc.).
-- [ ] **Marketing surface contrast gap.** `.landing-marketing` overrides `--bg`/`--fg`/`--border` but
-  not the callout soft/strong pairs or `--state-*` — a notice on the near-black marketing canvas
-  resolves to light-mode values. Define them in scope or guard against callouts there.
+- [x] **Marketing surface contrast gap.** **DONE:** `.landing-marketing` now overrides the inline-callout
+  pairs (`--bg/--fg-{error,warn,success,info}-*`) to their dark variants, so a notice on the near-black
+  marketing canvas reads as a dark-surface notice instead of a bright light-mode card. The agent-state
+  hues (`--state-*`) and `--state-*-soft` fills are mode-independent (alpha-composited), so they need no
+  override. Styleguide marketing section now includes an inline-notice demo.
 - [x] **No `info` (blue) callout pair.** **DONE:** added `--color-info` / `--color-info-soft` (blue hue
   245 — the presence-idle hue, following the same callout↔state hue pairing as error/warn/success),
   light + dark.

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -435,10 +435,6 @@
      canvas match the light theme (.dark flips this to dark below). */
   color-scheme: light;
 
-  /* Default color-scheme so native form controls, scrollbars, and the
-     canvas match the light theme (.dark flips this to dark below). */
-  color-scheme: light;
-
   /* Firefox / Windows scrollbar hint — keeps widths visually close to
      macOS overlay scrollbars so layout doesn't jump between platforms. */
   scrollbar-width: thin;
@@ -485,6 +481,21 @@
   --primary-hover: var(--brand-dim);
   --primary-on: var(--fg-on-vivid);
   --ring: var(--brand-ring);
+
+  /* Inline-callout pairs use the DARK variants here: .landing-marketing is a
+     dark surface (near-black canvas) but does not carry `.dark`, so without
+     this override an inline notice would resolve to the light-mode callout
+     values and read as a bright card on the dark canvas. The agent-state hues
+     (`--state-*`) and the `--state-*-soft` fills are mode-independent
+     (alpha-composited), so they need no override here. */
+  --bg-error-soft: oklch(0.28 0.06 25);
+  --fg-error-strong: oklch(0.82 0.14 25);
+  --bg-warn-soft: oklch(0.3 0.06 58);
+  --fg-warn-strong: oklch(0.86 0.14 58);
+  --bg-success-soft: oklch(0.28 0.05 150);
+  --fg-success-strong: oklch(0.82 0.14 150);
+  --bg-info-soft: oklch(0.28 0.06 245);
+  --fg-info-strong: oklch(0.82 0.14 245);
 
   color-scheme: dark;
 }

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -765,6 +765,17 @@ export function StyleguidePreviewPage() {
             <div style={{ marginTop: "var(--sp-4)" }}>
               <Button size="sm">Get started</Button>
             </div>
+            <div
+              className="text-label border border-error bg-error-soft text-error"
+              style={{
+                marginTop: "var(--sp-4)",
+                padding: "var(--sp-2) var(--sp-3)",
+                borderRadius: "var(--radius-input)",
+              }}
+            >
+              Inline notice — the callout (via the bg-error-soft / text-error utilities) is scoped to its dark variant
+              here, so it reads as a dark-surface notice rather than a bright light-mode card on the near-black canvas.
+            </div>
           </div>
         </Section>
       </div>


### PR DESCRIPTION
## Marketing-surface callout contrast (PR F, stacked on #698)

Closes the audit's P2 "marketing surface contrast gap". `.landing-marketing` is a fixed near-black dark surface that does **not** carry `.dark`, so its inline-callout pairs resolved to the `:root` **light-mode** values — a notice there would render as a bright light card on the dark canvas. Base is `feat/web-ds-prune-sp` (#698).

### Change
- **`index.css`**: override the 8 callout values (`--bg/--fg-{error,warn,success,info}-{soft,strong}`) to their **dark** variants within `.landing-marketing` scope (byte-identical to `.dark`). The agent-state hues (`--state-*`) and `--state-*-soft` fills are mode-independent (alpha-composited), so they need no override.
- **styleguide**: added an inline-notice demo to the Marketing section, using the idiomatic `bg-error-soft` / `text-error` / `border-error` utilities.

### Verification
- `pnpm check` (Biome) + `lint:tokens` + `typecheck` — all green
- Independent review ×2 — both **SHIP** (values byte-match `.dark`, tight scoping, correct `--state-*` exclusion, preventive fix that closes a latent trap)
- e2e on `/preview/styleguide`: inside `.landing-marketing`, the `bg-error-soft` utility **and** raw `var(--bg-error-soft)` resolve to the dark value `oklch(0.28 0.06 25)`; the demo notice computes dark text/border (`oklch(0.82 0.14 25)`); zero console errors.

> e2e finding worth recording: the `@theme inline` alias `var(--color-error-soft)` used **directly** does *not* pick up the scope override (it resolves to a fixed value) — real callouts consume the `bg-error-soft` utility or the raw `--bg-error-soft` token, both of which **do** respond. (My demo initially used the alias and showed light; corrected to the utility.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
