### PR TITLE
Add single-org invite entry gate

### DIFF
--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -58,6 +58,7 @@ type AgentRequestFn = (
  */
 export type CreateTestAppOptions = {
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
+  allowedOrganizationId?: string;
   /**
    * Drop `oauth.githubApp.slug` from the test config. Used by the
    * `/github-app-installation/install-url` 503 test — the slug is the
@@ -107,6 +108,9 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       refreshTokenExpiry: "30d",
       connectTokenExpiry: "10m",
     },
+    ...(opts.allowedOrganizationId !== undefined
+      ? { access: { allowedOrganizationId: opts.allowedOrganizationId.trim() || undefined } }
+      : {}),
     oauth: {
       // Stub GitHub App creds. Tests that exercise the App flow inject
       // fetchers / mocks at the service-call layer and never actually

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
+import { invitationRedemptions } from "../db/schema/invitations.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
-import { useTestApp } from "./helpers.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
  * End-to-end tests for the public GitHub-OAuth onboarding surface.
@@ -199,6 +201,122 @@ describe("GitHub OAuth onboarding flow", () => {
     expect(body.memberships[0]?.role).toBe("admin");
     expect(body.defaultOrganizationId).toBe(body.memberships[0]?.organizationId);
     expect(body.onboarding.step).toBe("connect");
+  });
+});
+
+describe("GitHub OAuth invite-only single-org entry gate", () => {
+  const allowedOrganizationId = "org-entry-gate-allowed";
+  const blockedOrganizationId = "org-entry-gate-blocked";
+  const getApp = useTestApp({ allowedOrganizationId });
+
+  async function ensureOrg(app: ReturnType<typeof getApp>, id: string, name: string): Promise<void> {
+    const [existing] = await app.db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.id, id));
+    if (existing) return;
+    await app.db.insert(organizations).values({ id, name, displayName: name });
+  }
+
+  async function rotateInviteForOrg(app: ReturnType<typeof getApp>, organizationId: string) {
+    const admin = await createTestAdmin(app, { username: `gate-admin-${randomUUID().slice(0, 8)}` });
+    const { rotateInvitation } = await import("../services/invitation.js");
+    return rotateInvitation(app.db, organizationId, admin.userId);
+  }
+
+  async function findGithubUserId(app: ReturnType<typeof getApp>, githubId: string): Promise<string> {
+    const [identity] = await app.db
+      .select({ userId: authIdentities.userId })
+      .from(authIdentities)
+      .where(eq(authIdentities.identifier, githubId));
+    if (!identity) throw new Error(`expected github identity ${githubId}`);
+    return identity.userId;
+  }
+
+  it("allows invite redemption for the configured organization", async () => {
+    const app = getApp();
+    await ensureOrg(app, allowedOrganizationId, "allowed-entry-gate");
+    const invite = await rotateInviteForOrg(app, allowedOrganizationId);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=1201&login=allowedinvite&next=/invite/${invite.token}`,
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = res.headers.location?.split("#")[1] ?? "";
+    const params = new URLSearchParams(fragment);
+    expect(params.get("joinPath")).toBe("invite");
+    expect(params.get("next")).toBe("/");
+
+    const userId = await findGithubUserId(app, "1201");
+    const memberRows = await app.db.select().from(members).where(eq(members.userId, userId));
+    expect(memberRows).toHaveLength(1);
+    expect(memberRows[0]?.organizationId).toBe(allowedOrganizationId);
+
+    const redemptions = await app.db
+      .select()
+      .from(invitationRedemptions)
+      .where(eq(invitationRedemptions.invitationId, invite.id));
+    expect(redemptions).toHaveLength(1);
+  });
+
+  it("rejects invite redemption for other organizations before membership or redemption side effects", async () => {
+    const app = getApp();
+    await ensureOrg(app, allowedOrganizationId, "allowed-entry-gate");
+    await ensureOrg(app, blockedOrganizationId, "blocked-entry-gate");
+    const invite = await rotateInviteForOrg(app, blockedOrganizationId);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=1202&login=blockedinvite&next=/invite/${invite.token}`,
+    });
+
+    expect(res.statusCode).toBe(403);
+    const userId = await findGithubUserId(app, "1202");
+    const memberRows = await app.db.select().from(members).where(eq(members.userId, userId));
+    expect(memberRows).toHaveLength(0);
+    const redemptions = await app.db
+      .select()
+      .from(invitationRedemptions)
+      .where(eq(invitationRedemptions.invitationId, invite.id));
+    expect(redemptions).toHaveLength(0);
+  });
+
+  it("rejects new users without invite and does not create a personal team", async () => {
+    const app = getApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=1203&login=blockedsolo",
+    });
+
+    expect(res.statusCode).toBe(403);
+    const userId = await findGithubUserId(app, "1203");
+    const memberRows = await app.db.select().from(members).where(eq(members.userId, userId));
+    expect(memberRows).toHaveLength(0);
+    const orgRows = await app.db.select().from(organizations).where(eq(organizations.name, "blockedsolo"));
+    expect(orgRows).toHaveLength(0);
+  });
+
+  it("allows existing members to return without an invite", async () => {
+    const app = getApp();
+    await ensureOrg(app, allowedOrganizationId, "allowed-entry-gate");
+    const invite = await rotateInviteForOrg(app, allowedOrganizationId);
+    await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=1204&login=returninggate&next=/invite/${invite.token}`,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=1204&login=returninggate",
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = res.headers.location?.split("#")[1] ?? "";
+    const params = new URLSearchParams(fragment);
+    expect(params.get("joinPath")).toBe("returning");
   });
 });
 

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -343,6 +343,7 @@ async function completeOauthFlow(
   targetOrganizationId: string | null,
 ) {
   const { userId } = await findOrCreateUserFromGithub(app.db, profile, oauthTokens);
+  const allowedOrganizationId = app.config.access?.allowedOrganizationId ?? null;
 
   // Track which signup path the user took. Surfaced to the SPA via the
   // post-OAuth fragment so the onboarding modal can pick context-aware copy.
@@ -362,6 +363,9 @@ async function completeOauthFlow(
     const inv = await findActiveByToken(app.db, token);
     if (!inv) {
       return reply.status(404).send({ error: "Invitation not found or no longer valid" });
+    }
+    if (allowedOrganizationId && inv.organizationId !== allowedOrganizationId) {
+      return reply.status(403).send({ error: "Invitation is not allowed on this server" });
     }
     await ensureMembership(app.db, {
       userId,
@@ -403,6 +407,9 @@ async function completeOauthFlow(
       resolvedOrganizationId = primary.organizationId;
       // joinPath stays "returning"; preserve caller's original `next` intent.
     } else {
+      if (allowedOrganizationId) {
+        return reply.status(403).send({ error: "This server requires an invitation link to join" });
+      }
       const personal = await createPersonalTeam(app.db, {
         userId,
         loginSeed: profile.login,

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getServerConfig } from "../server-config.js";
+import { getServerConfig, serverConfigSchema } from "../server-config.js";
 import { resetConfig, setConfig } from "../singleton.js";
 
 describe("server config", () => {
@@ -29,5 +29,13 @@ describe("server config", () => {
     process.env.NODE_ENV = "production";
     const prodModule = await import("../server-config.js");
     expect(prodModule.serverConfigSchema.observability.logging.format.schema.parse(undefined)).toBe("json");
+  });
+
+  it("trims allowed organization id and treats blank values as disabled", () => {
+    const fieldSchema = serverConfigSchema.access.shape.allowedOrganizationId.schema;
+
+    expect(fieldSchema.parse("  org_123  ")).toBe("org_123");
+    expect(fieldSchema.parse("")).toBeUndefined();
+    expect(fieldSchema.parse("   ")).toBeUndefined();
   });
 });

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -6,6 +6,12 @@ import { defineConfig, field, optional } from "./schema.js";
 import { getConfig } from "./singleton.js";
 import type { InferConfig } from "./types.js";
 
+const optionalTrimmedStringSchema = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}, z.string().min(1).optional());
+
 export const serverConfigSchema = defineConfig({
   /**
    * Which release channel this server speaks to. Single switch that drives
@@ -91,6 +97,15 @@ export const serverConfigSchema = defineConfig({
     refreshTokenExpiry: field(z.string().default("30d"), { env: "FIRST_TREE_AUTH_REFRESH_TOKEN_EXPIRY" }),
     connectTokenExpiry: field(z.string().default("10m"), { env: "FIRST_TREE_AUTH_CONNECT_TOKEN_EXPIRY" }),
   },
+  access: optional({
+    /**
+     * Invite-only entry gate for hosted environments that should accept new
+     * users only through one organization. Empty / whitespace disables it.
+     */
+    allowedOrganizationId: field(optionalTrimmedStringSchema, {
+      env: "FIRST_TREE_ALLOWED_ORGANIZATION_ID",
+    }),
+  }),
   // Context Tree (repo / branch / localPath) and GitHub integration
   // (webhook secret / allowed org) used to live here as global config.
   // They are now per-org settings in the `organization_settings` table —


### PR DESCRIPTION
## Summary
- add FIRST_TREE_ALLOWED_ORGANIZATION_ID as access.allowedOrganizationId server config
- block OAuth invite redemption for non-configured orgs before membership/redemption side effects
- block new solo OAuth onboarding when the gate is enabled while allowing returning members

## Tests
- pnpm check
- pnpm --filter @first-tree/shared exec vitest run --maxWorkers=2 src/config/__tests__/server-config.test.ts
- pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/oauth-flow.test.ts
- pnpm typecheck