### PR TITLE
docs: retire hub terminology from user-facing surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # =============================================================================
-# First Tree Hub — Environment Variables
+# First Tree — Environment Variables
 # Copy this file: cp .env.example .env
 # =============================================================================
 #
-# The Server section below is for the SaaS Hub (operated by the First Tree
+# The Server section below is for First Tree SaaS (operated by the First Tree
 # team) and dev-only `pnpm --filter @first-tree/server dev` runs. End
 # users only need the Client section.
 #
@@ -50,7 +50,7 @@ FIRST_TREE_HOST=0.0.0.0
 # Target repo where feedback issues are filed (owner/name).
 # The token only needs `issues:write` on this one repo, and is deliberately
 # distinct from FIRST_TREE_GITHUB_* so you can scope it narrowly.
-# HEARBACK_FEEDBACK_REPO=agent-team-foundation/first-tree-hub
+# HEARBACK_FEEDBACK_REPO=agent-team-foundation/first-tree
 # HEARBACK_GITHUB_TOKEN=
 
 # LLM used for the chat-guided bug-report flow (OpenAI-compatible).
@@ -59,7 +59,7 @@ FIRST_TREE_HOST=0.0.0.0
 # LLM_MODEL=openai/gpt-4o-mini
 
 # Trust x-forwarded-for for per-ip rate-limit attribution. Enable only when
-# the hub sits behind a proxy you control (CDN, ingress); otherwise clients
+# the server sits behind a proxy you control (CDN, ingress); otherwise clients
 # can spoof the header.
 # HEARBACK_TRUST_PROXY_HEADERS=false
 
@@ -84,11 +84,11 @@ FIRST_TREE_HOST=0.0.0.0
 # DEV_GITHUB_PAT=ghp_xxx
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
-# │ Client — Required (for first-tree-hub daemon start)                      │
+# │ Client — Required (for first-tree daemon start)                          │
 # └───────────────────────────────────────────────────────────────────────────┘
 
 # Server URL the client connects to
-# FIRST_TREE_SERVER_URL=https://hub.example.com
+# FIRST_TREE_SERVER_URL=https://first-tree.example.com
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Client — Optional                                                        │

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,6 +1,6 @@
 # First Tree CLI
 
-First Tree is the unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging.
+First Tree is the unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and team messaging.
 
 Install the CLI globally:
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,14 +2,14 @@
   "name": "first-tree-dev",
   "version": "0.5.3",
   "type": "module",
-  "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and Hub messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
+  "description": "First Tree — unified CLI for Context Tree onboarding, GitHub Scan automation, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [
     "agents",
     "cli",
     "context-tree",
     "first-tree",
     "github",
-    "hub"
+    "collaboration"
   ],
   "homepage": "https://github.com/agent-team-foundation/first-tree#readme",
   "bugs": {

--- a/apps/cli/src/__tests__/prompt-core.test.ts
+++ b/apps/cli/src/__tests__/prompt-core.test.ts
@@ -165,7 +165,7 @@ describe("prompt core", () => {
     await expect(promptAddAgent({ agentId: "missing" })).rejects.toThrow("HTTP 404");
 
     cliFetchMock.mockResolvedValueOnce(response(200, { name: null }));
-    await expect(promptAddAgent({ agentId: "tombstone" })).rejects.toThrow("has no hub name");
+    await expect(promptAddAgent({ agentId: "tombstone" })).rejects.toThrow("has no server-side name");
   });
 
   it("prompts for an agent id when omitted", async () => {

--- a/apps/cli/src/commands/_shared/connect-token.ts
+++ b/apps/cli/src/commands/_shared/connect-token.ts
@@ -58,14 +58,14 @@ export function deriveHubUrlFromToken(token: string): string {
   if (!payload) {
     throw new HubUrlDerivationError(
       "INVALID_TOKEN",
-      "Connect token is not a valid JWT. Generate a new one from your Hub web console.",
+      "Connect token is not a valid JWT. Generate a new one from the First Tree web console.",
     );
   }
   const iss = payload.iss;
   if (typeof iss !== "string" || iss.length === 0) {
     throw new HubUrlDerivationError(
       "TOKEN_MISSING_ISS",
-      "Connect token does not carry an issuer (`iss` claim). Generate a new token from a Hub running v0.10+.",
+      "Connect token does not carry an issuer (`iss` claim). Generate a new token from a First Tree server running v0.10+.",
     );
   }
   if (!/^https?:\/\//i.test(iss)) {

--- a/apps/cli/src/commands/_shared/status-blocks.ts
+++ b/apps/cli/src/commands/_shared/status-blocks.ts
@@ -41,18 +41,18 @@ export function renderServiceBlock(): void {
 export function renderHubBlock(): void {
   const clientYaml = join(defaultConfigDir(), "client.yaml");
   if (!existsSync(clientYaml)) {
-    print.line("  Hub:      (not configured — run `first-tree login <token>`)\n");
+    print.line("  Server:   (not configured — run `first-tree login <token>`)\n");
     return;
   }
   try {
     const cfg = readConfigFile(clientYaml);
     const serverUrl = getNested(cfg, "server.url");
     const clientId = getNested(cfg, "client.id");
-    print.line(`  Hub:      ${serverUrl ?? "(not configured)"}\n`);
+    print.line(`  Server:   ${serverUrl ?? "(not configured)"}\n`);
     print.line(`  Client:   ${clientId ?? "(not configured)"}\n`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    print.line(`  Hub:      (could not read ${clientYaml}: ${msg.slice(0, 60)})\n`);
+    print.line(`  Server:   (could not read ${clientYaml}: ${msg.slice(0, 60)})\n`);
   }
 }
 
@@ -75,7 +75,7 @@ export function renderAuthBlock(): void {
   const remainingSec = exp - Math.floor(Date.now() / 1000);
   if (remainingSec <= 0) {
     print.line("  Auth:     ✗ refresh token EXPIRED — re-run `first-tree login <token>`\n");
-    print.line("              (get a fresh token from your Hub's Web admin → Computers → New Connection)\n");
+    print.line("              (get a fresh token from the First Tree web console → Computers → New Connection)\n");
   } else if (remainingSec < 2 * 86400) {
     const hours = Math.floor(remainingSec / 3600);
     print.line(`  Auth:     ⚠ refresh token expires in ~${hours}h — re-login soon to stay online\n`);

--- a/apps/cli/src/commands/agent/add.ts
+++ b/apps/cli/src/commands/agent/add.ts
@@ -9,17 +9,17 @@ import { print } from "../../core/output.js";
 export function registerAgentAddCommand(agent: Command): void {
   agent
     .command("add")
-    .description("Register an existing Hub agent on this client (uses the agent name from the Hub)")
-    .option("--agent-id <id>", "Agent UUID on the Hub")
+    .description("Register an existing First Tree agent on this client (uses the agent name from the server)")
+    .option("--agent-id <id>", "Agent UUID on the First Tree server")
     .action(async (options?: { agentId?: string }) => {
       try {
         // Phase 3 of the agent-naming refactor retired the free-form local
         // alias — the local config dir is always keyed by the server-side
-        // `agent.name`. The prompt helper fetches that name from the Hub
+        // `agent.name`. The prompt helper fetches that name from the server
         // given the agent UUID.
         const { name: agentName, agentId } = await promptAddAgent({ agentId: options?.agentId });
         if (!agentName || !agentId) {
-          fail("MISSING_AGENT_ARGS", "Agent UUID (and a hub name for that UUID) are required.", 2);
+          fail("MISSING_AGENT_ARGS", "Agent UUID (and a server-side name for that UUID) are required.", 2);
         }
 
         const agentDir = join(defaultConfigDir(), "agents", agentName);

--- a/apps/cli/src/commands/agent/bind/client.ts
+++ b/apps/cli/src/commands/agent/bind/client.ts
@@ -13,7 +13,7 @@ export function registerAgentBindClientCommand(bind: Command): void {
       "--client-id <id>",
       "Client (machine) ID — must be owned by you. Run `first-tree login <token>` on that machine first.",
     )
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (agentName: string, options: { clientId: string; server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/agent/claim.ts
+++ b/apps/cli/src/commands/agent/claim.ts
@@ -9,7 +9,7 @@ export function registerAgentClaimCommand(agent: Command): void {
   agent
     .command("claim <agentName>")
     .description("Become the manager of an agent (admin-only, or self-claim an unmanaged agent)")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (agentName: string, options: { server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/agent/create.ts
+++ b/apps/cli/src/commands/agent/create.ts
@@ -7,7 +7,7 @@ import { print } from "../../core/output.js";
 export function registerAgentCreateCommand(agent: Command): void {
   agent
     .command("create <name>")
-    .description("Create an agent on Hub and bind it locally")
+    .description("Create an agent in First Tree and bind it locally")
     .requiredOption("--type <type>", "Agent type (human, agent)")
     .requiredOption(
       "--client-id <id>",
@@ -20,7 +20,7 @@ export function registerAgentCreateCommand(agent: Command): void {
     )
     .option("--display-name <name>", "Display name")
     .option("--org <id>", "Target organization id (required when you belong to multiple orgs)")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(
       async (
         name: string,

--- a/apps/cli/src/commands/agent/debug/register.ts
+++ b/apps/cli/src/commands/agent/debug/register.ts
@@ -6,7 +6,7 @@ export function registerAgentDebugRegisterCommand(debugCmd: Command): void {
   debugCmd
     .command("register")
     .description("Register this agent and return identity info")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (options: { agent?: string }) => {
       try {
         const sdk = createSdk(options.agent);

--- a/apps/cli/src/commands/agent/list.ts
+++ b/apps/cli/src/commands/agent/list.ts
@@ -14,9 +14,9 @@ export function registerAgentListCommand(agent: Command): void {
     // design — decouple-client-from-identity §4.5.1 case (b)). --org filters
     // the same response client-side; the server endpoint is unfiltered so
     // the cache works across views without an extra round-trip.
-    .option("--remote", "List every agent you manage on the Hub server (cross-org)")
+    .option("--remote", "List every agent you manage on the First Tree server (cross-org)")
     .option("--org <id>", "When listing remote, restrict to a single organization id")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (options: { remote?: boolean; org?: string; server?: string }) => {
       const wantRemote = options.remote === true || typeof options.org === "string";
       if (!wantRemote) {
@@ -30,7 +30,7 @@ export function registerAgentListCommand(agent: Command): void {
           for (const [name, config] of agents) {
             // Label the UUID column as `uuid` — NOT `agentId` — to discourage
             // agents from copy-pasting the uuid into `chat send <target>`,
-            // which expects the agent name. See the Agent Hub SDK section of
+            // which expects the agent name. See the First Tree agent runtime section of
             // the bootstrap-generated CLAUDE.md.
             print.line(`  ${name.padEnd(20)} runtime: ${config.runtime.padEnd(14)} uuid: ${config.agentId}\n`);
           }

--- a/apps/cli/src/commands/agent/prune.ts
+++ b/apps/cli/src/commands/agent/prune.ts
@@ -27,7 +27,7 @@ export function registerAgentPruneCommand(agent: Command): void {
     .description("Remove local agent aliases that won't bind on this client (unowned, pinned elsewhere, or unreadable)")
     .option("--yes", "Skip the interactive confirmation prompt")
     .option("--dry-run", "Only list what would be removed; don't touch the filesystem")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (options: { yes?: boolean; dryRun?: boolean; server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/agent/reset.ts
+++ b/apps/cli/src/commands/agent/reset.ts
@@ -8,7 +8,7 @@ export function registerAgentResetCommand(agent: Command): void {
   agent
     .command("reset <name>")
     .description("Reset agent error state to idle")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (name: string, options: { server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/agent/session/control.ts
+++ b/apps/cli/src/commands/agent/session/control.ts
@@ -18,7 +18,7 @@ export function registerAgentSessionControlCommands(sessionCmd: Command): void {
     sessionCmd
       .command(`${cmd} <agent-name> <chat-id>`)
       .description(desc)
-      .option("--server <url>", "Hub server URL")
+      .option("--server <url>", "First Tree server URL")
       .action(async (agentName: string, chatId: string, options: { server?: string }) => {
         try {
           const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/agent/session/list.ts
+++ b/apps/cli/src/commands/agent/session/list.ts
@@ -9,7 +9,7 @@ export function registerAgentSessionListCommand(sessionCmd: Command): void {
   sessionCmd
     .command("list <agent-name>")
     .description("List sessions for an agent")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .option("--state <state>", "Filter by session state (active/suspended/evicted)")
     .action(async (agentName: string, options: { server?: string; state?: string }) => {
       try {

--- a/apps/cli/src/commands/agent/status.ts
+++ b/apps/cli/src/commands/agent/status.ts
@@ -7,8 +7,8 @@ import { print } from "../../core/output.js";
 export function registerAgentStatusCommand(agent: Command): void {
   agent
     .command("status [name]")
-    .description("Show agent runtime status from Hub server")
-    .option("--server <url>", "Hub server URL")
+    .description("Show agent runtime status from the First Tree server")
+    .option("--server <url>", "First Tree server URL")
     .action(async (name?: string, options?: { server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options?.server);
@@ -78,7 +78,7 @@ export function registerAgentStatusCommand(agent: Command): void {
           return;
         }
 
-        print.line(`\n  Hub: ${serverUrl}\n\n`);
+        print.line(`\n  Server: ${serverUrl}\n\n`);
         print.line(`  Clients: ${data.clients} connected\n`);
         print.line(`  Agents: ${data.running} running / ${data.total} total\n`);
         print.line(

--- a/apps/cli/src/commands/attention/cancel.ts
+++ b/apps/cli/src/commands/attention/cancel.ts
@@ -13,7 +13,7 @@ export function registerAttentionCancelCommand(parent: Command): void {
     .command("cancel <id>")
     .description("Cancel an open attention you raised")
     .option("--reason <text>", "Optional cancellation reason recorded on the closed record (max 500 chars)")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (id: string, options: CancelOptions) => {
       try {
         const sdk = createSdk(options.agent);

--- a/apps/cli/src/commands/attention/list.ts
+++ b/apps/cli/src/commands/attention/list.ts
@@ -29,7 +29,7 @@ export function registerAttentionListCommand(parent: Command): void {
     .option("--from-agent <id>", "Filter to attentions raised by this origin agent id (overrides default)")
     .option("--in-chat <id>", "Filter to attentions anchored to this chat id")
     .option("-l, --limit <number>", "Max records to return (1-200)")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .option("--group-by-chat", "Render a human-readable grouping by chat on stderr (still emits JSON on stdout)")
     .action(async (options: ListOptions) => {
       try {

--- a/apps/cli/src/commands/attention/raise.ts
+++ b/apps/cli/src/commands/attention/raise.ts
@@ -39,7 +39,7 @@ export function registerAttentionRaiseCommand(parent: Command): void {
       [],
     )
     .option("--meta-json <json|@file>", "JSON object merged over flat --meta flags (escape hatch for complex shapes)")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (options: RaiseOptions) => {
       try {
         const body = await resolveBody(options.body);

--- a/apps/cli/src/commands/attention/show.ts
+++ b/apps/cli/src/commands/attention/show.ts
@@ -11,7 +11,7 @@ export function registerAttentionShowCommand(parent: Command): void {
   parent
     .command("show <id>")
     .description("Show a single attention by id")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (id: string, options: ShowOptions) => {
       try {
         const sdk = createSdk(options.agent);

--- a/apps/cli/src/commands/chat/history.ts
+++ b/apps/cli/src/commands/chat/history.ts
@@ -9,7 +9,7 @@ export function registerChatHistoryCommand(chat: Command): void {
     .description("View message history in a chat")
     .option("-l, --limit <number>", "Maximum messages to return (1-100)", "20")
     .option("--cursor <cursor>", "Pagination cursor from previous response")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (chatId: string, options: { limit: string; cursor?: string; agent?: string }) => {
       try {
         const limit = parseLimit(options.limit, 100);

--- a/apps/cli/src/commands/chat/invite.ts
+++ b/apps/cli/src/commands/chat/invite.ts
@@ -8,7 +8,7 @@ export function registerChatInviteCommand(chat: Command): void {
     .description(
       "Invite an agent into the caller's current chat (the chat identified by FIRST_TREE_CHAT_ID). Use before `chat send <agentName>` when the recipient is not yet a member.",
     )
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (agentName: string, options: { agent?: string }) => {
       try {
         const chatId = process.env.FIRST_TREE_CHAT_ID;

--- a/apps/cli/src/commands/chat/list.ts
+++ b/apps/cli/src/commands/chat/list.ts
@@ -9,7 +9,7 @@ export function registerChatListCommand(chat: Command): void {
     .description("List chats this agent participates in")
     .option("-l, --limit <number>", "Maximum chats to return (1-100)", "20")
     .option("--cursor <cursor>", "Pagination cursor from previous response")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (options: { limit: string; cursor?: string; agent?: string }) => {
       try {
         const limit = parseLimit(options.limit, 100);

--- a/apps/cli/src/commands/chat/open.ts
+++ b/apps/cli/src/commands/chat/open.ts
@@ -9,7 +9,7 @@ export function registerChatOpenCommand(chat: Command): void {
   chat
     .command("open <agent-name>")
     .description("Open an interactive chat with an agent (as the current member's human agent)")
-    .option("--server <url>", "Hub server URL")
+    .option("--server <url>", "First Tree server URL")
     .action(async (agentName: string, options: { server?: string }) => {
       try {
         const serverUrl = resolveServerUrl(options.server);

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -19,7 +19,7 @@ export function registerChatSendCommand(chat: Command): void {
     )
     .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
     .option("-m, --metadata <json>", "JSON metadata to attach")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (agentName: string, message: string | undefined, options: SendOptions) => {
       try {
         const chatId = process.env.FIRST_TREE_CHAT_ID;
@@ -27,7 +27,7 @@ export function registerChatSendCommand(chat: Command): void {
           fail(
             "NO_CHAT_CONTEXT",
             "`chat send` must be run from within an agent session that exports FIRST_TREE_CHAT_ID. " +
-              "Hub keeps a single group-chat model — there is no implicit direct chat to fall back to. " +
+              "First Tree keeps a single group-chat model — there is no implicit direct chat to fall back to. " +
               "To send from a shell, open the chat in the web UI instead.",
             2,
           );

--- a/apps/cli/src/commands/chat/set-topic.ts
+++ b/apps/cli/src/commands/chat/set-topic.ts
@@ -59,7 +59,7 @@ export function registerChatSetTopicCommand(chat: Command): void {
     .description(describe())
     .option("--chat <chatId>", "Target chat id (default: FIRST_TREE_CHAT_ID)")
     .option("--clear", "Clear the topic (sets it to null, falls back to auto-derived title)")
-    .option("--agent <name>", "Agent name on the Hub (default: first configured on this client)")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (topicArg: string | undefined, options: Options) => {
       await run(topicArg, options);
     });

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -106,7 +106,7 @@ async function exchangeToken(url: string, token: string): Promise<{ accessToken:
 export function registerLoginCommand(program: Command): void {
   program
     .command("login <token>")
-    .description("Sign this computer into the Hub using a token from the web console")
+    .description("Sign this computer into First Tree using a token from the web console")
     .option("--no-start", "Skip background daemon install/start (writes credentials and exits)")
     .option("--override", "Transfer ownership of this client from a different account (replaces `client claim`)")
     .action(async (token: string, options: { start?: boolean; override?: boolean }) => {
@@ -139,7 +139,7 @@ export function registerLoginCommand(program: Command): void {
 
         const clientConfigPath = join(defaultConfigDir(), "client.yaml");
         setConfigValue(clientConfigPath, "server.url", url);
-        print.line(`\n  ✓ Hub: ${url}\n`);
+        print.line(`\n  ✓ Server: ${url}\n`);
 
         saveCredentials({ ...tokens, serverUrl: url });
         print.line("  ✓ Authenticated\n");

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -14,7 +14,7 @@ import { print } from "../core/output.js";
 export function registerLogoutCommand(program: Command): void {
   program
     .command("logout")
-    .description("Disconnect from the Hub — stop daemon and clear credentials (symmetric to `login`)")
+    .description("Disconnect from First Tree — stop daemon and clear credentials (symmetric to `login`)")
     .option("--purge", "Also remove client.yaml (server.url etc.); default keeps it")
     .action((options: { purge?: boolean }) => {
       // 1. Stop daemon (best-effort).

--- a/apps/cli/src/commands/org/index.ts
+++ b/apps/cli/src/commands/org/index.ts
@@ -5,7 +5,7 @@ import { registerOrgBindTreeCommand } from "./bind-tree.js";
  * `first-tree org` — organization-level operations.
  *
  * Today this only ships `bind-tree`, called by onboarding agents after they
- * create a fresh context-tree GitHub repo so the Hub records the binding in
+ * create a fresh context-tree GitHub repo so First Tree records the binding in
  * the org's `context_tree` settings namespace. The verb mirrors first-tree
  * CLI's own `tree bind` vocabulary so agents reading "bind-tree" know what
  * it means without translation. See first-tree-context:agent-hub/onboarding.md §7.4

--- a/apps/cli/src/core/bootstrap.ts
+++ b/apps/cli/src/core/bootstrap.ts
@@ -17,7 +17,7 @@ type StoredCredentials = {
 };
 
 /**
- * Resolve Hub server URL from flag, env, or config.
+ * Resolve First Tree server URL from flag, env, or config.
  *
  * Uses resolveConfigReadonly (not the singleton getClientConfig) so CLI entry
  * points don't have to remember to call initConfig() first.

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -141,7 +141,7 @@ export class ClientRuntime {
       print.blank();
       print.status("✗", "auth rejected — pausing agents until fresh credentials arrive.");
       print.status("", err.message);
-      print.status("", "Recovery: get a new connect token from your Hub's Web admin");
+      print.status("", "Recovery: get a new connect token from the First Tree web console");
       print.status("", "          (Computers → + New Connection), then re-run `first-tree login <token>`.");
       print.status("", `Paused reason: ${reason}. Process is staying alive — no restart needed after login.`);
       this.ensureCredentialsWatcher();

--- a/apps/cli/src/core/migrate-agent-dirs.ts
+++ b/apps/cli/src/core/migrate-agent-dirs.ts
@@ -7,7 +7,7 @@ import { print } from "./output.js";
 /**
  * Phase 3 of the agent-naming refactor (first-tree-context:agent-hub/agent-naming.md §3.4 + §4):
  * reconcile every local agent directory name with the server-authoritative
- * `agent.name` slug. The free-form local alias concept is gone — the Hub is
+ * `agent.name` slug. The free-form local alias concept is gone — the server is
  * the only namespace authority — so on every client startup we walk the
  * local configs, ask the server what each agentId's canonical name is, and
  * rename the config/workspace/sessions state when they drift.

--- a/apps/cli/src/core/onboard.ts
+++ b/apps/cli/src/core/onboard.ts
@@ -209,7 +209,7 @@ export async function onboardCreate(args: OnboardArgs): Promise<void> {
   // `args.id`. The two usually agree, but the server may normalise or
   // reject on collision and a subsequent rename would be needed on first
   // start. Using `primary.name` here keeps the log message, local dir key,
-  // and the Hub's view aligned from the outset. The `?? args.id` fallback
+  // and the server's view aligned from the outset. The `?? args.id` fallback
   // covers servers that (for some reason) return a null name — the
   // idempotent migration on next start will reconcile.
   const primaryLocalName = primary.name ?? args.id;

--- a/apps/cli/src/core/prompt.ts
+++ b/apps/cli/src/core/prompt.ts
@@ -74,12 +74,12 @@ export async function promptMissingFields(options: {
  * alias — the local config dir is keyed by the server-authoritative
  * `agent.name` slug. This helper only asks the user for the agent UUID
  * (or takes it via `opts.agentId`), then fetches the canonical name
- * from the Hub. A `name` comes back null only if the agent was
+ * from the server. A `name` comes back null only if the agent was
  * tombstoned server-side, in which case the caller must refuse the
  * add (there's nothing sensible to key the local dir on).
  */
 export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{ name: string; agentId: string }> {
-  // Phase 3 needs a live Hub to resolve the canonical agent name, which
+  // Phase 3 needs a live server to resolve the canonical agent name, which
   // means the caller must have run `connect <token>` first. Detect the
   // two common "not connected yet" states up front with a clear error
   // instead of letting `ensureFreshAccessToken` or `resolveServerUrl`
@@ -98,7 +98,7 @@ export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{
   const agentId =
     opts.agentId ??
     (await input({
-      message: "Agent UUID on the Hub:",
+      message: "Agent UUID on the First Tree server:",
       validate: (v) => (v.length > 0 ? true : "Agent UUID is required"),
     }));
 
@@ -113,7 +113,7 @@ export async function promptAddAgent(opts: { agentId?: string } = {}): Promise<{
   const body = (await res.json()) as { name: string | null };
   if (!body.name) {
     throw new Error(
-      `Agent ${agentId} has no hub name (tombstoned or never named). Cannot add a local config without a name.`,
+      `Agent ${agentId} has no server-side name (tombstoned or never named). Cannot add a local config without a name.`,
     );
   }
   return { name: body.name, agentId };

--- a/apps/cli/src/core/update-state.ts
+++ b/apps/cli/src/core/update-state.ts
@@ -40,7 +40,7 @@ export type UpdateState = {
 /**
  * Override-able location of the state file. Production code uses the
  * default; tests pass a temp path so they don't stomp on the real
- * `~/.first-tree/hub/state/update-state.json`.
+ * `<FIRST_TREE_HOME>/state/update-state.json`.
  */
 export function defaultUpdateStatePath(): string {
   return join(defaultHome(), "state", "update-state.json");

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -45,10 +45,10 @@ because an agent is permanently bound to exactly one client machine.
 
 ## What `first-tree login` writes
 
-- `~/.first-tree/hub/config/credentials.json` (mode `0600`) —
+- `~/.first-tree/config/credentials.json` (mode `0600`) —
   `accessToken`, `refreshToken`, and the server URL derived from the
   token's `iss` claim.
-- `~/.first-tree/hub/config/client.yaml` — `client.id` (auto-generated
+- `~/.first-tree/config/client.yaml` — `client.id` (auto-generated
   on first login) and `server.url`.
 - On macOS / Linux, the background daemon is installed as a user-level
   service so the machine stays online across reboots. Pass `--no-start`
@@ -61,7 +61,7 @@ there are no per-agent bearer tokens.
 
 When an admin creates an agent with `--client-id <thisClientId>` (or
 binds an existing one via PATCH), the server pushes an `agent:pinned`
-frame and the running daemon writes `~/.first-tree/hub/config/agents/<name>/agent.yaml`
+frame and the running daemon writes `~/.first-tree/config/agents/<name>/agent.yaml`
 automatically. On reconnect, the server backfills any pins that landed
 while the client was offline.
 
@@ -108,15 +108,15 @@ retained as a read-only debug endpoint.
 
 | Variable | Purpose |
 |---|---|
-| `FIRST_TREE_HOME` | Override config/data home directory (default: `~/.first-tree/hub`) |
+| `FIRST_TREE_HOME` | Override config/data home directory (default: `~/.first-tree`) |
 | `FIRST_TREE_SERVER_URL` | Server URL (alternative to the token's `iss` claim) |
 
 ## Using the SDK
 
 ```ts
-import { FirstTreeHubSDK } from "first-tree";
+import { FirstTreeHubSDK as FirstTreeSDK } from "first-tree";
 
-const sdk = new FirstTreeHubSDK({
+const sdk = new FirstTreeSDK({
   serverUrl: process.env.FIRST_TREE_SERVER_URL ?? "http://localhost:8000",
   getAccessToken: async () => process.env.FIRST_TREE_ACCESS_TOKEN ?? "",
 });

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "type": "module",
-  "description": "First Tree SDK — programmatic client for the First Tree cloud (Hub) server",
+  "description": "First Tree SDK — programmatic client for First Tree Cloud",
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -208,7 +208,7 @@ describe("bootstrapWorkspace", () => {
     expect(existsSync(toolsPath)).toBe(true);
 
     const content = readFileSync(toolsPath, "utf-8");
-    expect(content).toContain("Agent Hub");
+    expect(content).toContain("First Tree Agent Runtime");
     expect(content).toContain("[From: <agent-name>]");
     expect(content).toContain("first-tree chat send");
     // L4 silent-turn protocol: the prompt directive that pairs with the
@@ -334,7 +334,7 @@ describe("bootstrapWorkspace", () => {
     });
 
     const content = readFileSync(join(workspace, ".agent", "tools.md"), "utf-8");
-    expect(content).toContain("`AskUserQuestion` is NOT available in this Hub");
+    expect(content).toContain("`AskUserQuestion` is NOT available in First Tree");
     expect(content).toContain("denied on call");
     // Conversion target is the request-type NHA, channel-resolved.
     expect(content).toContain("first-tree attention raise --requires-response");

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -969,9 +969,9 @@ function generateToolsDoc(): string {
   // hardcoding "first-tree" used to leave staging/dev agents calling a
   // binary that wasn't installed on the host.
   const bin = getCliBinding().binName;
-  return `# Agent Hub SDK
+  return `# First Tree Agent Runtime
 
-You are running inside **Agent Hub**, a messaging platform for agent teams.
+You are running inside **First Tree**, a messaging platform for agent teams.
 
 - Messages from other team members arrive as your prompt input. Each message has a
   \`[From: <agent-name>]\` header — that name is what you pass back to \`chat send\`.
@@ -1034,7 +1034,7 @@ echo "long body" | ${bin} chat send <agentName>
   message lands in the current chat and the recipient is woken if they were
   @mentioned (or — for two-speaker chats — implicitly).
 - **Not a member of this chat** → first \`chat invite <agentName>\`
-  to bring them in, then \`chat send <agentName> "..."\` like normal. Hub
+  to bring them in, then \`chat send <agentName> "..."\` like normal. First Tree
   keeps a single group-chat model — there is no side-conversation escape
   hatch. \`@<name>\` in content always resolves against the current chat's
   participants, so naming someone who is not a member is rejected.
@@ -1054,7 +1054,7 @@ this command.
 
 Use \`${bin} attention raise --requires-response\` before any irreversible or externally-visible action that needs the human's go-ahead (ask), use \`${bin} attention raise\` without the flag right after such an action completes while the human is not watching (notify), and use plain \`chat send\` for everything else — full trigger lists, body templates, and waiting behaviour live in the attention skill (\`.claude/skills/attention/SKILL.md\` or \`.agents/skills/attention/SKILL.md\`).
 
-**\`AskUserQuestion\` is NOT available in this Hub — it is denied on call.** If you ever invoke \`AskUserQuestion\` (or any built-in "ask the user" tool) and it is denied, you MUST re-issue the request as a request-type NHA via \`${bin} attention raise --requires-response\`. Do NOT fall back to asking the question as plain final-text or a \`chat send\`: a request-NHA is the only mechanism that targets a specific human, carries a response expectation, and resumes your turn when they reply. Convert each choice you would have offered into the NHA body (and \`metadata.options\` / \`metadata.questions\` when the human should click rather than type).
+**\`AskUserQuestion\` is NOT available in First Tree — it is denied on call.** If you ever invoke \`AskUserQuestion\` (or any built-in "ask the user" tool) and it is denied, you MUST re-issue the request as a request-type NHA via \`${bin} attention raise --requires-response\`. Do NOT fall back to asking the question as plain final-text or a \`chat send\`: a request-NHA is the only mechanism that targets a specific human, carries a response expectation, and resumes your turn when they reply. Convert each choice you would have offered into the NHA body (and \`metadata.options\` / \`metadata.questions\` when the human should click rather than type).
 
 ## Naming this Chat (Topic)
 
@@ -1085,7 +1085,7 @@ either an explicit \`Topic: <value>\` or the sentinel \`Topic: (unset ...)\`.
 
 Topics that look like \`PR repo#307: title\`, \`Issue repo#42\`, \`PR Review
 repo#X: ...\`, \`Discussion repo#X\`, or \`Commit repo@sha\` were auto-set
-by Hub when the chat was minted from a GitHub event, and Hub keeps them in
+by First Tree when the chat was minted from a GitHub event, and First Tree keeps them in
 sync with the upstream PR/issue title. Overriding them with your own label
 loses the repo / entity-id anchor that makes the chat list useful. **Do
 not run \`set-topic\` on a chat whose topic already has that shape.**

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="First Tree Hub — infrastructure for agent teams: registration, authentication, messaging, and admin dashboard." />
+    <meta name="description" content="First Tree — infrastructure for agent teams: registration, authentication, messaging, and admin dashboard." />
     <meta name="theme-color" content="#040404" />
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -899,7 +899,7 @@ function ComputerCardSkeleton({ label }: { label: string }) {
       <div className="text-body font-medium" style={{ color: "var(--fg-3)" }}>
         {label}
       </div>
-      <div className="text-caption text-muted-foreground">Looking for a machine running the Hub client…</div>
+      <div className="text-caption text-muted-foreground">Looking for a machine running the First Tree daemon…</div>
     </div>
   );
 }

--- a/packages/web/src/components/team-setup-modal.tsx
+++ b/packages/web/src/components/team-setup-modal.tsx
@@ -127,7 +127,7 @@ function JoinForm({ onDone }: { onDone: () => void }) {
     setBusy(true);
     setError(null);
     try {
-      // Strip whole invite URLs (e.g. https://hub/invite/abc) → just the token.
+      // Strip whole invite URLs (e.g. https://first-tree.example/invite/abc) → just the token.
       const raw = token.trim();
       const match = /\/invite\/([^/?#]+)/.exec(raw);
       const justToken = match?.[1] ?? raw;
@@ -154,7 +154,7 @@ function JoinForm({ onDone }: { onDone: () => void }) {
         aria-label="Invite token or full URL"
         value={token}
         onChange={(e) => setToken(e.target.value)}
-        placeholder="abc123… or https://hub/invite/abc123"
+        placeholder="abc123… or https://first-tree.example/invite/abc123"
         autoFocus
       />
       <Button type="submit" className="w-full" disabled={busy || !token.trim()}>

--- a/packages/web/src/pages/clients/new-connection-dialog.tsx
+++ b/packages/web/src/pages/clients/new-connection-dialog.tsx
@@ -83,7 +83,7 @@ const TOKEN_EXPIRY_BUFFER_MS = 2_000;
 /**
  * `NewConnectionDialog` props.
  *
- * Default UX is "pair a brand-new computer with this Hub". The optional
+ * Default UX is "pair a brand-new computer with First Tree". The optional
  * overrides re-purpose the dialog for the re-auth flow triggered from an
  * AuthExpired computer card — same mint + polling machinery, different
  * wording + a `targetClientId` constraint on the success-arrival detector
@@ -258,7 +258,7 @@ export function NewConnectionDialog({
           <DialogTitle>{titleOverride ?? "Connect computer"}</DialogTitle>
           <DialogDescription>
             {descriptionOverride ??
-              "Run this command on the machine you want to pair with this Hub. If first-tree isn't installed yet, the command includes the install step."}
+              "Run this command on the machine you want to pair with First Tree. If first-tree isn't installed yet, the command includes the install step."}
           </DialogDescription>
         </DialogHeader>
 

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -433,7 +433,7 @@ function ErrorState({ message }: { message: string }) {
 function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
   const title = snapshot.repo ? "Context Tree sync unavailable" : "Connect Context Tree";
   const detail = snapshot.repo
-    ? "Hub cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
+    ? "First Tree cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
     : "Connect a Context Tree repo to show the team knowledge agents can use.";
   const syncDetail = snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -242,8 +242,8 @@ function SuspendedBanner() {
     >
       <PauseCircle className="h-4 w-4 shrink-0" style={{ marginTop: "var(--sp-0_5)" }} />
       <span>
-        This installation is suspended upstream. GitHub is not delivering webhooks and Hub can't act as the App on this
-        account. Unsuspend it from the GitHub side to restore service.
+        This installation is suspended upstream. GitHub is not delivering webhooks and First Tree can't act as the App
+        on this account. Unsuspend it from the GitHub side to restore service.
       </span>
     </div>
   );

--- a/packages/web/src/pages/landing/features.tsx
+++ b/packages/web/src/pages/landing/features.tsx
@@ -11,13 +11,13 @@ type Feature = {
  * Three user-value statements, written from the operator's POV.
  *
  * Each headline names a problem the user is feeling today; each body
- * describes the relief Hub delivers, in plain language. Implementation
+ * describes the relief First Tree Cloud delivers, in plain language. Implementation
  * details (UUID v7, fan-out on write, Bearer tokens) belong in the docs,
  * not on the landing page — this section answers "why should I care", not
  * "how does it work".
  *
  * Keep value claims accurate against README capabilities; if a claim drifts
- * past what Hub actually delivers, soften it before shipping.
+ * past what First Tree Cloud actually delivers, soften it before shipping.
  */
 const FEATURES: ReadonlyArray<Feature> = [
   {
@@ -33,7 +33,7 @@ const FEATURES: ReadonlyArray<Feature> = [
   {
     icon: Plug,
     title: "Keep the agents you've built",
-    body: "Hub doesn't tell you how to build agents — it just gives the ones you already have somewhere to talk. No rewrites, no framework lock-in, no migrating off the runtime your team already trusts.",
+    body: "First Tree Cloud doesn't tell you how to build agents — it just gives the ones you already have somewhere to talk. No rewrites, no framework lock-in, no migrating off the runtime your team already trusts.",
   },
 ];
 

--- a/packages/web/src/pages/landing/nav.tsx
+++ b/packages/web/src/pages/landing/nav.tsx
@@ -29,7 +29,7 @@ export function LandingNav() {
         >
           <FirstTreeLogo width={18} height={20} />
           <span className="text-title">
-            First Tree <span className="font-normal text-fg-3">Hub</span>
+            First Tree <span className="font-normal text-fg-3">Cloud</span>
           </span>
         </Link>
         <nav aria-label="Primary" className="flex items-center gap-2">

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -64,9 +64,7 @@ export function LoginPage() {
             <div className="mb-2 flex justify-center text-foreground">
               <FirstTreeLogo width={28} height={32} />
             </div>
-            <CardTitle className="text-title">
-              First Tree <span className="font-normal text-muted-foreground">Hub</span>
-            </CardTitle>
+            <CardTitle className="text-title">First Tree</CardTitle>
             <p className="text-label text-muted-foreground" style={{ marginTop: "var(--sp-1)" }}>
               Sign in to set up your team and your first AI agent.
             </p>

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -10,9 +10,9 @@
  * Two paths:
  *   - existing tree (buildBindBootstrap): the frontend has already best-effort
  *     PUT the URL into the org's `context_tree` settings before sending, so the
- *     message doesn't ask the agent to record it on the Hub again.
+ *     message doesn't ask the agent to record it in First Tree again.
  *   - new tree (buildCreateBootstrap): the URL doesn't exist yet, so the message
- *     asks the agent to record the freshly-created tree URL on the Hub — the one
+ *     asks the agent to record the freshly-created tree URL in First Tree — the one
  *     bit the local skill doesn't own — so future teammates' agents can find it.
  *
  * Single source of truth: only the kickoff step sends these. If a future surface
@@ -68,7 +68,7 @@ export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
     "",
     skillLine,
     "",
-    "Once the tree repo is up on GitHub, record its URL on the Hub with the first-tree CLI so future teammates' agents can find it.",
+    "Once the tree repo is up on GitHub, record its URL in First Tree with the first-tree CLI so future teammates' agents can find it.",
     "",
     walkthrough,
     "",

--- a/skills/attention/SKILL.md
+++ b/skills/attention/SKILL.md
@@ -34,7 +34,7 @@ The system layer is intentionally thin. It stores, routes, and delivers; it does
 
 ## `AskUserQuestion` is not available — a denial means raise an NHA
 
-This Hub does **not** bridge the runtime's built-in `AskUserQuestion` (or any equivalent "ask the user" tool). Calling it is **denied** with a message redirecting you here. When that happens you MUST re-issue the request as a request-type NHA (`first-tree attention raise --requires-response`) — that is a hard rule, not a suggestion.
+First Tree does **not** bridge the runtime's built-in `AskUserQuestion` (or any equivalent "ask the user" tool). Calling it is **denied** with a message redirecting you here. When that happens you MUST re-issue the request as a request-type NHA (`first-tree attention raise --requires-response`) — that is a hard rule, not a suggestion.
 
 Do **not** fall back to asking the question as plain final-text or a `chat send`. Final text does not target a named human, carries no response expectation, and does not resume your turn on reply; a request-NHA does all three. Convert each option you would have offered into the NHA body, and use `metadata.options` / `metadata.questions` (see `references/metadata-shape.md`) when the human should click rather than type.
 

--- a/skills/first-tree-cloud/SKILL.md
+++ b/skills/first-tree-cloud/SKILL.md
@@ -3,17 +3,17 @@ name: first-tree-cloud
 description: Install, operate, and modify First Tree's cloud / collaboration layer with emphasis on the unified `first-tree` CLI, its `login`/`daemon`/`agent`/`chat`/`config` workflows, the JWT credential model, and the repo's collaboration surface for agent identity, inbox delivery, workspace bootstrap, and background-service operation. Use whenever the user mentions connecting a machine to the First Tree SaaS, installing or running the daemon as a background service (launchd/systemd), managing agent runtime configuration (model, prompt, MCP, env, git repos), onboarding a member, or changing code in `apps/cli`, `packages/client`, `packages/server`, or `packages/shared` — even if they don't say "CLI".
 ---
 
-# First Tree CLI — Cloud (Hub) Layer
+# First Tree CLI — Cloud Layer
 
 ## Overview
 
-Use this skill to map a user's hub / collaboration intent onto the right `first-tree` command or code path without re-discovering the repo each time. (For Context Tree onboarding and validation, the right skill is `first-tree`; for the GitHub notification daemon, it's `first-tree-github-scan`.)
+Use this skill to map a user's First Tree Cloud / collaboration intent onto the right `first-tree` command or code path without re-discovering the repo each time. (For Context Tree onboarding and validation, the right skill is `first-tree`; for the GitHub notification daemon, it's `first-tree-github-scan`.)
 
-Keep the mental model straight: First Tree's cloud (Hub) layer is the communication and identity backbone for agent teams. It is **not** the agent framework, not the orchestration engine, and not the Context Tree. The Hub has three principals:
+Keep the mental model straight: First Tree Cloud is the communication and identity backbone for agent teams. It is **not** the agent framework, not the orchestration engine, and not the Context Tree. First Tree Cloud has three principals:
 
 - **Server** — operated centrally as a SaaS by the First Tree team. Owns identity, persistence, admin surface, and the inbox. End users do not run their own server; the CLI has no `server` command group.
-- **Client** — one per computer. A machine signs in with a Hub member's credentials once, then runs every agent pinned to it.
-- **Agent** — many per Hub. Lives in the server's database; is bound to exactly one client machine.
+- **Client** — one per computer. A machine signs in with a First Tree member's credentials once, then runs every agent pinned to it.
+- **Agent** — many per First Tree organization. Lives in the server's database; is bound to exactly one client machine.
 
 This shape drives almost every command: `daemon` and `config` target this machine, `agent` targets a row in the server's database (usually acting as the member via their own JWT).
 
@@ -21,7 +21,7 @@ This shape drives almost every command: `daemon` and `config` target this machin
 
 1. **Classify the task before acting.** Most requests fall into one of these buckets. Pick the bucket, then go to the reference it names.
    - Install or sanity-check the CLI on a fresh machine → `references/command-surface.md`
-   - Connect a computer to the SaaS Hub (first time) → the **`login <token>`** section below, then `references/scenario-playbooks.md`
+   - Connect a computer to First Tree SaaS (first time) → the **`login <token>`** section below, then `references/scenario-playbooks.md`
    - Make a computer stay online permanently → the **Background daemon** section below
    - Map a natural-language request to an end-to-end CLI flow → `references/scenario-playbooks.md`
    - Walk an external agent prompt through onboarding → `references/onboarding-operator.md`
@@ -44,16 +44,16 @@ This shape drives almost every command: `daemon` and `config` target this machin
 
 ## The Credential Model (read this once)
 
-The CLI stores a single **member access JWT + refresh token** at `~/.first-tree/hub/credentials.json` (mode `0600`). Every command that talks to the Hub runs through `ensureFreshAccessToken()`, which refreshes 30s before expiry via `/api/v1/auth/refresh` and re-persists the token silently.
+The CLI stores a single **member access JWT + refresh token** at `~/.first-tree/config/credentials.json` (mode `0600`). Every command that talks to the First Tree server runs through `ensureFreshAccessToken()`, which refreshes 30s before expiry via `/api/v1/auth/refresh` and re-persists the token silently.
 
 Implications:
 
-- There is **one** way to sign in: `first-tree login <token>`. Paste the connect token from the Hub web console's "Connect a machine" dialog; the CLI decodes the token's `iss` claim to derive the hub URL, so the operator never supplies a URL separately. Username/password login has been removed.
+- There is **one** way to sign in: `first-tree login <token>`. Paste the connect token from the First Tree web console's "Connect a machine" dialog; the CLI decodes the token's `iss` claim to derive the server URL, so the operator never supplies a URL separately. Username/password login has been removed.
 - There is **no** standalone admin login, service-user token, or per-agent bearer token in the current CLI. Admin actions, agent-owner actions, and low-level SDK calls all use the signed-in member's JWT. The legacy `FIRST_TREE_AGENT_TOKEN` / `FIRST_TREE_AGENT` env vars and the old `agent token bootstrap` command have been removed.
 - `FIRST_TREE_SERVER_URL` still works for overriding the server URL per command, but auth itself is file-based.
 - Agents are database rows, owned by members. They do not hold their own tokens anymore — the client that runs them authenticates as the owning member.
 
-If a flow looks like "get an agent token, set an env var, then run the agent" — that flow is outdated. Point the user at `connect <token>` instead.
+If a flow looks like "get an agent token, set an env var, then run the agent" — that flow is outdated. Point the user at `login <token>` instead.
 
 ## First-Time Setup on a New Machine
 
@@ -69,10 +69,10 @@ Pass `--no-start` when the user wants to run inline (useful in containers or for
 
 After `login <token>` succeeds:
 
-- `~/.first-tree/hub/credentials.json` exists
-- `~/.first-tree/hub/config/client.yaml` has `server.url` and a generated `client.id`
+- `~/.first-tree/config/credentials.json` exists
+- `~/.first-tree/config/client.yaml` has `server.url` and a generated `client.id`
 - On macOS/Linux, the background daemon is installed and already running
-- Any agent pinned to this client (via the Hub UI or `agent create --client-id ...`) is automatically picked up by the running daemon
+- Any agent pinned to this client (via the First Tree web console or `agent create --client-id ...`) is automatically picked up by the running daemon
 
 ## Background Daemon (keep the machine online)
 
@@ -81,29 +81,29 @@ After `login <token>` succeeds:
 The `daemon` namespace owns the daemon lifecycle (`start` / `stop` / `restart` / `status` / `doctor`); install/repair is folded into `login <token>`. Tail logs directly:
 
 ```bash
-tail -f ~/.first-tree/hub/logs/client.log
+tail -f ~/.first-tree/logs/client.log
 ```
 
-To decommission a machine: stop and remove the unit at the OS level (`launchctl bootout` + `rm` of the plist on macOS; `systemctl --user disable --now` + `rm` of the unit file on Linux), then `rm -rf ~/.first-tree/hub`. See `docs/cli-reference.md` for the exact commands. To force-drop a client from the server side, use the Hub web admin (Computers → Disconnect) — the legacy `client disconnect` CLI verb was retired in Phase 1A.
+To decommission a machine: stop and remove the unit at the OS level (`launchctl bootout` + `rm` of the plist on macOS; `systemctl --user disable --now` + `rm` of the unit file on Linux), then `rm -rf ~/.first-tree`. See `docs/cli-reference.md` for the exact commands. To force-drop a client from the server side, use the First Tree web console (Computers → Disconnect) — the legacy `client disconnect` CLI verb was retired in Phase 1A.
 
 ## Operating Rules
 
 - **Keep subsystem boundaries clear.**
   - `login <token>` — first-time setup for this computer; folds in auth, `client.yaml` write, and background-daemon install.
-  - `daemon ...` — daemon lifecycle on a specific computer once it is connected (`start` / `stop` / `restart` / `status` / `doctor`). Hub-side client inventory moved to the web admin (Computers tab); local YAML editing moved to top-level `config`.
+  - `daemon ...` — daemon lifecycle on a specific computer once it is connected (`start` / `stop` / `restart` / `status` / `doctor`). Server-side client inventory moved to the web console (Computers tab); local YAML editing moved to top-level `config`.
   - `agent ...` — everything that is "about an agent record": local alias config (`add`/`remove`/`list`), creation and claiming, workspace cleanup, bindings, **runtime configuration via `agent config`**, status / reset / sessions.
   - `chat ...` — day-to-day messaging: `send`, `list`, `history`, and the interactive `open` REPL.
   - `onboard` — the guided "add a new member" flow; composes multiple low-level operations behind one command.
-- **Distinguish `agent config` (server-side runtime) from top-level `config` (local YAML).** `agent config set-model` or `append-prompt` mutates the Hub database via the admin API and affects the running agent everywhere. `config set` edits the local `client.yaml`, which controls the computer's own runtime behavior.
+- **Distinguish `agent config` (server-side runtime) from top-level `config` (local YAML).** `agent config set-model` or `append-prompt` mutates the First Tree database via the admin API and affects the running agent everywhere. `config set` edits the local `client.yaml`, which controls the computer's own runtime behavior.
 - **Respect config layering.** CLI args override env vars → env vars override YAML → YAML overrides auto-generated → auto-generated overrides defaults.
 - **Distinguish config scopes and paths.**
-  - Home defaults to `~/.first-tree/hub`; `FIRST_TREE_HOME` relocates it.
+  - Home defaults to `~/.first-tree`; `FIRST_TREE_HOME` relocates it.
   - Client config: `$FIRST_TREE_HOME/config/client.yaml`
   - Per-agent local alias: `$FIRST_TREE_HOME/config/agents/<name>/agent.yaml`
-  - Credentials: `$FIRST_TREE_HOME/credentials.json`
+  - Credentials: `$FIRST_TREE_HOME/config/credentials.json`
   - Onboard resume state: `$FIRST_TREE_HOME/.onboard-state.json`
   - Service logs: `$FIRST_TREE_HOME/logs/`
-- **Do not describe Hub as "the agents" or "the Context Tree".** It sits between them.
+- **Do not describe First Tree Cloud as "the agents" or "the Context Tree".** It sits between them.
 
 ## Common Workflows
 
@@ -111,10 +111,10 @@ To decommission a machine: stop and remove the unit at the OS level (`launchctl 
 
 - Install + verify: `npm install -g first-tree`, then `first-tree --version`.
 - Environment readiness: `first-tree daemon doctor` for a compact summary.
-- Connect a computer to the SaaS Hub: `first-tree login <token>` — paste the token from the Hub web console's *Connect a machine* dialog.
+- Connect a computer to First Tree SaaS: `first-tree login <token>` — paste the token from the First Tree web console's *Connect a machine* dialog.
 - Keep the computer online across reboots: handled automatically by `first-tree login <token>` (omit `--no-start`).
 - Run the runtime inline (no service): `first-tree daemon start`.
-- See which machines the Hub currently sees: open the Hub web admin's *Computers* tab. The legacy `client list` / `client disconnect` CLI verbs were retired in Phase 1A.
+- See which machines are connected: open the First Tree web console's *Computers* tab. The legacy `client list` / `client disconnect` CLI verbs were retired in Phase 1A.
 - Create an agent from the CLI: `first-tree agent create <name> --type <t> --client-id <id>`.
 - Change a running agent's configuration (model, prompt, MCP, env, repos): `first-tree agent config ...`.
 - Onboard a new human or autonomous agent end-to-end: `first-tree login <token>` + `agent create <name> --type ... --client-id ...` + `daemon start`. The single-shot `onboard` command was retired in Phase 1A.
@@ -140,7 +140,7 @@ To decommission a machine: stop and remove the unit at the OS level (`launchctl 
 
   ```bash
   first-tree login <token>                                   # one-time, if not done already
-  first-tree agent create <name> --type <t> --client-id <id> # creates the agent on the Hub + binds it
+  first-tree agent create <name> --type <t> --client-id <id> # creates the agent in First Tree + binds it
   first-tree daemon start                                    # only if no service is running
   ```
 

--- a/skills/first-tree-cloud/evals/evals.json
+++ b/skills/first-tree-cloud/evals/evals.json
@@ -4,15 +4,15 @@
     {
       "id": 0,
       "name": "new-machine",
-      "prompt": "I just bought a new Mac and want it to run as a Hub client, permanently connected to our team's Hub at https://hub.example.com/. Walk me through it from zero. One more thing — previously I always set FIRST_TREE_AGENT_TOKEN and ran `first-tree agent token bootstrap` to get my agent running. Do I still do that on the new machine?",
-      "expected_output": "Should recommend npm install → first-tree login <token> (paste the connect token from the Hub web console; the hub URL is derived from the token's iss claim), explain that the background service is installed automatically on macOS (launchd), and explicitly correct the user's outdated assumption: FIRST_TREE_AGENT_TOKEN and `agent token bootstrap` are gone; auth is now a single member JWT stored in credentials.json written by `connect <token>`.",
+      "prompt": "I just bought a new Mac and want it to run as a First Tree client, permanently connected to our team's First Tree server at https://first-tree.example.com/. Walk me through it from zero. One more thing — previously I always set FIRST_TREE_AGENT_TOKEN and ran `first-tree agent token bootstrap` to get my agent running. Do I still do that on the new machine?",
+      "expected_output": "Should recommend npm install → first-tree login <token> (paste the connect token from the First Tree web console; the server URL is derived from the token's iss claim), explain that the background service is installed automatically on macOS (launchd), and explicitly correct the user's outdated assumption: FIRST_TREE_AGENT_TOKEN and `agent token bootstrap` are gone; auth is now a single member JWT stored in credentials.json written by `login <token>`.",
       "files": []
     },
     {
       "id": 1,
       "name": "agent-config",
       "prompt": "I want to switch my 'alice' agent to use claude-opus-4-7 and also add a GitHub MCP server to it. Walk me through it via the first-tree CLI.",
-      "expected_output": "Should use `first-tree agent config set-model alice claude-opus-4-7` and `first-tree agent config add-mcp alice --name <n> --transport stdio --command gh --args mcp`. Must NOT suggest hand-editing ~/.first-tree/hub/config/agents/alice/agent.yaml (that's the local alias, not the runtime config). Bonus: mentions `agent config show alice` to verify, or `agent config dry-run` for preview.",
+      "expected_output": "Should use `first-tree agent config set-model alice claude-opus-4-7` and `first-tree agent config add-mcp alice --name <n> --transport stdio --command gh --args mcp`. Must NOT suggest hand-editing ~/.first-tree/config/agents/alice/agent.yaml (that's the local alias, not the runtime config). Bonus: mentions `agent config show alice` to verify, or `agent config dry-run` for preview.",
       "files": []
     },
     {

--- a/skills/first-tree-cloud/references/command-surface.md
+++ b/skills/first-tree-cloud/references/command-surface.md
@@ -5,30 +5,30 @@
 | User intent | Preferred entry point | Non-obvious note |
 | --- | --- | --- |
 | Install or verify the CLI on a fresh machine | `npm install -g first-tree` then `first-tree --version` | Requires Node.js `>= 22.16` |
-| Check whether a machine is ready for Hub | `first-tree daemon doctor` | `doctor` = readiness; top-level `status` = current state summary |
-| Sign this computer into a Hub server | `first-tree login <token> [--no-start]` | Paste a connect token from the Hub web console; hub URL is derived from the token's `iss` claim. Stores a member JWT at `~/.first-tree/hub/credentials.json`, writes `client.yaml`, and (by default) installs the background service |
+| Check whether a machine is ready for First Tree | `first-tree daemon doctor` | `doctor` = readiness; top-level `status` = current state summary |
+| Sign this computer into a First Tree server | `first-tree login <token> [--no-start]` | Paste a connect token from the First Tree web console; server URL is derived from the token's `iss` claim. Stores a member JWT at `~/.first-tree/config/credentials.json`, writes `client.yaml`, and (by default) installs the background service |
 | Run the client inline instead of via service | `first-tree daemon start` | Loads credentials written by `connect`; fails if there are none or if no agents are pinned to this client |
 | Keep the computer online across reboots | `first-tree login <token>` (omit `--no-start`) | Auto-installs launchd on macOS or `systemd --user` on Linux; Windows unsupported (falls back to inline) |
-| List machines the Hub currently sees | Hub web admin → Computers tab | The legacy `client list` / `client disconnect` CLI verbs were retired in Phase 1A — admin actions now live in the web admin |
-| Forcibly drop a machine from the Hub | Hub web admin → Computers → Disconnect | Same as above |
+| List machines First Tree currently sees | First Tree web console → Computers tab | The legacy `client list` / `client disconnect` CLI verbs were retired in Phase 1A — admin actions now live in the web admin |
+| Forcibly drop a machine from the First Tree server | First Tree web console → Computers → Disconnect | Same as above |
 | View / edit this machine's client.yaml | `first-tree config show/set/get` | Local YAML editing; scope is implicit |
-| Register a local alias for a Hub agent on this machine | `first-tree agent add [--agent-id <uuid>]` | Local-only; a running client auto-registers any agent an admin pins to this `clientId`, so `agent add` is mostly for scripted or unattended setups |
-| Create a fresh agent from the CLI | `first-tree agent create <name> --type <t> --client-id <id>` | Writes to the Hub via Admin API and saves the local alias in one step |
+| Register a local alias for a First Tree agent on this machine | `first-tree agent add [--agent-id <uuid>]` | Local-only; a running client auto-registers any agent an admin pins to this `clientId`, so `agent add` is mostly for scripted or unattended setups |
+| Create a fresh agent from the CLI | `first-tree agent create <name> --type <t> --client-id <id>` | Writes to First Tree via Admin API and saves the local alias in one step |
 | Take ownership of an existing agent | `first-tree agent claim <agentName>` | Sets `managerId` to the signed-in member |
 | Change an agent's runtime config (model, prompt, MCP, env, repos) | `first-tree agent config <sub>` | Server-side edit via `/api/v1/admin/agents/:id/config` — affects the running agent everywhere |
 | Day-to-day messaging | `first-tree chat send/list/history/open` | Authenticates as the signed-in member (no agent-specific token) |
 | Inspect session runtime state | `first-tree agent status [name]`, `agent session list <name>`, `agent session <suspend\|terminate>` | Reads `/api/v1/admin/agents/activity`, `/admin/sessions/agents/...` |
 | Reset an agent stuck in `error` state | `first-tree agent reset <name>` | POSTs `reset-activity` |
 | Clean old isolated chat workspaces | `first-tree agent workspace clean` | Respects the session registry — only removes evicted or untracked chats |
-| Onboard a new human or autonomous agent | `first-tree agent create` | Guided flow; requires prior `connect <token>` for credentials |
+| Onboard a new human or autonomous agent | `first-tree agent create` | Guided flow; requires prior `login <token>` for credentials |
 
 ## The Credential Model
 
-Every CLI command that talks to the Hub reaches for `~/.first-tree/hub/credentials.json`. The file is written by `connect <token>` and contains `{ accessToken, refreshToken, serverUrl }` (mode `0600`). `ensureFreshAccessToken()` auto-refreshes against `/api/v1/auth/refresh` when the token is within 30 seconds of expiry, silently re-persists the result, and then returns the fresh access token.
+Every CLI command that talks to First Tree reaches for `~/.first-tree/config/credentials.json`. The file is written by `login <token>` and contains `{ accessToken, refreshToken, serverUrl }` (mode `0600`). `ensureFreshAccessToken()` auto-refreshes against `/api/v1/auth/refresh` when the token is within 30 seconds of expiry, silently re-persists the result, and then returns the fresh access token.
 
 There are no separate admin or agent tokens. The member's JWT is used for every authenticated call — admin endpoints, agent creation, agent config, messaging, SDK debugging, everything. The old `FIRST_TREE_AGENT_TOKEN` / `FIRST_TREE_AGENT` environment variables and the `agent token bootstrap` subcommand have been removed.
 
-If `credentials.json` is missing or refresh fails, the CLI exits with a message pointing at `first-tree login <token>`. Do not paper over this with manual env vars — run `connect <token>`.
+If `credentials.json` is missing or refresh fails, the CLI exits with a message pointing at `first-tree login <token>`. Do not paper over this with manual env vars — run `login <token>`.
 
 ## Command Families
 
@@ -38,7 +38,7 @@ Everything that controls "the background process running on this machine". First
 
 - `daemon start` — foreground runtime loop. Loads credentials, initializes config, spins up `ClientRuntime`, watches the agents config directory for hot-add, and stays alive until SIGINT/SIGTERM. Fails closed when no credentials exist, pointing at `login`.
 - `daemon stop` / `daemon restart` — service-manager backed stop / restart against launchd or `systemd --user`.
-- `daemon status` — daemon-only view (service state, hub URL, auth health). The top-level `status` command adds CLI version + agents.
+- `daemon status` — daemon-only view (service state, server URL, auth health). The top-level `status` command adds CLI version + agents.
 - `daemon doctor` — Node version, client config, server reachability, agent configs, credential validity, WebSocket reachability, **and the background-service state** (running/inactive/not-installed/unsupported, with unit + log paths). The top-level `doctor` command will add cross-subsystem checks once Phase 3 wires `tree` / `github` through.
 
 ### `agent`
@@ -47,13 +47,13 @@ Everything that is "about one or more agent records". Subcommands split into sev
 
 **Local aliases**
 
-- `agent add [name] [--agent-id <uuid>]` — writes `~/.first-tree/hub/config/agents/<name>/agent.yaml`. Prompts interactively when arguments are missing. Local-only; does not create an agent on the Hub.
+- `agent add [name] [--agent-id <uuid>]` — writes `~/.first-tree/config/agents/<name>/agent.yaml`. Prompts interactively when arguments are missing. Local-only; does not create an agent in First Tree.
 - `agent remove <name>` — deletes the local alias, its workspaces under `data/workspaces/<name>/`, and its session registry file.
 - `agent list` — prints every locally configured alias.
 
-**Hub-side creation / ownership**
+**Server-side creation / ownership**
 
-- `agent create <name> --type <human|agent> --client-id <id> [--runtime <r>] [--display-name <n>] [--server <url>]` — calls `POST /api/v1/admin/agents` then saves the local alias. Requires the target `client-id` to be a machine you own (run `connect <token>` on that machine first).
+- `agent create <name> --type <human|agent> --client-id <id> [--runtime <r>] [--display-name <n>] [--server <url>]` — calls `POST /api/v1/admin/agents` then saves the local alias. Requires the target `client-id` to be a machine you own (run `login <token>` on that machine first).
 - `agent claim <agentName>` — sets `managerId` to the signed-in member via `PATCH /api/v1/admin/agents/:id`. Admins can claim any agent; non-admins can only self-claim unmanaged ones.
 
 **Runtime configuration** (server-side — see also `agent-config.ts`)
@@ -70,7 +70,7 @@ All `agent config` subcommands call `GET`/`PATCH`/`POST dry-run` on `/api/v1/adm
 
 **Workspaces**
 
-- `agent workspace clean [agent-name] [--ttl <days>]` — removes workspace directories under `~/.first-tree/hub/data/workspaces/<name>/` that are older than TTL (default 7 days) and not currently referenced by an active session in the registry.
+- `agent workspace clean [agent-name] [--ttl <days>]` — removes workspace directories under `~/.first-tree/data/workspaces/<name>/` that are older than TTL (default 7 days) and not currently referenced by an active session in the registry.
 
 **Bindings**
 
@@ -99,7 +99,7 @@ Messaging surface for agents and operators. All four subcommands accept
 locally (single-agent installs can omit it).
 
 - `chat send <agentName> [message] [-f format] [-m '<json>']` — sends a message to an agent by name. The recipient must already be a participant of the sender's current chat; otherwise the call errors with `AGENT_SEND_NON_MEMBER` and a hint pointing at `chat invite`. Reads from stdin when `[message]` is omitted.
-- `chat invite <agentName>` — pulls the named agent into the caller's current chat (the chat identified by `FIRST_TREE_CHAT_ID`). Replaces the retired `chat send --direct` escape hatch — Hub keeps a single group-chat model, so non-members get added rather than spawning a side conversation.
+- `chat invite <agentName>` — pulls the named agent into the caller's current chat (the chat identified by `FIRST_TREE_CHAT_ID`). Replaces the retired `chat send --direct` escape hatch — First Tree keeps a single group-chat model, so non-members get added rather than spawning a side conversation.
 - `chat list [-l <limit>] [--cursor]` — list chats this agent participates in (cursor-paginated, 1–100 per page).
 - `chat history <chatId> [-l <limit>] [--cursor]` — show history for a chat (cursor-paginated, 1–100 per page).
 - `chat open <agent-name>` — opens an admin-scoped REPL against the agent: creates a chat, polls messages every 2s, writes to the chat, exits on Ctrl+C.
@@ -116,7 +116,7 @@ Phase 1A.
 - `config get <key> [--show-secrets]` — alias for `show <key>` (kept for scripts that pre-date the rename).
 
 Agent-side runtime configuration lives under `agent config ...`, which
-mutates the Hub database via the admin API, not a local file.
+mutates First Tree database via the admin API, not a local file.
 
 ### Onboarding (sequence of `login` + `agent create` + `daemon start`)
 
@@ -126,7 +126,7 @@ independently:
 
 ```bash
 first-tree login <token>                                   # bind this machine
-first-tree agent create <name> --type <t> --client-id <id> # create the agent on the Hub
+first-tree agent create <name> --type <t> --client-id <id> # create the agent in First Tree
 first-tree daemon start                                    # bring the agent online
 ```
 
@@ -146,8 +146,8 @@ returns null, the command errors out and points at `first-tree login
 
 ### Paths
 
-- Home: `~/.first-tree/hub` by default; override with `FIRST_TREE_HOME`.
-- `$HOME/credentials.json` — member JWT + refresh token.
+- Home: `~/.first-tree` by default; override with `FIRST_TREE_HOME`.
+- `$HOME/config/credentials.json` — member JWT + refresh token.
 - `$HOME/config/client.yaml`
 - `$HOME/config/agents/<name>/agent.yaml`
 - `$HOME/.onboard-state.json`

--- a/skills/first-tree-cloud/references/core-concepts.md
+++ b/skills/first-tree-cloud/references/core-concepts.md
@@ -2,7 +2,7 @@
 
 ## Product Boundary
 
-First Tree's cloud (Hub) layer is shared infrastructure for agent teams. (Context Tree onboarding, GitHub Scan, and Tier-1 PR review are sibling layers covered by other skills.)
+First Tree Cloud is shared infrastructure for agent teams. (Context Tree onboarding, GitHub Scan, and Tier-1 PR review are sibling layers covered by other skills.)
 
 - It provides agent identity management, authentication, messaging, adapter bridges, background agent runtime, and the admin dashboard.
 - It is **not** the LLM agent runtime itself.
@@ -13,7 +13,7 @@ Use this distinction consistently when explaining the system or choosing where a
 
 ## Package Roles
 
-- `packages/server` — Fastify API server, admin APIs, agent APIs, database access, adapters, notifications. Operated centrally as the SaaS Hub.
+- `packages/server` — Fastify API server, admin APIs, agent APIs, database access, adapters, notifications. Operated centrally as the First Tree SaaS.
 - `packages/client` — Agent SDK, client runtime, WebSocket connection management, workspace/session handling.
 - `apps/cli` — Unified CLI entry point plus reusable core orchestration helpers (auth, service install, onboard, doctor). User-facing commands are limited to client / agent operations; the SaaS server runs from its own bundle (`packages/server/dist/index.mjs`).
 - `packages/shared` — Zod schemas, TypeScript types, and the schema-driven config system shared across packages.
@@ -29,7 +29,7 @@ The command package depends on the client package; it does not invoke server boo
 - The server is otherwise stateless.
 - There is no Redis or separate message queue in the intended design.
 
-### Agent identity is managed by Hub
+### Agent identity is managed by First Tree
 
 - Agent identities are created, updated, and owned via Admin API (used both by the web UI and by the CLI's `agent create` / `agent claim` / `agent create`).
 - Agent profile (markdown self-description) is stored in the `agents.profile` column.
@@ -45,7 +45,7 @@ The command package depends on the client package; it does not invoke server boo
 
 ### Auth uses one credential, everywhere
 
-- Clients sign in once via `first-tree login <token>`, which persists a member access JWT + refresh token in `~/.first-tree/hub/credentials.json`.
+- Clients sign in once via `first-tree login <token>`, which persists a member access JWT + refresh token in `~/.first-tree/config/credentials.json`.
 - Every subsequent CLI call runs through `ensureFreshAccessToken()`, which auto-refreshes 30s before expiry via `/api/v1/auth/refresh`.
 - Admin actions, agent-owner actions, `agent config` mutations, and SDK debug calls all use the same member JWT. Server enforcement is role-based.
 - There is no separate admin JWT or per-agent bearer token in the current model. The legacy `FIRST_TREE_AGENT_TOKEN` / `FIRST_TREE_AGENT` env vars and `agent token bootstrap` command are gone.
@@ -71,11 +71,11 @@ on startup:
 
 ### Client startup
 
-`daemon start` runs every locally configured agent against one Hub server.
+`daemon start` runs every locally configured agent against one First Tree server.
 
 The client runtime:
 
-- loads `~/.first-tree/hub/credentials.json` (member JWT + refresh)
+- loads `~/.first-tree/config/credentials.json` (member JWT + refresh)
 - reads `client.yaml` for `server.url` and `client.id`
 - reads every agent's local alias YAML to resolve `name → agentId`
 - establishes WebSocket and HTTP communication, refreshing the access token on demand
@@ -83,13 +83,13 @@ The client runtime:
 - manages session state and isolated chat workspaces
 - optionally syncs a shared Context Tree clone for organizational context
 
-The **background daemon** is installed automatically by `first-tree login <token>` (skip with `--no-start`). It runs `daemon start --no-interactive` under launchd (macOS) or `systemd --user` (Linux), with logs at `~/.first-tree/hub/logs/`. This is how a machine stays online across reboots without a terminal. The `daemon` namespace owns the daemon lifecycle (`start` / `stop` / `restart` / `status` / `doctor`); install / repair is folded into `login <token>`.
+The **background daemon** is installed automatically by `first-tree login <token>` (skip with `--no-start`). It runs `daemon start --no-interactive` under launchd (macOS) or `systemd --user` (Linux), with logs at `~/.first-tree/logs/`. This is how a machine stays online across reboots without a terminal. The `daemon` namespace owns the daemon lifecycle (`start` / `stop` / `restart` / `status` / `doctor`); install / repair is folded into `login <token>`.
 
 ### Workspace bootstrap
 
 When a handler starts, the client runtime bootstraps a per-chat workspace and writes `.agent/` files:
 
-- `self.md` from the agent's `profile` field (stored in Hub).
+- `self.md` from the agent's `profile` field (stored in First Tree).
 - If Context Tree is configured:
   - `agent-instructions.md` from the root `AGENT.md`
   - `domain-map.md` from the root `NODE.md`
@@ -106,9 +106,9 @@ Do not replace `agent create` with ad hoc Admin API calls unless the user explic
 
 ## Common Misunderstandings to Avoid
 
-- Do not say `agent add` creates an agent on the Hub. It only writes a local alias (`agents/<name>/agent.yaml`) mapping a friendly name to an existing `agentId`. Use `agent create` to create a server-side row.
+- Do not say `agent add` creates an agent in First Tree. It only writes a local alias (`agents/<name>/agent.yaml`) mapping a friendly name to an existing `agentId`. Use `agent create` to create a server-side row.
 - Do not say `daemon start` starts the server. It only runs configured agent clients against a server that must already be running.
-- Do not say the Context Tree owns agent identity. Hub does. Context Tree is an optional organizational knowledge source.
+- Do not say the Context Tree owns agent identity. First Tree does. Context Tree is an optional organizational knowledge source.
 - Do not frame the inbox as exactly-once delivery. The contract is at-least-once with client-side deduplication.
 - Do not reach for `FIRST_TREE_AGENT_TOKEN` or `FIRST_TREE_AGENT`. Neither env var is read by the CLI anymore; all auth flows through `credentials.json`.
 - Do not conflate `agent config ...` (server-side runtime configuration) with `config -a <name> ...` (local YAML editing for the alias file). Both are legitimate; they operate on different state.

--- a/skills/first-tree-cloud/references/developer-map.md
+++ b/skills/first-tree-cloud/references/developer-map.md
@@ -15,7 +15,7 @@ own file; helpers shared across namespaces live in `commands/_shared/`.
 
 - `apps/cli/src/cli/index.ts` — top-level Commander program and dispatcher. Registers 5 top-level shortcuts + 5 active namespaces + 2 placeholder namespaces.
 - **Top-level shortcuts** (single-verb files):
-  - `apps/cli/src/commands/login.ts` — `login <token> [--no-start] [--override]`. Decodes the token's `iss` claim to derive the hub URL, persists `credentials.json`, writes `server.url` into `client.yaml`, installs the background daemon (unless `--no-start`). `--override` folds in the old `client claim` behavior (POST `/clients/:id/claim` + stale alias cleanup).
+  - `apps/cli/src/commands/login.ts` — `login <token> [--no-start] [--override]`. Decodes the token's `iss` claim to derive the server URL, persists `credentials.json`, writes `server.url` into `client.yaml`, installs the background daemon (unless `--no-start`). `--override` folds in the old `client claim` behavior (POST `/clients/:id/claim` + stale alias cleanup).
   - `apps/cli/src/commands/logout.ts` — `logout [--purge]`. Symmetric to `login`: stops the daemon + deletes `credentials.json`; `--purge` also wipes `client.yaml`.
   - `apps/cli/src/commands/status.ts` — top-level cross-subsystem overview (CLI version + service + hub + auth + agents).
   - `apps/cli/src/commands/doctor.ts` — top-level cross-subsystem readiness check. Phase 1A ships the daemon-side checks; Phase 3 wires in tree / git / claude-code binary checks via the same shared helper.
@@ -31,14 +31,14 @@ own file; helpers shared across namespaces live in `commands/_shared/`.
 - **Shared helpers** (`apps/cli/src/commands/_shared/`):
   - `connect-token.ts` — `decodeJwtPayload`, `deriveHubUrlFromToken`, `HubUrlDerivationError`. Reused by `login` and any future caller that needs to introspect a connect token.
   - `local-agent.ts` — `resolveLocalAgent`, `createSdk`, `handleSdkError`, `readClientId`. Used by agent and chat namespaces to resolve the sender agent from the local config.
-  - `resolve-agent.ts` — `resolveAgent` (cross-org `/me/managed-agents` lookup), used by every command that addresses a Hub agent by name.
+  - `resolve-agent.ts` — `resolveAgent` (cross-org `/me/managed-agents` lookup), used by every command that addresses a First Tree agent by name.
   - `account-transfer.ts` — `postClaim` + `cleanupStaleAliasesAfterClaim`. Used by `login --override` to transfer machine ownership and prune the previous owner's local aliases.
   - `status-blocks.ts` — pure render blocks for `status` and `daemon status` (CLI version, service, hub, auth, agents).
 
 ## Reusable Core Logic
 
 - `apps/cli/src/core/bootstrap.ts` — credential persistence (`saveCredentials`, `loadCredentials`) and token freshness (`resolveAccessToken`, `ensureFreshAccessToken`), plus `resolveServerUrl` and `saveAgentConfig`. `ensureFreshAdminToken` is a back-compat alias of `ensureFreshAccessToken`.
-- `apps/cli/src/core/service-install.ts` — `installClientService`, `uninstallClientService`, `getClientServiceStatus`, `isServiceSupported`, `resolveCliInvocation`, plus the `startClientService` / `stopClientService` / `restartClientService` thin wrappers. Handles launchd (macOS) and `systemd --user` (Linux); marks other platforms as `unsupported`. Logs go to `~/.first-tree/hub/logs/`. The launchd plist / systemd unit templates spawn `daemon start --no-interactive`.
+- `apps/cli/src/core/service-install.ts` — `installClientService`, `uninstallClientService`, `getClientServiceStatus`, `isServiceSupported`, `resolveCliInvocation`, plus the `startClientService` / `stopClientService` / `restartClientService` thin wrappers. Handles launchd (macOS) and `systemd --user` (Linux); marks other platforms as `unsupported`. Logs go to `~/.first-tree/logs/`. The launchd plist / systemd unit templates spawn `daemon start --no-interactive`.
 - `apps/cli/src/core/client-runtime.ts` — the long-lived `ClientRuntime` used by `daemon start` and `login`'s inline-run fallback. Watches the agents config dir for hot-add and uses `ensureFreshAccessToken` on every WebSocket handshake.
 - `apps/cli/src/core/doctor.ts` — readiness checks used by `daemon doctor` and the top-level `doctor`: `checkNodeVersion`, `checkClientConfig`, `checkServerReachable`, `checkAgentConfigs`, `checkWebSocket`, `checkBackgroundService`, plus `reconcileAgentConfigs` (server-aware variant).
 - `apps/cli/src/core/agent-prune.ts` — `findStaleAliases`, `removeLocalAgent`, `formatStaleReason`. Used by `agent prune` and by `_shared/account-transfer.ts`.
@@ -89,7 +89,7 @@ If a flag, env var, or config key changes, inspect these files and update docs a
 The single-shot `onboard` command was retired in Phase 1A; onboarding is now a sequence of explicit verbs (`login` + `agent create` + optional `agent bind bot` + `daemon start`). To change onboarding behavior:
 
 1. `commands/login.ts` for token exchange / `--override` flow.
-2. `commands/agent/create.ts` for the Hub-side create + local bind step.
+2. `commands/agent/create.ts` for the server-side create + local bind step.
 3. `commands/agent/bind/{bot,user}.ts` for IM bindings.
 4. `docs/onboarding-guide.md` for user-facing changes.
 

--- a/skills/first-tree-cloud/references/onboarding-operator.md
+++ b/skills/first-tree-cloud/references/onboarding-operator.md
@@ -2,16 +2,16 @@
 
 Use this file when an external agent receives an onboarding task such as:
 
-> "Install First Tree CLI, read the onboarding guide with `gh`, and add a member. Server URL is `https://hub.example.com`."
+> "Install First Tree CLI, read the onboarding guide with `gh`, and add a member. Server URL is `https://first-tree.example.com`."
 
 The single-shot `onboard` command was retired in Phase 1A of the
 repo-merge refactor. Onboarding is now a sequence of explicit verbs:
 `login` to bind the machine, `agent create` to register the agent on the
-Hub, then `daemon start` to bring the agent online.
+First Tree, then `daemon start` to bring the agent online.
 
 ## Core Rules
 
-- Each verb in the sequence depends on a valid credential file. If this machine is not yet signed in, run `first-tree login <token>` first (paste the connect token from the Hub web console's *Computers → New Connection* dialog).
+- Each verb in the sequence depends on a valid credential file. If this machine is not yet signed in, run `first-tree login <token>` first (paste the connect token from the First Tree web console's *Computers → New Connection* dialog).
 - Ensure `gh` is installed and authenticated (`gh auth login`) — required for GitHub-identity agent creation.
 - Always run `first-tree status` after each verb to verify state before proceeding.
 
@@ -32,7 +32,7 @@ If the task only gives you a package name, a docs URL, and a server URL, transla
      --jq .content | base64 --decode
    ```
 
-4. Sign this machine into the Hub:
+4. Sign this machine into First Tree:
 
    ```bash
    first-tree login <connect-token>
@@ -40,7 +40,7 @@ If the task only gives you a package name, a docs URL, and a server URL, transla
    first-tree login <connect-token> --no-start
    ```
 
-5. Create the agent record on the Hub and bind it to this client:
+5. Create the agent record in First Tree and bind it to this client:
 
    ```bash
    first-tree agent create <name> \
@@ -68,7 +68,7 @@ Interpret it as:
 
 - Install (or `npx`-invoke) the published CLI.
 - Fetch the onboarding guide with `gh` rather than relying on a browser.
-- If this machine has no `~/.first-tree/hub/credentials.json`, run `first-tree login <token>` first (paste a connect token from the Hub web console's *Computers → New Connection* dialog — its `iss` claim carries the hub URL).
+- If this machine has no `~/.first-tree/config/credentials.json`, run `first-tree login <token>` first (paste a connect token from the First Tree web console's *Computers → New Connection* dialog — its `iss` claim carries the server URL).
 - Thread `https://first-tree.staging.unispark.dev/` through `--server` in every command.
 - Use the supported `agent create` + `daemon start` sequence instead of hand-rolling Admin API calls.
 

--- a/skills/first-tree-cloud/references/scenario-playbooks.md
+++ b/skills/first-tree-cloud/references/scenario-playbooks.md
@@ -26,14 +26,14 @@ gh auth status
 - Do not jump to `daemon start`, `login <token>`, or `agent create` on a machine where installation state is unknown.
 - If the user installed locally (`npm i`, not `npm i -g`), prefer `npx first-tree ...` so they do not have to fight PATH.
 
-## 1. "Connect this computer to an existing Hub server"
+## 1. "Connect this computer to an existing First Tree server"
 
-Use this when the Hub is already up and the user wants this machine to run agents against it.
+Use this when First Tree is already up and the user wants this machine to run agents against it.
 
 ### Flow
 
 ```bash
-# Paste a connect token from the Hub web console's "Connect a machine" dialog:
+# Paste a connect token from the First Tree web console's "Connect a machine" dialog:
 first-tree login <connect-token>
 
 # Skip the background service install (useful in containers):
@@ -47,7 +47,7 @@ To verify:
 ```bash
 first-tree daemon status          # local: service state + hub + auth health
 first-tree daemon doctor          # readiness checks (includes background-service state)
-# Server-side: open the Hub web admin → Computers tab to verify this
+# Server-side: open the First Tree web console → Computers tab to verify this
 # machine appears. (The legacy `client list` CLI verb was retired in Phase 1A.)
 ```
 
@@ -56,9 +56,9 @@ If something breaks, `daemon doctor` usually points at the culprit (no credentia
 ### What to remember
 
 - `login <token>` is the **only** supported way to sign in. There is no separate web login flow, username/password, or manual credential setup from the CLI side.
-- It writes `~/.first-tree/hub/credentials.json` and a generated `client.id` in `client.yaml`.
-- The hub URL is derived from the token's `iss` claim, so the operator never types a URL.
-- Agents are not registered by this command. Admins pin agents to this machine's `client.id` from the Hub UI (or via `agent create --client-id ...`). A running client auto-picks them up.
+- It writes `~/.first-tree/config/credentials.json` and a generated `client.id` in `client.yaml`.
+- The server URL is derived from the token's `iss` claim, so the operator never types a URL.
+- Agents are not registered by this command. Admins pin agents to this machine's `client.id` from the First Tree web console (or via `agent create --client-id ...`). A running client auto-picks them up.
 
 ## 2. "Keep this machine online across reboots"
 
@@ -71,7 +71,7 @@ Use this for a production desktop or a server that should run agents permanently
 ```bash
 first-tree login <token>                 # auto-installs the service
 first-tree daemon doctor                   # verify: shows running/inactive/not-installed
-tail -f ~/.first-tree/hub/logs/client.log      # tail logs (NDJSON)
+tail -f ~/.first-tree/logs/client.log      # tail logs (NDJSON)
 ```
 
 To repair a broken unit (binary moved, Node upgraded), re-run `login <token>` — it rewrites the unit file. Re-authentication is required (paste a fresh connect token).
@@ -88,10 +88,10 @@ systemctl --user disable --now first-treeent.service
 rm -f ~/.config/systemd/user/first-treeent.service
 
 # Both
-rm -rf ~/.first-tree/hub
+rm -rf ~/.first-tree
 ```
 
-To force-disconnect from the server side: use the Hub web admin (Computers → Disconnect). The CLI no longer ships an admin verb for this.
+To force-disconnect from the server side: use the First Tree web console (Computers → Disconnect). The CLI no longer ships an admin verb for this.
 
 ### What to remember
 
@@ -109,7 +109,7 @@ Add a real person to the team through the supported identity flow.
 # 0. Prereq on this machine: CLI installed, logged in.
 first-tree login <token>                                # if credentials.json does not exist
 
-# 1. Create the human agent record on the Hub + bind it to this client:
+# 1. Create the human agent record in First Tree + bind it to this client:
 first-tree agent create alice \
   --server <url> --type human --display-name "Alice" \
   --client-id "$(first-tree config get client.id | awk '{print $2}')"
@@ -172,7 +172,7 @@ first-tree agent config dry-run alice -f ./patch.json                  # preview
 - Requests carry an `expectedVersion` — concurrent edits get a conflict, not silent overwrite. On conflict, re-fetch with `agent config show` and retry.
 - `--sensitive` env values are encrypted at rest and always masked in subsequent `get`/`list`.
 - `dry-run` is the safe way to preview a big patch before committing it.
-- Do not confuse this with the local `agent.yaml` (alias → UUID mapping at `~/.first-tree/hub/config/agents/<name>/agent.yaml`), which is local-only state and unrelated to server-side runtime config.
+- Do not confuse this with the local `agent.yaml` (alias → UUID mapping at `~/.first-tree/config/agents/<name>/agent.yaml`), which is local-only state and unrelated to server-side runtime config.
 
 ## 6. "Why can't the client get online?" / "Why does startup fail?"
 
@@ -181,7 +181,7 @@ Diagnose before editing code or YAML.
 ### Flow
 
 ```bash
-first-tree daemon status          # local state: service, hub URL, agents
+first-tree daemon status          # local state: service, server URL, agents
 first-tree daemon doctor          # readiness checks (background-service state included)
 first-tree config show     # effective client YAML
 ```
@@ -190,7 +190,7 @@ first-tree config show     # effective client YAML
 
 - If `daemon doctor` flags "no credentials", the fix is `first-tree login <token>`, not a YAML edit.
 - If `daemon status` / web admin Computers tab shows the client but `daemon status` shows 0 agents, no agent is pinned to this machine — create one with `agent create --client-id <this-client-id>` or bind an existing agent with `agent bind client <name> --client-id <id>`.
-- The Hub server is operated by the First Tree team as a SaaS — when a client cannot reach it, the issue is local connectivity / credentials, not server config.
+- The First Tree server is operated by the First Tree team as a SaaS — when a client cannot reach it, the issue is local connectivity / credentials, not server config.
 
 ## 7. "Debug messaging between agents"
 
@@ -199,7 +199,7 @@ Verify delivery, inspect chats, send test messages manually.
 ### Flow
 
 ```bash
-# Prereq: this machine must have credentials.json (connect <token>).
+# Prereq: this machine must have credentials.json (`login <token>`).
 
 first-tree chat send <agentName> "hello"                   # send to an agent in the current chat
 first-tree chat invite <agentName>                # pull a non-member into the current chat first
@@ -243,20 +243,20 @@ first-tree agent workspace clean            # remove stale chat workspaces safel
 
 ## 9. "Roll out clients across many machines"
 
-The Hub server itself is operated by the First Tree team as a SaaS — there
+The First Tree server itself is operated by the First Tree team as a SaaS — there
 is no self-host path. Use this section when scaling out the *client* side.
 
 ### Flow
 
-1. Generate a connect token per machine from the Hub web console.
+1. Generate a connect token per machine from the First Tree web console.
 2. On each machine, run `first-tree login <token>` once — it signs the
    machine in and installs the background service in a single step so the
    runtime survives reboots.
-3. Verify with `first-tree daemon doctor` and the Hub web admin (Computers tab).
+3. Verify with `first-tree daemon doctor` and the First Tree web console (Computers tab).
 
 ### What to remember
 
-- Connect tokens carry the hub URL in their `iss` claim — operators never
+- Connect tokens carry the server URL in their `iss` claim — operators never
   type a URL.
 - Windows is unsupported. `login <token>` falls back to inline mode there;
   use a user-managed supervisor for permanent deployment.


### PR DESCRIPTION
## Summary
- replace legacy Hub wording in user-facing docs, env examples, package metadata, Web text, and CLI help/status output
- update First Tree Cloud and attention skills to use First Tree / First Tree Cloud / First Tree server terminology
- rename the generated agent prompt from Agent Hub SDK to First Tree Agent Runtime while leaving public API/type identifiers for later cleanup

## Validation
- pnpm check
- pnpm typecheck
- pnpm --filter first-tree-dev exec vitest run --maxWorkers=2 src/__tests__/prompt-core.test.ts src/__tests__/status-blocks.test.ts
- pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/bootstrap.test.ts