### PR TITLE
fix: make inbox acknowledgements reliable

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -419,7 +419,7 @@ describe("AgentSlot", () => {
     onSessionEvent("chat-callback", { type: "error", message: "oops" });
     onSessionRuntimeChange("chat-callback", "error");
 
-    expect(connection.sendInboxAck).toHaveBeenCalledWith(123);
+    expect(connection.sendInboxAck).toHaveBeenCalledWith(123, "agent-1");
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-callback", "suspended");
     expect(connection.reportRuntimeState).toHaveBeenCalledWith("agent-1", "blocked");
     expect(connection.reportSessionEvent).toHaveBeenCalledWith("agent-1", "chat-callback", {

--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -17,6 +17,7 @@ type PendingBind = {
 type ClientConnectionPrivate = {
   ws: FakeWebSocket | null;
   closing: boolean;
+  registered: boolean;
   pausedReason: "auth_rejected" | "auth_refresh_failed" | null;
   nextReconnectMinDelayMs: number;
   desiredBindings: Map<string, { agentId: string; runtimeType: string; runtimeVersion?: string }>;
@@ -118,6 +119,31 @@ async function makeConnection(overrides: Partial<ClientConnectionConfig> = {}): 
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+}
+
+function parseSent(socket: FakeWebSocket, index: number): Record<string, unknown> {
+  return JSON.parse(socket.sent[index] ?? "{}") as Record<string, unknown>;
+}
+
+async function openRegisteredConnection(
+  connection: ClientConnectionInstance,
+  capabilities: Record<string, boolean> = {},
+) {
+  const internal = priv(connection);
+  const openPromise = internal.openWebSocket();
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) throw new Error("missing fake socket");
+  socket.emitOpen();
+  await flushMicrotasks();
+  socket.emitMessage({
+    type: "server:welcome",
+    serverCommandVersion: "1.0.0",
+    serverTimeMs: Date.now(),
+    capabilities,
+  });
+  socket.emitMessage({ type: "client:registered" });
+  await openPromise;
+  return socket;
 }
 
 describe("ClientConnection — WebSocket edge coverage", () => {
@@ -294,5 +320,172 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     await internal.runProactiveAuthRefresh();
 
     expect(internal.nextReconnectMinDelayMs).toBe(30_000);
+  });
+
+  it("sends confirmed inbox ACKs with refs and resolves on accepted", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(42);
+    const frame = parseSent(socket, socket.sent.length - 1);
+    expect(frame).toMatchObject({ type: "inbox:ack", entryId: 42 });
+    expect(typeof frame.ref).toBe("string");
+
+    socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 42,
+      ref: frame.ref,
+      disposition: "acked",
+    });
+    await expect(ackPromise).resolves.toBeUndefined();
+  });
+
+  it("falls back to legacy inbox ACKs when the server does not advertise confirmations", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxDeliver: true });
+
+    await expect(connection.sendInboxAck(43)).resolves.toBeUndefined();
+    expect(parseSent(socket, socket.sent.length - 1)).toEqual({ type: "inbox:ack", entryId: 43 });
+  });
+
+  it("coalesces duplicate confirmed inbox ACKs and rejects on server rejection", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const first = connection.sendInboxAck(44);
+    const second = connection.sendInboxAck(44);
+    expect(second).toBe(first);
+    const ackFrames = socket.sent
+      .map((raw) => JSON.parse(raw) as { type?: string })
+      .filter((m) => m.type === "inbox:ack");
+    expect(ackFrames).toHaveLength(1);
+    const frame = parseSent(socket, socket.sent.length - 1);
+
+    socket.emitMessage({
+      type: "inbox:ack:rejected",
+      entryId: 44,
+      ref: frame.ref,
+      reason: "not_found_or_not_bound",
+    });
+    await expect(first).rejects.toThrow("not_found_or_not_bound");
+  });
+
+  it("retries confirmed inbox ACKs after timeout using the same ref", async () => {
+    vi.useFakeTimers();
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(45);
+    const first = parseSent(socket, socket.sent.length - 1);
+    await vi.advanceTimersByTimeAsync(3000);
+    const retry = parseSent(socket, socket.sent.length - 1);
+
+    expect(retry).toEqual(first);
+    socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 45,
+      ref: first.ref,
+      disposition: "acked",
+    });
+    await expect(ackPromise).resolves.toBeUndefined();
+  });
+
+  it("holds agent-scoped confirmed inbox ACKs until that agent is rebound on the current socket", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(47, "agent-1");
+    const ackFramesBeforeBind = socket.sent
+      .map((raw) => JSON.parse(raw) as { type?: string })
+      .filter((m) => m.type === "inbox:ack");
+    expect(ackFramesBeforeBind).toHaveLength(0);
+
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const ackFrame = parseSent(socket, socket.sent.length - 1);
+    expect(ackFrame).toMatchObject({ type: "inbox:ack", entryId: 47 });
+    socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 47,
+      ref: ackFrame.ref,
+      disposition: "acked",
+    });
+    await expect(ackPromise).resolves.toBeUndefined();
+  });
+
+  it("rejects held agent-scoped ACKs when the bind is rejected", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(48, "agent-1");
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bind:rejected",
+      ref: bindFrame.ref,
+      reason: "wrong_client",
+    });
+
+    await expect(bindPromise).rejects.toThrow("wrong_client");
+    await expect(ackPromise).rejects.toThrow("agent_bind_rejected:wrong_client");
+  });
+
+  it("rejects held agent-scoped ACKs when unbinding on a closed socket", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(49, "agent-1");
+    internal.closing = true;
+    socket.close(1006, "test close");
+
+    await connection.unbindAgent("agent-1");
+
+    await expect(ackPromise).rejects.toThrow("agent_unbound");
+  });
+
+  it("flushes pending confirmed inbox ACKs after reconnect and bind", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const firstSocket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const ackPromise = connection.sendInboxAck(46);
+    const firstAck = parseSent(firstSocket, firstSocket.sent.length - 1);
+    internal.closing = true;
+    firstSocket.close(1006, "test close");
+    internal.closing = false;
+
+    const secondSocket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(secondSocket, secondSocket.sent.length - 1);
+    secondSocket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const resentAck = parseSent(secondSocket, secondSocket.sent.length - 1);
+    expect(resentAck).toEqual(firstAck);
+    secondSocket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 46,
+      ref: firstAck.ref,
+      disposition: "already_acked",
+    });
+    await expect(ackPromise).resolves.toBeUndefined();
   });
 });

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -7,6 +7,8 @@ import {
   agentPinnedMessageSchema,
   type ClientPausedReason,
   type InboxDeliverFrame,
+  inboxAckAcceptedFrameSchema,
+  inboxAckRejectedFrameSchema,
   inboxDeliverFrameSchema,
   type RuntimeState,
   type ServerWelcomeFrame,
@@ -30,6 +32,18 @@ type BindRetryRecord = {
   attempts: number;
   nextAllowedAt: number;
   lastReason: string | null;
+};
+
+type PendingInboxAck = {
+  entryId: number;
+  agentId?: string;
+  ref: string;
+  attempts: number;
+  firstSentAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
 };
 
 export type ClientConnectionConfig = {
@@ -219,6 +233,7 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
 const WS_CONNECT_TIMEOUT_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
+const INBOX_ACK_CONFIRM_TIMEOUT_MS = 3_000;
 /**
  * Silence watchdog: if no server frame (data message OR control-frame pong)
  * arrives within this many ms, the socket is presumed dead and terminated so
@@ -368,6 +383,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   private pausedReason: ClientPausedReason | null = null;
   /** Count of `server:welcome` frames received; drives `isReconnect` flag. */
   private welcomeFramesReceived = 0;
+  private serverSupportsInboxAckConfirm = false;
   /**
    * Last handshake error, stashed for the `close` handler to surface a typed
    * reason (e.g. {@link ClientOrgMismatchError}) instead of a generic
@@ -404,6 +420,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * permanent → never).
    */
   private readonly bindRetryRecords = new Map<string, BindRetryRecord>();
+  private readonly pendingInboxAcks = new Map<number, PendingInboxAck>();
+  private readonly socketBoundAgentIds = new Set<string>();
 
   constructor(config: ClientConnectionConfig) {
     super();
@@ -465,23 +483,186 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   }
 
   /**
-   * Ack a delivered inbox entry over the WS data plane. Safe to call when
-   * the WS is closed — the frame is dropped (logged) and the entry stays
-   * `delivered` server-side until the next `agent:bind`, which resets every
-   * still-`delivered` row back to `pending` for redelivery (see
-   * inflight-message-recovery-design.md §4). The redelivered entry then
-   * surfaces as a duplicate dispatch and SessionManager's
-   * `(chatId, messageId)` Deduplicator collapses it.
+   * Ack a delivered inbox entry over the WS data plane. New servers confirm
+   * ACKs with a correlated response; until then this keeps an in-memory retry
+   * record and resolves only after the server accepts/rejects it. Legacy
+   * servers keep the old fire-and-forget behaviour.
    */
-  sendInboxAck(entryId: number): void {
+  sendInboxAck(entryId: number, agentId?: string): Promise<void> {
+    if (!this.serverSupportsInboxAckConfirm) {
+      this.sendLegacyInboxAck(entryId);
+      return Promise.resolve();
+    }
+
+    const existing = this.pendingInboxAcks.get(entryId);
+    if (existing) return existing.promise;
+
+    const pending = this.createPendingInboxAck(entryId, agentId);
+    this.pendingInboxAcks.set(entryId, pending);
+    this.sendPendingInboxAck(pending, false);
+    return pending.promise;
+  }
+
+  private sendLegacyInboxAck(entryId: number): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      // Visibility for the "ack lost on closed socket → next bind resets
-      // entry to pending → duplicate dispatch on reconnect" path. Warn-level
-      // so staging can correlate spikes against reconnect-storm windows.
-      this.wsLogger.warn({ entryId, readyState: this.ws?.readyState }, "inbox:ack dropped — socket not OPEN");
+      this.wsLogger.warn(
+        { entryId, connectionState: this.inboxAckConnectionState() },
+        "inbox:ack dropped — socket not OPEN",
+      );
       return;
     }
     this.ws.send(JSON.stringify({ type: "inbox:ack", entryId }));
+    this.wsLogger.debug(
+      {
+        entryId,
+        attempt: 1,
+        ackEvent: "inbox_ack_sent",
+        mode: "legacy",
+        connectionState: this.inboxAckConnectionState(),
+      },
+      "inbox:ack sent",
+    );
+  }
+
+  private createPendingInboxAck(entryId: number, agentId?: string): PendingInboxAck {
+    const pending: PendingInboxAck = {
+      entryId,
+      ...(agentId ? { agentId } : {}),
+      ref: `ack_${randomUUID().slice(0, 12)}`,
+      attempts: 0,
+      firstSentAt: 0,
+      timer: null,
+      promise: Promise.resolve(),
+      resolve: () => {},
+      reject: () => {},
+    };
+    pending.promise = new Promise<void>((resolve, reject) => {
+      pending.resolve = resolve;
+      pending.reject = reject;
+    });
+    return pending;
+  }
+
+  private sendPendingInboxAck(pending: PendingInboxAck, retry: boolean): void {
+    if (
+      !this.ws ||
+      this.ws.readyState !== WebSocket.OPEN ||
+      !this.registered ||
+      (pending.agentId && !this.socketBoundAgentIds.has(pending.agentId))
+    ) {
+      this.wsLogger.warn(
+        {
+          entryId: pending.entryId,
+          agentId: pending.agentId,
+          ref: pending.ref,
+          attempt: pending.attempts + 1,
+          connectionState: this.inboxAckConnectionState(),
+        },
+        "inbox:ack pending — socket not ready",
+      );
+      return;
+    }
+
+    if (!this.serverSupportsInboxAckConfirm) {
+      this.sendLegacyInboxAck(pending.entryId);
+      this.resolvePendingInboxAck(pending, "legacy_fallback");
+      return;
+    }
+
+    this.clearPendingInboxAckTimer(pending);
+    if (pending.firstSentAt === 0) pending.firstSentAt = Date.now();
+    pending.attempts += 1;
+    this.ws.send(JSON.stringify({ type: "inbox:ack", entryId: pending.entryId, ref: pending.ref }));
+    this.wsLogger.debug(
+      {
+        entryId: pending.entryId,
+        agentId: pending.agentId,
+        ref: pending.ref,
+        attempt: pending.attempts,
+        connectionState: this.inboxAckConnectionState(),
+        ackEvent: retry ? "inbox_ack_retry" : "inbox_ack_sent",
+      },
+      retry ? "inbox:ack retry sent" : "inbox:ack sent",
+    );
+
+    pending.timer = setTimeout(() => {
+      pending.timer = null;
+      if (!this.pendingInboxAcks.has(pending.entryId)) return;
+      this.wsLogger.warn(
+        {
+          entryId: pending.entryId,
+          agentId: pending.agentId,
+          ref: pending.ref,
+          attempt: pending.attempts,
+          timeoutMs: INBOX_ACK_CONFIRM_TIMEOUT_MS,
+          connectionState: this.inboxAckConnectionState(),
+          ackEvent: "inbox_ack_timeout",
+        },
+        "inbox:ack confirmation timed out",
+      );
+      this.sendPendingInboxAck(pending, true);
+    }, INBOX_ACK_CONFIRM_TIMEOUT_MS);
+  }
+
+  private flushPendingInboxAcks(): void {
+    for (const pending of this.pendingInboxAcks.values()) {
+      if (pending.timer === null) this.sendPendingInboxAck(pending, pending.attempts > 0);
+    }
+  }
+
+  private resolvePendingInboxAck(pending: PendingInboxAck, disposition: string): void {
+    this.clearPendingInboxAckTimer(pending);
+    this.pendingInboxAcks.delete(pending.entryId);
+    const latencyMs = pending.firstSentAt === 0 ? 0 : Date.now() - pending.firstSentAt;
+    this.wsLogger.debug(
+      {
+        entryId: pending.entryId,
+        agentId: pending.agentId,
+        ref: pending.ref,
+        attempt: pending.attempts,
+        disposition,
+        latencyMs,
+        connectionState: this.inboxAckConnectionState(),
+        ackEvent: "inbox_ack_accepted",
+        latencyEvent: "inbox_ack_latency_ms",
+      },
+      "inbox:ack accepted",
+    );
+    pending.resolve();
+  }
+
+  private rejectPendingInboxAck(pending: PendingInboxAck, reason: string): void {
+    this.clearPendingInboxAckTimer(pending);
+    this.pendingInboxAcks.delete(pending.entryId);
+    this.wsLogger.warn(
+      {
+        entryId: pending.entryId,
+        agentId: pending.agentId,
+        ref: pending.ref,
+        attempt: pending.attempts,
+        reason,
+        latencyMs: pending.firstSentAt === 0 ? 0 : Date.now() - pending.firstSentAt,
+        connectionState: this.inboxAckConnectionState(),
+        ackEvent: "inbox_ack_rejected",
+      },
+      "inbox:ack rejected",
+    );
+    pending.reject(new Error(`inbox:ack rejected (${reason})`));
+  }
+
+  private clearPendingInboxAckTimer(pending: PendingInboxAck): void {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+  }
+
+  private inboxAckConnectionState(): string {
+    if (!this.ws) return "no_socket";
+    if (this.ws.readyState !== WebSocket.OPEN) return `socket_${this.ws.readyState}`;
+    if (!this.registered) return "open_unregistered";
+    if (this.socketBoundAgentIds.size === 0) return "open_registered_unbound";
+    return this.serverSupportsInboxAckConfirm ? "open_registered_confirmed" : "open_registered_legacy";
   }
 
   /**
@@ -547,9 +728,11 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
 
   async unbindAgent(agentId: string): Promise<void> {
     this.desiredBindings.delete(agentId);
+    this.boundAgents.delete(agentId);
+    this.socketBoundAgentIds.delete(agentId);
+    this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "agent:unbind", agentId }));
-    this.boundAgents.delete(agentId);
   }
 
   reportSessionState(agentId: string, chatId: string, state: SessionState): void {
@@ -592,6 +775,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.connectAbort?.abort();
     this.clearTimers();
     this.rejectAllPendingBinds("Client disconnected");
+    this.rejectAllPendingInboxAcks("Client disconnected");
     if (this.ws) {
       this.ws.removeAllListeners();
       if (this.ws.readyState === WebSocket.OPEN) {
@@ -609,6 +793,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
     this.registered = false;
     this.boundAgents.clear();
+    this.socketBoundAgentIds.clear();
     this.emit("disconnected");
   }
 
@@ -747,8 +932,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       ws.on("close", (code) => {
         this.stopHeartbeat();
         this.clearAuthRefreshTimer();
+        this.clearPendingInboxAckTimers();
         const wasRegistered = this.registered;
         this.registered = false;
+        this.socketBoundAgentIds.clear();
         this.rejectAllPendingBinds("WebSocket closed");
 
         if (!settled) {
@@ -824,6 +1011,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       }
       const isReconnect = this.welcomeFramesReceived > 0;
       this.welcomeFramesReceived++;
+      this.serverSupportsInboxAckConfirm = parsed.data.capabilities?.wsInboxAckConfirm === true;
       this.emit("server:welcome", { frame: parsed.data, isReconnect });
       return;
     }
@@ -913,8 +1101,10 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           sdk,
         };
         this.boundAgents.set(agentId, agent);
+        this.socketBoundAgentIds.add(agentId);
         this.emit("agent:bound", agent);
         pending.resolve(agent);
+        this.flushPendingInboxAcks();
       }
       return;
     }
@@ -954,6 +1144,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           });
         }
         this.bindRetryRecords.set(pending.agentId, record);
+        this.rejectPendingInboxAcksForAgent(pending.agentId, `agent_bind_rejected:${reason}`);
         this.emit("agent:bind:rejected", reason, pending.agentId);
         pending.reject(new Error(`agent:bind rejected (${reason})`));
       }
@@ -963,6 +1154,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     if (type === "agent:unbound") {
       const agentId = msg.agentId as string;
       this.boundAgents.delete(agentId);
+      this.socketBoundAgentIds.delete(agentId);
+      this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
       this.emit("agent:unbound", agentId);
       return;
     }
@@ -983,6 +1176,8 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       const agentId = msg.agentId as string;
       if (agentId && this.boundAgents.has(agentId)) {
         this.boundAgents.delete(agentId);
+        this.socketBoundAgentIds.delete(agentId);
+        this.rejectPendingInboxAcksForAgent(agentId, "agent_force_disconnect");
         this.emit("agent:unbound", agentId, typeof msg.reason === "string" ? msg.reason : "server_forced");
       }
       return;
@@ -1006,6 +1201,56 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       return;
     }
 
+    if (type === "inbox:ack:accepted") {
+      const parsed = inboxAckAcceptedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:ack:accepted frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxAcks.get(parsed.data.entryId);
+      if (!pending || pending.ref !== parsed.data.ref) {
+        this.wsLogger.debug(
+          {
+            entryId: parsed.data.entryId,
+            ref: parsed.data.ref,
+            ackEvent: "inbox_ack_no_match",
+          },
+          "inbox:ack:accepted matched no pending ack",
+        );
+        return;
+      }
+      this.resolvePendingInboxAck(pending, parsed.data.disposition);
+      return;
+    }
+
+    if (type === "inbox:ack:rejected") {
+      const parsed = inboxAckRejectedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:ack:rejected frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxAcks.get(parsed.data.entryId);
+      if (!pending || pending.ref !== parsed.data.ref) {
+        this.wsLogger.debug(
+          {
+            entryId: parsed.data.entryId,
+            ref: parsed.data.ref,
+            ackEvent: "inbox_ack_no_match",
+          },
+          "inbox:ack:rejected matched no pending ack",
+        );
+        return;
+      }
+      this.rejectPendingInboxAck(pending, parsed.data.reason);
+      return;
+    }
+
     if (type === "inbox:deliver") {
       const parsed = inboxDeliverFrameSchema.safeParse(msg);
       if (!parsed.success) {
@@ -1026,7 +1271,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         const entryIdAcked =
           typeof rawEntryId === "number" && Number.isInteger(rawEntryId) && rawEntryId >= 0 ? rawEntryId : null;
         if (entryIdAcked !== null) {
-          this.sendInboxAck(entryIdAcked);
+          this.sendInboxAck(entryIdAcked).catch((err) => {
+            this.wsLogger.warn(
+              { entryId: entryIdAcked, err: err instanceof Error ? err.message : String(err) },
+              "malformed inbox:deliver best-effort ack failed",
+            );
+          });
         }
         // Per-issue path/message + the receiving frame keys so we can pinpoint
         // shape drift between server build and client schema during gradual
@@ -1095,6 +1345,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           nextAllowedAt: record.nextAllowedAt,
           lastReasonCode: record.lastReason,
         });
+        this.rejectPendingInboxAcksForAgent(desired.agentId, "agent_rebind_skipped");
         continue;
       }
       const previousAttempts = record?.attempts ?? 0;
@@ -1274,6 +1525,26 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.pendingBinds.clear();
   }
 
+  private rejectAllPendingInboxAcks(reason: string): void {
+    for (const pending of this.pendingInboxAcks.values()) {
+      this.clearPendingInboxAckTimer(pending);
+      pending.reject(new Error(reason));
+    }
+    this.pendingInboxAcks.clear();
+  }
+
+  private rejectPendingInboxAcksForAgent(agentId: string, reason: string): void {
+    for (const pending of [...this.pendingInboxAcks.values()]) {
+      if (pending.agentId === agentId) this.rejectPendingInboxAck(pending, reason);
+    }
+  }
+
+  private clearPendingInboxAckTimers(): void {
+    for (const pending of this.pendingInboxAcks.values()) {
+      this.clearPendingInboxAckTimer(pending);
+    }
+  }
+
   private clearTimers(): void {
     this.stopHeartbeat();
     if (this.wsConnectTimer) {
@@ -1285,6 +1556,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       this.reconnectTimer = null;
     }
     this.clearAuthRefreshTimer();
+    this.clearPendingInboxAckTimers();
   }
 
   private clearAuthRefreshTimer(): void {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -200,13 +200,7 @@ export class AgentSlot {
       // concurrent worktree adds for the same URL (PRD §5.1.5).
       const gitMirrorManager = this.config.gitMirrorManager;
 
-      // Ack is fire-and-forget over WS: `ws.send` doesn't block on flush and
-      // SessionManager treats ack as advisory. Wrap in a resolved Promise so
-      // the `(id) => Promise<void>` config signature is satisfied.
-      const ackEntry = (entryId: number) => {
-        this.clientConnection.sendInboxAck(entryId);
-        return Promise.resolve();
-      };
+      const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
 
       this.sessionManager = new SessionManager({
         session: this.config.session,

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -199,15 +199,18 @@ describe("inbox WS data-plane claim helpers", () => {
     // server treats this as 'no-op', preventing one socket from acking
     // another agent's deliveries.
     const denied = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, ["inbox_other"]);
-    expect(denied).toBeNull();
+    expect(denied).toEqual({ ok: false, reason: "not_found_or_not_bound" });
 
     const stillDelivered = await app.db.select().from(inboxEntries).where(eq(inboxEntries.id, entry.id));
     expect(stillDelivered[0]?.status).toBe("delivered");
 
     // Right scope: ack succeeds and flips status.
     const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
-    expect(accepted).not.toBeNull();
-    expect(accepted?.status).toBe("acked");
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack unexpectedly rejected");
+    expect(accepted.disposition).toBe("acked");
+    expect(accepted.transitionedFromDelivered).toBe(true);
+    expect(accepted.entry.status).toBe("acked");
   });
 
   it("ackEntryByIdForBoundAgents accepts when the inbox list contains the owner alongside other inboxes", async () => {
@@ -228,14 +231,65 @@ describe("inbox WS data-plane claim helpers", () => {
       a2.agent.inboxId,
       "inbox_other_b",
     ]);
-    expect(accepted).not.toBeNull();
-    expect(accepted?.status).toBe("acked");
-    expect(accepted?.inboxId).toBe(a2.agent.inboxId);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack unexpectedly rejected");
+    expect(accepted.entry.status).toBe("acked");
+    expect(accepted.entry.inboxId).toBe(a2.agent.inboxId);
+  });
+
+  it("ackEntryByIdForBoundAgents accepts duplicate ACKs idempotently", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
+    const entry = claimed[0];
+    if (!entry) throw new Error("seed claim failed");
+
+    const first = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(first.ok).toBe(true);
+
+    const second = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(second.ok).toBe(true);
+    if (!second.ok) throw new Error("duplicate ack unexpectedly rejected");
+    expect(second.disposition).toBe("already_acked");
+    expect(second.transitionedFromDelivered).toBe(false);
+    expect(second.entry.status).toBe("acked");
+  });
+
+  it("ackEntryByIdForBoundAgents accepts an owned pending row to close bind-reset races", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const [entry] = await app.db.select().from(inboxEntries).where(eq(inboxEntries.messageId, messageId)).limit(1);
+    if (!entry) throw new Error("seed entry missing");
+    expect(entry.status).toBe("pending");
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("pending ack unexpectedly rejected");
+    expect(accepted.disposition).toBe("accepted_from_pending");
+    expect(accepted.transitionedFromDelivered).toBe(false);
+    expect(accepted.entry.status).toBe("acked");
+  });
+
+  it("ackEntryByIdForBoundAgents rejects terminal failed rows", async () => {
+    const app = getApp();
+    const { a2, messageId } = await seedDeliverable(app);
+
+    const [entry] = await app.db
+      .update(inboxEntries)
+      .set({ status: "failed" })
+      .where(eq(inboxEntries.messageId, messageId))
+      .returning();
+    if (!entry) throw new Error("seed entry missing");
+
+    const rejected = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
+    expect(rejected).toEqual({ ok: false, reason: "failed_or_dead" });
   });
 
   it("ackEntryByIdForBoundAgents short-circuits on empty inbox list", async () => {
     const app = getApp();
     const res = await inboxService.ackEntryByIdForBoundAgents(app.db, 1, []);
-    expect(res).toBeNull();
+    expect(res).toEqual({ ok: false, reason: "not_found_or_not_bound" });
   });
 });

--- a/packages/server/src/__tests__/ws-server-welcome.test.ts
+++ b/packages/server/src/__tests__/ws-server-welcome.test.ts
@@ -82,11 +82,18 @@ describe("WS server:welcome — wire-additive frame after auth:ok", () => {
     ws.close();
 
     expect(frames[0]).toEqual({ type: "auth:ok" });
-    const welcome = frames[1] as { type: string; serverCommandVersion: string; serverTimeMs: number };
+    const welcome = frames[1] as {
+      type: string;
+      serverCommandVersion: string;
+      serverTimeMs: number;
+      capabilities?: { wsInboxDeliver?: boolean; wsInboxAckConfirm?: boolean };
+    };
     expect(welcome.type).toBe("server:welcome");
     expect(typeof welcome.serverCommandVersion).toBe("string");
     expect(welcome.serverCommandVersion.length).toBeGreaterThan(0);
     expect(typeof welcome.serverTimeMs).toBe("number");
     expect(welcome.serverTimeMs).toBeGreaterThan(0);
+    expect(welcome.capabilities?.wsInboxDeliver).toBe(true);
+    expect(welcome.capabilities?.wsInboxAckConfirm).toBe(true);
   });
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -428,7 +428,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 type: "server:welcome",
                 serverCommandVersion: app.commandVersion(),
                 serverTimeMs: Date.now(),
-                capabilities: { wsInboxDeliver: true },
+                capabilities: { wsInboxDeliver: true, wsInboxAckConfirm: true },
               }),
             );
           } catch (err) {
@@ -914,7 +914,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 socket.send(JSON.stringify({ type: "error", message: "Malformed inbox:ack frame" }));
                 return;
               }
-              const { entryId } = payloadResult.data;
+              const { entryId, ref } = payloadResult.data;
 
               // Find the agent / inbox this entry belongs to from the bind
               // map. We never trust an `agentId` from the wire here — that
@@ -922,29 +922,61 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               // we resolve the inbox via the DB (one round-trip) and check
               // the resulting inboxId is in this socket's bound set.
               try {
-                const ackedEntry = await inboxService.ackEntryByIdForBoundAgents(
+                const ackResult = await inboxService.ackEntryByIdForBoundAgents(
                   app.db,
                   entryId,
                   [...boundAgents.values()].map((a) => a.inboxId),
                 );
-                if (!ackedEntry) {
-                  // Either the entry doesn't exist, or it's not in 'delivered'
-                  // status, or it belongs to an inbox this socket hasn't bound.
-                  // All three are non-fatal — the client may be ack'ing a
-                  // stale entry from a previous run, or racing a `delivered →
-                  // pending` reset triggered by another socket binding the
-                  // same inbox. Debug-level only — every reconnect can race
-                  // here at low volume; promoting to warn would flood logs.
+                if (!ackResult.ok) {
+                  if (ref) {
+                    socket.send(
+                      JSON.stringify({
+                        type: "inbox:ack:rejected",
+                        entryId,
+                        ref,
+                        reason: ackResult.reason,
+                      }),
+                    );
+                  }
                   app.log.debug(
-                    { clientId, entryId, boundInboxes: boundAgents.size },
-                    "inbox:ack matched no row — stale ack or bind-reset race",
+                    {
+                      clientId,
+                      entryId,
+                      ref,
+                      agentId: null,
+                      boundInboxes: boundAgents.size,
+                      reason: ackResult.reason,
+                      ackEvent: "inbox_ack_rejected",
+                    },
+                    "inbox:ack rejected",
                   );
                   return;
                 }
                 // Find the agentId that owns this inbox to decrement the
                 // counter and trigger backlog drain.
-                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackedEntry.inboxId);
-                if (owner) {
+                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.entry.inboxId);
+                if (ref) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:ack:accepted",
+                      entryId,
+                      ref,
+                      disposition: ackResult.disposition,
+                    }),
+                  );
+                }
+                app.log.debug(
+                  {
+                    clientId,
+                    entryId,
+                    ref,
+                    agentId: owner?.agentId ?? null,
+                    disposition: ackResult.disposition,
+                    ackEvent: "inbox_ack_accepted",
+                  },
+                  "inbox:ack accepted",
+                );
+                if (owner && ackResult.transitionedFromDelivered) {
                   inboxInFlight.set(owner.agentId, Math.max(0, (inboxInFlight.get(owner.agentId) ?? 1) - 1));
                   // Slot freed → top up. Cheap when no backlog (single SQL
                   // statement returning 0 rows). Critical when the cap was

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -13,6 +13,15 @@ import { buildClientMessagePayloadsForInbox } from "./message-dispatcher.js";
  *  conversions (bigserial → number, timestamp → Date) flow through. */
 type ClaimedEntry = typeof inboxEntries.$inferSelect;
 
+export type AckEntryResult =
+  | {
+      ok: true;
+      entry: typeof inboxEntries.$inferSelect;
+      disposition: "acked" | "already_acked" | "accepted_from_pending";
+      transitionedFromDelivered: boolean;
+    }
+  | { ok: false; reason: "not_found_or_not_bound" | "failed_or_dead" };
+
 /** Structurally-typed DB so both `Database` and transaction clients work. */
 type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete" | "insert">;
 
@@ -413,10 +422,10 @@ async function collectPrecedingContext(
 }
 
 /**
- * Ack a delivered entry from the WS data plane, scoped to the inboxes the
- * connected socket has bound. Returns the acked row on success, `null` if no
- * row matches — a benign outcome the caller should ignore (the entry may
- * have already been acked, timed out, or never belonged to this socket).
+ * Ack an entry from the WS data plane, scoped to the inboxes the connected
+ * socket has bound. The operation is idempotent: duplicate ACKs for `acked`
+ * rows are accepted, and owned `pending` rows may be ACKed to close the
+ * bind-reset race after the client has already completed the turn.
  *
  * Trusts only the `inboxId` set the connected socket has bound (no `inboxId`
  * on the wire), and short-circuits on an empty `inboxIds`.
@@ -425,21 +434,44 @@ export async function ackEntryByIdForBoundAgents(
   db: Database,
   entryId: number,
   inboxIds: string[],
-): Promise<typeof inboxEntries.$inferSelect | null> {
-  if (inboxIds.length === 0) return null;
+): Promise<AckEntryResult> {
+  if (inboxIds.length === 0) return { ok: false, reason: "not_found_or_not_bound" };
   return withSpan("inbox.ack.ws", { [FIRST_TREE_ATTR.INBOX_ENTRY_ID]: String(entryId) }, async () => {
-    const [entry] = await db
-      .update(inboxEntries)
-      .set({ status: "acked", ackedAt: new Date() })
-      .where(
-        and(
-          eq(inboxEntries.id, entryId),
-          inArray(inboxEntries.inboxId, inboxIds),
-          eq(inboxEntries.status, "delivered"),
-        ),
-      )
-      .returning();
-    return entry ?? null;
+    return db.transaction(async (tx) => {
+      const [entry] = await tx
+        .select()
+        .from(inboxEntries)
+        .where(and(eq(inboxEntries.id, entryId), inArray(inboxEntries.inboxId, inboxIds)))
+        .for("update")
+        .limit(1);
+      if (!entry) return { ok: false, reason: "not_found_or_not_bound" };
+      if (entry.status === "acked") {
+        return { ok: true, entry, disposition: "already_acked", transitionedFromDelivered: false };
+      }
+      if (entry.status !== "delivered" && entry.status !== "pending") {
+        return { ok: false, reason: "failed_or_dead" };
+      }
+
+      const previousStatus = entry.status;
+      const [updated] = await tx
+        .update(inboxEntries)
+        .set({ status: "acked", ackedAt: new Date() })
+        .where(
+          and(
+            eq(inboxEntries.id, entryId),
+            inArray(inboxEntries.inboxId, inboxIds),
+            eq(inboxEntries.status, previousStatus),
+          ),
+        )
+        .returning();
+      if (!updated) return { ok: false, reason: "not_found_or_not_bound" };
+      return {
+        ok: true,
+        entry: updated,
+        disposition: previousStatus === "delivered" ? "acked" : "accepted_from_pending",
+        transitionedFromDelivered: previousStatus === "delivered",
+      };
+    });
   });
 }
 

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { inboxAckFrameSchema, inboxDeliverFrameSchema } from "../schemas/inbox-frames.js";
+import {
+  inboxAckAcceptedFrameSchema,
+  inboxAckFrameSchema,
+  inboxAckRejectedFrameSchema,
+  inboxDeliverFrameSchema,
+} from "../schemas/inbox-frames.js";
 
 const baseClientMessage = {
   id: "msg_1",
@@ -151,6 +156,14 @@ describe("inboxAckFrameSchema", () => {
     expect(res.success).toBe(true);
   });
 
+  it("accepts a confirmed ack ref", () => {
+    const res = inboxAckFrameSchema.safeParse({ type: "inbox:ack", entryId: 7, ref: "ack_123" });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.ref).toBe("ack_123");
+    }
+  });
+
   it("rejects wrong discriminator", () => {
     const res = inboxAckFrameSchema.safeParse({ type: "inbox:deliver", entryId: 7 });
     expect(res.success).toBe(false);
@@ -164,5 +177,29 @@ describe("inboxAckFrameSchema", () => {
   it("rejects non-integer entryId", () => {
     const res = inboxAckFrameSchema.safeParse({ type: "inbox:ack", entryId: 1.5 });
     expect(res.success).toBe(false);
+  });
+});
+
+describe("inboxAckAcceptedFrameSchema", () => {
+  it("accepts an ACK confirmation", () => {
+    const res = inboxAckAcceptedFrameSchema.safeParse({
+      type: "inbox:ack:accepted",
+      entryId: 7,
+      ref: "ack_123",
+      disposition: "accepted_from_pending",
+    });
+    expect(res.success).toBe(true);
+  });
+});
+
+describe("inboxAckRejectedFrameSchema", () => {
+  it("accepts an ACK rejection", () => {
+    const res = inboxAckRejectedFrameSchema.safeParse({
+      type: "inbox:ack:rejected",
+      entryId: 7,
+      ref: "ack_123",
+      reason: "not_found_or_not_bound",
+    });
+    expect(res.success).toBe(true);
   });
 });

--- a/packages/shared/src/__tests__/ws-auth-schema.test.ts
+++ b/packages/shared/src/__tests__/ws-auth-schema.test.ts
@@ -58,15 +58,16 @@ describe("serverWelcomeFrameSchema", () => {
       type: "server:welcome",
       serverCommandVersion: "1.0.0",
       serverTimeMs: 1_713_000_000_000,
-      capabilities: { wsInboxDeliver: true },
+      capabilities: { wsInboxDeliver: true, wsInboxAckConfirm: true },
     });
     expect(res.success).toBe(true);
     if (res.success) {
       expect(res.data.capabilities?.wsInboxDeliver).toBe(true);
+      expect(res.data.capabilities?.wsInboxAckConfirm).toBe(true);
     }
   });
 
-  it("accepts an empty capabilities object and defaults wsInboxDeliver to false", () => {
+  it("accepts an empty capabilities object and defaults WS capabilities to false", () => {
     const res = serverWelcomeFrameSchema.safeParse({
       type: "server:welcome",
       serverCommandVersion: "1.0.0",
@@ -78,6 +79,7 @@ describe("serverWelcomeFrameSchema", () => {
       // The field default + .partial() inflate `{}` → `{wsInboxDeliver:false}`,
       // matching the server-side behaviour: unset == "no opt-in".
       expect(res.data.capabilities?.wsInboxDeliver).toBe(false);
+      expect(res.data.capabilities?.wsInboxAckConfirm).toBe(false);
     }
   });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -337,11 +337,22 @@ export {
   inboxPollQuerySchema,
 } from "./schemas/inbox.js";
 export type {
+  InboxAckAcceptedDisposition,
+  InboxAckAcceptedFrame,
   InboxAckFrame,
+  InboxAckRejectedFrame,
+  InboxAckRejectedReason,
   InboxDeliverFrame,
 } from "./schemas/inbox-frames.js";
 // -- WebSocket inbox data-plane frames --
-export { inboxAckFrameSchema, inboxDeliverFrameSchema } from "./schemas/inbox-frames.js";
+export {
+  inboxAckAcceptedDispositionSchema,
+  inboxAckAcceptedFrameSchema,
+  inboxAckFrameSchema,
+  inboxAckRejectedFrameSchema,
+  inboxAckRejectedReasonSchema,
+  inboxDeliverFrameSchema,
+} from "./schemas/inbox-frames.js";
 export {
   INVITATION_DEFAULT_TTL_DAYS,
   type InvitationPreview,

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -29,5 +29,28 @@ export type InboxDeliverFrame = z.infer<typeof inboxDeliverFrameSchema>;
 export const inboxAckFrameSchema = z.object({
   type: z.literal("inbox:ack"),
   entryId: z.number().int().nonnegative(),
+  ref: z.string().min(1).optional(),
 });
 export type InboxAckFrame = z.infer<typeof inboxAckFrameSchema>;
+
+export const inboxAckAcceptedDispositionSchema = z.enum(["acked", "already_acked", "accepted_from_pending"]);
+export type InboxAckAcceptedDisposition = z.infer<typeof inboxAckAcceptedDispositionSchema>;
+
+export const inboxAckRejectedReasonSchema = z.enum(["not_found_or_not_bound", "failed_or_dead"]);
+export type InboxAckRejectedReason = z.infer<typeof inboxAckRejectedReasonSchema>;
+
+export const inboxAckAcceptedFrameSchema = z.object({
+  type: z.literal("inbox:ack:accepted"),
+  entryId: z.number().int().nonnegative(),
+  ref: z.string().min(1),
+  disposition: inboxAckAcceptedDispositionSchema,
+});
+export type InboxAckAcceptedFrame = z.infer<typeof inboxAckAcceptedFrameSchema>;
+
+export const inboxAckRejectedFrameSchema = z.object({
+  type: z.literal("inbox:ack:rejected"),
+  entryId: z.number().int().nonnegative(),
+  ref: z.string().min(1),
+  reason: inboxAckRejectedReasonSchema,
+});
+export type InboxAckRejectedFrame = z.infer<typeof inboxAckRejectedFrameSchema>;

--- a/packages/shared/src/schemas/ws-auth.ts
+++ b/packages/shared/src/schemas/ws-auth.ts
@@ -35,6 +35,12 @@ export const serverCapabilitiesSchema = z
      * 0.10.4 ~ 0.14.2 clients suppress their local 5s HTTP poll.
      */
     wsInboxDeliver: z.boolean().default(false),
+    /**
+     * Server confirms `inbox:ack` frames that include a client-generated
+     * `ref` with `inbox:ack:accepted` / `inbox:ack:rejected`. New clients use
+     * this to retry ACKs until the database transition is known durable.
+     */
+    wsInboxAckConfirm: z.boolean().default(false),
   })
   .partial();
 export type ServerCapabilities = z.infer<typeof serverCapabilitiesSchema>;


### PR DESCRIPTION
## Summary
- add capability-gated confirmed inbox ACK frames with accepted/rejected responses
- make server ACK transitions idempotent and scoped to bound inboxes, including owned pending rows
- add client pending ACK queue with ref coalescing, retry, reconnect/bind flush, legacy fallback, and structured ACK logs

## Compatibility
- new server keeps accepting legacy `{ type: "inbox:ack", entryId }` without requiring a response
- new client only enables confirmed ACKs when `server:welcome.capabilities.wsInboxAckConfirm` is true

## Review
- reviewed by codex-reviewer; blockers fixed and rereview passed

## Tests
- `pnpm check`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/shared exec vitest run src/__tests__/inbox-frames-schema.test.ts src/__tests__/ws-auth-schema.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/client-connection-websocket-coverage.test.ts src/__tests__/agent-slot.test.ts --pool=forks --poolOptions.forks.maxForks=1`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/inbox-ws-push.test.ts src/__tests__/ws-server-welcome.test.ts src/__tests__/messaging-e2e.test.ts src/__tests__/inbox-bind-recovery.test.ts --pool=forks --poolOptions.forks.maxForks=1`