### PR TITLE
fix(client): persist final session mappings; harden fs.watch handlers (#683)

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -109,6 +109,13 @@ vi.mock("../core/version.js", () => ({
   CLI_USER_AGENT: "first-tree-test/0.0.0",
 }));
 
+// Keep real fs behaviour but wrap `watch` so a single test can swap in a fake
+// FSWatcher and drive its runtime 'error' event deterministically.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return { ...actual, default: actual, watch: vi.fn(actual.watch) };
+});
+
 describe("ClientRuntime context-tree wiring", () => {
   const originalHome = process.env.FIRST_TREE_HOME;
   let home: string;
@@ -412,4 +419,33 @@ describe("ClientRuntime context-tree wiring", () => {
     },
     RUNTIME_TEST_TIMEOUT_MS,
   );
+
+  it("tears down the agents-dir watcher when it emits a runtime error", async () => {
+    const fs = await import("node:fs");
+    const { print } = await import("../core/output.js");
+    type Listener = (...args: unknown[]) => void;
+    const errorListeners: Listener[] = [];
+    const close = vi.fn();
+    const fakeWatcher = {
+      on(event: string, listener: Listener) {
+        if (event === "error") errorListeners.push(listener);
+        return this;
+      },
+      close,
+    };
+    vi.mocked(fs.watch).mockReturnValueOnce(fakeWatcher as unknown as ReturnType<typeof fs.watch>);
+
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://hub.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    rt.watchAgentsDir(agentsDir);
+
+    expect(errorListeners).toHaveLength(1);
+    errorListeners[0]?.(new Error("inotify exhausted"));
+
+    expect(print.status).toHaveBeenCalledWith("⚠️", expect.stringContaining("inotify exhausted"));
+    expect(close).toHaveBeenCalled();
+    await rt.stop();
+  });
 });

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -288,6 +288,13 @@ export class ClientRuntime {
         this.scanForNewAgents(agentsDir);
       }, 500);
     });
+    // A recursive FSWatcher can emit 'error' at runtime (watched dir removed,
+    // or inotify exhaustion on Linux). An unhandled 'error' throws and would
+    // take down the daemon — tear the watcher down so it degrades gracefully.
+    this.watcher.on("error", (err: Error) => {
+      print.status("⚠️", `agents dir watcher error: ${err.message}`);
+      this.unwatchAgentsDir();
+    });
   }
 
   unwatchAgentsDir(): void {
@@ -346,6 +353,13 @@ export class ClientRuntime {
             }
           }
         }, 250);
+      });
+      // Synchronous setup is wrapped in try/catch above, but the FSWatcher can
+      // still emit 'error' later; without a listener that would crash the
+      // daemon. Tear it down so paused-mode recovery degrades gracefully.
+      this.credentialsWatcher.on("error", (err: Error) => {
+        print.status("⚠️", `credentials watcher error: ${err.message}`);
+        this.stopCredentialsWatcher();
       });
     } catch (err) {
       print.status("⚠️", `credentials watcher failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/client/src/__tests__/session-registry.test.ts
+++ b/packages/client/src/__tests__/session-registry.test.ts
@@ -165,6 +165,28 @@ describe("SessionRegistry", () => {
     expect(existsSync(filePath)).toBe(false);
   });
 
+  it("dispose does not roll back a fresher flush — save(old) -> flush(new) -> dispose() leaves new on disk", () => {
+    vi.useFakeTimers();
+    const registry = new SessionRegistry(filePath);
+    const oldEntries = makeEntries({
+      "chat-1": { claudeSessionId: "sess-old", lastActivity: 1700000000000, status: "active" },
+    });
+    const newEntries = makeEntries({
+      "chat-1": { claudeSessionId: "sess-new", lastActivity: 1700000999999, status: "active" },
+    });
+
+    // Mimic the SessionManager shutdown path: a debounced save was queued
+    // earlier, then shutdown calls flush({ immediate: true }) with the final
+    // state, then dispose() tears the timer down.
+    registry.save(oldEntries);
+    registry.flush(newEntries);
+    registry.dispose();
+    vi.advanceTimersByTime(1000);
+
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    expect(raw.entries["chat-1"].claudeSessionId).toBe("sess-new");
+  });
+
   it("logs persistence failures without throwing", () => {
     const parentAsFile = join(testDir, "not-a-directory");
     writeFileSync(parentAsFile, "file blocks mkdir", "utf-8");

--- a/packages/client/src/__tests__/session-registry.test.ts
+++ b/packages/client/src/__tests__/session-registry.test.ts
@@ -138,7 +138,7 @@ describe("SessionRegistry", () => {
     registry.dispose();
   });
 
-  it("dispose cancels a pending debounced save", () => {
+  it("dispose flushes a pending debounced save", () => {
     vi.useFakeTimers();
     const registry = new SessionRegistry(filePath);
     const entries = makeEntries({
@@ -146,6 +146,19 @@ describe("SessionRegistry", () => {
     });
 
     registry.save(entries);
+    registry.dispose();
+    // flush() already cancelled the timer — nothing more should fire.
+    vi.advanceTimersByTime(1000);
+
+    expect(existsSync(filePath)).toBe(true);
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    expect(raw.entries["chat-1"].claudeSessionId).toBe("sess-x");
+  });
+
+  it("dispose without a pending save writes nothing", () => {
+    vi.useFakeTimers();
+    const registry = new SessionRegistry(filePath);
+
     registry.dispose();
     vi.advanceTimersByTime(1000);
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -588,8 +588,9 @@ export class SessionManager {
       }
     }
 
-    // Persist final state
-    this.persistRegistry();
+    // Persist final state — flush synchronously so the last batch reaches
+    // disk before dispose() tears the timer down.
+    this.persistRegistry({ immediate: true });
     this.registry?.dispose();
 
     this.sessions.clear();
@@ -1588,7 +1589,7 @@ export class SessionManager {
     }
   }
 
-  private persistRegistry(): void {
+  private persistRegistry(opts: { immediate?: boolean } = {}): void {
     if (!this.registry) return;
 
     const entries = new Map<string, { claudeSessionId: string; lastActivity: number; status: string }>();
@@ -1607,6 +1608,10 @@ export class SessionManager {
         status: "evicted",
       });
     }
-    this.registry.save(entries);
+    // On shutdown we MUST write synchronously: the alternative is
+    // `save()` (debounced 1s) followed by `dispose()`, which races the
+    // process exit and silently drops the last mapping batch.
+    if (opts.immediate) this.registry.flush(entries);
+    else this.registry.save(entries);
   }
 }

--- a/packages/client/src/runtime/session-registry.ts
+++ b/packages/client/src/runtime/session-registry.ts
@@ -76,6 +76,11 @@ export class SessionRegistry {
       clearTimeout(this.writeTimer);
       this.writeTimer = null;
     }
+    // flush(entries) is authoritative — `entries` is the freshest known
+    // state. Any older debounced snapshot in pendingEntries is now stale,
+    // so drop it; otherwise dispose()'s pending fallback would later
+    // rewrite the stale snapshot on top of what we just persisted.
+    this.pendingEntries = null;
 
     const data: RegistryData = {
       version: REGISTRY_VERSION,

--- a/packages/client/src/runtime/session-registry.ts
+++ b/packages/client/src/runtime/session-registry.ts
@@ -104,8 +104,15 @@ export class SessionRegistry {
     }
   }
 
-  /** Clean up timers. */
+  /** Flush any pending debounced write, then clean up timers. */
   dispose(): void {
+    if (this.pendingEntries) {
+      // flush() clears writeTimer internally — persist the last debounced
+      // mapping instead of dropping it when torn down inside the 1s window.
+      this.flush(this.pendingEntries);
+      this.pendingEntries = null;
+      return;
+    }
     if (this.writeTimer) {
       clearTimeout(this.writeTimer);
       this.writeTimer = null;


### PR DESCRIPTION
Closes #683.

## Summary

Two independent client robustness bugs surfaced in #683, both with concrete user-visible impact.

### Bug A — `SessionRegistry` lost its last batch on every shutdown

`SessionManager.shutdown()` called `persistRegistry()` (which only enqueues a 1s **debounced** write) and then `registry.dispose()` (which **dropped** the pending payload). After every SIGTERM / `systemctl stop` / daemon self-update restart, the final `chatId → claudeSessionId` mappings never reached disk — affected chats then came back as fresh Claude sessions on next start instead of reattaching, so the agent lost its conversation context.

**Fix:** make the shutdown path flush synchronously (`persistRegistry({ immediate: true })` → `registry.flush(...)`). `dispose()` also now flushes any pending payload as a defensive fallback, so the dispose-then-flush contract is safe regardless of call ordering.

### Bug B — recursive `fs.watch` had no `'error'` handler

Both `FSWatcher` instances in `ClientRuntime` (agents dir + `credentials.json`) only attached a change callback. A runtime `'error'` event (watched dir removed/renamed, inotify exhaustion on Linux, permission revoked) would crash the **entire daemon** because Node re-throws unhandled `EventEmitter` errors — taking all agents offline at once.

**Fix:** attach `.on("error", ...)` to each watcher; log + best-effort tear down so the daemon degrades gracefully instead of crashing.

## Scope confirmation

Surveyed the broader client/CLI for sibling bugs before scoping this PR:
- Only `SessionRegistry` exhibits the unsafe save-then-dispose pattern; `UpdateManager`, `ChildProcessRegistry`, and the watchers' own debounce timers are correct.
- Inventoried `fs.watch` call sites — only those two; nothing else.
- The daemon has no process-level `uncaughtException` net, but with the FSWatcher fix in place, there is no known concrete user-visible scenario it would prevent today. Decision (with @yuezengwu): not in scope for this PR.

## Test plan

- [x] `SessionRegistry` unit tests reproduce **Bug A** on unpatched src (red) and confirm green once patched — new `dispose flushes a pending debounced save` + `dispose without a pending save writes nothing`.
- [x] `ClientRuntime context-tree` test reproduces **Bug B** on unpatched src (red) and confirms green once patched — new `tears down the agents-dir watcher when it emits a runtime error` (mocked `FSWatcher` injects an `'error'` event; asserts `print.status` warns + `close` is called).
- [x] `@first-tree/client` full test suite — 941 passed, 3 skipped.
- [x] `@first-tree/client` + `first-tree-dev` typecheck — clean.
- [x] Biome check on touched files — clean.
- [x] `@first-tree/client` + `first-tree-dev` build — clean.
- [x] Static review confirms both FSWatchers have an `error` handler and `SessionManager.shutdown()` takes the immediate-flush path while live state-change writes still go through the debounced `save`.
- [ ] Manual: OS-level inotify exhaustion not exercised (`fs.watch` runtime error simulated via mocked `FSWatcher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)