### PR TITLE
docs(web): move DESIGN-AUDIT.md into packages/web/docs/

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -15,7 +15,7 @@
 ## Design language
 
 > Implementation status, the gap vs the current build, and the step-by-step
-> migration plan live in **[DESIGN-AUDIT.md](DESIGN-AUDIT.md)**. This document
+> migration plan live in **[DESIGN-AUDIT.md](docs/DESIGN-AUDIT.md)**. This document
 > describes the design system itself.
 
 **Four pillars:**
@@ -351,7 +351,7 @@ White-ish initials (`--fg-on-vivid`) clear WCAG AA on every hue in both modes.
   custom radio/checkbox cards surface a ring on `:focus-within` (the real input
   is `sr-only`). *(Some page-level form controls still carry the older `ring-1` —
   extending the `ring-2` recipe to the remaining primitives is a tracked
-  follow-up; see DESIGN-AUDIT.md.)*
+  follow-up; see docs/DESIGN-AUDIT.md.)*
 - Scrollbars are styled thin/consistent cross-platform to avoid layout jump.
 
 ---
@@ -373,7 +373,7 @@ White-ish initials (`--fg-on-vivid`) clear WCAG AA on every hue in both modes.
 ## Status & roadmap
 
 Current implementation status, the gap vs this design language, the phased
-migration plan, and known gaps all live in **[DESIGN-AUDIT.md](DESIGN-AUDIT.md)**.
+migration plan, and known gaps all live in **[DESIGN-AUDIT.md](docs/DESIGN-AUDIT.md)**.
 
 **Visual reference:** the living styleguide at `/preview/styleguide`
 (`src/pages/styleguide-preview.tsx`).

--- a/packages/web/docs/DESIGN-AUDIT.md
+++ b/packages/web/docs/DESIGN-AUDIT.md
@@ -1,7 +1,7 @@
 # Design System Audit & Fix Log
 
 > Recorded 2026-05-28 from a source-grounded review of `src/index.css` + `src/components/ui/*`.
-> Companion to [DESIGN.md](DESIGN.md) (the spec) and `/preview/styleguide` (the visual reference).
+> Companion to [DESIGN.md](../DESIGN.md) (the spec) and `/preview/styleguide` (the visual reference).
 >
 > **This doc owns:** current implementation state, the gap vs DESIGN.md's adopted design
 > language, the phased migration plan, the audit/fix log, and known structural gaps.

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -147,7 +147,7 @@
      on :root below, exposed to Tailwind via the --color-fg-* / --color-bg-* /
      --color-border-* utility aliases further down). The old --color-text-* /
      --color-surface-* / --color-border-subtle|default|emphasis "semantic" layer
-     was removed in the 2026-05-28 cleanup — it was unadopted (see DESIGN-AUDIT.md). */
+     was removed in the 2026-05-28 cleanup — it was unadopted (see docs/DESIGN-AUDIT.md). */
 
   /* ---- shadcn-compatible aliases (preserved) ------------------------------ */
   --color-background: var(--bg);

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -52,7 +52,7 @@ type SwatchDef = { name: string; token: string; note?: string };
 
 // Canonical names = the short tokens the codebase actually uses. The parallel
 // --color-text-* / --color-surface-* / --color-border-* alias layer is unadopted
-// (see DESIGN-AUDIT.md P2), so the styleguide shows the real names.
+// (see docs/DESIGN-AUDIT.md P2), so the styleguide shows the real names.
 const TEXT_COLORS: SwatchDef[] = [
   { name: "--fg", token: "var(--fg)", note: "primary ink" },
   { name: "--fg-2", token: "var(--fg-2)", note: "secondary" },


### PR DESCRIPTION
## What

Move `packages/web/DESIGN-AUDIT.md` → `packages/web/docs/DESIGN-AUDIT.md`.

`DESIGN.md` stays at the package root as the headline design contract — it's the linter-enforced source of truth, one-glance discoverable, and its links into `src/` + `scripts/` stay clean (no `../`). The time-bound migration/audit log moves into `docs/` next to `cross-platform-visual-qa.md`, matching this package's existing "situational docs live in `docs/`" convention.

## References updated (no broken links)

- `DESIGN.md`: 2 markdown links + 1 prose pointer → `docs/DESIGN-AUDIT.md`
- `DESIGN-AUDIT.md`: back-link → `../DESIGN.md`
- `src/index.css` + `src/pages/styleguide-preview.tsx`: comment pointers → `docs/DESIGN-AUDIT.md`

Full-repo scan confirms no stale `](DESIGN-AUDIT.md)` links remain. `git mv` preserves history (rename detected at 99%).

## Verification

`pnpm --filter @first-tree/web typecheck` → `tsc --noEmit` clean + `lint:tokens` ✓ design-token guardrails clean.

Pure docs move, no behavior change.

> Supersedes #703 (closed by a branch rename; same commit `ab4442c0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)