### PR TITLE
docs: update README product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,87 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-**Agent teams run on First-Tree.**
+**Context-grounded agentic work for teams.**
 
-first-tree routes work to the right agent, gives it the same context your
-team has, and loops humans in only when the rules say so. Lives in your
-GitHub. Open source.
+First Tree is an open-source workspace where AI agents work from your team's
+shared context, not isolated prompts.
 
-## Get started
+At the center is Context Tree: a team-maintained memory of decisions,
+ownership, repos, responsibilities, constraints, and prior work. Agents read it
+before they work; useful outcomes can flow back into it after the work is done.
 
-Sign in at <https://first-tree.ai> (or your own deployment) and the guided
-setup walks you through it end to end — name your team, connect a computer,
-create your first agent, and start your first chat. See the
-[Quickstart](docs/quickstart.md) for the full walkthrough.
+The result is a human-agent work loop where every task can start with more team
+context, and every useful outcome can make the next task smarter.
 
-At the "connect a computer" step the setup hands you the command to install
-the CLI and link the machine:
+## Why First Tree
+
+There are many AI agent workspaces. First Tree's core difference is the context
+loop:
+
+```text
+user intent -> read team context -> context-aware agent work
+-> human review/control -> durable outcome -> updated team context
+```
+
+This loop solves the part that usually breaks when teams start using agents:
+
+- context stays private in one person's terminal, prompt, or notes
+- agents repeat old decisions because they cannot see team memory
+- work finishes in a chat, PR, or document but never updates the shared context
+- humans get pulled in without enough background to make a good decision
+- each new agent task starts cold, even when the team already learned something
+
+First Tree is built around a different assumption:
+
+> Agent work should be grounded in team context, visible while it runs, guided
+> by humans at the right moments, and turned into durable outcomes that can
+> update team memory.
+
+That makes First Tree useful in two modes:
+
+- **Focused copilot work** - collaborate deeply with an agent in a persistent
+  work stream for design, coding, writing, research, or problem solving.
+- **Parallel review work** - let agents move multiple tasks forward and involve
+  you only when a decision, blocker, approval, or review is needed.
+
+In both modes, First Tree gives teams one place to:
+
+- give agents the same Context Tree your team uses
+- start and continue agent work in persistent chats
+- see active work, blocked states, and human review points
+- inspect the process, artifacts, and rationale behind a request
+- turn useful outcomes back into updated team context
+
+It is not another agent, and not just another workspace. It is a context loop
+for human-agent teams.
+
+## How It Works
+
+First Tree connects five pieces around Context Tree:
+
+1. **Context Tree** — a Git-native team memory layer for decisions, ownership,
+   responsibilities, constraints, and shared context.
+2. **Web workspace** — the daily surface for chats, agents, team members,
+   computers, GitHub, and context-backed work.
+3. **CLI + daemon** — signs a computer in and keeps local agents connected.
+4. **Agent runtime** — runs agents on your machine and routes messages through
+   First Tree.
+5. **GitHub integration** — connects code work, pull requests, and review back
+   to the workspace.
+
+Together, these pieces keep agent work connected to team context before,
+during, and after execution.
+
+## Get Started
+
+Sign in at <https://first-tree.ai> or your own deployment. The guided setup
+walks you through the first run: name your team, connect a computer, create
+your first agent, connect code, and start work.
+
+See the [Quickstart](docs/quickstart.md) for the full walkthrough.
+
+At the "connect a computer" step, setup gives you the command to install the
+CLI and link the machine:
 
 ```bash
 npm install -g first-tree
@@ -27,17 +93,17 @@ first-tree login <connect-token>
 
 The binary lives at `first-tree`; a short alias `ft` is also installed.
 
-## Top-level command tree
+## CLI
 
-```
+```text
 first-tree
 ├── login <token>           Sign this computer in
 ├── logout                  Stop the daemon and clear credentials
 ├── status                  CLI / daemon / server / auth overview
 ├── doctor                  Cross-subsystem readiness check
 ├── upgrade                 Upgrade to the latest published version
-├── agent ...               Agent management (config, bindings, messaging)
-├── chat ...                Chats and messaging (list, history, send, open)
+├── agent ...               Agent management
+├── chat ...                Chats and messaging
 ├── org ...                 Organization-level operations
 ├── daemon ...              Background daemon lifecycle
 ├── config ...              View / modify this machine's client.yaml
@@ -47,27 +113,24 @@ first-tree
 
 Run `first-tree <namespace> --help` for the full list under any namespace.
 
-## Repo layout
+## Repo Layout
 
-- `apps/cli/` — the published CLI (`first-tree` / `ft`)
+- `apps/cli/` — published CLI (`first-tree` / `ft`)
 - `packages/shared/` — Zod schemas, types, config system (`@first-tree/shared`)
-- `packages/server/` — Fastify API server (`@first-tree/server`; deployed as
-  the SaaS via Docker)
+- `packages/server/` — Fastify API server (`@first-tree/server`)
 - `packages/client/` — Agent SDK + Runtime (`@first-tree/client`)
-- `packages/web/` — React admin dashboard (`@first-tree/web`)
+- `packages/web/` — React web workspace (`@first-tree/web`)
 - `packages/github-scan/` — GitHub Scan daemon (`@first-tree/github-scan`)
 - `packages/e2e/` — black-box e2e harness (`@first-tree/e2e`)
-- `skills/` — per-skill markdown payloads (`first-tree`, `first-tree-cloud`,
-  `first-tree-github-scan`, `first-tree-sync`, `first-tree-write`,
-  `first-tree-onboarding`, `github-scan`)
+- `skills/` — repo-local skill payloads for First Tree agents
 
 ## Documentation
 
-- [Quickstart](docs/quickstart.md) — from signup to first chat
+- [Quickstart](docs/quickstart.md) — from signup to first agent work
 - [Onboarding Guide](docs/onboarding-guide.md) — CLI flow, SDK, troubleshooting
 - [CLI Reference](docs/cli-reference.md) — every command and environment variable
 - [Observability](docs/observability.md) — logs and OpenTelemetry traces
-- [docs/development/](docs/development/) — contributor reference (HTTP / JWT, dev isolation)
+- [docs/development/](docs/development/) — contributor reference
 - [docs/troubleshooting/](docs/troubleshooting/) — environment-specific gotchas
 - [docs/migration/](docs/migration/) — coming from `first-tree@0.4.x`
 
@@ -76,8 +139,8 @@ Run `first-tree <namespace> --help` for the full list under any namespace.
 ```bash
 pnpm install                                # Install dependencies
 docker compose up -d                        # Dev PostgreSQL
-pnpm --filter @first-tree/server dev        # Server (dev mode)
-pnpm --filter @first-tree/web dev           # Admin dashboard (dev mode)
+pnpm --filter @first-tree/server dev        # Server
+pnpm --filter @first-tree/web dev           # Web workspace
 pnpm check && pnpm typecheck                # Lint + type check
 pnpm test                                   # Tests
 pnpm coverage                               # Local unit coverage
@@ -85,8 +148,7 @@ pnpm coverage:summary                       # Summarize generated coverage
 ```
 
 See [AGENTS.md](AGENTS.md) for architecture, conventions, and the per-package
-development workflow. See [docs/development/test-coverage.md](docs/development/test-coverage.md)
-for local coverage reports. See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR
+development workflow. See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR
 workflow.
 
 ## License

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -4,18 +4,82 @@
   <a href="README.md">English</a> | 中文
 </p>
 
-**Agent 团队在 First-Tree 上运行。**
+**让 Agent 带着团队上下文工作。**
 
-first-tree 把工作分派给合适的 Agent，给它和团队同一份上下文，只在
-规则要求时把人类拉进流程。常驻在你的 GitHub 里。开源。
+First Tree 是一个开源工作空间，让 AI Agent 基于团队共享上下文工作，而不是
+每次都从零解释背景。
+
+核心是 Context Tree：一套由团队维护的记忆系统，记录决策、归属、代码仓库、
+职责、约束和过往工作。Agent 在工作前读取它；工作完成后，有价值的结果可以
+回到其中。
+
+这样形成了一种人和 Agent 的工作循环：每个任务都能带着更多团队上下文开始，
+每个有价值的结果都能让下一次任务更理解团队。
+
+## 为什么是 First Tree
+
+现在做 AI Agent 工作空间的产品很多。First Tree 的不同在于：它不是只提供一个
+“让 Agent 干活”的地方，而是提供一个让 Agent 工作持续积累团队上下文的地方。
+每一次工作都会读取已有上下文，并把新的决策、产物和经验沉淀回去，让下一次工作
+更理解团队。
+
+```text
+用户意图 -> 读取团队上下文 -> 带上下文的 Agent 工作
+-> 人的审核/控制 -> 可沉淀产出 -> 自动更新团队上下文
+```
+
+这个工作循环解决的是团队使用 Agent 时最容易断掉的部分：
+
+- 上下文留在某个人的终端、提示词或笔记里
+- Agent 看不到团队记忆，反复重复旧决策
+- 工作结束在对话、PR 或文档里，但不会更新共享上下文
+- 人被拉进来决策时，看不到足够背景
+- 每个新的 Agent 任务都像从零开始，即使团队已经学到过东西
+
+First Tree 基于一个不同判断构建：
+
+> Agent 工作应该基于团队上下文执行，执行过程可见，在正确时刻接受人的
+> 审核/控制，并形成可沉淀产出，再在重要时更新团队记忆。
+
+这让 First Tree 能支持两种使用方式：
+
+- **聚焦 Copilot 工作** - 在一个持续工作流里和 Agent 深度协作，用于
+  设计、写代码、写文档、研究或复杂问题拆解。
+- **并行审核工作** - 让 Agent 同时推进多个任务，只在需要决策、处理阻塞、批准
+  或审核时把人带入流程。
+
+在这两种模式里，First Tree 都给团队一个地方，用来：
+
+- 让 Agent 读取团队共同维护的 Context Tree
+- 在持久对话中开始和继续 Agent 工作
+- 看见进行中的工作、阻塞状态和需要人审核的节点
+- 查看某个请求背后的过程、产物和依据
+- 把有价值的结果变成更新后的团队上下文
+
+它不是另一个 Agent，也不只是另一个工作空间。它是人和 Agent 团队的上下文循环。
+
+## 它如何工作
+
+First Tree 围绕 Context Tree 连接五个部分：
+
+1. **Context Tree** — 基于 Git 的团队记忆层，用于沉淀决策、归属、职责、
+   约束和共享上下文。
+2. **Web 工作空间** — 日常工作表面，用于对话、Agent、团队成员、电脑、GitHub
+   和基于上下文的工作。
+3. **CLI + daemon** — 把电脑登入 First Tree，并让本地 Agent 持续在线。
+4. **Agent 运行时** — 在你的机器上运行 Agent，并通过 First Tree 路由消息。
+5. **GitHub 集成** — 把代码工作、PR 和审核连接回工作空间。
+
+这些部分共同保证 Agent 工作在执行前、执行中、执行后都和团队上下文连接在一起。
 
 ## 开始使用
 
-打开 <https://first-tree.ai>（或你自己的部署）登录，引导式 setup 会带你从头
-走完整个流程——给团队命名、连接一台电脑、创建第一个 Agent、开始第一条对话。
+打开 <https://first-tree.ai> 或你自己的部署登录。引导式流程会带你完成首次
+使用：给团队命名、连接一台电脑、创建第一个 Agent、连接代码、开始工作。
+
 完整步骤见 [Quickstart](docs/quickstart.md)。
 
-走到"连接一台电脑"这步时，setup 会给你安装 CLI、把这台机器登入的命令：
+走到“连接一台电脑”这步时，引导流程会给你安装 CLI、把这台机器登入的命令：
 
 ```bash
 npm install -g first-tree
@@ -24,17 +88,17 @@ first-tree login <connect-token>
 
 二进制名为 `first-tree`；同时安装短别名 `ft`。
 
-## 顶层命令树
+## CLI
 
-```
+```text
 first-tree
 ├── login <token>           把当前机器登入服务端
 ├── logout                  停止 daemon 并清除凭证
 ├── status                  CLI / daemon / 服务端 / auth 一屏概览
 ├── doctor                  跨子系统就绪检查
 ├── upgrade                 升级到最新发布版本
-├── agent ...               Agent 管理（配置、绑定、消息）
-├── chat ...                聊天与消息（list / history / send / open）
+├── agent ...               Agent 管理
+├── chat ...                对话与消息
 ├── org ...                 组织级操作
 ├── daemon ...              后台 daemon 生命周期
 ├── config ...              查看 / 修改本机 client.yaml
@@ -42,26 +106,26 @@ first-tree
 └── github scan ...         GitHub Scan daemon 与 inbox 运行时
 ```
 
-每个 namespace 跑 `first-tree <namespace> --help` 看完整子命令。
+每个命名空间跑 `first-tree <namespace> --help` 看完整子命令。
 
 ## 仓库结构
 
 - `apps/cli/` — 发布的 CLI 包（`first-tree` / `ft`）
 - `packages/shared/` — Zod schema、类型、配置系统（`@first-tree/shared`）
-- `packages/server/` — Fastify API server（`@first-tree/server`；通过 Docker 部署为 SaaS）
+- `packages/server/` — Fastify API 服务（`@first-tree/server`）
 - `packages/client/` — Agent SDK + Runtime（`@first-tree/client`）
-- `packages/web/` — React 管理后台（`@first-tree/web`）
+- `packages/web/` — React Web 工作空间（`@first-tree/web`）
 - `packages/github-scan/` — GitHub Scan daemon（`@first-tree/github-scan`）
 - `packages/e2e/` — 黑盒 e2e 测试框架（`@first-tree/e2e`）
-- `skills/` — 单 skill 的 markdown payload（`first-tree`、`first-tree-cloud`、`first-tree-github-scan`、`first-tree-sync`、`first-tree-write`、`first-tree-onboarding`、`github-scan`）
+- `skills/` — First Tree Agent 使用的仓库内技能内容
 
 ## 文档
 
-- [Quickstart](docs/quickstart.md) — 从注册到第一条对话
+- [Quickstart](docs/quickstart.md) — 从注册到第一次 Agent 工作
 - [Onboarding Guide](docs/onboarding-guide.md) — CLI 流程、SDK、故障排查
 - [CLI Reference](docs/cli-reference.md) — 所有命令和环境变量
 - [Observability](docs/observability.md) — 日志与 OpenTelemetry traces
-- [docs/development/](docs/development/) — 贡献者参考（HTTP / JWT、dev 隔离）
+- [docs/development/](docs/development/) — 贡献者参考
 - [docs/troubleshooting/](docs/troubleshooting/) — 环境相关问题排查
 - [docs/migration/](docs/migration/) — 从 `first-tree@0.4.x` 升级
 
@@ -70,15 +134,17 @@ first-tree
 ```bash
 pnpm install                                # 安装依赖
 docker compose up -d                        # 启动开发用 PostgreSQL
-pnpm --filter @first-tree/server dev        # Server（dev 模式）
-pnpm --filter @first-tree/web dev           # 管理后台（dev 模式）
+pnpm --filter @first-tree/server dev        # 服务端
+pnpm --filter @first-tree/web dev           # Web 工作空间
 pnpm check && pnpm typecheck                # Lint + 类型检查
 pnpm test                                   # 运行测试
+pnpm coverage                               # 本地单测覆盖率
+pnpm coverage:summary                       # 汇总覆盖率报告
 ```
 
-架构、约定、按 package 的开发流程详见 [AGENTS.md](AGENTS.md)。PR 流程
-详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+架构、约定、按 package 的开发流程详见 [AGENTS.md](AGENTS.md)。PR 流程详见
+[CONTRIBUTING.md](CONTRIBUTING.md)。
 
-## License
+## 许可证
 
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
## Summary

- Reframe the English README around context-grounded agentic work for teams.
- Add the same positioning to the Chinese README with clearer, less mixed-language wording.
- Emphasize Context Tree as the shared team context layer and the loop from user intent to durable outcomes and updated team context.
- Simplify capability-heavy sections so the README leads with product value, then setup and repo details.

## Verification

- `git diff --check HEAD~1 HEAD -- README.md README_zh-CN.md`