### PR TITLE
docs: remove Lark references from design language

### DIFF
--- a/packages/web/DESIGN-AUDIT.md
+++ b/packages/web/DESIGN-AUDIT.md
@@ -226,8 +226,8 @@ of P0 bug. Two additions catch the entire P0 list automatically and stop recurre
 ## Strategy A migration (design-language adoption — 2026-05-28)
 
 Adopted direction: **Strategy A** (see DESIGN.md → "Design language"). Migrate the app
-from green-primary to **neutral-primary + green-as-signature/semantic**, at Lark/Arco
-craft level. Reference mockup: `variant-F.html` (light + dark) in the design archive.
+from green-primary to **neutral-primary + green-as-signature/semantic**, with mature
+collaboration-product craft. Reference mockup: `variant-F.html` (light + dark) in the design archive.
 This is a full visual pass — do it phased, not in one shot. The earlier P1–P3 leftovers
 fold into the phases below.
 

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -36,10 +36,11 @@
    glyph), not hue. The states that want your attention are **warm** so they pop
    against the green/blue live baseline: needs-you = amber, blocked = orange,
    error = red. Present-but-idle = blue; offline = gray.
-4. **Lark / Arco craft, not Lark color.** Borrow the *discipline* — a neutral
-   gray token ramp, hairline borders, soft low-opacity elevation, thin line
-   icons, search + underline tabs, rounded-square avatars, comfortable aligned
-   spacing, a right Session sidebar. Do **not** borrow a saturated blue primary.
+4. **Mature collaboration craft, not borrowed color.** Borrow the *discipline*
+   — a neutral gray token ramp, hairline borders, soft low-opacity elevation,
+   thin line icons, search + underline tabs, rounded-square avatars,
+   comfortable aligned spacing, a right Session sidebar. Do **not** borrow a
+   saturated blue primary.
 
 **Semantic color map — the only places color appears:**
 

--- a/packages/web/src/components/unread-divider.tsx
+++ b/packages/web/src/components/unread-divider.tsx
@@ -5,7 +5,7 @@
  * persisted `latestKnownMessageId` — its position does not move as
  * new messages stream in during the session.
  *
- * The divider has no count by design (Lark-style): the count lives
+ * The divider has no count by design: the count lives
  * on the floating pill and tracks the live scroll position. Keeping
  * a number off the divider lets it remain a stable anchor even
  * after the user has scrolled past every new message.

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2546,8 +2546,8 @@ export function ChatView({
               )}
               {/* Chat details toggle — opens the right rail (Participants /
               GitHub / Chat actions). Sits at the panel's far right,
-              mirroring the rail's position. The "..." glyph matches the
-              Teams/Lark convention referenced in the design discussion. */}
+              mirroring the rail's position. The "..." glyph follows the
+              collaboration-product convention referenced in the design discussion. */}
               <button
                 type="button"
                 onClick={toggleSidebar}


### PR DESCRIPTION
## Summary

- Remove direct Lark references from the web design language docs.
- Replace the design-language rule with a generic mature collaboration-product craft principle.
- Clean up related implementation comments so the repository no longer names Lark as a design reference.

## Verification

- `rg -n "Lark|lark" .` returns no matches
- `git diff --check HEAD~1 HEAD`