### PR TITLE
feat(web): simplify chat list source grouping

### DIFF
--- a/packages/server/src/__tests__/me-chat-source-tags.test.ts
+++ b/packages/server/src/__tests__/me-chat-source-tags.test.ts
@@ -147,6 +147,56 @@ describe("conversation-list source tags", () => {
     expect(issueRow?.entityType).toBe("issue");
   });
 
+  it("projects createdByMe from the caller's chat membership role", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createAgent(app.db, {
+      name: `owner-peer-${crypto.randomUUID().slice(0, 8)}`,
+      type: "human",
+      displayName: "Owner Peer",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+
+    const ownedByMe = uuidv7();
+    const ownedByPeer = uuidv7();
+    await app.db.transaction(async (tx) => {
+      await tx.insert(chats).values([
+        {
+          id: ownedByMe,
+          organizationId: admin.organizationId,
+          type: "direct",
+          topic: "owned by me",
+          metadata: {},
+        },
+        {
+          id: ownedByPeer,
+          organizationId: admin.organizationId,
+          type: "direct",
+          topic: "owned by peer",
+          metadata: {},
+        },
+      ]);
+      await addChatParticipants(tx, ownedByMe, [
+        { agentId: admin.humanAgentUuid, role: "owner" },
+        { agentId: peer.uuid, role: "member" },
+      ]);
+      await addChatParticipants(tx, ownedByPeer, [
+        { agentId: peer.uuid, role: "owner" },
+        { agentId: admin.humanAgentUuid, role: "member" },
+      ]);
+    });
+
+    const rows = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "active",
+    });
+    const byId = new Map(rows.rows.map((r) => [r.chatId, r.createdByMe]));
+    expect(byId.get(ownedByMe)).toBe(true);
+    expect(byId.get(ownedByPeer)).toBe(false);
+  });
+
   it("listMeChatSourceCounts: chatCount + unreadChatCount, manual always present", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -343,6 +343,7 @@ export async function listMeChats(
       (SELECT count(*) FROM chat_membership
         WHERE chat_id = c.id AND access_mode = 'speaker') AS participant_count,
       cm.access_mode AS access_mode,
+      cm.role AS membership_role,
       COALESCE(cus.unread_mention_count, 0) AS unread_mention_count,
       COALESCE(cus.engagement_status, ${ACTIVE}) AS engagement_status,
       ${chatSourceSqlExpression} AS source,
@@ -382,6 +383,7 @@ export async function listMeChats(
     last_message_preview: string | null;
     participant_count: number | string;
     access_mode: "speaker" | "watcher";
+    membership_role: string;
     unread_mention_count: number;
     engagement_status: ChatEngagementStatus;
     source: ChatSource;
@@ -604,6 +606,7 @@ export async function listMeChats(
       chatId: r.chat_id,
       type: r.type,
       membershipKind: isSpeaker ? "participant" : "watching",
+      createdByMe: r.membership_role === "owner",
       source: r.source,
       entityType,
       title,

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -190,11 +190,11 @@ export const meChatRowSchema = z.object({
   type: z.string(),
   membershipKind: meChatMembershipKindSchema,
   /**
-   * True when the caller's membership row is the chat owner. The web rail uses
-   * this as a presentation bucket ("Created by me") without exposing the full
-   * membership role enum on the public row contract. Defaulted for web-ahead
-   * deploys so older servers keep grouping those rows under their normal
-   * source bucket.
+   * True when the caller's membership row is the chat owner. The web rail
+   * combines this with `source === "manual"` for the MINE bucket, without
+   * exposing the full membership role enum on the public row contract.
+   * Defaulted for web-ahead deploys so older servers keep grouping those rows
+   * under their normal source bucket.
    */
   createdByMe: z.boolean().default(false),
   /**

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -190,6 +190,14 @@ export const meChatRowSchema = z.object({
   type: z.string(),
   membershipKind: meChatMembershipKindSchema,
   /**
+   * True when the caller's membership row is the chat owner. The web rail uses
+   * this as a presentation bucket ("Created by me") without exposing the full
+   * membership role enum on the public row contract. Defaulted for web-ahead
+   * deploys so older servers keep grouping those rows under their normal
+   * source bucket.
+   */
+  createdByMe: z.boolean().default(false),
+  /**
    * Coarse-grained origin — `manual` / `github`. Mirrors the
    * projection driven by `chatSourceSqlExpression` in
    * `services/me-chat.ts`. Drives the rail's filter popover and

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -270,6 +270,7 @@ function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
     chatId: overrides.chatId ?? "chat-1",
     type: overrides.type ?? "group",
     membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
     source: overrides.source ?? "manual",
     entityType: overrides.entityType ?? null,
     title: overrides.title ?? "Launch planning",

--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -24,6 +24,7 @@ function row(overrides: Partial<MeChatRow>): MeChatRow {
     chatId: overrides.chatId ?? "preview",
     type: overrides.type ?? "direct",
     membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
     source: overrides.source ?? "manual",
     entityType: overrides.entityType ?? null,
     title: overrides.title ?? "preview",

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -148,7 +148,7 @@ describe("groupRows — source", () => {
     expect(buckets.find((b) => b.key === "github")?.rows.length).toBe(2);
   });
 
-  it("created-by-me takes precedence over the underlying source", () => {
+  it("keeps owner-role github rows in GITHUB", () => {
     const rows = [
       row({
         id: "mine-github",
@@ -159,7 +159,7 @@ describe("groupRows — source", () => {
       }),
     ];
     const buckets = groupRows(rows, "source", NOW);
-    expect(buckets.map((b) => b.key)).toEqual(["created-by-me"]);
+    expect(buckets.map((b) => b.key)).toEqual(["github"]);
     expect(buckets[0]?.rows.map((r) => r.chatId)).toEqual(["mine-github"]);
   });
 

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -2,6 +2,7 @@ import type { MeChatRow } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import {
   groupRows,
+  parseGroupMode,
   rowAttentionReason,
   rowIsFailed,
   rowNeedsYou,
@@ -19,6 +20,7 @@ function row(overrides: Partial<MeChatRow> & { id: string; lastMessageAt: string
     chatId: overrides.id,
     type: overrides.type ?? "direct",
     membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
     source: overrides.source ?? "manual",
     entityType: overrides.entityType ?? null,
     title: overrides.title ?? overrides.id,
@@ -46,18 +48,19 @@ function offsetIso(hours: number): string {
   return new Date(NOW.getTime() + hours * 60 * 60_000).toISOString();
 }
 
-describe("groupRows — none", () => {
-  it("returns a single label-less bucket", () => {
-    const rows = [row({ id: "a", lastMessageAt: offsetIso(-1) })];
-    const buckets = groupRows(rows, "none", NOW);
-    expect(buckets).toHaveLength(1);
-    expect(buckets[0]?.label).toBeNull();
-    expect(buckets[0]?.rows).toHaveLength(1);
+describe("parseGroupMode", () => {
+  it("supports only source and recency", () => {
+    expect(parseGroupMode("source")).toBe("source");
+    expect(parseGroupMode("recency")).toBe("recency");
+    expect(parseGroupMode("type")).toBe("source");
+    expect(parseGroupMode("none")).toBe("source");
+    expect(parseGroupMode(null)).toBe("source");
   });
 
   it("returns an empty single bucket when there are no rows", () => {
-    const buckets = groupRows([], "none", NOW);
+    const buckets = groupRows([], "source", NOW);
     expect(buckets).toHaveLength(1);
+    expect(buckets[0]?.label).toBeNull();
     expect(buckets[0]?.rows).toHaveLength(0);
   });
 });
@@ -127,20 +130,37 @@ describe("groupRows — recency", () => {
 });
 
 describe("groupRows — source", () => {
-  it("buckets rows by ChatSource in canonical order", () => {
+  it("buckets rows by ownership and ChatSource in canonical order", () => {
     const rows = [
       row({ id: "g1", source: "github", entityType: "issue", lastMessageAt: offsetIso(-1) }),
       row({ id: "m", source: "manual", lastMessageAt: offsetIso(-1) }),
+      row({ id: "mine", source: "manual", createdByMe: true, lastMessageAt: offsetIso(-1) }),
       row({ id: "g2", source: "github", entityType: "pull_request", lastMessageAt: offsetIso(-1) }),
     ];
     const buckets = groupRows(rows, "source", NOW);
     // Canonical order is the one declared inside `group-rows.ts`:
-    // manual → github.
-    expect(buckets.map((b) => b.key)).toEqual(["manual", "github"]);
+    // created-by-me → manual → github.
+    expect(buckets.map((b) => b.key)).toEqual(["created-by-me", "manual", "github"]);
+    expect(buckets.map((b) => b.label)).toEqual(["MINE", "MANUAL", "GITHUB"]);
     // Both github rows land in the single `github` bucket regardless
     // of inner entityType — the popover collapse is a per-origin axis,
     // not a per-entity one.
     expect(buckets.find((b) => b.key === "github")?.rows.length).toBe(2);
+  });
+
+  it("created-by-me takes precedence over the underlying source", () => {
+    const rows = [
+      row({
+        id: "mine-github",
+        source: "github",
+        entityType: "issue",
+        createdByMe: true,
+        lastMessageAt: offsetIso(-1),
+      }),
+    ];
+    const buckets = groupRows(rows, "source", NOW);
+    expect(buckets.map((b) => b.key)).toEqual(["created-by-me"]);
+    expect(buckets[0]?.rows.map((r) => r.chatId)).toEqual(["mine-github"]);
   });
 
   it("omits source buckets with no rows", () => {
@@ -148,39 +168,6 @@ describe("groupRows — source", () => {
     const buckets = groupRows(rows, "source", NOW);
     expect(buckets).toHaveLength(1);
     expect(buckets[0]?.key).toBe("manual");
-  });
-});
-
-describe("groupRows — type", () => {
-  it("buckets direct vs group chats with IM-style labels", () => {
-    const rows = [
-      row({ id: "d1", type: "direct", lastMessageAt: offsetIso(-1) }),
-      row({ id: "g1", type: "group", lastMessageAt: offsetIso(-1) }),
-      row({ id: "d2", type: "direct", lastMessageAt: offsetIso(-1) }),
-    ];
-    const buckets = groupRows(rows, "type", NOW);
-    expect(buckets.map((b) => b.key)).toEqual(["direct", "group"]);
-    expect(buckets[0]?.label).toBe("1:1");
-    expect(buckets[1]?.label).toBe("Team");
-    expect(buckets[0]?.rows.length).toBe(2);
-    expect(buckets[1]?.rows.length).toBe(1);
-  });
-
-  it("omits type buckets with no rows", () => {
-    const rows = [row({ id: "d", type: "direct", lastMessageAt: offsetIso(-1) })];
-    const buckets = groupRows(rows, "type", NOW);
-    expect(buckets).toHaveLength(1);
-    expect(buckets[0]?.key).toBe("direct");
-  });
-
-  it("sinks unknown chat type into an Other bucket so the row stays visible", () => {
-    const rows = [
-      row({ id: "u", type: "future-channel-kind", lastMessageAt: offsetIso(-1) }),
-      row({ id: "d", type: "direct", lastMessageAt: offsetIso(-1) }),
-    ];
-    const buckets = groupRows(rows, "type", NOW);
-    expect(buckets.map((b) => b.key)).toEqual(["direct", "other"]);
-    expect(buckets[1]?.label).toBe("Other");
   });
 });
 

--- a/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
@@ -232,8 +232,6 @@ describe("nextParamsForGroup", () => {
 
   it("sets non-default modes", () => {
     expect(nextParamsForGroup(paramsOf(""), "recency").get("group")).toBe("recency");
-    expect(nextParamsForGroup(paramsOf(""), "type").get("group")).toBe("type");
-    expect(nextParamsForGroup(paramsOf(""), "none").get("group")).toBe("none");
   });
 
   it("preserves the chat selection (grouping is purely visual)", () => {

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -15,7 +15,7 @@ export function parseGroupMode(raw: string | null): GroupMode {
 
 export type GroupBucket = {
   key: string;
-  /** `null` = no header rendered (used by `none`). */
+  /** `null` = no header rendered (used only by the empty-list fallback). */
   label: string | null;
   rows: ReadonlyArray<MeChatRow>;
   defaultCollapsed: boolean;
@@ -113,9 +113,13 @@ function groupByRecency(rows: ReadonlyArray<MeChatRow>, now: Date): ReadonlyArra
 // ---------------------------------------------------------------------------
 
 const SOURCE_BUCKETS: ReadonlyArray<{ key: string; label: string; match: (row: MeChatRow) => boolean }> = [
-  { key: "created-by-me", label: "MINE", match: (row) => row.createdByMe === true },
+  {
+    key: "created-by-me",
+    label: "MINE",
+    match: (row) => row.createdByMe === true && (row.source ?? "manual") === "manual",
+  },
   { key: "manual", label: "MANUAL", match: (row) => row.createdByMe !== true && (row.source ?? "manual") === "manual" },
-  { key: "github", label: "GITHUB", match: (row) => row.createdByMe !== true && row.source === "github" },
+  { key: "github", label: "GITHUB", match: (row) => row.source === "github" },
 ];
 
 function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket> {

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -1,6 +1,6 @@
-import type { ChatSource, MeChatRow } from "@first-tree/shared";
+import type { MeChatRow } from "@first-tree/shared";
 
-export type GroupMode = "recency" | "source" | "type" | "none";
+export type GroupMode = "recency" | "source";
 
 /**
  * Parse a `?group=` URL value into a `GroupMode`. Unknown / missing
@@ -9,7 +9,7 @@ export type GroupMode = "recency" | "source" | "type" | "none";
  * (`ConversationList`) share one canonical parser.
  */
 export function parseGroupMode(raw: string | null): GroupMode {
-  if (raw === "recency" || raw === "type" || raw === "none") return raw;
+  if (raw === "recency") return raw;
   return "source";
 }
 
@@ -26,23 +26,19 @@ export type GroupBucket = {
  * `Group by` mode. Pure function — the caller is expected to memo with
  * the rows array as the input.
  *
- * `none` returns a single label-less bucket so the render path stays
- * uniform. The list scroll container always renders bucket-by-bucket,
- * never a separate flat code path.
+ * Empty input returns a single label-less bucket so the render path stays
+ * uniform while the empty state owns the visible copy.
  */
 export function groupRows(
   rows: ReadonlyArray<MeChatRow>,
   mode: GroupMode,
   now: Date = new Date(),
 ): ReadonlyArray<GroupBucket> {
-  if (mode === "none" || rows.length === 0) {
+  if (rows.length === 0) {
     return [{ key: "all", label: null, rows, defaultCollapsed: false }];
   }
   if (mode === "recency") {
     return groupByRecency(rows, now);
-  }
-  if (mode === "type") {
-    return groupByType(rows);
   }
   return groupBySource(rows);
 }
@@ -116,18 +112,20 @@ function groupByRecency(rows: ReadonlyArray<MeChatRow>, now: Date): ReadonlyArra
 // Source
 // ---------------------------------------------------------------------------
 
-const SOURCE_BUCKETS: ReadonlyArray<{ key: ChatSource; label: string }> = [
-  { key: "manual", label: "Manual" },
-  { key: "github", label: "GitHub" },
+const SOURCE_BUCKETS: ReadonlyArray<{ key: string; label: string; match: (row: MeChatRow) => boolean }> = [
+  { key: "created-by-me", label: "MINE", match: (row) => row.createdByMe === true },
+  { key: "manual", label: "MANUAL", match: (row) => row.createdByMe !== true && (row.source ?? "manual") === "manual" },
+  { key: "github", label: "GITHUB", match: (row) => row.createdByMe !== true && row.source === "github" },
 ];
 
 function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket> {
-  const map = new Map<ChatSource, MeChatRow[]>();
+  const map = new Map<string, MeChatRow[]>();
   for (const r of rows) {
-    // Same defence as `SourceIcon`: if `r.source` is missing because
-    // an older server build hasn't shipped the column yet, treat the
-    // row as Manual so it still gets a bucket instead of vanishing.
-    const key: ChatSource = r.source ?? "manual";
+    const bucket = SOURCE_BUCKETS.find((b) => b.match(r));
+    // Same defence as `SourceIcon`: if `r.source` is missing or unfamiliar
+    // because an older/newer server build is out of step, treat the row as
+    // Manual so it still gets a bucket instead of vanishing.
+    const key = bucket?.key ?? "manual";
     const list = map.get(key);
     if (list) list.push(r);
     else map.set(key, [r]);
@@ -137,45 +135,6 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
     const list = map.get(b.key);
     if (!list || list.length === 0) continue;
     buckets.push({ key: b.key, label: b.label, rows: list, defaultCollapsed: false });
-  }
-  return buckets;
-}
-
-// ---------------------------------------------------------------------------
-// Type (topology — direct vs group)
-// ---------------------------------------------------------------------------
-//
-// `chats.type` is `direct | group` (set when the chat is created based on
-// participant count). The bucket labels read in IM-style shorthand —
-// "1:1" / "Team" — because the raw `direct` / `group` values are
-// implementation jargon. Anything unknown sinks into the catch-all
-// "Other" bucket; in practice we never expect to see one.
-
-const TYPE_BUCKETS: ReadonlyArray<{ key: string; label: string; match: (t: string) => boolean }> = [
-  { key: "direct", label: "1:1", match: (t) => t === "direct" },
-  { key: "group", label: "Team", match: (t) => t === "group" },
-];
-
-function groupByType(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket> {
-  const byKey = new Map<string, MeChatRow[]>();
-  for (const r of rows) {
-    const bucket = TYPE_BUCKETS.find((b) => b.match(r.type));
-    const key = bucket?.key ?? "other";
-    const list = byKey.get(key);
-    if (list) list.push(r);
-    else byKey.set(key, [r]);
-  }
-  const buckets: GroupBucket[] = [];
-  for (const b of TYPE_BUCKETS) {
-    const list = byKey.get(b.key);
-    if (!list || list.length === 0) continue;
-    buckets.push({ key: b.key, label: b.label, rows: list, defaultCollapsed: false });
-  }
-  // `other` is a defensive bucket for any unknown topology — surfaced
-  // last so users can still see the row instead of having it vanish.
-  const other = byKey.get("other");
-  if (other && other.length > 0) {
-    buckets.push({ key: "other", label: "Other", rows: other, defaultCollapsed: false });
   }
   return buckets;
 }

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -38,10 +38,8 @@ const ENGAGEMENT_OPTIONS: ReadonlyArray<{ value: ChatEngagementView; label: stri
 ];
 
 const GROUP_OPTIONS: ReadonlyArray<{ value: GroupMode; label: string }> = [
-  { value: "recency", label: "Recency" },
   { value: "source", label: "Source" },
-  { value: "type", label: "Type" },
-  { value: "none", label: "None" },
+  { value: "recency", label: "Recency" },
 ];
 
 function formatRowTime(iso: string | null): string {

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -20,7 +20,7 @@ import { ConversationList, DRAFT_CHAT_ID } from "./conversations/index.js";
  *   - `?watching=1` (default off) — chats where the caller is a watcher
  *   - `?origin=manual,pr,issue,…` (default empty = unfiltered) — multi-select
  *   - `?with=agent-x,agent-y` (default empty = unfiltered) — participants
- *   - `?group=recency|source|type|none` (default `source`) — list grouping
+ *   - `?group=recency|source` (default `source`) — list grouping
  *
  * Phase B replaces the Phase A single-value `?source=` with the multi-select
  * `?origin=`; the legacy key is still accepted on first load and upgraded


### PR DESCRIPTION
## Summary
- limit the chat-list Group menu to Source and Recency
- add a MINE source bucket before existing MANUAL and GITHUB buckets
- project createdByMe from chat membership role and cover it with tests

## Verification
- pnpm --filter @first-tree/web exec vitest run src/pages/workspace/__tests__/group-rows.test.ts src/pages/workspace/__tests__/url-transitions.test.ts
- pnpm --filter @first-tree/server exec vitest run src/__tests__/me-chat-source-tags.test.ts
- pnpm check && pnpm typecheck